### PR TITLE
Tet 4390/fix signup login sans mdp

### DIFF
--- a/app.territoiresentransitions.react/src/app/pages/CollectivitesEngagees/CollectivitesEngagees.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/CollectivitesEngagees/CollectivitesEngagees.tsx
@@ -23,7 +23,7 @@ const CollectivitesEngagees = () => {
 };
 
 const FinaliserMonInscription = () => (
-  <div className="mx-auto my-8" data-test="FinaliserInscription">
+  <div className="fr-container my-8" data-test="FinaliserInscription">
     <EmptyCard
       picto={(props) => <PictoCarte {...props} />}
       title="Merci pour votre inscription !"
@@ -33,6 +33,7 @@ const FinaliserMonInscription = () => (
           children: 'Découvrir les collectivités',
           onClick: () => (window.location.href = recherchesCollectivitesUrl),
           variant: 'outlined',
+          size: 'md',
         },
         {
           children: 'Rejoindre une collectivité',
@@ -40,6 +41,7 @@ const FinaliserMonInscription = () => (
             (window.location.href = getRejoindreCollectivitePath(
               document.location.origin
             )),
+          size: 'md',
         },
       ]}
       size="xl"

--- a/packages/auth/components/Login/Login.stories.tsx
+++ b/packages/auth/components/Login/Login.stories.tsx
@@ -1,8 +1,8 @@
-import {useState} from 'react';
-import {Meta, StoryObj} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
-import {Login} from './Login';
-import {LoginView} from './type';
+import { action } from '@storybook/addon-actions';
+import { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { Login } from './Login';
+import { LoginView } from './type';
 
 const meta: Meta<typeof Login> = {
   component: Login,
@@ -14,9 +14,9 @@ const meta: Meta<typeof Login> = {
       action('getPasswordStrength')(...args);
       return null;
     },
-    defaultValues: {email: 'yolo@dodo.com', otp: ''},
+    defaultValues: { email: 'yolo@dodo.com', otp: '' },
   },
-  render: props => {
+  render: (props) => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const [view, setView] = useState<LoginView>(props.view || 'etape1');
     const onSetView: typeof setView = (...args) => {
@@ -31,38 +31,30 @@ export default meta;
 
 type Story = StoryObj<typeof Login>;
 
-export const SansMotDePasse: Story = {
+export const Default: Story = {
   args: {},
 };
 
 export const MsgLienEnvoye: Story = {
-  args: {view: 'msg_lien_envoye'},
+  args: { view: 'msg_lien_envoye' },
 };
 
 export const AvecErreur: Story = {
-  args: {error: 'Une erreur est survenue...'},
-};
-
-export const AvecMotDePasse: Story = {
-  args: {withPassword: true},
-};
-
-export const AvecMotDePasseEtErreur: Story = {
-  args: {withPassword: true, error: 'Une erreur est survenue...'},
+  args: { error: 'Une erreur est survenue...' },
 };
 
 export const MotDePasseOublie: Story = {
-  args: {view: 'mdp_oublie'},
+  args: { view: 'mdp_oublie' },
 };
 
 export const MsgInitMdp: Story = {
-  args: {view: 'msg_init_mdp'},
+  args: { view: 'msg_init_mdp' },
 };
 
 export const Recover: Story = {
-  args: {view: 'recover'},
+  args: { view: 'recover' },
 };
 
 export const ReinitMotDePasse: Story = {
-  args: {view: 'reset_mdp'},
+  args: { view: 'reset_mdp' },
 };

--- a/packages/auth/components/Login/LoginTabs.tsx
+++ b/packages/auth/components/Login/LoginTabs.tsx
@@ -44,7 +44,7 @@ const useLoginForm = (isPasswordless: boolean, email: string) => {
 export const LoginTabs = (props: LoginPropsWithState) => {
   const { formState: signupState, withPassword } = props;
   const { email } = signupState;
-  const [isPasswordless, setIsPasswordless] = useState(!withPassword);
+  const [isPasswordless, setIsPasswordless] = useState(false);
   const form = useLoginForm(isPasswordless, email);
   const ongletTracker = useOngletTracker('auth/login');
 
@@ -53,16 +53,16 @@ export const LoginTabs = (props: LoginPropsWithState) => {
       <TrackPageView pageName="auth/login" />
       <Tabs
         className="justify-center"
-        defaultActiveTab={isPasswordless ? 0 : 1}
+        defaultActiveTab={isPasswordless ? 1 : 0}
         onChange={(activeTab) => {
           if (activeTab === 0) {
             // reset le champ mdp qui peut être rempli quand on passe d'un onglet à l'autre
+            setIsPasswordless(false);
+            ongletTracker('avec_mdp');
+          } else {
             form.setValue('password', '');
             setIsPasswordless(true);
             ongletTracker('sans_mdp');
-          } else {
-            setIsPasswordless(false);
-            ongletTracker('avec_mdp');
           }
         }}
       >

--- a/packages/auth/components/Login/LoginTabs.tsx
+++ b/packages/auth/components/Login/LoginTabs.tsx
@@ -42,7 +42,7 @@ const useLoginForm = (isPasswordless: boolean, email: string) => {
  * (saisir un email et éventuellement un mot de passe)
  */
 export const LoginTabs = (props: LoginPropsWithState) => {
-  const { formState: signupState, withPassword } = props;
+  const { formState: signupState } = props;
   const { email } = signupState;
   const [isPasswordless, setIsPasswordless] = useState(false);
   const form = useLoginForm(isPasswordless, email);

--- a/packages/auth/components/Login/type.ts
+++ b/packages/auth/components/Login/type.ts
@@ -30,8 +30,6 @@ export type LoginProps = {
   error: string | null;
   /** Indique qu'un appel réseau est en cours */
   isLoading?: boolean;
-  /** Indique que l'option "avec mot de passe" est activée */
-  withPassword?: boolean;
   /** Fonction appelée à l'envoi du formulaire */
   onSubmit: (formData: LoginData) => void;
   /** Fonction appelée à l'annulation du formulaire */

--- a/packages/auth/components/Signup/Signup.stories.tsx
+++ b/packages/auth/components/Signup/Signup.stories.tsx
@@ -1,8 +1,8 @@
-import {useState} from 'react';
-import {Meta, StoryObj} from '@storybook/react';
-import {action} from '@storybook/addon-actions';
-import {Signup} from './Signup';
-import {SignupView} from './type';
+import { action } from '@storybook/addon-actions';
+import { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { Signup } from './Signup';
+import { SignupView } from './type';
 
 const meta: Meta<typeof Signup> = {
   component: Signup,
@@ -11,8 +11,8 @@ const meta: Meta<typeof Signup> = {
       email: 'yolo@dodo.com',
     },
     collectivites: [
-      {value: 1270, label: 'Grenoble'},
-      {value: 5460, label: '#Collectivité Test'},
+      { value: 1270, label: 'Grenoble' },
+      { value: 5460, label: '#Collectivité Test' },
     ],
     onSubmit: action('onSubmit'),
     onCancel: action('onCancel'),
@@ -22,7 +22,7 @@ const meta: Meta<typeof Signup> = {
       return null;
     },
   },
-  render: props => {
+  render: (props) => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const [view, setView] = useState<SignupView>(props.view || 'etape1');
     const onSetView: typeof setView = (...args) => {
@@ -41,13 +41,6 @@ export const Default: Story = {
   args: {},
 };
 
-export const Etape1AvecMdp: Story = {
-  args: {
-    view: 'etape1',
-    withPassword: true,
-  },
-};
-
 export const Etape2: Story = {
   args: {
     view: 'etape2',
@@ -55,13 +48,13 @@ export const Etape2: Story = {
 };
 
 export const Etape2Erreur: Story = {
-  args: {view: 'etape2', error: "Message d'erreur"},
+  args: { view: 'etape2', error: "Message d'erreur" },
 };
 
 export const Etape3: Story = {
-  args: {view: 'etape3'},
+  args: { view: 'etape3' },
 };
 
 export const Etape3Erreur: Story = {
-  args: {view: 'etape3', error: "Message d'erreur"},
+  args: { view: 'etape3', error: "Message d'erreur" },
 };

--- a/packages/auth/components/Signup/SignupStep1.tsx
+++ b/packages/auth/components/Signup/SignupStep1.tsx
@@ -43,7 +43,7 @@ const useSignupStep1 = (isPasswordless: boolean, email: string) => {
 export const SignupStep1 = (props: SignupPropsWithState) => {
   const { formState, withPassword } = props;
   const { email } = formState;
-  const [isPasswordless, setIsPasswordless] = useState(!withPassword);
+  const [isPasswordless, setIsPasswordless] = useState(false);
   const form = useSignupStep1(isPasswordless, email);
   const ongletTracker = useOngletTracker('auth/signup');
 
@@ -52,16 +52,16 @@ export const SignupStep1 = (props: SignupPropsWithState) => {
       <TrackPageView pageName="auth/signup" />
       <Tabs
         className="justify-center"
-        defaultActiveTab={isPasswordless ? 0 : 1}
+        defaultActiveTab={isPasswordless ? 1 : 0}
         onChange={(activeTab) => {
           if (activeTab === 0) {
             // reset le champ mdp qui peut être rempli quand on passe d'un onglet à l'autre
+            setIsPasswordless(false);
+            ongletTracker('avec_mdp');
+          } else {
             form.setValue('password', '');
             setIsPasswordless(true);
             ongletTracker('sans_mdp');
-          } else {
-            setIsPasswordless(false);
-            ongletTracker('avec_mdp');
           }
         }}
       >
@@ -116,6 +116,7 @@ const SignupStep1Form = (
 
   const email = watch('email');
   const password = watch('password');
+
   const res = isPasswordless ? null : getPasswordStrength(password, [email]);
 
   return (

--- a/packages/auth/components/Signup/SignupStep1.tsx
+++ b/packages/auth/components/Signup/SignupStep1.tsx
@@ -41,7 +41,7 @@ const useSignupStep1 = (isPasswordless: boolean, email: string) => {
  * (saisir un email et éventuellement un mot de passe)
  */
 export const SignupStep1 = (props: SignupPropsWithState) => {
-  const { formState, withPassword } = props;
+  const { formState } = props;
   const { email } = formState;
   const [isPasswordless, setIsPasswordless] = useState(false);
   const form = useSignupStep1(isPasswordless, email);

--- a/packages/auth/components/Signup/type.ts
+++ b/packages/auth/components/Signup/type.ts
@@ -40,8 +40,6 @@ export type SignupProps = {
   error: string | null;
   /** Indique qu'un appel réseau est en cours */
   isLoading?: boolean;
-  /** Indique que l'option "avec mot de passe" est activée */
-  withPassword?: boolean;
   /** Liste de collectivités auxquelles le compte peut être rattaché */
   collectivites: Array<{ value: number; label: string }>;
   /** Appelé pour filtrer la liste des collectivités */


### PR DESCRIPTION
TLDR bug -> le bouton `Valider` est toujours `disabled` même lorsque l'adresse mail renseignée est valide.

Il y a deux semaines, les tab login et signup avec et sans mot de passe ont été interverties.
Comme le composant `Tabs` utilise l'ordre du HTML pour afficher l'onglet actif, il faut aussi changer le `onChange`, ce qui n'avait pas été fait.

![Capture d’écran 2025-01-20 à 16 11 29](https://github.com/user-attachments/assets/75333e19-8f3b-49f1-815a-22b68c2f6761)
