### PR TITLE
fix: hide editing actions from auditeurs

### DIFF
--- a/apps/app/src/plans/plans/create-plan/components/create-plan.button.tsx
+++ b/apps/app/src/plans/plans/create-plan/components/create-plan.button.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useIsVisitor } from '@/app/core-logic/hooks/permissions/useIsVisitor';
 import { CreatePlanOptionLinksList } from '@/app/plans/plans/create-plan/components/create-plan-option-link.list.tsx';
+import { useIsAuditeur } from '@/app/referentiels/audits/useAudit';
 import { Button, ButtonSize, Modal } from '@/ui';
 
 export const CreatePlanButton = ({
@@ -15,7 +16,8 @@ export const CreatePlanButton = ({
   size?: ButtonSize;
 }) => {
   const isVisitor = useIsVisitor();
-  if (isVisitor) return null;
+  const isAuditeur = useIsAuditeur();
+  if (isVisitor || isAuditeur) return null;
 
   return (
     <Modal

--- a/apps/app/src/plans/plans/list-all-plans/all-plans.view.tsx
+++ b/apps/app/src/plans/plans/list-all-plans/all-plans.view.tsx
@@ -4,6 +4,7 @@ import { CreatePlanButton } from '@/app/plans/plans/create-plan/components/creat
 import { ImportPlanButton } from '@/app/plans/plans/import-plan/support';
 import { EmptyAllPlansVisitorView } from '@/app/plans/plans/list-all-plans/empty-all-plans-visitor.view';
 import { EmptyAllPlansView } from '@/app/plans/plans/list-all-plans/empty-all-plans.view';
+import { useIsAuditeur } from '@/app/referentiels/audits/useAudit';
 import { Plan } from '@/domain/plans/plans';
 import { Spacer } from '@/ui';
 import { VisibleWhen } from '@/ui/design-system/VisibleWhen';
@@ -18,6 +19,7 @@ type Props = {
 
 export const AllPlansView = ({ plans, collectiviteId, panierId }: Props) => {
   const isVisitor = useIsVisitor();
+  const isAuditeur = useIsAuditeur();
   return (
     <>
       <Header
@@ -39,7 +41,7 @@ export const AllPlansView = ({ plans, collectiviteId, panierId }: Props) => {
       <VisibleWhen condition={plans.length === 0}>
         <Spacer height={3} />
         <div className="min-h-[60vh]">
-          {isVisitor ? (
+          {isVisitor || isAuditeur ? (
             <EmptyAllPlansVisitorView />
           ) : (
             <EmptyAllPlansView


### PR DESCRIPTION
But : enlever les boutons d'action si la page est consultée en mode auditeurs.

<img width="1457" height="638" alt="Capture d’écran 2025-08-06 à 23 28 55" src="https://github.com/user-attachments/assets/380fd1dc-55b7-4571-bce8-44812c436aad" />
