### PR TITLE
Mise à jour du proxy posthog dans l'app

### DIFF
--- a/app.territoiresentransitions.react/package.json
+++ b/app.territoiresentransitions.react/package.json
@@ -49,7 +49,7 @@
     "express": "^4.17.1",
     "formik": "^2.2.9",
     "html2canvas": "^1.4.1",
-    "http-proxy-middleware": "^2.0.0",
+    "http-proxy-middleware": "^3.0.0",
     "posthog-js": "^1.108.4",
     "prettier": "^2.3.0",
     "react": "^18.2.0",

--- a/app.territoiresentransitions.react/server.js
+++ b/app.territoiresentransitions.react/server.js
@@ -1,7 +1,7 @@
 require('dotenv').config();
 const path = require('path');
 const express = require('express');
-const httpProxy = require('http-proxy');
+const {createProxyMiddleware} = require('http-proxy-middleware');
 const zipUrls = require('./src/server/zipUrls');
 
 const app = express();
@@ -9,21 +9,15 @@ const directory = '/' + (process.env.STATIC_DIR || 'build');
 app.use(express.static(__dirname + directory));
 
 // redirection des requêtes sur posthog
-const proxy = httpProxy.createProxyServer();
-app.use('/ingest', (req, res) => {
-  proxy.web(req, res, {
+app.use(
+  '/ingest',
+  createProxyMiddleware({
     target: 'https://eu.posthog.com',
     changeOrigin: true,
     secure: true,
     xfwd: true,
-    headers: {
-      // These headers aren't necessary, but are useful for our metrics.
-      'X-Real-IP': req.ip,
-      'X-Forwarded-For': req.ip,
-      'X-Forwarded-Host': req.hostname,
-    },
-  });
-});
+  })
+);
 
 app.use(express.json()); // for parsing application/json
 app.post('/zip', zipUrls);

--- a/app.territoiresentransitions.react/src/setupProxy.js
+++ b/app.territoiresentransitions.react/src/setupProxy.js
@@ -1,18 +1,7 @@
 const express = require('express');
-const {createProxyMiddleware} = require('http-proxy-middleware');
 const zipUrls = require('./server/zipUrls');
 
 module.exports = function (app) {
-  if (process.env.REACT_APP_WITH_PROXY === 'TRUE') {
-    app.use(
-      '/api',
-      createProxyMiddleware({
-        target: 'http://localhost:8080',
-        changeOrigin: true,
-      })
-    );
-  }
-
   app.use(express.json()); // for parsing application/json
   app.post('/zip', zipUrls);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "express": "^4.17.1",
         "formik": "^2.2.9",
         "html2canvas": "^1.4.1",
-        "http-proxy-middleware": "^2.0.0",
+        "http-proxy-middleware": "^3.0.0",
         "posthog-js": "^1.108.4",
         "prettier": "^2.3.0",
         "react": "^18.2.0",
@@ -1771,6 +1771,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "app.territoiresentransitions.react/node_modules/http-proxy-middleware": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.0.tgz",
+      "integrity": "sha512-36AV1fIaI2cWRzHo+rbcxhe3M3jUDCNzc4D5zRl57sEWRAxdXYtw7FSQKYY6PDKssiAKjLYypbssHk+xs/kMXw==",
+      "dependencies": {
+        "@types/http-proxy": "^1.17.10",
+        "debug": "^4.3.4",
+        "http-proxy": "^1.18.1",
+        "is-glob": "^4.0.1",
+        "is-plain-obj": "^3.0.0",
+        "micromatch": "^4.0.5"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "app.territoiresentransitions.react/node_modules/jscodeshift": {


### PR DESCRIPTION
Devrait permettre d'éviter des erreurs de type `ECONNRESET` associée à l'utilisation de `http-proxy` dans le serveur de l'app.

Idéalement on devrait se passer de proxy en configurant des CSP mais l'emploi de scripts inline (pour le module userguiding notamment) le rend plus difficile.

Si le problème persiste ce sera la marche à suivre.