### PR TITLE
FA: statut “à venir” par défaut à la création d’une fiche action

### DIFF
--- a/data_layer/sqitch/deploy/plan_action/fiches.sql
+++ b/data_layer/sqitch/deploy/plan_action/fiches.sql
@@ -2,74 +2,10 @@
 
 BEGIN;
 
--- Ajoute les computed fields pour filtrer les fiche actions
--- 👇
+-- Modifie la valeur par défaut du champ 'statut' de la table 'fiche_action'
 
-CREATE OR REPLACE FUNCTION public.fiche_action_service_tag(public.fiches_action)
-    RETURNS SETOF public.fiche_action_service_tag
-    LANGUAGE SQL
-    STABLE
-    SECURITY DEFINER
-    SET search_path TO ''
-BEGIN ATOMIC
-    SELECT *
-    FROM public.fiche_action_service_tag
-    WHERE fiche_id = $1.id
-    ;
-END;
+ALTER TABLE public.fiche_action
+  ALTER COLUMN statut SET DEFAULT 'À venir'::public.fiche_action_statuts;
 
-CREATE OR REPLACE FUNCTION public.fiche_action_structure_tag(public.fiches_action)
-    RETURNS SETOF public.fiche_action_structure_tag
-    LANGUAGE SQL
-    STABLE
-    SECURITY DEFINER
-    SET search_path TO ''
-BEGIN ATOMIC
-    SELECT *
-    FROM public.fiche_action_structure_tag
-    WHERE fiche_id = $1.id
-    ;
-END;
-
-CREATE OR REPLACE FUNCTION public.fiche_action_personne_tag(public.fiches_action)
-    RETURNS SETOF public.fiche_action_pilote
-    LANGUAGE SQL
-    STABLE
-    SECURITY DEFINER
-    SET search_path TO ''
-BEGIN ATOMIC
-    SELECT *
-    FROM public.fiche_action_pilote
-    WHERE fiche_id = $1.id
-    ;
-END;
-
-
-CREATE OR REPLACE FUNCTION public.fiche_action_pilote(public.fiches_action)
-    RETURNS SETOF public.fiche_action_pilote
-    LANGUAGE SQL
-    STABLE
-    SECURITY DEFINER
-    SET search_path TO ''
-BEGIN ATOMIC
-    SELECT *
-    FROM public.fiche_action_pilote
-    WHERE fiche_id = $1.id
-    ;
-END;
-
-CREATE OR REPLACE FUNCTION public.fiche_action_axe(public.fiches_action)
-    RETURNS SETOF public.axe
-    LANGUAGE SQL
-    STABLE
-    SECURITY DEFINER
-    SET search_path TO ''
-BEGIN ATOMIC
-    SELECT axe.*
-    FROM public.fiche_action_axe
-    JOIN public.axe ON fiche_action_axe.axe_id = axe.id
-    WHERE fiche_action_axe.fiche_id = $1.id
-    ;
-END;
 
 COMMIT;

--- a/data_layer/sqitch/deploy/plan_action/fiches@v3.6.0.sql
+++ b/data_layer/sqitch/deploy/plan_action/fiches@v3.6.0.sql
@@ -1,0 +1,75 @@
+-- Deploy tet:plan_action/fiches to pg
+
+BEGIN;
+
+-- Ajoute les computed fields pour filtrer les fiche actions
+-- 👇
+
+CREATE OR REPLACE FUNCTION public.fiche_action_service_tag(public.fiches_action)
+    RETURNS SETOF public.fiche_action_service_tag
+    LANGUAGE SQL
+    STABLE
+    SECURITY DEFINER
+    SET search_path TO ''
+BEGIN ATOMIC
+    SELECT *
+    FROM public.fiche_action_service_tag
+    WHERE fiche_id = $1.id
+    ;
+END;
+
+CREATE OR REPLACE FUNCTION public.fiche_action_structure_tag(public.fiches_action)
+    RETURNS SETOF public.fiche_action_structure_tag
+    LANGUAGE SQL
+    STABLE
+    SECURITY DEFINER
+    SET search_path TO ''
+BEGIN ATOMIC
+    SELECT *
+    FROM public.fiche_action_structure_tag
+    WHERE fiche_id = $1.id
+    ;
+END;
+
+CREATE OR REPLACE FUNCTION public.fiche_action_personne_tag(public.fiches_action)
+    RETURNS SETOF public.fiche_action_pilote
+    LANGUAGE SQL
+    STABLE
+    SECURITY DEFINER
+    SET search_path TO ''
+BEGIN ATOMIC
+    SELECT *
+    FROM public.fiche_action_pilote
+    WHERE fiche_id = $1.id
+    ;
+END;
+
+
+CREATE OR REPLACE FUNCTION public.fiche_action_pilote(public.fiches_action)
+    RETURNS SETOF public.fiche_action_pilote
+    LANGUAGE SQL
+    STABLE
+    SECURITY DEFINER
+    SET search_path TO ''
+BEGIN ATOMIC
+    SELECT *
+    FROM public.fiche_action_pilote
+    WHERE fiche_id = $1.id
+    ;
+END;
+
+CREATE OR REPLACE FUNCTION public.fiche_action_axe(public.fiches_action)
+    RETURNS SETOF public.axe
+    LANGUAGE SQL
+    STABLE
+    SECURITY DEFINER
+    SET search_path TO ''
+BEGIN ATOMIC
+    SELECT axe.*
+    FROM public.fiche_action_axe
+    JOIN public.axe ON fiche_action_axe.axe_id = axe.id
+    WHERE fiche_action_axe.fiche_id = $1.id
+    ;
+END;
+
+COMMIT;

--- a/data_layer/sqitch/revert/plan_action/fiches.sql
+++ b/data_layer/sqitch/revert/plan_action/fiches.sql
@@ -2,10 +2,9 @@
 
 BEGIN;
 
-DROP FUNCTION public.fiche_action_service_tag(public.fiches_action);
-DROP FUNCTION public.fiche_action_structure_tag(public.fiches_action);
-DROP FUNCTION public.fiche_action_personne_tag(public.fiches_action);
-DROP FUNCTION public.fiche_action_pilote(public.fiches_action);
-DROP FUNCTION public.fiche_action_axe(public.fiches_action);
+-- Enlève la valeur par défaut du champ 'statut' de la table 'fiche_action'
+
+ALTER TABLE public.fiche_action
+  ALTER COLUMN statut DROP DEFAULT;
 
 COMMIT;

--- a/data_layer/sqitch/revert/plan_action/fiches@v3.6.0.sql
+++ b/data_layer/sqitch/revert/plan_action/fiches@v3.6.0.sql
@@ -1,0 +1,11 @@
+-- Deploy tet:plan_action/fiches to pg
+
+BEGIN;
+
+DROP FUNCTION public.fiche_action_service_tag(public.fiches_action);
+DROP FUNCTION public.fiche_action_structure_tag(public.fiches_action);
+DROP FUNCTION public.fiche_action_personne_tag(public.fiches_action);
+DROP FUNCTION public.fiche_action_pilote(public.fiches_action);
+DROP FUNCTION public.fiche_action_axe(public.fiches_action);
+
+COMMIT;

--- a/data_layer/sqitch/sqitch.plan
+++ b/data_layer/sqitch/sqitch.plan
@@ -678,3 +678,5 @@ indicateur/filtre [indicateur/filtre@v3.5.0] 2024-06-25T09:00:01Z Frederic Arnou
 
 indicateur/filtre [indicateur/filtre@v3.6.0] 2024-06-25T15:16:51Z Frederic Arnoux <frederic.arnoux@beta.gouv.fr> # Ajoute des indexes pour améliorer la performance des requêtes de filtrage des indicateurs
 plan_action/fiches [plan_action/fiches@v3.6.0] 2024-07-02T09:46:13Z Frederic Arnoux <frederic.arnoux@beta.gouv.fr> # Crée une Fiche Action avec le statut "à venir" par défaut
+@v3.7.0 2024-07-02T13:19:49Z Frederic Arnoux <frederic.arnoux@beta.gouv.fr> # Crée une Fiche Action avec le statut "à venir" par défaut
+

--- a/data_layer/sqitch/sqitch.plan
+++ b/data_layer/sqitch/sqitch.plan
@@ -677,3 +677,4 @@ indicateur/filtre [indicateur/filtre@v3.5.0] 2024-06-25T09:00:01Z Frederic Arnou
 @v3.6.0 2024-06-25T13:27:12Z Frederic Arnoux <frederic.arnoux@beta.gouv.fr> # Supprime la vérification de droits sur les axes liés aux indicateurs.\nCette vérification est par ailleurs déjà faite sur la vue indicateur_definitions qui l'utilise.\nCette suppression permet de corriger le filtre des indicateurs par plan action.
 
 indicateur/filtre [indicateur/filtre@v3.6.0] 2024-06-25T15:16:51Z Frederic Arnoux <frederic.arnoux@beta.gouv.fr> # Ajoute des indexes pour améliorer la performance des requêtes de filtrage des indicateurs
+plan_action/fiches [plan_action/fiches@v3.6.0] 2024-07-02T09:46:13Z Frederic Arnoux <frederic.arnoux@beta.gouv.fr> # Crée une Fiche Action avec le statut "à venir" par défaut

--- a/data_layer/sqitch/verify/plan_action/fiches@v3.6.0.sql
+++ b/data_layer/sqitch/verify/plan_action/fiches@v3.6.0.sql
@@ -1,0 +1,5 @@
+-- Verify tet:plan_action/fiches on pg
+
+BEGIN;
+
+ROLLBACK;


### PR DESCRIPTION
🔗 [Ticket Notion](https://www.notion.so/accelerateur-transition-ecologique-ademe/Statuts-venir-par-d-faut-la-cr-ation-d-une-FA-d3cf1b9e557b475f8bc75295d085d6c2?pvs=4)

J'ai changé le statut par défaut d'une fiche action en modifiant directement au niveau BDD.

Le champ `statut` de la table `fiche_action` a désormais comme valeur par défaut `À venir` (valeur de l'enum `fiche_action_statuts`)
