### PR TITLE
Corrige la fonction labellisation_peut_commencer_audit

### DIFF
--- a/data_layer/sqitch/deploy/labellisation/audit.sql
+++ b/data_layer/sqitch/deploy/labellisation/audit.sql
@@ -1,62 +1,24 @@
 -- Deploy tet:labellisation/audit to pg
 BEGIN;
 
-create or replace function labellisation.update_labellisation_after_scores() returns trigger
-    language plpgsql
-    security definer
-as
-$$
-declare
-    etoile integer;
-begin
-    select etoiles::text::integer
-    from labellisation.demande d
-             join labellisation.audit a on d.id = a.demande_id
-    where a.id = new.audit_id
-    limit 1
-    into etoile;
-    if
-        -- Vérifie si la labellisation de l'audit a été validé
-        (select a.valide_labellisation from labellisation.audit a where a.id = new.audit_id) and
-            -- Vérifie si la labellisation n'existe pas déjà
-        (select count(*)=0
-         from labellisation l
-         where l.collectivite_id = new.collectivite_id
-           and l.referentiel = new.referentiel
-           and l.etoiles = etoile
-           and l.obtenue_le>(now()-interval '4 year'))
-    then
-        with
-            score AS (
-                SELECT Round((case
-                                  when (sc ->> 'point_potentiel'::text)::float= 0 then 0
-                                  else (sc ->> 'point_fait'::text)::float / (sc ->> 'point_potentiel'::text)::float
-                                  end * 100)::numeric, 1) as score_realise,
-                       Round((case
-                                  when (sc ->> 'point_potentiel'::text)::float = 0 then 0
-                                  else (sc ->> 'point_programme'::text)::float / (sc ->> 'point_potentiel'::text)::float
-                                  end * 100)::numeric, 1) as score_programme
-                FROM jsonb_array_elements(new.scores) sc
-                WHERE case when new.referentiel = 'eci'then
-                               sc @> '{"action_id": "eci"}'::jsonb
-                           else
-                               sc @> '{"action_id": "cae"}'::jsonb
-                          end
-            )
-        insert into labellisation (collectivite_id, referentiel, obtenue_le, etoiles, score_realise, score_programme)
-        select new.collectivite_id, new.referentiel, now(), etoile, score.score_realise, score.score_programme
-        from score
-        on conflict (collectivite_id, annee, referentiel) do update
-            set obtenue_le = excluded.obtenue_le,
-                etoiles = excluded.etoiles,
-                score_realise = excluded.score_realise,
-                score_programme = excluded.score_programme;
-
-    end if;
-    return new;
-end
-$$;
-comment on function labellisation.update_labellisation_after_scores is
-    'Ajoute automatiquement la labellisation si cette dernière a été validé et n''existe pas déjà';
+create or replace function labellisation_peut_commencer_audit(
+  collectivite_id integer, referentiel referentiel
+) returns boolean
+  stable
+  security definer
+  language sql
+BEGIN
+  ATOMIC
+  SELECT ((a.date_debut IS NULL) AND (auth.uid() IN (SELECT aa.auditeur
+                                                     FROM audit_auditeur aa
+                                                     WHERE (a.id = aa.audit_id))))
+  FROM labellisation.audit a
+  WHERE a.collectivite_id = labellisation_peut_commencer_audit.collectivite_id
+    AND a.referentiel = labellisation_peut_commencer_audit.referentiel
+    AND a.clos = false
+    AND now() <@ tstzrange(a.date_debut, a.date_fin)
+  ORDER BY a.date_debut DESC NULLS LAST
+  LIMIT 1;
+END;
 
 COMMIT;

--- a/data_layer/sqitch/deploy/labellisation/audit@v4.27.1.sql
+++ b/data_layer/sqitch/deploy/labellisation/audit@v4.27.1.sql
@@ -1,0 +1,62 @@
+-- Deploy tet:labellisation/audit to pg
+BEGIN;
+
+create or replace function labellisation.update_labellisation_after_scores() returns trigger
+    language plpgsql
+    security definer
+as
+$$
+declare
+    etoile integer;
+begin
+    select etoiles::text::integer
+    from labellisation.demande d
+             join labellisation.audit a on d.id = a.demande_id
+    where a.id = new.audit_id
+    limit 1
+    into etoile;
+    if
+        -- Vérifie si la labellisation de l'audit a été validé
+        (select a.valide_labellisation from labellisation.audit a where a.id = new.audit_id) and
+            -- Vérifie si la labellisation n'existe pas déjà
+        (select count(*)=0
+         from labellisation l
+         where l.collectivite_id = new.collectivite_id
+           and l.referentiel = new.referentiel
+           and l.etoiles = etoile
+           and l.obtenue_le>(now()-interval '4 year'))
+    then
+        with
+            score AS (
+                SELECT Round((case
+                                  when (sc ->> 'point_potentiel'::text)::float= 0 then 0
+                                  else (sc ->> 'point_fait'::text)::float / (sc ->> 'point_potentiel'::text)::float
+                                  end * 100)::numeric, 1) as score_realise,
+                       Round((case
+                                  when (sc ->> 'point_potentiel'::text)::float = 0 then 0
+                                  else (sc ->> 'point_programme'::text)::float / (sc ->> 'point_potentiel'::text)::float
+                                  end * 100)::numeric, 1) as score_programme
+                FROM jsonb_array_elements(new.scores) sc
+                WHERE case when new.referentiel = 'eci'then
+                               sc @> '{"action_id": "eci"}'::jsonb
+                           else
+                               sc @> '{"action_id": "cae"}'::jsonb
+                          end
+            )
+        insert into labellisation (collectivite_id, referentiel, obtenue_le, etoiles, score_realise, score_programme)
+        select new.collectivite_id, new.referentiel, now(), etoile, score.score_realise, score.score_programme
+        from score
+        on conflict (collectivite_id, annee, referentiel) do update
+            set obtenue_le = excluded.obtenue_le,
+                etoiles = excluded.etoiles,
+                score_realise = excluded.score_realise,
+                score_programme = excluded.score_programme;
+
+    end if;
+    return new;
+end
+$$;
+comment on function labellisation.update_labellisation_after_scores is
+    'Ajoute automatiquement la labellisation si cette dernière a été validé et n''existe pas déjà';
+
+COMMIT;

--- a/data_layer/sqitch/revert/labellisation/audit.sql
+++ b/data_layer/sqitch/revert/labellisation/audit.sql
@@ -1,61 +1,23 @@
 -- Deploy tet:labellisation/audit to pg
 BEGIN;
 
-create or replace function labellisation.update_labellisation_after_scores() returns trigger
-    language plpgsql
-    security definer
-as
-$$
-declare
-    etoile integer;
-begin
-    select etoiles::text::integer
-    from labellisation.demande d
-             join labellisation.audit a on d.id = a.demande_id
-    where a.id = new.audit_id
-    limit 1
-    into etoile;
-    if
-        -- Vérifie si la labellisation de l'audit a été validé
-        (select a.valide_labellisation from labellisation.audit a where a.id = new.audit_id) and
-            -- Vérifie si la labellisation n'existe pas déjà
-        (select count(*)=0
-         from labellisation l
-         where l.collectivite_id = new.collectivite_id
-           and l.referentiel = new.referentiel
-           and l.etoiles = etoile)
-    then
-        with
-            score AS (
-                SELECT Round((case
-                                  when (sc ->> 'point_potentiel'::text)::float= 0 then 0
-                                  else (sc ->> 'point_fait'::text)::float / (sc ->> 'point_potentiel'::text)::float
-                                  end * 100)::numeric, 1) as score_realise,
-                       Round((case
-                                  when (sc ->> 'point_potentiel'::text)::float = 0 then 0
-                                  else (sc ->> 'point_programme'::text)::float / (sc ->> 'point_potentiel'::text)::float
-                                  end * 100)::numeric, 1) as score_programme
-                FROM jsonb_array_elements(new.scores) sc
-                WHERE case when new.referentiel = 'eci'then
-                               sc @> '{"action_id": "eci"}'::jsonb
-                           else
-                               sc @> '{"action_id": "cae"}'::jsonb
-                          end
-            )
-        insert into labellisation (collectivite_id, referentiel, obtenue_le, etoiles, score_realise, score_programme)
-        select new.collectivite_id, new.referentiel, now(), etoile, score.score_realise, score.score_programme
-        from score
-        on conflict (collectivite_id, annee, referentiel) do update
-            set obtenue_le = excluded.obtenue_le,
-                etoiles = excluded.etoiles,
-                score_realise = excluded.score_realise,
-                score_programme = excluded.score_programme;
-
-    end if;
-    return new;
-end
-$$;
-comment on function labellisation.update_labellisation_after_scores is
-    'Ajoute automatiquement la labellisation si cette dernière a été validé et n''existe pas déjà';
+create or replace function labellisation_peut_commencer_audit(
+  collectivite_id integer, referentiel referentiel
+) returns boolean
+  stable
+  security definer
+  language sql
+BEGIN
+  ATOMIC
+  SELECT ((a.date_debut IS NULL) AND (auth.uid() IN (SELECT aa.auditeur
+                                                     FROM audit_auditeur aa
+                                                     WHERE (a.id = aa.audit_id))))
+  FROM labellisation.audit a
+  WHERE a.collectivite_id = labellisation_peut_commencer_audit.collectivite_id
+    AND a.referentiel = labellisation_peut_commencer_audit.referentiel
+    AND now() <@ tstzrange(a.date_debut, a.date_fin)
+  ORDER BY a.date_debut DESC NULLS LAST
+  LIMIT 1;
+END;
 
 COMMIT;

--- a/data_layer/sqitch/revert/labellisation/audit@v4.27.1.sql
+++ b/data_layer/sqitch/revert/labellisation/audit@v4.27.1.sql
@@ -1,0 +1,61 @@
+-- Deploy tet:labellisation/audit to pg
+BEGIN;
+
+create or replace function labellisation.update_labellisation_after_scores() returns trigger
+    language plpgsql
+    security definer
+as
+$$
+declare
+    etoile integer;
+begin
+    select etoiles::text::integer
+    from labellisation.demande d
+             join labellisation.audit a on d.id = a.demande_id
+    where a.id = new.audit_id
+    limit 1
+    into etoile;
+    if
+        -- Vérifie si la labellisation de l'audit a été validé
+        (select a.valide_labellisation from labellisation.audit a where a.id = new.audit_id) and
+            -- Vérifie si la labellisation n'existe pas déjà
+        (select count(*)=0
+         from labellisation l
+         where l.collectivite_id = new.collectivite_id
+           and l.referentiel = new.referentiel
+           and l.etoiles = etoile)
+    then
+        with
+            score AS (
+                SELECT Round((case
+                                  when (sc ->> 'point_potentiel'::text)::float= 0 then 0
+                                  else (sc ->> 'point_fait'::text)::float / (sc ->> 'point_potentiel'::text)::float
+                                  end * 100)::numeric, 1) as score_realise,
+                       Round((case
+                                  when (sc ->> 'point_potentiel'::text)::float = 0 then 0
+                                  else (sc ->> 'point_programme'::text)::float / (sc ->> 'point_potentiel'::text)::float
+                                  end * 100)::numeric, 1) as score_programme
+                FROM jsonb_array_elements(new.scores) sc
+                WHERE case when new.referentiel = 'eci'then
+                               sc @> '{"action_id": "eci"}'::jsonb
+                           else
+                               sc @> '{"action_id": "cae"}'::jsonb
+                          end
+            )
+        insert into labellisation (collectivite_id, referentiel, obtenue_le, etoiles, score_realise, score_programme)
+        select new.collectivite_id, new.referentiel, now(), etoile, score.score_realise, score.score_programme
+        from score
+        on conflict (collectivite_id, annee, referentiel) do update
+            set obtenue_le = excluded.obtenue_le,
+                etoiles = excluded.etoiles,
+                score_realise = excluded.score_realise,
+                score_programme = excluded.score_programme;
+
+    end if;
+    return new;
+end
+$$;
+comment on function labellisation.update_labellisation_after_scores is
+    'Ajoute automatiquement la labellisation si cette dernière a été validé et n''existe pas déjà';
+
+COMMIT;

--- a/data_layer/sqitch/sqitch.plan
+++ b/data_layer/sqitch/sqitch.plan
@@ -779,3 +779,4 @@ plan_action/fiches [plan_action/fiches@v4.28.0] 2024-11-25T17:04:51Z System Admi
 @v4.28.1 2024-11-25T18:42:06Z System Administrator <root@MacBook-Air-de-Eli.local> # Tag en v4.28.1
 
 plan_action/fiche_action_etape 2024-11-21T13:40:26Z Amandine <ours@ours> # Ajoute des etapes aux fiches actions
+labellisation/audit [labellisation/audit@v4.27.1] 2024-11-20T13:56:04Z Amandine <ours@ours> # Corrige la fonction labellisation_peut_commencer_audit qui prenait à tord une demander 1ère étoile pour l'audit en cours

--- a/data_layer/sqitch/verify/labellisation/audit.sql
+++ b/data_layer/sqitch/verify/labellisation/audit.sql
@@ -2,6 +2,6 @@
 
 BEGIN;
 
-select has_function_privilege('labellisation.update_labellisation_after_scores()', 'execute');
+select has_function_privilege('labellisation_peut_commencer_audit(integer, referentiel)', 'execute');
 
 ROLLBACK;

--- a/data_layer/sqitch/verify/labellisation/audit@v4.27.1.sql
+++ b/data_layer/sqitch/verify/labellisation/audit@v4.27.1.sql
@@ -1,0 +1,7 @@
+-- Verify tet:labellisation/audit on pg
+
+BEGIN;
+
+select has_function_privilege('labellisation.update_labellisation_after_scores()', 'execute');
+
+ROLLBACK;


### PR DESCRIPTION
Conversation [mattermost](https://mattermost.incubateur.net/betagouv/pl/xg6r9nmgpigz7epm1dfnae8byo).

Corrige un bug dans la fonction `labellisation_peut_commencer_audit` qui permet de vérifier si un auditeur peut démarrer un audit. La récupération du bon audit ne se basait que sur des dates. Sauf que la collectivité avait déjà une demande 1ere étoile (qui ne nécessite pas d'audit) et donc avec un "audit" sans dates. La vérification prenait donc cet "audit" sans date au lieu du bon audit. L'ajout de la condition sur l'attribut `clos` permet de résoudre ce problème car il n'y a qu'un audit ouvert pour une collectivité et un référentiel à la fois.