### PR TITLE
trigger Crisp au clique sur "Tous les plans d'action" quand la collectivité n'a pas de PA

### DIFF
--- a/app.territoiresentransitions.react/src/app/Layout/Header/MenuPrincipal.tsx
+++ b/app.territoiresentransitions.react/src/app/Layout/Header/MenuPrincipal.tsx
@@ -15,6 +15,7 @@ import {
   TNavItem,
   TNavItemsList,
 } from './types';
+import { usePlansNavigation } from '@/app/app/pages/collectivite/PlansActions/PlanAction/data/usePlansNavigation';
 
 /**
  * Affiche la nvaigation principale et le sélecteur de collectivité
@@ -44,11 +45,20 @@ export const MenuPrincipal = (props: HeaderPropsWithModalState) => {
     return () => document.body.removeEventListener('mousedown', onClickOutside);
   }, []);
 
+  const { data: axes } = usePlansNavigation();
+  const hasPlansAction =
+    axes && axes.filter((axe) => axe.depth === 0).length > 0;
+
   let items = [] as TNavItemsList;
   let secondaryItems = [] as TNavItemsList;
   if (currentCollectivite) {
     // récupère la liste des items à afficher dans le menu
-    items = makeNavItems(currentCollectivite, auth.user, panierId);
+    items = makeNavItems(
+      currentCollectivite,
+      auth.user,
+      panierId,
+      hasPlansAction
+    );
     secondaryItems = makeSecondaryNavItems(currentCollectivite);
   }
 
@@ -132,6 +142,7 @@ const NavItem = (props: HeaderPropsWithModalState & { item: TNavItem }) => {
         aria-controls="modal-header__menu"
         aria-current={current}
         onClick={() => {
+          item.onClick?.();
           setModalOpened(false);
           setOpenedId(null);
         }}

--- a/app.territoiresentransitions.react/src/app/Layout/Header/makeNavItems.ts
+++ b/app.territoiresentransitions.react/src/app/Layout/Header/makeNavItems.ts
@@ -26,9 +26,12 @@ import { TNavDropdown, TNavItem, TNavItemsList } from './types';
 export const makeNavItems = (
   collectivite: CurrentCollectivite,
   user: UserData | null,
-  panierId: string | undefined
+  panierId: string | undefined,
+  hasPlansAction?: boolean
 ): TNavItemsList => {
-  return filtreItems(makeNavItemsBase(collectivite, user, panierId));
+  return filtreItems(
+    makeNavItemsBase(collectivite, user, panierId, hasPlansAction)
+  );
 };
 
 const isVisiteur = ({
@@ -45,7 +48,8 @@ const isVisiteur = ({
 const makeNavItemsBase = (
   collectivite: CurrentCollectivite,
   user: UserData | null,
-  panierId: string | undefined
+  panierId: string | undefined,
+  hasPlansAction?: boolean
 ): TNavItemsList => {
   const collectiviteId = collectivite.collectiviteId;
   const confidentiel =
@@ -206,6 +210,29 @@ const makeNavItemsBase = (
           to: makeCollectivitePlansActionsLandingUrl({
             collectiviteId,
           }),
+          onClick: () => {
+            console.log(hasPlansAction);
+            if (!hasPlansAction) {
+              $crisp.push(['do', 'chat:open']);
+              $crisp.push([
+                'do',
+                'message:show',
+                [
+                  'text',
+                  'On est là pour vous aider à mettre en ligne vos plans d’action. Si vous hésitez entre les options de mise en ligne ou que vous avez des questions, contactez-nous !',
+                ],
+              ]);
+              $crisp.push([
+                'do',
+                'message:show',
+                [
+                  'text',
+                  "Vous trouverez aussi des infos utiles dans notre [Centre d'aide](https://aide.territoiresentransitions.fr/fr/article/comment-mettre-en-ligne-votre-plan-daction-1skcwdw/)",
+                ],
+              ]);
+              $crisp.push(['do', 'message:show', ['text', 'À bientôt 😄']]);
+            }
+          },
         },
         {
           label: 'Toutes les fiches action',

--- a/app.territoiresentransitions.react/src/app/Layout/Header/types.ts
+++ b/app.territoiresentransitions.react/src/app/Layout/Header/types.ts
@@ -6,6 +6,7 @@ import { Maintenance } from '../useMaintenance';
 export type TNavItem = {
   label: string;
   to: string;
+  onClick?: () => void;
   dataTest?: string;
   urlPrefix?: string[];
   // indique que l'item n'est pas affiché quand la collectivité est confidentielle


### PR DESCRIPTION
J'ai du ajouter un hook pour récupérer le nombre de plan dans le header mais je ne suis pas très fan.
Malheureusement c'est l'unique solution que j'ai trouvé.

En effet j'ai testé plusieurs approches:
- `useEffect` avec array vide à la landing de la sélection d'option de création mais cela trigger quand meme plusieurs fois crisp (je pense que c'est du au strict mode en dev) mais cette solution n'est pas top car lorsque l'utilisateur reviens en arrière cela retrigger et push de nouveaux les messages.
- la redirection dans `PlansActionRoute` mais je me suis rendu compte que c'était trigger à chaque fois même si la collectivité a déjà un PA, bien qu'il y ait le `exact` au niveau de la route