### PR TITLE
Autorise plusieurs notes de suivi d'une fiche action pour la même année

### DIFF
--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/NotesDeSuivi/ModaleCreationNote.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/NotesDeSuivi/ModaleCreationNote.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import {
   Alert,
   Button,
@@ -9,6 +8,7 @@ import {
   Select,
   Textarea,
 } from '@tet/ui';
+import { useState } from 'react';
 import { EditedNote } from '../data/useUpsertNoteSuivi';
 
 export const getYearsOptions = () => {

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/NotesDeSuivi/ModaleEditionNote.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/NotesDeSuivi/ModaleEditionNote.tsx
@@ -37,7 +37,7 @@ const ModaleEditionNote = ({
       note.trim().length > 0 &&
       (note !== editedNote.note || year !== initialYear)
     ) {
-      onEdit({ note, year });
+      onEdit({ id: editedNote.id, note, year });
     }
   };
 

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/NotesDeSuivi/ModaleSuppressionNote.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/NotesDeSuivi/ModaleSuppressionNote.tsx
@@ -36,7 +36,7 @@ const ModaleSuppressionNote = ({
           btnCancelProps={{ onClick: close }}
           btnOKProps={{
             onClick: () => {
-              onDelete({ year });
+              onDelete({ id: editedNote.id });
               close();
             },
           }}

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/data/useUpsertNoteSuivi.ts
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/data/useUpsertNoteSuivi.ts
@@ -1,9 +1,12 @@
-import { useMutation, useQueryClient } from 'react-query';
 import { FicheAction, FicheActionNote } from '@tet/api/plan-actions';
 import { useApiClient } from 'core-logic/api/useApiClient';
+import { useMutation, useQueryClient } from 'react-query';
 
-export type EditedNote = Pick<FicheActionNote, 'note'> & { year: number };
-export type DeletedNote = { year: number };
+export type EditedNote = Pick<FicheActionNote, 'note'> & {
+  id?: number;
+  year: number;
+};
+export type DeletedNote = { id: number };
 
 // renvoie une fonction de modification des notes de suivi
 export const useUpsertNoteSuivi = ({
@@ -14,11 +17,13 @@ export const useUpsertNoteSuivi = ({
   const queryClient = useQueryClient();
 
   return useMutation(
-    async ({ note, year }: EditedNote) => {
+    async ({ id, note, year }: EditedNote) => {
       return api.put({
         route: `/collectivites/${collectiviteId}/fiches-action/${ficheId}/notes`,
         params: {
-          notes: [{ note, dateNote: new Date(`${year}-01-01`).toISOString() }],
+          notes: [
+            { id, note, dateNote: new Date(`${year}-01-01`).toISOString() },
+          ],
         },
       });
     },
@@ -45,10 +50,10 @@ export const useDeleteNoteSuivi = ({
   const queryClient = useQueryClient();
 
   return useMutation(
-    async ({ year }: DeletedNote) => {
+    async ({ id }: DeletedNote) => {
       return api.delete({
         route: `/collectivites/${collectiviteId}/fiches-action/${ficheId}/note`,
-        params: { dateNote: new Date(`${year}-01-01`).toISOString() },
+        params: { id },
       });
     },
     {

--- a/app.territoiresentransitions.react/src/core-logic/api/useApiClient.ts
+++ b/app.territoiresentransitions.react/src/core-logic/api/useApiClient.ts
@@ -8,6 +8,7 @@ type JSONValue =
   | number
   | boolean
   | null
+  | undefined
   | { [x: string]: JSONValue }
   | Array<JSONValue>;
 

--- a/backend/src/fiches/controllers/fiches-action.controller.ts
+++ b/backend/src/fiches/controllers/fiches-action.controller.ts
@@ -152,7 +152,7 @@ export class FichesActionController {
   ) {
     return this.fichesActionUpdateService.deleteNote(
       ficheId,
-      body.dateNote,
+      body.id,
       tokenInfo
     );
   }

--- a/backend/src/fiches/models/fiche-action-note.table.ts
+++ b/backend/src/fiches/models/fiche-action-note.table.ts
@@ -1,4 +1,4 @@
-import { date, integer, pgTable, primaryKey, text } from 'drizzle-orm/pg-core';
+import { date, integer, pgTable, serial, text } from 'drizzle-orm/pg-core';
 import { InferSelectModel } from 'drizzle-orm';
 import { z } from 'zod';
 import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
@@ -10,35 +10,26 @@ import {
   modifiedBy,
 } from '../../common/models/column.helpers';
 
-export const ficheActionNoteTable = pgTable(
-  'fiche_action_note',
-  {
-    ficheId: integer('fiche_id')
-      .references(() => ficheActionTable.id)
-      .notNull(),
-    dateNote: date('date_note').notNull(),
-    note: text('note').notNull(),
-    createdAt,
-    modifiedAt,
-    createdBy,
-    modifiedBy,
-  },
-  (table) => {
-    return {
-      pk: primaryKey({ columns: [table.ficheId, table.dateNote] }),
-    };
-  }
-);
+export const ficheActionNoteTable = pgTable('fiche_action_note', {
+  id: serial('id').primaryKey(),
+  ficheId: integer('fiche_id')
+    .references(() => ficheActionTable.id)
+    .notNull(),
+  dateNote: date('date_note').notNull(),
+  note: text('note').notNull(),
+  createdAt,
+  modifiedAt,
+  createdBy,
+  modifiedBy,
+});
 
 export const ficheActionNoteSchema = createSelectSchema(ficheActionNoteTable);
 
 export const upsertFicheActionNoteSchema = createInsertSchema(
   ficheActionNoteTable
-).pick({ dateNote: true, note: true });
+).pick({ id: true, dateNote: true, note: true });
 
-export const deleteFicheActionNoteSchema = upsertFicheActionNoteSchema.omit({
-  note: true,
-});
+export const deleteFicheActionNoteSchema = z.object({ id: z.number() });
 
 export type FicheActionNoteType = InferSelectModel<typeof ficheActionNoteTable>;
 export type UpsertFicheActionNoteType = z.infer<

--- a/backend/src/fiches/services/fiche.service.ts
+++ b/backend/src/fiches/services/fiche.service.ts
@@ -207,6 +207,7 @@ export default class FicheService {
     const modifiedByDCP = aliasedTable(dcpTable, 'modifiedByDCP');
     const rows = await this.databaseService.db
       .select({
+        id: ficheActionNoteTable.id,
         note: ficheActionNoteTable.note,
         dateNote: ficheActionNoteTable.dateNote,
         createdAt: ficheActionNoteTable.createdAt,

--- a/backend/src/fiches/services/fiches-action-update.service.ts
+++ b/backend/src/fiches/services/fiches-action-update.service.ts
@@ -454,7 +454,7 @@ export default class FichesActionUpdateService {
         }))
       )
       .onConflictDoUpdate({
-        target: [ficheActionNoteTable.ficheId, ficheActionNoteTable.dateNote],
+        target: [ficheActionNoteTable.id],
         set: buildConflictUpdateColumns(ficheActionNoteTable, [
           'note',
           'modifiedAt',
@@ -466,25 +466,23 @@ export default class FichesActionUpdateService {
   /** Supprime une note */
   async deleteNote(
     ficheId: number,
-    dateNote: string,
+    noteId: number,
     tokenInfo: AuthenticatedUser
   ) {
     this.logger.log(
-      `Vérifie les droits avant de supprimer la note datée ${dateNote} de la fiche ${ficheId}`
+      `Vérifie les droits avant de supprimer la note ${noteId} de la fiche ${ficheId}`
     );
 
     const canWrite = await this.ficheService.canWriteFiche(ficheId, tokenInfo);
     if (!canWrite) return false;
 
-    this.logger.log(
-      `Supprime la note datée ${dateNote} de la fiche ${ficheId}`
-    );
+    this.logger.log(`Supprime la note ${noteId} de la fiche ${ficheId}`);
     return this.databaseService.db
       .delete(ficheActionNoteTable)
       .where(
         and(
           eq(ficheActionNoteTable.ficheId, ficheId),
-          eq(ficheActionNoteTable.dateNote, dateNote)
+          eq(ficheActionNoteTable.id, noteId)
         )
       );
   }

--- a/data_layer/sqitch/deploy/plan_action/fiche_note.sql
+++ b/data_layer/sqitch/deploy/plan_action/fiche_note.sql
@@ -2,25 +2,10 @@
 
 BEGIN;
 
-create table public.fiche_action_note
-(
-    fiche_id integer references fiche_action not null,
-    date_note date not null,
-    note text not null,
-    modified_at timestamp with time zone default CURRENT_TIMESTAMP not null,
-    created_at timestamp with time zone default CURRENT_TIMESTAMP not null,
-    modified_by uuid default auth.uid() references auth.users not null,
-    created_by uuid default auth.uid() references auth.users not null,
-    primary key (fiche_id, date_note)
-);
+alter table public.fiche_action_note
+  drop constraint fiche_action_note_pkey;
 
-comment on table public.fiche_action_note is
-    'Notes de suivi annuel et points de vigilance associés à une fiche action';
-
-alter table public.fiche_action_note enable row level security;
-create policy allow_read on public.fiche_action_note for select using(peut_lire_la_fiche(fiche_id));
-create policy allow_insert on public.fiche_action_note for insert with check(peut_modifier_la_fiche(fiche_id));
-create policy allow_update on public.fiche_action_note for update using(peut_modifier_la_fiche(fiche_id));
-create policy allow_delete on public.fiche_action_note for delete using(peut_modifier_la_fiche(fiche_id));
+alter table public.fiche_action_note
+  add column id serial primary key;
 
 COMMIT;

--- a/data_layer/sqitch/deploy/plan_action/fiche_note@v4.28.1.sql
+++ b/data_layer/sqitch/deploy/plan_action/fiche_note@v4.28.1.sql
@@ -1,0 +1,26 @@
+-- Deploy tet:plan_action/fiche_note to pg
+
+BEGIN;
+
+create table public.fiche_action_note
+(
+    fiche_id integer references fiche_action not null,
+    date_note date not null,
+    note text not null,
+    modified_at timestamp with time zone default CURRENT_TIMESTAMP not null,
+    created_at timestamp with time zone default CURRENT_TIMESTAMP not null,
+    modified_by uuid default auth.uid() references auth.users not null,
+    created_by uuid default auth.uid() references auth.users not null,
+    primary key (fiche_id, date_note)
+);
+
+comment on table public.fiche_action_note is
+    'Notes de suivi annuel et points de vigilance associés à une fiche action';
+
+alter table public.fiche_action_note enable row level security;
+create policy allow_read on public.fiche_action_note for select using(peut_lire_la_fiche(fiche_id));
+create policy allow_insert on public.fiche_action_note for insert with check(peut_modifier_la_fiche(fiche_id));
+create policy allow_update on public.fiche_action_note for update using(peut_modifier_la_fiche(fiche_id));
+create policy allow_delete on public.fiche_action_note for delete using(peut_modifier_la_fiche(fiche_id));
+
+COMMIT;

--- a/data_layer/sqitch/revert/plan_action/fiche_note.sql
+++ b/data_layer/sqitch/revert/plan_action/fiche_note.sql
@@ -1,7 +1,14 @@
--- Revert tet:plan_action/fiche_note from pg
+-- Deploy tet:plan_action/fiche_note to pg
 
 BEGIN;
 
-drop table public.fiche_action_note;
+alter table public.fiche_action_note
+  drop constraint fiche_action_note_pkey;
+
+alter table public.fiche_action_note
+  drop column id;
+
+alter table public.fiche_action_note
+  add primary key (fiche_id, date_note);
 
 COMMIT;

--- a/data_layer/sqitch/revert/plan_action/fiche_note@v4.28.1.sql
+++ b/data_layer/sqitch/revert/plan_action/fiche_note@v4.28.1.sql
@@ -1,0 +1,7 @@
+-- Revert tet:plan_action/fiche_note from pg
+
+BEGIN;
+
+drop table public.fiche_action_note;
+
+COMMIT;

--- a/data_layer/sqitch/sqitch.plan
+++ b/data_layer/sqitch/sqitch.plan
@@ -783,3 +783,5 @@ labellisation/audit [labellisation/audit@v4.27.1] 2024-11-20T13:56:04Z Amandine 
 referentiel/score_snapshot 2024-11-25T11:25:21Z System Administrator <root@MacBook-Air-de-Thibaut-2.local> # Ajout de la table permettant de sauvegarder/figer des scores de referentiel
 plan_action/fiches [plan_action/fiches@v4.28.1] 2024-11-29T13:01:29Z Frederic Arnoux <frederic.arnoux@beta.gouv.fr> # Fix unicity constraint for fiche action pilotes
 @v4.29.0 2024-12-02T11:47:31Z Frederic Arnoux <frederic.arnoux@beta.gouv.fr> # Tag 4.29.0
+
+plan_action/fiche_note [plan_action/fiche_note@v4.28.1] 2024-12-02T09:23:16Z Marc Rutkowski <marc@attractive-media.fr> # Change la clé primaire de `fiche_action_note` pour utiliser un id unique (permet d'avoir plusieurs notes de suivi de la FA pour la même année)

--- a/data_layer/sqitch/verify/plan_action/fiche_note@v4.28.1.sql
+++ b/data_layer/sqitch/verify/plan_action/fiche_note@v4.28.1.sql
@@ -3,7 +3,6 @@
 BEGIN;
 
 select
-    id,
     fiche_id,
     date_note,
     note,

--- a/packages/api/src/plan-actions/domain/fiche-action.schema.ts
+++ b/packages/api/src/plan-actions/domain/fiche-action.schema.ts
@@ -145,6 +145,7 @@ export const ficheActionSchema = z.object({
 export type FicheAction = z.infer<typeof ficheActionSchema>;
 
 export const noteSuiviSchema = z.object({
+  id: z.number(),
   createdAt: z.string().datetime(),
   createdBy: z.string(),
   modifiedAt: z.string().datetime(),


### PR DESCRIPTION
Evite que la note initiale soit écrasée, sans avertissement, lors de  l'ajout d'une nouvelle note de suivi pour la même année.