### PR TITLE
Ajout des étapes aux fiches actions

### DIFF
--- a/backend/src/fiches/fiche-action-etape/fiche-action-etape.router.e2e-spec.ts
+++ b/backend/src/fiches/fiche-action-etape/fiche-action-etape.router.e2e-spec.ts
@@ -1,0 +1,125 @@
+import { getTestApp, getTestDatabase, getTestRouter } from '../../../test/common/app-utils';
+import { AuthenticatedUser } from './../../auth/models/auth.models';
+import { getAuthUser } from '../../../test/auth/auth-utils';
+import { inferProcedureInput } from '@trpc/server';
+import { AppRouter, TrpcRouter } from '../../trpc/trpc.router';
+import { eq } from 'drizzle-orm';
+import DatabaseService from '../../common/services/database.service';
+import { ficheActionEtapeTable } from './fiche-action-etape.table';
+
+type upsertInput = inferProcedureInput<
+  AppRouter['plans']['fiches']['etapes']['upsert']
+>;
+type deleteInput = inferProcedureInput<
+  AppRouter['plans']['fiches']['etapes']['delete']
+>;
+type listInput = inferProcedureInput<
+  AppRouter['plans']['fiches']['etapes']['list']
+>;
+
+describe('Route CRUD des étapes des fiches actions', () => {
+  let router: TrpcRouter;
+  let yoloDodoUser: AuthenticatedUser;
+  let databaseService: DatabaseService;
+
+  beforeAll(async () => {
+    router = await getTestRouter();
+    yoloDodoUser = await getAuthUser();
+    const app = await getTestApp();
+    databaseService = await getTestDatabase(app);
+  });
+
+  test(`Test la gestion de l'ordre des étapes d'une fiche action`, async () => {
+    const caller = router.createCaller({ user: yoloDodoUser });
+    const ficheId: listInput = {
+      ficheId: 1,
+    };
+    const etapeA: upsertInput = {
+      ficheId: ficheId.ficheId,
+      nom: 'A',
+      ordre: 1,
+    };
+    const etapeB: upsertInput = {
+      ficheId: ficheId.ficheId,
+      nom: 'B',
+      ordre: 2,
+    };
+    const etapeC: upsertInput = {
+      ficheId: ficheId.ficheId,
+      nom: 'C',
+      ordre: 2,
+    };
+
+    // Ajout de deux étapes A et B
+    const upsertA = await caller.plans.fiches.etapes.upsert(etapeA);
+    expect(upsertA.id).not.toBeNull();
+    const upsertB = await caller.plans.fiches.etapes.upsert(etapeB);
+    expect(upsertB.id).not.toBeNull();
+    // Vérifie que l'ordre est A=1, B=2
+    let ordre = await caller.plans.fiches.etapes.list(ficheId);
+    expect(ordre.length).toBe(2);
+    expect(ordre[0].nom).toBe('A');
+    expect(ordre[0].ordre).toBe(1);
+    expect(ordre[1].nom).toBe('B');
+    expect(ordre[1].ordre).toBe(2);
+    // Ajout d'une étape C entre A et B
+    const upsertC = await caller.plans.fiches.etapes.upsert(etapeC);
+    expect(upsertC.id).not.toBeNull();
+    expect(upsertC.realise).toBe(false);
+    // Vérifie que l'ordre est A=1, C=2, B=3
+    ordre = await caller.plans.fiches.etapes.list(ficheId);
+    expect(ordre.length).toBe(3);
+    expect(ordre[0].nom).toBe('A');
+    expect(ordre[0].ordre).toBe(1);
+    expect(ordre[1].nom).toBe('C');
+    expect(ordre[1].ordre).toBe(2);
+    expect(ordre[2].nom).toBe('B');
+    expect(ordre[2].ordre).toBe(3);
+    // Déplace l'étape C vers la troisième position et passe réalisé à true
+    const updatedEtapeC = upsertC;
+    upsertC.ordre = 3;
+    upsertC.realise = true;
+    await caller.plans.fiches.etapes.upsert(updatedEtapeC);
+    // Vérifie que l'ordre est A=1, B=2, C=3
+    ordre = await caller.plans.fiches.etapes.list(ficheId);
+    expect(ordre.length).toBe(3);
+    expect(ordre[0].nom).toBe('A');
+    expect(ordre[0].ordre).toBe(1);
+    expect(ordre[1].nom).toBe('B');
+    expect(ordre[1].ordre).toBe(2);
+    expect(ordre[2].nom).toBe('C');
+    expect(ordre[2].ordre).toBe(3);
+    // Vérifie que réalisé a bien été modifié
+    expect(ordre[2].realise).toBe(true);
+    // Supprime l'étape B
+    await caller.plans.fiches.etapes.delete({
+      etapeId: upsertB.id,
+    } as deleteInput);
+    // Vérifie que l'ordre est A=1, C=2
+    ordre = await caller.plans.fiches.etapes.list(ficheId);
+    expect(ordre.length).toBe(2);
+    expect(ordre[0].nom).toBe('A');
+    expect(ordre[0].ordre).toBe(1);
+    expect(ordre[1].nom).toBe('C');
+    expect(ordre[1].ordre).toBe(2);
+    // Supprime l'étape A
+    await caller.plans.fiches.etapes.delete({
+      etapeId: upsertA.id,
+    } as deleteInput);
+    // Vérifie que l'ordre est C=1
+    ordre = await caller.plans.fiches.etapes.list(ficheId);
+    expect(ordre.length).toBe(1);
+    expect(ordre[0].nom).toBe('C');
+    expect(ordre[0].ordre).toBe(1);
+
+    onTestFinished(async () => {
+      try{
+        await databaseService.db
+          .delete(ficheActionEtapeTable)
+          .where(eq(ficheActionEtapeTable.ficheId, 1));
+      }catch(error){
+        console.error('Erreur lors de la suppression:', error);
+      }
+    });
+  });
+});

--- a/backend/src/fiches/fiche-action-etape/fiche-action-etape.router.ts
+++ b/backend/src/fiches/fiche-action-etape/fiche-action-etape.router.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@nestjs/common';
+import { FicheActionEtapeService } from './fiche-action-etape.service';
+import { TrpcService } from '../../trpc/trpc.service';
+import { upsertFicheActionEtapeSchema } from '@tet/backend/fiches/fiche-action-etape/fiche-action-etape.table';
+import { z } from 'zod';
+
+
+@Injectable()
+export class FicheActionEtapeRouter {
+  constructor(
+    private readonly trpc: TrpcService,
+    private readonly service: FicheActionEtapeService
+  ) {}
+
+  router = this.trpc.router({
+    upsert: this.trpc.authedProcedure
+      .input(upsertFicheActionEtapeSchema)
+      .query(({ ctx, input }) => {
+        return this.service.upsertEtape(input, ctx.user);
+      }),
+    delete: this.trpc.authedProcedure
+      .input(z.object({etapeId : z.number()}))
+      .query(({ ctx, input }) => {
+        return this.service.deleteEtape(input.etapeId, ctx.user);
+      }),
+    list: this.trpc.authedProcedure
+      .input(z.object({ficheId : z.number()}))
+      .query(({ ctx, input }) => {
+        return this.service.getEtapesByFicheId(input.ficheId, ctx.user);
+      }),
+  });
+}

--- a/backend/src/fiches/fiche-action-etape/fiche-action-etape.service.ts
+++ b/backend/src/fiches/fiche-action-etape/fiche-action-etape.service.ts
@@ -1,0 +1,182 @@
+import { Injectable } from '@nestjs/common';
+import { ficheActionEtapeTable } from './fiche-action-etape.table';
+import { eq, and, gte, sql, lt, gt, lte } from 'drizzle-orm';
+import {
+  FicheActionEtapeType,
+  UpsertFicheActionEtapeType,
+} from './fiche-action-etape.table';
+import { AuthenticatedUser } from '../../auth/models/auth.models';
+import FicheService from '../services/fiche.service';
+import DatabaseService from '../../common/services/database.service';
+
+@Injectable()
+export class FicheActionEtapeService {
+  constructor(
+    private readonly databaseService: DatabaseService,
+    private readonly ficheService: FicheService
+  ) {}
+
+  /**
+   * Ajoute ou modifie une étape d'une fiche
+   * et réorganise les autres étapes en fonction
+   * @param etape
+   * @param tokenInfo
+   */
+  async upsertEtape(
+    etape: UpsertFicheActionEtapeType,
+    tokenInfo: AuthenticatedUser
+  ) : Promise<FicheActionEtapeType> {
+    const { id, ficheId, nom, ordre, realise = false } = etape;
+    await this.ficheService.canWriteFiche(ficheId, tokenInfo);
+    const userId = tokenInfo?.id;
+
+    return await this.databaseService.db.transaction(async (trx) => {
+      if (id) {
+        // Si on déplace une étape existante (drag and drop)
+        const currentEtape = await trx
+          .select({
+            ordre: ficheActionEtapeTable.ordre,
+          })
+          .from(ficheActionEtapeTable)
+          .where(
+            and(
+              eq(ficheActionEtapeTable.id, id),
+              eq(ficheActionEtapeTable.ficheId, ficheId)
+            )
+          )
+          .limit(1);
+
+        if (currentEtape.length === 0) {
+          throw new Error("L'étape spécifiée n'existe pas.");
+        }
+
+        const currentOrdre = currentEtape[0].ordre;
+
+        if (currentOrdre !== ordre) {
+          if (currentOrdre < ordre) {
+            // Si l'étape descend (ex : de 2 à 4)
+            await trx
+              .update(ficheActionEtapeTable)
+              .set({ ordre: sql`${ficheActionEtapeTable.ordre} - 1` })
+              .where(
+                and(
+                  eq(ficheActionEtapeTable.ficheId, ficheId),
+                  gt(ficheActionEtapeTable.ordre, currentOrdre),
+                  lte(ficheActionEtapeTable.ordre, ordre)
+                )
+              );
+          } else {
+            // Si l'étape monte (ex : de 4 à 2)
+            await trx
+              .update(ficheActionEtapeTable)
+              .set({ ordre: sql`${ficheActionEtapeTable.ordre} + 1` })
+              .where(
+                and(
+                  eq(ficheActionEtapeTable.ficheId, ficheId),
+                  gte(ficheActionEtapeTable.ordre, ordre),
+                  lt(ficheActionEtapeTable.ordre, currentOrdre)
+                )
+              );
+          }
+        }
+      } else {
+        // Si on insère une nouvelle étape
+        await trx
+          .update(ficheActionEtapeTable)
+          .set({ ordre: sql`${ficheActionEtapeTable.ordre} + 1` })
+          .where(
+            and(
+              eq(ficheActionEtapeTable.ficheId, ficheId),
+              gte(ficheActionEtapeTable.ordre, ordre)
+            )
+          );
+      }
+
+      // Insertion ou mise à jour de l'étape avec `RETURNING`
+      const [result] = await trx
+        .insert(ficheActionEtapeTable)
+        .values({
+          id, // Si `id` est défini, mise à jour via `onConflict`
+          ficheId,
+          nom,
+          ordre,
+          realise,
+          createdBy: userId,
+          modifiedBy: userId,
+          createdAt: new Date(),
+          modifiedAt: new Date(),
+        })
+        .onConflictDoUpdate({
+          target: [ficheActionEtapeTable.id],
+          set: {
+            nom,
+            ordre,
+            realise,
+            modifiedBy: userId,
+            modifiedAt: new Date(),
+          },
+        })
+        .returning();
+      return result;
+    });
+  }
+
+  /**
+   * Supprime une étape d'une fiche et réorganise les autres étapes en fonction
+   * @param etapeId
+   * @param tokenInfo
+   */
+  async deleteEtape(etapeId: number, tokenInfo: AuthenticatedUser) {
+    return this.databaseService.db.transaction(async (trx) => {
+      // Récupérer l'ordre et la fiche de l'étape à supprimer
+      const stepToDelete = await trx
+        .select({
+          ordre: ficheActionEtapeTable.ordre,
+          ficheId: ficheActionEtapeTable.ficheId,
+        })
+        .from(ficheActionEtapeTable)
+        .where(eq(ficheActionEtapeTable.id, etapeId))
+        .then((res) => res[0]);
+
+      if (!stepToDelete) {
+        throw new Error('Step not found');
+      }
+
+      const { ordre: deletedOrder, ficheId } = stepToDelete;
+      await this.ficheService.canWriteFiche(ficheId, tokenInfo);
+
+      // Supprimer l'étape
+      await trx
+        .delete(ficheActionEtapeTable)
+        .where(eq(ficheActionEtapeTable.id, etapeId));
+
+      // Réorganiser les étapes après celle supprimée
+      await trx
+        .update(ficheActionEtapeTable)
+        .set({ ordre: sql`${ficheActionEtapeTable.ordre} - 1` })
+        .where(
+          and(
+            eq(ficheActionEtapeTable.ficheId, ficheId),
+            gte(ficheActionEtapeTable.ordre, deletedOrder)
+          )
+        );
+    });
+  }
+
+  /**
+   * Récupère les étapes d'une fiche
+   * @param ficheId
+   * @param tokenInfo
+   */
+  async getEtapesByFicheId(
+    ficheId: number,
+    tokenInfo: AuthenticatedUser
+  ): Promise<FicheActionEtapeType[]> {
+    await this.ficheService.canReadFiche(ficheId, tokenInfo);
+    return this.databaseService.db
+      .select()
+      .from(ficheActionEtapeTable)
+      .where(eq(ficheActionEtapeTable.ficheId, ficheId))
+      .orderBy(ficheActionEtapeTable.ordre);
+  }
+}

--- a/backend/src/fiches/fiche-action-etape/fiche-action-etape.table.ts
+++ b/backend/src/fiches/fiche-action-etape/fiche-action-etape.table.ts
@@ -1,0 +1,42 @@
+import {
+  pgTable,
+  serial,
+  integer,
+  text,
+  timestamp,
+  boolean,
+  uuid,
+} from 'drizzle-orm/pg-core';
+import { createInsertSchema } from 'drizzle-zod';
+import { InferSelectModel } from 'drizzle-orm';
+import { z } from 'zod';
+import { ficheActionTable } from '../models/fiche-action.table';
+import { createdAt, createdBy, modifiedAt, modifiedBy } from '@tet/backend/common/models/column.helpers';
+
+export const ficheActionEtapeTable = pgTable('fiche_action_etape', {
+  id: serial('id').primaryKey(),
+  ficheId: integer('fiche_id')
+    .notNull()
+    .references(() => ficheActionTable.id, { onDelete: 'cascade' }),
+  nom: text('nom'),
+  ordre: integer('ordre').notNull(),
+  realise: boolean('realise').notNull().default(false),
+  createdAt,
+  modifiedAt,
+  createdBy,
+  modifiedBy,
+});
+
+export const upsertFicheActionEtapeSchema = createInsertSchema(
+  ficheActionEtapeTable
+).partial({
+  modifiedBy: true,
+  createdBy: true,
+});
+
+export type FicheActionEtapeType = InferSelectModel<
+  typeof ficheActionEtapeTable
+>;
+export type UpsertFicheActionEtapeType = z.infer<
+  typeof upsertFicheActionEtapeSchema
+>;

--- a/backend/src/fiches/fiches-action.module.ts
+++ b/backend/src/fiches/fiches-action.module.ts
@@ -8,6 +8,8 @@ import FichesActionUpdateService from './services/fiches-action-update.service';
 import FicheService from './services/fiche.service';
 import TagService from '../taxonomie/services/tag.service';
 import { CountByStatutRouter } from './count-by-statut/count-by-statut.router';
+import { FicheActionEtapeRouter } from './fiche-action-etape/fiche-action-etape.router';
+import { FicheActionEtapeService } from './fiche-action-etape/fiche-action-etape.service';
 
 @Module({
   imports: [CommonModule, AuthModule, CollectivitesModule],
@@ -17,8 +19,15 @@ import { CountByStatutRouter } from './count-by-statut/count-by-statut.router';
     FichesActionUpdateService,
     TagService,
     CountByStatutRouter,
+    FicheActionEtapeService,
+    FicheActionEtapeRouter,
   ],
-  exports: [CountByStatutService, CountByStatutRouter],
+  exports: [
+    CountByStatutService,
+    CountByStatutRouter,
+    FicheActionEtapeService,
+    FicheActionEtapeRouter,
+  ],
   controllers: [FichesActionController],
 })
 export class FichesActionModule {}

--- a/backend/src/trpc/trpc.router.ts
+++ b/backend/src/trpc/trpc.router.ts
@@ -2,12 +2,13 @@ import { INestApplication, Injectable, Logger } from '@nestjs/common';
 import { createExpressMiddleware } from '@trpc/server/adapters/express';
 import { PersonnesRouter } from '../collectivites/personnes.router';
 import SupabaseService from '../common/services/supabase.service';
+import { CountByStatutRouter } from '../fiches/count-by-statut/count-by-statut.router';
 import { TrajectoiresRouter } from '../indicateurs/routers/trajectoires.router';
 import { createContext, TrpcService } from './trpc.service';
-import { CountByStatutRouter } from '../fiches/count-by-statut/count-by-statut.router';
 import {
   GetCategoriesByCollectiviteRouter
 } from '../taxonomie/routers/get-categories-by-collectivite.router';
+import { FicheActionEtapeRouter } from '../fiches/fiche-action-etape/fiche-action-etape.router';
 
 @Injectable()
 export class TrpcRouter {
@@ -19,7 +20,8 @@ export class TrpcRouter {
     private readonly trajectoiresRouter: TrajectoiresRouter,
     private readonly countByStatutRouter: CountByStatutRouter,
     private readonly getCategoriesByCollectiviteRouter: GetCategoriesByCollectiviteRouter,
-    private readonly personnes: PersonnesRouter
+    private readonly personnes: PersonnesRouter,
+    private readonly ficheActionEtapeRouter : FicheActionEtapeRouter,
   ) {}
 
   appRouter = this.trpc.router({
@@ -28,7 +30,8 @@ export class TrpcRouter {
     },
     plans: {
       fiches: {
-        ...this.countByStatutRouter.router,
+        countByStatut : this.countByStatutRouter.router.countByStatut,
+        etapes : this.ficheActionEtapeRouter.router,
       },
     },
     collectivites: {

--- a/data_layer/sqitch/deploy/plan_action/fiche_action_etape.sql
+++ b/data_layer/sqitch/deploy/plan_action/fiche_action_etape.sql
@@ -1,0 +1,28 @@
+-- Deploy tet:plan_action/fiche_action_etape to pg
+
+BEGIN;
+
+create table fiche_action_etape
+(
+  id          serial primary key,
+  fiche_id    integer references fiche_action on delete cascade                 not null,
+  nom         text,
+  ordre       integer                                                           not null,
+  realise     boolean                  default false                            not null,
+  modified_at timestamp with time zone default CURRENT_TIMESTAMP                not null,
+  created_at  timestamp with time zone default CURRENT_TIMESTAMP                not null,
+  modified_by uuid                     default auth.uid() references auth.users not null,
+  created_by  uuid                     default auth.uid() references auth.users not null
+);
+
+comment on table fiche_action_etape is
+  'Etapes (ou tâches) nécessaires à la réalisation de la fiche action';
+
+alter table fiche_action_etape
+  enable row level security;
+create policy allow_read on fiche_action_etape for select using (peut_lire_la_fiche(fiche_id));
+create policy allow_insert on fiche_action_etape for insert with check (peut_modifier_la_fiche(fiche_id));
+create policy allow_update on fiche_action_etape for update using (peut_modifier_la_fiche(fiche_id));
+create policy allow_delete on fiche_action_etape for delete using (peut_modifier_la_fiche(fiche_id));
+
+COMMIT;

--- a/data_layer/sqitch/revert/plan_action/fiche_action_etape.sql
+++ b/data_layer/sqitch/revert/plan_action/fiche_action_etape.sql
@@ -1,0 +1,7 @@
+-- Revert tet:plan_action/fiche_action_etape from pg
+
+BEGIN;
+
+drop table fiche_action_etape;
+
+COMMIT;

--- a/data_layer/sqitch/sqitch.plan
+++ b/data_layer/sqitch/sqitch.plan
@@ -777,3 +777,5 @@ referentiel/verification_score 2024-11-20T16:04:26Z System Administrator <root@M
 
 plan_action/fiches [plan_action/fiches@v4.28.0] 2024-11-25T17:04:51Z System Administrator <root@MacBook-Air-de-Eli.local> # Ajoute ON DELETE CASCADE à fiche_action_libre_tag
 @v4.28.1 2024-11-25T18:42:06Z System Administrator <root@MacBook-Air-de-Eli.local> # Tag en v4.28.1
+
+plan_action/fiche_action_etape 2024-11-21T13:40:26Z Amandine <ours@ours> # Ajoute des etapes aux fiches actions

--- a/data_layer/sqitch/verify/plan_action/fiche_action_etape.sql
+++ b/data_layer/sqitch/verify/plan_action/fiche_action_etape.sql
@@ -1,0 +1,17 @@
+-- Verify tet:plan_action/fiche_action_etape on pg
+
+BEGIN;
+
+select id,
+       fiche_id,
+       nom,
+       ordre,
+       realise,
+       modified_at,
+       created_at,
+       modified_by,
+       created_by
+from fiche_action_etape
+where false;
+
+ROLLBACK;


### PR DESCRIPTION
<h2>API pour gérer les étapes d'une fiche action: </h2>

<h3>Pour récupérer les étapes d'une fiche dans l'ordre : </h3>

`await caller.plans.fiches.etapes.list({ficheId : 1});`

<h3>Pour supprimer une étape : </h3>

`await caller.plans.fiches.etapes.delete({etapeId: 1})`

_Si l'étape supprimée n'était pas à la fin, les autres étapes se décaleront automatiquement._

<h3>Pour ajouter ou modifier une fiche :  </h3>

```
const etape = {
ficheId: 1,
nom: 'etape',
ordre: 1,
};
const etapeAjoutee = await caller.plans.fiches.etapes.upsert(etape);
// Modifie l'étape
etapeAjoutee.realise = true;
await caller.plans.fiches.etapes.upsert(etapeAjoutee);
```

_Si l'ordre indiqué lors d'un ajout n'est pas à la fin, les autres étapes se décaleront automatiquement.
Si l'ordre d'une étape existante est modifié, les autres étapes se décaleront automatiquement._

