### PR TITLE
🎭 Rendre à nouveau inaccessible les profils de collectivités pour les utilisateurs sans compte “vérifié”

### DIFF
--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/recherches/collectivites/page.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/recherches/collectivites/page.tsx
@@ -1,4 +1,6 @@
+import { getUser } from '@/api/users/user-details.fetch.server';
 import { CollectivitesView } from '@/app/app/pages/CollectivitesEngagees/Views/collectivites/CollectivitesView';
+import { UnverifiedUserCard } from '@/app/users/unverified-user-card';
 import { notFound } from 'next/navigation';
 import z from 'zod';
 
@@ -7,6 +9,12 @@ export default async function Page({
 }: {
   params: Promise<{ collectiviteId: number }>;
 }) {
+  const user = await getUser();
+
+  if (!user.isVerified) {
+    return <UnverifiedUserCard />;
+  }
+
   const { collectiviteId: rawCollectiviteId } = await params;
   const collectiviteId = z.coerce.number().safeParse(rawCollectiviteId);
   if (!collectiviteId.success) {

--- a/apps/app/app/(authed)/finaliser-mon-inscription/page.tsx
+++ b/apps/app/app/(authed)/finaliser-mon-inscription/page.tsx
@@ -1,7 +1,5 @@
 'use client';
-
 import { getRejoindreCollectivitePath } from '@/api';
-import { recherchesCollectivitesUrl } from '@/app/app/paths';
 import { EmptyCard } from '@/ui';
 import PageContainer from '@/ui/components/layout/page-container';
 import { useRouter } from 'next/navigation';
@@ -11,18 +9,12 @@ export default function Page() {
   const router = useRouter();
 
   return (
-    <PageContainer dataTest="FinaliserInscription">
+    <PageContainer>
       <EmptyCard
         picto={(props) => <PictoCarte {...props} />}
         title="Merci pour votre inscription !"
-        description="Dernière étape pour accéder à l'ensemble des fonctionnalités de Territoires en Transitions : rejoindre une collectivité. Vous pouvez également découvrir les collectivités déjà inscrites sur la plateforme."
+        description="Dernière étape pour accéder à l'ensemble des fonctionnalités de Territoires en Transitions : rejoindre une collectivité."
         actions={[
-          {
-            children: 'Découvrir les collectivités',
-            onClick: () => router.push(recherchesCollectivitesUrl),
-            variant: 'outlined',
-            size: 'md',
-          },
           {
             children: 'Rejoindre une collectivité',
             onClick: () =>

--- a/apps/app/src/app/Layout/Header/MenuPrincipal.tsx
+++ b/apps/app/src/app/Layout/Header/MenuPrincipal.tsx
@@ -61,6 +61,13 @@ export const MenuPrincipal = (props: HeaderPropsWithModalState) => {
     supportItems = makeSupportNavItems(currentCollectivite, user, isDemoMode);
   }
 
+  const userHasCollectivites = !!user?.collectivites?.length;
+
+  const shouldShowFinaliserInscription =
+    !!user && !user.isVerified && !userHasCollectivites;
+
+  const shouldShowCollectivites = !!user?.isVerified;
+
   return (
     <nav
       className={cn('fr-nav flex', {
@@ -84,32 +91,11 @@ export const MenuPrincipal = (props: HeaderPropsWithModalState) => {
           )
         )}
         {user && (
-          <>
-            {!user.collectivites?.length && (
-              <NavItem
-                item={{
-                  label: 'Finaliser mon inscription',
-                  to: finaliserMonInscriptionUrl,
-                }}
-                {...props}
-              />
-            )}
-            <NavItem
-              key="collectivites"
-              item={{
-                label: 'Collectivités',
-                dataTest: 'nav-collectivites',
-                to: currentCollectivite
-                  ? getRechercheViewUrl({
-                      collectiviteId: currentCollectivite.collectiviteId,
-                      view: 'collectivites',
-                    })
-                  : recherchesCollectivitesUrl,
-                urlPrefix: ['/recherches'],
-              }}
-              {...props}
-            />
-          </>
+          <CollectivitesNavItemOrFallback
+            shouldShowFinaliserInscription={shouldShowFinaliserInscription}
+            shouldShowCollectivites={shouldShowCollectivites}
+            {...props}
+          />
         )}
         {supportItems.map((item, i) =>
           Object.prototype.hasOwnProperty.call(item, 'to') ? (
@@ -162,6 +148,62 @@ const NavItem = (props: HeaderPropsWithModalState & { item: TNavItem }) => {
         {label}
       </Link>
     </li>
+  );
+};
+
+const CollectivitesNavItemOrFallback = (
+  props: HeaderPropsWithModalState & {
+    shouldShowFinaliserInscription: boolean;
+    shouldShowCollectivites: boolean;
+  }
+) => {
+  const {
+    shouldShowFinaliserInscription,
+    shouldShowCollectivites,
+    currentCollectivite,
+  } = props;
+
+  return (
+    <>
+      {shouldShowFinaliserInscription && (
+        <NavItem
+          item={{
+            label: 'Finaliser mon inscription',
+            to: finaliserMonInscriptionUrl,
+          }}
+          user={props.user}
+          currentCollectivite={props.currentCollectivite}
+          panierId={props.panierId}
+          modalOpened={props.modalOpened}
+          setModalOpened={props.setModalOpened}
+          openedId={props.openedId}
+          setOpenedId={props.setOpenedId}
+        />
+      )}
+      {shouldShowCollectivites && (
+        <NavItem
+          key="collectivites"
+          item={{
+            label: 'Collectivités',
+            dataTest: 'nav-collectivites',
+            to: currentCollectivite
+              ? getRechercheViewUrl({
+                  collectiviteId: currentCollectivite.collectiviteId,
+                  view: 'collectivites',
+                })
+              : recherchesCollectivitesUrl,
+            urlPrefix: ['/recherches'],
+          }}
+          user={props.user}
+          currentCollectivite={props.currentCollectivite}
+          panierId={props.panierId}
+          modalOpened={props.modalOpened}
+          setModalOpened={props.setModalOpened}
+          openedId={props.openedId}
+          setOpenedId={props.setOpenedId}
+        />
+      )}
+    </>
   );
 };
 

--- a/apps/app/src/users/unverified-user-card.tsx
+++ b/apps/app/src/users/unverified-user-card.tsx
@@ -1,0 +1,28 @@
+'use client';
+import { EmptyCard } from '@/ui';
+import PageContainer from '@/ui/components/layout/page-container';
+import { useRouter } from 'next/navigation';
+import PictoCarte from '../../app/(authed)/finaliser-mon-inscription/carte.svg';
+
+export function UnverifiedUserCard() {
+  const router = useRouter();
+
+  return (
+    <PageContainer bgColor="primary">
+      <EmptyCard
+        picto={() => <PictoCarte height="200" width="200" />}
+        title="Votre compte n'a pas encore été vérifié"
+        subTitle="Pour accéder à cette page, votre compte doit être vérifié. N'hésitez pas à contacter le support via le chat ou par mail à l'adresse contact@territoiresentransitions.fr."
+        actions={[
+          {
+            children: "Retourner à la page d'accueil",
+            onClick: () => {
+              router.push('/');
+            },
+            variant: 'outlined',
+          },
+        ]}
+      />
+    </PageContainer>
+  );
+}


### PR DESCRIPTION
Répond à [ce ticket](https://www.notion.so/accelerateur-transition-ecologique-ademe/Rendre-nouveau-inaccessible-les-profils-de-collectivit-s-pour-les-utilisateurs-sans-compte-v-rifi-2106523d57d7807881f4f7b6695a0c25?source=copy_link).

Scenarii implémentés avec captures d'écran [ici](https://www.notion.so/accelerateur-transition-ecologique-ademe/Rendre-nouveau-inaccessible-les-profils-de-collectivit-s-pour-les-utilisateurs-sans-compte-v-rifi-2106523d57d7807881f4f7b6695a0c25?source=copy_link#2106523d57d78070be11eb51adcd0f7a).