### PR TITLE
fix(indicateurs): Dans la recherche, afficher uniquement les parents pour les indicateurs composés

### DIFF
--- a/packages/api/src/indicateurs/actions/fetchFilteredIndicateurs.ts
+++ b/packages/api/src/indicateurs/actions/fetchFilteredIndicateurs.ts
@@ -123,8 +123,7 @@ export async function fetchFilteredIndicateurs(
   // une recherche par id ou si un des filtres complémentaires est actif)
   const filtrerParParent =
     !filtresOptions.estPerso &&
-    filters.categorieNoms?.length &&
-    !filters.categorieNoms.find(nom => nom === 'crte') &&
+    !filters.categorieNoms?.find(nom => nom === 'crte') &&
     !searchById &&
     !Object.values(filtrerPar).includes(true);
 


### PR DESCRIPTION
-> [Ticket Notion](https://www.notion.so/accelerateur-transition-ecologique-ademe/Afficher-uniquement-les-previews-des-parents-pour-les-indicateurs-compos-s-addd9a9f6ba84265a49a0ffa8673bed3?pvs=4)