### PR TITLE
TET-4367: Détailler manuellement le score à la sous-action

### DIFF
--- a/data_layer/sqitch/deploy/referentiel/justification_ajustement.sql
+++ b/data_layer/sqitch/deploy/referentiel/justification_ajustement.sql
@@ -2,99 +2,48 @@
 
 BEGIN;
 
-create table justification_ajustement
-(
-    collectivite_id integer references collectivite               not null,
-    action_id       action_id references action_relation          not null,
-    texte           text                                          not null,
-    modified_by     uuid references auth.users default auth.uid() not null,
-    modified_at     timestamp with time zone                      not null,
-    primary key (collectivite_id, action_id)
-);
-comment on table justification_ajustement is 'Les justifications pour les scores ajustés.';
+-- Desactivate triggers
+ALTER TABLE action_commentaire DISABLE TRIGGER save_history;
+ALTER TABLE action_commentaire DISABLE TRIGGER set_modified_at_before_action_commentaire_update;
 
-select private.add_modified_at_trigger('public', 'justification_ajustement');
-select private.add_modified_by_trigger('public', 'justification_ajustement');
+-- Insert new rows into action_commentaire or update existing rows
+INSERT INTO action_commentaire (collectivite_id, action_id, commentaire, modified_by, modified_at)
+SELECT
+  ja.collectivite_id,
+  ja.action_id,
+  ja.texte AS commentaire,
+  ja.modified_by,
+  ja.modified_at
+FROM
+  justification_ajustement ja
+ON CONFLICT (collectivite_id, action_id)
+DO UPDATE
+SET
+  commentaire = action_commentaire.commentaire || '
+–
+' || EXCLUDED.commentaire,
+  modified_by = CASE
+    WHEN action_commentaire.modified_at > EXCLUDED.modified_at THEN action_commentaire.modified_by
+    ELSE EXCLUDED.modified_by
+  END,
+  modified_at = CASE
+    WHEN action_commentaire.modified_at > EXCLUDED.modified_at THEN action_commentaire.modified_at
+    ELSE EXCLUDED.modified_at
+  END
+  ;
 
-alter table justification_ajustement
-    enable row level security;
+-- Re-enable triggers after the modifications
+ALTER TABLE action_commentaire ENABLE TRIGGER save_history;
+ALTER TABLE action_commentaire ENABLE TRIGGER set_modified_at_before_action_commentaire_update;
 
-create policy allow_read
-    on justification_ajustement
-    for select
-    using (est_verifie() or have_lecture_acces(collectivite_id));
+-- For a later migration once validated: drop the justification_ajustement table and its triggers
 
-create policy allow_insert
-    on justification_ajustement
-    for insert
-    with check (have_edition_acces(collectivite_id) OR est_auditeur_action(collectivite_id, action_id));
+-- drop table justification_ajustement;
+-- drop trigger if exists modified_at on justification_ajustement;
+-- drop trigger if exists modified_by on justification_ajustement;
 
-create policy allow_update
-    on justification_ajustement
-    for update
-    using (have_edition_acces(collectivite_id) OR est_auditeur_action(collectivite_id, action_id));
-
-
-create table historique.justification_ajustement
-(
-    id                   serial primary key,
-    collectivite_id      integer   not null,
-    action_id            action_id not null,
-    modified_by          uuid,
-    previous_modified_by uuid,
-    modified_at          timestamp with time zone,
-    previous_modified_at timestamp with time zone,
-    texte                text      not null,
-    previous_texte       text
-);
-
-create function historique.save_justification_ajustement() returns trigger
-as
-$$
-declare
-    updated integer;
-begin
-    -- debounce
-    update historique.justification_ajustement
-    set texte       = new.texte,
-        modified_at = new.modified_at
-    where id in (select id
-                 from historique.justification_ajustement
-                 where collectivite_id = new.collectivite_id
-                   and action_id = new.action_id
-                   and modified_by = new.modified_by
-                   and modified_at > new.modified_at - interval '1 hour'
-                 order by modified_by desc
-                 limit 1)
-    returning id into updated;
-
-    if updated is null
-    then
-        insert into historique.justification_ajustement (collectivite_id,
-                                                         action_id,
-                                                         modified_by,
-                                                         previous_modified_by,
-                                                         modified_at,
-                                                         previous_modified_at,
-                                                         texte,
-                                                         previous_texte)
-        values (new.collectivite_id,
-                new.action_id,
-                auth.uid(),
-                old.modified_by,
-                new.modified_at,
-                old.modified_at,
-                new.texte,
-                old.texte);
-    end if;
-    return new;
-end ;
-$$ language plpgsql security definer;
-
-create trigger save_history
-    after insert or update
-    on justification_ajustement
-    for each row
-execute procedure historique.save_justification_ajustement();
+-- drop trigger if exists save_history on justification_ajustement;
+-- drop function if exists historique.save_justification_ajustement();
+-- drop table historique.justification_ajustement;
 
 COMMIT;

--- a/data_layer/sqitch/deploy/referentiel/justification_ajustement@v4.38.0.sql
+++ b/data_layer/sqitch/deploy/referentiel/justification_ajustement@v4.38.0.sql
@@ -1,0 +1,100 @@
+-- Deploy tet:referentiel/justification_ajustement to pg
+
+BEGIN;
+
+create table justification_ajustement
+(
+    collectivite_id integer references collectivite               not null,
+    action_id       action_id references action_relation          not null,
+    texte           text                                          not null,
+    modified_by     uuid references auth.users default auth.uid() not null,
+    modified_at     timestamp with time zone                      not null,
+    primary key (collectivite_id, action_id)
+);
+comment on table justification_ajustement is 'Les justifications pour les scores ajustés.';
+
+select private.add_modified_at_trigger('public', 'justification_ajustement');
+select private.add_modified_by_trigger('public', 'justification_ajustement');
+
+alter table justification_ajustement
+    enable row level security;
+
+create policy allow_read
+    on justification_ajustement
+    for select
+    using (est_verifie() or have_lecture_acces(collectivite_id));
+
+create policy allow_insert
+    on justification_ajustement
+    for insert
+    with check (have_edition_acces(collectivite_id) OR est_auditeur_action(collectivite_id, action_id));
+
+create policy allow_update
+    on justification_ajustement
+    for update
+    using (have_edition_acces(collectivite_id) OR est_auditeur_action(collectivite_id, action_id));
+
+
+create table historique.justification_ajustement
+(
+    id                   serial primary key,
+    collectivite_id      integer   not null,
+    action_id            action_id not null,
+    modified_by          uuid,
+    previous_modified_by uuid,
+    modified_at          timestamp with time zone,
+    previous_modified_at timestamp with time zone,
+    texte                text      not null,
+    previous_texte       text
+);
+
+create function historique.save_justification_ajustement() returns trigger
+as
+$$
+declare
+    updated integer;
+begin
+    -- debounce
+    update historique.justification_ajustement
+    set texte       = new.texte,
+        modified_at = new.modified_at
+    where id in (select id
+                 from historique.justification_ajustement
+                 where collectivite_id = new.collectivite_id
+                   and action_id = new.action_id
+                   and modified_by = new.modified_by
+                   and modified_at > new.modified_at - interval '1 hour'
+                 order by modified_by desc
+                 limit 1)
+    returning id into updated;
+
+    if updated is null
+    then
+        insert into historique.justification_ajustement (collectivite_id,
+                                                         action_id,
+                                                         modified_by,
+                                                         previous_modified_by,
+                                                         modified_at,
+                                                         previous_modified_at,
+                                                         texte,
+                                                         previous_texte)
+        values (new.collectivite_id,
+                new.action_id,
+                auth.uid(),
+                old.modified_by,
+                new.modified_at,
+                old.modified_at,
+                new.texte,
+                old.texte);
+    end if;
+    return new;
+end ;
+$$ language plpgsql security definer;
+
+create trigger save_history
+    after insert or update
+    on justification_ajustement
+    for each row
+execute procedure historique.save_justification_ajustement();
+
+COMMIT;

--- a/data_layer/sqitch/revert/referentiel/justification_ajustement.sql
+++ b/data_layer/sqitch/revert/referentiel/justification_ajustement.sql
@@ -1,10 +1,102 @@
--- Revert tet:referentiel/justification_ajustement from pg
+-- Deploy tet:referentiel/justification_ajustement to pg
 
 BEGIN;
 
-drop trigger save_history on justification_ajustement;
-drop function historique.save_justification_ajustement;
-drop table historique.justification_ajustement;
-drop table justification_ajustement;
+-- décommenter pour une future migration qui drop la table justification_ajustement
+
+-- create table justification_ajustement
+-- (
+--     collectivite_id integer references collectivite               not null,
+--     action_id       action_id references action_relation          not null,
+--     texte           text                                          not null,
+--     modified_by     uuid references auth.users default auth.uid() not null,
+--     modified_at     timestamp with time zone                      not null,
+--     primary key (collectivite_id, action_id)
+-- );
+-- comment on table justification_ajustement is 'Les justifications pour les scores ajustés.';
+
+-- select private.add_modified_at_trigger('public', 'justification_ajustement');
+-- select private.add_modified_by_trigger('public', 'justification_ajustement');
+
+-- alter table justification_ajustement
+--     enable row level security;
+
+-- create policy allow_read
+--     on justification_ajustement
+--     for select
+--     using (est_verifie() or have_lecture_acces(collectivite_id));
+
+-- create policy allow_insert
+--     on justification_ajustement
+--     for insert
+--     with check (have_edition_acces(collectivite_id) OR est_auditeur_action(collectivite_id, action_id));
+
+-- create policy allow_update
+--     on justification_ajustement
+--     for update
+--     using (have_edition_acces(collectivite_id) OR est_auditeur_action(collectivite_id, action_id));
+
+
+-- create table historique.justification_ajustement
+-- (
+--     id                   serial primary key,
+--     collectivite_id      integer   not null,
+--     action_id            action_id not null,
+--     modified_by          uuid,
+--     previous_modified_by uuid,
+--     modified_at          timestamp with time zone,
+--     previous_modified_at timestamp with time zone,
+--     texte                text      not null,
+--     previous_texte       text
+-- );
+
+-- create function historique.save_justification_ajustement() returns trigger
+-- as
+-- $$
+-- declare
+--     updated integer;
+-- begin
+--     -- debounce
+--     update historique.justification_ajustement
+--     set texte       = new.texte,
+--         modified_at = new.modified_at
+--     where id in (select id
+--                  from historique.justification_ajustement
+--                  where collectivite_id = new.collectivite_id
+--                    and action_id = new.action_id
+--                    and modified_by = new.modified_by
+--                    and modified_at > new.modified_at - interval '1 hour'
+--                  order by modified_by desc
+--                  limit 1)
+--     returning id into updated;
+
+--     if updated is null
+--     then
+--         insert into historique.justification_ajustement (collectivite_id,
+--                                                          action_id,
+--                                                          modified_by,
+--                                                          previous_modified_by,
+--                                                          modified_at,
+--                                                          previous_modified_at,
+--                                                          texte,
+--                                                          previous_texte)
+--         values (new.collectivite_id,
+--                 new.action_id,
+--                 auth.uid(),
+--                 old.modified_by,
+--                 new.modified_at,
+--                 old.modified_at,
+--                 new.texte,
+--                 old.texte);
+--     end if;
+--     return new;
+-- end ;
+-- $$ language plpgsql security definer;
+
+-- create trigger save_history
+--     after insert or update
+--     on justification_ajustement
+--     for each row
+-- execute procedure historique.save_justification_ajustement();
 
 COMMIT;

--- a/data_layer/sqitch/revert/referentiel/justification_ajustement@v4.38.0.sql
+++ b/data_layer/sqitch/revert/referentiel/justification_ajustement@v4.38.0.sql
@@ -1,0 +1,10 @@
+-- Revert tet:referentiel/justification_ajustement from pg
+
+BEGIN;
+
+drop trigger save_history on justification_ajustement;
+drop function historique.save_justification_ajustement;
+drop table historique.justification_ajustement;
+drop table justification_ajustement;
+
+COMMIT;

--- a/data_layer/sqitch/sqitch.plan
+++ b/data_layer/sqitch/sqitch.plan
@@ -827,3 +827,4 @@ collectivite/collectivite [collectivite/collectivite@v4.41.0] 2025-03-14T10:22:1
 @v4.42.0 2025-03-20T08:39:29Z Marc Rutkowski <marc@attractive-media.fr> # Gère les valeurs cible et seuil
 
 labellisation/labellisation [labellisation/labellisation@v4.38.0] 2025-03-03T13:31:49Z Frederic Arnoux <frederic.arnoux@beta.gouv.fr> # Ajoute des RLS à etoile_meta
+referentiel/justification_ajustement [referentiel/justification_ajustement@v4.38.0] 2025-02-25T14:58:57Z Frederic Arnoux <frederic.arnoux@beta.gouv.fr> # Supprime les justifications des actions de referentiel

--- a/data_layer/sqitch/verify/referentiel/justification_ajustement@v4.38.0.sql
+++ b/data_layer/sqitch/verify/referentiel/justification_ajustement@v4.38.0.sql
@@ -2,4 +2,6 @@
 
 BEGIN;
 
+-- XXX Add verifications here.
+
 ROLLBACK;


### PR DESCRIPTION
- [x] Ajoute le script de migration des données des justifications vers les commentaires
- [ ] Supprimer la fonctionnalité "Personnaliser le score” depuis la modale "Détailler l’avancement" d'une sous-action avec tâches