### PR TITLE
✨(fiche-action): Split `cibles` enum values

### DIFF
--- a/app.territoiresentransitions.react/src/types/alias.ts
+++ b/app.territoiresentransitions.react/src/types/alias.ts
@@ -7,6 +7,7 @@ import {
   Views,
   NonNullableFields,
 } from '@tet/api';
+import { Cible } from '@tet/api/plan-actions';
 
 export type TFlatAxe = NonNullableFields<CompositeTypes<'flat_axe_node'>>;
 
@@ -62,7 +63,8 @@ export type TPersonne = CompositeTypes<'personne'>;
 
 export type TFinanceurMontant = CompositeTypes<'financeur_montant'>;
 
-export type TFicheActionCibles = Enums<'fiche_action_cibles'>;
+export type TFicheActionCibles = Cible;
+
 export type TFicheActionNiveauxPriorite =
   Enums<'fiche_action_niveaux_priorite'>;
 export type TFicheActionPiliersECI = Enums<'fiche_action_piliers_eci'>;

--- a/app.territoiresentransitions.react/src/ui/dropdownLists/listesStatiques.ts
+++ b/app.territoiresentransitions.react/src/ui/dropdownLists/listesStatiques.ts
@@ -14,8 +14,12 @@ type Options<T extends string> = {
 
 export const ficheActionCiblesOptions: Options<TFicheActionCibles> = [
   {
-    value: 'Grand public et associations',
-    label: 'Grand public et associations',
+    value: 'Grand public',
+    label: 'Grand public',
+  },
+  {
+    value: 'Associations',
+    label: 'Associations',
   },
   {
     value: 'Public Scolaire',

--- a/backend/src/fiches/models/fiche-action.table.ts
+++ b/backend/src/fiches/models/fiche-action.table.ts
@@ -12,6 +12,7 @@ import {
   varchar,
 } from 'drizzle-orm/pg-core';
 import { collectiviteTable } from '../../collectivites/models/collectivite.table';
+import { z } from 'zod';
 
 export const ficheActionPiliersEciEnum = pgEnum('fiche_action_piliers_eci', [
   'Approvisionnement durable',
@@ -62,6 +63,8 @@ export const ficheActionStatutsEnum = pgEnum('fiche_action_statuts', [
 ]);
 
 export enum FicheActionCiblesEnumType {
+  GRAND_PUBLIC = 'Grand public',
+  ASSOCIATIONS = 'Associations',
   GRAND_PUBLIC_ET_ASSOCIATIONS = 'Grand public et associations',
   PUBLIC_SCOLAIRE = 'Public Scolaire',
   AUTRES_COLLECTIVITES_DU_TERRITOIRE = 'Autres collectivités du territoire',
@@ -75,7 +78,9 @@ export enum FicheActionCiblesEnumType {
   AGENTS = 'Agents',
 }
 
-export const ficheActionCiblesEnum = pgEnum('fiche_action_cibles', [
+export const ficheActionCiblesEnumValues = [
+  FicheActionCiblesEnumType.GRAND_PUBLIC,
+  FicheActionCiblesEnumType.ASSOCIATIONS,
   FicheActionCiblesEnumType.GRAND_PUBLIC_ET_ASSOCIATIONS,
   FicheActionCiblesEnumType.PUBLIC_SCOLAIRE,
   FicheActionCiblesEnumType.AUTRES_COLLECTIVITES_DU_TERRITOIRE,
@@ -87,7 +92,14 @@ export const ficheActionCiblesEnum = pgEnum('fiche_action_cibles', [
   FicheActionCiblesEnumType.COLLECTIVITE_ELLE_MEME,
   FicheActionCiblesEnumType.ELUS_LOCAUX,
   FicheActionCiblesEnumType.AGENTS,
-]);
+] as const;
+
+export const ficheActionCiblesEnumSchema = z.enum(ficheActionCiblesEnumValues);
+
+export const ficheActionCiblesEnum = pgEnum(
+  'fiche_action_cibles',
+  ficheActionCiblesEnumValues
+);
 
 export const ficheActionNiveauxPrioriteEnum = pgEnum(
   'fiche_action_niveaux_priorite',
@@ -105,7 +117,9 @@ export const ficheActionTable = pgTable('fiche_action', {
   objectifs: varchar('objectifs', { length: 10000 }),
   resultatsAttendus:
     ficheActionResultatsAttendusEnum('resultats_attendus').array(),
-  cibles: ficheActionCiblesEnum('cibles').array(),
+  cibles: text('cibles', {
+    enum: ficheActionCiblesEnumValues,
+  }).array(),
   ressources: varchar('ressources', { length: 10000 }),
   financements: text('financements'),
   budgetPrevisionnel: numeric('budget_previsionnel', {

--- a/backend/src/fiches/models/get-fiches-actions-filter.request.ts
+++ b/backend/src/fiches/models/get-fiches-actions-filter.request.ts
@@ -1,7 +1,7 @@
 import { extendApi } from '@anatine/zod-openapi';
 import { z } from 'zod';
 import { modifiedSinceSchema } from '../../common/models/modified-since.enum';
-import { FicheActionCiblesEnumType } from './fiche-action.table';
+import { ficheActionCiblesEnumSchema } from './fiche-action.table';
 
 export const getFichesActionFilterRequestSchema = extendApi(
   z
@@ -9,7 +9,7 @@ export const getFichesActionFilterRequestSchema = extendApi(
       cibles: z
         .string()
         .transform((value) => value.split(','))
-        .pipe(z.nativeEnum(FicheActionCiblesEnumType).array())
+        .pipe(ficheActionCiblesEnumSchema.array())
         .optional()
         .openapi({
           description: 'Liste des cibles séparées par des virgules',

--- a/data_layer/sqitch/deploy/plan_action/fiches.sql
+++ b/data_layer/sqitch/deploy/plan_action/fiches.sql
@@ -2,7 +2,48 @@
 
 BEGIN;
 
-drop view private.fiches_action;
+-- Drop related functions and views
+DROP TRIGGER IF EXISTS save_history ON public.fiche_action;
+DROP FUNCTION historique.save_fiche_action();
+DROP FUNCTION public.plan_action_export(id integer);
+DROP TRIGGER IF EXISTS upsert ON public.fiches_action;
+DROP VIEW public.fiches_action;
+DROP VIEW private.fiches_action;
+
+
+
+
+-- Step 1: Change the column type from enum fiche_action_cibles[] to text[]
+ALTER TABLE fiche_action
+ALTER COLUMN cibles TYPE text[];
+
+-- Step 2: Update existing data
+UPDATE fiche_action
+SET cibles = (
+    SELECT array_agg(new_value)
+    FROM (
+        SELECT unnest(
+            CASE
+                WHEN unnest = 'Grand public et associations' THEN ARRAY['Grand public', 'Associations']
+                WHEN unnest = 'Acteurs économiques' THEN ARRAY['Acteurs économiques']
+                WHEN unnest = 'Acteurs économiques du secteur primaire' THEN ARRAY['Acteurs économiques du secteur primaire']
+                WHEN unnest = 'Acteurs économiques du secteur secondaire' THEN ARRAY['Acteurs économiques du secteur secondaire']
+                WHEN unnest = 'Acteurs économiques du secteur tertiaire' THEN ARRAY['Acteurs économiques du secteur tertiaire']
+                WHEN unnest = 'Public Scolaire' THEN ARRAY['Public Scolaire']
+                WHEN unnest = 'Autres collectivités du territoire' THEN ARRAY['Autres collectivités du territoire']
+                WHEN unnest = 'Partenaires' THEN ARRAY['Partenaires']
+                WHEN unnest = 'Collectivité elle-même' THEN ARRAY['Collectivité elle-même']
+                WHEN unnest = 'Elus locaux' THEN ARRAY['Elus locaux']
+                WHEN unnest = 'Agents' THEN ARRAY['Agents']
+                ELSE ARRAY[unnest]
+            END
+        ) AS new_value
+        FROM unnest(cibles)
+    ) AS expanded_values
+);
+
+
+-- Re-create related functions and views
 create view private.fiches_action
 as
 SELECT fa.modified_at,
@@ -163,6 +204,7 @@ LEFT JOIN (
           GROUP BY faea.fiche_id
           ) eff ON eff.fiche_id = fa.id;
 
+
 create or replace view public.fiches_action as
 SELECT *
 FROM private.fiches_action
@@ -170,6 +212,178 @@ WHERE CASE
         WHEN fiches_action.restreint = true THEN have_lecture_acces(fiches_action.collectivite_id) OR est_support()
         ELSE can_read_acces_restreint(fiches_action.collectivite_id)
       END;
+
+CREATE OR REPLACE FUNCTION public.plan_action_export(id integer)
+ RETURNS SETOF fiche_action_export
+ LANGUAGE sql
+BEGIN ATOMIC
+ WITH RECURSIVE parents AS (
+          SELECT axe.id,
+             axe.nom,
+             axe.collectivite_id,
+             0 AS depth,
+             ARRAY[]::text[] AS path,
+             ('0 '::text || axe.nom) AS sort_path
+            FROM axe
+           WHERE ((axe.parent IS NULL) AND (axe.id = plan_action_export.id) AND can_read_acces_restreint(axe.collectivite_id))
+         UNION ALL
+          SELECT a.id,
+             a.nom,
+             a.collectivite_id,
+             (p_1.depth + 1),
+             (p_1.path || p_1.nom),
+             ((((p_1.sort_path || ' '::text) || (p_1.depth + 1)) || ' '::text) || a.nom)
+            FROM (parents p_1
+              JOIN axe a ON ((a.parent = p_1.id)))
+         ), fiches AS (
+          SELECT a.id AS axe_id,
+             f_1.*::fiches_action AS fiche,
+             f_1.titre
+            FROM ((parents a
+              JOIN fiche_action_axe faa ON ((a.id = faa.axe_id)))
+              JOIN fiches_action f_1 ON (((f_1.collectivite_id = a.collectivite_id) AND (faa.fiche_id = f_1.id))))
+         )
+  SELECT p.id,
+     p.nom,
+     p.path,
+     to_jsonb(f.*) AS to_jsonb
+    FROM (parents p
+      LEFT JOIN fiches f ON ((p.id = f.axe_id)))
+   ORDER BY (naturalsort((p.sort_path || (COALESCE(f.titre, ''::character varying))::text)));
+END;
+
+CREATE OR REPLACE TRIGGER upsert
+    INSTEAD OF INSERT OR UPDATE
+    ON public.fiches_action
+    FOR EACH ROW
+    EXECUTE FUNCTION public.upsert_fiche_action();
+
+CREATE OR REPLACE FUNCTION historique.save_fiche_action()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+declare
+    updated integer;
+    id_fiche integer;
+    previous_fiche integer;
+begin
+    id_fiche = coalesce(new.id, old.id);
+    update historique.fiche_action
+    set
+        titre = new.titre,
+        description = new.description,
+        piliers_eci = new.piliers_eci::text[],
+        objectifs = new.objectifs,
+        resultats_attendus = new.resultats_attendus::text[],
+        cibles = new.cibles::text[],
+        ressources = new.ressources,
+        financements = new.financements,
+        budget_previsionnel = new.budget_previsionnel,
+        statut = new.statut::text,
+        niveau_priorite = new.niveau_priorite::text,
+        date_debut = new.date_debut,
+        date_fin_provisoire = new.date_fin_provisoire,
+        amelioration_continue = new.amelioration_continue,
+        calendrier = new.calendrier,
+        notes_complementaires = new.notes_complementaires,
+        maj_termine = new.maj_termine,
+        modified_at = new.modified_at,
+        modified_by = new.modified_by,
+        restreint = new.restreint,
+        deleted = new is null
+    where id in (select id
+                 from historique.fiche_action
+                 where fiche_id = id_fiche
+                   and modified_at > new.modified_at - interval '1 hour'
+                 order by modified_by desc
+                 limit 1)
+    returning id into updated;
+
+    if updated is null
+    then
+        insert into historique.fiche_action
+        values (default,
+                id_fiche,
+                new.titre,
+                old.titre,
+                new.description,
+                old.description,
+                new.piliers_eci::text[],
+                old.piliers_eci::text[],
+                new.objectifs,
+                old.objectifs,
+                new.resultats_attendus::text[],
+                old.resultats_attendus::text[],
+                new.cibles::text[],
+                old.cibles::text[],
+                new.ressources,
+                old.ressources,
+                new.financements,
+                old.financements,
+                new.budget_previsionnel,
+                old.budget_previsionnel,
+                new.statut::text,
+                old.statut::text,
+                new.niveau_priorite::text,
+                old.niveau_priorite::text,
+                new.date_debut,
+                old.date_debut,
+                new.date_fin_provisoire,
+                old.date_fin_provisoire,
+                new.amelioration_continue,
+                old.amelioration_continue,
+                new.calendrier,
+                old.calendrier,
+                new.notes_complementaires,
+                old.notes_complementaires,
+                new.maj_termine,
+                old.maj_termine,
+                new.collectivite_id,
+                new.created_at,
+                new.modified_at,
+                old.modified_at,
+                auth.uid(),
+                old.modified_by,
+                new.restreint,
+                old.restreint,
+                new is null)
+        returning id into updated;
+
+        select id
+        from historique.fiche_action faa
+        where fiche_id = id_fiche
+        and id <> updated
+        order by faa.modified_at desc
+        limit 1 into previous_fiche;
+
+        if previous_fiche is not null then
+            insert into historique.fiche_action_pilote (fiche_historise_id, user_id, tag_nom, previous)
+            select updated, fap.user_id, fap.tag_nom, true
+            from historique.fiche_action_pilote fap
+            where fap.fiche_historise_id = previous_fiche;
+        end if;
+
+    else
+        delete from historique.fiche_action_pilote where fiche_historise_id = updated and previous = false;
+    end if;
+
+    insert into historique.fiche_action_pilote (fiche_historise_id, user_id, tag_nom, previous)
+    select updated, fap.user_id, pt.nom, false
+    from public.fiche_action_pilote fap
+    left join personne_tag pt on fap.tag_id = pt.id
+    where fiche_id = id_fiche;
+
+    return new;
+end ;
+$function$
+;
+
+CREATE OR REPLACE TRIGGER save_history
+    AFTER INSERT OR DELETE OR UPDATE
+    ON public.fiche_action
+    FOR EACH ROW
+    EXECUTE FUNCTION historique.save_fiche_action();
 
 COMMIT;
 

--- a/data_layer/sqitch/deploy/plan_action/fiches@v4.18.0.sql
+++ b/data_layer/sqitch/deploy/plan_action/fiches@v4.18.0.sql
@@ -1,0 +1,175 @@
+-- Deploy tet:plan_action/fiches to pg
+
+BEGIN;
+
+drop view private.fiches_action;
+create view private.fiches_action
+as
+SELECT fa.modified_at,
+       fa.id,
+       fa.titre,
+       fa.description,
+       fa.piliers_eci,
+       fa.objectifs,
+       eff.resultats_attendus,
+       fa.cibles,
+       fa.ressources,
+       fa.financements,
+       fa.budget_previsionnel,
+       fa.statut,
+       fa.niveau_priorite,
+       fa.date_debut,
+       fa.date_fin_provisoire,
+       fa.amelioration_continue,
+       fa.calendrier,
+       fa.notes_complementaires,
+       fa.maj_termine,
+       fa.collectivite_id,
+       fa.created_at,
+       fa.modified_by,
+       t.thematiques,
+       st.sous_thematiques,
+       p.partenaires,
+       s.structures,
+       (
+       SELECT array_agg(ROW (pil.nom, pil.collectivite_id, pil.tag_id, pil.user_id)::personne) AS array_agg
+       FROM (
+            SELECT COALESCE(pt.nom, concat(dcp.prenom, ' ', dcp.nom)) AS nom,
+                   pt.collectivite_id,
+                   fap.tag_id,
+                   fap.user_id
+            FROM fiche_action_pilote fap
+            LEFT JOIN personne_tag pt ON fap.tag_id = pt.id
+            LEFT JOIN dcp ON fap.user_id = dcp.user_id
+            WHERE fap.fiche_id = fa.id
+            ) pil
+       ) AS pilotes,
+       (
+       SELECT array_agg(ROW (ref.nom, ref.collectivite_id, ref.tag_id, ref.user_id)::personne) AS array_agg
+       FROM (
+            SELECT COALESCE(pt.nom, concat(dcp.prenom, ' ', dcp.nom)) AS nom,
+                   pt.collectivite_id,
+                   far.tag_id,
+                   far.user_id
+            FROM fiche_action_referent far
+            LEFT JOIN personne_tag pt ON far.tag_id = pt.id
+            LEFT JOIN dcp ON far.user_id = dcp.user_id
+            WHERE far.fiche_id = fa.id
+            ) ref
+       ) AS referents,
+       pla.axes,
+       act.actions,
+       (
+       SELECT array_agg(ROW (indi.id, indi.groupement_id, indi.collectivite_id, indi.identifiant_referentiel, indi.titre, indi.titre_long, indi.description, indi.unite, indi.borne_min, indi.borne_max, indi.participation_score, indi.sans_valeur_utilisateur, indi.valeur_calcule, indi.modified_at, indi.created_at, indi.modified_by, indi.created_by)::indicateur_definition) AS array_agg
+       FROM (
+            SELECT id.id,
+                   id.groupement_id,
+                   id.collectivite_id,
+                   id.identifiant_referentiel,
+                   id.titre,
+                   id.titre_long,
+                   id.description,
+                   id.unite,
+                   id.borne_min,
+                   id.borne_max,
+                   id.participation_score,
+                   id.sans_valeur_utilisateur,
+                   id.valeur_calcule,
+                   id.modified_at,
+                   id.created_at,
+                   id.modified_by,
+                   id.created_by
+            FROM fiche_action_indicateur fai
+            JOIN indicateur_definition id ON fai.indicateur_id::text = id.id::text
+            WHERE fai.fiche_id = fa.id
+            ) indi
+       ) AS indicateurs,
+       ser.services,
+       (
+       SELECT array_agg(ROW (fin.financeur_tag, fin.montant_ttc, fin.id)::financeur_montant) AS financeurs
+       FROM (
+            SELECT ft.*::financeur_tag AS financeur_tag,
+                   faft.montant_ttc,
+                   faft.id
+            FROM financeur_tag ft
+            JOIN fiche_action_financeur_tag faft ON ft.id = faft.financeur_tag_id
+            WHERE faft.fiche_id = fa.id
+            ) fin
+       ) AS financeurs,
+       fic.fiches_liees,
+       fa.restreint
+FROM fiche_action fa
+LEFT JOIN (
+          SELECT fath.fiche_id,
+                 array_agg(th.*) AS thematiques
+          FROM thematique th
+          JOIN fiche_action_thematique fath ON fath.thematique_id = th.id
+          GROUP BY fath.fiche_id
+          ) t ON t.fiche_id = fa.id
+LEFT JOIN (
+          SELECT fasth.fiche_id,
+                 array_agg(sth.*) AS sous_thematiques
+          FROM sous_thematique sth
+          JOIN fiche_action_sous_thematique fasth ON fasth.thematique_id = sth.id
+          GROUP BY fasth.fiche_id
+          ) st ON st.fiche_id = fa.id
+LEFT JOIN (
+          SELECT fapt.fiche_id,
+                 array_agg(pt.*) AS partenaires
+          FROM partenaire_tag pt
+          JOIN fiche_action_partenaire_tag fapt ON fapt.partenaire_tag_id = pt.id
+          GROUP BY fapt.fiche_id
+          ) p ON p.fiche_id = fa.id
+LEFT JOIN (
+          SELECT fast.fiche_id,
+                 array_agg(st_1.*) AS structures
+          FROM structure_tag st_1
+          JOIN fiche_action_structure_tag fast ON fast.structure_tag_id = st_1.id
+          GROUP BY fast.fiche_id
+          ) s ON s.fiche_id = fa.id
+LEFT JOIN (
+          SELECT fapa.fiche_id,
+                 array_agg(pa.*) AS axes
+          FROM axe pa
+          JOIN fiche_action_axe fapa ON fapa.axe_id = pa.id
+          GROUP BY fapa.fiche_id
+          ) pla ON pla.fiche_id = fa.id
+LEFT JOIN (
+          SELECT faa.fiche_id,
+                 array_agg(ar.*) AS actions
+          FROM action_relation ar
+          JOIN fiche_action_action faa ON faa.action_id::text = ar.id::text
+          GROUP BY faa.fiche_id
+          ) act ON act.fiche_id = fa.id
+LEFT JOIN (
+          SELECT fast.fiche_id,
+                 array_agg(st_1.*) AS services
+          FROM service_tag st_1
+          JOIN fiche_action_service_tag fast ON fast.service_tag_id = st_1.id
+          GROUP BY fast.fiche_id
+          ) ser ON ser.fiche_id = fa.id
+LEFT JOIN (
+          SELECT falpf.fiche_id,
+                 array_agg(fr.*) AS fiches_liees
+          FROM private.fiche_resume fr
+          JOIN fiches_liees_par_fiche falpf ON falpf.fiche_liee_id = fr.id
+          GROUP BY falpf.fiche_id
+          ) fic ON fic.fiche_id = fa.id
+LEFT JOIN (
+          SELECT faea.fiche_id,
+                 array_agg(ea.*) AS resultats_attendus
+          FROM effet_attendu ea
+          JOIN fiche_action_effet_attendu faea ON ea.id = faea.effet_attendu_id
+          GROUP BY faea.fiche_id
+          ) eff ON eff.fiche_id = fa.id;
+
+create or replace view public.fiches_action as
+SELECT *
+FROM private.fiches_action
+WHERE CASE
+        WHEN fiches_action.restreint = true THEN have_lecture_acces(fiches_action.collectivite_id) OR est_support()
+        ELSE can_read_acces_restreint(fiches_action.collectivite_id)
+      END;
+
+COMMIT;
+

--- a/data_layer/sqitch/revert/plan_action/fiches.sql
+++ b/data_layer/sqitch/revert/plan_action/fiches.sql
@@ -2,7 +2,50 @@
 
 BEGIN;
 
-create or replace view public.fiches_action
+-- Drop related functions and views
+DROP TRIGGER IF EXISTS save_history ON public.fiche_action;
+DROP FUNCTION historique.save_fiche_action();
+DROP FUNCTION public.plan_action_export(id integer);
+DROP TRIGGER IF EXISTS upsert ON public.fiches_action;
+DROP VIEW public.fiches_action;
+DROP VIEW private.fiches_action;
+
+
+
+-- Step 1: Revert the data changes
+UPDATE fiche_action
+SET cibles = (
+    SELECT array_agg(new_value)
+    FROM (
+        SELECT unnest(
+            CASE
+                WHEN unnest = 'Grand public' THEN ARRAY['Grand public et associations']
+                WHEN unnest = 'Associations' THEN ARRAY['Grand public et associations']
+                WHEN unnest = 'Acteurs économiques' THEN ARRAY['Acteurs économiques']
+                WHEN unnest = 'Acteurs économiques du secteur primaire' THEN ARRAY['Acteurs économiques du secteur primaire']
+                WHEN unnest = 'Acteurs économiques du secteur secondaire' THEN ARRAY['Acteurs économiques du secteur secondaire']
+                WHEN unnest = 'Acteurs économiques du secteur tertiaire' THEN ARRAY['Acteurs économiques du secteur tertiaire']
+                WHEN unnest = 'Public Scolaire' THEN ARRAY['Public Scolaire']
+                WHEN unnest = 'Autres collectivités du territoire' THEN ARRAY['Autres collectivités du territoire']
+                WHEN unnest = 'Partenaires' THEN ARRAY['Partenaires']
+                WHEN unnest = 'Collectivité elle-même' THEN ARRAY['Collectivité elle-même']
+                WHEN unnest = 'Elus locaux' THEN ARRAY['Elus locaux']
+                WHEN unnest = 'Agents' THEN ARRAY['Agents']
+                ELSE ARRAY[unnest]
+            END
+        ) AS new_value
+        FROM unnest(cibles) AS unnest
+    ) AS expanded_values
+);
+
+-- Step 2: Change the column type back to enum fiche_action_cibles[]
+ALTER TABLE fiche_action
+ALTER COLUMN cibles TYPE fiche_action_cibles[] USING cibles::fiche_action_cibles[];
+
+
+-- Re-create related functions and views
+
+create view private.fiches_action
 as
 SELECT fa.modified_at,
        fa.id,
@@ -161,6 +204,188 @@ LEFT JOIN (
           JOIN fiche_action_effet_attendu faea ON ea.id = faea.effet_attendu_id
           GROUP BY faea.fiche_id
           ) eff ON eff.fiche_id = fa.id;
+
+
+create or replace view public.fiches_action as
+SELECT *
+FROM private.fiches_action
+WHERE CASE
+        WHEN fiches_action.restreint = true THEN have_lecture_acces(fiches_action.collectivite_id) OR est_support()
+        ELSE can_read_acces_restreint(fiches_action.collectivite_id)
+      END;
+
+CREATE OR REPLACE FUNCTION public.plan_action_export(id integer)
+ RETURNS SETOF fiche_action_export
+ LANGUAGE sql
+BEGIN ATOMIC
+ WITH RECURSIVE parents AS (
+          SELECT axe.id,
+             axe.nom,
+             axe.collectivite_id,
+             0 AS depth,
+             ARRAY[]::text[] AS path,
+             ('0 '::text || axe.nom) AS sort_path
+            FROM axe
+           WHERE ((axe.parent IS NULL) AND (axe.id = plan_action_export.id) AND can_read_acces_restreint(axe.collectivite_id))
+         UNION ALL
+          SELECT a.id,
+             a.nom,
+             a.collectivite_id,
+             (p_1.depth + 1),
+             (p_1.path || p_1.nom),
+             ((((p_1.sort_path || ' '::text) || (p_1.depth + 1)) || ' '::text) || a.nom)
+            FROM (parents p_1
+              JOIN axe a ON ((a.parent = p_1.id)))
+         ), fiches AS (
+          SELECT a.id AS axe_id,
+             f_1.*::fiches_action AS fiche,
+             f_1.titre
+            FROM ((parents a
+              JOIN fiche_action_axe faa ON ((a.id = faa.axe_id)))
+              JOIN fiches_action f_1 ON (((f_1.collectivite_id = a.collectivite_id) AND (faa.fiche_id = f_1.id))))
+         )
+  SELECT p.id,
+     p.nom,
+     p.path,
+     to_jsonb(f.*) AS to_jsonb
+    FROM (parents p
+      LEFT JOIN fiches f ON ((p.id = f.axe_id)))
+   ORDER BY (naturalsort((p.sort_path || (COALESCE(f.titre, ''::character varying))::text)));
+END;
+
+CREATE OR REPLACE TRIGGER upsert
+    INSTEAD OF INSERT OR UPDATE
+    ON public.fiches_action
+    FOR EACH ROW
+    EXECUTE FUNCTION public.upsert_fiche_action();
+
+CREATE OR REPLACE FUNCTION historique.save_fiche_action()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+declare
+    updated integer;
+    id_fiche integer;
+    previous_fiche integer;
+begin
+    id_fiche = coalesce(new.id, old.id);
+    update historique.fiche_action
+    set
+        titre = new.titre,
+        description = new.description,
+        piliers_eci = new.piliers_eci::text[],
+        objectifs = new.objectifs,
+        resultats_attendus = new.resultats_attendus::text[],
+        cibles = new.cibles::text[],
+        ressources = new.ressources,
+        financements = new.financements,
+        budget_previsionnel = new.budget_previsionnel,
+        statut = new.statut::text,
+        niveau_priorite = new.niveau_priorite::text,
+        date_debut = new.date_debut,
+        date_fin_provisoire = new.date_fin_provisoire,
+        amelioration_continue = new.amelioration_continue,
+        calendrier = new.calendrier,
+        notes_complementaires = new.notes_complementaires,
+        maj_termine = new.maj_termine,
+        modified_at = new.modified_at,
+        modified_by = new.modified_by,
+        restreint = new.restreint,
+        deleted = new is null
+    where id in (select id
+                 from historique.fiche_action
+                 where fiche_id = id_fiche
+                   and modified_at > new.modified_at - interval '1 hour'
+                 order by modified_by desc
+                 limit 1)
+    returning id into updated;
+
+    if updated is null
+    then
+        insert into historique.fiche_action
+        values (default,
+                id_fiche,
+                new.titre,
+                old.titre,
+                new.description,
+                old.description,
+                new.piliers_eci::text[],
+                old.piliers_eci::text[],
+                new.objectifs,
+                old.objectifs,
+                new.resultats_attendus::text[],
+                old.resultats_attendus::text[],
+                new.cibles::text[],
+                old.cibles::text[],
+                new.ressources,
+                old.ressources,
+                new.financements,
+                old.financements,
+                new.budget_previsionnel,
+                old.budget_previsionnel,
+                new.statut::text,
+                old.statut::text,
+                new.niveau_priorite::text,
+                old.niveau_priorite::text,
+                new.date_debut,
+                old.date_debut,
+                new.date_fin_provisoire,
+                old.date_fin_provisoire,
+                new.amelioration_continue,
+                old.amelioration_continue,
+                new.calendrier,
+                old.calendrier,
+                new.notes_complementaires,
+                old.notes_complementaires,
+                new.maj_termine,
+                old.maj_termine,
+                new.collectivite_id,
+                new.created_at,
+                new.modified_at,
+                old.modified_at,
+                auth.uid(),
+                old.modified_by,
+                new.restreint,
+                old.restreint,
+                new is null)
+        returning id into updated;
+
+        select id
+        from historique.fiche_action faa
+        where fiche_id = id_fiche
+        and id <> updated
+        order by faa.modified_at desc
+        limit 1 into previous_fiche;
+
+        if previous_fiche is not null then
+            insert into historique.fiche_action_pilote (fiche_historise_id, user_id, tag_nom, previous)
+            select updated, fap.user_id, fap.tag_nom, true
+            from historique.fiche_action_pilote fap
+            where fap.fiche_historise_id = previous_fiche;
+        end if;
+
+    else
+        delete from historique.fiche_action_pilote where fiche_historise_id = updated and previous = false;
+    end if;
+
+    insert into historique.fiche_action_pilote (fiche_historise_id, user_id, tag_nom, previous)
+    select updated, fap.user_id, pt.nom, false
+    from public.fiche_action_pilote fap
+    left join personne_tag pt on fap.tag_id = pt.id
+    where fiche_id = id_fiche;
+
+    return new;
+end ;
+$function$
+;
+
+CREATE OR REPLACE TRIGGER save_history
+    AFTER INSERT OR DELETE OR UPDATE
+    ON public.fiche_action
+    FOR EACH ROW
+    EXECUTE FUNCTION historique.save_fiche_action();
+
 
 COMMIT;
 

--- a/data_layer/sqitch/revert/plan_action/fiches@v4.18.0.sql
+++ b/data_layer/sqitch/revert/plan_action/fiches@v4.18.0.sql
@@ -1,0 +1,166 @@
+-- Deploy tet:plan_action/fiches to pg
+
+BEGIN;
+
+create or replace view public.fiches_action
+as
+SELECT fa.modified_at,
+       fa.id,
+       fa.titre,
+       fa.description,
+       fa.piliers_eci,
+       fa.objectifs,
+       eff.resultats_attendus,
+       fa.cibles,
+       fa.ressources,
+       fa.financements,
+       fa.budget_previsionnel,
+       fa.statut,
+       fa.niveau_priorite,
+       fa.date_debut,
+       fa.date_fin_provisoire,
+       fa.amelioration_continue,
+       fa.calendrier,
+       fa.notes_complementaires,
+       fa.maj_termine,
+       fa.collectivite_id,
+       fa.created_at,
+       fa.modified_by,
+       t.thematiques,
+       st.sous_thematiques,
+       p.partenaires,
+       s.structures,
+       (
+       SELECT array_agg(ROW (pil.nom, pil.collectivite_id, pil.tag_id, pil.user_id)::personne) AS array_agg
+       FROM (
+            SELECT COALESCE(pt.nom, concat(dcp.prenom, ' ', dcp.nom)) AS nom,
+                   pt.collectivite_id,
+                   fap.tag_id,
+                   fap.user_id
+            FROM fiche_action_pilote fap
+            LEFT JOIN personne_tag pt ON fap.tag_id = pt.id
+            LEFT JOIN dcp ON fap.user_id = dcp.user_id
+            WHERE fap.fiche_id = fa.id
+            ) pil
+       ) AS pilotes,
+       (
+       SELECT array_agg(ROW (ref.nom, ref.collectivite_id, ref.tag_id, ref.user_id)::personne) AS array_agg
+       FROM (
+            SELECT COALESCE(pt.nom, concat(dcp.prenom, ' ', dcp.nom)) AS nom,
+                   pt.collectivite_id,
+                   far.tag_id,
+                   far.user_id
+            FROM fiche_action_referent far
+            LEFT JOIN personne_tag pt ON far.tag_id = pt.id
+            LEFT JOIN dcp ON far.user_id = dcp.user_id
+            WHERE far.fiche_id = fa.id
+            ) ref
+       ) AS referents,
+       pla.axes,
+       act.actions,
+       (
+       SELECT array_agg(ROW (indi.id, indi.groupement_id, indi.collectivite_id, indi.identifiant_referentiel, indi.titre, indi.titre_long, indi.description, indi.unite, indi.borne_min, indi.borne_max, indi.participation_score, indi.sans_valeur_utilisateur, indi.valeur_calcule, indi.modified_at, indi.created_at, indi.modified_by, indi.created_by)::indicateur_definition) AS array_agg
+       FROM (
+            SELECT id.id,
+                   id.groupement_id,
+                   id.collectivite_id,
+                   id.identifiant_referentiel,
+                   id.titre,
+                   id.titre_long,
+                   id.description,
+                   id.unite,
+                   id.borne_min,
+                   id.borne_max,
+                   id.participation_score,
+                   id.sans_valeur_utilisateur,
+                   id.valeur_calcule,
+                   id.modified_at,
+                   id.created_at,
+                   id.modified_by,
+                   id.created_by
+            FROM fiche_action_indicateur fai
+            JOIN indicateur_definition id ON fai.indicateur_id::text = id.id::text
+            WHERE fai.fiche_id = fa.id
+            ) indi
+       ) AS indicateurs,
+       ser.services,
+       (
+       SELECT array_agg(ROW (fin.financeur_tag, fin.montant_ttc, fin.id)::financeur_montant) AS financeurs
+       FROM (
+            SELECT ft.*::financeur_tag AS financeur_tag,
+                   faft.montant_ttc,
+                   faft.id
+            FROM financeur_tag ft
+            JOIN fiche_action_financeur_tag faft ON ft.id = faft.financeur_tag_id
+            WHERE faft.fiche_id = fa.id
+            ) fin
+       ) AS financeurs,
+       fic.fiches_liees,
+       fa.restreint
+FROM fiche_action fa
+LEFT JOIN (
+          SELECT fath.fiche_id,
+                 array_agg(th.*) AS thematiques
+          FROM thematique th
+          JOIN fiche_action_thematique fath ON fath.thematique_id = th.id
+          GROUP BY fath.fiche_id
+          ) t ON t.fiche_id = fa.id
+LEFT JOIN (
+          SELECT fasth.fiche_id,
+                 array_agg(sth.*) AS sous_thematiques
+          FROM sous_thematique sth
+          JOIN fiche_action_sous_thematique fasth ON fasth.thematique_id = sth.id
+          GROUP BY fasth.fiche_id
+          ) st ON st.fiche_id = fa.id
+LEFT JOIN (
+          SELECT fapt.fiche_id,
+                 array_agg(pt.*) AS partenaires
+          FROM partenaire_tag pt
+          JOIN fiche_action_partenaire_tag fapt ON fapt.partenaire_tag_id = pt.id
+          GROUP BY fapt.fiche_id
+          ) p ON p.fiche_id = fa.id
+LEFT JOIN (
+          SELECT fast.fiche_id,
+                 array_agg(st_1.*) AS structures
+          FROM structure_tag st_1
+          JOIN fiche_action_structure_tag fast ON fast.structure_tag_id = st_1.id
+          GROUP BY fast.fiche_id
+          ) s ON s.fiche_id = fa.id
+LEFT JOIN (
+          SELECT fapa.fiche_id,
+                 array_agg(pa.*) AS axes
+          FROM axe pa
+          JOIN fiche_action_axe fapa ON fapa.axe_id = pa.id
+          GROUP BY fapa.fiche_id
+          ) pla ON pla.fiche_id = fa.id
+LEFT JOIN (
+          SELECT faa.fiche_id,
+                 array_agg(ar.*) AS actions
+          FROM action_relation ar
+          JOIN fiche_action_action faa ON faa.action_id::text = ar.id::text
+          GROUP BY faa.fiche_id
+          ) act ON act.fiche_id = fa.id
+LEFT JOIN (
+          SELECT fast.fiche_id,
+                 array_agg(st_1.*) AS services
+          FROM service_tag st_1
+          JOIN fiche_action_service_tag fast ON fast.service_tag_id = st_1.id
+          GROUP BY fast.fiche_id
+          ) ser ON ser.fiche_id = fa.id
+LEFT JOIN (
+          SELECT falpf.fiche_id,
+                 array_agg(fr.*) AS fiches_liees
+          FROM private.fiche_resume fr
+          JOIN fiches_liees_par_fiche falpf ON falpf.fiche_liee_id = fr.id
+          GROUP BY falpf.fiche_id
+          ) fic ON fic.fiche_id = fa.id
+LEFT JOIN (
+          SELECT faea.fiche_id,
+                 array_agg(ea.*) AS resultats_attendus
+          FROM effet_attendu ea
+          JOIN fiche_action_effet_attendu faea ON ea.id = faea.effet_attendu_id
+          GROUP BY faea.fiche_id
+          ) eff ON eff.fiche_id = fa.id;
+
+COMMIT;
+

--- a/data_layer/sqitch/sqitch.plan
+++ b/data_layer/sqitch/sqitch.plan
@@ -740,3 +740,4 @@ indicateur/indicateurs_gaz_effet_serre [indicateur/indicateurs_gaz_effet_serre@v
 
 labellisation/preuve_v2 [labellisation/preuve_v2@v4.5.0] 2024-08-13T15:07:27Z ,,, <jacquelina@LanceLibre> # Ajoute la notion de confidentialité à un document
 @v4.18.0 2024-10-28T09:32:41Z Marc Rutkowski <marc@attractive-media.fr> # Ajoute la notion de confidentialité à un document
+plan_action/fiches [plan_action/fiches@v4.18.0] 2024-11-04T16:05:14Z Frederic Arnoux <frederic.arnoux@beta.gouv.fr> # Refactor enum fiche_action_cibles

--- a/data_layer/sqitch/verify/plan_action/fiches@v4.18.0.sql
+++ b/data_layer/sqitch/verify/plan_action/fiches@v4.18.0.sql
@@ -1,0 +1,5 @@
+-- Verify tet:plan_action/fiches on pg
+
+BEGIN;
+
+ROLLBACK;

--- a/packages/api/src/plan-actions/domain/fiche-action.schema.ts
+++ b/packages/api/src/plan-actions/domain/fiche-action.schema.ts
@@ -29,6 +29,8 @@ export const niveauPrioriteSchema = z.enum(['Élevé', 'Moyen', 'Bas']);
 export type NiveauPriorite = z.infer<typeof niveauPrioriteSchema>;
 
 export const cibleSchema = z.enum([
+  'Grand public',
+  'Associations',
   'Grand public et associations',
   'Public Scolaire',
   'Autres collectivités du territoire',


### PR DESCRIPTION
Sépare les cibles “associations” et “grand public” dans les FA.

**Solution technique** 

Changement du type de la colonne `cibles` de la table `fiche_action` 
- initialement type basé sur l'enum `fiche_action_cibles` : `fiche_action_cibles[]`
- vers un nouveau type `text[]`

Choix de la simplicité, j'ai trouvé overkill de faire une table dédiée pour le moment. J'ai ajouté plus de souplesse avec un simple `text[]`, on pourra ajouter une table dédiée plus solide mais plus complexe à gérer si besoin plus tard.

---
Une fois cette PR validée en prod, nécessité d'une 2ème PR à suivre pour supprimer définitivement la valeur "Grand public et associations" des valeurs possibles, et supprimer l'enum `fiche_action_cibles` en BDD.