### PR TITLE
Affiche le score pré audit avant le score d'audit dans l'évolution du score

### DIFF
--- a/app.territoiresentransitions.react/src/referentiels/evolutions/evolutions-score-total.chart.tsx
+++ b/app.territoiresentransitions.react/src/referentiels/evolutions/evolutions-score-total.chart.tsx
@@ -17,7 +17,11 @@ const theme = importedTheme;
  */
 const sortSnapshots = (snapshots: SnapshotDetails[], ascending = true) => {
   if (!snapshots?.length) return [];
-  return [...snapshots].sort((a, b) => sortByDate(a.date, b.date, ascending));
+  return [...snapshots].sort((a, b) => {
+    if (a.jalon === 'pre_audit' && b.jalon === 'post_audit') return -1;
+    if (a.jalon === 'post_audit' && b.jalon === 'pre_audit') return 1;
+    return sortByDate(a.date, b.date, ascending);
+  });
 };
 
 const sizeConfig = {


### PR DESCRIPTION
Ticket : https://www.notion.so/accelerateur-transition-ecologique-ademe/Inverser-audit-et-avant-audit-dans-les-graph-des-sauvegardes-des-tats-des-lieux-1e46523d57d7809a9bcbd2875f91492e?source=copy_link