### PR TITLE
N'applique pas le filtre automatique sur le taux de remplissage lorsque le filtre sur le niveau de labellisation est actif

### DIFF
--- a/app.territoiresentransitions.react/src/app/pages/CollectivitesEngagees/data/useFilteredCollectivites.ts
+++ b/app.territoiresentransitions.react/src/app/pages/CollectivitesEngagees/data/useFilteredCollectivites.ts
@@ -92,9 +92,12 @@ const buildQueryFromFilters = (filters: CollectiviteEngagee.Filters) => {
         filter('completude_eci_intervalle', 'in', filters.tauxDeRemplissage);
     }
   }
-  // en l'absence de taux sélectionné, la selection d'un référentiel équivaut
-  // à un taux de remplissage qui n'est pas 0
-  else if (filters.referentiel.length > 0) {
+  // en l'absence de taux ou de niveau de labellisation sélectionné, la
+  // selection d'un référentiel équivaut à un taux de remplissage qui n'est pas 0
+  else if (
+    filters.referentiel.length > 0 &&
+    filters.niveauDeLabellisation.length === 0
+  ) {
     const intervalles = ['0-49', '50-79', '80-99', '100'];
     if (filters.referentiel.length === 1) {
       if (filters.referentiel.includes('cae'))


### PR DESCRIPTION
Ref: https://www.notion.so/accelerateur-transition-ecologique-ademe/Probl-me-de-filtres-dans-la-page-Collectivit-s-40af8d9695204562a17a811a02b4165a