### PR TITLE
Bug: Impossible de modifier la description d'un indicateur

### DIFF
--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/Indicateur/useIndicateurDefinition.ts
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/Indicateur/useIndicateurDefinition.ts
@@ -4,14 +4,20 @@ import { RouterInput, trpc } from '@/api/utils/trpc/client';
 type ListDefinitionsInput = RouterInput['indicateurs']['definitions']['list'];
 
 /** Charge la définition détaillée d'un indicateur */
-export const useIndicateurDefinition = (indicateurId: number | string) => {
+export const useIndicateurDefinition = (
+  indicateurId: number | string,
+  collectiviteId: number
+) => {
   const estIdReferentiel = typeof indicateurId === 'string';
-  const { data, ...other } = trpc.indicateurs.definitions.list.useQuery({
-    ...(estIdReferentiel
-      ? { identifiantsReferentiel: [indicateurId] }
-      : { indicateurIds: [indicateurId] }),
-  });
-  return { data: data?.[0], ...other };
+  const { data, error, isLoading } = trpc.indicateurs.definitions.list.useQuery(
+    {
+      collectiviteId,
+      ...(estIdReferentiel
+        ? { identifiantsReferentiel: [indicateurId] }
+        : { indicateurIds: [indicateurId] }),
+    }
+  );
+  return { data: data?.[0], error, isLoading };
 };
 
 /** Charge la définition détaillée de plusieurs indicateurs */

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/CommentaireIndicateurInput.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/CommentaireIndicateurInput.tsx
@@ -7,7 +7,7 @@ type Props = {
   updateDescription: (value: string) => void;
 };
 
-const DescriptionIndicateurInput = ({
+export const CommentaireIndicateurInput = ({
   description,
   disabled,
   updateDescription,
@@ -29,5 +29,3 @@ const DescriptionIndicateurInput = ({
     </Field>
   );
 };
-
-export default DescriptionIndicateurInput;

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/DonneesIndicateur.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/DonneesIndicateur.tsx
@@ -9,7 +9,7 @@ import { useIndicateurPersonnalisation } from '../data/use-indicateur-personnali
 import IndicateurDetailChart from '../Indicateur/detail/IndicateurDetailChart';
 import { IndicateurValuesTabs } from '../Indicateur/detail/IndicateurValuesTabs';
 import { TIndicateurDefinition } from '../types';
-import DescriptionIndicateurInput from './DescriptionIndicateurInput';
+import { CommentaireIndicateurInput } from './CommentaireIndicateurInput';
 import { IndicateurSourcesSelect } from './indicateur-sources.select';
 import ThematiquesIndicateurInput from './ThematiquesIndicateurInput';
 import { TypeSegmentationSelect } from './type-segmentation.select';
@@ -109,7 +109,6 @@ const DonneesIndicateur = ({
         <Divider className="mt-6" />
       </div>
 
-      {/* Thématiques */}
       {isPerso && (
         <ThematiquesIndicateurInput
           definition={definition}
@@ -117,9 +116,8 @@ const DonneesIndicateur = ({
         />
       )}
 
-      {/* Description */}
-      <DescriptionIndicateurInput
-        description={isPerso ? description : commentaire}
+      <CommentaireIndicateurInput
+        description={commentaire}
         updateDescription={updateDescription}
         disabled={isReadonly}
       />

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/IndicateurDetail.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/IndicateurDetail.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useCollectiviteId } from '@/api/collectivites';
 import { INDICATEUR_TRAJECTOIRE_IDENTFIANTS } from '@/app/app/pages/collectivite/Trajectoire/constants';
 import SpinnerLoader from '@/app/ui/shared/SpinnerLoader';
 import { useEffect } from 'react';
@@ -19,8 +20,11 @@ export const IndicateurDetail = ({
   indicateurId,
   isPerso = false,
 }: Props) => {
-  const { data: definition, isLoading } = useIndicateurDefinition(indicateurId);
-
+  const collectiviteId = useCollectiviteId();
+  const { data: definition, isLoading } = useIndicateurDefinition(
+    indicateurId,
+    collectiviteId
+  );
   const {
     mutate: calcul,
     isLoading: isLoadingTrajectoire,

--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/IndicateurLayout.tsx
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/detail/IndicateurLayout.tsx
@@ -34,49 +34,31 @@ const IndicateurLayout = ({
   const composeSansAgregation = !!enfants && enfants.length > 0 && sansValeur;
   const composeAvecAgregation = !!enfants && enfants.length > 0 && !sansValeur;
 
-  // Mise à jour des champs de l'indicateur
   const handleUpdate = (
     name: 'description' | 'commentaire' | 'unite' | 'titre',
     value: string
   ) => {
     const trimmedValue = value.trim();
-    if (collectiviteId && trimmedValue !== definition[name]) {
-      const indicateurDefinition: Indicateurs.domain.IndicateurDefinitionUpdate =
-        {
-          ...definition,
-          [name]: trimmedValue,
-          confidentiel: definition.confidentiel || false,
-        };
-
-      updateDefinition(indicateurDefinition);
+    const isFieldUpdated = trimmedValue !== definition[name];
+    if (isFieldUpdated === false) {
+      return;
     }
+    const indicateurDefinition: Indicateurs.domain.IndicateurDefinitionUpdate =
+      {
+        ...definition,
+        [name]: trimmedValue,
+        confidentiel: definition.confidentiel || false,
+      };
+
+    updateDefinition(indicateurDefinition);
   };
 
   const handleTitreUpdate = (value: string) => handleUpdate('titre', value);
 
-  const handleCommentaireUpdate = (value: string) =>
-    handleUpdate('commentaire', value);
-
   const handleUniteUpdate = (value: string) => handleUpdate('unite', value);
 
-  /**
-   * TEMPORARY: currently, description input feeds two columns:
-   * `description` column in `indicateur_definition`
-   * `commentaire` column in `indicateur_collectivite` (via the hardcoded ['commentaire'] prop).
-   *
-   * TO DO: remove this function and change
-   * handleUpdate('description', e.target.value) to handleUpdate('commentaire', e.target.value).
-   *
-   * Related to this PR: https://github.com/incubateur-ademe/territoires-en-transitions/pull/3313.
-   */
-  const handleDescriptionUpdate = (value: string) => {
-    const trimmedValue = value.trim();
-    updateDefinition({
-      ...definition,
-      description: trimmedValue,
-      commentaire: trimmedValue,
-      confidentiel: definition.confidentiel || false,
-    });
+  const handleCommentaireUpdate = (value: string) => {
+    handleUpdate('commentaire', value);
   };
 
   const enfantsIds = enfants?.map(({ id }) => id) || [];
@@ -110,11 +92,7 @@ const IndicateurLayout = ({
                   <DonneesIndicateur
                     {...{ definition, isPerso, isReadOnly }}
                     updateUnite={handleUniteUpdate}
-                    updateDescription={(value) =>
-                      isPerso
-                        ? handleDescriptionUpdate(value)
-                        : handleCommentaireUpdate(value)
-                    }
+                    updateDescription={handleCommentaireUpdate}
                   />
                 </Tab>
 
@@ -132,7 +110,6 @@ const IndicateurLayout = ({
                   </Tab>
                 ) : undefined}
 
-                {/* Mesures des référentiels liées */}
                 {!isPerso ? (
                   <Tab label="Mesures des référentiels">
                     <ActionsLiees
@@ -143,7 +120,6 @@ const IndicateurLayout = ({
                   </Tab>
                 ) : undefined}
 
-                {/* Fiches action liées */}
                 <Tab label="Fiches action">
                   <FichesLiees
                     definition={definition}


### PR DESCRIPTION
Ticket: https://www.notion.so/accelerateur-transition-ecologique-ademe/Indicateurs-Impossible-d-crire-du-texte-dans-la-description-22b6523d57d781b5affad121069a9414?source=copy_link

Reproduction du bug:

https://github.com/user-attachments/assets/90f85ca0-1761-44eb-b238-c876e51a2114



L'update du champ était bien effective et sauvegardée en DB mais le paramètre `collectiviteId` manquait dans le call API pour être à même de performer le LEFT JOIN qui permet de récupérer la description d'un indicateur.

Est-ce que l'on peut supprimer la colonne `description` de `indicateur_définition` qui ne semble plus être utile dorénavant ? (cf les commentaires de Marine supprimés)