### PR TITLE
fix: show "Aucune fiche action ne correspond à votre recherche"

### DIFF
--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/ToutesLesFichesAction/FichesActionListe.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/ToutesLesFichesAction/FichesActionListe.tsx
@@ -27,6 +27,7 @@ import { FicheResume } from 'packages/api/src/plan-actions';
 import ActionsGroupeesMenu from '../ActionsGroupees/ActionsGroupeesMenu';
 import EmptyFichePicto from '../FicheAction/FichesLiees/EmptyFichePicto';
 import { useCreateFicheAction } from '../FicheAction/data/useCreateFicheAction';
+import { useFicheActionCount } from '../FicheAction/data/useFicheActionCount';
 import { useCreatePlanAction } from '../PlanAction/data/useUpsertAxe';
 
 type sortByOptionsType = SortFichesAction & {
@@ -140,10 +141,7 @@ const FichesActionListe = ({
   const { data, isLoading } = useFicheResumesFetch({
     options: ficheResumesOptions,
   });
-
-  const { data: ficheExistenceData } = useFicheResumesFetch();
-
-  const hasFiches = !!ficheExistenceData?.data?.length;
+  const { count: hasFiches } = useFicheActionCount();
 
   /** Gère les fiches sélectionnées pour les actions groupées */
   const handleSelectFiche = (fiche: FicheResume) => {

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/ToutesLesFichesAction/FichesActionListe.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/ToutesLesFichesAction/FichesActionListe.tsx
@@ -140,7 +140,10 @@ const FichesActionListe = ({
   const { data, isLoading } = useFicheResumesFetch({
     options: ficheResumesOptions,
   });
-  const hasFiches = !!data?.data?.length;
+
+  const { data: ficheExistenceData } = useFicheResumesFetch();
+
+  const hasFiches = !!ficheExistenceData?.data?.length;
 
   /** Gère les fiches sélectionnées pour les actions groupées */
   const handleSelectFiche = (fiche: FicheResume) => {


### PR DESCRIPTION
Bug identifié : quand aucune fiche action ne correspond à la recherche, l'état "Vous n'avez pas encore créé de FA" s'affiche au lieu de "Aucune fiche action ne correspond à votre recherche".

@marc-rutkowski je crois que ce bug est introduit par un bug fix que tu as fait (à raison ! Le bug était que les FA ne s'affichaient pas à partir des pages "actions dont je suis responsable" et "actions récentes"). Cette fois, je crois que c'est bon, mais dis-moi si jamais tu vois une solution plus proprette :) 