### PR TITLE
Fix : cache le lien "actions à impact" dans la nav si user en visite

### DIFF
--- a/app.territoiresentransitions.react/src/app/Layout/Header/makeNavItems.ts
+++ b/app.territoiresentransitions.react/src/app/Layout/Header/makeNavItems.ts
@@ -20,7 +20,7 @@ import {
   makeReferentielUrl,
   makeTableauBordUrl,
 } from '@/app/app/paths';
-import { CurrentCollectivite } from '@/app/core-logic/hooks/useCurrentCollectivite';
+import { CurrentCollectivite } from '@/app/collectivites/use-get-current-collectivite';
 import { TNavDropdown, TNavItem, TNavItemsList } from './types';
 
 /** Génère les liens de navigation pour une collectivité donnée */
@@ -58,7 +58,7 @@ const makeNavItemsBase = (
     collectivite.accesRestreint &&
     collectivite.niveauAcces === null &&
     notSupport;
-  const hideToVisitor = isVisiteur({ user, collectivite });
+  const hideFromVisitor = isVisiteur({ user, collectivite });
 
   // items communs qque soient les droits de l'utilisateur courant
   return [
@@ -187,6 +187,7 @@ const makeNavItemsBase = (
           urlPrefix: ['/tableau-de-bord/collectivite'],
         },
         {
+          hideFromVisitor,
           label: 'Mon suivi personnel',
           dataTest: 'pa-tdb-perso',
           to: makeTableauBordUrl({
@@ -194,7 +195,6 @@ const makeNavItemsBase = (
             view: 'personnel',
           }),
           urlPrefix: ['/tableau-de-bord/personnel'],
-          hideToVisitor,
         },
         {
           label: "Tous les plans d'action",
@@ -211,7 +211,7 @@ const makeNavItemsBase = (
           }),
         },
         {
-          confidentiel,
+          hideFromVisitor,
           label: 'Actions à Impact',
           dataTest: 'pa-ai',
           to: makeCollectivitePanierUrl({
@@ -258,7 +258,7 @@ const makeNavItemsBase = (
 const filtreItems = (items: TNavItemsList): TNavItemsList =>
   items
     ?.filter((item) => !item.confidentiel)
-    .filter((item) => !item.hideToVisitor)
+    .filter((item) => !item.hideFromVisitor)
     .map((item) => {
       return Object.prototype.hasOwnProperty.call(item, 'items')
         ? {

--- a/app.territoiresentransitions.react/src/app/Layout/Header/types.ts
+++ b/app.territoiresentransitions.react/src/app/Layout/Header/types.ts
@@ -10,7 +10,7 @@ export type TNavItem = {
   /** indique que l'item n'est pas affiché quand la collectivité est confidentielle */
   confidentiel?: boolean;
   /** indique que l'item n'est pas affiché quand l'utilisateur est un visiteur */
-  hideToVisitor?: boolean;
+  hideFromVisitor?: boolean;
 };
 
 export type TNavDropdown = {
@@ -22,7 +22,7 @@ export type TNavDropdown = {
   // indique que l'item n'est pas affiché quand la collectivité est confidentielle
   confidentiel?: boolean;
   // indique que l'item n'est pas affiché quand l'utilisateur est un visiteur
-  hideToVisitor?: boolean;
+  hideFromVisitor?: boolean;
 };
 
 export type TNavItemsList = (TNavItem | TNavDropdown)[];


### PR DESCRIPTION
Répare ce bug : https://www.notion.so/accelerateur-transition-ecologique-ademe/Support-Action-impact-disponible-en-Visite-1ce6523d57d780859e95f9289c8866ce?pvs=4