### PR TITLE
Corrige les permissions de la liste des indicateurs sur sa propre CT et en non vérifié

### DIFF
--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/Indicateur/useIndicateurDefinition.ts
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/Indicateur/useIndicateurDefinition.ts
@@ -5,8 +5,11 @@ type ListDefinitionsInput = RouterInput['indicateurs']['definitions']['list'];
 
 /** Charge la définition détaillée d'un indicateur */
 export const useIndicateurDefinition = (indicateurId: number | string) => {
+  const collectiviteId = useCollectiviteId();
+
   const estIdReferentiel = typeof indicateurId === 'string';
   const { data, ...other } = trpc.indicateurs.definitions.list.useQuery({
+    collectiviteId,
     ...(estIdReferentiel
       ? { identifiantsReferentiel: [indicateurId] }
       : { indicateurIds: [indicateurId] }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -304,7 +304,7 @@ importers:
         version: 6.10.1
       nuqs:
         specifier: ^2.4.3
-        version: 2.4.3(next@15.3.2(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(@playwright/test@1.52.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.89.0))(react-router-dom@5.3.4(react@18.3.1))(react@18.3.1)
+        version: 2.4.3(next@15.3.3(@babel/core@7.27.1)(@opentelemetry/api@1.9.0)(@playwright/test@1.52.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.89.0))(react-router-dom@5.3.4(react@18.3.1))(react@18.3.1)
       pdf-parse-debugging-disabled:
         specifier: ^1.1.1
         version: 1.1.1


### PR DESCRIPTION
La suppression du passage de `collectiviteId` à l'appel à `indicateurs.definitions.list` fait que les droits au niveau du service sont vérifiés uniquement au niveau de la ressource `PLATEFORME` et non plus au niveau `COLLECTIVITE`. 

Pour un utilisateur "non vérifié" mais membre d'une CT, ça lui empêche ainsi de consulter la liste des indicateurs qui reste vide.

Je rétablis donc l'ancien comportement, mais j'ai du mal à voir comment adapter le partage des fiches entre CT en conséquence. Ce serait plus simple d'en discuter en direct avec toi @dthib à ton retour. Vu que c'est pour le moment en feature flag, je laisse tel quel.