### PR TITLE
Ajout de l'onglet indicateurs sur les pages collectivité personnalisées

### DIFF
--- a/packages/site/app/collectivites/[code]/[name]/PageContent.tsx
+++ b/packages/site/app/collectivites/[code]/[name]/PageContent.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { Tab, Tabs } from '@tet/ui';
+
+type PageContentType = {
+  indicateurs: JSX.Element | null;
+  programme: JSX.Element | null;
+};
+
+const PageContent = ({ indicateurs, programme }: PageContentType) => {
+  if (!indicateurs && !programme)
+    return <div className="col-span-full md:col-span-7 lg:col-span-8" />;
+
+  if (indicateurs && programme) {
+    return (
+      <Tabs
+        className="col-span-full md:col-span-7 lg:col-span-8"
+        tabsListClassName="!bg-primary-1"
+      >
+        <Tab label="Indicateurs locaux">{indicateurs}</Tab>
+        <Tab label="Programme T.E.T.E.">{programme}</Tab>
+      </Tabs>
+    );
+  } else if (indicateurs) return indicateurs;
+  else if (programme) return programme;
+};
+
+export default PageContent;

--- a/packages/site/app/collectivites/[code]/[name]/page.tsx
+++ b/packages/site/app/collectivites/[code]/[name]/page.tsx
@@ -17,6 +17,7 @@ import AccesCompte from './AccesCompte';
 import { getUpdatedMetadata } from '@tet/site/src/utils/getUpdatedMetadata';
 import HistoriqueLabellisation from './HistoriqueLabellisation';
 import { notFound } from 'next/navigation';
+import PageContent from './PageContent';
 
 export async function generateMetadata(
   { params }: { params: { code: string } },
@@ -141,21 +142,26 @@ const DetailCollectivite = async ({ params }: { params: { code: string } }) => {
       </div>
 
       {/* Contenu */}
-      {strapiData?.contenu ? (
-        <ContenuCollectivite contenu={strapiData.contenu} />
-      ) : strapiDefaultData ? (
-        <IndicateursCollectivite
-          defaultData={strapiDefaultData.indicateurs}
-          indicateurs={{
-            artificialisation_sols:
-              collectiviteData.collectivite.indicateur_artificialisation,
-            gaz_effet_serre:
-              collectiviteData.collectivite.indicateurs_gaz_effet_serre,
-          }}
-        />
-      ) : (
-        <div className="col-span-full md:col-span-7 lg:col-span-8" />
-      )}
+      <PageContent
+        indicateurs={
+          strapiDefaultData ? (
+            <IndicateursCollectivite
+              defaultData={strapiDefaultData.indicateurs}
+              indicateurs={{
+                artificialisation_sols:
+                  collectiviteData.collectivite.indicateur_artificialisation,
+                gaz_effet_serre:
+                  collectiviteData.collectivite.indicateurs_gaz_effet_serre,
+              }}
+            />
+          ) : null
+        }
+        programme={
+          strapiData?.contenu ? (
+            <ContenuCollectivite contenu={strapiData.contenu} />
+          ) : null
+        }
+      />
     </Section>
   );
 };


### PR DESCRIPTION
Ticket associé : https://www.notion.so/accelerateur-transition-ecologique-ademe/Afficher-plus-d-informations-sur-les-pages-publiques-de-chaque-collectivit-10b6523d57d7807bad0fe9445a5ca7fe?pvs=4