### PR TITLE
buxfix actions groupées toutes les fiches avec pagination

### DIFF
--- a/apps/app/src/plans/fiches/list-all-fiches/hooks/use-fiche-action-selection.ts
+++ b/apps/app/src/plans/fiches/list-all-fiches/hooks/use-fiche-action-selection.ts
@@ -17,7 +17,7 @@ export const useFicheActionSelection = (
   const handleSelectAll = (checked: boolean) => {
     if (checked) {
       setSelectedFicheIds(
-        ficheResumes?.data?.map((fiche: any) => fiche.id) || []
+        ficheResumes.allIds || []
       );
     } else {
       setSelectedFicheIds([]);


### PR DESCRIPTION
Lié a ce bug : https://www.notion.so/accelerateur-transition-ecologique-ademe/Page-Toutes-les-FA-S-lection-group-e-partielle-tri-non-respect-l-export-PDF-25e6523d57d78155bfa8ecefc3067692