### PR TITLE
fix: update public directory path in Earthfile for correct asset copying

### DIFF
--- a/apps/app/Earthfile
+++ b/apps/app/Earthfile
@@ -72,7 +72,7 @@ docker:
   RUN addgroup --system --gid 1001 nodejs
   RUN adduser --system --uid 1001 nextjs
 
-  COPY +build/public ./public
+  COPY +build/public ./apps/app/public
 
   # Set the correct permission for prerender cache
   RUN mkdir .next


### PR DESCRIPTION
Répond à ce bug : https://www.notion.so/accelerateur-transition-ecologique-ademe/Fichier-d-import-introuvable-Erreur-404empty-all-2476523d57d7809795e5e5b0c8c3022a?source=copy_link

Mise à jour à faire suite à la réorganisation des dossiers de la semaine dernière.