### PR TITLE
[backend] fiche-action: Actions groupées pour statut et pilotes

### DIFF
--- a/backend/src/collectivites/services/personnes.service.ts
+++ b/backend/src/collectivites/services/personnes.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { dcpTable } from '@tet/backend/auth/models/dcp.table';
 import { utilisateurDroitTable } from '@tet/backend/auth/models/private-utilisateur-droit.table';
 import DatabaseService from '@tet/backend/common/services/database.service';
@@ -21,9 +21,7 @@ export type ListRequest = z.infer<typeof listRequestSchema>;
 
 @Injectable()
 export class PersonnesService {
-  private readonly logger = new Logger(PersonnesService.name);
   private db = this.database.db;
-
   constructor(private readonly database: DatabaseService) {}
 
   async list(request: ListRequest) {

--- a/backend/src/fiches/bulk-edit/bulk-edit.router.e2e-spec.ts
+++ b/backend/src/fiches/bulk-edit/bulk-edit.router.e2e-spec.ts
@@ -133,6 +133,31 @@ describe('BulkEditRouter', () => {
     await caller.plans.fiches.bulkEdit(input);
     expect(result).toBeUndefined();
 
+    // Remove one pilote and add another one
+    const input2 = {
+      ficheIds,
+      pilotes: {
+        add: [{ tagId: 3 }],
+        remove: [
+          { tagId: input.pilotes.add[0].tagId },
+          { userId: yoloDodo.id },
+        ],
+      },
+    } satisfies Input;
+
+    await caller.plans.fiches.bulkEdit(input2);
+    expect(result).toBeUndefined();
+
+    // Verify that all fiches have been updated with tags and users
+    const updatedFiches = await getFichesWithPilotes(ficheIds);
+
+    for (const fiche of updatedFiches) {
+      expect(fiche.tagIds).toContain(input2.pilotes.add[0].tagId);
+
+      expect(fiche.userIds).not.toContain(input.pilotes.add[1].userId);
+      expect(fiche.tagIds).not.toContain(input2.pilotes.remove[0].tagId);
+    }
+
     // Delete inserted or existing pilotes after test
     onTestFinished(async () => {
       await db.db

--- a/backend/src/fiches/bulk-edit/bulk-edit.router.e2e-spec.ts
+++ b/backend/src/fiches/bulk-edit/bulk-edit.router.e2e-spec.ts
@@ -1,0 +1,114 @@
+import DatabaseService from '@tet/backend/common/services/database.service';
+import { inferProcedureInput } from '@trpc/server';
+import { eq, inArray } from 'drizzle-orm';
+import { getAuthUser } from '../../../test/auth/auth-utils';
+import { YOLO_DODO, YULU_DUDU } from '../../../test/auth/test-users.samples';
+import {
+  getTestApp,
+  getTestDatabase,
+  getTestRouter,
+} from '../../../test/common/app-utils';
+import { AuthenticatedUser } from '../../auth/models/auth.models';
+import { AppRouter, TrpcRouter } from '../../trpc/trpc.router';
+import {
+  FicheActionStatutsEnumType,
+  ficheActionTable,
+} from '../models/fiche-action.table';
+
+type Input = inferProcedureInput<AppRouter['plans']['fiches']['bulkEdit']>;
+
+const COLLECTIVITE_ID = YOLO_DODO.collectiviteId.admin;
+
+describe('BulkEditRouter', () => {
+  let router: TrpcRouter;
+  let yoloDodo: AuthenticatedUser;
+  let db: DatabaseService;
+  let ficheIds: number[];
+
+  function selectFiches(limit = 3) {
+    return db.db
+      .select()
+      .from(ficheActionTable)
+      .where(eq(ficheActionTable.collectiviteId, COLLECTIVITE_ID))
+      .limit(limit);
+  }
+
+  function fetchFiches() {
+    return db.db
+      .select()
+      .from(ficheActionTable)
+      .where(inArray(ficheActionTable.id, ficheIds));
+  }
+
+  beforeAll(async () => {
+    const app = await getTestApp();
+    router = await getTestRouter(app);
+    db = await getTestDatabase(app);
+    yoloDodo = await getAuthUser(YOLO_DODO);
+
+    const fiches = await selectFiches();
+    expect(fiches.length).toBeGreaterThan(0);
+
+    ficheIds = fiches.map((f) => f.id);
+  });
+
+  test('authenticated, bulk edit statut', async () => {
+    const caller = router.createCaller({ user: yoloDodo });
+
+    const input1 = {
+      ficheIds,
+      statut: FicheActionStatutsEnumType.EN_RETARD,
+    };
+
+    const result = await caller.plans.fiches.bulkEdit(input1);
+
+    expect(result).toBeUndefined();
+
+    // Verify that all fiches have been updated
+    const fiches1 = await fetchFiches();
+    for (const fiche of fiches1) {
+      expect(fiche.statut).toBe(input1.statut);
+    }
+
+    // Change again the statut value
+    const input2 = {
+      ficheIds,
+      statut: null,
+    };
+
+    await caller.plans.fiches.bulkEdit(input2);
+
+    // Verify that all fiches have been updated
+    const fiches2 = await fetchFiches();
+    for (const fiche of fiches2) {
+      expect(fiche.statut).toBe(input2.statut);
+    }
+  });
+
+  test('authenticated, without access to some fiches', async () => {
+    const yuluDudu = await getAuthUser(YULU_DUDU);
+    const caller = router.createCaller({ user: yuluDudu });
+
+    const input = {
+      ficheIds,
+      statut: FicheActionStatutsEnumType.EN_RETARD,
+    };
+
+    await expect(() =>
+      caller.plans.fiches.bulkEdit(input)
+    ).rejects.toThrowError(/not authorized/i);
+  });
+
+  test('not authenticated', async () => {
+    const caller = router.createCaller({ user: null });
+
+    const input = {
+      ficheIds,
+      statut: FicheActionStatutsEnumType.EN_RETARD,
+    };
+
+    await expect(() =>
+      caller.plans.fiches.bulkEdit(input)
+    ).rejects.toThrowError(/not authenticated/i);
+  });
+});

--- a/backend/src/fiches/bulk-edit/bulk-edit.router.ts
+++ b/backend/src/fiches/bulk-edit/bulk-edit.router.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import { TrpcService } from '../../trpc/trpc.service';
+import { BulkEditService } from './bulk-edit.service';
+
+@Injectable()
+export class BulkEditRouter {
+  constructor(
+    private readonly trpc: TrpcService,
+    private readonly service: BulkEditService
+  ) {}
+
+  router = this.trpc.router({
+    bulkEdit: this.trpc.authedProcedure
+      .input(this.service.bulkEditRequestSchema)
+      .mutation(({ input, ctx }) => {
+        return this.service.bulkEdit(input);
+      }),
+  });
+}

--- a/backend/src/fiches/bulk-edit/bulk-edit.router.ts
+++ b/backend/src/fiches/bulk-edit/bulk-edit.router.ts
@@ -13,7 +13,7 @@ export class BulkEditRouter {
     bulkEdit: this.trpc.authedProcedure
       .input(this.service.bulkEditRequestSchema)
       .mutation(({ input, ctx }) => {
-        return this.service.bulkEdit(input);
+        return this.service.bulkEdit(input, ctx.user);
       }),
   });
 }

--- a/backend/src/fiches/bulk-edit/bulk-edit.service.ts
+++ b/backend/src/fiches/bulk-edit/bulk-edit.service.ts
@@ -1,0 +1,59 @@
+import { Injectable } from '@nestjs/common';
+import { inArray } from 'drizzle-orm';
+import z from 'zod';
+import { AuthService } from '../../auth/services/auth.service';
+import DatabaseService from '../../common/services/database.service';
+import {
+  ficheActionSchema,
+  ficheActionTable,
+} from '../models/fiche-action.table';
+
+const requestSchema = z.object({
+  ficheIds: z.array(z.number()),
+  statut: bodySchema(ficheActionSchema.shape.statut),
+  personnePilotes: bodySchema(z.object({})),
+});
+
+type Request = z.infer<typeof requestSchema>;
+
+@Injectable()
+export class BulkEditService {
+  private db = this.database.db;
+
+  constructor(
+    private readonly database: DatabaseService,
+    private readonly auth: AuthService
+  ) {}
+
+  bulkEditRequestSchema = requestSchema;
+
+  async bulkEdit(request: Request) {
+    const { ficheIds, statut } = request;
+
+    await this.db
+      .update(ficheActionTable)
+      .set({
+        statut: statut,
+      })
+      .where(inArray(ficheActionTable.id, ficheIds));
+  }
+}
+
+function bodySchema<T extends z.ZodTypeAny>(
+  schema: T
+): T extends z.ZodArray<infer U>
+  ? z.ZodObject<{ add?: z.ZodArray<U>; remove: z.ZodArray<U> }>
+  : z.ZodOptional<T> {
+  if (schema instanceof z.ZodArray) {
+    return z.object({
+      add: z.array(schema).optional(),
+      remove: z.array(schema).optional(),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }) as any;
+  }
+
+  // The `as any` casts are necessary because TypeScript can't perfectly infer
+  // the exact type transformation happening in the function.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return schema.optional() as any;
+}

--- a/backend/src/fiches/bulk-edit/bulk-edit.service.ts
+++ b/backend/src/fiches/bulk-edit/bulk-edit.service.ts
@@ -5,10 +5,12 @@ import { inArray } from 'drizzle-orm';
 import z from 'zod';
 import { AuthService } from '../../auth/services/auth.service';
 import DatabaseService from '../../common/services/database.service';
+import { ficheActionPiloteTable } from '../models/fiche-action-pilote.table';
 import {
   ficheActionSchema,
   ficheActionTable,
 } from '../models/fiche-action.table';
+import { updateFicheActionRequestSchema } from '../models/update-fiche-action.request';
 
 @Injectable()
 export class BulkEditService {
@@ -21,15 +23,17 @@ export class BulkEditService {
 
   bulkEditRequestSchema = z.object({
     ficheIds: z.array(z.number()),
-    statut: bodySchema(ficheActionSchema.shape.statut),
-    personnePilotes: bodySchema(z.object({})),
+    statut: ficheActionSchema.shape.statut.optional(),
+    pilotes: listSchema(
+      updateFicheActionRequestSchema.shape.pilotes.unwrap().unwrap()
+    ),
   });
 
   async bulkEdit(
     request: z.infer<typeof this.bulkEditRequestSchema>,
     user: AuthUser
   ) {
-    const { ficheIds, statut } = request;
+    const { ficheIds, ...params } = request;
 
     // Get all the distinct collectiviteIds of the fiches
     const collectiviteIds = await this.db
@@ -44,31 +48,42 @@ export class BulkEditService {
       NiveauAcces.EDITION
     );
 
-    await this.db
-      .update(ficheActionTable)
-      .set({
-        statut: statut,
-      })
-      .where(inArray(ficheActionTable.id, ficheIds));
+    const { statut, pilotes } = params;
+
+    await this.db.transaction(async (tx) => {
+      // Update base params
+      if (statut !== undefined) {
+        await tx
+          .update(ficheActionTable)
+          .set({ statut })
+          .where(inArray(ficheActionTable.id, ficheIds));
+      }
+
+      // Update external relations
+      if (pilotes !== undefined && pilotes.add?.length) {
+        const values = ficheIds.flatMap((ficheId) => {
+          return (pilotes.add ?? []).map((pilote) => ({
+            ficheId,
+            tagId: pilote.tagId ?? null,
+            userId: pilote.userId ?? null,
+          }));
+        });
+
+        await tx
+          .insert(ficheActionPiloteTable)
+          .values(values)
+          .onConflictDoNothing();
+      }
+    });
   }
 }
 
-// Helper function to create a sub-schema for each type of field in the input body
-function bodySchema<T extends z.ZodTypeAny>(
-  schema: T
-): T extends z.ZodArray<infer U>
-  ? z.ZodObject<{ add?: z.ZodArray<U>; remove: z.ZodArray<U> }>
-  : z.ZodOptional<T> {
-  if (schema instanceof z.ZodArray) {
-    return z.object({
-      add: z.array(schema).optional(),
-      remove: z.array(schema).optional(),
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    }) as any;
-  }
-
-  // The `as any` casts are necessary because TypeScript can't perfectly infer
-  // the exact type transformation happening in the function.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return schema.optional() as any;
+// Utility function to create a sub-schema for array field in the input body
+function listSchema<T extends z.ZodTypeAny>(schema: T) {
+  return z
+    .object({
+      add: schema.optional(),
+      remove: schema.optional(),
+    })
+    .optional();
 }

--- a/backend/src/fiches/controllers/fiches-action.controller.ts
+++ b/backend/src/fiches/controllers/fiches-action.controller.ts
@@ -9,20 +9,20 @@ import {
   Query,
 } from '@nestjs/common';
 import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import { z } from 'zod';
 import { TokenInfo } from '../../auth/decorators/token-info.decorators';
 import type { AuthenticatedUser } from '../../auth/models/auth.models';
+import { CountByStatutService } from '../count-by-statut/count-by-statut.service';
+import { ficheActionNoteSchema } from '../models/fiche-action-note.table';
 import { getFichesActionSyntheseSchema } from '../models/get-fiches-action-synthese.response';
 import { getFichesActionFilterRequestSchema } from '../models/get-fiches-actions-filter.request';
 import { updateFicheActionRequestSchema } from '../models/update-fiche-action.request';
-import { CountByStatutService } from '../count-by-statut/count-by-statut.service';
-import FichesActionUpdateService from '../services/fiches-action-update.service';
 import {
   deleteFicheActionNotesRequestSchema,
   upsertFicheActionNotesRequestSchema,
 } from '../models/upsert-fiche-action-note.request';
 import FicheService from '../services/fiche.service';
-import { ficheActionNoteSchema } from '../models/fiche-action-note.table';
-import { z } from 'zod';
+import FichesActionUpdateService from '../services/fiches-action-update.service';
 
 /**
  * Création des classes de réponse à partir du schema pour générer automatiquement la documentation OpenAPI
@@ -35,7 +35,10 @@ export class GetFichesActionFilterRequestClass extends createZodDto(
   getFichesActionFilterRequestSchema
 ) {}
 export class UpdateFicheActionRequestClass extends createZodDto(
-  updateFicheActionRequestSchema
+  updateFicheActionRequestSchema.refine(
+    (schema) => Object.keys(schema).length > 0,
+    'Body cannot be empty'
+  )
 ) {}
 
 export class GetFicheActionNotesResponseClass extends createZodDto(

--- a/backend/src/fiches/fiche-action-etape/fiche-action-etape.router.ts
+++ b/backend/src/fiches/fiche-action-etape/fiche-action-etape.router.ts
@@ -1,9 +1,8 @@
 import { Injectable } from '@nestjs/common';
-import { FicheActionEtapeService } from './fiche-action-etape.service';
-import { TrpcService } from '../../trpc/trpc.service';
 import { upsertFicheActionEtapeSchema } from '@tet/backend/fiches/fiche-action-etape/fiche-action-etape.table';
 import { z } from 'zod';
-
+import { TrpcService } from '../../trpc/trpc.service';
+import { FicheActionEtapeService } from './fiche-action-etape.service';
 
 @Injectable()
 export class FicheActionEtapeRouter {
@@ -13,20 +12,22 @@ export class FicheActionEtapeRouter {
   ) {}
 
   router = this.trpc.router({
-    upsert: this.trpc.authedProcedure
-      .input(upsertFicheActionEtapeSchema)
-      .query(({ ctx, input }) => {
-        return this.service.upsertEtape(input, ctx.user);
-      }),
-    delete: this.trpc.authedProcedure
-      .input(z.object({etapeId : z.number()}))
-      .query(({ ctx, input }) => {
-        return this.service.deleteEtape(input.etapeId, ctx.user);
-      }),
-    list: this.trpc.authedProcedure
-      .input(z.object({ficheId : z.number()}))
-      .query(({ ctx, input }) => {
-        return this.service.getEtapesByFicheId(input.ficheId, ctx.user);
-      }),
+    etapes: {
+      upsert: this.trpc.authedProcedure
+        .input(upsertFicheActionEtapeSchema)
+        .query(({ ctx, input }) => {
+          return this.service.upsertEtape(input, ctx.user);
+        }),
+      delete: this.trpc.authedProcedure
+        .input(z.object({ etapeId: z.number() }))
+        .query(({ ctx, input }) => {
+          return this.service.deleteEtape(input.etapeId, ctx.user);
+        }),
+      list: this.trpc.authedProcedure
+        .input(z.object({ ficheId: z.number() }))
+        .query(({ ctx, input }) => {
+          return this.service.getEtapesByFicheId(input.ficheId, ctx.user);
+        }),
+    },
   });
 }

--- a/backend/src/fiches/fiches-action.module.ts
+++ b/backend/src/fiches/fiches-action.module.ts
@@ -23,7 +23,6 @@ import FichesActionUpdateService from './services/fiches-action-update.service';
     BulkEditRouter,
     FichesActionUpdateService,
     TagService,
-    CountByStatutRouter,
     FicheActionEtapeService,
     FicheActionEtapeRouter,
   ],

--- a/backend/src/fiches/fiches-action.module.ts
+++ b/backend/src/fiches/fiches-action.module.ts
@@ -2,20 +2,25 @@ import { Module } from '@nestjs/common';
 import { AuthModule } from '../auth/auth.module';
 import { CollectivitesModule } from '../collectivites/collectivites.module';
 import { CommonModule } from '../common/common.module';
-import { FichesActionController } from './controllers/fiches-action.controller';
-import { CountByStatutService } from './count-by-statut/count-by-statut.service';
-import FichesActionUpdateService from './services/fiches-action-update.service';
-import FicheService from './services/fiche.service';
 import TagService from '../taxonomie/services/tag.service';
+import { BulkEditRouter } from './bulk-edit/bulk-edit.router';
+import { BulkEditService } from './bulk-edit/bulk-edit.service';
+import { FichesActionController } from './controllers/fiches-action.controller';
 import { CountByStatutRouter } from './count-by-statut/count-by-statut.router';
+import { CountByStatutService } from './count-by-statut/count-by-statut.service';
 import { FicheActionEtapeRouter } from './fiche-action-etape/fiche-action-etape.router';
 import { FicheActionEtapeService } from './fiche-action-etape/fiche-action-etape.service';
+import FicheService from './services/fiche.service';
+import FichesActionUpdateService from './services/fiches-action-update.service';
 
 @Module({
   imports: [CommonModule, AuthModule, CollectivitesModule],
   providers: [
     FicheService,
     CountByStatutService,
+    CountByStatutRouter,
+    BulkEditService,
+    BulkEditRouter,
     FichesActionUpdateService,
     TagService,
     CountByStatutRouter,
@@ -27,6 +32,7 @@ import { FicheActionEtapeService } from './fiche-action-etape/fiche-action-etape
     CountByStatutRouter,
     FicheActionEtapeService,
     FicheActionEtapeRouter,
+    BulkEditRouter,
   ],
   controllers: [FichesActionController],
 })

--- a/backend/src/fiches/models/fiche-action-pilote.table.ts
+++ b/backend/src/fiches/models/fiche-action-pilote.table.ts
@@ -1,4 +1,11 @@
-import { integer, pgTable, uniqueIndex, uuid } from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
+import {
+  check,
+  integer,
+  pgTable,
+  uniqueIndex,
+  uuid,
+} from 'drizzle-orm/pg-core';
 import { personneTagTable } from '../../taxonomie/models/personne-tag.table';
 import { ficheActionTable } from './fiche-action.table';
 
@@ -18,6 +25,10 @@ export const ficheActionPiloteTable = pgTable(
       oneTagPerFiche: uniqueIndex('one_tag_per_fiche ').on(
         table.ficheId,
         table.tagId
+      ),
+      eitherUserOrTagNotNull: check(
+        'either_user_or_tag_not_null',
+        sql`${table.userId} IS NOT NULL OR ${table.tagId} IS NOT NULL`
       ),
     };
   }

--- a/backend/src/fiches/models/fiche-action.table.ts
+++ b/backend/src/fiches/models/fiche-action.table.ts
@@ -175,8 +175,6 @@ export const ficheActionSchema = createSelectSchema(ficheActionTable, {
   cibles: z.array(ficheActionCiblesEnumSchema),
 });
 
-export type FicheActionSelectType = z.infer<typeof ficheActionSchema>;
-
 export const createFicheActionSchema = createInsertSchema(ficheActionTable, {
   // Overriding array types as a workaround for drizzle-zod parsing issue
   // See https://github.com/drizzle-team/drizzle-orm/issues/1609

--- a/backend/src/fiches/models/fiche-action.table.ts
+++ b/backend/src/fiches/models/fiche-action.table.ts
@@ -1,3 +1,4 @@
+import { getEnumValues } from '@tet/backend/utils/enum.utils';
 import { InferInsertModel } from 'drizzle-orm';
 import {
   boolean,
@@ -77,13 +78,9 @@ export enum FicheActionStatutsEnumType {
 
 export const SANS_STATUT_FICHE_ACTION_SYNTHESE_KEY = 'Sans statut';
 
-export const ficheActionStatutsEnum = pgEnum(
-  'fiche_action_statuts',
-  Object.values(FicheActionStatutsEnumType) as [
-    FicheActionStatutsEnumType,
-    ...FicheActionStatutsEnumType[]
-  ]
-);
+export const statutsEnumValues = getEnumValues(FicheActionStatutsEnumType);
+export const statutsEnumSchema = z.enum(statutsEnumValues);
+export const statutsPgEnum = pgEnum('fiche_action_statuts', statutsEnumValues);
 
 export enum FicheActionCiblesEnumType {
   GRAND_PUBLIC = 'Grand public',
@@ -140,9 +137,7 @@ export const ficheActionTable = pgTable('fiche_action', {
     precision: 12,
     scale: 0,
   }),
-  statut: ficheActionStatutsEnum('statut').default(
-    FicheActionStatutsEnumType.A_VENIR
-  ),
+  statut: statutsPgEnum('statut').default(FicheActionStatutsEnumType.A_VENIR),
   niveauPriorite: ficheActionNiveauxPrioriteEnum('niveau_priorite'),
   dateDebut: timestamp('date_debut', { withTimezone: true, mode: 'string' }),
   dateFinProvisoire: timestamp('date_fin_provisoire', {
@@ -171,8 +166,6 @@ export const ficheActionTable = pgTable('fiche_action', {
   restreint: boolean('restreint').default(false),
 });
 
-export type FicheActionTableType = typeof ficheActionTable;
-
 export type CreateFicheActionType = InferInsertModel<typeof ficheActionTable>;
 
 export const ficheActionSchema = createSelectSchema(ficheActionTable, {
@@ -181,6 +174,8 @@ export const ficheActionSchema = createSelectSchema(ficheActionTable, {
   piliersEci: z.array(piliersEciEnumSchema),
   cibles: z.array(ficheActionCiblesEnumSchema),
 });
+
+export type FicheActionSelectType = z.infer<typeof ficheActionSchema>;
 
 export const createFicheActionSchema = createInsertSchema(ficheActionTable, {
   // Overriding array types as a workaround for drizzle-zod parsing issue

--- a/backend/src/fiches/models/update-fiche-action.request.ts
+++ b/backend/src/fiches/models/update-fiche-action.request.ts
@@ -1,23 +1,23 @@
 import z from 'zod';
-import {
-  FicheActionCiblesEnumType,
-  piliersEciEnumType,
-  ficheActionSchema,
-  updateFicheActionSchema,
-} from './fiche-action.table';
-import { axeSchema } from './axe.table';
-import { thematiqueSchema } from '../../taxonomie/models/thematique.table';
+import { indicateurDefinitionSchema } from '../../indicateurs/models/indicateur-definition.table';
+import { actionRelationSchema } from '../../referentiels/models/action-relation.table';
+import { effetAttenduSchema } from '../../taxonomie/models/effet-attendu.table';
+import { financeurTagSchema } from '../../taxonomie/models/financeur-tag.table';
 import { partenaireTagSchema } from '../../taxonomie/models/partenaire-tag.table';
 import { serviceTagSchema } from '../../taxonomie/models/service-tag.table';
-import { effetAttenduSchema } from '../../taxonomie/models/effet-attendu.table';
-import { actionRelationSchema } from '../../referentiels/models/action-relation.table';
-import { indicateurDefinitionSchema } from '../../indicateurs/models/indicateur-definition.table';
 import { sousThematiqueSchema } from '../../taxonomie/models/sous-thematique.table';
-import { financeurTagSchema } from '../../taxonomie/models/financeur-tag.table';
 import { structureTagSchema } from '../../taxonomie/models/structure-tag.table';
+import { thematiqueSchema } from '../../taxonomie/models/thematique.table';
+import { axeSchema } from './axe.table';
+import {
+  FicheActionCiblesEnumType,
+  ficheActionSchema,
+  piliersEciEnumType,
+  updateFicheActionSchema,
+} from './fiche-action.table';
 
 // There is no proper Pilote or Referent tables, so we use a custom schema here
-const personneSchema = z.object({
+export const personneSchema = z.object({
   tagId: z.number().nullish(),
   userId: z.string().uuid().nullish(),
 });
@@ -31,63 +31,58 @@ const financeurWithMontantSchema = z.object({
   montantTtc: z.number().nullish(),
 });
 
-export const updateFicheActionRequestSchema = updateFicheActionSchema
-  .extend({
-    // We're overriding piliersEci and cibles because,
-    // for some unknown reason (a bug with zod/drizzle ?), extend() looses enum's array
-    piliersEci: z
-      .preprocess(
-        (val) => (typeof val === 'string' ? val.replace(/'/g, '’') : val),
-        z.nativeEnum(piliersEciEnumType)
-      )
-      .array()
-      .nullish(),
-    cibles: z.nativeEnum(FicheActionCiblesEnumType).array().nullish(),
-    // Overriding because numeric and timestamp types are not properly converted otherwise (a bug with zod/drizzle ?)
-    budgetPrevisionnel: z
-      .union([z.string(), z.number()])
-      .transform((val) => val.toString())
-      .refine((val) => !isNaN(Number(val)), {
-        message: "Expected 'budgetPrevisionnel' to be a numeric string",
-      })
-      .nullish(),
-    dateDebut: z
-      .string()
-      .nullable()
-      .refine((val) => val === null || !isNaN(Date.parse(val)), {
-        message: "Invalid date format for 'dateDebut'",
-      })
-      .nullish(),
+export const updateFicheActionRequestSchema = updateFicheActionSchema.extend({
+  // We're overriding piliersEci and cibles because,
+  // for some unknown reason (a bug with zod/drizzle ?), extend() looses enum's array
+  piliersEci: z
+    .preprocess(
+      (val) => (typeof val === 'string' ? val.replace(/'/g, '’') : val),
+      z.nativeEnum(piliersEciEnumType)
+    )
+    .array()
+    .nullish(),
+  cibles: z.nativeEnum(FicheActionCiblesEnumType).array().nullish(),
+  // Overriding because numeric and timestamp types are not properly converted otherwise (a bug with zod/drizzle ?)
+  budgetPrevisionnel: z
+    .union([z.string(), z.number()])
+    .transform((val) => val.toString())
+    .refine((val) => !isNaN(Number(val)), {
+      message: "Expected 'budgetPrevisionnel' to be a numeric string",
+    })
+    .nullish(),
+  dateDebut: z
+    .string()
+    .nullable()
+    .refine((val) => val === null || !isNaN(Date.parse(val)), {
+      message: "Invalid date format for 'dateDebut'",
+    })
+    .nullish(),
 
-    tempsDeMiseEnOeuvre: z
-      .union([
-        z.number(),
-        z.object({
-          id: z.number(),
-          nom: z.string(),
-        }),
-      ])
-      .transform((val) => (typeof val === 'number' ? val : val.id))
-      .nullish(),
+  tempsDeMiseEnOeuvre: z
+    .union([
+      z.number(),
+      z.object({
+        id: z.number(),
+        nom: z.string(),
+      }),
+    ])
+    .transform((val) => (typeof val === 'number' ? val : val.id))
+    .nullish(),
 
-    axes: axeSchema.pick({ id: true }).array().nullish(),
-    thematiques: thematiqueSchema.pick({ id: true }).array().nullish(),
-    sousThematiques: sousThematiqueSchema.pick({ id: true }).array().nullish(),
-    partenaires: partenaireTagSchema.pick({ id: true }).array().nullish(),
-    structures: structureTagSchema.pick({ id: true }).array().nullish(),
-    pilotes: personneSchema.array().nullish(),
-    referents: personneSchema.array().nullish(),
-    actions: actionRelationSchema.pick({ id: true }).array().nullish(),
-    indicateurs: indicateurDefinitionSchema
-      .pick({ id: true })
-      .array()
-      .nullish(),
-    services: serviceTagSchema.pick({ id: true }).array().nullish(),
-    financeurs: z.array(financeurWithMontantSchema).nullish(),
-    fichesLiees: ficheActionSchema.pick({ id: true }).array().nullish(),
-    resultatsAttendus: effetAttenduSchema.pick({ id: true }).array().nullish(),
-  })
-  .refine((schema) => Object.keys(schema).length > 0, 'Body cannot be empty');
+  axes: axeSchema.pick({ id: true }).array().nullish(),
+  thematiques: thematiqueSchema.pick({ id: true }).array().nullish(),
+  sousThematiques: sousThematiqueSchema.pick({ id: true }).array().nullish(),
+  partenaires: partenaireTagSchema.pick({ id: true }).array().nullish(),
+  structures: structureTagSchema.pick({ id: true }).array().nullish(),
+  pilotes: personneSchema.array().nullish(),
+  referents: personneSchema.array().nullish(),
+  actions: actionRelationSchema.pick({ id: true }).array().nullish(),
+  indicateurs: indicateurDefinitionSchema.pick({ id: true }).array().nullish(),
+  services: serviceTagSchema.pick({ id: true }).array().nullish(),
+  financeurs: z.array(financeurWithMontantSchema).nullish(),
+  fichesLiees: ficheActionSchema.pick({ id: true }).array().nullish(),
+  resultatsAttendus: effetAttenduSchema.pick({ id: true }).array().nullish(),
+});
 
 export type UpdateFicheActionRequestType = z.infer<
   typeof updateFicheActionRequestSchema

--- a/backend/src/trpc/trpc.router.ts
+++ b/backend/src/trpc/trpc.router.ts
@@ -2,14 +2,13 @@ import { INestApplication, Injectable, Logger } from '@nestjs/common';
 import { createExpressMiddleware } from '@trpc/server/adapters/express';
 import { PersonnesRouter } from '../collectivites/personnes.router';
 import SupabaseService from '../common/services/supabase.service';
+import { IndicateurFiltreRouter } from '../indicateurs/indicateur-filtre/indicateur-filtre.router';
+import { GetCategoriesByCollectiviteRouter } from '../taxonomie/routers/get-categories-by-collectivite.router';
+import { FicheActionEtapeRouter } from '../fiches/fiche-action-etape/fiche-action-etape.router';
+import { BulkEditRouter } from '../fiches/bulk-edit/bulk-edit.router';
 import { CountByStatutRouter } from '../fiches/count-by-statut/count-by-statut.router';
 import { TrajectoiresRouter } from '../indicateurs/routers/trajectoires.router';
 import { createContext, TrpcService } from './trpc.service';
-import { IndicateurFiltreRouter } from '../indicateurs/indicateur-filtre/indicateur-filtre.router';
-import {
-  GetCategoriesByCollectiviteRouter
-} from '../taxonomie/routers/get-categories-by-collectivite.router';
-import { FicheActionEtapeRouter } from '../fiches/fiche-action-etape/fiche-action-etape.router';
 
 @Injectable()
 export class TrpcRouter {
@@ -22,26 +21,29 @@ export class TrpcRouter {
     private readonly countByStatutRouter: CountByStatutRouter,
     private readonly getCategoriesByCollectiviteRouter: GetCategoriesByCollectiviteRouter,
     private readonly personnes: PersonnesRouter,
-    private readonly ficheActionEtapeRouter : FicheActionEtapeRouter,
-    private readonly indicateurFiltreRouter : IndicateurFiltreRouter,
+    private readonly ficheActionEtapeRouter: FicheActionEtapeRouter,
+    private readonly indicateurFiltreRouter: IndicateurFiltreRouter,
+    private readonly bulkEditRouter: BulkEditRouter
   ) {}
 
   appRouter = this.trpc.router({
     indicateurs: {
       trajectoires: this.trajectoiresRouter.router,
-      filtre : this.indicateurFiltreRouter.router
+      filtre: this.indicateurFiltreRouter.router,
     },
     plans: {
       fiches: {
-        countByStatut : this.countByStatutRouter.router.countByStatut,
-        etapes : this.ficheActionEtapeRouter.router,
+        countByStatut: this.countByStatutRouter.router.countByStatut,
+        etapes: this.ficheActionEtapeRouter.router,
+        ...this.countByStatutRouter.router,
+        ...this.bulkEditRouter.router,
       },
     },
     collectivites: {
       personnes: this.personnes.router,
     },
     tags: {
-      categories : this.getCategoriesByCollectiviteRouter.router
+      categories: this.getCategoriesByCollectiviteRouter.router,
     },
   });
 

--- a/backend/src/trpc/trpc.router.ts
+++ b/backend/src/trpc/trpc.router.ts
@@ -2,12 +2,12 @@ import { INestApplication, Injectable, Logger } from '@nestjs/common';
 import { createExpressMiddleware } from '@trpc/server/adapters/express';
 import { PersonnesRouter } from '../collectivites/personnes.router';
 import SupabaseService from '../common/services/supabase.service';
-import { IndicateurFiltreRouter } from '../indicateurs/indicateur-filtre/indicateur-filtre.router';
-import { GetCategoriesByCollectiviteRouter } from '../taxonomie/routers/get-categories-by-collectivite.router';
-import { FicheActionEtapeRouter } from '../fiches/fiche-action-etape/fiche-action-etape.router';
 import { BulkEditRouter } from '../fiches/bulk-edit/bulk-edit.router';
 import { CountByStatutRouter } from '../fiches/count-by-statut/count-by-statut.router';
+import { FicheActionEtapeRouter } from '../fiches/fiche-action-etape/fiche-action-etape.router';
+import { IndicateurFiltreRouter } from '../indicateurs/indicateur-filtre/indicateur-filtre.router';
 import { TrajectoiresRouter } from '../indicateurs/routers/trajectoires.router';
+import { GetCategoriesByCollectiviteRouter } from '../taxonomie/routers/get-categories-by-collectivite.router';
 import { createContext, TrpcService } from './trpc.service';
 
 @Injectable()
@@ -32,12 +32,11 @@ export class TrpcRouter {
       filtre: this.indicateurFiltreRouter.router,
     },
     plans: {
-      fiches: {
-        countByStatut: this.countByStatutRouter.router.countByStatut,
-        etapes: this.ficheActionEtapeRouter.router,
-        ...this.countByStatutRouter.router,
-        ...this.bulkEditRouter.router,
-      },
+      fiches: this.trpc.mergeRouters(
+        this.countByStatutRouter.router,
+        this.bulkEditRouter.router,
+        this.ficheActionEtapeRouter.router
+      ),
     },
     collectivites: {
       personnes: this.personnes.router,

--- a/backend/src/utils/enum.utils.ts
+++ b/backend/src/utils/enum.utils.ts
@@ -1,0 +1,6 @@
+export function getEnumValues<Enum extends string>(
+  enumObj: Record<string, Enum>
+) {
+  // Returns as a non-empty array
+  return Object.values(enumObj) as [Enum, ...Enum[]];
+}

--- a/data_layer/sqitch/deploy/plan_action/fiches.sql
+++ b/data_layer/sqitch/deploy/plan_action/fiches.sql
@@ -2,14 +2,8 @@
 
 BEGIN;
 
-ALTER TABLE fiche_action_libre_tag
-DROP CONSTRAINT fiche_action_libre_tag_fiche_id_fkey;
-
-ALTER TABLE fiche_action_libre_tag
-ADD CONSTRAINT fiche_action_libre_tag_fiche_id_fkey
-FOREIGN KEY (fiche_id)
-REFERENCES fiche_action(id)
-ON DELETE CASCADE;
-
+ALTER TABLE public.fiche_action_pilote
+ADD CONSTRAINT either_user_or_tag_not_null
+CHECK (user_id IS NOT NULL OR tag_id IS NOT NULL);
 
 COMMIT;

--- a/data_layer/sqitch/deploy/plan_action/fiches@v4.28.1.sql
+++ b/data_layer/sqitch/deploy/plan_action/fiches@v4.28.1.sql
@@ -1,0 +1,15 @@
+-- Deploy tet:plan_action/fiches to pg
+
+BEGIN;
+
+ALTER TABLE fiche_action_libre_tag
+DROP CONSTRAINT fiche_action_libre_tag_fiche_id_fkey;
+
+ALTER TABLE fiche_action_libre_tag
+ADD CONSTRAINT fiche_action_libre_tag_fiche_id_fkey
+FOREIGN KEY (fiche_id)
+REFERENCES fiche_action(id)
+ON DELETE CASCADE;
+
+
+COMMIT;

--- a/data_layer/sqitch/revert/plan_action/fiches.sql
+++ b/data_layer/sqitch/revert/plan_action/fiches.sql
@@ -1,13 +1,8 @@
--- Revert tet:plan_action/fiches from pg
+-- Deploy tet:plan_action/fiches to pg
 
 BEGIN;
 
-ALTER TABLE fiche_action_libre_tag
-DROP CONSTRAINT fiche_action_libre_tag_fiche_id_fkey;
-
-ALTER TABLE fiche_action_libre_tag
-ADD CONSTRAINT fiche_action_libre_tag_fiche_id_fkey
-FOREIGN KEY (fiche_id)
-REFERENCES fiche_action(id);
+ALTER TABLE public.fiche_action_pilote
+DROP CONSTRAINT IF EXISTS either_user_or_tag_not_null;
 
 COMMIT;

--- a/data_layer/sqitch/revert/plan_action/fiches@v4.28.1.sql
+++ b/data_layer/sqitch/revert/plan_action/fiches@v4.28.1.sql
@@ -1,0 +1,13 @@
+-- Revert tet:plan_action/fiches from pg
+
+BEGIN;
+
+ALTER TABLE fiche_action_libre_tag
+DROP CONSTRAINT fiche_action_libre_tag_fiche_id_fkey;
+
+ALTER TABLE fiche_action_libre_tag
+ADD CONSTRAINT fiche_action_libre_tag_fiche_id_fkey
+FOREIGN KEY (fiche_id)
+REFERENCES fiche_action(id);
+
+COMMIT;

--- a/data_layer/sqitch/sqitch.plan
+++ b/data_layer/sqitch/sqitch.plan
@@ -781,3 +781,4 @@ plan_action/fiches [plan_action/fiches@v4.28.0] 2024-11-25T17:04:51Z System Admi
 plan_action/fiche_action_etape 2024-11-21T13:40:26Z Amandine <ours@ours> # Ajoute des etapes aux fiches actions
 labellisation/audit [labellisation/audit@v4.27.1] 2024-11-20T13:56:04Z Amandine <ours@ours> # Corrige la fonction labellisation_peut_commencer_audit qui prenait à tord une demander 1ère étoile pour l'audit en cours
 referentiel/score_snapshot 2024-11-25T11:25:21Z System Administrator <root@MacBook-Air-de-Thibaut-2.local> # Ajout de la table permettant de sauvegarder/figer des scores de referentiel
+plan_action/fiches [plan_action/fiches@v4.28.1] 2024-11-29T13:01:29Z Frederic Arnoux <frederic.arnoux@beta.gouv.fr> # Fix unicity constraint for fiche action pilotes

--- a/data_layer/sqitch/verify/plan_action/fiches.sql
+++ b/data_layer/sqitch/verify/plan_action/fiches.sql
@@ -2,13 +2,4 @@
 
 BEGIN;
 
-SELECT tc.constraint_name,
-       rc.delete_rule
-FROM information_schema.table_constraints tc
-JOIN information_schema.referential_constraints rc
-    ON tc.constraint_name = rc.constraint_name
-WHERE tc.table_name = 'fiche_action_libre_tag'
-    AND tc.constraint_name = 'fiche_action_libre_tag_fiche_id_fkey'
-    AND rc.delete_rule = 'CASCADE';
-
 ROLLBACK;

--- a/data_layer/sqitch/verify/plan_action/fiches@v4.28.1.sql
+++ b/data_layer/sqitch/verify/plan_action/fiches@v4.28.1.sql
@@ -1,0 +1,14 @@
+-- Verify tet:plan_action/fiches on pg
+
+BEGIN;
+
+SELECT tc.constraint_name,
+       rc.delete_rule
+FROM information_schema.table_constraints tc
+JOIN information_schema.referential_constraints rc
+    ON tc.constraint_name = rc.constraint_name
+WHERE tc.table_name = 'fiche_action_libre_tag'
+    AND tc.constraint_name = 'fiche_action_libre_tag_fiche_id_fkey'
+    AND rc.delete_rule = 'CASCADE';
+
+ROLLBACK;


### PR DESCRIPTION
Bulk edit de fiche actions ok pour :

- [x] statut
- [x] pilotes

---
## Usage

Mise à jour d'un statut :
```
const input = {
      ficheIds: [1, 2, 3],
      statut: FicheActionStatutsEnumType.EN_RETARD,
};

await trpc.plans.fiches.bulkEdit(input);
```

Mise à jour de pilotes :
```
const input = {
      ficheIds: [1, 2, 3],
      pilotes: {
         add: [{tagId: 1}, {userId: 'abcd-efgh'}]
      }
};

await trpc.plans.fiches.bulkEdit(input);
```