### PR TITLE
Répare l'accès à l'API Sirene

### DIFF
--- a/apps/tools/.env.default
+++ b/apps/tools/.env.default
@@ -24,8 +24,7 @@ SUPABASE_DATABASE_URL=postgresql://postgres:postgres@localhost:54322/postgres
 
 # Clé et URL de l'API SIRENE
 SIRENE_API_KEY=
-SIRENE_API_URL=https://api.insee.fr/entreprises/sirene/V3.11
-SIRENE_AUTH_URL=https://api.insee.fr/token
+SIRENE_API_URL=https://api.insee.fr/api-sirene/3.11
 
 # Clé et URL de l'API Connect
 CONNECT_CLIENT_ID=

--- a/apps/tools/src/config/configuration.model.ts
+++ b/apps/tools/src/config/configuration.model.ts
@@ -85,10 +85,6 @@ export const toolsAutomationApiConfigurationSchema = z.object({
   ENABLE_CRON_JOBS: z.coerce.boolean().describe('Activer les cron jobs'),
   SIRENE_API_KEY: z.string().min(1).describe("Clé pour accéder à l'API SIRENE"),
   SIRENE_API_URL: z.string().min(1).describe("URL de l'API SIRENE"),
-  SIRENE_AUTH_URL: z
-    .string()
-    .min(1)
-    .describe("URL d'authentification à l'API SIRENE"),
   CONNECT_URL: z.string().min(1).describe("Adresse de l'API Connect"),
   CONNECT_CLIENT_ID: z
     .string()

--- a/apps/tools/src/sirene/sirene.service.ts
+++ b/apps/tools/src/sirene/sirene.service.ts
@@ -1,17 +1,8 @@
-import {
-  Injectable,
-  InternalServerErrorException,
-  Logger,
-} from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { chunk, flatten } from 'es-toolkit';
-import { objectToCamel } from 'ts-case-convert';
 import { ZodSchema } from 'zod';
 import ConfigurationService from '../config/configuration.service';
-import {
-  GetNICResponse,
-  getNICResponseSchema,
-  getTokenResponseSchema,
-} from './sirene.model';
+import { GetNICResponse, getNICResponseSchema } from './sirene.model';
 
 // l'API autorise au maximum 1000 éléments par réponse
 const MAX_RESULTS = 1000;
@@ -19,73 +10,29 @@ const MAX_RESULTS = 1000;
 @Injectable()
 export class SireneService {
   private logger = new Logger(SireneService.name);
-  private accessToken: string | undefined = undefined;
-  private expiresAt: number | undefined = undefined;
 
   constructor(private readonly configurationService: ConfigurationService) {}
 
-  /** Récupère/rafraichit le jeton d'accès */
-  private async getAccessToken(refresh = false) {
-    // renvoi le jeton courant si il est encore valide et que le
-    // rafraichissement n'est pas forcé
-    const expired = Date.now() >= (this.expiresAt ?? 0);
-    if (this.accessToken && !expired && !refresh) {
-      this.logger.log(
-        `Jeton accès SIRENE valide jusqu'à ${new Date(
-          this.expiresAt as number
-        ).toISOString()}`
-      );
-      return this.accessToken;
-    }
-
-    // demande le jeton
-    const options ={
-      method: 'POST',
-      headers: {
-        accept: 'application/json',
-        authorization: `Basic ${this.configurationService.get(
-          'SIRENE_API_KEY'
-        )}`,
-        'content-type': 'application/x-www-form-urlencoded',
-      },
-      body: new URLSearchParams({ grant_type: 'client_credentials' }).toString(),
-    }
-    const response = await fetch(this.configurationService.get('SIRENE_AUTH_URL'), options);
-
-    if (!response.ok) {
-      throw new InternalServerErrorException(
-        `Erreur de création du jeton SIRENE (${response.status}: ${response.statusText})\n${JSON.stringify(options)}`
-      );
-    }
-
-    const content = await response.json();
-    const result = getTokenResponseSchema.parse(content);
-    const { accessToken, expiresIn } = objectToCamel(result);
-
-    this.accessToken = accessToken;
-    this.expiresAt = Date.now() + expiresIn * 1000;
-    this.logger.log(
-      `Nouveau jeton d'accès SIRENE, valide jusqu'à ${new Date(
-        this.expiresAt as number
-      ).toISOString()}`
-    );
-
-    return this.accessToken;
-  }
-
   /** Fait un appel POST à l'API */
-  private async post<T>(endpoint: string, body: Record<string, string>, schema: ZodSchema) {
-    const token = await this.getAccessToken();
-    const response = await fetch(`${this.configurationService.get('SIRENE_API_URL')}/${endpoint}`, {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/x-www-form-urlencoded',
-        accept: 'application/json',
-        'accept-encoding': 'gzip',
-        authorization: `Bearer ${token}`,
-      },
-      body: new URLSearchParams(body).toString(),
-    });
+  private async post<T>(
+    endpoint: string,
+    body: Record<string, string>,
+    schema: ZodSchema
+  ) {
+    const response = await fetch(
+      `${this.configurationService.get('SIRENE_API_URL')}/${endpoint}`,
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded',
+          accept: 'application/json',
+          'accept-encoding': 'gzip',
+          'X-INSEE-Api-Key-Integration':
+            this.configurationService.get('SIRENE_API_KEY'),
+        },
+        body: new URLSearchParams(body).toString(),
+      }
+    );
 
     if (!response.ok) {
       this.logger.log(

--- a/apps/tools/vitest.config.mts
+++ b/apps/tools/vitest.config.mts
@@ -9,7 +9,7 @@ export default defineConfig(({ mode }) => ({
 
   plugins: [
     swc.vite({ tsconfigFile: './tsconfig.spec.json' }),
-    tsconfigPaths({ projects: ['./tsconfig.json'] }),
+    tsconfigPaths({ projects: ['../../tsconfig.base.json'] }),
   ],
 
   test: {


### PR DESCRIPTION
Depuis quelques temps l’accès à l’API Sirene, utilisé pour déterminer le SIRET (SIREN+NIC) à partir du SIREN d’une collectivité pour la synchro avec le CMS Connect est cassé et des erreurs “Erreur de création du jeton SIRENE (404: Not Found)” sont visibles dans datadog.