### PR TITLE
👩‍✈️ Actualiser l’export des référentiels aux derniers développements

### DIFF
--- a/app.territoiresentransitions.react/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/action/[actionId]/_components/header/action.header.tsx
+++ b/app.territoiresentransitions.react/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/action/[actionId]/_components/header/action.header.tsx
@@ -4,8 +4,8 @@ import { useCurrentCollectivite } from '@/api/collectivites';
 import { ActionDefinitionSummary } from '@/app/referentiels/ActionDefinitionSummaryReadEndpoint';
 import ActionEditModal from '@/app/referentiels/actions/action-edit.modal';
 import { ActionSidePanelToolbar } from '@/app/referentiels/actions/action.side-panel.toolbar';
-import { useActionPilotesList } from '@/app/referentiels/actions/use-action-pilotes';
-import { useActionServicesPilotesList } from '@/app/referentiels/actions/use-action-services-pilotes';
+import { useListMesurePilotes } from '@/app/referentiels/actions/use-mesure-pilotes';
+import { useListMesureServicesPilotes } from '@/app/referentiels/actions/use-mesure-services-pilotes';
 import { ActionDetailed } from '@/app/referentiels/use-snapshot';
 import { Button } from '@/ui';
 import Breadcrumb from './breadcrumb';
@@ -29,8 +29,8 @@ export const ActionHeader = ({
 }) => {
   const { isReadOnly } = useCurrentCollectivite();
 
-  const { data: pilotes } = useActionPilotesList(action.actionId);
-  const { data: services } = useActionServicesPilotesList(action.actionId);
+  const { data: pilotes } = useListMesurePilotes(action.actionId);
+  const { data: services } = useListMesureServicesPilotes(action.actionId);
 
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
 

--- a/app.territoiresentransitions.react/src/referentiels/actions/action-edit.modal.tsx
+++ b/app.territoiresentransitions.react/src/referentiels/actions/action-edit.modal.tsx
@@ -3,13 +3,13 @@ import { useState } from 'react';
 
 import { useCollectiviteId } from '@/api/collectivites';
 import {
-  useActionPilotesDelete,
-  useActionPilotesUpsert,
-} from '@/app/referentiels/actions/use-action-pilotes';
+  useDeleteMesurePilotes,
+  useUpsertMesurePilotes,
+} from '@/app/referentiels/actions/use-mesure-pilotes';
 import {
-  useActionServicesPilotesDelete,
-  useActionServicesPilotesUpsert,
-} from '@/app/referentiels/actions/use-action-services-pilotes';
+  useDeleteMesureServicesPilotes,
+  useUpsertMesureServicesPilotes,
+} from '@/app/referentiels/actions/use-mesure-services-pilotes';
 import PersonnesDropdown from '@/app/ui/dropdownLists/PersonnesDropdown/PersonnesDropdown';
 import { getPersonneStringId } from '@/app/ui/dropdownLists/PersonnesDropdown/utils';
 import ServicesPilotesDropdown from '@/app/ui/dropdownLists/ServicesPilotesDropdown/ServicesPilotesDropdown';
@@ -34,11 +34,11 @@ const ActionEditModal = ({
 }: Props) => {
   const collectiviteId = useCollectiviteId();
 
-  const { mutate: upsertPilotes } = useActionPilotesUpsert();
-  const { mutate: deletePilotes } = useActionPilotesDelete();
+  const { mutate: upsertPilotes } = useUpsertMesurePilotes();
+  const { mutate: deletePilotes } = useDeleteMesurePilotes();
 
-  const { mutate: upsertServicesPilotes } = useActionServicesPilotesUpsert();
-  const { mutate: deleteServicesPilotes } = useActionServicesPilotesDelete();
+  const { mutate: upsertServicesPilotes } = useUpsertMesureServicesPilotes();
+  const { mutate: deleteServicesPilotes } = useDeleteMesureServicesPilotes();
 
   const [editedPilotes, setEditedPilotes] = useState<
     PersonneTagOrUser[] | undefined
@@ -57,11 +57,11 @@ const ActionEditModal = ({
       )
     ) {
       if (editedPilotes?.length === 0) {
-        deletePilotes({ collectiviteId, actionId });
+        deletePilotes({ collectiviteId, mesureId: actionId });
       } else {
         upsertPilotes({
           collectiviteId,
-          actionId,
+          mesureId: actionId,
           pilotes: (editedPilotes ?? []).map((pilote) => ({
             tagId: pilote.tagId ?? undefined,
             userId: pilote.userId ?? undefined,
@@ -78,11 +78,11 @@ const ActionEditModal = ({
       )
     ) {
       if (editedServices?.length === 0) {
-        deleteServicesPilotes({ collectiviteId, actionId });
+        deleteServicesPilotes({ collectiviteId, mesureId: actionId });
       } else {
         upsertServicesPilotes({
           collectiviteId,
-          actionId,
+          mesureId: actionId,
           services: (editedServices ?? []).map((s) => ({ serviceTagId: s.id })),
         });
       }

--- a/app.territoiresentransitions.react/src/referentiels/actions/use-mesure-pilotes.ts
+++ b/app.territoiresentransitions.react/src/referentiels/actions/use-mesure-pilotes.ts
@@ -1,23 +1,27 @@
 import { useCollectiviteId } from '@/api/collectivites';
 import { trpc } from '@/api/utils/trpc/client';
 
-/** Récupère la liste des pilotes d'une mesure */
-export const useActionPilotesList = (actionId: string) => {
+export const useListMesurePilotes = (actionId: string) => {
   const collectiviteId = useCollectiviteId();
-  return trpc.referentiels.actions.listPilotes.useQuery({
+
+  const { data: pilotesData } = trpc.referentiels.actions.listPilotes.useQuery({
     collectiviteId,
-    actionId,
+    mesureIds: [actionId],
   });
+
+  return {
+    data: pilotesData?.[actionId] || [],
+  };
 };
 
 /** Modifie la liste des pilotes d'une mesure */
-export const useActionPilotesUpsert = () => {
+export const useUpsertMesurePilotes = () => {
   const utils = trpc.useUtils();
   return trpc.referentiels.actions.upsertPilotes.useMutation({
     onSuccess: (data, variables) => {
       utils.referentiels.actions.listPilotes.invalidate({
         collectiviteId: variables.collectiviteId,
-        actionId: variables.actionId,
+        mesureIds: [variables.mesureId],
       });
       utils.referentiels.actions.listActions.invalidate({
         collectiviteId: variables.collectiviteId,
@@ -27,13 +31,13 @@ export const useActionPilotesUpsert = () => {
 };
 
 /** Supprime les pilotes d'une mesure */
-export const useActionPilotesDelete = () => {
+export const useDeleteMesurePilotes = () => {
   const utils = trpc.useUtils();
   return trpc.referentiels.actions.deletePilotes.useMutation({
     onSuccess: (data, variables) => {
       utils.referentiels.actions.listPilotes.invalidate({
         collectiviteId: variables.collectiviteId,
-        actionId: variables.actionId,
+        mesureIds: [variables.mesureId],
       });
       utils.referentiels.actions.listActions.invalidate({
         collectiviteId: variables.collectiviteId,

--- a/app.territoiresentransitions.react/src/referentiels/actions/use-mesure-services-pilotes.ts
+++ b/app.territoiresentransitions.react/src/referentiels/actions/use-mesure-services-pilotes.ts
@@ -2,22 +2,28 @@ import { useCollectiviteId } from '@/api/collectivites';
 import { trpc } from '@/api/utils/trpc/client';
 
 /** Récupère la liste des services pilotes d'une mesure */
-export const useActionServicesPilotesList = (actionId: string) => {
+export const useListMesureServicesPilotes = (actionId: string) => {
   const collectiviteId = useCollectiviteId();
-  return trpc.referentiels.actions.listServices.useQuery({
-    collectiviteId,
-    actionId,
-  });
+
+  const { data: servicesData } =
+    trpc.referentiels.actions.listServices.useQuery({
+      collectiviteId,
+      mesureIds: [actionId],
+    });
+
+  return {
+    data: servicesData?.[actionId] || [],
+  };
 };
 
 /** Modifie la liste des services pilotes d'une mesure */
-export const useActionServicesPilotesUpsert = () => {
+export const useUpsertMesureServicesPilotes = () => {
   const utils = trpc.useUtils();
   return trpc.referentiels.actions.upsertServices.useMutation({
     onSuccess: (data, variables) => {
       utils.referentiels.actions.listServices.invalidate({
         collectiviteId: variables.collectiviteId,
-        actionId: variables.actionId,
+        mesureIds: [variables.mesureId],
       });
       utils.referentiels.actions.listActions.invalidate({
         collectiviteId: variables.collectiviteId,
@@ -27,13 +33,13 @@ export const useActionServicesPilotesUpsert = () => {
 };
 
 /** Supprime les services pilotes d'une mesure */
-export const useActionServicesPilotesDelete = () => {
+export const useDeleteMesureServicesPilotes = () => {
   const utils = trpc.useUtils();
   return trpc.referentiels.actions.deleteServices.useMutation({
     onSuccess: (data, variables) => {
       utils.referentiels.actions.listServices.invalidate({
         collectiviteId: variables.collectiviteId,
-        actionId: variables.actionId,
+        mesureIds: [variables.mesureId],
       });
       utils.referentiels.actions.listActions.invalidate({
         collectiviteId: variables.collectiviteId,

--- a/backend/src/plans/fiches/list-fiches/list-fiches.service.ts
+++ b/backend/src/plans/fiches/list-fiches/list-fiches.service.ts
@@ -615,10 +615,11 @@ export default class ListFichesService {
     }
 
     if (filters && Object.keys(filters).length > 0) {
+      const filterSummary = this.formatLogs(filters);
       this.logger.log(
-        `Récupération des fiches action pour la collectivité ${collectiviteId}: filtres ${JSON.stringify(
-          filters
-        )}`
+        `Récupération des fiches action pour la collectivité ${collectiviteId} ${
+          filterSummary ? `(filtre(s) appliqué(s): ${filterSummary})` : ''
+        }`
       );
       conditions.push(...this.getConditions(filters));
     } else {
@@ -850,6 +851,28 @@ export default class ListFichesService {
         sql`unaccent(${column}) ilike unaccent(${`%${searchText}%`})`
       );
     }
+  }
+
+  private formatLogs(filters: ListFichesRequestFilters): string {
+    const filterEntries = Object.entries(filters).filter(([_, value]) => value);
+
+    const MAX_ITEMS_TO_SHOW = 10;
+
+    if (filterEntries.length > MAX_ITEMS_TO_SHOW) {
+      return `${filterEntries.length} filtres appliqués`;
+    }
+
+    return filterEntries
+      .map(([name, value]) => {
+        if (Array.isArray(value)) {
+          if (value.length > MAX_ITEMS_TO_SHOW) {
+            return `${name}, ${value.length} éléments`;
+          }
+          return `${name}: ${value.join(',')}`;
+        }
+        return `${name}: ${value}`;
+      })
+      .join(', ');
   }
 
   private getConditions(
@@ -1140,10 +1163,11 @@ export default class ListFichesService {
     nbOfPages: number;
     data: FicheResume[];
   }> {
+    const filterSummary = filters ? this.formatLogs(filters) : '';
     this.logger.log(
-      `Récupération des fiches actions résumées pour la collectivité ${collectiviteId} avec les filtres ${JSON.stringify(
-        filters
-      )}`
+      `Récupération des fiches actions résumées pour la collectivité ${collectiviteId} ${
+        filterSummary ? `(${filterSummary})` : ''
+      }`
     );
     const { data: fiches, count } = await this.getFichesActionWithCount(
       collectiviteId,

--- a/backend/src/referentiels/export-score/export-score.controller.e2e-spec.ts
+++ b/backend/src/referentiels/export-score/export-score.controller.e2e-spec.ts
@@ -34,10 +34,11 @@ describe('Referentiels scoring routes', () => {
     const exportFileName = responseSnapshotExport.headers['content-disposition']
       .split('filename=')[1]
       .split(';')[0];
+
     expect(exportFileName).toBe(
       `"Export_ECI_Ambe?rieu-en-Bugey_${currentDate}.xlsx"`
     );
-    const expectedExportSize = 33.702;
+    const expectedExportSize = 50.546;
     const exportFileSize = parseInt(
       responseSnapshotExport.headers['content-length']
     );

--- a/backend/src/referentiels/export-score/export-score.controller.ts
+++ b/backend/src/referentiels/export-score/export-score.controller.ts
@@ -1,4 +1,3 @@
-import { PermissionService } from '@/backend/auth/authorizations/permission.service';
 import { AllowAnonymousAccess } from '@/backend/auth/decorators/allow-anonymous-access.decorator';
 import { TokenInfo } from '@/backend/auth/decorators/token-info.decorators';
 import { AuthUser } from '@/backend/auth/index-domain';
@@ -21,10 +20,7 @@ import { ExportScoreService } from './export-score.service';
 export class ExportScoreController {
   private readonly logger = new Logger(ExportScoreController.name);
 
-  constructor(
-    private readonly exportScoreService: ExportScoreService,
-    private readonly permissionsService: PermissionService
-  ) {}
+  constructor(private readonly exportScoreService: ExportScoreService) {}
 
   @AllowAnonymousAccess()
   @Get(
@@ -42,14 +38,6 @@ export class ExportScoreController {
     this.logger.log(
       `Export du score du referentiel ${referentielId} pour la collectivite ${collectiviteId} et le snapshot ${snapshotRef}`
     );
-
-    // TODO: why commented?
-    // this.permissionsService.isAllowed(
-    //   user,
-    //   PermissionOperation.REFERENTIELS_LECTURE,
-    //   ResourceType.COLLECTIVITE,
-    //   collectiviteId
-    // );
 
     try {
       const { fileName, content } =

--- a/backend/src/referentiels/export-score/export-score.service.spec.ts
+++ b/backend/src/referentiels/export-score/export-score.service.spec.ts
@@ -1,6 +1,10 @@
+import { PersonneTagOrUser, Tag } from '@/backend/collectivites/index-domain';
+import ListFichesService from '@/backend/plans/fiches/list-fiches/list-fiches.service';
 import { Test } from '@nestjs/testing';
 import ScoresService from '../compute-score/scores.service';
 import { GetReferentielService } from '../get-referentiel/get-referentiel.service';
+import { HandleMesurePilotesService } from '../handle-mesure-pilotes/handle-mesure-pilotes.service';
+import { HandleMesureServicesService } from '../handle-mesure-services/handle-mesure-services.service';
 import { deeperReferentielScoring } from '../models/samples/deeper-referentiel-scoring.sample';
 import { simpleReferentielScoring } from '../models/samples/simple-referentiel-scoring.sample';
 import { SnapshotsService } from '../snapshots/snapshots.service';
@@ -17,7 +21,10 @@ describe('ExportReferentielScoreService', () => {
         if (
           token === GetReferentielService ||
           token === ScoresService ||
-          token === SnapshotsService
+          token === SnapshotsService ||
+          token === HandleMesurePilotesService ||
+          token === HandleMesureServicesService ||
+          token === ListFichesService
         ) {
           return {};
         }
@@ -28,9 +35,40 @@ describe('ExportReferentielScoreService', () => {
   });
 
   it(`getActionScoreRowValues for simple referentiel`, () => {
+    const pilotes: Record<string, PersonneTagOrUser[]> = {};
+    const services: Record<string, Tag[]> = {};
+
+    pilotes['eci_1.1'] = [
+      {
+        userId: '17440546-f389-4d4f-bfdb-b0c94a1bd0f9',
+        nom: 'Yolo Dodo',
+      },
+      {
+        tagId: 1,
+        nom: 'Lou Piote',
+      },
+    ];
+
+    services['eci_1.1'] = [
+      {
+        id: 1,
+        nom: 'Super Service',
+        collectiviteId: 1,
+      },
+      {
+        id: 2,
+        nom: 'Ultra Service',
+        collectiviteId: 1,
+      },
+    ];
+
     const dataRows = exportReferentielScoreService.getActionScoreRowValues(
       simpleReferentielScoring,
-      undefined
+      undefined,
+      {}, // descriptions vides pour le test
+      pilotes,
+      services,
+      {} // fiches actions liées vides pour le test
     );
     const dataRowValues = dataRows.map((r) => r.values);
 
@@ -38,21 +76,28 @@ describe('ExportReferentielScoreService', () => {
       [
         '1',
         "Définition d'une stratégie globale de la politique économie circulaire et inscription dans le territoire",
+        '', // description
+        '',
+        '',
         '',
         30,
         30,
         10,
-        0.33,
+        0.333,
         0,
         0,
         '',
         '',
         '',
+        '', // fiches actions liées
       ],
       [
         '1.1',
         'Définir une stratégie globale de la politique Economie Circulaire et assurer un portage politique fort',
+        '', // description
         '',
+        'Yolo Dodo, Lou Piote',
+        'Super Service, Ultra Service',
         10,
         10,
         10,
@@ -62,10 +107,14 @@ describe('ExportReferentielScoreService', () => {
         'Fait',
         '',
         '',
+        '', // fiches actions liées
       ],
       [
         '1.2',
         "Développer une démarche transversale avec l'ensemble des politiques de la collectivité",
+        '', // description
+        '',
+        '',
         '',
         20,
         20,
@@ -76,10 +125,14 @@ describe('ExportReferentielScoreService', () => {
         'Non renseigné',
         '',
         '',
+        '', // fiches actions liées
       ],
       [
         '2',
         'Développement des services de réduction, collecte et valorisation des déchets',
+        '', // description
+        '',
+        '',
         '',
         70,
         70,
@@ -90,10 +143,14 @@ describe('ExportReferentielScoreService', () => {
         '',
         '',
         '',
+        '', // fiches actions liées
       ],
       [
         '2.0',
         'Respecter la réglementation en matière de prévention de déchets',
+        '', // description
+        '',
+        '',
         '',
         0,
         0,
@@ -104,11 +161,15 @@ describe('ExportReferentielScoreService', () => {
         'Non renseigné',
         '',
         '',
+        '', // fiches actions liées
       ],
       [
         '2.1',
         'Mettre en œuvre les actions du PLPDMA',
+        '', // description
         'Mise en œuvre',
+        '',
+        '',
         65,
         65,
         0,
@@ -119,10 +180,14 @@ describe('ExportReferentielScoreService', () => {
         'Explication de mise en œuvre',
         `preuve1.pdf
 https://example.com/preuve2.pdf`,
+        '', // fiches actions liées
       ],
       [
         '2.2',
         "Disposer d'une commission consultative d'élaboration et de suivi (CCES) élargie",
+        '', // description
+        '',
+        '',
         '',
         5,
         5,
@@ -133,24 +198,59 @@ https://example.com/preuve2.pdf`,
         'Non renseigné',
         '',
         '',
+        '', // fiches actions liées
       ],
-      ['Total', '', '', 100, 100, 10, 0.1, 0, 0, '', '', ''],
+      ['Total', '', '', '', '', '', 100, 100, 10, 0.1, 0, 0, '', '', '', ''], // fiches actions liées
     ]);
   });
 
   it(`getActionScoreRowValues for deeper referentiel`, () => {
+    const pilotes: Record<string, PersonneTagOrUser[]> = {};
+    const services: Record<string, Tag[]> = {};
+
+    pilotes['eci_1.1'] = [
+      {
+        userId: '17440546-f389-4d4f-bfdb-b0c94a1bd0f9',
+        nom: 'Yolo Dodo',
+      },
+      {
+        tagId: 1,
+        nom: 'Lou Piote',
+      },
+    ];
+
+    services['eci_1.1'] = [
+      {
+        id: 1,
+        nom: 'Super Service',
+        collectiviteId: 1,
+      },
+      {
+        id: 2,
+        nom: 'Ultra Service',
+        collectiviteId: 1,
+      },
+    ];
+
     const dataRows = exportReferentielScoreService.getActionScoreRowValues(
       deeperReferentielScoring,
-      undefined
+      undefined,
+      {}, // descriptions vides pour le test
+      pilotes,
+      services,
+      {} // fiches actions liées vides pour le test
     );
     const dataRowValues = dataRows.map((r) => r.values);
 
     expect(dataRowValues).toEqual([
-      ['1', 'Action 1', '', 30, 30, 0, 0, 0, 0, '', '', ''],
+      ['1', 'Action 1', '', '', '', '', 30, 30, 0, 0, 0, 0, '', '', '', ''], // fiches actions liées
       [
         '1.1',
         'Sous-action 1.1',
+        '', // description
         'Effets',
+        'Yolo Dodo, Lou Piote',
+        'Super Service, Ultra Service',
         10,
         10,
         0,
@@ -160,10 +260,14 @@ https://example.com/preuve2.pdf`,
         'Non concerné',
         '',
         '',
+        '', // fiches actions liées
       ],
       [
         '1.2',
         'Sous-action 1.2',
+        '', // description
+        '',
+        '',
         '',
         20,
         20,
@@ -174,13 +278,51 @@ https://example.com/preuve2.pdf`,
         'Non concerné',
         '',
         '',
+        '', // fiches actions liées
       ],
-      ['2', 'Action 2', '', 70, 70, 65, 0.93, 0, 0, '', '', ''],
-      ['2.0', 'Sous-action 2.0', '', 0, 0, 0, 0, 0, 0, 'Non renseigné', '', ''],
+      [
+        '2',
+        'Action 2',
+        '',
+        '',
+        '',
+        '',
+        70,
+        70,
+        65,
+        0.929,
+        0,
+        0,
+        '',
+        '',
+        '',
+        '',
+      ], // fiches actions liées
+      [
+        '2.0',
+        'Sous-action 2.0',
+        '', // description
+        '',
+        '',
+        '',
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        'Non renseigné',
+        '',
+        '',
+        '', // fiches actions liées
+      ],
       [
         '2.1',
         'Sous-action 2.1',
+        '', // description
         'Mise en œuvre',
+        '',
+        '',
         65,
         65,
         65,
@@ -190,15 +332,201 @@ https://example.com/preuve2.pdf`,
         'Fait',
         '',
         '',
+        '', // fiches actions liées
       ],
-      ['2.1.0', 'Tache 2.1.0', '', 0, 0, 0, 0, 0, 0, '', '', ''],
-      ['2.1.1', 'Tache 2.1.1', '', 40, 40, 32, 0.8, 8, 0.2, 'Détaillé', '', ''],
-      ['2.1.2', 'Tache 2.1.2', '', 25, 25, 0, 0, 0, 0, '', '', ''],
-      ['2.2', 'Sous-action 2.2', 'Bases', 5, 5, 0, 0, 0, 0, 'Détaillé', '', ''],
-      ['2.2.1', 'Tache 2.2.1', '', 2, 2, 0, 0, 0, 0, '', '', ''],
-      ['2.2.2', 'Tache 2.2.2', '', 1.5, 1.5, 0, 0, 0, 0, 'Pas fait', '', ''],
-      ['2.2.3', 'Tache 2.2.3', '', 1.5, 1.5, 0, 0, 0, 0, '', '', ''],
-      ['Total', '', '', 100, 100, 65, 0.65, 0, 0, '', '', ''],
+      [
+        '2.1.0',
+        'Tache 2.1.0',
+        '',
+        '',
+        '',
+        '',
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        '',
+        '',
+        '',
+        '',
+      ], // fiches actions liées
+      [
+        '2.1.1',
+        'Tache 2.1.1',
+        '', // description
+        '',
+        '',
+        '',
+        40,
+        40,
+        32,
+        0.8,
+        8,
+        0.2,
+        'Détaillé',
+        '',
+        '',
+        '', // fiches actions liées
+      ],
+      [
+        '2.1.2',
+        'Tache 2.1.2',
+        '',
+        '',
+        '',
+        '',
+        25,
+        25,
+        0,
+        0,
+        0,
+        0,
+        '',
+        '',
+        '',
+        '',
+      ], // fiches actions liées
+      [
+        '2.2',
+        'Sous-action 2.2',
+        '', // description
+        'Bases',
+        '',
+        '',
+        5,
+        5,
+        0,
+        0,
+        0,
+        0,
+        'Détaillé',
+        '',
+        '',
+        '', // fiches actions liées
+      ],
+      [
+        '2.2.1',
+        'Tache 2.2.1',
+        '',
+        '',
+        '',
+        '',
+        2,
+        2,
+        0,
+        0,
+        0,
+        0,
+        '',
+        '',
+        '',
+        '',
+      ], // fiches actions liées
+      [
+        '2.2.2',
+        'Tache 2.2.2',
+        '', // description
+        '',
+        '',
+        '',
+        1.5,
+        1.5,
+        0,
+        0,
+        0,
+        0,
+        'Pas fait',
+        '',
+        '',
+        '', // fiches actions liées
+      ],
+      [
+        '2.2.3',
+        'Tache 2.2.3',
+        '',
+        '',
+        '',
+        '',
+        1.5,
+        1.5,
+        0,
+        0,
+        0,
+        0,
+        '',
+        '',
+        '',
+        '', // fiches actions liées
+      ],
+      ['Total', '', '', '', '', '', 100, 100, 65, 0.65, 0, 0, '', '', '', ''], // fiches actions liées
     ]);
+  });
+
+  it(`getActionScoreRowValues uses provided descriptions`, () => {
+    const pilotes: Record<string, PersonneTagOrUser[]> = {};
+    const services: Record<string, Tag[]> = {};
+    const descriptions: Record<string, string> = {
+      'eci_1.1': 'Description personnalisée pour eci_1.1',
+      'eci_2.1': 'Description détaillée pour eci_2.1',
+    };
+
+    const dataRows = exportReferentielScoreService.getActionScoreRowValues(
+      simpleReferentielScoring,
+      undefined,
+      descriptions,
+      pilotes,
+      services,
+      {} // fiches actions liées vides pour ce test
+    );
+
+    const mesure11Row = dataRows.find(
+      (row) => row.actionScore.identifiant === '1.1'
+    );
+    const mesure21Row = dataRows.find(
+      (row) => row.actionScore.identifiant === '2.1'
+    );
+
+    expect(mesure11Row?.values[2]).toBe(
+      'Description personnalisée pour eci_1.1'
+    );
+    expect(mesure21Row?.values[2]).toBe('Description détaillée pour eci_2.1');
+  });
+
+  it(`getActionScoreRowValues includes fiches actions liées`, () => {
+    const pilotes: Record<string, PersonneTagOrUser[]> = {};
+    const services: Record<string, Tag[]> = {};
+    const descriptions: Record<string, string> = {};
+    const fichesActionLiees: Record<string, string> = {
+      'eci_1.1': 'Fiche action mobilité\nFiche action énergie',
+      'eci_2.1': 'Fiche action déchets',
+      'eci_2.2': '', // Test avec chaîne vide
+    };
+
+    const dataRows = exportReferentielScoreService.getActionScoreRowValues(
+      simpleReferentielScoring,
+      undefined,
+      descriptions,
+      pilotes,
+      services,
+      fichesActionLiees
+    );
+
+    const mesure11Row = dataRows.find(
+      (row) => row.actionScore.identifiant === '1.1'
+    );
+    const mesure21Row = dataRows.find(
+      (row) => row.actionScore.identifiant === '2.1'
+    );
+    const mesure22Row = dataRows.find(
+      (row) => row.actionScore.identifiant === '2.2'
+    );
+
+    expect(mesure11Row?.values[15]).toBe(
+      'Fiche action mobilité\nFiche action énergie'
+    );
+    expect(mesure21Row?.values[15]).toBe('Fiche action déchets');
+    expect(mesure22Row?.values[15]).toBe(''); // Chaîne vide
   });
 });

--- a/backend/src/referentiels/export-score/export-score.service.ts
+++ b/backend/src/referentiels/export-score/export-score.service.ts
@@ -1,9 +1,19 @@
+import { PersonneTagOrUser, Tag } from '@/backend/collectivites/index-domain';
+import {
+  ActionDefinition,
+  MesureId,
+  ScoreFinalFields,
+} from '@/backend/referentiels/index-domain';
 import { Injectable, Logger } from '@nestjs/common';
 import { Row, Workbook } from 'exceljs';
 import { PreuveEssential } from '../../collectivites/documents/models/preuve.dto';
 import * as Utils from '../../utils/excel/export-excel.utils';
 import { roundTo } from '../../utils/number.utils';
-import { ActionDefinition, ScoreFinalFields } from '../index-domain';
+import { HandleMesurePilotesService } from '../handle-mesure-pilotes/handle-mesure-pilotes.service';
+
+import ListFichesService from '@/backend/plans/fiches/list-fiches/list-fiches.service';
+import { HandleMesureServicesService } from '@/backend/referentiels/handle-mesure-services/handle-mesure-services.service';
+import { GetReferentielService } from '../get-referentiel/get-referentiel.service';
 import {
   ActionDefinitionEssential,
   TreeNode,
@@ -25,7 +35,9 @@ import { ScoresPayload } from '../snapshots/scores-payload.dto';
 import { SnapshotsService } from '../snapshots/snapshots.service';
 
 type ActionDefinitionFields = ActionDefinitionEssential &
-  Partial<Pick<ActionDefinition, 'identifiant' | 'nom' | 'categorie'>>;
+  Partial<
+    Pick<ActionDefinition, 'identifiant' | 'nom' | 'categorie' | 'description'>
+  >;
 
 type ActionWithScore = TreeNode<ActionDefinitionFields & ScoreFinalFields>;
 
@@ -37,23 +49,30 @@ export class ExportScoreService {
   private readonly COL_INDEX = {
     arbo: 1,
     intitule: 2,
-    phase: 3,
-    points_max_referentiel: 4,
-    points_max_personnalises: 5,
-    points_realises: 6,
-    score_realise: 7,
-    points_programmes: 8,
-    score_programme: 9,
-    statut: 10,
-    commentaires: 11,
-    docs: 12,
+    description: 3,
+    phase: 4,
+    pilotes: 5,
+    services: 6,
+    points_max_referentiel: 7,
+    points_max_personnalises: 8,
+    points_realises: 9,
+    score_realise: 10,
+    points_programmes: 11,
+    score_programme: 12,
+    statut: 13,
+    commentaires: 14,
+    docs: 15,
+    fiches_actions_liees: 16,
   };
 
   // libellés de toutes les colonnes
   private readonly COLUMN_LABELS = [
-    '', // identifiant action
-    '', // intitulé action
+    'N°',
+    'Intitulé',
+    'Description',
     'Phase',
+    'Personnes pilotes',
+    'Services ou Directions pilotes',
     'Potentiel max',
     'Potentiel collectivité',
     'Points réalisés',
@@ -63,6 +82,7 @@ export class ExportScoreService {
     'statut',
     "Champs de précision de l'état d'avancement",
     'Documents liés',
+    'Fiches actions liées',
   ];
 
   private readonly AVANCEMENT_TO_LABEL: Record<
@@ -82,7 +102,13 @@ export class ExportScoreService {
   private readonly EXPORT_TITLE = 'Export référentiel';
   private readonly EXPORT_SUBTITLE = 'Évaluation dans la plateforme';
 
-  constructor(private readonly snapshotsService: SnapshotsService) {}
+  constructor(
+    private readonly snapshotsService: SnapshotsService,
+    private readonly assignPilotesService: HandleMesurePilotesService,
+    private readonly assignServicesService: HandleMesureServicesService,
+    private readonly getReferentielService: GetReferentielService,
+    private readonly listFichesService: ListFichesService
+  ) {}
 
   // couleurs de fond des lignes par axe et sous-axe
   BG_COLORS: Record<number, string[]> = {
@@ -99,7 +125,7 @@ export class ExportScoreService {
   BG_COLOR4 = 'd8d8d8'; // niveau 4 (CAE seulement)
 
   // détermine la couleur de fond d'une ligne en fonction de la profondeur dans l'arbo
-  getActionRowColor = (
+  private getActionRowColor = (
     actionScore: ActionWithScore,
     referentielId: ReferentielId
   ): string | null => {
@@ -122,7 +148,7 @@ export class ExportScoreService {
   };
 
   /** applique le formatage numérique aux colonnes points/scores à partir de l'index (base 1) donné */
-  setScoreFormats(row: Row, colIndex: number) {
+  private setScoreFormats(row: Row, colIndex: number) {
     Utils.setCellNumFormat(row.getCell(colIndex));
     Utils.setCellNumFormat(row.getCell(colIndex + 1));
     Utils.setCellNumFormat(row.getCell(colIndex + 2), Utils.FORMAT_PERCENT);
@@ -131,7 +157,7 @@ export class ExportScoreService {
     row.getCell(colIndex + 5).style.alignment = Utils.ALIGN_CENTER;
   }
 
-  formatActionStatut(
+  private formatActionStatut(
     actionScore: ActionWithScore | undefined,
     parentActionScore: ActionWithScore | undefined
   ): string {
@@ -187,16 +213,110 @@ export class ExportScoreService {
     return this.AVANCEMENT_TO_LABEL[avancement];
   }
 
-  formatPreuves(preuves?: PreuveEssential[]): string | undefined {
+  private formatPreuves(preuves?: PreuveEssential[]): string | undefined {
     return preuves
       ?.map((p) => p?.url || p?.filename || null)
       .filter((s) => !!s)
       .join('\n');
   }
 
+  private getAllMesureIds(actionScore: ActionWithScore): MesureId[] {
+    const ids: MesureId[] = [];
+    if (actionScore.actionId) {
+      ids.push(actionScore.actionId);
+    }
+    actionScore.actionsEnfant?.forEach((child) => {
+      ids.push(...this.getAllMesureIds(child));
+    });
+    return ids;
+  }
+
+  private async getActionDescriptions(
+    referentielId: ReferentielId
+  ): Promise<Record<MesureId, string>> {
+    const referentiel = await this.getReferentielService.getReferentielTree(
+      referentielId,
+      false
+    );
+
+    const descriptions: Record<string, string> = {};
+
+    type ActionWithAllFields = typeof referentiel.itemsTree & {
+      description?: string;
+      nom?: string;
+      identifiant?: string;
+      actionsEnfant?: ActionWithAllFields[];
+    };
+
+    const extractDescriptions = (action: ActionWithAllFields) => {
+      if (action.actionId && action.description) {
+        descriptions[action.actionId] = Utils.cleanHtmlDescription(
+          action.description
+        );
+      }
+      if (action.actionsEnfant) {
+        action.actionsEnfant.forEach(extractDescriptions);
+      }
+    };
+
+    extractDescriptions(referentiel.itemsTree as ActionWithAllFields);
+    return descriptions;
+  }
+
+  private async getFichesActionLiees(
+    collectiviteId: number,
+    mesureIds: MesureId[]
+  ): Promise<Record<MesureId, string>> {
+    const fichesActionLiees: Record<string, string[]> = {};
+
+    try {
+      const fiches = await this.listFichesService.getFichesAction(
+        collectiviteId,
+        { mesureIds }
+      );
+
+      if (fiches && fiches.length > 0) {
+        for (const fiche of fiches) {
+          if (!fiche.mesures || !fiche.titre) continue;
+
+          for (const mesure of fiche.mesures) {
+            if (!mesureIds.includes(mesure.id)) continue;
+
+            if (!fichesActionLiees[mesure.id]) {
+              fichesActionLiees[mesure.id] = [fiche.titre];
+            } else {
+              fichesActionLiees[mesure.id].push(fiche.titre);
+            }
+          }
+        }
+      }
+    } catch (error) {
+      this.logger.warn(
+        `Erreur lors de la récupération des fiches d'action liées:`,
+        error
+      );
+    }
+
+    // trie les fiches par ordre alphabétique et met en forme
+    const sortedFiches: Record<string, string> = {};
+    for (const [actionId, titres] of Object.entries(fichesActionLiees)) {
+      sortedFiches[actionId] = titres
+        .map((titre) => titre.trim())
+        .filter((titre) => titre.length > 0)
+        .sort((a, b) => a.localeCompare(b, 'fr', { sensitivity: 'base' }))
+        .join('\n');
+    }
+
+    return sortedFiches;
+  }
+
   getActionScoreRowValues(
     actionScore: ActionWithScore,
     parentActionScore: ActionWithScore | undefined,
+    descriptions: Record<string, string> = {},
+    pilotes: Record<string, PersonneTagOrUser[]>,
+    services: Record<string, Tag[]>,
+    fichesActionLiees: Record<string, string> = {},
     rowValues: {
       actionScore: ActionWithScore;
       values: (string | number | null | undefined)[];
@@ -214,8 +334,18 @@ export class ExportScoreService {
       actionScore.actionType === ActionTypeEnum.REFERENTIEL
         ? ''
         : actionScore?.nom,
+      // description
+      actionScore.actionType === ActionTypeEnum.REFERENTIEL
+        ? ''
+        : descriptions[actionScore.actionId] || actionScore?.description || '',
       // phase
       Utils.capitalize(actionScore?.categorie),
+
+      // pilotes
+      pilotes[actionScore.actionId]?.map((p) => p.nom).join(', ') || '',
+
+      // services
+      services[actionScore.actionId]?.map((s) => s.nom).join(', ') || '',
 
       // points max réf.
       actionScore.score.pointReferentiel,
@@ -226,19 +356,22 @@ export class ExportScoreService {
       roundTo(
         (actionScore.score.pointFait || 0) /
           (actionScore.score.pointPotentiel || 1),
-        2
+        3
       ),
       actionScore.score.pointProgramme,
       roundTo(
         (actionScore.score.pointProgramme || 0) /
           (actionScore.score.pointPotentiel || 1),
-        2
+        3
       ),
       this.formatActionStatut(actionScore, parentActionScore),
 
       // commentaires et documents,
       actionScore.score.explication || '',
       this.formatPreuves(actionScore.preuves) || '',
+
+      // fiches actions liées
+      fichesActionLiees[actionScore.actionId] || '',
     ];
 
     // Referentiel actions est mis en dernier
@@ -248,7 +381,15 @@ export class ExportScoreService {
 
     // ajoute les sous-actions
     actionScore.actionsEnfant?.forEach((actionEnfantScore) => {
-      this.getActionScoreRowValues(actionEnfantScore, actionScore, rowValues);
+      this.getActionScoreRowValues(
+        actionEnfantScore,
+        actionScore,
+        descriptions,
+        pilotes,
+        services,
+        fichesActionLiees,
+        rowValues
+      );
     });
 
     if (actionScore.actionType === ActionTypeEnum.REFERENTIEL) {
@@ -258,7 +399,13 @@ export class ExportScoreService {
     return rowValues;
   }
 
-  private async exportScoreToXlsx(referentielScore: ScoresPayload) {
+  private async exportScoreToXlsx(
+    referentielScore: ScoresPayload,
+    descriptions: Record<string, string>,
+    pilotes: Record<string, PersonneTagOrUser[]>,
+    services: Record<string, Tag[]>,
+    fichesActionLiees: Record<string, string>
+  ) {
     // crée le classeur et la feuille de calcul
     const workbook = new Workbook();
     const worksheet = workbook.addWorksheet(
@@ -266,12 +413,16 @@ export class ExportScoreService {
     );
 
     // ajoute les colonnes avec une largeur par défaut et quelques exceptions
-    worksheet.columns = new Array(this.COL_INDEX.docs + 1).fill({
-      width: 12,
-    });
+    worksheet.columns = new Array(this.COL_INDEX.fiches_actions_liees + 1).fill(
+      {
+        width: 12,
+      }
+    );
     worksheet.getColumn(this.COL_INDEX.intitule).width = 50;
+    worksheet.getColumn(this.COL_INDEX.description).width = 50;
     worksheet.getColumn(this.COL_INDEX.commentaires).width = 50;
     worksheet.getColumn(this.COL_INDEX.docs).width = 50;
+    worksheet.getColumn(this.COL_INDEX.fiches_actions_liees).width = 50;
 
     // génère les lignes d'en-tête
     const headerRows = [
@@ -289,9 +440,14 @@ export class ExportScoreService {
     ];
 
     // Get flat list of actions
+
     const dataRows = this.getActionScoreRowValues(
       referentielScore.scores,
-      undefined
+      undefined,
+      descriptions,
+      pilotes,
+      services,
+      fichesActionLiees
     );
     const dataRowValues = dataRows.map((r) => r.values);
     worksheet.addRows([...headerRows, ...dataRowValues]);
@@ -318,9 +474,13 @@ export class ExportScoreService {
     // ajoute des styles à certaines colonnes et cellules
     worksheet.getColumn(this.COL_INDEX.intitule).alignment =
       Utils.ALIGN_LEFT_WRAP;
+    worksheet.getColumn(this.COL_INDEX.description).alignment =
+      Utils.ALIGN_LEFT_WRAP;
     worksheet.getColumn(this.COL_INDEX.commentaires).alignment =
       Utils.ALIGN_LEFT_WRAP;
     worksheet.getColumn(this.COL_INDEX.docs).alignment = Utils.ALIGN_LEFT_WRAP;
+    worksheet.getColumn(this.COL_INDEX.fiches_actions_liees).alignment =
+      Utils.ALIGN_LEFT_WRAP;
     worksheet.getColumn(this.COL_INDEX.points_max_referentiel).font =
       Utils.ITALIC;
     if (this.COL_INDEX.phase) {
@@ -337,7 +497,7 @@ export class ExportScoreService {
       worksheet,
       rowIndex.tableHeader2,
       this.COL_INDEX.arbo,
-      this.COL_INDEX.docs,
+      this.COL_INDEX.fiches_actions_liees,
       Utils.HEADING2
     );
     Utils.setCellsStyle(
@@ -371,7 +531,7 @@ export class ExportScoreService {
           worksheet,
           r,
           this.COL_INDEX.arbo,
-          this.COL_INDEX.docs,
+          this.COL_INDEX.fiches_actions_liees,
           {
             font: Utils.BOLD,
           }
@@ -404,7 +564,7 @@ export class ExportScoreService {
     return workbook.xlsx;
   }
 
-  getExportFileName(referentielScore: ScoresPayload) {
+  private getExportFileName(referentielScore: ScoresPayload) {
     const filename = `Export_${referentielScore.referentielId?.toUpperCase()}_${
       referentielScore.collectiviteInfo?.nom
     }_${referentielScore.date.substring(0, 10)}.xlsx`;
@@ -428,9 +588,34 @@ export class ExportScoreService {
 
     const referentielScore = snapshot.scoresPayload;
 
+    const descriptions = await this.getActionDescriptions(referentielId);
+
+    const mesureIds = this.getAllMesureIds(referentielScore.scores);
+
+    const pilotes = await this.assignPilotesService.listPilotes(
+      referentielScore.collectiviteInfo.id,
+      mesureIds
+    );
+
+    const services = await this.assignServicesService.listServices(
+      referentielScore.collectiviteInfo.id,
+      mesureIds
+    );
+
+    const fichesActionLiees = await this.getFichesActionLiees(
+      collectiviteId,
+      mesureIds
+    );
+
     return {
       fileName: this.getExportFileName(referentielScore).normalize('NFD'),
-      content: await this.exportScoreToXlsx(referentielScore),
+      content: await this.exportScoreToXlsx(
+        referentielScore,
+        descriptions,
+        pilotes,
+        services,
+        fichesActionLiees
+      ),
     };
   }
 }

--- a/backend/src/referentiels/models/action-definition.table.ts
+++ b/backend/src/referentiels/models/action-definition.table.ts
@@ -75,3 +75,6 @@ export const actionDefinitionMinimalWithTypeAndLevel =
 export type ActionDefinitionMinimalWithTypeAndLevel = z.infer<
   typeof actionDefinitionMinimalWithTypeAndLevel
 >;
+
+export const mesureIdSchema = z.string();
+export type MesureId = z.infer<typeof mesureIdSchema>;

--- a/backend/src/referentiels/referentiels.module.ts
+++ b/backend/src/referentiels/referentiels.module.ts
@@ -1,4 +1,5 @@
 import { IndicateursModule } from '@/backend/indicateurs/indicateurs.module';
+import { FichesModule } from '@/backend/plans/fiches/fiches.module';
 import ActionStatutHistoryService from '@/backend/referentiels/compute-score/action-statut-history.service';
 import ScoresAnalysisService from '@/backend/referentiels/compute-score/scores-analysis.service';
 import { ListLabellisationsController } from '@/backend/referentiels/labellisations/list-labellisations.controller';
@@ -8,15 +9,15 @@ import { Module } from '@nestjs/common';
 import { CollectivitesModule } from '../collectivites/collectivites.module';
 import { PersonnalisationsModule } from '../personnalisations/personnalisations.module';
 import { SheetModule } from '../utils/google-sheets/sheet.module';
-import { AssignPilotesRouter } from './assign-pilotes/assign-pilotes.router';
-import { AssignPilotesService } from './assign-pilotes/assign-pilotes.service';
-import { AssignServicesRouter } from './assign-services/assign-services.router';
-import { AssignServicesService } from './assign-services/assign-services.service';
 import ScoresService from './compute-score/scores.service';
 import { ExportScoreController } from './export-score/export-score.controller';
 import { ExportScoreService } from './export-score/export-score.service';
 import { GetReferentielController } from './get-referentiel/get-referentiel.controller';
 import { GetReferentielService } from './get-referentiel/get-referentiel.service';
+import { HandleMesurePilotesRouter } from './handle-mesure-pilotes/handle-mesure-pilotes.router';
+import { HandleMesurePilotesService } from './handle-mesure-pilotes/handle-mesure-pilotes.service';
+import { HandleMesuresServicesRouter } from './handle-mesure-services/handle-mesure-services.router';
+import { HandleMesureServicesService } from './handle-mesure-services/handle-mesure-services.service';
 import { ImportReferentielController } from './import-referentiel/import-referentiel.controller';
 import { ImportReferentielService } from './import-referentiel/import-referentiel.service';
 import { GetLabellisationRouter } from './labellisations/get-labellisation.router';
@@ -40,6 +41,7 @@ import { UpdateActionStatutService } from './update-action-statut/update-action-
     SheetModule,
     PersonnalisationsModule,
     IndicateursModule,
+    FichesModule,
   ],
   providers: [
     ActionStatutHistoryService,
@@ -71,11 +73,11 @@ import { UpdateActionStatutService } from './update-action-statut/update-action-
     ValidateAuditService,
     ValidateAuditRouter,
 
-    AssignPilotesService,
-    AssignPilotesRouter,
+    HandleMesurePilotesService,
+    HandleMesurePilotesRouter,
 
-    AssignServicesService,
-    AssignServicesRouter,
+    HandleMesureServicesService,
+    HandleMesuresServicesRouter,
   ],
   exports: [ReferentielsRouter],
   controllers: [

--- a/backend/src/referentiels/referentiels.router.ts
+++ b/backend/src/referentiels/referentiels.router.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { TrpcService } from '../utils/trpc/trpc.service';
-import { AssignPilotesRouter } from './assign-pilotes/assign-pilotes.router';
-import { AssignServicesRouter } from './assign-services/assign-services.router';
+import { HandleMesurePilotesRouter } from './handle-mesure-pilotes/handle-mesure-pilotes.router';
+import { HandleMesuresServicesRouter } from './handle-mesure-services/handle-mesure-services.router';
 import { GetLabellisationRouter } from './labellisations/get-labellisation.router';
 import { StartAuditRouter } from './labellisations/start-audit/start-audit.router';
 import { ValidateAuditRouter } from './labellisations/validate-audit/validate-audit.router';
@@ -18,8 +18,8 @@ export class ReferentielsRouter {
     private readonly getLabellisation: GetLabellisationRouter,
     private readonly startAudit: StartAuditRouter,
     private readonly validateAudit: ValidateAuditRouter,
-    private readonly assignPilotesRouter: AssignPilotesRouter,
-    private readonly assignServicesRouter: AssignServicesRouter
+    private readonly assignPilotesRouter: HandleMesurePilotesRouter,
+    private readonly assignServicesRouter: HandleMesuresServicesRouter
   ) {}
 
   router = this.trpc.router({

--- a/backend/src/utils/excel/export-excel.utils.ts
+++ b/backend/src/utils/excel/export-excel.utils.ts
@@ -166,3 +166,60 @@ export const normalizeWorksheetName = (name: string) =>
 export const formatDate = (dateStr: Date | string | null | undefined) => {
   return dateStr ? format(new Date(dateStr), 'dd/MM/yyyy') : '';
 };
+
+/**
+ * Nettoie une description HTML pour la rendre lisible dans Excel
+ * - Supprime toutes les balises HTML
+ * - Convertit les listes en texte avec puces
+ * - Gère les paragraphes avec des retours à la ligne
+ * - Nettoie les espaces en trop
+ */
+export const cleanHtmlDescription = (htmlDescription: string): string => {
+  if (!htmlDescription) {
+    return '';
+  }
+
+  let cleaned = htmlDescription;
+
+  // Remplace les éléments de liste par des puces (gérer les <p> dans <li>)
+  cleaned = cleaned.replace(/<li[^>]*>\s*<p[^>]*>/g, '• ');
+  cleaned = cleaned.replace(/<\/p>\s*<\/li>/g, '\n');
+
+  // Gère les li simples sans p
+  cleaned = cleaned.replace(/<li[^>]*>/g, '• ');
+  cleaned = cleaned.replace(/<\/li>/g, '\n');
+
+  // Remplace les paragraphes par des retours à la ligne
+  cleaned = cleaned.replace(/<\/p>/g, '\n');
+  cleaned = cleaned.replace(/<p[^>]*>/g, '');
+
+  // Remplace les listes par des retours à la ligne
+  cleaned = cleaned.replace(/<\/?ul[^>]*>/g, '\n');
+  cleaned = cleaned.replace(/<\/?ol[^>]*>/g, '\n');
+
+  // Remplace les divs par des retours à la ligne
+  cleaned = cleaned.replace(/<\/div>/g, '\n');
+  cleaned = cleaned.replace(/<div[^>]*>/g, '');
+
+  // Remplace les br par des retours à la ligne
+  cleaned = cleaned.replace(/<br[^>]*\/?>/g, '\n');
+
+  // Supprime toutes les autres balises HTML
+  cleaned = cleaned.replace(/<[^>]*>/g, '');
+
+  // Décode les entités HTML communes
+  cleaned = cleaned.replace(/&nbsp;/g, ' ');
+  cleaned = cleaned.replace(/&amp;/g, '&');
+  cleaned = cleaned.replace(/&lt;/g, '<');
+  cleaned = cleaned.replace(/&gt;/g, '>');
+  cleaned = cleaned.replace(/&quot;/g, '"');
+  cleaned = cleaned.replace(/&#39;/g, "'");
+
+  // Nettoie les espaces et retours à la ligne en trop
+  cleaned = cleaned.replace(/\n+/g, '\n'); // Supprime les lignes vides multiples
+  cleaned = cleaned.replace(/^\s+|\s+$/g, ''); // Supprime les espaces en début/fin
+  cleaned = cleaned.replace(/[ \t]+/g, ' '); // Normalise les espaces
+  cleaned = cleaned.replace(/\n\s+/g, '\n'); // Supprime les espaces après retour ligne
+
+  return cleaned;
+};


### PR DESCRIPTION
Implémente ces tickets : 
- [Adapter l’export pour prendre en compte les pilotes](https://www.notion.so/accelerateur-transition-ecologique-ademe/Adapter-l-export-pour-prendre-en-compte-les-pilotes-1776523d57d780fd8211f640966334cd?pvs=4) ;
- [Ajouter une décimale dans les scores](https://www.notion.so/accelerateur-transition-ecologique-ademe/Ajouter-une-d-cimale-dans-les-scores-des-colonnes-G-et-I-1e06523d57d7808b9977ef5f3e5faa83?source=copy_link).
- [Ajouter les titres des fiches liées dans l’export Excel du référentiel](https://www.notion.so/accelerateur-transition-ecologique-ademe/Ajouter-les-titres-des-fiches-li-es-dans-l-export-Excel-du-r-f-rentiel-1286523d57d780999ad0e5d6df396cb6?source=copy_link)
- [Ajouter les descriptions des mesures et ajouter des titres aux 2 premières colonnes](https://www.notion.so/accelerateur-transition-ecologique-ademe/Ajouter-les-descriptions-des-mesures-et-ajouter-des-titres-aux-2-premi-res-colonnes-1d76523d57d7801abeaae00e2209de35?source=copy_link)

En résumé : quand on clique sur l'export, on veut avoir l'export du référentiel sous forme d'excel avec les nouvelles colonnes "description", "personnes pilotes" et "services ou directions pilotes" et "fiches actions liées".

- Pour la `description` et les `fiches actions liées`, on récupère les données à partir des services dédiées et on réalise un mapping avec chaque mesure du référentiel.

- Pour la partie pilotes et services pilotes, une refactorisation des méthodes de `list` a été nécessaire. Jusqu'ici, celles-ci n'acceptaient qu'un seul id de mesure. Désormais, elles acceptent un tableau d'id afin de pouvoir récupérer tous les pilotes pour toutes les mesures. 

- [x] Ajouter une colonne "Personnes pilotes" (backend/src/referentiels/export-score/export-score.service.ts)
- [x] Ajouter une colonne "Directions ou services pilotes" (backend/src/referentiels/export-score/export-score.service.ts)

- [x] Modifier la méthode `listPilotes` pour qu'elle accepte plusieurs actions id
- [x] Idem pour la méthode `listServices`

- [x] Mettre à jour les tests e2e backend

