### PR TITLE
[Indicateurs] le bouton export de tous les indicateurs n’apparait plus

### DIFF
--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/lists/indicateurs-list/badge-list.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/lists/indicateurs-list/badge-list.tsx
@@ -28,9 +28,9 @@ const BadgeList = ({
   });
 
   const displayBadgesList = !!filterBadges?.length;
-  const displayExportButton = !isEmpty && !isLoading;
 
-  if (!displayBadgesList) return null;
+  const displayExportButton = !isEmpty && !isLoading;
+  if (!displayBadgesList && !displayExportButton) return null;
 
   return (
     <div className="flex flex-row justify-between items-start">


### PR DESCRIPTION
https://www.notion.so/accelerateur-transition-ecologique-ademe/Indicateurs-Export-de-tous-les-indicateurs-n-apparait-plus-2246523d57d781e9b787dd9b64b0bfd7?source=copy_link