### PR TITLE
Add cascade constraints to fiche action related tables

### DIFF
--- a/backend/src/fiches/models/fiche-action-libre-tag.table.ts
+++ b/backend/src/fiches/models/fiche-action-libre-tag.table.ts
@@ -6,8 +6,12 @@ import { ficheActionTable } from './fiche-action.table';
 export const ficheActionLibreTagTable = pgTable(
   'fiche_action_libre_tag',
   {
-    ficheId: integer('fiche_id').references(() => ficheActionTable.id),
-    libreTagId: integer('libre_tag_id').references(() => libreTagTable.id),
+    ficheId: integer('fiche_id').references(() => ficheActionTable.id, {
+      onDelete: 'cascade',
+    }),
+    libreTagId: integer('libre_tag_id').references(() => libreTagTable.id, {
+      onDelete: 'cascade',
+    }),
     createdAt,
     createdBy,
   },

--- a/backend/src/fiches/models/fiche-action-note.table.ts
+++ b/backend/src/fiches/models/fiche-action-note.table.ts
@@ -13,8 +13,8 @@ import { ficheActionTable } from './fiche-action.table';
 export const ficheActionNoteTable = pgTable('fiche_action_note', {
   id: serial('id').primaryKey(),
   ficheId: integer('fiche_id')
-    .references(() => ficheActionTable.id)
-    .notNull(),
+    .notNull()
+    .references(() => ficheActionTable.id, { onDelete: 'cascade' }),
   dateNote: date('date_note').notNull(),
   note: text('note').notNull(),
   createdAt,

--- a/backend/src/fiches/models/fiche-action-partenaire-tag.table.ts
+++ b/backend/src/fiches/models/fiche-action-partenaire-tag.table.ts
@@ -1,13 +1,16 @@
 import { integer, pgTable, primaryKey } from 'drizzle-orm/pg-core';
-import { ficheActionTable } from './fiche-action.table';
 import { partenaireTagTable } from '../../taxonomie/models/partenaire-tag.table';
+import { ficheActionTable } from './fiche-action.table';
 
 export const ficheActionPartenaireTagTable = pgTable(
   'fiche_action_partenaire_tag',
   {
-    ficheId: integer('fiche_id').references(() => ficheActionTable.id),
+    ficheId: integer('fiche_id').references(() => ficheActionTable.id, {
+      onDelete: 'cascade',
+    }),
     partenaireTagId: integer('partenaire_tag_id').references(
-      () => partenaireTagTable.id
+      () => partenaireTagTable.id,
+      { onDelete: 'cascade' }
     ),
   },
   (table) => {

--- a/backend/src/fiches/models/fiche-action-service-tag.table.ts
+++ b/backend/src/fiches/models/fiche-action-service-tag.table.ts
@@ -1,13 +1,16 @@
 import { integer, pgTable, primaryKey } from 'drizzle-orm/pg-core';
-import { ficheActionTable } from './fiche-action.table';
 import { serviceTagTable } from '../../taxonomie/models/service-tag.table';
+import { ficheActionTable } from './fiche-action.table';
 
 export const ficheActionServiceTagTable = pgTable(
   'fiche_action_service_tag',
   {
-    ficheId: integer('fiche_id').references(() => ficheActionTable.id),
+    ficheId: integer('fiche_id').references(() => ficheActionTable.id, {
+      onDelete: 'cascade',
+    }),
     serviceTagId: integer('service_tag_id').references(
-      () => serviceTagTable.id
+      () => serviceTagTable.id,
+      { onDelete: 'cascade' }
     ),
   },
   (table) => {

--- a/backend/src/fiches/models/fiche-action-structure-tag.table.ts
+++ b/backend/src/fiches/models/fiche-action-structure-tag.table.ts
@@ -1,13 +1,16 @@
 import { integer, pgTable, primaryKey } from 'drizzle-orm/pg-core';
-import { ficheActionTable } from './fiche-action.table';
 import { structureTagTable } from '../../taxonomie/models/structure-tag.table';
+import { ficheActionTable } from './fiche-action.table';
 
 export const ficheActionStructureTagTable = pgTable(
   'fiche_action_structure_tag',
   {
-    ficheId: integer('fiche_id').references(() => ficheActionTable.id),
+    ficheId: integer('fiche_id').references(() => ficheActionTable.id, {
+      onDelete: 'cascade',
+    }),
     structureTagId: integer('structure_tag_id').references(
-      () => structureTagTable.id
+      () => structureTagTable.id,
+      { onDelete: 'cascade' }
     ),
   },
   (table) => {

--- a/data_layer/sqitch/deploy/plan_action/fiches.sql
+++ b/data_layer/sqitch/deploy/plan_action/fiches.sql
@@ -2,8 +2,85 @@
 
 BEGIN;
 
-ALTER TABLE public.fiche_action_pilote
-ADD CONSTRAINT either_user_or_tag_not_null
-CHECK (user_id IS NOT NULL OR tag_id IS NOT NULL);
+-- Cascade on fiche_action_note.fiche_id
+ALTER TABLE fiche_action_note
+DROP CONSTRAINT fiche_action_note_fiche_id_fkey;
+
+ALTER TABLE fiche_action_note
+ADD CONSTRAINT fiche_action_note_fiche_id_fkey
+FOREIGN KEY (fiche_id)
+REFERENCES public.fiche_action(id)
+ON DELETE CASCADE;
+
+-- Cascade on fiche_action_note.created_by
+ALTER TABLE fiche_action_note
+DROP CONSTRAINT fiche_action_note_created_by_fkey;
+
+ALTER TABLE fiche_action_note
+ADD CONSTRAINT fiche_action_note_created_by_fkey
+FOREIGN KEY (created_by)
+REFERENCES auth.users(id)
+ON DELETE CASCADE;
+
+-- Cascade on fiche_action_note.modified_by
+ALTER TABLE fiche_action_note
+DROP CONSTRAINT fiche_action_note_modified_by_fkey;
+
+ALTER TABLE fiche_action_note
+ADD CONSTRAINT fiche_action_note_modified_by_fkey
+FOREIGN KEY (modified_by)
+REFERENCES auth.users(id)
+ON DELETE CASCADE;
+
+-- Cascade on fiche_action_libre_tag.created_by
+ALTER TABLE fiche_action_libre_tag
+DROP CONSTRAINT fiche_action_libre_tag_created_by_fkey;
+
+ALTER TABLE fiche_action_libre_tag
+ADD CONSTRAINT fiche_action_libre_tag_created_by_fkey
+FOREIGN KEY (created_by)
+REFERENCES auth.users(id)
+ON DELETE CASCADE;
+
+-- Cascade on fiche_action_libre_tag.libre_tag_id
+ALTER TABLE fiche_action_libre_tag
+DROP CONSTRAINT fiche_action_libre_tag_libre_tag_id_fkey;
+
+ALTER TABLE fiche_action_libre_tag
+ADD CONSTRAINT fiche_action_libre_tag_libre_tag_id_fkey
+FOREIGN KEY (libre_tag_id)
+REFERENCES public.libre_tag(id)
+ON DELETE CASCADE;
+
+-- Cascade on fiche_action_partenaire_tag.partenaire_tag_id
+ALTER TABLE fiche_action_partenaire_tag
+DROP CONSTRAINT fiche_action_partenaire_tag_partenaire_tag_id_fkey;
+
+ALTER TABLE fiche_action_partenaire_tag
+ADD CONSTRAINT fiche_action_partenaire_tag_partenaire_tag_id_fkey
+FOREIGN KEY (partenaire_tag_id)
+REFERENCES public.partenaire_tag(id)
+ON DELETE CASCADE;
+
+-- Cascade on fiche_action_service_tag.fiche_id
+ALTER TABLE fiche_action_service_tag
+DROP CONSTRAINT fiche_action_service_tag_fiche_id_fkey;
+
+ALTER TABLE fiche_action_service_tag
+ADD CONSTRAINT fiche_action_service_tag_fiche_id_fkey
+FOREIGN KEY (fiche_id)
+REFERENCES public.fiche_action(id)
+ON DELETE CASCADE;
+
+-- Cascade on fiche_action_structure_tag.fiche_id
+ALTER TABLE fiche_action_structure_tag
+DROP CONSTRAINT fiche_action_structure_tag_fiche_id_fkey;
+
+ALTER TABLE fiche_action_structure_tag
+ADD CONSTRAINT fiche_action_structure_tag_fiche_id_fkey
+FOREIGN KEY (fiche_id)
+REFERENCES public.fiche_action(id)
+ON DELETE CASCADE;
 
 COMMIT;
+

--- a/data_layer/sqitch/deploy/plan_action/fiches@v4.33.0.sql
+++ b/data_layer/sqitch/deploy/plan_action/fiches@v4.33.0.sql
@@ -1,0 +1,9 @@
+-- Deploy tet:plan_action/fiches to pg
+
+BEGIN;
+
+ALTER TABLE public.fiche_action_pilote
+ADD CONSTRAINT either_user_or_tag_not_null
+CHECK (user_id IS NOT NULL OR tag_id IS NOT NULL);
+
+COMMIT;

--- a/data_layer/sqitch/revert/plan_action/fiches.sql
+++ b/data_layer/sqitch/revert/plan_action/fiches.sql
@@ -1,8 +1,85 @@
--- Deploy tet:plan_action/fiches to pg
+-- Revert tet:plan_action/fiches from pg
 
 BEGIN;
 
-ALTER TABLE public.fiche_action_pilote
-DROP CONSTRAINT IF EXISTS either_user_or_tag_not_null;
+-- Cascade on fiche_action_note.fiche_id
+ALTER TABLE fiche_action_note
+DROP CONSTRAINT fiche_action_note_fiche_id_fkey;
+
+ALTER TABLE fiche_action_note
+ADD CONSTRAINT fiche_action_note_fiche_id_fkey
+FOREIGN KEY (fiche_id)
+REFERENCES fiche_action(id)
+;
+
+-- Cascade on fiche_action_note.created_by
+ALTER TABLE fiche_action_note
+DROP CONSTRAINT fiche_action_note_created_by_fkey;
+
+ALTER TABLE fiche_action_note
+ADD CONSTRAINT fiche_action_note_created_by_fkey
+FOREIGN KEY (created_by)
+REFERENCES auth.users(id)
+;
+
+-- Cascade on fiche_action_note.modified_by
+ALTER TABLE fiche_action_note
+DROP CONSTRAINT fiche_action_note_modified_by_fkey;
+
+ALTER TABLE fiche_action_note
+ADD CONSTRAINT fiche_action_note_modified_by_fkey
+FOREIGN KEY (modified_by)
+REFERENCES auth.users(id)
+;
+
+-- Cascade on fiche_action_libre_tag.created_by
+ALTER TABLE fiche_action_libre_tag
+DROP CONSTRAINT fiche_action_libre_tag_created_by_fkey;
+
+ALTER TABLE fiche_action_libre_tag
+ADD CONSTRAINT fiche_action_libre_tag_created_by_fkey
+FOREIGN KEY (created_by)
+REFERENCES auth.users(id)
+;
+
+-- Cascade on fiche_action_libre_tag.libre_tag_id
+ALTER TABLE fiche_action_libre_tag
+DROP CONSTRAINT fiche_action_libre_tag_libre_tag_id_fkey;
+
+ALTER TABLE fiche_action_libre_tag
+ADD CONSTRAINT fiche_action_libre_tag_libre_tag_id_fkey
+FOREIGN KEY (libre_tag_id)
+REFERENCES public.libre_tag(id)
+;
+
+-- Cascade on fiche_action_partenaire_tag.partenaire_tag_id
+ALTER TABLE fiche_action_partenaire_tag
+DROP CONSTRAINT fiche_action_partenaire_tag_partenaire_tag_id_fkey;
+
+ALTER TABLE fiche_action_partenaire_tag
+ADD CONSTRAINT fiche_action_partenaire_tag_partenaire_tag_id_fkey
+FOREIGN KEY (partenaire_tag_id)
+REFERENCES public.partenaire_tag(id)
+;
+
+-- Cascade on fiche_action_service_tag.fiche_id
+ALTER TABLE fiche_action_service_tag
+DROP CONSTRAINT fiche_action_service_tag_fiche_id_fkey;
+
+ALTER TABLE fiche_action_service_tag
+ADD CONSTRAINT fiche_action_service_tag_fiche_id_fkey
+FOREIGN KEY (fiche_id)
+REFERENCES public.fiche_action(id)
+;
+
+-- Cascade on fiche_action_structure_tag.fiche_id
+ALTER TABLE fiche_action_structure_tag
+DROP CONSTRAINT fiche_action_structure_tag_fiche_id_fkey;
+
+ALTER TABLE fiche_action_structure_tag
+ADD CONSTRAINT fiche_action_structure_tag_fiche_id_fkey
+FOREIGN KEY (fiche_id)
+REFERENCES public.fiche_action(id)
+;
 
 COMMIT;

--- a/data_layer/sqitch/revert/plan_action/fiches@v4.33.0.sql
+++ b/data_layer/sqitch/revert/plan_action/fiches@v4.33.0.sql
@@ -1,0 +1,8 @@
+-- Deploy tet:plan_action/fiches to pg
+
+BEGIN;
+
+ALTER TABLE public.fiche_action_pilote
+DROP CONSTRAINT IF EXISTS either_user_or_tag_not_null;
+
+COMMIT;

--- a/data_layer/sqitch/sqitch.plan
+++ b/data_layer/sqitch/sqitch.plan
@@ -790,3 +790,4 @@ plan_action/fiche_note [plan_action/fiche_note@v4.28.1] 2024-12-02T09:23:16Z Mar
 indicateur/change_unite_emission_ges 2024-10-16T21:13:38Z System Administrator <root@AirdeThibaut2.lan> # changement d'unité des indicateurs d'emission GES teq CO2 vers kteq CO2
 @v4.33.0 2024-12-16T10:55:49Z System Administrator <root@MacBook-Air-de-Thibaut-2.local> # changement d'unité des indicateurs d'emission GES teq CO2 vers kteq CO2
 
+plan_action/fiches [plan_action/fiches@v4.33.0] 2024-12-17T14:05:30Z Frederic Arnoux <frederic.arnoux@beta.gouv.fr> # Add cascade constraints

--- a/data_layer/sqitch/verify/plan_action/fiches.sql
+++ b/data_layer/sqitch/verify/plan_action/fiches.sql
@@ -2,4 +2,13 @@
 
 BEGIN;
 
+SELECT tc.constraint_name,
+       rc.delete_rule
+FROM information_schema.table_constraints tc
+JOIN information_schema.referential_constraints rc
+    ON tc.constraint_name = rc.constraint_name
+WHERE tc.table_name = 'fiche_action_note'
+    AND tc.constraint_name = 'fiche_action_note_fiche_id_fkey'
+    AND rc.delete_rule = 'CASCADE';
+
 ROLLBACK;

--- a/data_layer/sqitch/verify/plan_action/fiches@v4.33.0.sql
+++ b/data_layer/sqitch/verify/plan_action/fiches@v4.33.0.sql
@@ -1,0 +1,5 @@
+-- Verify tet:plan_action/fiches on pg
+
+BEGIN;
+
+ROLLBACK;


### PR DESCRIPTION
Ajoute des cascade delete sur les tables liées à la fiche action car par exemple pour les notes, ça empêche la suppression d'une fiche (et du plan au dessus)