### PR TITLE
Content security policy

### DIFF
--- a/app.territoiresentransitions.react/public/index.html
+++ b/app.territoiresentransitions.react/public/index.html
@@ -6,15 +6,29 @@
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta
-        name="description"
-        content="Territoires en transitions accompagne les collectivités afin de les aider à piloter plus facilement leur transition écologique."
+      name="description"
+      content="Territoires en transitions accompagne les collectivités afin de les aider à piloter plus facilement leur transition écologique."
     />
 
     <meta charset="utf-8" />
-    <link rel="icon" type="image/png"
-          href="https://dteci.ademe.fr/favicon.png" />
+    <link
+      rel="icon"
+      type="image/png"
+      href="https://dteci.ademe.fr/favicon.png"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#333333">
+    <meta name="theme-color" content="#333333" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="
+        default-src 'self';
+        script-src 'self' *.data.gouv.fr/ 'sha256-kO6puxapZiqpb3t6i8bI0xf0enmClp/hvy3/u7oanbw=' https://client.crisp.chat;
+        connect-src 'self' http://localhost:8000 ws://localhost:8000;
+        img-src 'self' data: https://dteci.ademe.fr;
+        font-src 'self' data: https://client.crisp.chat;
+        style-src 'self' 'unsafe-inline' https://client.crisp.chat;
+        "
+    />
     <title>Territoires en Transitions</title>
     <script async src="https://stats.data.gouv.fr//piwik.js"></script>
     <script type="text/javascript">
@@ -30,11 +44,10 @@
     </script>
   </head>
   <body class="fr">
-  <noscript>You need to enable JavaScript to run this app.</noscript>
-  <div id="root">
-  </div>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
 
-<!--  <script type="module" src="dsfr/dsfr.module.min.js"></script>-->
-<!--  <script type="text/javascript" nomodule src="dsfr/dsfr.nomodule.min.js"></script>-->
+    <!--  <script type="module" src="dsfr/dsfr.module.min.js"></script>-->
+    <!--  <script type="text/javascript" nomodule src="dsfr/dsfr.nomodule.min.js"></script>-->
   </body>
 </html>

--- a/app.territoiresentransitions.react/public/index.html
+++ b/app.territoiresentransitions.react/public/index.html
@@ -18,17 +18,6 @@
     />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#333333" />
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="
-        default-src 'self';
-        script-src 'self' *.data.gouv.fr/ 'sha256-kO6puxapZiqpb3t6i8bI0xf0enmClp/hvy3/u7oanbw=' https://client.crisp.chat;
-        connect-src 'self' http://localhost:8000 ws://localhost:8000;
-        img-src 'self' data: https://dteci.ademe.fr;
-        font-src 'self' data: https://client.crisp.chat;
-        style-src 'self' 'unsafe-inline' https://client.crisp.chat;
-        "
-    />
     <title>Territoires en Transitions</title>
     <script async src="https://stats.data.gouv.fr//piwik.js"></script>
     <script type="text/javascript">

--- a/app.territoiresentransitions.react/public/index.html
+++ b/app.territoiresentransitions.react/public/index.html
@@ -18,19 +18,9 @@
     />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#333333" />
+
     <title>Territoires en Transitions</title>
-    <script async src="https://stats.data.gouv.fr//piwik.js"></script>
-    <script type="text/javascript">
-      window.$crisp = [];
-      window.CRISP_WEBSITE_ID = '%REACT_APP_CRISP_WEBSITE_ID%';
-      (function () {
-        d = document;
-        s = d.createElement('script');
-        s.src = 'https://client.crisp.chat/l.js';
-        s.async = 1;
-        d.getElementsByTagName('head')[0].appendChild(s);
-      })();
-    </script>
+    <script async src="https://stats.data.gouv.fr/piwik.js"></script>
   </head>
   <body class="fr">
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/app.territoiresentransitions.react/server.js
+++ b/app.territoiresentransitions.react/server.js
@@ -2,9 +2,13 @@ require('dotenv').config();
 const path = require('path');
 const express = require('express');
 const zipUrls = require('./src/server/zipUrls');
+const setHeaders = require('./src/server/setHeaders');
 
 const app = express();
 const directory = '/' + (process.env.STATIC_DIR || 'build');
+
+setHeaders(app);
+
 app.use(express.static(__dirname + directory));
 
 app.use(express.json()); // for parsing application/json

--- a/app.territoiresentransitions.react/src/app/App.tsx
+++ b/app.territoiresentransitions.react/src/app/App.tsx
@@ -16,6 +16,7 @@ import {ToutesLesCollectivitesPage} from 'app/pages/ToutesLesCollectivites/Toute
 import {ProfilPage} from './pages/Profil/ProfilPage';
 import Layout from 'app/Layout';
 import {AuthProvider} from 'core-logic/api/auth/AuthProvider';
+import {useCrispClient} from './useCrispClient';
 
 const theme = createTheme({
   palette: {
@@ -28,6 +29,8 @@ const theme = createTheme({
 const queryClient = new QueryClient();
 
 export const App = () => {
+  useCrispClient();
+
   return (
     <QueryClientProvider client={queryClient}>
       <AuthProvider>

--- a/app.territoiresentransitions.react/src/app/useCrispClient.ts
+++ b/app.territoiresentransitions.react/src/app/useCrispClient.ts
@@ -1,0 +1,15 @@
+import {useEffect} from 'react';
+
+/** Initialise le client Crisp */
+export const useCrispClient = () => {
+  useEffect(() => {
+    const w = window as any;
+    w.$crisp = [];
+    w.CRISP_WEBSITE_ID = process.env.REACT_APP_CRISP_WEBSITE_ID;
+    const d = document;
+    const s = d.createElement('script');
+    s.src = 'https://client.crisp.chat/l.js';
+    s.async = true;
+    d.getElementsByTagName('head')[0].appendChild(s);
+  }, []);
+};

--- a/app.territoiresentransitions.react/src/core-logic/api/auth/AuthProvider.tsx
+++ b/app.territoiresentransitions.react/src/core-logic/api/auth/AuthProvider.tsx
@@ -122,8 +122,7 @@ const clearCrispUserData = () => {
   if ('$crisp' in window) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const {$crisp} = window as any;
-    $crisp.push(['set', 'user:nickname', [null]]);
-    $crisp.push(['set', 'user:email', [null]]);
+    $crisp.push(['do', 'session:reset']);
   }
 };
 

--- a/app.territoiresentransitions.react/src/server/setHeaders.js
+++ b/app.territoiresentransitions.react/src/server/setHeaders.js
@@ -1,0 +1,24 @@
+/** Doc MDN - Content Security Policy (CSP) - https://developer.mozilla.org/fr/docs/Web/HTTP/CSP */
+/** Doc MDN - Strict-Transport-Security - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security#syntax */
+
+const setHeaders = app => {
+  const webSocketSupabaseKey = process.env.REACT_APP_SUPABASE_URL.replace(
+    'http',
+    'ws'
+  );
+  app.use((req, res, next) => {
+    if (req.secure) {
+      res.header(
+        'Strict-Transport-Security',
+        'max-age=31540000; includeSubDomains'
+      ); // 1 année
+    }
+    res.header(
+      'Content-Security-Policy-Report-Only',
+      `default-src 'self'; script-src 'self' *.data.gouv.fr/ 'sha256-kO6puxapZiqpb3t6i8bI0xf0enmClp/hvy3/u7oanbw=' https://client.crisp.chat; connect-src 'self' ${process.env.REACT_APP_SUPABASE_URL} ${webSocketSupabaseKey}; img-src 'self' data: https://dteci.ademe.fr; font-src 'self' data: https://client.crisp.chat; style-src 'self' 'unsafe-inline' https://client.crisp.chat; frame-ancestors 'none'`
+    );
+    next();
+  });
+};
+
+module.exports = setHeaders;

--- a/app.territoiresentransitions.react/src/server/setHeaders.js
+++ b/app.territoiresentransitions.react/src/server/setHeaders.js
@@ -14,7 +14,7 @@ const setHeaders = app => {
       ); // 1 année
     }
     res.header(
-      'Content-Security-Policy-Report-Only',
+      'Content-Security-Policy-Report-Only', // enlever -Report-Only pour activer la sécurité
       `default-src 'self'; script-src 'self' *.data.gouv.fr/ 'sha256-kO6puxapZiqpb3t6i8bI0xf0enmClp/hvy3/u7oanbw=' https://client.crisp.chat; connect-src 'self' ${process.env.REACT_APP_SUPABASE_URL} ${webSocketSupabaseKey}; img-src 'self' data: https://dteci.ademe.fr; font-src 'self' data: https://client.crisp.chat; style-src 'self' 'unsafe-inline' https://client.crisp.chat; frame-ancestors 'none'`
     );
     next();

--- a/app.territoiresentransitions.react/src/setupProxy.js
+++ b/app.territoiresentransitions.react/src/setupProxy.js
@@ -1,8 +1,11 @@
 const express = require('express');
 const {createProxyMiddleware} = require('http-proxy-middleware');
 const zipUrls = require('./server/zipUrls');
+const setHeaders = require('./server/setHeaders');
 
 module.exports = function (app) {
+  setHeaders(app);
+
   if (process.env.REACT_APP_WITH_PROXY === 'TRUE') {
     app.use(
       '/api',


### PR DESCRIPTION
[X-Frame-Option](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options) est déprécié en faveur de frame-ancestor dans les CSP.

J'ai bien mis 'Content-Security-Policy-Report-Only' pour uniquement générer des rapports dans un premier temps afin de s'assurer que tout fonctionne. Cela peut bloquer l'accès aux fonctions vitales du site si mal configuré.
À changer en 'Content-Security-Policy' afin d'activer cette sécurité. Plus d'infos sur [la doc MDN de CSP](https://developer.mozilla.org/fr/docs/Web/HTTP/CSP)

J'ai aussi vu beaucoup de gens utiliser [helmet](https://helmetjs.github.io/) pour setup ces sécurités dans express ([meme la doc express](http://expressjs.com/fr/advanced/best-practice-security.html#utilisez-helmet)).
Cela rajoute une dépendance au projet cependant, à voir si c'est vraiment nécessaire.

Je laisse @marc-rutkowski  prendre la suite pour tester avec les test e2e