### PR TITLE
Fix migration

### DIFF
--- a/data_layer/sqitch/deploy/plan_action/plan_action.sql
+++ b/data_layer/sqitch/deploy/plan_action/plan_action.sql
@@ -4,6 +4,7 @@ BEGIN;
 
 insert into plan_action_type (categorie, type)
 values ('Plans thématiques', 'Plan de protection de l''atmosphère (incluant Plans qualité de l''air)');
+on conflict (categorie, type) do nothing;
 
 update plan_action_type
 set type = 'Autre transverse'


### PR DESCRIPTION
Ajoute la gestion en cas de conflit.
Fix nécessaire pour faire passer la migration sur la staging (mon hypothèse : le schéma de la BDD a été copié de la BDD de prod lors de la synchronisation, et du coup la migration faisait une duplication de key interdite).