### PR TITLE
Ajoute les enums manquants à l'import des FA.

### DIFF
--- a/supabase/functions/import_plan_action/fonctionsDeNettoyage.ts
+++ b/supabase/functions/import_plan_action/fonctionsDeNettoyage.ts
@@ -29,7 +29,8 @@ const ficheActionResultatsAttendus = [
 ];
 
 const ficheActionCibles = [
-    "Grand public et associations" ,
+    "Grand public",
+    "Associations",
     "Public Scolaire" ,
     "Autres collectivités du territoire" ,
     "Acteurs économiques" ,
@@ -42,7 +43,7 @@ const ficheActionCibles = [
     "Agents"
 ];
 
-const ficheActionStatuts = ["À venir", "En cours", "Réalisé", "En pause", "Abandonné"];
+const ficheActionStatuts = ["À venir", "A discuter", "En retard", "En pause", "Bloqué", "Abandonné", "Réalisé", "En cours"];
 const ficheActionNiveauxPrioritesSynonyme : Record<string, string> = {
     'Faible' : 'Bas',
     'Haut' : 'Élevé'


### PR DESCRIPTION
Corrige potentiellement ce [bug](https://www.notion.so/accelerateur-transition-ecologique-ademe/A-SURVEILLER-Double-affichage-dans-l-entr-e-cible-suite-un-import-1376523d57d780ab9956d32813a8b3d3) "également.