### PR TITLE
Mises à jour sur les images du site

### DIFF
--- a/packages/site/app/actus/[id]/[slug]/ParagrapheArticle.tsx
+++ b/packages/site/app/actus/[id]/[slug]/ParagrapheArticle.tsx
@@ -19,7 +19,8 @@ const ParagrapheArticle = ({
       {image && alignementImage === 'Centre Haut' && (
         <StrapiImage
           data={image}
-          containerClassName="max-w-full lg:max-w-[80%] h-full flex flex-col justify-center items-center mb-6 mx-auto"
+          containerClassName="max-w-full lg:max-w-[80%] h-fit flex flex-col justify-center items-center mb-6 mx-auto"
+          className="h-full max-h-[500px]"
           displayCaption={legendeVisible}
         />
       )}
@@ -60,7 +61,8 @@ const ParagrapheArticle = ({
       {image && alignementImage === 'Centre Bas' && (
         <StrapiImage
           data={image}
-          containerClassName="max-w-full lg:max-w-[80%] h-full flex flex-col justify-center items-center mb-6 mx-auto"
+          containerClassName="max-w-full lg:max-w-[80%] h-fit flex flex-col justify-center items-center mb-6 mx-auto"
+          className="h-full max-h-[500px]"
           displayCaption={legendeVisible}
         />
       )}

--- a/packages/site/app/actus/[id]/[slug]/page.tsx
+++ b/packages/site/app/actus/[id]/[slug]/page.tsx
@@ -47,11 +47,18 @@ const Article = async ({ params }: { params: { id: string } }) => {
     <>
       <Section className="gap-8">
         {/* Image de couverture */}
-        <StrapiImage
-          data={data.couverture}
-          className="fr-responsive-img max-h-[550px] object-cover"
-          displayCaption={false}
-        />
+        <div className="max-h-[550px] w-full overflow-hidden relative">
+          <StrapiImage
+            data={data.couverture}
+            className="object-cover object-center h-full w-full"
+            containerClassName="object-cover object-center h-full w-full"
+          />
+          {(data.couverture.attributes.caption as unknown as string) && (
+            <div className="text-right text-grey-1 text-[14px] leading-4 py-1 px-2 absolute right-0 top-[526px] bg-grey-8/50 rounded-tl-sm">
+              {data.couverture.attributes.caption as unknown as string}
+            </div>
+          )}
+        </div>
 
         <div>
           {/* Titre */}

--- a/packages/site/app/collectivites/[code]/[name]/CollectiviteHeader.tsx
+++ b/packages/site/app/collectivites/[code]/[name]/CollectiviteHeader.tsx
@@ -44,12 +44,19 @@ const CollectiviteHeader = ({
     <div className="flex flex-col md:rounded-[10px] bg-primary-7">
       <div className="relative w-full h-[314px] overflow-hidden md:rounded-t-[10px]">
         {couverture ? (
-          <StrapiImage
-            data={couverture}
-            className="object-cover object-center h-full w-full"
-            containerClassName="h-full w-full object-cover object-center"
-            displayCaption={false}
-          />
+          <>
+            <StrapiImage
+              data={couverture}
+              className="object-cover object-center h-full w-full"
+              containerClassName="h-full w-full object-cover object-center"
+              displayCaption={false}
+            />
+            {(couverture.attributes.caption as unknown as string) && (
+              <div className="text-right text-grey-1 text-[14px] leading-4 py-1 px-2 absolute right-0 top-[290px] bg-grey-8/50 rounded-tl-sm">
+                {couverture.attributes.caption as unknown as string}
+              </div>
+            )}
+          </>
         ) : (
           <div className="bg-primary-3 h-full w-full relative">
             <div className="h-full w-full absolute top-0 left-0 flex flex-col justify-center items-center">


### PR DESCRIPTION
Tickets associés : 

https://www.notion.so/accelerateur-transition-ecologique-ademe/Pouvoir-ajouter-des-cr-dits-photo-sur-la-banni-re-Actu-et-page-collectivit-9288c8c2425a4573a80b8a534e8633e8?pvs=4

https://www.notion.so/accelerateur-transition-ecologique-ademe/Taille-des-images-1046523d57d780868ea1dcfb5887bbcd?pvs=4