### PR TITLE
Améliore le rendu des textes importé

### DIFF
--- a/apps/backend/src/utils/html-to-text.utils.ts
+++ b/apps/backend/src/utils/html-to-text.utils.ts
@@ -4,5 +4,5 @@ export function htmlToText(
   html: string,
   options: { wordwrap: number | false } = { wordwrap: false }
 ) {
-  return htmlToTextBase(html, options);
+  return htmlToTextBase(html.replaceAll('\n', '<br />'), options);
 }

--- a/packages/ui/src/design-system/RichTextEditor/RichTextEditor.tsx
+++ b/packages/ui/src/design-system/RichTextEditor/RichTextEditor.tsx
@@ -120,8 +120,8 @@ export default function RichTextEditor({
 
         // essaye de faire le parsing html
         const blocks = await editor.tryParseHTMLToBlocks(
-          // en conservant éventuels sauts de lignes initiaux
-          initialValue.replaceAll('\n', '<p>&nbsp;</p>')
+          // en conservant les éventuels sauts de lignes initiaux
+          initialValue.replaceAll('\n', '<br />')
         );
         editor.replaceBlocks(editor.document, blocks);
 


### PR DESCRIPTION
- conserve les sauts de ligne des textes importés dans les exports PDF
- évite l'affichage non voulu d'un espace au début des paragraphes de texte importé