### PR TITLE
BUG BLOQUANT : Impossible de valider une modification sur plusieurs FA + impossible ajouter un tag personnalisé

### DIFF
--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/FicheActionDescription/FicheDescriptionForm.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/FicheActionDescription/FicheDescriptionForm.tsx
@@ -77,6 +77,9 @@ export const FicheDescriptionForm = ({
       sousThematiques: updatedFiche.sousThematiques,
       libreTags: updatedFiche.libreTags,
       description: updatedFiche.description,
+      collectiviteId: updatedFiche.collectiviteId,
+      collectiviteNom: updatedFiche.collectiviteNom ?? null,
+      sharedWithCollectivites: updatedFiche.sharedWithCollectivites ?? null,
     });
   };
 

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/FicheActionDescription/FicheDescriptionForm.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/FicheActionDescription/FicheDescriptionForm.tsx
@@ -69,8 +69,14 @@ export const FicheDescriptionForm = ({
     const titleToSave = (updatedFiche.titre ?? '').trim();
 
     onSubmit({
-      ...updatedFiche,
+      id: updatedFiche.id,
       titre: titleToSave.length ? titleToSave : null,
+      ressources: updatedFiche.ressources,
+      instanceGouvernance: updatedFiche.instanceGouvernance,
+      thematiques: updatedFiche.thematiques,
+      sousThematiques: updatedFiche.sousThematiques,
+      libreTags: updatedFiche.libreTags,
+      description: updatedFiche.description,
     });
   };
 

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/FicheActionPlanning/ModalePlanning.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/FicheActionPlanning/ModalePlanning.tsx
@@ -46,7 +46,7 @@ const ModalePlanning = ({ isOpen, setIsOpen, fiche }: ModalePlanningProps) => {
           dateDebut: editedFiche.dateDebut,
           dateFin: editedFiche.dateFin,
           ameliorationContinue: editedFiche.ameliorationContinue,
-          tempsDeMiseEnOeuvre: editedFiche.tempsDeMiseEnOeuvre,
+          tempsDeMiseEnOeuvre: editedFiche.tempsDeMiseEnOeuvre?.id || null,
           statut: editedFiche.statut,
           priorite: editedFiche.priorite,
           calendrier: editedFiche.calendrier,

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/FicheActionPlanning/ModalePlanning.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/FicheActionPlanning/ModalePlanning.tsx
@@ -46,7 +46,7 @@ const ModalePlanning = ({ isOpen, setIsOpen, fiche }: ModalePlanningProps) => {
           dateDebut: editedFiche.dateDebut,
           dateFin: editedFiche.dateFin,
           ameliorationContinue: editedFiche.ameliorationContinue,
-          tempsDeMiseEnOeuvre: editedFiche.tempsDeMiseEnOeuvre?.id ?? null,
+          tempsDeMiseEnOeuvre: editedFiche.tempsDeMiseEnOeuvre,
           statut: editedFiche.statut,
           priorite: editedFiche.priorite,
           calendrier: editedFiche.calendrier,

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/FicheActionPlanning/ModalePlanning.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/PlansActions/FicheAction/FicheActionPlanning/ModalePlanning.tsx
@@ -46,7 +46,7 @@ const ModalePlanning = ({ isOpen, setIsOpen, fiche }: ModalePlanningProps) => {
           dateDebut: editedFiche.dateDebut,
           dateFin: editedFiche.dateFin,
           ameliorationContinue: editedFiche.ameliorationContinue,
-          tempsDeMiseEnOeuvre: editedFiche.tempsDeMiseEnOeuvre?.id || null,
+          tempsDeMiseEnOeuvre: editedFiche.tempsDeMiseEnOeuvre,
           statut: editedFiche.statut,
           priorite: editedFiche.priorite,
           calendrier: editedFiche.calendrier,

--- a/backend/src/plans/fiches/shared/models/fiche-action.table.ts
+++ b/backend/src/plans/fiches/shared/models/fiche-action.table.ts
@@ -229,6 +229,7 @@ export const ficheSchemaUpdate = ficheSchemaCreate
     createdBy: true,
     modifiedAt: true,
     modifiedBy: true,
+    tempsDeMiseEnOeuvre: true
   })
   .partial();
 

--- a/backend/src/plans/fiches/update-fiche/update-fiche.request.ts
+++ b/backend/src/plans/fiches/update-fiche/update-fiche.request.ts
@@ -59,7 +59,16 @@ export const updateFicheRequestSchema = ficheSchemaUpdate.extend({
     })
     .nullish(),
 
-  // tempsDeMiseEnOeuvre: tempsDeMiseEnOeuvreSchema.pick({ id: true }).nullish(),
+  tempsDeMiseEnOeuvre: z
+    .union([
+      z.number(),
+      z.object({
+        id: z.number(),
+        nom: z.string(),
+      }),
+    ])
+    .transform((val) => (typeof val === 'number' ? val : val.id))
+    .nullish(),
   axes: axeSchema.pick({ id: true }).array().nullish(),
   thematiques: thematiqueSchema.pick({ id: true }).array().nullish(),
   sousThematiques: sousThematiqueSchema.pick({ id: true }).array().nullish(),

--- a/backend/src/plans/fiches/update-fiche/update-fiche.request.ts
+++ b/backend/src/plans/fiches/update-fiche/update-fiche.request.ts
@@ -7,6 +7,7 @@ import { structureTagSchema } from '@/backend/collectivites/tags/structure-tag.t
 import { indicateurDefinitionSchema } from '@/backend/indicateurs/index-domain';
 import { actionRelationSchema } from '@/backend/referentiels/models/action-relation.table';
 import { effetAttenduSchema } from '@/backend/shared/effet-attendu/effet-attendu.table';
+import { tempsDeMiseEnOeuvreSchema } from '@/backend/shared/index-domain';
 import { sousThematiqueSchema } from '@/backend/shared/thematiques/sous-thematique.table';
 import { thematiqueSchema } from '@/backend/shared/thematiques/thematique.table';
 import z from 'zod';
@@ -59,9 +60,7 @@ export const updateFicheRequestSchema = ficheSchemaUpdate.extend({
     })
     .nullish(),
 
-  tempsDeMiseEnOeuvre:
-    z.number()
-      .nullish(),
+  tempsDeMiseEnOeuvre: tempsDeMiseEnOeuvreSchema.pick({ id: true }).nullish(),
   axes: axeSchema.pick({ id: true }).array().nullish(),
   thematiques: thematiqueSchema.pick({ id: true }).array().nullish(),
   sousThematiques: sousThematiqueSchema.pick({ id: true }).array().nullish(),

--- a/backend/src/plans/fiches/update-fiche/update-fiche.request.ts
+++ b/backend/src/plans/fiches/update-fiche/update-fiche.request.ts
@@ -59,16 +59,9 @@ export const updateFicheRequestSchema = ficheSchemaUpdate.extend({
     })
     .nullish(),
 
-  tempsDeMiseEnOeuvre: z
-    .union([
-      z.number(),
-      z.object({
-        id: z.number(),
-        nom: z.string(),
-      }),
-    ])
-    .transform((val) => (typeof val === 'number' ? val : val.id))
-    .nullish(),
+  tempsDeMiseEnOeuvre:
+    z.number()
+      .nullish(),
   axes: axeSchema.pick({ id: true }).array().nullish(),
   thematiques: thematiqueSchema.pick({ id: true }).array().nullish(),
   sousThematiques: sousThematiqueSchema.pick({ id: true }).array().nullish(),

--- a/backend/src/plans/fiches/update-fiche/update-fiche.router.e2e-spec.ts
+++ b/backend/src/plans/fiches/update-fiche/update-fiche.router.e2e-spec.ts
@@ -194,7 +194,7 @@ describe('UpdateFicheService', () => {
         calendrier: 'Calendrier prévisionnel',
         notesComplementaires: 'Vive le vélo !',
         majTermine: true,
-        tempsDeMiseEnOeuvre: 1,
+        tempsDeMiseEnOeuvre: { id: 1 },
         participationCitoyenne:
           'La participation citoyenne a été approuvée en réunion plénière',
         participationCitoyenneType: 'information',

--- a/backend/src/plans/fiches/update-fiche/update-fiche.service.ts
+++ b/backend/src/plans/fiches/update-fiche/update-fiche.service.ts
@@ -66,7 +66,7 @@ export default class UpdateFicheService {
     private readonly ficheActionListService: ListFichesService,
     private readonly fichePermissionService: FicheActionPermissionsService,
     private readonly shareFicheService: ShareFicheService
-  ) {}
+  ) { }
 
   async updateFiche({
     ficheId,
@@ -97,6 +97,7 @@ export default class UpdateFicheService {
       effetsAttendus,
       libreTags,
       sharedWithCollectivites,
+      tempsDeMiseEnOeuvre,
       ...unsafeFicheAction
     } = ficheFields;
 
@@ -107,9 +108,22 @@ export default class UpdateFicheService {
       // Removes all props that are not in the schema
       const ficheAction = ficheSchemaUpdate.parse(unsafeFicheAction);
 
+
+
+
       /**
        * Updates fiche action properties
        */
+
+      // if (tempsDeMiseEnOeuvre !== undefined) {
+      //   await tx
+      //     .update(ficheActionTable)
+      //     .set({
+      //       ...ficheAction,
+      //       tempsDeMiseEnOeuvre: tempsDeMiseEnOeuvre?.id,
+      //     })
+      //     .where(eq(ficheActionTable.id, ficheId));
+      // }
 
       if (Object.keys(ficheFields).length > 0) {
         await tx
@@ -118,6 +132,7 @@ export default class UpdateFicheService {
             ...ficheAction,
             modifiedBy: user.id,
             modifiedAt: new Date().toISOString(),
+            tempsDeMiseEnOeuvre: tempsDeMiseEnOeuvre?.id ?? null,
           })
           .where(eq(ficheActionTable.id, ficheId));
       }
@@ -125,6 +140,7 @@ export default class UpdateFicheService {
       /**
        * Updates junction tables
        */
+
 
       if (axes !== undefined) {
         await this.updateRelations(

--- a/backend/src/plans/fiches/update-fiche/update-fiche.service.ts
+++ b/backend/src/plans/fiches/update-fiche/update-fiche.service.ts
@@ -65,7 +65,7 @@ export default class UpdateFicheService {
     private readonly webhookService: WebhookService,
     private readonly ficheActionListService: ListFichesService,
     private readonly fichePermissionService: FicheActionPermissionsService,
-    private readonly shareFicheService: ShareFicheService
+    private readonly shareFicheService: ShareFicheService,
   ) { }
 
   async updateFiche({


### PR DESCRIPTION
Cela venait du champs tempsDeMiseEnOeuvre dont le schema était invalide.

https://www.notion.so/accelerateur-transition-ecologique-ademe/Impossible-de-valider-une-modification-sur-plusieurs-FA-impossible-ajouter-un-tag-personnalis-21e6523d57d781edbe56dfac5edb728d?source=copy_link