### PR TITLE
🔗 Ajoute les liens des indicateurs aux graphiques de la trajectoire

### DIFF
--- a/apps/app/src/app/pages/collectivite/Trajectoire/TrajectoireCalculee.tsx
+++ b/apps/app/src/app/pages/collectivite/Trajectoire/TrajectoireCalculee.tsx
@@ -1,4 +1,8 @@
 import { useCurrentCollectivite } from '@/api/collectivites';
+import {
+  IndicateurViewParamOption,
+  makeCollectiviteIndicateursUrl,
+} from '@/app/app/paths';
 import { useSearchParams } from '@/app/core-logic/hooks/query';
 import { Dataset } from '@/app/ui/charts/echarts/utils';
 import {
@@ -7,6 +11,7 @@ import {
   Card,
   Event,
   Modal,
+  Spacer,
   Tab,
   Tabs,
   useEventTracker,
@@ -170,6 +175,12 @@ export const TrajectoireCalculee = () => {
                     objectifs={objectifs}
                     resultats={resultats}
                   />
+                  <Spacer height={0.5} />
+                  <LinksToIndicateurs
+                    indicateurData={valeursSecteur}
+                    collectiviteId={collectiviteId}
+                    indicateurView="cae"
+                  />
                 </Card>
               )
             }
@@ -185,6 +196,12 @@ export const TrajectoireCalculee = () => {
                     unite={indicateur.unite}
                     titre={`${indicateur.titreSecteur}, secteur ${secteur.nom}`}
                     sousSecteurs={valeursSousSecteurs as Dataset[]}
+                  />
+                  <Spacer height={0.5} />
+                  <LinksToIndicateurs
+                    indicateurData={valeursSousSecteurs}
+                    collectiviteId={collectiviteId}
+                    indicateurView="cae"
                   />
                 </Card>
               )
@@ -222,5 +239,69 @@ export const TrajectoireCalculee = () => {
         </div>
       </div>
     )
+  );
+};
+
+type IndicateurWithId = Dataset & {
+  id: string;
+  name: string;
+};
+
+const LinksToIndicateurs = ({
+  indicateurData,
+  collectiviteId,
+  indicateurView,
+}: {
+  indicateurData: IndicateurWithId | IndicateurWithId[];
+  collectiviteId: number;
+  indicateurView: IndicateurViewParamOption | undefined;
+  className?: string;
+}) => {
+  const hasSingleIndicateur = !Array.isArray(indicateurData);
+
+  if (hasSingleIndicateur) {
+    return (
+      <Button
+        size="sm"
+        variant="underlined"
+        external
+        href={makeCollectiviteIndicateursUrl({
+          collectiviteId,
+          indicateurView,
+          identifiantReferentiel: indicateurData.id,
+        })}
+        aria-label={`Consulter la fiche de l'indicateur ${indicateurData.name}`}
+      >
+        Voir la fiche de l&apos;indicateur
+      </Button>
+    );
+  }
+
+  return (
+    <div className="flex gap-2 items-center">
+      <div className="text-primary-8 text-xs font-medium mb-1">
+        Voir les fiches des indicateurs&nbsp;:
+      </div>
+      <ul role="list" className="flex gap-4 items-end mb-0">
+        {indicateurData.map((indicateur) => (
+          <li key={indicateur.id}>
+            <Button
+              size="xs"
+              variant="underlined"
+              external
+              href={makeCollectiviteIndicateursUrl({
+                collectiviteId,
+                indicateurView,
+                identifiantReferentiel: indicateur.id,
+              })}
+              title={indicateur.name}
+              aria-label={`Consulter la fiche de l'indicateur ${indicateur.name}`}
+            >
+              {indicateur.name}
+            </Button>
+          </li>
+        ))}
+      </ul>
+    </div>
   );
 };


### PR DESCRIPTION
Implémente ce [ticket](https://www.notion.so/accelerateur-transition-ecologique-ademe/Faire-le-lien-vers-l-indicateur-li-chaque-secteur-1576523d57d78090a862f9b59dc662a6?source=copy_link).

<img width="865" height="673" alt="Capture d’écran 2025-09-03 à 20 01 35" src="https://github.com/user-attachments/assets/32ae0c4f-e553-4864-96b5-a1c82c26c633" />

<img width="863" height="767" alt="Capture d’écran 2025-09-03 à 20 02 26" src="https://github.com/user-attachments/assets/7efb29d2-a02e-4111-b789-a267f4332dfc" />

NB : mise en forme finale à valider avec Arnaud.
