### PR TITLE
Découpe la page détail des indicateurs avec des onglets

### DIFF
--- a/app.territoiresentransitions.react/src/app/pages/collectivite/CollectivitePageLayout/CollectivitePageLayout.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/CollectivitePageLayout/CollectivitePageLayout.tsx
@@ -1,12 +1,12 @@
+import classNames from 'classnames';
 import React, { useEffect, useMemo, useState } from 'react';
-import SideNavContainer, { SideNavContainerProps } from './SideNavContainer';
+import Panel from './Panel/Panel';
 import {
   PanelProvider,
   usePanelDispatch,
   usePanelState,
 } from './Panel/PanelContext';
-import classNames from 'classnames';
-import Panel from './Panel/Panel';
+import SideNavContainer, { SideNavContainerProps } from './SideNavContainer';
 
 type Props = {
   children: React.ReactNode;
@@ -62,7 +62,7 @@ const PageLayout = ({ children, sideNav, dataTest }: Props) => {
   return (
     <div
       data-test={dataTest}
-      className={`grid ${gridCols} m-auto xl:max-w-[90rem] 2xl:px-6`}
+      className={`grid ${gridCols} mx-auto xl:max-w-[90rem] 2xl:px-6`}
     >
       {/** Side nav */}
       {sideNav && (

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/Indicateur/FichesActionLiees.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/Indicateur/FichesActionLiees.tsx
@@ -26,7 +26,7 @@ export const FichesActionLiees = (props: TFichesActionProps) => {
   const isReadonly = collectivite?.isReadOnly ?? false;
 
   return (
-    <>
+    <div className="flex flex-col gap-8">
       <Field title="Fiches des plans liées">
         <FichesActionsDropdown
           disabled={isReadonly}
@@ -42,6 +42,6 @@ export const FichesActionLiees = (props: TFichesActionProps) => {
       </Field>
 
       <FichesLieesListe fiches={fiches ?? []} />
-    </>
+    </div>
   );
 };

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/Indicateur/Indicateur.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/Indicateur/Indicateur.tsx
@@ -8,7 +8,7 @@ import {
 import { useCollectiviteId } from '@/app/core-logic/hooks/params';
 import { redirect } from 'next/navigation';
 import { useParams } from 'react-router-dom';
-import { IndicateurPersonnalise } from './IndicateurPersonnalise';
+import IndicateurDetail from '../detail/IndicateurDetail';
 import { IndicateurPredefini } from './IndicateurPredefini';
 
 /**
@@ -49,7 +49,8 @@ const Indicateur = () => {
       }
     >
       {isPerso ? (
-        <IndicateurPersonnalise indicateurId={indicateurId as number} />
+        // <IndicateurPersonnalise indicateurId={indicateurId as number} />
+        <IndicateurDetail indicateurId={indicateurId} isPerso />
       ) : (
         <IndicateurPredefini indicateurId={indicateurId} />
       )}

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/Indicateur/Indicateur.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/Indicateur/Indicateur.tsx
@@ -9,7 +9,6 @@ import { useCollectiviteId } from '@/app/core-logic/hooks/params';
 import { redirect } from 'next/navigation';
 import { useParams } from 'react-router-dom';
 import IndicateurDetail from '../detail/IndicateurDetail';
-import { IndicateurPredefini } from './IndicateurPredefini';
 
 /**
  * Affiche le détail d'un indicateur
@@ -42,19 +41,12 @@ const Indicateur = () => {
   }
 
   return (
-    <div
-      className="w-full"
-      data-test={
+    <IndicateurDetail
+      dataTest={
         indicateurId !== undefined ? `ind-${indicateurId}` : `ind-v-${view}`
       }
-    >
-      {isPerso ? (
-        // <IndicateurPersonnalise indicateurId={indicateurId as number} />
-        <IndicateurDetail indicateurId={indicateurId} isPerso />
-      ) : (
-        <IndicateurPredefini indicateurId={indicateurId} />
-      )}
-    </div>
+      {...{ indicateurId, isPerso }}
+    />
   );
 };
 

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/Indicateur/detail/HeaderIndicateur.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/Indicateur/detail/HeaderIndicateur.tsx
@@ -52,7 +52,7 @@ export const HeaderIndicateur = ({
   return (
     <div
       className={classNames(
-        'mt-4 group sticky top-0 flex items-center mx-auto py-6 px-6 text-grey-9 bg-bf925 z-40',
+        'group sticky top-0 flex items-center mx-auto py-6 px-6 text-grey-9 bg-bf925 z-40',
         { 'cursor-text': !isReadonly }
       )}
       onClick={!isReadonly ? handleEditFocus : undefined}
@@ -62,17 +62,22 @@ export const HeaderIndicateur = ({
           data-test="HeaderTitleInput"
           ref={titreInputRef}
           className={classNames(
-            'w-full leading-snug !outline-none !resize-none !text-lg'
+            'w-full leading-snug !outline-none !resize-none !text-lg',
+            {
+              '!cursor-default disabled:!text-grey-9': isReadonly,
+            }
           )}
           initialValue={title}
           placeholder={'Sans titre'}
           onBlur={handleChangeTitle}
           disabled={isReadonly}
         />
-        <Icon
-          icon="edit-line"
-          className="my-auto ml-6 hidden group-hover:block"
-        />
+        {!isReadonly && (
+          <Icon
+            icon="edit-line"
+            className="my-auto ml-6 hidden group-hover:block"
+          />
+        )}
       </div>
     </div>
   );

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/Indicateur/detail/IndicateurCompose.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/Indicateur/detail/IndicateurCompose.tsx
@@ -59,7 +59,9 @@ export const IndicateurCompose = ({
   );
 };
 // détermine les actions liées communes à un ensemble de définitions
-const findCommonLinkedActions = (definitions: IndicateurDefinition[]) => {
+export const findCommonLinkedActions = (
+  definitions: IndicateurDefinition[]
+) => {
   // extrait les tableaux d'ids
   const actionsIds = definitions.map(({ actions }) => actions.map((a) => a.id));
 

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/Indicateur/detail/IndicateurInfoLiees.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/Indicateur/detail/IndicateurInfoLiees.tsx
@@ -56,7 +56,7 @@ export const IndicateurInfoLiees = (props: TIndicateurInfoLieesProps) => {
     .filter((id) => !!id) as string[];
 
   return (
-    <>
+    <div className="flex flex-col gap-8">
       {/** personne pilote */}
       <Field title="Personne pilote">
         <PersonnesDropdown
@@ -97,6 +97,6 @@ export const IndicateurInfoLiees = (props: TIndicateurInfoLieesProps) => {
           />
         </Field>
       )}
-    </>
+    </div>
   );
 };

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/components/BadgeIndicateurPerso.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/components/BadgeIndicateurPerso.tsx
@@ -10,7 +10,7 @@ const BadgeIndicateurPerso = ({ size }: Props) => {
       size={size}
       light
       iconPosition="left"
-      icon="line-chart-line"
+      icon="user-line"
     />
   );
 };

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/ActionsLiees.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/ActionsLiees.tsx
@@ -1,0 +1,33 @@
+import { EmptyCard } from '@/ui';
+import ActionPicto from '../../PlansActions/FicheAction/ActionsLiees/ActionPicto';
+import ActionsLieesListe from '../../PlansActions/FicheAction/ActionsLiees/ActionsLieesListe';
+
+type Props = {
+  actionsIds: string[];
+};
+
+const ActionsLiees = ({ actionsIds }: Props) => {
+  const isEmpty = actionsIds.length === 0;
+
+  return isEmpty ? (
+    <EmptyCard
+      picto={(props) => <ActionPicto {...props} />}
+      title="Aucune action des référentiels n'est liée !"
+      size="xs"
+    />
+  ) : (
+    <div>
+      <div className="w-full border-b border-primary-3 mb-6">
+        <h6 className="text-lg h-[2.125rem] mb-5">
+          Actions du référentiel associées
+        </h6>
+      </div>
+      <ActionsLieesListe
+        actionsIds={actionsIds}
+        className="sm:grid-cols-2 md:grid-cols-3"
+      />
+    </div>
+  );
+};
+
+export default ActionsLiees;

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/ActionsLiees.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/ActionsLiees.tsx
@@ -19,7 +19,7 @@ const ActionsLiees = ({ actionsIds }: Props) => {
     <div>
       <div className="w-full border-b border-primary-3 mb-6">
         <h6 className="text-lg h-[2.125rem] mb-5">
-          Actions du référentiel associées
+          Actions des référentiels liées
         </h6>
       </div>
       <ActionsLieesListe

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/DescriptionIndicateurInput.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/DescriptionIndicateurInput.tsx
@@ -1,0 +1,26 @@
+import { AutoResizedTextarea, Field } from '@/ui';
+
+type Props = {
+  description: string | undefined | null;
+  disabled?: boolean;
+  updateDescription: (value: string) => void;
+};
+
+const DescriptionIndicateurInput = ({
+  description,
+  disabled,
+  updateDescription,
+}: Props) => {
+  return (
+    <Field title="Description et méthodologie de calcul">
+      <AutoResizedTextarea
+        data-test="desc"
+        value={description ?? undefined}
+        disabled={disabled}
+        onBlur={(evt) => updateDescription(evt.currentTarget.value)}
+      />
+    </Field>
+  );
+};
+
+export default DescriptionIndicateurInput;

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/DonneesIndicateur.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/DonneesIndicateur.tsx
@@ -1,0 +1,61 @@
+import IndicateurDetailChart from '../Indicateur/detail/IndicateurDetailChart';
+import { IndicateurInfoLiees } from '../Indicateur/detail/IndicateurInfoLiees';
+import { IndicateurValuesTabs } from '../Indicateur/detail/IndicateurValuesTabs';
+import { TIndicateurDefinition } from '../types';
+import DescriptionIndicateurInput from './DescriptionIndicateurInput';
+import UniteIndicateurInput from './UniteIndicateurInput';
+
+type Props = {
+  definition: TIndicateurDefinition;
+  isPerso?: boolean;
+  isReadonly?: boolean;
+  updateUnite: (value: string) => void;
+  updateDescription: (value: string) => void;
+};
+
+const DonneesIndicateur = ({
+  definition,
+  isPerso = false,
+  isReadonly = false,
+  updateUnite,
+  updateDescription,
+}: Props) => {
+  const { description, unite, rempli, titre } = definition;
+
+  return (
+    <div className="flex flex-col gap-8">
+      {/* Graphe */}
+      <IndicateurDetailChart
+        className="mb-8"
+        definition={definition}
+        rempli={rempli}
+        titre={titre}
+        fileName={titre}
+      />
+
+      {/* Tableau */}
+      <IndicateurValuesTabs definition={definition} />
+
+      {/* Description */}
+      <DescriptionIndicateurInput
+        description={description}
+        updateDescription={updateDescription}
+        disabled={isReadonly}
+      />
+
+      {/* Infos liées - à déplacer */}
+      <IndicateurInfoLiees definition={definition} />
+
+      {/* Unité personnalisée - à déplacer */}
+      {isPerso && (
+        <UniteIndicateurInput
+          unite={unite}
+          updateUnite={updateUnite}
+          disabled={isReadonly}
+        />
+      )}
+    </div>
+  );
+};
+
+export default DonneesIndicateur;

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/DonneesIndicateur.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/DonneesIndicateur.tsx
@@ -1,6 +1,8 @@
+import { ImportSourcesSelector } from '../Indicateur/detail/ImportSourcesSelector';
 import IndicateurDetailChart from '../Indicateur/detail/IndicateurDetailChart';
 import { IndicateurInfoLiees } from '../Indicateur/detail/IndicateurInfoLiees';
 import { IndicateurValuesTabs } from '../Indicateur/detail/IndicateurValuesTabs';
+import { useIndicateurImportSources } from '../Indicateur/detail/useImportSources';
 import { TIndicateurDefinition } from '../types';
 import DescriptionIndicateurInput from './DescriptionIndicateurInput';
 import UniteIndicateurInput from './UniteIndicateurInput';
@@ -20,25 +22,42 @@ const DonneesIndicateur = ({
   updateUnite,
   updateDescription,
 }: Props) => {
-  const { description, unite, rempli, titre } = definition;
+  const { description, commentaire, unite, rempli, titre, titreLong } =
+    definition;
+
+  const { sources, currentSource, setCurrentSource } =
+    useIndicateurImportSources(definition.id);
 
   return (
     <div className="flex flex-col gap-8">
+      {!!sources?.length && (
+        <ImportSourcesSelector
+          definition={definition}
+          sources={sources}
+          currentSource={currentSource}
+          setCurrentSource={setCurrentSource}
+        />
+      )}
+
       {/* Graphe */}
       <IndicateurDetailChart
         className="mb-8"
         definition={definition}
+        source={currentSource}
         rempli={rempli}
-        titre={titre}
+        titre={titreLong || titre}
         fileName={titre}
       />
 
       {/* Tableau */}
-      <IndicateurValuesTabs definition={definition} />
+      <IndicateurValuesTabs
+        definition={definition}
+        importSource={currentSource}
+      />
 
       {/* Description */}
       <DescriptionIndicateurInput
-        description={description}
+        description={isPerso ? description : commentaire}
         updateDescription={updateDescription}
         disabled={isReadonly}
       />

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/FichesLiees.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/FichesLiees.tsx
@@ -1,0 +1,85 @@
+import { Button, EmptyCard } from '@/ui';
+import { useState } from 'react';
+import { objectToSnake } from 'ts-case-convert';
+import FichePicto from '../../PlansActions/FicheAction/FichesLiees/FichePicto';
+import ModaleFichesLiees from '../../PlansActions/FicheAction/FichesLiees/ModaleFichesLiees';
+import FichesActionListe from '../../PlansActions/ToutesLesFichesAction/FichesActionListe';
+import {
+  useFichesActionLiees,
+  useUpdateFichesActionLiees,
+} from '../Indicateur/useFichesActionLiees';
+import { TIndicateurDefinition } from '../types';
+
+type Props = {
+  definition: TIndicateurDefinition;
+  isReadonly: boolean;
+};
+
+const FichesLiees = ({ definition, isReadonly }: Props) => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const { data: fiches } = useFichesActionLiees(definition);
+  const fichesLiees = (fiches ? objectToSnake(fiches) : []).map((f) => f.id);
+
+  const { mutate: updateFichesActionLiees } =
+    useUpdateFichesActionLiees(definition);
+
+  const isEmpty = fiches.length === 0;
+
+  return (
+    <>
+      {isEmpty ? (
+        <EmptyCard
+          picto={(props) => <FichePicto {...props} />}
+          title="Aucune fiche action de vos plans d'actions n'est liée !"
+          isReadonly={isReadonly}
+          actions={[
+            {
+              children: 'Lier une fiche action',
+              icon: 'link',
+              onClick: () => setIsModalOpen(true),
+            },
+          ]}
+          size="xs"
+        />
+      ) : (
+        <div>
+          <div className="flex justify-between items-center flex-wrap mb-5">
+            <h6 className="text-lg mb-0">Fiches des plans liées</h6>
+            {!isReadonly && (
+              <Button
+                icon="link"
+                size="xs"
+                className="w-fit"
+                onClick={() => setIsModalOpen(true)}
+              >
+                Lier une fiche action
+              </Button>
+            )}
+          </div>
+          <FichesActionListe
+            filtres={{ ficheActionIds: fichesLiees }}
+            sortSettings={{
+              defaultSort: 'titre',
+            }}
+            isReadOnly={isReadonly}
+            enableGroupedActions
+            containeClassName="bg-white"
+          />
+        </div>
+      )}
+
+      {isModalOpen && (
+        <ModaleFichesLiees
+          isOpen={isModalOpen && !isReadonly}
+          setIsOpen={setIsModalOpen}
+          currentFicheId={null}
+          linkedFicheIds={fichesLiees}
+          updateLinkedFicheIds={updateFichesActionLiees}
+        />
+      )}
+    </>
+  );
+};
+
+export default FichesLiees;

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/FichesLiees.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/FichesLiees.tsx
@@ -65,6 +65,11 @@ const FichesLiees = ({ definition, isReadonly }: Props) => {
             isReadOnly={isReadonly}
             enableGroupedActions
             containerClassName="bg-white"
+            onUnlink={(ficheId) =>
+              updateFichesActionLiees(
+                fichesLiees.filter((id) => id !== ficheId)
+              )
+            }
           />
         </div>
       )}

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/FichesLiees.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/FichesLiees.tsx
@@ -64,7 +64,7 @@ const FichesLiees = ({ definition, isReadonly }: Props) => {
             }}
             isReadOnly={isReadonly}
             enableGroupedActions
-            containeClassName="bg-white"
+            containerClassName="bg-white"
           />
         </div>
       )}

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/IndicateurDetail.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/IndicateurDetail.tsx
@@ -1,0 +1,17 @@
+import { useIndicateurDefinition } from '../Indicateur/useIndicateurDefinition';
+import IndicateurLayout from './IndicateurLayout';
+
+type Props = {
+  indicateurId: number | string;
+  isPerso?: boolean;
+};
+
+const IndicateurDetail = ({ indicateurId, isPerso = false }: Props) => {
+  const definition = useIndicateurDefinition(indicateurId);
+
+  if (!definition) return null;
+
+  return <IndicateurLayout definition={definition} isPerso={isPerso} />;
+};
+
+export default IndicateurDetail;

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/IndicateurDetail.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/IndicateurDetail.tsx
@@ -2,16 +2,21 @@ import { useIndicateurDefinition } from '../Indicateur/useIndicateurDefinition';
 import IndicateurLayout from './IndicateurLayout';
 
 type Props = {
+  dataTest?: string;
   indicateurId: number | string;
   isPerso?: boolean;
 };
 
-const IndicateurDetail = ({ indicateurId, isPerso = false }: Props) => {
+const IndicateurDetail = ({
+  dataTest,
+  indicateurId,
+  isPerso = false,
+}: Props) => {
   const definition = useIndicateurDefinition(indicateurId);
 
   if (!definition) return null;
 
-  return <IndicateurLayout definition={definition} isPerso={isPerso} />;
+  return <IndicateurLayout {...{ dataTest, definition, isPerso }} />;
 };
 
 export default IndicateurDetail;

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/IndicateurLayout.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/IndicateurLayout.tsx
@@ -1,0 +1,131 @@
+import { referentielToName } from '@/app/app/labels';
+import BadgeIndicateurPerso from '@/app/app/pages/collectivite/Indicateurs/components/BadgeIndicateurPerso';
+import { useCurrentCollectivite } from '@/app/core-logic/hooks/useCurrentCollectivite';
+import ScrollTopButton from '@/app/ui/buttons/ScrollTopButton';
+import { BadgeACompleter } from '@/app/ui/shared/Badge/BadgeACompleter';
+import { Badge, Tab, Tabs } from '@/ui';
+import ActionsLieesListe from '../../PlansActions/FicheAction/ActionsLiees/ActionsLieesListe';
+import { FichesActionLiees } from '../Indicateur/FichesActionLiees';
+import { HeaderIndicateur } from '../Indicateur/detail/HeaderIndicateur';
+import { useUpdateIndicateurDefinition } from '../Indicateur/useUpdateIndicateurDefinition';
+import BadgeOpenData from '../components/BadgeOpenData';
+import { TIndicateurDefinition } from '../types';
+import DonneesIndicateur from './DonneesIndicateur';
+import IndicateurToolbar from './IndicateurToolbar';
+
+type IndicateurLayoutProps = {
+  dataTest?: string;
+  definition: TIndicateurDefinition;
+  isPerso?: boolean;
+};
+
+const IndicateurLayout = ({
+  dataTest,
+  definition,
+  isPerso = false,
+}: IndicateurLayoutProps) => {
+  const { titre, rempli } = definition;
+
+  const { mutate: updateDefinition } = useUpdateIndicateurDefinition();
+  const collectivite = useCurrentCollectivite();
+
+  const collectiviteId = collectivite?.collectivite_id;
+  const isReadonly = !collectivite || collectivite?.readonly;
+
+  // Mise à jour des champs de l'indicateur
+  const handleUpdate = (
+    name: 'description' | 'commentaire' | 'unite' | 'titre',
+    value: string
+  ) => {
+    const trimmedValue = value.trim();
+    if (collectiviteId && trimmedValue !== definition[name]) {
+      updateDefinition({ ...definition, [name]: trimmedValue });
+    }
+  };
+
+  const handleTitreUpdate = (value: string) => handleUpdate('titre', value);
+
+  const handleUniteUpdate = (value: string) => handleUpdate('unite', value);
+
+  /**
+   * TEMPORARY: currently, description input feeds two columns:
+   * `description` column in `indicateur_definition`
+   * `commentaire` column in `indicateur_collectivite` (via the hardcoded ['commentaire'] prop).
+   *
+   * TO DO: remove this function and change
+   * handleUpdate('description', e.target.value) to handleUpdate('commentaire', e.target.value).
+   *
+   * Related to this PR: https://github.com/incubateur-ademe/territoires-en-transitions/pull/3313.
+   */
+  const handleDescriptionUpdate = (value: string) => {
+    const trimmedValue = value.trim();
+    updateDefinition({
+      ...definition,
+      description: trimmedValue,
+      commentaire: trimmedValue,
+    });
+  };
+
+  return (
+    <div data-test={dataTest} className="w-full min-h-full !mt-0">
+      <HeaderIndicateur
+        title={titre}
+        isReadonly={isReadonly || !isPerso}
+        onUpdate={handleTitreUpdate}
+      />
+
+      <div className="flex flex-col px-10 py-6">
+        <div className="flex items-center justify-between">
+          <div className="flex gap-2">
+            <BadgeACompleter a_completer={!rempli} />
+            <BadgeIndicateurPerso />
+            {definition.participationScore && (
+              <Badge
+                title={`Participe au score ${referentielToName.cae}`}
+                uppercase={false}
+                state="grey"
+              />
+            )}
+            {definition.hasOpenData && <BadgeOpenData />}
+          </div>
+
+          <IndicateurToolbar
+            {...{ definition, isPerso, isReadonly }}
+            collectiviteId={collectiviteId!}
+          />
+        </div>
+
+        {/* Indicateur sans enfant, groupe d'indicateurs avec agrégation,
+        ou indicateur personnalisé */}
+        <Tabs className="mt-12" tabsListClassName="!justify-start">
+          {/* Données */}
+          <Tab label="Données">
+            <DonneesIndicateur
+              {...{ definition, isPerso, isReadonly }}
+              updateUnite={handleUniteUpdate}
+              updateDescription={handleDescriptionUpdate}
+            />
+          </Tab>
+
+          {/* Actions des référentiels liées */}
+          {!isPerso ? (
+            <Tab label="Actions des référentiels liées">
+              <ActionsLieesListe
+                actionsIds={(definition.actions ?? []).map((a) => a.id)}
+              />
+            </Tab>
+          ) : undefined}
+
+          {/* Fiches des plans liées */}
+          <Tab label="Fiches des plans liées">
+            <FichesActionLiees definition={definition} />
+          </Tab>
+        </Tabs>
+
+        <ScrollTopButton className="mt-8" />
+      </div>
+    </div>
+  );
+};
+
+export default IndicateurLayout;

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/IndicateurLayout.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/IndicateurLayout.tsx
@@ -116,7 +116,7 @@ const IndicateurLayout = ({
           // ou indicateur personnalisé
           <Tabs
             className="mt-12"
-            tabsListClassName="!justify-start flex-nowrap overflow-x-scroll"
+            tabsListClassName="!justify-start flex-nowrap overflow-x-auto"
           >
             {/* Données */}
             <Tab label="Données">

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/IndicateurLayout.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/IndicateurLayout.tsx
@@ -4,11 +4,11 @@ import { useCurrentCollectivite } from '@/app/core-logic/hooks/useCurrentCollect
 import ScrollTopButton from '@/app/ui/buttons/ScrollTopButton';
 import { BadgeACompleter } from '@/app/ui/shared/Badge/BadgeACompleter';
 import { Badge, Tab, Tabs } from '@/ui';
-import ActionsLieesListe from '../../PlansActions/FicheAction/ActionsLiees/ActionsLieesListe';
 import { HeaderIndicateur } from '../Indicateur/detail/HeaderIndicateur';
 import { useUpdateIndicateurDefinition } from '../Indicateur/useUpdateIndicateurDefinition';
 import BadgeOpenData from '../components/BadgeOpenData';
 import { TIndicateurDefinition } from '../types';
+import ActionsLiees from './ActionsLiees';
 import DonneesIndicateur from './DonneesIndicateur';
 import FichesLiees from './FichesLiees';
 import IndicateurToolbar from './IndicateurToolbar';
@@ -141,7 +141,7 @@ const IndicateurLayout = ({
             {/* Actions des référentiels liées */}
             {!isPerso ? (
               <Tab label="Actions des référentiels liées">
-                <ActionsLieesListe
+                <ActionsLiees
                   actionsIds={(definition.actions ?? []).map((a) => a.id)}
                 />
               </Tab>

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/IndicateurLayout.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/IndicateurLayout.tsx
@@ -31,8 +31,8 @@ const IndicateurLayout = ({
 
   const collectivite = useCurrentCollectivite();
 
-  const collectiviteId = collectivite?.collectivite_id;
-  const isReadonly = !collectivite || collectivite?.readonly;
+  const collectiviteId = collectivite?.collectiviteId;
+  const isReadonly = !collectivite || collectivite?.isReadOnly;
 
   const composeSansAgregation = !!enfants && enfants.length > 0 && sansValeur;
   const composeAvecAgregation = !!enfants && enfants.length > 0 && !sansValeur;

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/IndicateurLayout.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/IndicateurLayout.tsx
@@ -5,12 +5,12 @@ import ScrollTopButton from '@/app/ui/buttons/ScrollTopButton';
 import { BadgeACompleter } from '@/app/ui/shared/Badge/BadgeACompleter';
 import { Badge, Tab, Tabs } from '@/ui';
 import ActionsLieesListe from '../../PlansActions/FicheAction/ActionsLiees/ActionsLieesListe';
-import { FichesActionLiees } from '../Indicateur/FichesActionLiees';
 import { HeaderIndicateur } from '../Indicateur/detail/HeaderIndicateur';
 import { useUpdateIndicateurDefinition } from '../Indicateur/useUpdateIndicateurDefinition';
 import BadgeOpenData from '../components/BadgeOpenData';
 import { TIndicateurDefinition } from '../types';
 import DonneesIndicateur from './DonneesIndicateur';
+import FichesLiees from './FichesLiees';
 import IndicateurToolbar from './IndicateurToolbar';
 import SousIndicateurs from './SousIndicateurs';
 
@@ -114,7 +114,10 @@ const IndicateurLayout = ({
         ) : (
           // Indicateur sans enfant, groupe d'indicateurs avec agrégation,
           // ou indicateur personnalisé
-          <Tabs className="mt-12" tabsListClassName="!justify-start">
+          <Tabs
+            className="mt-12"
+            tabsListClassName="!justify-start flex-nowrap overflow-x-scroll"
+          >
             {/* Données */}
             <Tab label="Données">
               <DonneesIndicateur
@@ -146,7 +149,7 @@ const IndicateurLayout = ({
 
             {/* Fiches des plans liées */}
             <Tab label="Fiches des plans liées">
-              <FichesActionLiees definition={definition} />
+              <FichesLiees definition={definition} isReadonly={isReadonly} />
             </Tab>
           </Tabs>
         )}

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/IndicateurToolbar.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/IndicateurToolbar.tsx
@@ -1,0 +1,86 @@
+import { ToolbarIconButton } from '@/app/ui/buttons/ToolbarIconButton';
+import { Modal, ModalFooterOKCancel } from '@/ui';
+import { useState } from 'react';
+import { IndicateurSidePanelToolbar } from '../Indicateur/IndicateurSidePanelToolbar';
+import { useExportIndicateurs } from '../Indicateur/useExportIndicateurs';
+import { useDeleteIndicateurPerso } from '../Indicateur/useRemoveIndicateurPerso';
+import { TIndicateurDefinition } from '../types';
+
+type Props = {
+  definition: TIndicateurDefinition;
+  collectiviteId: number;
+  isPerso?: boolean;
+  isReadonly?: boolean;
+};
+
+const IndicateurToolbar = ({
+  definition,
+  collectiviteId,
+  isPerso = false,
+  isReadonly = false,
+}: Props) => {
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+
+  const { mutate: exportIndicateurs, isLoading } = useExportIndicateurs(
+    isPerso ? 'app/indicateurs/perso' : 'app/indicateurs/predefini',
+    [definition]
+  );
+
+  const { mutate: deleteIndicateurPerso } = useDeleteIndicateurPerso(
+    collectiviteId,
+    definition.id
+  );
+
+  return (
+    <>
+      <div className="flex gap-2">
+        <ToolbarIconButton
+          disabled={isLoading}
+          icon="download"
+          title="Exporter"
+          onClick={() => exportIndicateurs()}
+        />
+        {!isReadonly && isPerso && (
+          <ToolbarIconButton
+            className="text-error-1"
+            disabled={isLoading}
+            icon="delete"
+            title="Supprimer"
+            aria-label="Supprimer"
+            onClick={() => setIsDeleteModalOpen(true)}
+          />
+        )}
+        {!isPerso && <IndicateurSidePanelToolbar definition={definition} />}
+      </div>
+
+      {isDeleteModalOpen && (
+        <Modal
+          openState={{
+            isOpen: isDeleteModalOpen,
+            setIsOpen: setIsDeleteModalOpen,
+          }}
+          title="Suppression de l'indicateur"
+          subTitle={definition.titre}
+          description="Êtes-vous sûr de vouloir supprimer cet indicateur personnalisé ? Vous perdrez définitivement les données associées à cet indicateur."
+          renderFooter={({ close }) => (
+            <ModalFooterOKCancel
+              btnCancelProps={{
+                onClick: () => close(),
+              }}
+              btnOKProps={{
+                'aria-label': 'Supprimer',
+                children: 'Supprimer',
+                onClick: () => {
+                  deleteIndicateurPerso();
+                  close();
+                },
+              }}
+            />
+          )}
+        />
+      )}
+    </>
+  );
+};
+
+export default IndicateurToolbar;

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/IndicateurToolbar.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/IndicateurToolbar.tsx
@@ -1,5 +1,6 @@
 import { ToolbarIconButton } from '@/app/ui/buttons/ToolbarIconButton';
 import { Modal, ModalFooterOKCancel } from '@/ui';
+import classNames from 'classnames';
 import { useState } from 'react';
 import { IndicateurSidePanelToolbar } from '../Indicateur/IndicateurSidePanelToolbar';
 import { useExportIndicateurs } from '../Indicateur/useExportIndicateurs';
@@ -11,6 +12,7 @@ type Props = {
   collectiviteId: number;
   isPerso?: boolean;
   isReadonly?: boolean;
+  className?: string;
 };
 
 const IndicateurToolbar = ({
@@ -18,6 +20,7 @@ const IndicateurToolbar = ({
   collectiviteId,
   isPerso = false,
   isReadonly = false,
+  className,
 }: Props) => {
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
@@ -33,7 +36,7 @@ const IndicateurToolbar = ({
 
   return (
     <>
-      <div className="flex gap-2">
+      <div className={classNames('flex gap-2', className)}>
         <ToolbarIconButton
           disabled={isLoading}
           icon="download"

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/IndicateurToolbar.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/IndicateurToolbar.tsx
@@ -30,7 +30,6 @@ const IndicateurToolbar = ({
   );
 
   const { mutate: deleteIndicateurPerso } = useDeleteIndicateurPerso(
-    collectiviteId,
     definition.id
   );
 

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/SousIndicateurs.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/SousIndicateurs.tsx
@@ -1,0 +1,41 @@
+import { findCommonLinkedActions } from '../Indicateur/detail/IndicateurCompose';
+import { IndicateurEnfant } from '../Indicateur/detail/IndicateurEnfant';
+import { useIndicateurDefinitions } from '../Indicateur/useIndicateurDefinition';
+import { TIndicateurDefinition } from '../types';
+
+type Props = {
+  definition: TIndicateurDefinition;
+  enfantsIds: number[];
+};
+
+const SousIndicateurs = ({ definition, enfantsIds }: Props) => {
+  const { data: enfants } = useIndicateurDefinitions(definition.id, enfantsIds);
+
+  if (!enfants?.length) return null;
+
+  const actionsLieesCommunes = findCommonLinkedActions([
+    definition,
+    ...enfants,
+  ]);
+
+  const enfantsTries = enfants.sort((a, b) => {
+    if (!a.identifiant || !b.identifiant) {
+      return 0;
+    }
+    return a.identifiant.localeCompare(b.identifiant);
+  });
+
+  return (
+    <div>
+      {enfantsTries.map((enfant) => (
+        <IndicateurEnfant
+          key={enfant.id}
+          definition={enfant}
+          actionsLieesCommunes={actionsLieesCommunes}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default SousIndicateurs;

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/UniteIndicateurInput.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/UniteIndicateurInput.tsx
@@ -1,0 +1,26 @@
+import { Field, Input } from '@/ui';
+import { useState } from 'react';
+
+type Props = {
+  unite: string;
+  disabled?: boolean;
+  updateUnite: (value: string) => void;
+};
+
+const UniteIndicateurInput = ({ unite, disabled, updateUnite }: Props) => {
+  const [uniteInput, setUniteInput] = useState(unite);
+
+  return (
+    <Field title="Unité">
+      <Input
+        type="text"
+        value={uniteInput}
+        onChange={(evt) => setUniteInput(evt.target.value)}
+        onBlur={(evt) => updateUnite(evt.target.value)}
+        disabled={disabled}
+      />
+    </Field>
+  );
+};
+
+export default UniteIndicateurInput;

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/Carte/FicheActionCard.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/Carte/FicheActionCard.tsx
@@ -7,8 +7,8 @@ import { useState } from 'react';
 import { QueryKey } from 'react-query';
 import BadgePriorite from '../../components/BadgePriorite';
 import BadgeStatut from '../../components/BadgeStatut';
-import { generateTitle } from '../data/utils';
 import ModaleSuppression from '../Header/actions/ModaleSuppression';
+import { generateTitle } from '../data/utils';
 import FicheActionFooterInfo from './FicheActionFooterInfo';
 import ModifierFicheModale from './ModifierFicheModale';
 
@@ -118,7 +118,7 @@ const FicheActionCard = ({
         dataTest="FicheActionCarte"
         id={carteId}
         className={classNames(
-          'h-full px-4 py-[1.125rem] !gap-3 !text-grey-8 !shadow-none transition',
+          'h-full !p-4 !gap-2 !text-grey-8 !shadow-none transition',
           {
             'hover:border-primary-3 hover:!bg-primary-1': !isNotClickable,
           }
@@ -155,23 +155,27 @@ const FicheActionCard = ({
         }
         footer={
           // Bas de la carte
-          <div className="flex flex-col gap-3 text-grey-8 font-normal">
-            {/* Date de dernière modification */}
-            {!!ficheAction.modifiedAt && (
-              <span
-                className="text-xs font-medium italic"
-                title="Dernière modification"
-              >
-                Modifié {getModifiedSince(ficheAction.modifiedAt)}
-              </span>
-            )}
-
+          <div className="flex flex-col gap-2 font-normal">
             {/* Personnes pilote et date de fin prévisionnelle */}
             <FicheActionFooterInfo
               pilotes={ficheAction.pilotes}
               dateDeFin={ficheAction.dateFinProvisoire}
+              services={ficheAction.services}
               ameliorationContinue={ficheAction.ameliorationContinue}
             />
+
+            {/* Date de dernière modification */}
+            {!!ficheAction.modifiedAt && (
+              <>
+                <div className="h-[0.5px] w-full bg-primary-3 mt-1" />
+                <span
+                  className="text-xs font-medium italic text-grey-6"
+                  title="Dernière modification"
+                >
+                  Modifié {getModifiedSince(ficheAction.modifiedAt)}
+                </span>
+              </>
+            )}
           </div>
         }
       >

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/Carte/FicheActionFooterInfo.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/Carte/FicheActionFooterInfo.tsx
@@ -1,80 +1,109 @@
 import { Personne } from '@/api/collectivites';
 import { getTextFormattedDate } from '@/app/utils/formatUtils';
+import { Tag } from '@/domain/collectivites';
 import { Icon, Tooltip } from '@/ui';
 import classNames from 'classnames';
 import { isBefore, startOfToday } from 'date-fns';
-import { Fragment } from 'react';
 
 type FicheActionFooterInfoProps = {
   pilotes: Personne[] | null | undefined;
+  services: Tag[] | null | undefined;
   dateDeFin: string | null | undefined;
   ameliorationContinue: boolean | null | undefined;
 };
 
 const FicheActionFooterInfo = ({
   pilotes,
+  services,
   dateDeFin,
   ameliorationContinue,
 }: FicheActionFooterInfoProps) => {
   const hasPilotes = !!pilotes && pilotes.length > 0;
+  const hasServices = !!services && services.length > 0;
   const hasDateDeFin = !!dateDeFin;
-
-  if (!hasPilotes && !hasDateDeFin && !ameliorationContinue) return null;
 
   const isLate = hasDateDeFin && isBefore(new Date(dateDeFin), startOfToday());
 
   return (
-    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm">
-      {/* Personnes pilote */}
-      {hasPilotes && (
-        <span title="Pilotes">
-          <Icon icon="user-line" size="sm" className="mr-1" />
-          {pilotes[0].nom}
-          {pilotes.length > 1 && (
-            <Tooltip
-              openingDelay={250}
-              label={
-                <ul className="max-w-xs list-disc list-inside">
-                  {pilotes.map((pilote, i) => (
-                    <li key={i}>{pilote.nom}</li>
-                  ))}
-                </ul>
-              }
-            >
-              <span className="ml-1.5 font-medium text-primary-8">
-                +{pilotes.length - 1}
-              </span>
-            </Tooltip>
-          )}
-        </span>
-      )}
-
+    <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-primary-10 min-h-5">
       {/* Date de fin prévisionnelle */}
       {!!dateDeFin && (
-        <Fragment>
-          {hasPilotes && <div className="w-[1px] h-4 bg-grey-5" />}
-          <span
-            title="Échéance"
-            className={classNames({ 'text-error-1': isLate })}
-          >
-            <Icon icon="calendar-line" size="sm" className="mr-1" />
-            {getTextFormattedDate({
-              date: dateDeFin,
-              shortMonth: true,
-            })}
-          </span>
-        </Fragment>
+        <span
+          title="Échéance"
+          className={classNames({ 'text-error-1': isLate })}
+        >
+          <Icon icon="calendar-line" size="sm" className="mr-1" />
+          {getTextFormattedDate({
+            date: dateDeFin,
+            shortMonth: true,
+          })}
+        </span>
       )}
 
       {/* Action récurrente */}
       {!hasDateDeFin && ameliorationContinue && (
-        <Fragment>
-          {hasPilotes && <div className="w-[1px] h-4 bg-grey-5" />}
-          <span title="Échéance">
-            <Icon icon="loop-left-line" size="sm" className="mr-1" />
-            Tous les ans
+        <span title="Échéance">
+          <Icon icon="loop-left-line" size="sm" className="mr-1" />
+          Tous les ans
+        </span>
+      )}
+
+      {/* Personnes pilote */}
+      {hasPilotes && (
+        <>
+          {(hasDateDeFin || ameliorationContinue) && (
+            <div className="w-[0.5px] h-4 bg-grey-5" />
+          )}
+          <span title="Pilotes">
+            <Icon icon="user-line" size="sm" className="mr-1" />
+            {pilotes[0].nom}
+            {pilotes.length > 1 && (
+              <Tooltip
+                openingDelay={250}
+                label={
+                  <ul className="max-w-xs list-disc list-inside">
+                    {pilotes.map((pilote, i) => (
+                      <li key={i}>{pilote.nom}</li>
+                    ))}
+                  </ul>
+                }
+              >
+                <span className="ml-1.5 font-medium text-primary-8">
+                  +{pilotes.length - 1}
+                </span>
+              </Tooltip>
+            )}
           </span>
-        </Fragment>
+        </>
+      )}
+
+      {/* Services pilote */}
+      {hasServices && (
+        <>
+          {(hasDateDeFin || ameliorationContinue || hasPilotes) && (
+            <div className="w-[0.5px] h-4 bg-grey-5" />
+          )}{' '}
+          <span title="Direction ou service pilote">
+            <Icon icon="leaf-line" size="sm" className="mr-1" />
+            {services[0].nom}
+            {services.length > 1 && (
+              <Tooltip
+                openingDelay={250}
+                label={
+                  <ul className="max-w-xs list-disc list-inside">
+                    {services.map((service, i) => (
+                      <li key={i}>{service.nom}</li>
+                    ))}
+                  </ul>
+                }
+              >
+                <span className="ml-1.5 font-medium text-primary-8">
+                  +{services.length - 1}
+                </span>
+              </Tooltip>
+            )}
+          </span>
+        </>
       )}
     </div>
   );

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/FichesLiees/ModaleFichesLiees.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/FichesLiees/ModaleFichesLiees.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from 'react';
 type ModaleFichesLieesProps = {
   isOpen: boolean;
   setIsOpen: (opened: boolean) => void;
-  currentFicheId: number;
+  currentFicheId: number | null;
   linkedFicheIds: number[];
   updateLinkedFicheIds: (ficheIds: number[]) => void;
 };

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/ToutesLesFichesAction/FichesActionListe.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/ToutesLesFichesAction/FichesActionListe.tsx
@@ -23,7 +23,7 @@ import FilterBadges, {
   CustomFilterBadges,
   useFiltersToBadges,
 } from '@/app/ui/shared/filters/filter-badges';
-import _ from 'lodash';
+import { isEqual } from 'es-toolkit';
 import { FicheResume } from 'packages/api/src/plan-actions';
 import ActionsGroupeesMenu from '../ActionsGroupees/ActionsGroupeesMenu';
 import EmptyFichePicto from '../FicheAction/FichesLiees/EmptyFichePicto';
@@ -69,7 +69,7 @@ type Props = {
   sortSettings?: SortFicheActionSettings;
   enableGroupedActions?: boolean;
   isReadOnly?: boolean;
-  containeClassName?: string;
+  containerClassName?: string;
 };
 
 /** Liste de fiches action avec tri et options de fitlre */
@@ -84,7 +84,7 @@ const FichesActionListe = ({
   maxNbOfCards = 15,
   enableGroupedActions = false,
   isReadOnly,
-  containeClassName,
+  containerClassName,
 }: Props) => {
   const collectiviteId = useCollectiviteId();
 
@@ -158,7 +158,7 @@ const FichesActionListe = ({
   };
 
   useEffect(() => {
-    if (!_.isEqual(filtres, filtresLocal.current)) {
+    if (!isEqual(filtres, filtresLocal.current)) {
       filtresLocal.current = filtres;
       setCurrentPage(1);
     }
@@ -209,7 +209,7 @@ const FichesActionListe = ({
         <div
           className={classNames(
             'flex flex-col gap-8 bg-grey-2',
-            containeClassName
+            containerClassName
           )}
         >
           <div className="relative bg-inherit">

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/ToutesLesFichesAction/FichesActionListe.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/ToutesLesFichesAction/FichesActionListe.tsx
@@ -70,6 +70,8 @@ type Props = {
   enableGroupedActions?: boolean;
   isReadOnly?: boolean;
   containerClassName?: string;
+  displayEditionMenu?: boolean;
+  onUnlink?: (ficheId: number) => void;
 };
 
 /** Liste de fiches action avec tri et options de fitlre */
@@ -85,6 +87,8 @@ const FichesActionListe = ({
   enableGroupedActions = false,
   isReadOnly,
   containerClassName,
+  displayEditionMenu = false,
+  onUnlink,
 }: Props) => {
   const collectiviteId = useCollectiviteId();
 
@@ -335,7 +339,8 @@ const FichesActionListe = ({
                   <FicheActionCard
                     key={fiche.id}
                     ficheAction={fiche}
-                    isEditable
+                    isEditable={displayEditionMenu}
+                    onUnlink={onUnlink ? () => onUnlink(fiche.id) : undefined}
                     onSelect={
                       isGroupedActionsOn
                         ? () => handleSelectFiche(fiche)

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/ToutesLesFichesAction/FichesActionListe.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/ToutesLesFichesAction/FichesActionListe.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import {
   FetchOptions,
@@ -23,6 +23,7 @@ import FilterBadges, {
   CustomFilterBadges,
   useFiltersToBadges,
 } from '@/app/ui/shared/filters/filter-badges';
+import _ from 'lodash';
 import { FicheResume } from 'packages/api/src/plan-actions';
 import ActionsGroupeesMenu from '../ActionsGroupees/ActionsGroupeesMenu';
 import EmptyFichePicto from '../FicheAction/FichesLiees/EmptyFichePicto';
@@ -60,7 +61,7 @@ const sortByOptions: sortByOptionsType[] = [
 ];
 
 type Props = {
-  settings: (openState: OpenState) => React.ReactNode;
+  settings?: (openState: OpenState) => React.ReactNode;
   filtres: Filtre;
   customFilterBadges?: CustomFilterBadges;
   resetFilters?: () => void;
@@ -68,6 +69,7 @@ type Props = {
   sortSettings?: SortFicheActionSettings;
   enableGroupedActions?: boolean;
   isReadOnly?: boolean;
+  containeClassName?: string;
 };
 
 /** Liste de fiches action avec tri et options de fitlre */
@@ -82,8 +84,11 @@ const FichesActionListe = ({
   maxNbOfCards = 15,
   enableGroupedActions = false,
   isReadOnly,
+  containeClassName,
 }: Props) => {
   const collectiviteId = useCollectiviteId();
+
+  const filtresLocal = useRef(filtres);
 
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [isGroupedActionsOn, setIsGroupedActionsOn] = useState(false);
@@ -153,7 +158,10 @@ const FichesActionListe = ({
   };
 
   useEffect(() => {
-    setCurrentPage(1);
+    if (!_.isEqual(filtres, filtresLocal.current)) {
+      filtresLocal.current = filtres;
+      setCurrentPage(1);
+    }
   }, [filtres]);
 
   useEffect(() => {
@@ -198,9 +206,14 @@ const FichesActionListe = ({
       )}
 
       {hasFiches && (
-        <>
-          <div className="relative">
-            <div className="relative z-[1] bg-grey-2 flex max-xl:flex-col justify-between xl:items-center gap-4 py-6 border-y border-primary-3">
+        <div
+          className={classNames(
+            'flex flex-col gap-8 bg-grey-2',
+            containeClassName
+          )}
+        >
+          <div className="relative bg-inherit">
+            <div className="relative z-[1] bg-inherit flex max-xl:flex-col justify-between xl:items-center gap-4 py-6 border-y border-primary-3">
               <div className="flex max-md:flex-col gap-x-8 gap-y-4 md:items-center">
                 {/** Tri */}
                 <div className="w-full md:w-64">
@@ -257,7 +270,7 @@ const FichesActionListe = ({
                   displaySize="sm"
                 />
                 {/** Bouton d'édition des filtres (une modale avec bouton ou un ButtonMenu) */}
-                {settings({
+                {settings?.({
                   isOpen: isSettingsOpen,
                   setIsOpen: setIsSettingsOpen,
                 })}
@@ -365,7 +378,7 @@ const FichesActionListe = ({
           )}
 
           <ActionsGroupeesMenu {...{ isGroupedActionsOn, selectedFiches }} />
-        </>
+        </div>
       )}
     </>
   );

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/ToutesLesFichesAction/ToutesLesFichesAction.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/ToutesLesFichesAction/ToutesLesFichesAction.tsx
@@ -144,6 +144,7 @@ const ToutesLesFichesAction = () => {
         )}
         enableGroupedActions={!isReadOnly}
         isReadOnly={isReadOnly}
+        displayEditionMenu
       />
     </div>
   );

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/TableauDeBord/Personnel/ModuleFichesActions/ModuleFichesActionsPage.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/TableauDeBord/Personnel/ModuleFichesActions/ModuleFichesActionsPage.tsx
@@ -94,6 +94,7 @@ const ModuleFichesActionsPage = ({ view, slug, sortSettings }: Props) => {
               )}
           </>
         )}
+        displayEditionMenu
       />
     </ModulePage>
   );


### PR DESCRIPTION
Ticket : https://www.notion.so/accelerateur-transition-ecologique-ademe/Refonte-Onglets-page-indicateur-commune-1606523d57d780539af7d93421cdde37?pvs=4

- Onglets Données / Sous indicateurs / Actions des référentiels liées / Fiches des plans liées
- L'onglet données contient le graphe, le tableau, et les différents champs de personnalisation (certains seront ensuite déplacés à la refonte du header)
- Les sous-indicateurs ne suivent pas encore la maquette, la mise en forme utilisée en prod a été conservée
- Pas de grosse modification sur l'onglet actions, simple déplacement de la liste des cartes
- L'onglet fiches permet maintenant de rechercher, de trier, et de faire des actions groupées (réutilisation du composant fait pour la page toutes les fiches actions)