### PR TITLE
Simplifie le workflow de `/rejoindre-une-collectivite`

### DIFF
--- a/packages/auth/app/rejoindre-une-collectivite/page.tsx
+++ b/packages/auth/app/rejoindre-une-collectivite/page.tsx
@@ -1,9 +1,7 @@
 'use client';
 
-import { getAuthPaths, restoreSessionFromAuthTokens } from '@/api';
 import { useRejoindreUneCollectivite } from '@/auth/app/rejoindre-une-collectivite/useRejoindreUneCollectivite';
 import { RejoindreUneCollectiviteModal } from '@/auth/components/RejoindreUneCollectivite';
-import { supabase } from '@/auth/src/clientAPI';
 import { useEffect } from 'react';
 
 /**
@@ -22,17 +20,6 @@ const RejoindreUneCollectivitePage = ({
   };
 }) => {
   const state = useRejoindreUneCollectivite({ redirectTo: redirect_to });
-
-  // redirige sur la page de login si l'utilisateur n'est pas  connecté
-  useEffect(() => {
-    const restore = async () => {
-      const ret = await restoreSessionFromAuthTokens(supabase);
-      if (!ret?.data.session) {
-        document.location.replace(getAuthPaths(redirect_to).login);
-      }
-    };
-    restore();
-  }, [redirect_to]);
 
   // initialement charge les 10 premières collectivités
   useEffect(() => {

--- a/packages/auth/app/rejoindre-une-collectivite/useRejoindreUneCollectivite.ts
+++ b/packages/auth/app/rejoindre-une-collectivite/useRejoindreUneCollectivite.ts
@@ -1,8 +1,4 @@
-import {
-  getCollectivitePath,
-  makeSearchString,
-  restoreSessionFromAuthTokens,
-} from '@/api';
+import { getCollectivitePath, makeSearchString } from '@/api';
 import {
   CollectiviteInfo,
   CollectiviteNom,
@@ -23,7 +19,6 @@ export const useRejoindreUneCollectivite = ({
   redirectTo: string;
 }) => {
   const router = useRouter();
-  restoreSessionFromAuthTokens(supabase);
 
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);

--- a/packages/auth/app/signup/useSignupState.tsx
+++ b/packages/auth/app/signup/useSignupState.tsx
@@ -128,9 +128,9 @@ export const useSignupState = ({
     // ETAPE 3
     if (view === 'etape3') {
       // enregistre les DCP
-      const { data } = await supabase.auth.getSession();
-      const user_id = data.session?.user.id;
-      const email = data.session?.user.email;
+      const { data } = await supabase.auth.getUser();
+      const user_id = data.user?.id;
+      const email = data.user?.email;
 
       if (user_id && email) {
         const { telephone, prenom, nom } = formData as SignupDataStep3;


### PR DESCRIPTION
- Utilise plutôt `getUser` que `getSession()` qui ne rafraichit pas le token
- Supprime la logique de redirection des hooks en faveur de celle du `middleware`
- Supprime la restauration automatique de session depuis les cookies