### PR TITLE
[BUG] Filtres ne sont pas pris en compte dans les modules personnalisés

### DIFF
--- a/backend/src/plans/fiches/count-by/count-by.types.ts
+++ b/backend/src/plans/fiches/count-by/count-by.types.ts
@@ -1,0 +1,41 @@
+const arrayCountByPropertyValues = [
+  'partenaires',
+  'services',
+  'plans',
+  'libreTags',
+  'thematiques',
+  'sousThematiques',
+  'structures',
+  'effetsAttendus',
+] as const;
+
+type FilterArray =
+  | 'partenaireIds'
+  | 'servicePiloteIds'
+  | 'planActionIds'
+  | 'libreTagsIds'
+  | 'thematiqueIds'
+  | 'sousThematiqueIds'
+  | 'structurePiloteIds';
+
+export type ArrayCountByProperty = (typeof arrayCountByPropertyValues)[number];
+
+export const countByPropertyFichesFiltersKeysMapping: Partial<
+  Record<ArrayCountByProperty, FilterArray>
+> = {
+  partenaires: 'partenaireIds',
+  services: 'servicePiloteIds',
+  plans: 'planActionIds',
+  libreTags: 'libreTagsIds',
+  thematiques: 'thematiqueIds',
+  sousThematiques: 'sousThematiqueIds',
+  structures: 'structurePiloteIds',
+};
+
+export const isArrayCountByProperty = (
+  countByProperty: string
+): countByProperty is ArrayCountByProperty => {
+  return arrayCountByPropertyValues.includes(
+    countByProperty as ArrayCountByProperty
+  );
+};

--- a/backend/src/plans/fiches/count-by/utils/count-by-array-value.test.ts
+++ b/backend/src/plans/fiches/count-by/utils/count-by-array-value.test.ts
@@ -1,0 +1,58 @@
+import { ListFichesRequestFilters } from '@/backend/plans/fiches/list-fiches/list-fiches.request';
+import { CountByRecordGeneralType } from '@/backend/utils/count-by.dto';
+import { ArrayCountByProperty } from '../count-by.types';
+import { countByArrayValues } from './count-by-array-value';
+
+describe('countByArrayValues', () => {
+  describe('basic functionality', () => {
+    it('should count values and map them to the countByMap object', () => {
+      const valueArray = [
+        { id: 1, nom: 'Partenaire 1' },
+        { id: 2, nom: 'Partenaire 2' },
+        { id: 1, nom: 'Partenaire 1' },
+      ];
+      const filters: ListFichesRequestFilters = {};
+      const countByMap: CountByRecordGeneralType = {};
+
+      countByArrayValues({
+        valueArray,
+        filters,
+        countByMap,
+        countByProperty: 'partenaires',
+      });
+
+      expect(countByMap).toEqual({
+        '1': { value: 1, label: 'Partenaire 1', count: 2 },
+        '2': { value: 2, label: 'Partenaire 2', count: 1 },
+      });
+    });
+
+    it('should filter out values that match the filter criteria', () => {
+      const valueArray = [
+        { id: 1, nom: 'Partenaire 1' },
+        { id: 2, nom: 'Partenaire 2' },
+        { id: 3, nom: 'Partenaire 3' },
+        { id: 3, nom: 'Partenaire 3' },
+        { id: 3, nom: 'Partenaire 3' },
+        { id: 4, nom: 'Partenaire 4' },
+        { id: 5, nom: 'Partenaire 5' },
+      ];
+      const filters: ListFichesRequestFilters = {
+        partenaireIds: [1, 3], // Filter in partners with IDs 1 and 3
+      };
+      const countByMap: CountByRecordGeneralType = {};
+
+      countByArrayValues({
+        valueArray,
+        filters,
+        countByMap,
+        countByProperty: 'partenaires' as ArrayCountByProperty,
+      });
+
+      expect(countByMap).toEqual({
+        '3': { value: 3, label: 'Partenaire 3', count: 3 },
+        '1': { value: 1, label: 'Partenaire 1', count: 1 },
+      });
+    });
+  });
+});

--- a/backend/src/plans/fiches/count-by/utils/count-by-array-value.ts
+++ b/backend/src/plans/fiches/count-by/utils/count-by-array-value.ts
@@ -1,0 +1,41 @@
+import { ListFichesRequestFilters } from '@/backend/plans/fiches/list-fiches/list-fiches.request';
+import { CountByRecordGeneralType } from '@/backend/utils/count-by.dto';
+import {
+  ArrayCountByProperty,
+  countByPropertyFichesFiltersKeysMapping,
+} from '../count-by.types';
+
+export function countByArrayValues({
+  valueArray,
+  filters,
+  countByMap,
+  countByProperty,
+}: {
+  valueArray: Array<{ id: string | number; nom: string }>;
+  filters: ListFichesRequestFilters;
+  countByMap: CountByRecordGeneralType;
+  countByProperty: ArrayCountByProperty;
+}) {
+  const filterKey = countByPropertyFichesFiltersKeysMapping[countByProperty];
+
+  const additionalFilters = filterKey ? filters[filterKey] || null : null;
+
+  valueArray.forEach((value) => {
+    const valueKey = `${value.id}`;
+
+    const isValueSpecificallyFilteredOut =
+      additionalFilters?.some((filter) => filter === value.id) === false;
+
+    if (isValueSpecificallyFilteredOut) {
+      return;
+    }
+    if (!countByMap[valueKey]) {
+      countByMap[valueKey] = {
+        value: value.id,
+        label: value.nom,
+        count: 0,
+      };
+    }
+    countByMap[valueKey].count++;
+  });
+}

--- a/backend/src/plans/fiches/list-fiches/list-fiches.request.ts
+++ b/backend/src/plans/fiches/list-fiches/list-fiches.request.ts
@@ -1,12 +1,10 @@
-import {
-  getPaginationSchema,
-} from '@/backend/utils/index-domain';
+import { getPaginationSchema } from '@/backend/utils/index-domain';
 import { modifiedSinceSchema } from '@/backend/utils/modified-since.enum';
 import { z } from 'zod';
 import {
   ciblesEnumSchema,
   prioriteEnumSchema,
-  statutsEnumSchema
+  statutsEnumSchema,
 } from '../shared/models/fiche-action.table';
 
 export const typePeriodeEnumValues = [
@@ -24,32 +22,43 @@ export const listFichesRequestFiltersSchema = z
     // `z.coerce.boolean()` is used to convert the string 'true' to a boolean
     // This is necessary because our custom `useSearchParams` only returns strings
     // TODO: use z.coerce.boolean() when we migrate to nuqs library
-    noPilote: z.coerce.boolean()
+    noPilote: z.coerce
+      .boolean()
       .optional()
       .describe(
         `Aucun utilisateur ou personne pilote n'est associé à la fiche`
       ),
-    hasBudgetPrevisionnel: z.coerce.boolean()
+    hasBudgetPrevisionnel: z.coerce
+      .boolean()
       .optional()
       .describe(`A un budget prévisionnel`),
-    hasIndicateurLies: z.coerce.boolean()
+    hasIndicateurLies: z.coerce
+      .boolean()
       .optional()
       .describe(`A indicateur(s) associé(s)`),
     indicateurIds: z.array(z.coerce.number()).optional(),
-    hasMesuresLiees: z.coerce.boolean()
+    hasMesuresLiees: z.coerce
+      .boolean()
       .optional()
       .describe(`A mesure(s) des référentiels associée(s)`),
-    isBelongsToSeveralPlans: z.coerce.boolean()
+    isBelongsToSeveralPlans: z.coerce
+      .boolean()
       .optional()
       .describe(`Actions mutualisées dans plusieurs plans`),
-    hasDateDeFinPrevisionnelle: z.coerce.boolean()
+    hasDateDeFinPrevisionnelle: z.coerce
+      .boolean()
       .optional()
       .describe(`A une date de fin prévisionnelle`),
-    ameliorationContinue: z.coerce.boolean()
+    ameliorationContinue: z.coerce
+      .boolean()
       .optional()
       .describe(`Est en amélioration continue`),
-    restreint: z.coerce.boolean().optional().describe(`Fiche action en mode privé`),
-    noServicePilote: z.coerce.boolean()
+    restreint: z.coerce
+      .boolean()
+      .optional()
+      .describe(`Fiche action en mode privé`),
+    noServicePilote: z.coerce
+      .boolean()
       .optional()
       .describe(`Aucune direction ou service pilote n'est associée à la fiche`),
     sharedWithCollectivites: z
@@ -195,6 +204,13 @@ export const listFichesRequestFiltersSchema = z
 export type ListFichesRequestFilters = z.output<
   typeof listFichesRequestFiltersSchema
 >;
+export type ListFichesRequestFiltersKeys = keyof ListFichesRequestFilters;
+
+export const isListFichesRequestFiltersKeys = (
+  filters: string
+): filters is ListFichesRequestFiltersKeys => {
+  return Object.keys(listFichesRequestFiltersSchema.shape).includes(filters);
+};
 
 const sortValues = ['modified_at', 'created_at', 'titre'] as const;
 


### PR DESCRIPTION
A la création d'un module personnalisé pour un count by par tag par exemple, la 2nde étape permet de rajouter des filtres additionnels dont les tags personnalisés mais ceux-ci n'étaient pas considérés d'où un affichage avec plu d'info que nécessaire pour certains utilisateurs:
https://www.notion.so/accelerateur-transition-ecologique-ademe/TDB-Module-personnalis-Mauvais-tags-pris-en-compte-2336523d57d781fcb151cf637d49b505?source=copy_link

Je serais bien parti dans un refacto un peu plus lourd pour notamment limiter la répétition de code, améliorer la lisibilité et limiter les mutations d'objet mais je me suis limité au fix avec un ajout de test pour le scope de ce ticket.


Avant:
<img width="728" height="413" alt="Capture d’écran 2025-07-24 à 13 24 06" src="https://github.com/user-attachments/assets/81f39867-1a52-4fc3-81fa-fe6ce2946875" />


Après:
<img width="728" height="413" alt="Capture d’écran 2025-07-24 à 13 31 41" src="https://github.com/user-attachments/assets/e552f4a6-53d0-4f58-b470-b3b54baaaf6f" />
