### PR TITLE
Masque la page de Strasbourg sur le site public

### DIFF
--- a/packages/site/app/collectivites/[code]/[name]/page.tsx
+++ b/packages/site/app/collectivites/[code]/[name]/page.tsx
@@ -6,7 +6,7 @@ import { getUpdatedMetadata } from '@/site/src/utils/getUpdatedMetadata';
 import { natureCollectiviteToLabel } from '@/site/src/utils/labels';
 import classNames from 'classnames';
 import { Metadata, ResolvingMetadata } from 'next';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 import {
   fetchCollectivite,
   getStrapiData,
@@ -69,6 +69,9 @@ const DetailCollectivite = async ({
 
   if (!collectiviteData || !collectiviteData.collectivite.nom)
     return notFound();
+
+  // Evite un doublon pour la page de Strasbourg
+  if (code === '67482') redirect(`/collectivites/246700488`);
 
   return (
     <Section

--- a/packages/site/app/collectivites/[code]/page.tsx
+++ b/packages/site/app/collectivites/[code]/page.tsx
@@ -26,6 +26,9 @@ const DetailCodeCollectivite = async ({
 
   if (!data) return notFound();
 
+  // Evite un doublon pour la page de Strasbourg
+  if (code === '67482') redirect(`/collectivites/246700488`);
+
   redirect(
     `/collectivites/${code}/${convertNameToSlug(data?.collectivite.nom ?? '')}`
   );

--- a/packages/site/app/collectivites/collectivites.page.tsx
+++ b/packages/site/app/collectivites/collectivites.page.tsx
@@ -4,6 +4,7 @@ import CollectiviteSearch from '@/site/app/collectivites/_components/collectivit
 import CarteAvecFiltres from '@/site/components/carte/CarteAvecFiltres';
 import { useCarteCollectivitesEngagees } from '@/site/components/carte/useCarteCollectivitesEngagees';
 import { StrapiItem } from '@/site/src/strapi/StrapiItem';
+import { natureCollectiviteToLabel } from '@/site/src/utils/labels';
 import PageContainer from '@/ui/components/layout/page-container';
 import CollectiviteCard, { LoadingCard } from './_components/collectivite.card';
 
@@ -27,7 +28,9 @@ const CollectivitesPage = ({ collectivitesStrapi }: Props) => {
     region: col.region_name,
     departement: col.departement_name,
     population: col.population_totale,
-    type: col.type_collectivite,
+    type: col.nature_collectivite
+      ? natureCollectiviteToLabel[col.nature_collectivite]
+      : col.type_collectivite,
     etoilesCAE: col.cae_etoiles ?? 0,
     etoilesECI: col.eci_etoiles ?? 0,
     siren: col.code_siren_insee,

--- a/packages/site/app/useFilteredCollectivites.ts
+++ b/packages/site/app/useFilteredCollectivites.ts
@@ -7,6 +7,7 @@ export const useFilteredCollectivites = (search: string) => {
     const query = supabase
       .from('site_labellisation')
       .select('collectivite_id, nom, code_siren_insee')
+      .neq('code_siren_insee', 67482) // Evite un doublon pour la page de Strasbourg
       .order('nom');
 
     // Nous devons charger la liste entière pour pouvoir utiliser la recherche fuse.


### PR DESCRIPTION
Ticket : https://www.notion.so/accelerateur-transition-ecologique-ademe/Supprimer-fiche-Ville-de-Strasbourg-sur-le-site-public-1596523d57d780049514d7acde94575e?source=copy_link