### PR TITLE
Suppression de la valeur de l'indicateur cae_6.c associée

### DIFF
--- a/markdown/indicateurs/eci/eci_006.md
+++ b/markdown/indicateurs/eci/eci_006.md
@@ -3,7 +3,6 @@
 id: eci_6
 identifiant: 6
 unite: '%'
-valeur: cae_6.c
 
 titre_long: Part de déchets soumis à la collecte séparée dans les Ordures Ménagers et Assimilés (OMR) et la benne tout venant déchetterie (%)
 actions:


### PR DESCRIPTION
Les 2 indicateurs étaient identifiés comme étant égaux alors qu'ils ne le sont pas.