### PR TITLE
Mise à jour graphique les cartes mesure et la page référentiel

### DIFF
--- a/app.territoiresentransitions.react/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/(overview)/@tabs/header.tsx
+++ b/app.territoiresentransitions.react/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/(overview)/@tabs/header.tsx
@@ -20,8 +20,8 @@ export const Header = ({ referentielId }: { referentielId: ReferentielId }) => {
 
   return (
     <>
-      <div className="flex items-center justify-between items-baseline">
-        <h1>
+      <div className="flex max-md:flex-col md:items-center md:justify-between gap-4 mb-6">
+        <h1 className="mb-0">
           Référentiel{' '}
           {referentielToName[referentielId as ReferentielOfIndicateur]}
         </h1>
@@ -54,14 +54,14 @@ export const Header = ({ referentielId }: { referentielId: ReferentielId }) => {
       </div>
 
       {referentiel && (
-        <div className="flex items-center gap-4 pb-4 mb-4 border-b border-primary-3">
+        <div className="flex max-sm:flex-col sm:items-center gap-4 pb-4 mb-4 border-b border-primary-3">
           <ScoreProgressBar
             className="grow"
             id={referentiel.id}
             identifiant={referentiel.identifiant}
             type={referentiel.type}
           />
-          <ScoreRatioBadge actionId={referentiel.id} className="ml-auto" />
+          <ScoreRatioBadge actionId={referentiel.id} className="sm:ml-auto" />
         </div>
       )}
     </>

--- a/app.territoiresentransitions.react/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/(overview)/@tabs/layout.tsx
+++ b/app.territoiresentransitions.react/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/(overview)/@tabs/layout.tsx
@@ -22,7 +22,7 @@ export default async function Layout({
     <PageContainer>
       <Header referentielId={referentielId} />
 
-      <Tabs tabsListClassName="!justify-start pl-0 flex-nowrap bg-transparent">
+      <Tabs tabsListClassName="!justify-start pl-0 flex-nowrap bg-transparent overflow-x-auto">
         <TabsList>
           <TabsTab href="progression" label="Mesures"></TabsTab>
           <TabsTab href="priorisation" label="Aide à la priorisation"></TabsTab>

--- a/app.territoiresentransitions.react/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/(overview)/@tabs/progression/_components/action.list.tsx
+++ b/app.territoiresentransitions.react/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/(overview)/@tabs/progression/_components/action.list.tsx
@@ -50,8 +50,8 @@ const ActionList = () => {
   };
 
   return (
-    <main data-test="ActionsReferentiels" className="flex flex-col gap-6">
-      <div className="relative flex max-md:flex-col md:items-center gap-6 pb-6 border-b border-grey-4">
+    <main data-test="ActionsReferentiels" className="flex flex-col">
+      <div className="relative flex max-md:flex-col md:items-center gap-x-6 gap-y-4 pb-6 border-b border-grey-4">
         <div className="w-full md:w-56">
           <Select
             options={[
@@ -70,47 +70,51 @@ const ActionList = () => {
           />
         </div>
 
-        <Checkbox
-          label="Afficher la description des mesures"
-          variant="switch"
-          labelClassname="font-normal text-sm !text-grey-7"
-          containerClassname="items-center"
-          checked={showDescriptionOn}
-          onChange={() => setShowDescription(!showDescriptionOn)}
-          disabled={isLoading}
-        />
-
-        <ButtonMenu
-          openState={{
-            isOpen: isFilterOpen,
-            setIsOpen: setIsFilterOpen,
-          }}
-          className="ml-auto"
-          size="sm"
-          variant="outlined"
-          icon="equalizer-line"
-          text="Filtrer"
-        >
-          <Filters
-            filters={filters}
-            setFilters={(filters) => onFilterChange(filters)}
+        <div className="flex max-sm:flex-col sm:items-center sm:justify-between w-full gap-x-6 gap-y-4">
+          <Checkbox
+            label="Afficher la description des mesures"
+            variant="switch"
+            labelClassname="font-normal text-sm !text-grey-7"
+            containerClassname="items-center"
+            checked={showDescriptionOn}
+            onChange={() => setShowDescription(!showDescriptionOn)}
+            disabled={isLoading}
           />
-        </ButtonMenu>
 
-        <div className="w-px h-8 bg-grey-4" />
+          <div className="flex items-center gap-6 max-sm:w-full sm:ml-auto">
+            <ButtonMenu
+              openState={{
+                isOpen: isFilterOpen,
+                setIsOpen: setIsFilterOpen,
+              }}
+              size="sm"
+              variant="outlined"
+              icon="equalizer-line"
+              text="Filtrer"
+            >
+              <Filters
+                filters={filters}
+                setFilters={(filters) => onFilterChange(filters)}
+              />
+            </ButtonMenu>
 
-        <Button
-          data-test="export-scores"
-          icon={'download-fill'}
-          disabled={isLoading}
-          onClick={() => exportScore()}
-          size="sm"
-        />
+            <div className="w-px h-8 bg-grey-4" />
+
+            <Button
+              data-test="export-scores"
+              icon={'download-fill'}
+              disabled={isLoading}
+              onClick={() => exportScore()}
+              size="sm"
+            />
+          </div>
+        </div>
       </div>
 
       <FilterBadges
         badges={filterBadges}
         resetFilters={() => onFilterChange(initialFilters)}
+        className="mt-6"
       />
 
       <List

--- a/app.territoiresentransitions.react/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/(overview)/@tabs/progression/_components/axe.tsx
+++ b/app.territoiresentransitions.react/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/(overview)/@tabs/progression/_components/axe.tsx
@@ -47,24 +47,25 @@ const Axe = ({ axe, accordionProps, showDescription }: Props) => {
       expanded={isOpen}
       setExpanded={() => setIsOpened(!isOpen)}
       headerContent={
-        <div className="flex items-center">
+        <div className="flex items-center justify-between gap-3">
           <ScoreProgressBar
             id={axe.actionId}
             identifiant={axe.identifiant}
             type={axe.actionType as ActionType}
-            className="w-48"
+            className="w-48 max-md:hidden"
           />
           <ScoreRatioBadge
             actionId={axe.actionId}
-            className="justify-end w-64"
+            className="justify-end w-40 max-sm:hidden"
+            size="sm"
           />
         </div>
       }
       content={
         isActionChildren ? (
           <div
-            className={classNames('grid grid-rows-1 grid-cols-3 gap-4 mb-4', {
-              '!grid-cols-1': showDescription,
+            className={classNames('grid grid-rows-1 grid-cols-1 gap-4 mb-4', {
+              'md:grid-cols-2 xl:grid-cols-3': !showDescription,
             })}
           >
             {axe.children?.map((child) => (
@@ -83,8 +84,8 @@ const Axe = ({ axe, accordionProps, showDescription }: Props) => {
                 axe={{ ...child, nom: `${child.identifiant} ${child.nom}` }}
                 accordionProps={{
                   containerClassname: 'ml-4 !border-0 !text-grey-7',
-                  headerClassname: '!py-4 !text-grey-7',
-                  arrowClassname: '!text-grey-7',
+                  headerClassname: '!py-4 !text-grey-6',
+                  arrowClassname: '!text-grey-6',
                 }}
                 showDescription={showDescription}
               />

--- a/app.territoiresentransitions.react/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/(overview)/@tabs/progression/_components/list.tsx
+++ b/app.territoiresentransitions.react/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/(overview)/@tabs/progression/_components/list.tsx
@@ -47,6 +47,7 @@ const List = ({
       <EmptyCard
         picto={(props) => <PictoDocument {...props} />}
         title="Aucun résultat pour ce filtre !"
+        className="mt-6"
         actions={[
           {
             children: 'Modifier le filtre',
@@ -75,8 +76,8 @@ const List = ({
   if (display === 'action') {
     return (
       <div
-        className={classNames('grid grid-cols-1 gap-4 grid-rows-1', {
-          'sm:grid-cols-2 lg:grid-cols-3': !showDescriptionOn,
+        className={classNames('grid grid-cols-1 gap-5 grid-rows-1 mt-6', {
+          'md:grid-cols-2 lg:grid-cols-3': !showDescriptionOn,
         })}
       >
         {actionList

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/ActionsLiees.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/ActionsLiees.tsx
@@ -26,10 +26,7 @@ const ActionsLiees = ({ actionsIds }: Props) => {
           Mesures des référentiels liées
         </h6>
       </div>
-      <ActionsLieesListe
-        actionIds={actionsIds}
-        className="sm:grid-cols-2 md:grid-cols-3"
-      />
+      <ActionsLieesListe actionIds={actionsIds} />
     </div>
   );
 };

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/ActionsLiees/ActionsLieesListe.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/ActionsLiees/ActionsLieesListe.tsx
@@ -36,7 +36,7 @@ const ActionsLieesListe = ({
     <div>
       <div
         className={classNames(
-          'grid lg:grid-cols-2 xl:grid-cols-3 gap-3',
+          'grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3',
           className
         )}
       >

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/ActionsLiees/ActionsLieesTab.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/ActionsLiees/ActionsLieesTab.tsx
@@ -68,7 +68,7 @@ const ActionsLieesTab = ({
           <ActionsLieesListe
             isReadonly={isReadonly}
             actionIds={mesures?.map((action) => action.id)}
-            className="sm:grid-cols-2 md:grid-cols-3"
+            className="md:!grid-cols-2 lg:!grid-cols-1 xl:!grid-cols-2"
             onLoad={setIsLoading}
             onUnlink={(actionsLieeId) =>
               updateFiche({

--- a/app.territoiresentransitions.react/src/referentiels/actions/action.card.tsx
+++ b/app.territoiresentransitions.react/src/referentiels/actions/action.card.tsx
@@ -3,8 +3,8 @@ import { useState } from 'react';
 import { useCurrentCollectivite } from '@/api/collectivites';
 import { makeReferentielActionUrl } from '@/app/app/paths';
 import ActionEditModal from '@/app/referentiels/actions/action-edit.modal';
-import ListWithTooltip from '@/app/ui/lists/ListWithTooltip';
 import Markdown from '@/app/ui/Markdown';
+import ListWithTooltip from '@/app/ui/lists/ListWithTooltip';
 import {
   Action,
   ActionType,
@@ -60,36 +60,36 @@ export const ActionCard = ({ action, showDescription }: ActionCardProps) => {
           referentielId: referentiel,
           actionId: id,
         })}
-        className="font-normal h-full"
+        className="font-normal h-full !gap-2 !p-4 !bg-grey-1 hover:!border-grey-3 hover:!bg-grey-2 !shadow-none"
       >
         {/** Title + description */}
-        <div className="flex-grow">
-          <span className="text-lg font-bold text-primary-9">
-            {identifiant} {title}
-          </span>
+        <span className="text-base leading-5 font-bold text-primary-9">
+          {identifiant} {title}
+        </span>
 
-          {showDescription && description && (
-            <Markdown
-              className="htmlContent text-sm text-grey-9 font-light my-6"
-              content={description}
-            />
-          )}
-        </div>
+        {showDescription && description && (
+          <Markdown
+            className="htmlContent [&_*]:text-sm [&_*]:leading-6 text-grey-8 [&>*]:font-normal"
+            content={description}
+          />
+        )}
 
         {/** Score */}
-        <div className="mt-auto">
-          <ScoreRatioBadge actionId={id} className={'mb-3'} />
+        <div className="mt-auto flex gap-3 items-center justify-between">
           <ScoreProgressBar
             id={id}
             identifiant={identifiant}
             type={'action' as ActionType}
-            className="w-full"
+            className="grow shrink"
           />
+          <div className="w-36 shrink-0 flex justify-end">
+            <ScoreRatioBadge actionId={id} size="sm" />
+          </div>
         </div>
 
         {/** Pilotes et services */}
         {(action.pilotes.length > 0 || action.services.length > 0) && (
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-primary-10">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-primary-10">
             {action.pilotes.length > 0 && (
               <ListWithTooltip
                 icon="user-line"

--- a/app.territoiresentransitions.react/src/referentiels/actions/action.linked-card.tsx
+++ b/app.territoiresentransitions.react/src/referentiels/actions/action.linked-card.tsx
@@ -1,7 +1,7 @@
 import { useCollectiviteId } from '@/api/collectivites';
 import { referentielToName } from '@/app/app/labels';
 import { makeReferentielTacheUrl } from '@/app/app/paths';
-import ActionStatutBadge from '@/app/referentiels/actions/action-statut/action-statut.badge';
+import ListWithTooltip from '@/app/ui/lists/ListWithTooltip';
 import { Action, ActionTypeEnum } from '@/domain/referentiels';
 import { Button, Card } from '@/ui';
 import { ScoreProgressBar } from '../scores/score.progress-bar';
@@ -21,7 +21,9 @@ const ActionLinkedCard = ({
   onUnlink,
 }: ActionCardProps) => {
   const collectiviteId = useCollectiviteId();
-  const { actionId, identifiant, nom, referentiel, statut } = action;
+  const { actionId, identifiant, nom, referentiel } = action;
+
+  console.log(action);
 
   const link = makeReferentielTacheUrl({
     collectiviteId,
@@ -46,10 +48,9 @@ const ActionLinkedCard = ({
       <Card
         dataTest="ActionCarte"
         id={`action-${actionId}`}
-        className="h-full px-4 py-[1.125rem] !gap-3 text-grey-8 hover:border-primary-3 hover:!bg-primary-1 !shadow-none transition"
+        className="h-full !p-4 !gap-2 text-grey-8 hover:border-primary-3 hover:!bg-primary-1 !shadow-none transition"
         href={link}
         external={openInNewTab}
-        header={statut ? <ActionStatutBadge statut={statut} /> : null}
       >
         {/* Référentiel de l'action */}
         <span className="text-grey-8 text-sm font-medium">
@@ -57,20 +58,45 @@ const ActionLinkedCard = ({
         </span>
 
         {/* Identifiant et titre de l'action */}
-        <span className="text-base font-bold text-primary-9">
+        <span className="text-base leading-5 font-bold text-primary-9">
           {identifiant} {nom}
         </span>
 
         {/** Score */}
-        <div className="mt-auto">
-          <ScoreRatioBadge actionId={actionId} className={'mb-3'} />
+        <div className="mt-auto flex gap-3 items-center justify-between">
           <ScoreProgressBar
             id={actionId}
             identifiant={identifiant}
             type={ActionTypeEnum.ACTION}
-            className="w-full"
+            className="grow shrink"
           />
+          <div className="w-36 shrink-0 flex justify-end">
+            <ScoreRatioBadge actionId={actionId} size="sm" />
+          </div>
         </div>
+
+        {/** Pilotes et services */}
+        {(action.pilotes.length > 0 || action.services.length > 0) && (
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs font-normal text-primary-10">
+            {action.pilotes.length > 0 && (
+              <ListWithTooltip
+                icon="user-line"
+                title="Pilotes"
+                list={action.pilotes.map((p) => p.nom ?? '')}
+              />
+            )}
+            {action.pilotes.length > 0 && action.services.length > 0 && (
+              <div className="w-[0.5px] h-4 bg-grey-5" />
+            )}
+            {action.services.length > 0 && (
+              <ListWithTooltip
+                icon="leaf-line"
+                title="Direction ou service pilote"
+                list={action.services.map((s) => s.nom ?? '')}
+              />
+            )}
+          </div>
+        )}
       </Card>
     </div>
   );

--- a/app.territoiresentransitions.react/src/referentiels/scores/score.ratio-badge.tsx
+++ b/app.territoiresentransitions.react/src/referentiels/scores/score.ratio-badge.tsx
@@ -1,13 +1,14 @@
-import { Badge } from '@/ui';
+import { Badge, BadgeSize } from '@/ui';
 import classNames from 'classnames';
 import { useScore } from '../use-snapshot';
 
 type Props = {
   actionId: string;
+  size?: BadgeSize;
   className?: string;
 };
 
-export const ScoreRatioBadge = ({ actionId, className }: Props) => {
+export const ScoreRatioBadge = ({ actionId, size, className }: Props) => {
   const score = useScore(actionId);
 
   if (!score) {
@@ -34,21 +35,25 @@ export const ScoreRatioBadge = ({ actionId, className }: Props) => {
   return (
     <div className={classNames('flex', className)}>
       {pointPotentiel === 0 ? (
-        <Badge title="0 point" state="grey" uppercase={false} />
+        <Badge title="0 point" state="grey" uppercase={false} size={size} />
       ) : (
         <>
           <Badge
             title={`${calculatePercentage(pointFait, pointPotentiel)} %`}
             state="success"
             uppercase={false}
-            className="!rounded-r-none border-2 border-r-0"
+            className="!rounded-r-none border-[0.5px] !border-success-3 border-r-0 shrink-0"
+            size={size}
+            trim={false}
           />
           <Badge
             title={`${roundPointFait} / ${roundPointPotentiel} points`}
             state="success"
             light
-            className="!rounded-l-none border-2"
+            className="!rounded-l-none border-[0.5px] !border-success-3 border-l-0 shrink-0"
             uppercase={false}
+            size={size}
+            trim={false}
           />
         </>
       )}

--- a/packages/ui/src/design-system/Accordion/Accordion.tsx
+++ b/packages/ui/src/design-system/Accordion/Accordion.tsx
@@ -79,7 +79,7 @@ export const AccordionControlled = forwardRef<
           }}
           onClick={() => setExpanded(!expanded)}
           className={classNames(
-            'flex gap-3 items-center py-6 font-bold text-primary-9 cursor-pointer',
+            'flex gap-3 items-center py-6 font-bold text-base text-primary-9 cursor-pointer',
             headerClassname
           )}
         >


### PR DESCRIPTION
Ticket : https://www.notion.so/accelerateur-transition-ecologique-ademe/Supprimer-le-statut-sur-les-cartes-des-mesures-dans-les-FA-2026523d57d78054943ecec06faac317?source=copy_link
- Suppression du statut sur les cartes mesures dans les pages FA et indicateur
- Mise à jour graphique des cartes mesure dans les pages référentiel, FA et indicateur
- Harmonisation et comportement responsif sur la page toutes les mesures