### PR TITLE
Ajustement valeurs cibles dechets

### DIFF
--- a/markdown/indicateurs/cae/cae_006.md
+++ b/markdown/indicateurs/cae/cae_006.md
@@ -28,7 +28,7 @@ Les déchets produits par les services municipaux (déchets de l’assainissemen
 Le calcul ne considère que les services de collecte opérationnels, c'est-à-dire ceux qui ont fonctionné au moins une journée au cours de l'année de référence du calcul et les déchèteries opérationnelles, c'est-à-dire des déchèteries qui ont été ouvertes au moins une journée au cours de l'année de référence du calcul.
 Pour la production par habitant, la production totale du territoire est rapportée à la population légale au sens de l’INSEE.
 La valeur limite est issue des chiffres-clés déchets de l’ADEME, édition 2016, basé sur l’enquête Collecte 2013 et la valeur cible des 47 territoires pionniers en France.
-- Valeur limite TETE : 573 kg/hab.an
+- Valeur limite TETE : 580 kg/hab.an
 - Valeur cible TETE : 480 kg/hab.an
 
 **Objectif opérationnel national fixé par les documents de référence: Feuille de route et loi anti-gaspillage pour une économie circulaire :**
@@ -84,8 +84,8 @@ climat_pratic_ids:
 ```
 ## Description
 L'indicateur concerne uniquement les ordures ménagères résiduelles, c’est-à-dire les déchets collectés en mélange (poubelles ordinaires). La valeur limite est issue des chiffres-clés déchets de l’ADEME, édition 2016, basé sur l’enquête Collecte 2013 et la valeur cible des 47 territoires pionniers en France.
-- Valeur limite : 265 kg/hab.an
-- Valeur cible : 120 kg/hab.an
+- Valeur limite : 254 kg/hab.an
+- Valeur cible : 114 kg/hab.an
 
 
 # Production de déchets collectés sélectivement

--- a/markdown/indicateurs/cae/cae_007.md
+++ b/markdown/indicateurs/cae/cae_007.md
@@ -26,6 +26,9 @@ Il s’agit de la part (en poids) des déchets ménagers et assimilés (DMA) ori
 
 NB : On mesure les déchets « orientés vers le recyclage », les refus de tri ne sont donc pas déduits. Ne sont pas considérés ici comme « orientés vers le recyclage » les déchets entrant dans des installations de tri mécanobiologique. Pour ces derniers, seuls les flux sortant orientés vers la valorisation organique (compostage ou méthanisation) ou vers le recyclage matière (métaux récupérés) sont à intégrer dans les flux « orientés vers le recyclage ». Les mâchefers valorisés ainsi que les métaux récupérés sur mâchefers ne sont pas intégrés.
 
+- Valeur limite TETE : 45%
+- Valeur cible TETE : 65%
+
 Cet indicateur est proposé par le SYDEV pour le suivi des PCAET.
 
 # Recyclage des déchets matières


### PR DESCRIPTION
Ajustement des valeurs cible et limite pour les indicateurs déchets qui n'étaient pas mis à jour sur TeT depuis un moment (sont maintenant conformes aux valeurs indiquées sur le fichier de collecte pour les CNL).