### PR TITLE
TET-5219 bugfix: Date invalid when format when date entered was '0021-01-01'.

### DIFF
--- a/app.territoiresentransitions.react/src/utils/formatUtils.ts
+++ b/app.territoiresentransitions.react/src/utils/formatUtils.ts
@@ -10,7 +10,11 @@ export const getTextFormattedDate = ({
   date: string;
   shortMonth?: boolean;
 }) => {
+
   const localDate = date ? new Date(date) : new Date();
+  if (!isDateValid(date)) {
+    return 'Date invalide';
+  }
   const dayOfMonth = format(localDate, 'd');
 
   if (dayOfMonth === '1') {
@@ -25,6 +29,9 @@ export const getTextFormattedDate = ({
 
 // Renvoie le format ISO d'une date avec uniquement jour mois et année
 export const getIsoFormattedDate = (date: string) => {
+  if (!isDateValid(date)) {
+    return null;
+  }
   const localDate = date ? new Date(date) : new Date();
   return localDate.toISOString().slice(0, 10);
 };
@@ -85,13 +92,18 @@ export const getTruncatedText = (text: string | null, limit: number) => {
   const truncatedText =
     text !== null
       ? _.truncate(text, {
-          length: limit,
-          separator: ' ',
-          omission: '',
-        })
+        length: limit,
+        separator: ' ',
+        omission: '',
+      })
       : null;
 
   const isTextTruncated = truncatedText !== text;
 
   return { truncatedText: `${truncatedText}...`, isTextTruncated };
+};
+
+
+export const isDateValid = (dateStr: string) => {
+  return !isNaN(new Date(dateStr).getTime());
 };


### PR DESCRIPTION
https://www.notion.so/accelerateur-transition-ecologique-ademe/Erreur-chargement-page-2096523d57d78091aa9bcacd913e2083?source=copy_link

Dans l'input de date on pouvait saisir une date comme '01/01/0021'  la date était valide mais elle nous revenait du backend comme ça "0021-01-01 00:00:00+00" ce qui faisait péter le format dans getTextFormattedDate.

J'ai rajouter un guard dans la fonction getTextFormattedDate et un message d'erreur sur le front si la date est inférieure à 1900-01-01.