### PR TITLE
📅 Corriger les dates d'enregistrement des scores (snapshots)

### DIFF
--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Referentiels/SaveScore/save-score.button.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Referentiels/SaveScore/save-score.button.tsx
@@ -1,13 +1,35 @@
+import SaveScoreModal, {
+  SaveScoreProps,
+} from '@/app/app/pages/collectivite/Referentiels/SaveScore/save-score.modal';
 import { Button } from '@/ui';
-import SaveScoreModal, { SaveScoreProps } from '@/app/app/pages/collectivite/Referentiels/SaveScore/save-score.modal';
+import { useState } from 'react';
 
 const SaveScoreButton = ({ referentielId, collectiviteId }: SaveScoreProps) => {
+  const [isOpen, setIsOpen] = useState(false);
   return (
-    <SaveScoreModal collectiviteId={collectiviteId} referentielId={referentielId}>
-      <Button icon="save-3-line" variant="primary" size="sm" className="whitespace-nowrap">
+    <>
+      <Button
+        icon="save-3-line"
+        variant="primary"
+        size="sm"
+        className="whitespace-nowrap"
+        onClick={() => setIsOpen(true)}
+      >
         Figer le référentiel
       </Button>
-    </SaveScoreModal>
+      {isOpen && (
+        <SaveScoreModal
+          collectiviteId={collectiviteId}
+          referentielId={referentielId}
+          openState={{
+            isOpen,
+            setIsOpen: (value: boolean) => {
+              setIsOpen(value);
+            },
+          }}
+        />
+      )}
+    </>
   );
 };
 

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Referentiels/SaveScore/save-score.button.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Referentiels/SaveScore/save-score.button.tsx
@@ -23,9 +23,7 @@ const SaveScoreButton = ({ referentielId, collectiviteId }: SaveScoreProps) => {
           referentielId={referentielId}
           openState={{
             isOpen,
-            setIsOpen: (value: boolean) => {
-              setIsOpen(value);
-            },
+            setIsOpen,
           }}
         />
       )}

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Referentiels/SaveScore/save-score.button.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Referentiels/SaveScore/save-score.button.tsx
@@ -15,7 +15,7 @@ const SaveScoreButton = ({ referentielId, collectiviteId }: SaveScoreProps) => {
         className="whitespace-nowrap"
         onClick={() => setIsOpen(true)}
       >
-        Figer le référentiel
+        Figer l'état des lieux
       </Button>
       {isOpen && (
         <SaveScoreModal

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Referentiels/SaveScore/save-score.modal.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Referentiels/SaveScore/save-score.modal.tsx
@@ -102,15 +102,14 @@ const SaveScoreModal = ({
     <>
       {renderToast()}
       <Modal
-        title="Figer le référentiel"
+        title="Figer l'état des lieux"
         size="md"
         render={({ descriptionId, close }) => (
           <div id={descriptionId} className="space-y-6">
             {/*Info */}
             <Alert
-              description="Une sauvegarde sera automatiquement réalisée lors du démarrage d'un audit et lors de la clôture d'un audit.
-          Une sauvegarde sera proposée lors du dépôt du rapport de visite annuelle.
-          Vous pouvez figer le référentiel à la fin de l'état des lieux initial (ex: Etat-des-lieux-initial) ou à un autre moment clé (ex: pre-visite-annuelle), etc."
+              description="Vous pouvez figer les scores et textes renseignés dans le référentiel à la fin de l'état des lieux initial (ex: Etat-des-lieux-initial) ou à un autre moment clé (ex: pre-visite-annuelle), etc.
+Une sauvegarde sera automatiquement réalisée lors du démarrage d'un audit et lors de la clôture d'un audit. Une sauvegarde sera également prochainement proposée lors du dépôt du rapport de visite annuelle."
               rounded
             />
             {/* Choix entre 'Date d'aujourd'hui' et 'A une date antérieure' */}

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Referentiels/SaveScore/save-score.modal.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Referentiels/SaveScore/save-score.modal.tsx
@@ -1,3 +1,4 @@
+import { RouterInput } from '@/api/utils/trpc/client';
 import { useSaveScore } from '@/app/app/pages/collectivite/Referentiels/SaveScore/useSaveScore';
 import { useCurrentCollectivite } from '@/app/core-logic/hooks/useCurrentCollectivite';
 import { getIsoFormattedDate } from '@/app/utils/formatUtils';
@@ -12,7 +13,6 @@ import {
 } from '@/ui';
 import { DateTime } from 'luxon';
 import { ReactNode, useRef, useState } from 'react';
-import { ReferentielId } from '../../../../../../../backend/src/referentiels/index-domain';
 
 const generateBeforeDate = (
   date: string | null | undefined
@@ -36,6 +36,8 @@ const getDisplayedYear = (
   }
   return new Date().getFullYear().toString();
 };
+
+type ComputeScoreType = RouterInput['referentiels']['scores']['computeScore'];
 
 export type SaveScoreProps = {
   referentielId: string;
@@ -72,7 +74,7 @@ const SaveScoreModal = ({
     upsertSnapshot(
       {
         collectiviteId,
-        referentiel: referentielId as ReferentielId,
+        referentiel: referentielId as ComputeScoreType['referentielId'],
         snapshotNom: finalNomVersion,
         date: dateVersion ? generateBeforeDate(dateVersion) : undefined,
       },

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Referentiels/SaveScore/save-score.modal.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Referentiels/SaveScore/save-score.modal.tsx
@@ -1,17 +1,8 @@
 import { RouterInput } from '@/api/utils/trpc/client';
 import { useSaveScore } from '@/app/app/pages/collectivite/Referentiels/SaveScore/useSaveScore';
 import { useBaseToast } from '@/app/core-logic/hooks/useBaseToast';
-import { useCurrentCollectivite } from '@/app/core-logic/hooks/useCurrentCollectivite';
 import { getIsoFormattedDate } from '@/app/utils/formatUtils';
-import {
-  Alert,
-  Button,
-  ButtonGroup,
-  Field,
-  Input,
-  Modal,
-  useEventTracker,
-} from '@/ui';
+import { Alert, Button, ButtonGroup, Field, Input, Modal } from '@/ui';
 import { ReactNode, useRef, useState } from 'react';
 
 type computeScoreType = RouterInput['referentiels']['scores']['computeScore'];
@@ -43,6 +34,7 @@ const SaveScoreModal = ({
     return new Date().getFullYear().toString();
   };
 
+  // TODO: change date to include hours
   const finalDateVersion = dateVersion || getIsoFormattedDate('');
   const finalNomVersion = `${getDisplayedYear()} - ${nomVersion?.trim()}`;
 

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Referentiels/SaveScore/save-score.modal.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Referentiels/SaveScore/save-score.modal.tsx
@@ -34,9 +34,22 @@ const SaveScoreModal = ({
     return new Date().getFullYear().toString();
   };
 
-  // TODO: change date to include hours
-  const finalDateVersion = dateVersion || getIsoFormattedDate('');
+  const generateBeforeDate = (date: string) => {
+    const dateObject = new Date(date);
+    dateObject.setHours(23, 59, 0);
+    return dateObject.toISOString();
+  };
+
+  const useServerTimestampForNowDate = () => {
+    // We're returning undefined to let the backend timestamp the current date
+    return undefined;
+  };
+
   const finalNomVersion = `${getDisplayedYear()} - ${nomVersion?.trim()}`;
+
+  const finalDateVersion = dateVersion
+    ? generateBeforeDate(dateVersion)
+    : useServerTimestampForNowDate();
 
   const { refetch, isFetching } = useSaveScore(
     referentielId as computeScoreType['referentielId'],

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Referentiels/SaveScore/save-score.modal.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Referentiels/SaveScore/save-score.modal.tsx
@@ -4,11 +4,11 @@ import { useCurrentCollectivite } from '@/app/core-logic/hooks/useCurrentCollect
 import { getIsoFormattedDate } from '@/app/utils/formatUtils';
 import {
   Alert,
-  Button,
   ButtonGroup,
   Field,
   Input,
   Modal,
+  ModalFooterOKCancel,
   useEventTracker,
 } from '@/ui';
 import { OpenState } from '@/ui/utils/types';
@@ -145,37 +145,25 @@ Une sauvegarde sera automatiquement réalisée lors du démarrage d'un audit et 
                 />
               </div>
             </Field>
-            {/* Boutons annuler et valider */}
-            <div className="flex gap-4 justify-end">
-              <Button
-                variant="grey"
-                size="sm"
-                onClick={() => openState.setIsOpen(false)}
-              >
-                Annuler
-              </Button>
-              <Button
-                variant="primary"
-                size="sm"
-                disabled={
-                  isSaving ||
-                  !nomVersion?.trim() ||
-                  (selectedButton !== 'now' && !dateVersion)
-                }
-                onClick={() => {
-                  tracker('referentiels:scores:sauvegarde', {
-                    collectiviteId,
-                    niveauAcces,
-                    role,
-                    dateDuJour: selectedButton === 'now',
-                  });
-                  handleSave();
-                }}
-              >
-                {isSaving ? 'Sauvegarde en cours...' : 'Figer cette version'}
-              </Button>
-            </div>
           </div>
+        )}
+        renderFooter={({ close }) => (
+          <ModalFooterOKCancel
+            btnCancelProps={{ onClick: close }}
+            btnOKProps={{
+              children: `Figer l'état des lieux`,
+              onClick: () => {
+                tracker('referentiels:scores:sauvegarde', {
+                  collectiviteId,
+                  niveauAcces,
+                  role,
+                  dateDuJour: selectedButton === 'now',
+                });
+                handleSave();
+                close();
+              },
+            }}
+          />
         )}
       />
     </>

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Referentiels/SaveScore/save-score.modal.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Referentiels/SaveScore/save-score.modal.tsx
@@ -2,9 +2,32 @@ import { useSaveScore } from '@/app/app/pages/collectivite/Referentiels/SaveScor
 import { useBaseToast } from '@/app/core-logic/hooks/useBaseToast';
 import { getIsoFormattedDate } from '@/app/utils/formatUtils';
 import { Alert, Button, ButtonGroup, Field, Input, Modal } from '@/ui';
+import { DateTime } from 'luxon';
 import { ReactNode, useRef, useState } from 'react';
 import { ReferentielId } from '../../../../../../../backend/src/referentiels/index-domain';
 
+const generateBeforeDate = (
+  date: string | null | undefined
+): string | undefined => {
+  if (!date) return undefined;
+
+  const result = DateTime.fromISO(date, { zone: 'Europe/Paris' })
+    .set({ hour: 23, minute: 59, second: 0 })
+    .toUTC()
+    .toISO();
+
+  return result ?? undefined;
+};
+
+const getDisplayedYear = (
+  selectedButton: string,
+  dateVersion: string | undefined
+): string => {
+  if (selectedButton === 'before' && dateVersion) {
+    return new Date(dateVersion).getFullYear().toString();
+  }
+  return new Date().getFullYear().toString();
+};
 
 export type SaveScoreProps = {
   referentielId: string;

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Referentiels/SaveScore/useSaveScore.ts
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Referentiels/SaveScore/useSaveScore.ts
@@ -10,9 +10,9 @@ export const useSaveScore = (mutationOptions?: MutationOptions) => {
   return trpc.referentiels.snapshots.upsert.useMutation({
     ...mutationOptions,
     onSuccess: (data, variables, context) => {
-      /*
-      utils.collectivites.tableauDeBord.list.invalidate({
+      utils.referentiels.snapshots.listSummary.invalidate({
         collectiviteId: data.collectiviteId,
+        referentielId: data.referentielId,
       });
 
       utils.collectivites.tableauDeBord.get.invalidate({

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Referentiels/SaveScore/useSaveScore.ts
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Referentiels/SaveScore/useSaveScore.ts
@@ -15,11 +15,15 @@ export const useSaveScore = (mutationOptions?: MutationOptions) => {
         referentielId: data.referentielId,
       });
 
-      utils.collectivites.tableauDeBord.get.invalidate({
-        collectiviteId: data.collectiviteId,
-        id: data.id,
-      });*/
       mutationOptions?.onSuccess?.(data, variables, context);
+    },
+    meta: {
+      success: 'État des lieux figé avec succès',
+      error: `Une sauvegarde de l'état des lieux à la date ${
+        mutationOptions?.meta?.date
+          ? mutationOptions?.meta?.date
+          : `d'aujourd'hui`
+      } ou/et avec le nom "${mutationOptions?.meta?.snapshotNom}" existe déjà.`,
     },
   });
 };

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Referentiels/SaveScore/useSaveScore.ts
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Referentiels/SaveScore/useSaveScore.ts
@@ -3,9 +3,9 @@ import { RouterInput, trpc } from '@/api/utils/trpc/client';
 type computeScoreType = RouterInput['referentiels']['scores']['computeScore'];
 
 export const useSaveScore = (
-  referentielId: computeScoreType["referentielId"],
+  referentielId: computeScoreType['referentielId'],
   collectiviteId: number,
-  dateVersion: string,
+  dateVersion: string | undefined, // If undefined, the backend will timestamp the current date
   nomVersion: string
 ) => {
   // It's a query, not a mutation because the call doesn't save if parameters.snapshot is false
@@ -16,7 +16,7 @@ export const useSaveScore = (
       parameters: {
         snapshot: true,
         snapshotNom: nomVersion,
-        date: new Date(dateVersion).toISOString(),
+        date: dateVersion || undefined,
       },
     },
     {

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Referentiels/SaveScore/useSaveScore.ts
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Referentiels/SaveScore/useSaveScore.ts
@@ -19,11 +19,8 @@ export const useSaveScore = (mutationOptions?: MutationOptions) => {
     },
     meta: {
       success: 'État des lieux figé avec succès',
-      error: `Une sauvegarde de l'état des lieux à la date ${
-        mutationOptions?.meta?.date
-          ? mutationOptions?.meta?.date
-          : `d'aujourd'hui`
-      } ou/et avec le nom "${mutationOptions?.meta?.snapshotNom}" existe déjà.`,
+      error:
+        "Une sauvegarde de l'état des lieux à cette date et/ou avec ce nom existe déjà.",
     },
   });
 };

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Referentiels/SaveScore/useSaveScore.ts
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Referentiels/SaveScore/useSaveScore.ts
@@ -1,27 +1,25 @@
-import { RouterInput, trpc } from '@/api/utils/trpc/client';
+import { trpc } from '@/api/utils/trpc/client';
 
-type computeScoreType = RouterInput['referentiels']['scores']['computeScore'];
+type MutationOptions = Parameters<
+  typeof trpc.referentiels.snapshots.upsert.useMutation
+>[0];
 
-export const useSaveScore = (
-  referentielId: computeScoreType['referentielId'],
-  collectiviteId: number,
-  dateVersion: string | undefined, // If undefined, the backend will timestamp the current date
-  nomVersion: string
-) => {
-  // It's a query, not a mutation because the call doesn't save if parameters.snapshot is false
-  return trpc.referentiels.scores.computeScore.useQuery(
-    {
-      referentielId: referentielId,
-      collectiviteId: collectiviteId,
-      parameters: {
-        snapshot: true,
-        snapshotNom: nomVersion,
-        date: dateVersion,
-      },
+export const useSaveScore = (mutationOptions?: MutationOptions) => {
+  const utils = trpc.useUtils();
+
+  return trpc.referentiels.snapshots.upsert.useMutation({
+    ...mutationOptions,
+    onSuccess: (data, variables, context) => {
+      /*
+      utils.collectivites.tableauDeBord.list.invalidate({
+        collectiviteId: data.collectiviteId,
+      });
+
+      utils.collectivites.tableauDeBord.get.invalidate({
+        collectiviteId: data.collectiviteId,
+        id: data.id,
+      });*/
+      mutationOptions?.onSuccess?.(data, variables, context);
     },
-    {
-      enabled: false,
-      refetchOnWindowFocus: false,
-    }
-  );
+  });
 };

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Referentiels/SaveScore/useSaveScore.ts
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Referentiels/SaveScore/useSaveScore.ts
@@ -16,7 +16,7 @@ export const useSaveScore = (
       parameters: {
         snapshot: true,
         snapshotNom: nomVersion,
-        date: dateVersion || undefined,
+        date: dateVersion,
       },
     },
     {

--- a/backend/src/referentiels/compute-score/referentiels-scoring.service.ts
+++ b/backend/src/referentiels/compute-score/referentiels-scoring.service.ts
@@ -1257,8 +1257,7 @@ export default class ReferentielsScoringService {
         referentielVersion: referentiel.version,
         collectiviteId,
         collectiviteInfo,
-        date:
-          parameters.date || DateTime.now().setZone('Europe/Paris').toISO()!,
+        date: parameters.date || DateTime.now().toISO(),
         scores: referentielWithScore,
       };
 

--- a/backend/src/referentiels/compute-score/referentiels-scoring.service.ts
+++ b/backend/src/referentiels/compute-score/referentiels-scoring.service.ts
@@ -1257,7 +1257,8 @@ export default class ReferentielsScoringService {
         referentielVersion: referentiel.version,
         collectiviteId,
         collectiviteInfo,
-        date: parameters.date || DateTime.now().toISO(),
+        date:
+          parameters.date || DateTime.now().setZone('Europe/Paris').toISO()!,
         scores: referentielWithScore,
       };
 

--- a/backend/src/referentiels/snapshots/score-snaphots.router.ts
+++ b/backend/src/referentiels/snapshots/score-snaphots.router.ts
@@ -2,9 +2,11 @@ import { TrpcService } from '@/backend/utils/trpc/trpc.service';
 import { Injectable } from '@nestjs/common';
 import z from 'zod';
 import ReferentielsScoringService from '../compute-score/referentiels-scoring.service';
+import { ComputeScoreMode } from '../models/compute-scores-mode.enum';
 import { referentielIdEnumSchema } from '../models/referentiel-id.enum';
 import ReferentielsScoringSnapshotsService from './referentiels-scoring-snapshots.service';
 import { SnapshotJalon } from './snapshot-jalon.enum';
+import { upsertSnapshotRequestSchema } from './upsert-snapshot.request';
 
 export const getScoreSnapshotInfosTrpcRequestSchema = z.object({
   referentielId: referentielIdEnumSchema,
@@ -51,6 +53,22 @@ export class ScoreSnapshotsRouter {
           input.collectiviteId,
           input.referentielId,
           true
+        );
+      }),
+
+    upsert: this.trpc.authedProcedure
+      .input(upsertSnapshotRequestSchema)
+      .mutation(({ input, ctx }) => {
+        return this.referentielsScoringService.computeScoreForCollectivite(
+          input.referentiel,
+          input.collectiviteId,
+          {
+            mode: ComputeScoreMode.RECALCUL,
+            snapshot: true,
+            snapshotNom: input.snapshotNom,
+            date: input.date,
+          },
+          ctx.user
         );
       }),
 

--- a/backend/src/referentiels/snapshots/score-snapshots.router.e2e-spec.ts
+++ b/backend/src/referentiels/snapshots/score-snapshots.router.e2e-spec.ts
@@ -141,4 +141,26 @@ describe('ScoreSnapshotsRouter', () => {
       );
     expect(foundSnapshotAfterDelete).toBeUndefined();
   });
+
+  test("Création d'un snapshot avec nom et date spécifique", async () => {
+    const caller = router.createCaller({ user: yoloDodoUser });
+    const snapshotDate = '2024-09-21T21:59:00.000Z';
+    const snapshotNom = 'Test snapshot avec date';
+
+    const input = {
+      referentiel: referentielIdEnumSchema.enum.cae,
+      collectiviteId: 1,
+      snapshotNom,
+      date: snapshotDate,
+    };
+
+    const result = await caller.referentiels.snapshots.upsert(input);
+
+    expect(result.snapshot).toBeDefined();
+    expect(result.snapshot?.nom).toBe(snapshotNom);
+    expect(result.date).toBe(snapshotDate);
+    expect(result.snapshot?.ref).toBe(
+      `${snapshotNom.toLowerCase().replace(/\s+/g, '-')}`
+    );
+  });
 });

--- a/backend/src/referentiels/snapshots/upsert-snapshot.request.ts
+++ b/backend/src/referentiels/snapshots/upsert-snapshot.request.ts
@@ -1,0 +1,9 @@
+import z from 'zod';
+import { collectiviteRequestSchema } from '../../collectivites/collectivite.request';
+import { referentielIdEnumSchema } from '../models/referentiel-id.enum';
+
+export const upsertSnapshotRequestSchema = collectiviteRequestSchema.extend({
+  referentiel: referentielIdEnumSchema,
+  snapshotNom: z.string(),
+  date: z.string().datetime().optional(),
+});


### PR DESCRIPTION
Actuellement, quand je fige un état des lieux à la date d'aujourd'hui, un snapshot est créé avec comme heure de création minuit. 

Problème 1 : si jamais j'ai actualisé mon état des lieux dans la journée et que je fige une version, mon score courant est actualisé, mais le score du snapshot créé ne l'est pas (puisqu'il reflète ce qui s'est passé à minuit).

Problème 2 : cela m'empêche de figer plusieurs versions de l'état des lieux dans une même journée, car la contrainte de la table `score_snapshot` est `collectivite_id, referentiel_id, type_jalon, date` (par défnition, `collectivite_id` et `referentiel_id` ne varient pas, et `type_jalon` non plus , car ça a toujours la valeur `date_personnalise`).

A faire :

- [x] Modifier la date transmise au back lors de la sauvegarde du snapshot lorsqu'on enregistre un snapshot à la date d'aujourd'hui (il faut transmettre l'heure à laquelle l'neregistrement est fait).

- [x] Modifier la date transmise au back lors de la sauvegarde du snapshot lorsqu'on enregistre un snapshot à une date antérieure (il faut changer minuit pour 23 h 59, afin que tous les changements de score faits dans la journée soient pris en compte).

- [x] Ajouter une route trpc qui est vraiment associée aux snapshots et qui fait une mutation, afin de ne plus utiliser `useQuery` dans `useSaveScore.ts`.