### PR TITLE
Fix : afficher le pourcentage dans les pages "actions"

### DIFF
--- a/app.territoiresentransitions.react/src/app/pages/collectivite/EtatDesLieux/Referentiel/SuiviAction/SubActionHeader.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/EtatDesLieux/Referentiel/SuiviAction/SubActionHeader.tsx
@@ -112,7 +112,8 @@ const SubActionHeader = ({
 
             {displayProgressBar && (
               <div className="flex justify-end w-[155px]">
-                <ActionProgressBar action={action} />
+                {/* TODO(temporary): Temporary patch to display percentage */}
+                <ActionProgressBar action={action} TEMP_displayValue={true} />
               </div>
             )}
           </div>

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Referentiels/ActionHeader.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Referentiels/ActionHeader.tsx
@@ -62,6 +62,8 @@ export const ActionHeader = ({
               <ActionProgressBar
                 action={action}
                 className="border-r border-r-[#ddd] fr-pr-5v"
+                // TODO(temporary): Temporary patch to display percentage
+                TEMP_displayValue={true}
               />
               <ScoreDisplay
                 score={actionScore?.points_realises ?? null}

--- a/app.territoiresentransitions.react/src/ui/referentiels/ActionProgressBar.tsx
+++ b/app.territoiresentransitions.react/src/ui/referentiels/ActionProgressBar.tsx
@@ -10,10 +10,15 @@ export const ActionProgressBar = ({
   // remettre actionId au lieu de action une fois l'affichage des scores par % généralisé
   className,
   progressBarStyleOptions,
+  // TODO(temporary): This prop is a temporary patch to only display percentage
+  // in ActionHeader and SubActionHeader components. Should be revisited during
+  // the score display refactoring.
+  TEMP_displayValue = false,
 }: {
   action: ActionDefinitionSummary;
   className?: string;
   progressBarStyleOptions?: ProgressBarStyleOptions;
+  TEMP_displayValue?: boolean; // TEMP: see comment above
 }) => {
   const score = useActionScore(action.id);
 
@@ -64,6 +69,7 @@ export const ActionProgressBar = ({
         }}
         percent={action.type === 'tache'}
         progressBarStyleOptions={progressBarStyleOptions}
+        valueToDisplay={TEMP_displayValue ? avancementToLabel.fait : undefined}
       />
     </div>
   );

--- a/app.territoiresentransitions.react/src/ui/score/ProgressBar.tsx
+++ b/app.territoiresentransitions.react/src/ui/score/ProgressBar.tsx
@@ -1,3 +1,5 @@
+import { TweenText } from '@/app/ui/shared/TweenText';
+import { toFixed } from '@/app/utils/toFixed';
 import classNames from 'classnames';
 
 export type ProgressBarStyleOptions = {
@@ -43,6 +45,13 @@ const ProgressBar = ({
 
   return (
     <div className="flex gap-3 items-center">
+      {/* Légende à gauche de la barre de progression */}
+      {displayedValue !== undefined && displayedValue !== null && (
+        <div className="text-sm font-bold">
+          <TweenText text={`${toFixed(displayedValue)} %`} align-right />
+        </div>
+      )}
+      {/* Barre de progression */}
       <div
         style={{ backgroundColor: defaultScore.color }}
         className={classNames(


### PR DESCRIPTION
Répare une régression introduire par la refonte de la page "progression" des référentiels.
Quand, à partir de cette dernière, je clique sur une action et que j'arrive sur la page de ladite action, je veux que le % de réalisation s'affiche à gauche de la barre de progression, comme ici : 

<img width="841" alt="Capture d’écran 2025-01-24 à 18 38 34" src="https://github.com/user-attachments/assets/77727d59-b340-472c-aedb-c3de46d6e532" />

⚠️ Il s'agit d'un patch temporaire, car il fait coexister deux affichages possibles pour le composant `ActionProgressBar`. A terme, il est prévu que le design du % et de la barre de progression soit refondu partout, pour être iso avec la refonte de la page "progession".