### PR TITLE
Tet 2699/fix dnd fiche titre modification

### DIFF
--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/Carte/FicheActionCard.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/Carte/FicheActionCard.tsx
@@ -31,6 +31,8 @@ type FicheActionCardProps = {
   onUnlink?: () => void;
   /** Sélection de la fiche action */
   onSelect?: (isSelected: boolean) => void;
+  /** Exécuté à l'ouverture et à la fermeture de la fiche action */
+  onToggleOpen?: (isOpen: boolean) => void;
 };
 
 const FicheActionCard = ({
@@ -43,6 +45,7 @@ const FicheActionCard = ({
   isSelected = false,
   onUnlink,
   onSelect,
+  onToggleOpen,
 }: FicheActionCardProps) => {
   const collectivite = useCurrentCollectivite();
 
@@ -52,6 +55,11 @@ const FicheActionCard = ({
 
   const isNotClickable =
     collectivite?.niveauAcces === null && !!ficheAction.restreint;
+
+  const toggleOpen = (isOpen: boolean) => {
+    setIsEditOpen(isOpen);
+    onToggleOpen?.(isOpen);
+  };
 
   return (
     <div className="relative group h-full">
@@ -75,7 +83,7 @@ const FicheActionCard = ({
                     initialFiche={ficheAction}
                     axeId={axeIdToInvalidate}
                     isOpen={isEditOpen}
-                    setIsOpen={() => setIsEditOpen(!isEditOpen)}
+                    setIsOpen={() => toggleOpen(!isEditOpen)}
                     keysToInvalidate={editKeysToInvalidate}
                   />
                 )}
@@ -86,7 +94,7 @@ const FicheActionCard = ({
                   title="Modifier la fiche"
                   variant="grey"
                   size="xs"
-                  onClick={() => setIsEditOpen(!isEditOpen)}
+                  onClick={() => toggleOpen(!isEditOpen)}
                 />
               </>
               <ModaleSuppression

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/PlanAction/DragAndDropNestedContainers/Fiche.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/PlanAction/DragAndDropNestedContainers/Fiche.tsx
@@ -14,14 +14,13 @@ export type FicheDndData = {
 };
 
 type Props = {
-  planId: number;
   axeId: number;
   url?: string;
   fiche: FicheResume;
   editKeysToInvalidate?: QueryKey[];
 };
 
-const Fiche = ({ planId, axeId, url, fiche, editKeysToInvalidate }: Props) => {
+const Fiche = ({ axeId, url, fiche, editKeysToInvalidate }: Props) => {
   const collectivite = useCurrentCollectivite();
 
   const canDrag =
@@ -36,7 +35,7 @@ const Fiche = ({ planId, axeId, url, fiche, editKeysToInvalidate }: Props) => {
     listeners,
     setNodeRef: draggableRef,
   } = useDraggable({
-    id: fiche.id!,
+    id: fiche.id,
     data: {
       axeId,
       type: 'fiche',

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/PlanAction/DragAndDropNestedContainers/Fiche.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/PlanAction/DragAndDropNestedContainers/Fiche.tsx
@@ -2,6 +2,7 @@ import { FicheResume } from '@/api/plan-actions';
 import { useCurrentCollectivite } from '@/app/core-logic/hooks/useCurrentCollectivite';
 import { DragOverlay, useDraggable } from '@dnd-kit/core';
 import classNames from 'classnames';
+import { useState } from 'react';
 import { createPortal } from 'react-dom';
 import { QueryKey } from 'react-query';
 import FicheActionCard from '../../FicheAction/Carte/FicheActionCard';
@@ -27,6 +28,8 @@ const Fiche = ({ planId, axeId, url, fiche, editKeysToInvalidate }: Props) => {
     collectivite?.niveauAcces === 'admin' ||
     collectivite?.niveauAcces === 'edition';
 
+  const [isDisabled, setIsDisabled] = useState(!canDrag);
+
   const {
     active,
     attributes,
@@ -39,7 +42,7 @@ const Fiche = ({ planId, axeId, url, fiche, editKeysToInvalidate }: Props) => {
       type: 'fiche',
       fiche,
     },
-    disabled: !canDrag,
+    disabled: isDisabled,
   });
 
   const isDragging =
@@ -60,7 +63,7 @@ const Fiche = ({ planId, axeId, url, fiche, editKeysToInvalidate }: Props) => {
         )}
       {!active && (
         <div
-          className={classNames('h-full', { 'cursor-default': !canDrag })}
+          className={classNames('h-full', { 'cursor-default': isDisabled })}
           ref={draggableRef}
           {...listeners}
           {...attributes}
@@ -72,6 +75,7 @@ const Fiche = ({ planId, axeId, url, fiche, editKeysToInvalidate }: Props) => {
             link={url}
             isEditable
             editKeysToInvalidate={editKeysToInvalidate}
+            onToggleOpen={(isOpen) => setIsDisabled(isOpen)}
           />
         </div>
       )}

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/PlanAction/DragAndDropNestedContainers/Fiches.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/PlanAction/DragAndDropNestedContainers/Fiches.tsx
@@ -27,29 +27,28 @@ const Fiches = ({ isDndActive, isAxePage, ficheIds, planId, axeId }: Props) => {
         ? ficheIds.map((id) => <FicheActionCardSkeleton key={id} />)
         : data &&
           data.map((fiche) => {
-            if (fiche.id! < 0) {
+            if (fiche.id < 0) {
               return <FicheActionCardSkeleton key={fiche.id} />;
             } else {
               return (
                 <Fiche
                   key={fiche.id}
                   axeId={axeId}
-                  planId={planId}
                   fiche={fiche}
                   editKeysToInvalidate={[['axe_fiches', axeId, ficheIds]]}
                   url={
                     fiche.id
                       ? isAxePage
                         ? makeCollectivitePlanActionAxeFicheUrl({
-                            collectiviteId: fiche.collectiviteId!,
+                            collectiviteId: fiche.collectiviteId,
                             planActionUid: planId.toString(),
                             ficheUid: fiche.id.toString(),
                             axeUid: axeId.toString(),
                           })
                         : makeCollectivitePlanActionFicheUrl({
-                            collectiviteId: fiche.collectiviteId!,
+                            collectiviteId: fiche.collectiviteId,
                             planActionUid: planId.toString(),
-                            ficheUid: fiche.id!.toString(),
+                            ficheUid: fiche.id.toString(),
                           })
                       : undefined
                   }


### PR DESCRIPTION
Répare un bug sur le drag and drop d'une fiche action dans la page "Tous les plans d'actions".

Dans la modale de modification de la FA, lorsque l'utilisateur tente de sélectionner le titre avec le curseur, la FA passe en mode drag.

Le fix consiste à désactiver le drag lorsque la fiche est ouverte, pour cela il faut une nouvelle fonction qui permet de récupérer l'état d'ouverture de la fiche.