### PR TITLE
Suppression de la valeur de l'indicateur cae_11 associée.md

### DIFF
--- a/business/tests/data/dl_content/indicateurs.json
+++ b/business/tests/data/dl_content/indicateurs.json
@@ -666,7 +666,7 @@
       "titre_long": "Artificialisation des espaces naturels, agricoles, forestiers (ha)",
       "type": null,
       "unite": "%",
-      "valeur_indicateur": "cae_11"
+      "valeur_indicateur": null
     },
     {
       "action_ids": [
@@ -1653,8 +1653,8 @@
       "participation_score": false,
       "programmes": [
         "pcaet",
-        "clef",
-        "cae"
+        "cae",
+        "clef"
       ],
       "sans_valeur": false,
       "selection": true,
@@ -1979,8 +1979,8 @@
       "participation_score": false,
       "programmes": [
         "pcaet",
-        "clef",
-        "cae"
+        "cae",
+        "clef"
       ],
       "sans_valeur": false,
       "selection": true,
@@ -3141,9 +3141,9 @@
       "parent": "emission_polluants_atmo",
       "participation_score": false,
       "programmes": [
-        "pcaet",
         "clef",
-        "cae"
+        "cae",
+        "pcaet"
       ],
       "sans_valeur": false,
       "selection": true,
@@ -3167,9 +3167,9 @@
       "parent": "emission_polluants_atmo",
       "participation_score": false,
       "programmes": [
-        "pcaet",
         "clef",
-        "cae"
+        "cae",
+        "pcaet"
       ],
       "sans_valeur": false,
       "selection": true,
@@ -3193,9 +3193,9 @@
       "parent": "emission_polluants_atmo",
       "participation_score": false,
       "programmes": [
-        "pcaet",
         "clef",
-        "cae"
+        "cae",
+        "pcaet"
       ],
       "sans_valeur": false,
       "selection": true,
@@ -3219,9 +3219,9 @@
       "parent": "emission_polluants_atmo",
       "participation_score": false,
       "programmes": [
-        "pcaet",
         "clef",
-        "cae"
+        "cae",
+        "pcaet"
       ],
       "sans_valeur": false,
       "selection": true,
@@ -3245,9 +3245,9 @@
       "parent": "emission_polluants_atmo",
       "participation_score": false,
       "programmes": [
-        "pcaet",
         "clef",
-        "cae"
+        "cae",
+        "pcaet"
       ],
       "sans_valeur": false,
       "selection": true,
@@ -3271,9 +3271,9 @@
       "parent": "emission_polluants_atmo",
       "participation_score": false,
       "programmes": [
-        "pcaet",
         "clef",
-        "cae"
+        "cae",
+        "pcaet"
       ],
       "sans_valeur": false,
       "selection": true,
@@ -3370,9 +3370,9 @@
       "parent": null,
       "participation_score": false,
       "programmes": [
-        "pcaet",
         "clef",
-        "cae"
+        "cae",
+        "pcaet"
       ],
       "sans_valeur": false,
       "selection": true,
@@ -4013,9 +4013,9 @@
       "parent": null,
       "participation_score": false,
       "programmes": [
-        "pcaet",
         "clef",
-        "cae"
+        "cae",
+        "pcaet"
       ],
       "sans_valeur": false,
       "selection": false,

--- a/data_layer/content/indicateurs.json
+++ b/data_layer/content/indicateurs.json
@@ -666,7 +666,7 @@
       "titre_long": "Artificialisation des espaces naturels, agricoles, forestiers (ha)",
       "type": null,
       "unite": "%",
-      "valeur_indicateur": "cae_11"
+      "valeur_indicateur": null
     },
     {
       "action_ids": [
@@ -1653,8 +1653,8 @@
       "participation_score": false,
       "programmes": [
         "pcaet",
-        "clef",
-        "cae"
+        "cae",
+        "clef"
       ],
       "sans_valeur": false,
       "selection": true,
@@ -1979,8 +1979,8 @@
       "participation_score": false,
       "programmes": [
         "pcaet",
-        "clef",
-        "cae"
+        "cae",
+        "clef"
       ],
       "sans_valeur": false,
       "selection": true,
@@ -3141,9 +3141,9 @@
       "parent": "emission_polluants_atmo",
       "participation_score": false,
       "programmes": [
-        "pcaet",
         "clef",
-        "cae"
+        "cae",
+        "pcaet"
       ],
       "sans_valeur": false,
       "selection": true,
@@ -3167,9 +3167,9 @@
       "parent": "emission_polluants_atmo",
       "participation_score": false,
       "programmes": [
-        "pcaet",
         "clef",
-        "cae"
+        "cae",
+        "pcaet"
       ],
       "sans_valeur": false,
       "selection": true,
@@ -3193,9 +3193,9 @@
       "parent": "emission_polluants_atmo",
       "participation_score": false,
       "programmes": [
-        "pcaet",
         "clef",
-        "cae"
+        "cae",
+        "pcaet"
       ],
       "sans_valeur": false,
       "selection": true,
@@ -3219,9 +3219,9 @@
       "parent": "emission_polluants_atmo",
       "participation_score": false,
       "programmes": [
-        "pcaet",
         "clef",
-        "cae"
+        "cae",
+        "pcaet"
       ],
       "sans_valeur": false,
       "selection": true,
@@ -3245,9 +3245,9 @@
       "parent": "emission_polluants_atmo",
       "participation_score": false,
       "programmes": [
-        "pcaet",
         "clef",
-        "cae"
+        "cae",
+        "pcaet"
       ],
       "sans_valeur": false,
       "selection": true,
@@ -3271,9 +3271,9 @@
       "parent": "emission_polluants_atmo",
       "participation_score": false,
       "programmes": [
-        "pcaet",
         "clef",
-        "cae"
+        "cae",
+        "pcaet"
       ],
       "sans_valeur": false,
       "selection": true,
@@ -3370,9 +3370,9 @@
       "parent": null,
       "participation_score": false,
       "programmes": [
-        "pcaet",
         "clef",
-        "cae"
+        "cae",
+        "pcaet"
       ],
       "sans_valeur": false,
       "selection": true,
@@ -4013,9 +4013,9 @@
       "parent": null,
       "participation_score": false,
       "programmes": [
-        "pcaet",
         "clef",
-        "cae"
+        "cae",
+        "pcaet"
       ],
       "sans_valeur": false,
       "selection": false,

--- a/markdown/indicateurs/eci/eci_023.md
+++ b/markdown/indicateurs/eci/eci_023.md
@@ -3,7 +3,6 @@
 id: eci_23
 identifiant: 23
 unite: '%'
-valeur: cae_11
 
 titre_long: Artificialisation des espaces naturels, agricoles, forestiers (ha)
 programmes:


### PR DESCRIPTION
eci_23 = "Nombre d'hectares artificialisés total / Nombre d'hectares des terres agricoles, naturelles et forestières. Dans la logique du Zéro Artificialisation Net."
cae_11 = Surface annuelle artificialisée en ha/an