### PR TITLE
build: change l'image Docker du site

### DIFF
--- a/.earthlyignore
+++ b/.earthlyignore
@@ -1,5 +1,7 @@
 node_modules
 dist
+.git
+.env*
 .nx
 .vscode
 .github

--- a/.github/workflows/cd-site.yml
+++ b/.github/workflows/cd-site.yml
@@ -1,4 +1,4 @@
-name: Déploiement à la demande du site
+name: Déploiement du site
 run-name: Déploiement du site sur ${{ github.event.inputs.target }}
 
 on:
@@ -32,7 +32,7 @@ jobs:
           earthly
           --use-inline-cache --save-inline-cache --push
           --platform=linux/amd64
-          +site-build
+          +site-docker
           --ENV_NAME=${{ github.event.inputs.target }}
           --ANON_KEY=${{ secrets.ANON_KEY }} --API_URL=${{ secrets.API_URL }}
           --STRAPI_KEY=${{ secrets.STRAPI_KEY }} --STRAPI_URL=${{ secrets.STRAPI_URL }}

--- a/Earthfile
+++ b/Earthfile
@@ -265,7 +265,10 @@ business-parse:
     SAVE ARTIFACT /content AS LOCAL $BUSINESS_DIR/tests/data/dl_content
 
 node-alpine:
-  FROM node:20-alpine
+  # Pinning the docker image version to node:20.15.1-alpine
+  # because of existing memory leaks from using the fetch() API in node 20.16.0
+  # https://www.reddit.com/r/node/comments/1ejzn64/sudden_inexplicable_memory_leak_on_new_builds/
+  FROM node:20.15.1-alpine
 
   # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
   RUN apk add --no-cache libc6-compat

--- a/backend/Earthfile
+++ b/backend/Earthfile
@@ -4,19 +4,13 @@ build:
   FROM ../+front-deps
 
   COPY . ./backend
-  # COPY ../packages/api ./packages/api
-  # COPY --chown=node:node root+$BACKEND_DIR ./
-  # COPY --chown=node:node ../packages/api/. $API_DIR
 
   RUN pnpm build:backend
-  RUN pnpm prune --prod # Remove packages from devDependencies
 
-
-  SAVE ARTIFACT dist /dist AS LOCAL dist
-  SAVE ARTIFACT node_modules /node_modules AS LOCAL node_modules
+  SAVE ARTIFACT dist /dist AS LOCAL earthly-build/dist
 
 docker:
-  FROM ../+node-fr
+  FROM ../+prod-deps
 
   ARG DOCKER_IMAGE=$BACKEND_IMG_NAME
 
@@ -28,9 +22,7 @@ docker:
 
   EXPOSE ${PORT}
 
-  # COPY --chown=node:node +backend-pre-build/app/package*.json .
   COPY +build/dist ./dist
-  COPY +build/node_modules ./node_modules
 
   CMD ["node", "dist/backend/main.js"]
   SAVE IMAGE --push $DOCKER_IMAGE

--- a/packages/site/.env.sample
+++ b/packages/site/.env.sample
@@ -1,3 +1,4 @@
 NEXT_PUBLIC_SUPABASE_URL=http://localhost:8000
 NEXT_PUBLIC_SUPABASE_ANON_KEY=${SUPABASE_ANON_KEY}
 NEXT_PUBLIC_CRISP_WEBSITE_ID="// Crisp integration (warning: use different ID by deployment env.)"
+NEXT_PUBLIC_AXEPTIO_ID=${AXEPTIO_ID}

--- a/packages/site/Earthfile
+++ b/packages/site/Earthfile
@@ -1,0 +1,91 @@
+VERSION 0.8
+
+build:
+  FROM ../../+node-alpine-with-all-deps
+
+  ARG --required ANON_KEY
+  ARG --required API_URL
+  ARG --required STRAPI_KEY
+  ARG --required STRAPI_URL
+  ARG --required AXEPTIO_ID
+
+  COPY . ./packages/site
+
+  # Disable telemetry during build
+  ENV NEXT_TELEMETRY_DISABLED=1
+
+  ENV NEXT_PUBLIC_STRAPI_KEY=$STRAPI_KEY
+  ENV NEXT_PUBLIC_STRAPI_URL=$STRAPI_URL
+  ENV NEXT_PUBLIC_SUPABASE_ANON_KEY=$ANON_KEY
+  ENV NEXT_PUBLIC_SUPABASE_URL=$API_URL
+  ENV NEXT_PUBLIC_POSTHOG_HOST=$POSTHOG_HOST
+  ENV NEXT_PUBLIC_POSTHOG_KEY=$POSTHOG_KEY
+  ENV NEXT_PUBLIC_AXEPTIO_ID=$AXEPTIO_ID
+  ENV NEXT_PUBLIC_CRISP_WEBSITE_ID=$CRISP_WEBSITE_ID
+
+  RUN pnpm build:site
+
+  SAVE ARTIFACT ./packages/site/.next
+  SAVE ARTIFACT ./packages/site/public
+
+# See official Dockerfile at https://github.com/vercel/next.js/blob/canary/examples/with-docker/Dockerfile
+docker:
+  FROM ../../+node-alpine
+
+  ARG --required ANON_KEY
+  ARG --required API_URL
+  ARG --required STRAPI_KEY
+  ARG --required STRAPI_URL
+  ARG --required AXEPTIO_ID
+  ARG POSTHOG_HOST
+  ARG POSTHOG_KEY
+
+  ENV NEXT_PUBLIC_STRAPI_KEY=$STRAPI_KEY
+  ENV NEXT_PUBLIC_STRAPI_URL=$STRAPI_URL
+  ENV NEXT_PUBLIC_SUPABASE_ANON_KEY=$ANON_KEY
+  ENV NEXT_PUBLIC_SUPABASE_URL=$API_URL
+  ENV NEXT_PUBLIC_POSTHOG_HOST=$POSTHOG_HOST
+  ENV NEXT_PUBLIC_POSTHOG_KEY=$POSTHOG_KEY
+  ENV NEXT_PUBLIC_AXEPTIO_ID=$AXEPTIO_ID
+  ENV NEXT_PUBLIC_CRISP_WEBSITE_ID=$CRISP_WEBSITE_ID
+
+  ARG DOCKER_IMAGE=$SITE_IMG_NAME
+
+  # ENV PUBLIC_PATH="/app/public"
+
+  RUN addgroup --system --gid 1001 nodejs
+  RUN adduser --system --uid 1001 nextjs
+
+  COPY +build/public ./public
+
+  # Set the correct permission for prerender cache
+  RUN mkdir .next
+  RUN chown nextjs:nodejs .next
+
+  # Automatically leverage output traces to reduce docker image size
+  # https://nextjs.org/docs/advanced-features/output-file-tracing
+  COPY --chown=nextjs:nodejs +build/.next/standalone ./
+  COPY --chown=nextjs:nodejs +build/.next/static ./packages/site/.next/static
+
+  USER nextjs
+
+
+  # Prepare the app for production
+  ENV NEXT_TELEMETRY_DISABLED=1
+  ENV HOSTNAME="0.0.0.0"
+  ENV NODE_ENV production
+
+  ENV PORT=3000
+  EXPOSE 3000
+
+  # server.js is created by next build from the standalone output
+  # https://nextjs.org/docs/pages/api-reference/next-config-js/output
+  CMD ["node", "packages/site/server.js"]
+
+  SAVE IMAGE --push $DOCKER_IMAGE
+
+deploy:
+  ARG --required KOYEB_API_KEY
+  FROM +koyeb
+  RUN ./koyeb services update $ENV_NAME-site/front --docker $SITE_IMG_NAME
+

--- a/packages/site/Earthfile
+++ b/packages/site/Earthfile
@@ -86,6 +86,6 @@ docker:
 
 deploy:
   ARG --required KOYEB_API_KEY
-  FROM +koyeb
+  FROM ../../+koyeb
   RUN ./koyeb services update $ENV_NAME-site/front --docker $SITE_IMG_NAME
 

--- a/packages/site/Earthfile
+++ b/packages/site/Earthfile
@@ -86,6 +86,6 @@ docker:
 
 deploy:
   ARG --required KOYEB_API_KEY
-  FROM ../../+koyeb
+  FROM ../../+koyeb --KOYEB_API_KEY=$KOYEB_API_KEY
   RUN ./koyeb services update $ENV_NAME-site/front --docker $SITE_IMG_NAME
 

--- a/packages/site/next.config.mjs
+++ b/packages/site/next.config.mjs
@@ -27,7 +27,6 @@ const nextConfig = {
     esmExternals: 'loose',
   },
   images: {
-    unoptimized: true,
     remotePatterns: [
       { protocol: 'https', hostname: '**.strapiapp.com' },
       { protocol: 'http', hostname: '127.0.0.1' },

--- a/packages/site/next.config.mjs
+++ b/packages/site/next.config.mjs
@@ -14,6 +14,10 @@ const nextConfig = {
     svgr: false,
   },
 
+  // Useful for self-hosting in a Docker container
+  // See https://nextjs.org/docs/app/api-reference/next-config-js/output#automatically-copying-traced-files
+  output: 'standalone',
+
   // active le mode strict pour détecter le problèmes en dev
   reactStrictMode: true,
   // active la minification


### PR DESCRIPTION
Nouvelle image Docker basé sur `node:alpine`.
Taille finale de l'image avec le tree-shaking des dépendances de Next : 482MB.