### PR TITLE
BUGFIX : Le statut "Non concernée" était affiché quand les propriétés "concerné" et "desactive" étaient "undefined"

### DIFF
--- a/app.territoiresentransitions.react/src/referentiels/preuves/Bibliotheque/IdentifiantAction.tsx
+++ b/app.territoiresentransitions.react/src/referentiels/preuves/Bibliotheque/IdentifiantAction.tsx
@@ -24,5 +24,5 @@ export const IdentifiantAction = (props: TIdentifiantActionProps) => {
 
 export const isDisabledAction = (action: TPreuveAction) => {
   const { concerne, desactive } = action;
-  return !concerne || desactive;
+  return concerne === false || desactive === true;
 };


### PR DESCRIPTION
Le statut "Non concernée" était affiché quand les propriétés "concerné" et "desactive" étaient "undefined"

https://www.notion.so/accelerateur-transition-ecologique-ademe/Bug-EDL-affichage-erron-de-la-mention-non-concern-e-dans-les-documents-de-chaque-mesure-ECi-et-2226523d57d781f08d98eff99dd448f7?source=copy_link