### PR TITLE
Corrige le lien vers les indicateurs opendata

### DIFF
--- a/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/lists/indicateurs-list/use-indicateurs-list-params.ts
+++ b/app.territoiresentransitions.react/src/app/pages/collectivite/Indicateurs/lists/indicateurs-list/use-indicateurs-list-params.ts
@@ -5,6 +5,7 @@ import {
 } from '@/domain/indicateurs';
 import { omit, pick } from 'es-toolkit';
 import {
+  createSerializer,
   parseAsBoolean,
   parseAsInteger,
   parseAsJson,
@@ -61,10 +62,20 @@ const optionsNameToParams: Record<keyof ListOptions, string> = {
 } as const;
 
 export type SearchParams = ListIndicateursRequestFilters & ListOptions;
-export const searchParamsMap = {
+export const searchParamsShortMap = {
   ...indicateursNameToParams,
   ...optionsNameToParams,
 };
+
+const searchParamsMap = {
+  sortBy: parseAsStringLiteral(sortByValues),
+  displayGraphs: parseAsBoolean,
+  currentPage: parseAsInteger.withDefault(1),
+  filter: parseAsJson(listIndicateursRequestFiltersSchema.parse),
+};
+
+export const listIndicateursParamsSerializer =
+  createSerializer(searchParamsMap);
 
 /** Gère les paramètres d'une liste d'indicateurs */
 export const useIndicateursListParams = (
@@ -73,20 +84,17 @@ export const useIndicateursListParams = (
 ) => {
   const [searchParams, setSearchParams] = useQueryStates(
     {
-      sortBy: parseAsStringLiteral(sortByValues).withDefault(
+      ...searchParamsMap,
+      sortBy: searchParamsMap.sortBy.withDefault(
         defaultOptions?.sortBy ?? 'estComplet'
       ),
-      displayGraphs: parseAsBoolean.withDefault(
+      displayGraphs: searchParamsMap.displayGraphs.withDefault(
         defaultOptions?.displayGraphs ?? true
       ),
-      currentPage: parseAsInteger.withDefault(1),
-
-      filter: parseAsJson(
-        listIndicateursRequestFiltersSchema.parse
-      ).withDefault(defaultFilters),
+      filter: searchParamsMap.filter.withDefault(defaultFilters),
     },
     {
-      urlKeys: searchParamsMap,
+      urlKeys: searchParamsShortMap,
     }
   );
 

--- a/app.territoiresentransitions.react/src/referentiels/tableau-de-bord/IndicateursCard.tsx
+++ b/app.territoiresentransitions.react/src/referentiels/tableau-de-bord/IndicateursCard.tsx
@@ -1,4 +1,5 @@
 import { referentielToName } from '@/app/app/labels';
+import { listIndicateursParamsSerializer } from '@/app/app/pages/collectivite/Indicateurs/lists/indicateurs-list/use-indicateurs-list-params';
 import { makeCollectiviteTousLesIndicateursUrl } from '@/app/app/paths';
 import { ReferentielId } from '@/domain/referentiels';
 import { Button, Event, useEventTracker } from '@/ui';
@@ -67,7 +68,12 @@ const IndicateursCard = ({
             }
             href={`${makeCollectiviteTousLesIndicateursUrl({
               collectiviteId,
-            })}?cat=${referentielId}&od=true`}
+            })}${listIndicateursParamsSerializer({
+              filter: {
+                categorieNoms: [referentielId],
+                hasOpenData: true,
+              },
+            })}`}
             variant="outlined"
             size="sm"
           >


### PR DESCRIPTION
Les query params du lien étaient mise en dur…
J'ai adapté avec un serializer de `nuqs` pour éviter que ca se reproduise.