### PR TITLE
Fix : répare boucle infinie dans graphique évolution des scores

### DIFF
--- a/app.territoiresentransitions.react/src/referentiels/evolutions/index.tsx
+++ b/app.territoiresentransitions.react/src/referentiels/evolutions/index.tsx
@@ -69,7 +69,7 @@ export const ScoreEvolutions = () => {
     if (initialDisplaySnapsNames.length > 0) {
       setSelectedSnapsNames(initialDisplaySnapsNames);
     }
-  }, [initialDisplaySnapsNames, snapshotList]);
+  }, [snapshotList]);
 
   if (hasSavedSnapshots) {
     return (


### PR DESCRIPTION
Répare bug introduit dans ce commit : https://github.com/incubateur-ademe/territoires-en-transitions/commit/22c5b199fbd0154afd70960c0e67971b058539a7#diff-12b10a3a267213bb364c601ed6cce3e9cdd39fe152eb12362cc0ae12817f96c0.

Comportement observé : le hook `useEffect`créait une boucle infinie.