### PR TITLE
❤️‍🩹 Répare redirection vers la visite d'un profil CT

### DIFF
--- a/.github/workflows/cd-auth.yml
+++ b/.github/workflows/cd-auth.yml
@@ -38,6 +38,7 @@ jobs:
           --ANON_KEY=${{ secrets.ANON_KEY }}
           --API_URL=${{ secrets.API_URL }}
           --BACKEND_URL=${{ vars.BACKEND_URL }}
+          --APP_URL=${{ vars.APP_URL }}
 
       - name: Deploy auth on Koyeb
         run: >

--- a/Earthfile
+++ b/Earthfile
@@ -537,11 +537,13 @@ auth-build: ## construit l'image du module d'authentification
     ARG --required ANON_KEY
     ARG --required API_URL
     ARG BACKEND_URL
+    ARG APP_URL
     ARG vars
     FROM +front-deps
     ENV NEXT_PUBLIC_SUPABASE_ANON_KEY=$ANON_KEY
     ENV NEXT_PUBLIC_SUPABASE_URL=$API_URL
     ENV NEXT_PUBLIC_BACKEND_URL=$BACKEND_URL
+    ENV NEXT_PUBLIC_APP_URL=$APP_URL
 
     ENV NEXT_TELEMETRY_DISABLED=1
     ENV PUBLIC_PATH="/app/apps/auth/public"

--- a/apps/app/middleware.ts
+++ b/apps/app/middleware.ts
@@ -6,6 +6,7 @@ import { createClient } from '@/api/utils/supabase/middleware-client';
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import {
+  collectiviteBasePath,
   finaliserMonInscriptionUrl,
   invitationPath,
   makeTdbCollectiviteUrl,
@@ -149,7 +150,8 @@ function isAllowedPathnameWhenNoCollectivite(pathname: string) {
     pathname === finaliserMonInscriptionUrl ||
     pathname.startsWith(invitationPath) ||
     pathname.startsWith(recherchesPath) ||
-    pathname.startsWith(profilPath)
+    pathname.startsWith(profilPath) ||
+    pathname.startsWith(collectiviteBasePath)
   );
 }
 

--- a/apps/app/src/app/paths.ts
+++ b/apps/app/src/app/paths.ts
@@ -78,7 +78,8 @@ export type ActionTabParamOption =
 
 type LabellisationTab = 'suivi' | 'cycles' | 'criteres';
 
-export const collectivitePath = `/collectivite/:${collectiviteParam}`;
+export const collectiviteBasePath = '/collectivite';
+export const collectivitePath = `${collectiviteBasePath}/:${collectiviteParam}`;
 
 export const collectiviteIndicateursBasePath = `${collectivitePath}/indicateurs`;
 export const collectiviteIndicateurPath = `${collectiviteIndicateursBasePath}/:${indicateurViewParam}/:${indicateurIdParam}?`;

--- a/apps/app/src/fixtures/userData.ts
+++ b/apps/app/src/fixtures/userData.ts
@@ -18,5 +18,6 @@ export const fakeUserData: UserDetails = {
   updated_at: '2022-07-26T12:38:33.382147Z',
   user_metadata: {},
   isSupport: false,
+  isVerified: true,
   collectivites: [],
 };

--- a/apps/auth/app/layout.tsx
+++ b/apps/auth/app/layout.tsx
@@ -1,4 +1,6 @@
+import { fetchUserDetails } from '@/api/users/user-details.fetch.server';
 import { UserProvider } from '@/api/users/user-provider';
+import { getAuthUser } from '@/api/utils/supabase/auth-user.server';
 import { getCookieOptions } from '@/api/utils/supabase/cookie-options';
 import { SupabaseProvider } from '@/api/utils/supabase/use-supabase';
 import { ReactQueryAndTRPCProvider } from '@/api/utils/trpc/client';
@@ -39,6 +41,10 @@ export default async function RootLayout({
   const hostname = (await headers()).get('host');
   const supabaseCookieOptions = getCookieOptions(hostname ?? undefined);
 
+  const authUser = await getAuthUser();
+
+  const user = authUser ? await fetchUserDetails(authUser) : null;
+
   return (
     <html lang="fr">
       <PostHogProvider
@@ -50,7 +56,7 @@ export default async function RootLayout({
         <body className="min-h-screen overflow-x-visible flex flex-col">
           <div className="flex flex-col grow">
             <SupabaseProvider cookieOptions={supabaseCookieOptions}>
-              <UserProvider user={null}>
+              <UserProvider user={user}>
                 <ReactQueryAndTRPCProvider>
                   <Header />
                   <div className="bg-grey-2 grow flex flex-col">

--- a/apps/auth/app/rejoindre-une-collectivite/CollectiviteSelectionnee.tsx
+++ b/apps/auth/app/rejoindre-une-collectivite/CollectiviteSelectionnee.tsx
@@ -1,3 +1,4 @@
+import { useUser } from '@/api/users/user-provider';
 import { Alert, Button, Icon, useCopyToClipboard } from '@/ui';
 import { CollectiviteInfo } from './useRejoindreUneCollectivite';
 
@@ -7,6 +8,9 @@ type Props = {
 
 export const CollectiviteSelectionnee = ({ collectivite }: Props) => {
   const { copy } = useCopyToClipboard();
+
+  const { isVerified } = useUser();
+
   if (!collectivite) return;
 
   const { url, contacts } = collectivite;
@@ -16,11 +20,7 @@ export const CollectiviteSelectionnee = ({ collectivite }: Props) => {
       <Alert
         state="info"
         title="Contactez l'une des personnes admin par mail pour recevoir un lien d’invitation"
-        footer={
-          <Button target="_blank" href={url}>
-            Consulter le profil de cette collectivité en mode visiteur
-          </Button>
-        }
+        className="mb-4"
       />
       {!!contacts?.length && (
         <table className="w-full my-4">
@@ -51,6 +51,11 @@ export const CollectiviteSelectionnee = ({ collectivite }: Props) => {
             ))}
           </tbody>
         </table>
+      )}
+      {isVerified && (
+        <Button target="_blank" href={url} variant="outlined" className="mt-6">
+          En attendant l’accès, visitez le profil de cette collectivité
+        </Button>
       )}
     </div>
   );

--- a/packages/api/src/users/user-details.fetch.server.ts
+++ b/packages/api/src/users/user-details.fetch.server.ts
@@ -20,16 +20,19 @@ export interface UserDetails extends Omit<User, 'email'>, DCP {
   // email: string;
   isSupport: boolean;
   collectivites: MaCollectivite[];
+  isVerified: boolean;
 }
 
 export async function fetchUserDetails(user: User): Promise<UserDetails> {
   const supabase = await createClient();
 
-  const [dcp, { data: isSupport }, collectivites] = await Promise.all([
-    dcpFetch({ dbClient: supabase, user_id: user.id }),
-    supabase.rpc('est_support'),
-    fetchUserCollectivites(supabase),
-  ]);
+  const [dcp, { data: isSupport }, collectivites, { data: isVerified }] =
+    await Promise.all([
+      dcpFetch({ dbClient: supabase, user_id: user.id }),
+      supabase.rpc('est_support'),
+      fetchUserCollectivites(supabase),
+      supabase.rpc('est_verifie'),
+    ]);
 
   if (!dcp) {
     redirect('/');
@@ -40,6 +43,7 @@ export async function fetchUserDetails(user: User): Promise<UserDetails> {
     ...dcp,
     isSupport: isSupport ?? false,
     collectivites,
+    isVerified: isVerified ?? false,
   };
 }
 

--- a/packages/api/src/utils/pathUtils.ts
+++ b/packages/api/src/utils/pathUtils.ts
@@ -57,14 +57,14 @@ export function getAuthUrl(
 
 /** Donne l'url d'une page collectivité */
 export const getCollectivitePath = (collectivite_id: number) =>
-  `${process.env.NEXT_PUBLIC_APP_URL}/collectivite/${collectivite_id}/accueil`;
+  `${process.env.NEXT_PUBLIC_APP_URL}/collectivite/${collectivite_id}/tableau-de-bord/synthetique`;
 
 /** Donne l'url d'un plan d'action */
 export const getCollectivitePlanPath = (
   collectivite_id: number,
   plan_id: number
 ) =>
-  `${process.env.NEXT_PUBLIC_APP_URL}/collectivite/${collectivite_id}/plans/plan/${plan_id}`;
+  `${process.env.NEXT_PUBLIC_APP_URL}/collectivite/${collectivite_id}/plans/${plan_id}`;
 
 /** Donne l'url de la page "rejoindre une collectivité" */
 export const getRejoindreCollectivitePath = (originUrl: string) => {


### PR DESCRIPTION
Répond à [ce ticket](https://www.notion.so/accelerateur-transition-ecologique-ademe/Inscription-Ne-redirige-pas-vers-la-visite-d-un-profil-CT-2386523d57d78094b3f5f1429c8bee7f?source=copy_link).

Points abordés :
- Le bouton renvoyait vers une adresse type `https://auth.territoiresentransitions.fr/undefined/collectivite/604/accueil`. Cela venait du fait que NEXT_PUBLIC_APP_URL n'était pas définie par lors du build de `auth`.

- L'équipe produit a demandé un changement du comportement : si le user n'est pas vérifié, le bouton ne doit pas s'afficher. J'ai ajouté un hook pour récupérer le statut "vérifié", en passant par l'ancien système supabase. Concernant la gestion du hook côté front, j'ai opté pour `useSWR` pour être iso avec d'autres hooks de `auth` et aller au plus simple en attendant une éventuelle mise à niveau technique plus globale de `auth`.