### PR TITLE
Corrige le chargement de la page de personnalisation des référentiels

### DIFF
--- a/apps/app/src/collectivites/panier/data/useGetCollectivitePanierInfo.ts
+++ b/apps/app/src/collectivites/panier/data/useGetCollectivitePanierInfo.ts
@@ -8,7 +8,7 @@ export const useGetCollectivitePanierInfo = (collectiviteId: number | null) => {
   const { data } = useQuery({
     queryKey: ['collectivite_panier_info', collectiviteId],
     queryFn: async () => {
-      if (!collectiviteId) return;
+      if (!collectiviteId) return null;
       return fetchCollectivitePanierInfo(supabase, collectiviteId);
     },
   });

--- a/apps/app/src/referentiels/personnalisations/PersoReferentielThematique/PersoReferentielThematique.tsx
+++ b/apps/app/src/referentiels/personnalisations/PersoReferentielThematique/PersoReferentielThematique.tsx
@@ -1,24 +1,24 @@
 'use client';
 
-import { useState } from 'react';
 import { useParams } from 'next/navigation';
+import { useState } from 'react';
 
 import { useCurrentCollectivite } from '@/api/collectivites';
-import PageContainer from '@/ui/components/layout/page-container';
-import { Button, Checkbox } from '@/ui';
 import {
   makeCollectivitePersoRefThematiqueUrl,
   makeCollectivitePersoRefUrl,
 } from '@/app/app/paths';
+import { Button, Checkbox } from '@/ui';
+import PageContainer from '@/ui/components/layout/page-container';
 
 import { usePersonnalisationReferentiels } from '../personnalisation-referentiel.context';
-import { useChangeReponseHandler } from '../PersoPotentielModal/useChangeReponseHandler';
 import { QuestionReponseList } from '../PersoPotentielModal/PersoPotentielQR';
+import { useChangeReponseHandler } from '../PersoPotentielModal/useChangeReponseHandler';
+import { CarteIdentite } from './CarteIdentite';
 import { useCarteIdentite } from './useCarteIdentite';
 import { useNextThematiqueId } from './useNextThematiqueId';
 import { useQuestionsReponses } from './useQuestionsReponses';
 import { useThematique } from './useThematique';
-import { CarteIdentite } from './CarteIdentite';
 
 export const PersoReferentielThematique = () => {
   const { collectiviteId } = useCurrentCollectivite();

--- a/apps/app/src/referentiels/personnalisations/PersoReferentielThematique/useQuestions.ts
+++ b/apps/app/src/referentiels/personnalisations/PersoReferentielThematique/useQuestions.ts
@@ -21,9 +21,9 @@ export const useQuestions = (filters: TFilters) => {
   return useQuery({
     queryKey: ['questions', collectiviteId, filters],
     queryFn: () => fetchQuestions(supabase, collectiviteId, filters),
-    initialData: [],
   });
 };
+
 const fetchQuestions = async (
   supabase: DBClient,
   collectiviteId: number,

--- a/apps/app/src/referentiels/personnalisations/PersoReferentielThematique/useQuestionsReponses.ts
+++ b/apps/app/src/referentiels/personnalisations/PersoReferentielThematique/useQuestionsReponses.ts
@@ -10,7 +10,8 @@ import { useReponses } from './useReponses';
 export const useQuestionsReponses = (filters: TFilters) => {
   // charge les questions et les réponses
   const { data: questions } = useQuestions(filters);
-  const reponses = useReponses(questions!);
+
+  const reponses = useReponses(questions || []);
 
   // indexe les réponses par id de question
   const reponsesByQuestionId = new Map<

--- a/apps/app/src/referentiels/personnalisations/PersoReferentielThematique/useReponses.ts
+++ b/apps/app/src/referentiels/personnalisations/PersoReferentielThematique/useReponses.ts
@@ -42,7 +42,7 @@ const fetchReponse = async (
     throw new Error(error.message);
   }
 
-  return data?.length ? transform(data[0] as TReponseRead) : undefined;
+  return data?.length ? transform(data[0] as TReponseRead) : null;
 };
 
 // met à jour si nécessaire la valeur d'une réponse lue depuis la base


### PR DESCRIPTION
Ne pas fournir `initialData` à `useQuery` quand ce n'est pas de la vraie data.