### PR TITLE
Ajout d'une question de personnalisation pour l'indicateur cae_25b

### DIFF
--- a/markdown/questions/identite.md
+++ b/markdown/questions/identite.md
@@ -69,4 +69,10 @@ thematique_id: identite
 actions: [cae_1.2.2]
 ```
 
-
+# La collectivité possède-t-elle un potentiel de développement des énergies hydraulique ou éolienne ?
+```yaml
+id: potentiel_ENR
+type: binaire
+thematique_id: identite
+indicateurs: [cae_25.b]
+```


### PR DESCRIPTION
Vérifier comment il est possible d'attacher/associer la question à l'indicateur cae_25.b et de ne pas poser la question aux collectivités situées en outre-mer