### PR TITLE
Tracking création plan d'action

### DIFF
--- a/app.territoiresentransitions.react/src/app/pages/collectivite/CollectivitePageLayout/SideNavContainer.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/CollectivitePageLayout/SideNavContainer.tsx
@@ -1,6 +1,7 @@
 import { useFonctionTracker } from '@/app/core-logic/hooks/useFonctionTracker';
 import classNames from 'classnames';
 import SideNav, { SideNavLinks } from './SideNav';
+import { Button } from '@/ui';
 
 export type SideNavContainerProps = {
   links: SideNavLinks;
@@ -29,8 +30,11 @@ const SideNavContainer = ({ isOpen, setIsOpen, sideNav }: Props) => {
           )}
         >
           {isHideable && (
-            <button
-              className="ml-auto mr-4 mb-4 fr-btn fr-btn--tertiary fr-btn--icon fr-btn--sm fr-fi-arrow-left-s-line-double"
+            <Button
+              className="ml-auto mr-4 mb-4"
+              variant="grey"
+              size="xs"
+              icon="arrow-left-double-line"
               onClick={() => {
                 setIsOpen(false);
                 tracker({
@@ -46,8 +50,11 @@ const SideNavContainer = ({ isOpen, setIsOpen, sideNav }: Props) => {
           </div>
         </div>
       ) : (
-        <button
-          className="mt-4 mx-auto fr-btn fr-btn--tertiary fr-btn--icon fr-btn--sm fr-fi-arrow-right-s-line-double"
+        <Button
+          className="mt-4 mx-auto"
+          variant="grey"
+          size="xs"
+          icon="arrow-right-double-line"
           onClick={() => {
             setIsOpen(true);
             tracker({ fonction: 'navigation_laterale', action: 'ouverture' });

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/ParcoursCreationPlan/Selection.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/ParcoursCreationPlan/Selection.tsx
@@ -1,67 +1,79 @@
+import { useNbActionsDansPanier } from '@/app/app/Layout/Header/useNbActionsDansPanier';
 import {
   makeCollectivitePanierUrl,
   makeCollectivitePlansActionsCreerUrl,
   makeCollectivitePlansActionsImporterUrl,
 } from '@/app/app/paths';
-import { useCollectiviteId } from '@/app/core-logic/hooks/params';
 import { useCurrentCollectivite } from '@/app/core-logic/hooks/useCurrentCollectivite';
-import { TrackingPlan, useEventTracker } from '@/ui';
+import { TrackingPlan, TrackPageView, useEventTracker } from '@/ui';
 import classNames from 'classnames';
+import { pick } from 'es-toolkit';
 import Link from 'next/link';
 import { ReactComponent as DocumentAddPicto } from './document-add.svg';
 import { ReactComponent as DocumentDownloadPicto } from './document-download.svg';
 import { ReactComponent as ShoppingBasket } from './shopping-basket.svg';
-import { useNbActionsDansPanier } from '@/app/app/Layout/Header/useNbActionsDansPanier';
 
 const Selection = () => {
-  const collectivite_id = useCollectiviteId();
+  const collectivite = useCurrentCollectivite()!;
 
-  const { data: panier } = useNbActionsDansPanier(collectivite_id);
+  const collectiviteId = collectivite.collectiviteId;
+
+  const { data: panier } = useNbActionsDansPanier(collectiviteId);
 
   return (
-    <div
-      data-test="choix-creation-plan"
-      className="max-w-5xl mx-auto flex flex-col grow py-12"
-    >
-      <div className="flex flex-col py-14 px-24 text-center bg-primary-0">
-        <h3 className="mb-4">Créer un plan d’action</h3>
-        <p className="text-lg text-grey-6">Vous souhaitez</p>
-        <div className="flex justify-between gap-6 mt-4">
-          <SelectFlowButton
-            isPrimary
-            dataTest="CreerPlan"
-            title="Créer un plan d’action"
-            subTitle="directement sur la plateforme"
-            icon={<DocumentAddPicto />}
-            url={makeCollectivitePlansActionsCreerUrl({
-              collectiviteId: collectivite_id!,
-            })}
-            trackingId="cta_creer"
-          />
-          <SelectFlowButton
-            dataTest="ImporterPlan"
-            title="Importer un plan d’action"
-            subTitle="à partir d’un modèle"
-            icon={<DocumentDownloadPicto />}
-            url={makeCollectivitePlansActionsImporterUrl({
-              collectiviteId: collectivite_id!,
-            })}
-            trackingId="cta_importer"
-          />
-          <SelectFlowButton
-            dataTest="InitierPlan"
-            title="Initier votre plan d’action"
-            subTitle="grâce aux “Actions à Impact”"
-            icon={<ShoppingBasket className="my-3" />}
-            url={makeCollectivitePanierUrl({
-              collectiviteId: collectivite_id,
-              panierId: panier?.panierId,
-            })}
-            trackingId="cta_commencer_pai"
-          />
+    <>
+      <TrackPageView
+        pageName="app/creer-plan"
+        properties={pick(collectivite, [
+          'collectiviteId',
+          'niveauAcces',
+          'role',
+        ])}
+      />
+      <div
+        data-test="choix-creation-plan"
+        className="max-w-5xl mx-auto flex flex-col grow py-12"
+      >
+        <div className="flex flex-col py-14 px-24 text-center bg-primary-0">
+          <h3 className="mb-4">Créer un plan d’action</h3>
+          <p className="text-lg text-grey-6">Vous souhaitez</p>
+          <div className="flex justify-between gap-6 mt-4">
+            <SelectFlowButton
+              isPrimary
+              dataTest="CreerPlan"
+              title="Créer un plan d’action"
+              subTitle="directement sur la plateforme"
+              icon={<DocumentAddPicto />}
+              url={makeCollectivitePlansActionsCreerUrl({
+                collectiviteId,
+              })}
+              trackingId="cta_creer"
+            />
+            <SelectFlowButton
+              dataTest="ImporterPlan"
+              title="Importer un plan d’action"
+              subTitle="à partir d’un modèle"
+              icon={<DocumentDownloadPicto />}
+              url={makeCollectivitePlansActionsImporterUrl({
+                collectiviteId,
+              })}
+              trackingId="cta_importer"
+            />
+            <SelectFlowButton
+              dataTest="InitierPlan"
+              title="Initier votre plan d’action"
+              subTitle="grâce aux “Actions à Impact”"
+              icon={<ShoppingBasket className="my-3" />}
+              url={makeCollectivitePanierUrl({
+                collectiviteId,
+                panierId: panier?.panierId,
+              })}
+              trackingId="cta_commencer_pai"
+            />
+          </div>
         </div>
       </div>
-    </div>
+    </>
   );
 };
 

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/PlansActionsRoutes.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/PlansActionsRoutes.tsx
@@ -23,7 +23,8 @@ import {
   generatePlanActionNavigationLinks,
   usePlansNavigation,
 } from './PlanAction/data/usePlansNavigation';
-import { Button } from '@/ui';
+import { Button, useEventTracker } from '@/ui';
+import { useCurrentCollectivite } from '@/app/core-logic/hooks/useCurrentCollectivite';
 
 type Props = {
   collectivite_id: number;
@@ -34,11 +35,15 @@ type Props = {
  * Routes starting with collectivite/:collectiviteId/plans see CollectiviteRoutes.tsx
  */
 export const PlansActionsRoutes = ({ collectivite_id, readonly }: Props) => {
+  const collectivite = useCurrentCollectivite()!;
+
   const { data: axes } = usePlansNavigation();
   const { data: fichesNonClasseesListe } =
     useFichesNonClasseesListe(collectivite_id);
 
   const { mutate: createFicheAction } = useCreateFicheAction();
+
+  const trackEvent = useEventTracker('app/plans');
 
   const hasFicheNonClassees =
     (fichesNonClasseesListe && fichesNonClasseesListe.length > 0) || false;
@@ -58,7 +63,7 @@ export const PlansActionsRoutes = ({ collectivite_id, readonly }: Props) => {
           <>
             <li className="p-0 list-none">
               <Button
-                dataTest="CreerFicheAction"
+                data-test="CreerFicheAction"
                 variant="outlined"
                 size="sm"
                 onClick={() => createFicheAction()}
@@ -68,12 +73,16 @@ export const PlansActionsRoutes = ({ collectivite_id, readonly }: Props) => {
             </li>
             <li className="mt-4 p-0 list-none">
               <Button
-                dataTest="AjouterPlanAction"
+                data-test="AjouterPlanAction"
                 size="sm"
                 href={makeCollectivitePlansActionsNouveauUrl({
                   collectiviteId: collectivite_id,
                 })}
                 onClick={() => {
+                  trackEvent(
+                    'plansAction:side-nav-ajouter-plan-click',
+                    collectivite
+                  );
                   $crisp.push(['do', 'chat:open']);
                   $crisp.push([
                     'do',

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/PlansActionsRoutes.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/PlansActionsRoutes.tsx
@@ -23,6 +23,7 @@ import {
   generatePlanActionNavigationLinks,
   usePlansNavigation,
 } from './PlanAction/data/usePlansNavigation';
+import { Button } from '@/ui';
 
 type Props = {
   collectivite_id: number;
@@ -55,19 +56,20 @@ export const PlansActionsRoutes = ({ collectivite_id, readonly }: Props) => {
         ),
         actions: !readonly && (
           <>
-            <li className="fr-sidemenu_item p-0 list-none">
-              <button
-                data-test="CreerFicheAction"
-                className="fr-btn fr-btn--primary"
+            <li className="p-0 list-none">
+              <Button
+                dataTest="CreerFicheAction"
+                variant="outlined"
+                size="sm"
                 onClick={() => createFicheAction()}
               >
                 Créer une fiche action
-              </button>
+              </Button>
             </li>
-            <li className="fr-sidemenu_item mt-6 p-0 list-none">
-              <Link
-                data-test="AjouterPlanAction"
-                className="fr-btn fr-btn--tertiary"
+            <li className="mt-4 p-0 list-none">
+              <Button
+                dataTest="AjouterPlanAction"
+                size="sm"
                 href={makeCollectivitePlansActionsNouveauUrl({
                   collectiviteId: collectivite_id,
                 })}
@@ -93,7 +95,7 @@ export const PlansActionsRoutes = ({ collectivite_id, readonly }: Props) => {
                 }}
               >
                 Ajouter un plan d&apos;action
-              </Link>
+              </Button>
             </li>
           </>
         ),

--- a/packages/ui/src/components/tracking/trackingPlan.ts
+++ b/packages/ui/src/components/tracking/trackingPlan.ts
@@ -321,6 +321,19 @@ export interface TrackingPlan extends Record<never, Page> {
     };
   };
 
+  /**
+   * Match toutes les pages du pilier plan d'action.
+   * Permet de tracker des événements communs à plusieurs pages
+   * comme le bouton "Ajouter un plan d'action".
+   */
+  'app/plans': {
+    properties: CollectiviteDefaultProps;
+    onglets: never;
+    events: {
+      'plansAction:side-nav-ajouter-plan-click': {};
+    };
+  };
+
   /** Trajectoire SNBC territorialisée */
   'app/trajectoires/snbc': {
     properties: CollectiviteDefaultProps &


### PR DESCRIPTION
Tracking creation PA :
- ajout du pageview `app/creer-plan`
- ajout de l'event `plansAction:side-nav-ajouter-plan-click` avec la page définit comme `app/plans` qui ne correspond pas à une page réelle mais obligé de définir une page pour track un event. Je fais cela car le bouton est présent sur plusieurs URLs.

Modification UI :
- "Ajouter un plan d'action" devient le CTA principal de la side nav plans d'action

<img width="290" alt="Capture d’écran 2025-02-11 à 16 32 02" src="https://github.com/user-attachments/assets/8d03d600-80ec-41c3-8ab1-486d5e4a8d28" />