### PR TITLE
Put Posthog behind Next.js proxy

### DIFF
--- a/app.territoiresentransitions.react/.env.sample
+++ b/app.territoiresentransitions.react/.env.sample
@@ -3,7 +3,6 @@ NEXT_PUBLIC_SUPABASE_URL=${API_URL}
 NEXT_PUBLIC_CRISP_WEBSITE_ID="// Crisp integration (warning: use different ID by deployment env.)"
 NEXT_PUBLIC_SENTRY_DSN=
 POSTHOG_KEY=
-POSTHOG_HOST=
 NEXT_PUBLIC_AUTH_URL=http://localhost:3003
 NEXT_PUBLIC_BACKEND_URL=http://localhost:8080
 NEXT_PUBLIC_PANIER_URL=http://localhost:3002

--- a/app.territoiresentransitions.react/Earthfile
+++ b/app.territoiresentransitions.react/Earthfile
@@ -109,7 +109,6 @@ deploy:
   RUN ./koyeb services update $ENV_NAME-app/front \
     --docker $DOCKER_IMAGE \
     --docker-private-registry-secret ghcr \
-    --env POSTHOG_HOST=@POSTHOG_HOST \
     --env POSTHOG_KEY=@POSTHOG_KEY \
     --env DEPLOYMENT_TIMESTAMP=$DEPLOYMENT_TIMESTAMP
 

--- a/packages/ui/src/components/tracking/TrackingProvider.tsx
+++ b/packages/ui/src/components/tracking/TrackingProvider.tsx
@@ -23,13 +23,12 @@ export const TrackingProvider = ({
       ui_host: 'https://eu.posthog.com',
       // create profiles for authenticated users only
       person_profiles: 'identified_only',
-      persistence: getConsent() ? 'cookie' : 'memory',
+      persistence: getConsent() ? 'localStorage+cookie' : 'memory',
       capture_pageview: false, // on utilise PostHogPageView pour capturer les `page views`
 
       loaded: (posthog) => {
         if (process.env.NODE_ENV === 'development') posthog.debug();
       },
-
     });
 
     onClientInit?.(posthog);


### PR DESCRIPTION
Keep variable `POSTHOG_HOST` empty on hosting provider to (re)enable proxy mode.

The previous deletion of the proxy was to avoid “431 Header Too Large” error when sending events to PostHog with big cookies. But I think this problem is mainly occurring for our developers playing with multiple environments, all under `.territoiresentransitions.fr` domain. This is not likely to be a problem for our real users, and anyway seems to be a lower issue than the users using ad blockers blocking Posthog.

If ever this needs to be fixed, maybe look at implementing the reverse proxy ourselves in the `middleware`, and filtering only the Posthog cookie needing to limit header size ?

👀 https://posthog.com/docs/advanced/proxy/nextjs-middleware