### PR TITLE
feat: API REST partenaires pour les plans et fiches action

### DIFF
--- a/apps/backend/src/plans/partner-api/dto/partner-fiche.dto.ts
+++ b/apps/backend/src/plans/partner-api/dto/partner-fiche.dto.ts
@@ -1,0 +1,182 @@
+import { createZodDto } from 'nestjs-zod';
+import { z } from 'zod';
+import { paginationResponseSchema } from './partner-query.dto';
+
+const tagSchema = z.object({
+  id: z.number().describe("Identifiant"),
+  nom: z.string().describe('Libellé'),
+});
+
+const piloteSchema = z
+  .object({
+    nom: z.string().nullable().describe('Nom du pilote'),
+    prenom: z.string().nullable().optional().describe('Prénom du pilote'),
+  })
+  .describe('Pilote ou référent de la fiche');
+
+const financeurSchema = z
+  .object({
+    id: z.number().describe('Identifiant du financeur'),
+    nom: z.string().describe('Nom du financeur'),
+    montantTtc: z
+      .number()
+      .nullable()
+      .describe('Montant TTC du financement (en euros)'),
+  })
+  .describe("Financeur associé à la fiche");
+
+const indicateurSchema = z
+  .object({
+    id: z.number().describe("Identifiant de l'indicateur"),
+    nom: z.string().nullable().describe("Nom de l'indicateur"),
+    unite: z.string().nullable().describe("Unité de mesure"),
+  })
+  .describe('Indicateur associé à la fiche');
+
+const planRefSchema = z
+  .object({
+    id: z.number().describe("Identifiant du plan"),
+    nom: z.string().nullable().describe("Nom du plan"),
+  })
+  .describe("Référence à un plan d'action");
+
+const axeRefSchema = z
+  .object({
+    id: z.number().describe("Identifiant de l'axe"),
+    nom: z.string().nullable().describe("Nom de l'axe"),
+    planId: z.number().nullable().describe('Identifiant du plan parent'),
+  })
+  .describe("Référence à un axe d'un plan");
+
+const ficheSummarySchema = z
+  .object({
+    id: z.number().describe('Identifiant de la fiche action'),
+    titre: z.string().nullable().describe('Titre de la fiche'),
+    description: z.string().nullable().describe('Description de la fiche'),
+    statut: z
+      .string()
+      .nullable()
+      .describe(
+        'Statut de la fiche (ex: "En cours", "Réalisé", "À venir", "En pause", "Abandonné")'
+      ),
+    priorite: z
+      .string()
+      .nullable()
+      .describe('Niveau de priorité (ex: "Fort", "Moyen", "Bas")'),
+    dateDebut: z
+      .string()
+      .nullable()
+      .describe('Date de début prévue (format YYYY-MM-DD)'),
+    dateFin: z
+      .string()
+      .nullable()
+      .describe('Date de fin prévue (format YYYY-MM-DD)'),
+    budgetPrevisionnel: z
+      .number()
+      .nullable()
+      .describe('Budget prévisionnel global (en euros)'),
+    ameliorationContinue: z
+      .boolean()
+      .nullable()
+      .describe("Fiche en amélioration continue (sans date de fin)"),
+    thematiques: z.array(tagSchema).describe('Thématiques associées'),
+    sousThematiques: z.array(tagSchema).describe('Sous-thématiques associées'),
+    pilotes: z.array(piloteSchema).describe('Pilotes de la fiche'),
+    structures: z.array(tagSchema).describe('Structures pilotes'),
+    plans: z.array(planRefSchema).describe("Plans d'action de rattachement"),
+    axes: z.array(axeRefSchema).describe('Axes de rattachement'),
+    effetsAttendus: z.array(tagSchema).describe('Effets attendus'),
+    financeurs: z.array(financeurSchema).describe('Financeurs'),
+    indicateurs: z.array(indicateurSchema).describe('Indicateurs de suivi'),
+    createdAt: z.string().datetime().describe('Date de création (ISO 8601)'),
+    modifiedAt: z.string().datetime().describe('Date de dernière modification (ISO 8601)'),
+  })
+  .describe('Résumé d\'une fiche action');
+
+export const listFichesResponseSchema = z
+  .object({
+    data: z.array(ficheSummarySchema).describe('Liste des fiches action'),
+    pagination: paginationResponseSchema,
+  })
+  .describe('Réponse paginée de la liste des fiches action');
+
+export class ListFichesResponseDto extends createZodDto(
+  listFichesResponseSchema
+) {}
+
+const etapeSchema = z
+  .object({
+    id: z.number().describe("Identifiant de l'étape"),
+    nom: z.string().nullable().describe("Nom de l'étape"),
+    realise: z.boolean().describe("Étape réalisée ou non"),
+    ordre: z.number().describe("Ordre d'affichage"),
+  })
+  .describe("Étape de mise en œuvre");
+
+const budgetSchema = z
+  .object({
+    id: z.number().describe('Identifiant du budget'),
+    type: z.string().describe('Type de budget (ex: "investissement", "fonctionnement")'),
+    unite: z.string().describe('Unité monétaire'),
+    annee: z.number().nullable().describe("Année budgétaire"),
+    budgetPrevisionnel: z.number().nullable().describe('Budget prévisionnel (en euros)'),
+    budgetReel: z.number().nullable().describe('Budget réel (en euros)'),
+    estEtale: z.boolean().describe("Budget étalé sur plusieurs années"),
+  })
+  .describe('Ligne budgétaire annuelle');
+
+const mesureSchema = z
+  .object({
+    id: z.string().describe("Identifiant de l'action du référentiel (ex: \"cae_1.1.1\")"),
+  })
+  .describe('Action du référentiel liée à la fiche');
+
+const ficheLieeSchema = z
+  .object({
+    id: z.number().describe('Identifiant de la fiche liée'),
+    titre: z.string().nullable().describe('Titre de la fiche liée'),
+  })
+  .describe('Référence à une fiche action liée');
+
+export const getFicheResponseSchema = ficheSummarySchema
+  .extend({
+    objectifs: z.string().nullable().describe('Objectifs de la fiche'),
+    ressources: z.string().nullable().describe('Ressources nécessaires'),
+    calendrier: z.string().nullable().describe('Calendrier de mise en œuvre'),
+    cibles: z
+      .array(z.string())
+      .nullable()
+      .describe('Publics cibles (ex: "Grand public", "Entreprises")'),
+    piliersEci: z
+      .array(z.string())
+      .nullable()
+      .describe("Piliers de l'économie circulaire concernés"),
+    participationCitoyenne: z
+      .string()
+      .nullable()
+      .describe('Description de la participation citoyenne'),
+    participationCitoyenneType: z
+      .string()
+      .nullable()
+      .describe('Type de participation citoyenne'),
+    tempsDeMiseEnOeuvre: z
+      .string()
+      .nullable()
+      .describe('Temps de mise en œuvre estimé (ex: "Moins de 1 an")'),
+    etapes: z.array(etapeSchema).describe('Étapes de mise en œuvre'),
+    mesures: z
+      .array(mesureSchema)
+      .describe('Actions du référentiel liées'),
+    budgets: z.array(budgetSchema).describe('Détail budgétaire par année'),
+    partenaires: z.array(tagSchema).describe('Partenaires'),
+    services: z.array(tagSchema).describe('Services de la collectivité'),
+    referents: z.array(piloteSchema).describe('Référents de la fiche'),
+    fichesLiees: z
+      .array(ficheLieeSchema)
+      .describe('Fiches action liées (non-restreintes uniquement)'),
+  })
+  .describe("Détail complet d'une fiche action avec toutes ses relations");
+
+export class GetFicheResponseDto extends createZodDto(
+  getFicheResponseSchema
+) {}

--- a/apps/backend/src/plans/partner-api/dto/partner-plan.dto.ts
+++ b/apps/backend/src/plans/partner-api/dto/partner-plan.dto.ts
@@ -1,0 +1,66 @@
+import { createZodDto } from 'nestjs-zod';
+import { z } from 'zod';
+
+const planTypeSchema = z
+  .object({
+    id: z.number().describe("Identifiant du type de plan"),
+    type: z.string().describe('Libellé du type (ex: "Plan Climat Air Énergie Territorial")'),
+    categorie: z.string().describe('Catégorie du type (ex: "Plans thématiques")'),
+  })
+  .describe("Type de plan d'action");
+
+const planSummarySchema = z
+  .object({
+    id: z.number().describe("Identifiant du plan"),
+    nom: z.string().nullable().describe("Nom du plan d'action"),
+    type: planTypeSchema.nullable().describe("Type du plan (null si non typé)"),
+    collectiviteId: z.number().describe('Identifiant de la collectivité'),
+    nbAxes: z.number().describe("Nombre d'axes dans le plan"),
+    nbFiches: z.number().describe('Nombre de fiches action non-restreintes'),
+    createdAt: z.string().datetime().describe('Date de création (ISO 8601)'),
+    modifiedAt: z.string().datetime().describe('Date de dernière modification (ISO 8601)'),
+  })
+  .describe("Résumé d'un plan d'action");
+
+export const listPlansResponseSchema = z
+  .object({
+    plans: z.array(planSummarySchema).describe("Liste des plans d'action"),
+  })
+  .describe("Réponse de la liste des plans d'action d'une collectivité");
+
+export class ListPlansResponseDto extends createZodDto(
+  listPlansResponseSchema
+) {}
+
+const axeTreeNodeSchema: z.ZodType<{
+  id: number;
+  nom: string | null;
+  axes: unknown[];
+  ficheIds: number[];
+}> = z.lazy(() =>
+  z.object({
+    id: z.number().describe("Identifiant de l'axe"),
+    nom: z.string().nullable().describe("Nom de l'axe"),
+    axes: z.array(axeTreeNodeSchema).describe('Sous-axes enfants'),
+    ficheIds: z
+      .array(z.number())
+      .describe('Identifiants des fiches action rattachées à cet axe'),
+  })
+);
+
+export const getPlanResponseSchema = z
+  .object({
+    id: z.number().describe("Identifiant du plan"),
+    nom: z.string().nullable().describe("Nom du plan d'action"),
+    type: planTypeSchema.nullable().describe("Type du plan (null si non typé)"),
+    collectiviteId: z.number().describe('Identifiant de la collectivité'),
+    ficheIds: z
+      .array(z.number())
+      .describe('Identifiants des fiches action rattachées directement au plan'),
+    axes: z.array(axeTreeNodeSchema).describe("Arborescence des axes du plan"),
+    createdAt: z.string().datetime().describe('Date de création (ISO 8601)'),
+    modifiedAt: z.string().datetime().describe('Date de dernière modification (ISO 8601)'),
+  })
+  .describe("Détail d'un plan d'action avec arborescence complète des axes");
+
+export class GetPlanResponseDto extends createZodDto(getPlanResponseSchema) {}

--- a/apps/backend/src/plans/partner-api/dto/partner-query.dto.ts
+++ b/apps/backend/src/plans/partner-api/dto/partner-query.dto.ts
@@ -1,0 +1,85 @@
+import { createZodDto } from 'nestjs-zod';
+import { statutEnumValues } from '@tet/domain/plans';
+import { z } from 'zod';
+
+export const collectiviteIdParamSchema = z
+  .object({
+    collectiviteId: z.coerce
+      .number()
+      .int()
+      .positive()
+      .describe('Identifiant de la collectivité'),
+  })
+  .describe('Paramètre de chemin pour identifier une collectivité');
+
+export class CollectiviteIdParamDto extends createZodDto(
+  collectiviteIdParamSchema
+) {}
+
+export const planIdParamSchema = collectiviteIdParamSchema.extend({
+  planId: z.coerce
+    .number()
+    .int()
+    .positive()
+    .describe("Identifiant du plan d'action"),
+});
+
+export class PlanIdParamDto extends createZodDto(planIdParamSchema) {}
+
+export const ficheIdParamSchema = collectiviteIdParamSchema.extend({
+  ficheId: z.coerce
+    .number()
+    .int()
+    .positive()
+    .describe('Identifiant de la fiche action'),
+});
+
+export class FicheIdParamDto extends createZodDto(ficheIdParamSchema) {}
+
+export const listFichesQuerySchema = z
+  .object({
+    planId: z.coerce
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe("Filtrer par plan d'action"),
+    statut: z
+      .enum(statutEnumValues)
+      .optional()
+      .describe(
+        'Filtrer par statut (ex: "En cours", "Réalisé", "À venir")'
+      ),
+    page: z.coerce
+      .number()
+      .int()
+      .positive()
+      .default(1)
+      .describe('Numéro de page (défaut: 1)'),
+    limit: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .max(100)
+      .default(20)
+      .describe('Nombre de résultats par page (défaut: 20, max: 100)'),
+    modifiedSince: z
+      .string()
+      .datetime({ offset: true })
+      .optional()
+      .describe(
+        'Date ISO 8601 pour filtrer les fiches modifiées depuis cette date (synchro incrémentale)'
+      ),
+  })
+  .describe('Paramètres de filtrage et pagination pour la liste des fiches');
+
+export class ListFichesQueryDto extends createZodDto(listFichesQuerySchema) {}
+
+export const paginationResponseSchema = z
+  .object({
+    page: z.number().describe('Page courante'),
+    limit: z.number().describe('Nombre de résultats par page'),
+    count: z.number().describe('Nombre total de résultats'),
+    nbOfPages: z.number().describe('Nombre total de pages'),
+  })
+  .describe('Informations de pagination');

--- a/apps/backend/src/plans/partner-api/partner-api.module.ts
+++ b/apps/backend/src/plans/partner-api/partner-api.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { PartnerFichesController } from './partner-fiches.controller';
+import { PartnerFichesService } from './partner-fiches.service';
+import { PartnerPlansController } from './partner-plans.controller';
+import { PartnerPlansService } from './partner-plans.service';
+
+@Module({
+  providers: [PartnerPlansService, PartnerFichesService],
+  controllers: [PartnerPlansController, PartnerFichesController],
+})
+export class PartnerApiModule {}

--- a/apps/backend/src/plans/partner-api/partner-fiches.controller.ts
+++ b/apps/backend/src/plans/partner-api/partner-fiches.controller.ts
@@ -1,0 +1,75 @@
+import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { TokenInfo } from '../../users/decorators/token-info.decorators';
+import type { AuthUser } from '../../users/models/auth.models';
+import { ApiUsageEnum } from '../../utils/api/api-usage-type.enum';
+import { ApiUsage } from '../../utils/api/api-usage.decorator';
+import {
+  GetFicheResponseDto,
+  ListFichesResponseDto,
+} from './dto/partner-fiche.dto';
+import {
+  CollectiviteIdParamDto,
+  FicheIdParamDto,
+  ListFichesQueryDto,
+} from './dto/partner-query.dto';
+import { PartnerPermissionGuard } from './partner-permission.guard';
+import { PartnerFichesService } from './partner-fiches.service';
+
+@ApiTags('API Partenaires - Fiches')
+@ApiBearerAuth()
+@UseGuards(PartnerPermissionGuard)
+@Controller('collectivites/:collectiviteId/fiches')
+export class PartnerFichesController {
+  constructor(private readonly partnerFichesService: PartnerFichesService) {}
+
+  @ApiUsage([ApiUsageEnum.EXTERNAL_API])
+  @Get()
+  @ApiOperation({
+    summary:
+      "Liste paginée des fiches action non-restreintes d'une collectivité.",
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Liste paginée des fiches action.',
+    type: ListFichesResponseDto,
+  })
+  async listFiches(
+    @Param() params: CollectiviteIdParamDto,
+    @Query() query: ListFichesQueryDto,
+    @TokenInfo() _tokenInfo: AuthUser
+  ) {
+    return this.partnerFichesService.listFiches(params.collectiviteId, {
+      planId: query.planId,
+      statut: query.statut,
+      page: query.page,
+      limit: query.limit,
+      modifiedSince: query.modifiedSince,
+    });
+  }
+
+  @ApiUsage([ApiUsageEnum.EXTERNAL_API])
+  @Get(':ficheId')
+  @ApiOperation({
+    summary: "Détail complet d'une fiche action non-restreinte.",
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Détail de la fiche action.',
+    type: GetFicheResponseDto,
+  })
+  async getFiche(
+    @Param() params: FicheIdParamDto,
+    @TokenInfo() _tokenInfo: AuthUser
+  ) {
+    return this.partnerFichesService.getFiche(
+      params.collectiviteId,
+      params.ficheId
+    );
+  }
+}

--- a/apps/backend/src/plans/partner-api/partner-fiches.e2e-spec.ts
+++ b/apps/backend/src/plans/partner-api/partner-fiches.e2e-spec.ts
@@ -1,0 +1,254 @@
+import { INestApplication } from '@nestjs/common';
+import {
+  getAuthUser,
+  getServiceRoleUser,
+  getTestApp,
+} from '@tet/backend/test';
+import { GenerateTokenRequest } from '@tet/backend/users/apikeys/generate-token.request';
+import { GenerateTokenResponse } from '@tet/backend/users/apikeys/generate-token.response';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
+import { default as request } from 'supertest';
+
+describe('Partner API - Fiches', () => {
+  let app: INestApplication;
+  let router: TrpcRouter;
+  let yoloDodoUser: AuthenticatedUser;
+  let partnerToken: string;
+  let limitedToken: string;
+  let apiKeyClientId: string;
+  let limitedApiKeyClientId: string;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    router = app.get(TrpcRouter);
+    yoloDodoUser = await getAuthUser();
+
+    const caller = router.createCaller({ user: getServiceRoleUser() });
+
+    // Create API key with partner.plans.read permission
+    const apiKey = await caller.users.apikeys.create({
+      userId: yoloDodoUser.id,
+      permissions: ['partner.plans.read'],
+    });
+    apiKeyClientId = apiKey.clientId;
+
+    const tokenResponse = await request(app.getHttpServer())
+      .post('/oauth/token')
+      .send({
+        grant_type: 'client_credentials',
+        client_id: apiKey.clientId,
+        client_secret: apiKey.clientSecret,
+      } satisfies GenerateTokenRequest)
+      .expect(201);
+
+    partnerToken = (tokenResponse.body as GenerateTokenResponse).access_token;
+
+    // Create API key WITHOUT partner.plans.read permission
+    const limitedApiKey = await caller.users.apikeys.create({
+      userId: yoloDodoUser.id,
+      permissions: ['indicateurs.valeurs.read'],
+    });
+    limitedApiKeyClientId = limitedApiKey.clientId;
+
+    const limitedTokenResponse = await request(app.getHttpServer())
+      .post('/oauth/token')
+      .send({
+        grant_type: 'client_credentials',
+        client_id: limitedApiKey.clientId,
+        client_secret: limitedApiKey.clientSecret,
+      } satisfies GenerateTokenRequest)
+      .expect(201);
+
+    limitedToken = (limitedTokenResponse.body as GenerateTokenResponse)
+      .access_token;
+  });
+
+  afterAll(async () => {
+    const caller = router.createCaller({ user: getServiceRoleUser() });
+    await caller.users.apikeys.delete({ clientId: apiKeyClientId });
+    await caller.users.apikeys.delete({ clientId: limitedApiKeyClientId });
+    await app.close();
+  });
+
+  describe('GET /collectivites/:collectiviteId/fiches', () => {
+    test('Sans auth → 401', async () => {
+      await request(app.getHttpServer())
+        .get('/collectivites/1/fiches')
+        .expect(401);
+    });
+
+    test('Avec token sans permission partner.plans.read → 403', async () => {
+      await request(app.getHttpServer())
+        .get('/collectivites/1/fiches')
+        .set('Authorization', `Bearer ${limitedToken}`)
+        .expect(403);
+    });
+
+    test('Liste fiches → 200 + pagination', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/collectivites/1/fiches')
+        .set('Authorization', `Bearer ${partnerToken}`)
+        .expect(200);
+
+      expect(response.body).toHaveProperty('data');
+      expect(Array.isArray(response.body.data)).toBe(true);
+      expect(response.body).toHaveProperty('pagination');
+      expect(response.body.pagination).toHaveProperty('page');
+      expect(response.body.pagination).toHaveProperty('limit');
+      expect(response.body.pagination).toHaveProperty('count');
+      expect(response.body.pagination).toHaveProperty('nbOfPages');
+
+      if (response.body.data.length > 0) {
+        const fiche = response.body.data[0];
+        expect(fiche).toHaveProperty('id');
+        expect(fiche).toHaveProperty('titre');
+        expect(fiche).toHaveProperty('statut');
+        expect(fiche).toHaveProperty('thematiques');
+        expect(fiche).toHaveProperty('pilotes');
+        expect(fiche).toHaveProperty('plans');
+        expect(fiche).toHaveProperty('createdAt');
+        expect(fiche).toHaveProperty('modifiedAt');
+      }
+    });
+
+    test('Aucune fiche restreinte dans le résultat', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/collectivites/1/fiches?limit=100')
+        .set('Authorization', `Bearer ${partnerToken}`)
+        .expect(200);
+
+      // All returned fiches should be non-restricted
+      // (We can't directly check the `restreint` field since it's not in the response,
+      // but the service filters them out)
+      expect(response.body).toHaveProperty('data');
+      expect(Array.isArray(response.body.data)).toBe(true);
+    });
+
+    test('Pagination avec page et limit', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/collectivites/1/fiches?page=1&limit=5')
+        .set('Authorization', `Bearer ${partnerToken}`)
+        .expect(200);
+
+      expect(response.body.data.length).toBeLessThanOrEqual(5);
+      expect(response.body.pagination.page).toBe(1);
+      expect(response.body.pagination.limit).toBe(5);
+    });
+
+    test('Filtrage par statut', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/collectivites/1/fiches?statut=En cours')
+        .set('Authorization', `Bearer ${partnerToken}`)
+        .expect(200);
+
+      for (const fiche of response.body.data) {
+        expect(fiche.statut).toBe('En cours');
+      }
+    });
+
+    test('Filtrage par planId', async () => {
+      // First get a plan ID
+      const plansResponse = await request(app.getHttpServer())
+        .get('/collectivites/1/plans')
+        .set('Authorization', `Bearer ${partnerToken}`)
+        .expect(200);
+
+      if (plansResponse.body.plans.length === 0) {
+        return; // Skip if no plans exist
+      }
+
+      const planId = plansResponse.body.plans[0].id;
+
+      const response = await request(app.getHttpServer())
+        .get(`/collectivites/1/fiches?planId=${planId}`)
+        .set('Authorization', `Bearer ${partnerToken}`)
+        .expect(200);
+
+      expect(response.body).toHaveProperty('data');
+      expect(Array.isArray(response.body.data)).toBe(true);
+    });
+
+    test('Collectivité sans fiches → 200 + data vide', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/collectivites/99999/fiches')
+        .set('Authorization', `Bearer ${partnerToken}`)
+        .expect(200);
+
+      expect(response.body.data).toEqual([]);
+      expect(response.body.pagination.count).toBe(0);
+    });
+  });
+
+  describe('GET /collectivites/:collectiviteId/fiches/:ficheId', () => {
+    test('Sans auth → 401', async () => {
+      await request(app.getHttpServer())
+        .get('/collectivites/1/fiches/1')
+        .expect(401);
+    });
+
+    test('Avec token sans permission → 403', async () => {
+      await request(app.getHttpServer())
+        .get('/collectivites/1/fiches/1')
+        .set('Authorization', `Bearer ${limitedToken}`)
+        .expect(403);
+    });
+
+    test('Fiche inexistante → 404', async () => {
+      await request(app.getHttpServer())
+        .get('/collectivites/1/fiches/999999')
+        .set('Authorization', `Bearer ${partnerToken}`)
+        .expect(404);
+    });
+
+    test('Fiche détaillée → 200 + shape complète', async () => {
+      // First get a valid fiche ID
+      const listResponse = await request(app.getHttpServer())
+        .get('/collectivites/1/fiches?limit=1')
+        .set('Authorization', `Bearer ${partnerToken}`)
+        .expect(200);
+
+      if (listResponse.body.data.length === 0) {
+        return; // Skip if no fiches exist
+      }
+
+      const ficheId = listResponse.body.data[0].id;
+
+      const response = await request(app.getHttpServer())
+        .get(`/collectivites/1/fiches/${ficheId}`)
+        .set('Authorization', `Bearer ${partnerToken}`)
+        .expect(200);
+
+      // Summary fields
+      expect(response.body).toHaveProperty('id', ficheId);
+      expect(response.body).toHaveProperty('titre');
+      expect(response.body).toHaveProperty('statut');
+      expect(response.body).toHaveProperty('thematiques');
+      expect(response.body).toHaveProperty('pilotes');
+      expect(response.body).toHaveProperty('plans');
+      expect(response.body).toHaveProperty('axes');
+      expect(response.body).toHaveProperty('financeurs');
+      expect(response.body).toHaveProperty('indicateurs');
+      expect(response.body).toHaveProperty('createdAt');
+      expect(response.body).toHaveProperty('modifiedAt');
+
+      // Detail-only fields
+      expect(response.body).toHaveProperty('objectifs');
+      expect(response.body).toHaveProperty('ressources');
+      expect(response.body).toHaveProperty('calendrier');
+      expect(response.body).toHaveProperty('etapes');
+      expect(response.body).toHaveProperty('mesures');
+      expect(response.body).toHaveProperty('budgets');
+      expect(response.body).toHaveProperty('partenaires');
+      expect(response.body).toHaveProperty('services');
+      expect(response.body).toHaveProperty('referents');
+      expect(response.body).toHaveProperty('fichesLiees');
+
+      // Should NOT contain excluded fields
+      expect(response.body).not.toHaveProperty('createdBy');
+      expect(response.body).not.toHaveProperty('modifiedBy');
+      expect(response.body).not.toHaveProperty('restreint');
+      expect(response.body).not.toHaveProperty('deleted');
+    });
+  });
+});

--- a/apps/backend/src/plans/partner-api/partner-fiches.service.ts
+++ b/apps/backend/src/plans/partner-api/partner-fiches.service.ts
@@ -1,0 +1,722 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { financeurTagTable } from '@tet/backend/collectivites/tags/financeur-tag.table';
+import { partenaireTagTable } from '@tet/backend/collectivites/tags/partenaire-tag.table';
+import { personneTagTable } from '@tet/backend/collectivites/tags/personnes/personne-tag.table';
+import { serviceTagTable } from '@tet/backend/collectivites/tags/service-tag.table';
+import { structureTagTable } from '@tet/backend/collectivites/tags/structure-tag.table';
+import { indicateurDefinitionTable } from '@tet/backend/indicateurs/definitions/indicateur-definition.table';
+import { ficheActionBudgetTable } from '@tet/backend/plans/fiches/fiche-action-budget/fiche-action-budget.table';
+import { ficheActionEtapeTable } from '@tet/backend/plans/fiches/fiche-action-etape/fiche-action-etape.table';
+import { axeTable } from '@tet/backend/plans/fiches/shared/models/axe.table';
+import { ficheActionActionTable } from '@tet/backend/plans/fiches/shared/models/fiche-action-action.table';
+import { ficheActionAxeTable } from '@tet/backend/plans/fiches/shared/models/fiche-action-axe.table';
+import { ficheActionEffetAttenduTable } from '@tet/backend/plans/fiches/shared/models/fiche-action-effet-attendu.table';
+import { ficheActionFinanceurTagTable } from '@tet/backend/plans/fiches/shared/models/fiche-action-financeur-tag.table';
+import { ficheActionIndicateurTable } from '@tet/backend/plans/fiches/shared/models/fiche-action-indicateur.table';
+import { ficheActionLienTable } from '@tet/backend/plans/fiches/shared/models/fiche-action-lien.table';
+import { ficheActionPartenaireTagTable } from '@tet/backend/plans/fiches/shared/models/fiche-action-partenaire-tag.table';
+import { ficheActionPiloteTable } from '@tet/backend/plans/fiches/shared/models/fiche-action-pilote.table';
+import { ficheActionReferentTable } from '@tet/backend/plans/fiches/shared/models/fiche-action-referent.table';
+import { ficheActionServiceTagTable } from '@tet/backend/plans/fiches/shared/models/fiche-action-service-tag.table';
+import { ficheActionSousThematiqueTable } from '@tet/backend/plans/fiches/shared/models/fiche-action-sous-thematique.table';
+import { ficheActionStructureTagTable } from '@tet/backend/plans/fiches/shared/models/fiche-action-structure-tag.table';
+import { ficheActionThematiqueTable } from '@tet/backend/plans/fiches/shared/models/fiche-action-thematique.table';
+import { ficheActionTable } from '@tet/backend/plans/fiches/shared/models/fiche-action.table';
+import { effetAttenduTable } from '@tet/backend/shared/effet-attendu/effet-attendu.table';
+import { tempsDeMiseEnOeuvreTable } from '@tet/backend/shared/models/temps-de-mise-en-oeuvre.table';
+import { sousThematiqueTable } from '@tet/backend/shared/thematiques/sous-thematique.table';
+import { thematiqueTable } from '@tet/backend/shared/thematiques/thematique.table';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import {
+  and,
+  count,
+  desc,
+  eq,
+  gte,
+  inArray,
+  or,
+  sql,
+  type SQL,
+} from 'drizzle-orm';
+
+interface ListFichesFilters {
+  planId?: number;
+  statut?: string;
+  page: number;
+  limit: number;
+  modifiedSince?: string;
+}
+
+@Injectable()
+export class PartnerFichesService {
+  constructor(private readonly databaseService: DatabaseService) {}
+
+  async listFiches(collectiviteId: number, filters: ListFichesFilters) {
+    const db = this.databaseService.db;
+    const { page, limit } = filters;
+
+    // Base conditions: non-restricted, non-deleted, correct collectivite
+    const conditions: SQL[] = [
+      eq(ficheActionTable.collectiviteId, collectiviteId),
+      eq(ficheActionTable.restreint, false),
+      eq(ficheActionTable.deleted, false),
+    ];
+
+    if (filters.statut) {
+      conditions.push(
+        sql`${ficheActionTable.statut} = ${filters.statut}`
+      );
+    }
+
+    if (filters.modifiedSince) {
+      conditions.push(gte(ficheActionTable.modifiedAt, filters.modifiedSince));
+    }
+
+    // If filtering by plan, join through fiche_action_axe -> axe
+    let ficheIdsFromPlan: number[] | undefined;
+    if (filters.planId) {
+      const ficheRows = await db
+        .selectDistinct({
+          ficheId: ficheActionAxeTable.ficheId,
+        })
+        .from(ficheActionAxeTable)
+        .innerJoin(axeTable, eq(axeTable.id, ficheActionAxeTable.axeId))
+        .where(
+          sql`COALESCE(${axeTable.plan}, ${axeTable.id}) = ${filters.planId}`
+        );
+      ficheIdsFromPlan = ficheRows.map((r) => r.ficheId);
+      if (ficheIdsFromPlan.length === 0) {
+        return {
+          data: [],
+          pagination: { page, limit, count: 0, nbOfPages: 0 },
+        };
+      }
+      conditions.push(inArray(ficheActionTable.id, ficheIdsFromPlan));
+    }
+
+    // Count total
+    const [{ total }] = await db
+      .select({ total: count() })
+      .from(ficheActionTable)
+      .where(and(...conditions));
+
+    const totalCount = Number(total);
+    const nbOfPages = Math.ceil(totalCount / limit);
+
+    // Get paginated fiche IDs
+    const ficheRows = await db
+      .select({
+        id: ficheActionTable.id,
+      })
+      .from(ficheActionTable)
+      .where(and(...conditions))
+      .orderBy(desc(ficheActionTable.modifiedAt), desc(ficheActionTable.id))
+      .limit(limit)
+      .offset((page - 1) * limit);
+
+    const ficheIds = ficheRows.map((r) => r.id);
+
+    if (ficheIds.length === 0) {
+      return {
+        data: [],
+        pagination: { page, limit, count: totalCount, nbOfPages },
+      };
+    }
+
+    // Get fiches with base data
+    const fiches = await db
+      .select({
+        id: ficheActionTable.id,
+        titre: ficheActionTable.titre,
+        description: ficheActionTable.description,
+        statut: ficheActionTable.statut,
+        priorite: ficheActionTable.priorite,
+        dateDebut: ficheActionTable.dateDebut,
+        dateFin: ficheActionTable.dateFin,
+        budgetPrevisionnel: ficheActionTable.budgetPrevisionnel,
+        ameliorationContinue: ficheActionTable.ameliorationContinue,
+        createdAt: ficheActionTable.createdAt,
+        modifiedAt: ficheActionTable.modifiedAt,
+      })
+      .from(ficheActionTable)
+      .where(inArray(ficheActionTable.id, ficheIds))
+      .orderBy(desc(ficheActionTable.modifiedAt), desc(ficheActionTable.id));
+
+    // Load all relations in parallel
+    const [
+      thematiques,
+      sousThematiques,
+      pilotes,
+      structures,
+      plans,
+      axes,
+      effetsAttendus,
+      financeurs,
+      indicateurs,
+    ] = await Promise.all([
+      this.getThematiques(ficheIds),
+      this.getSousThematiques(ficheIds),
+      this.getPilotes(ficheIds),
+      this.getStructures(ficheIds),
+      this.getPlans(ficheIds),
+      this.getAxes(ficheIds),
+      this.getEffetsAttendus(ficheIds),
+      this.getFinanceurs(ficheIds),
+      this.getIndicateurs(ficheIds),
+    ]);
+
+    const data = fiches.map((fiche) => ({
+      id: fiche.id,
+      titre: fiche.titre,
+      description: fiche.description,
+      statut: fiche.statut,
+      priorite: fiche.priorite,
+      dateDebut: fiche.dateDebut,
+      dateFin: fiche.dateFin,
+      budgetPrevisionnel: fiche.budgetPrevisionnel
+        ? Number(fiche.budgetPrevisionnel)
+        : null,
+      ameliorationContinue: fiche.ameliorationContinue,
+      thematiques: thematiques.get(fiche.id) ?? [],
+      sousThematiques: sousThematiques.get(fiche.id) ?? [],
+      pilotes: pilotes.get(fiche.id) ?? [],
+      structures: structures.get(fiche.id) ?? [],
+      plans: plans.get(fiche.id) ?? [],
+      axes: axes.get(fiche.id) ?? [],
+      effetsAttendus: effetsAttendus.get(fiche.id) ?? [],
+      financeurs: financeurs.get(fiche.id) ?? [],
+      indicateurs: indicateurs.get(fiche.id) ?? [],
+      createdAt: fiche.createdAt,
+      modifiedAt: fiche.modifiedAt,
+    }));
+
+    return {
+      data,
+      pagination: { page, limit, count: totalCount, nbOfPages },
+    };
+  }
+
+  async getFiche(collectiviteId: number, ficheId: number) {
+    const db = this.databaseService.db;
+
+    const [fiche] = await db
+      .select({
+        id: ficheActionTable.id,
+        titre: ficheActionTable.titre,
+        description: ficheActionTable.description,
+        statut: ficheActionTable.statut,
+        priorite: ficheActionTable.priorite,
+        dateDebut: ficheActionTable.dateDebut,
+        dateFin: ficheActionTable.dateFin,
+        budgetPrevisionnel: ficheActionTable.budgetPrevisionnel,
+        ameliorationContinue: ficheActionTable.ameliorationContinue,
+        objectifs: ficheActionTable.objectifs,
+        ressources: ficheActionTable.ressources,
+        calendrier: ficheActionTable.calendrier,
+        cibles: ficheActionTable.cibles,
+        piliersEci: ficheActionTable.piliersEci,
+        participationCitoyenne: ficheActionTable.participationCitoyenne,
+        participationCitoyenneType: ficheActionTable.participationCitoyenneType,
+        tempsDeMiseEnOeuvreId: ficheActionTable.tempsDeMiseEnOeuvre,
+        restreint: ficheActionTable.restreint,
+        deleted: ficheActionTable.deleted,
+        createdAt: ficheActionTable.createdAt,
+        modifiedAt: ficheActionTable.modifiedAt,
+      })
+      .from(ficheActionTable)
+      .where(
+        and(
+          eq(ficheActionTable.id, ficheId),
+          eq(ficheActionTable.collectiviteId, collectiviteId)
+        )
+      )
+      .limit(1);
+
+    // Return 404 for non-existent OR restricted fiches (don't leak existence)
+    if (!fiche || fiche.restreint || fiche.deleted) {
+      throw new NotFoundException(`Fiche ${ficheId} not found`);
+    }
+
+    const ficheIds = [ficheId];
+
+    // Load all relations in parallel (summary + detail)
+    const [
+      thematiques,
+      sousThematiques,
+      pilotes,
+      structures,
+      plansData,
+      axesData,
+      effetsAttendus,
+      financeurs,
+      indicateurs,
+      etapes,
+      mesures,
+      budgets,
+      partenaires,
+      services,
+      referents,
+      fichesLiees,
+      tempsMiseEnOeuvre,
+    ] = await Promise.all([
+      this.getThematiques(ficheIds),
+      this.getSousThematiques(ficheIds),
+      this.getPilotes(ficheIds),
+      this.getStructures(ficheIds),
+      this.getPlans(ficheIds),
+      this.getAxes(ficheIds),
+      this.getEffetsAttendus(ficheIds),
+      this.getFinanceurs(ficheIds),
+      this.getIndicateurs(ficheIds),
+      this.getEtapes(ficheIds),
+      this.getMesures(ficheIds),
+      this.getBudgets(ficheIds),
+      this.getPartenaires(ficheIds),
+      this.getServices(ficheIds),
+      this.getReferents(ficheIds),
+      this.getFichesLiees(ficheId, collectiviteId),
+      fiche.tempsDeMiseEnOeuvreId
+        ? this.getTempsMiseEnOeuvre(fiche.tempsDeMiseEnOeuvreId)
+        : Promise.resolve(null),
+    ]);
+
+    return {
+      id: fiche.id,
+      titre: fiche.titre,
+      description: fiche.description,
+      statut: fiche.statut,
+      priorite: fiche.priorite,
+      dateDebut: fiche.dateDebut,
+      dateFin: fiche.dateFin,
+      budgetPrevisionnel: fiche.budgetPrevisionnel
+        ? Number(fiche.budgetPrevisionnel)
+        : null,
+      ameliorationContinue: fiche.ameliorationContinue,
+      thematiques: thematiques.get(ficheId) ?? [],
+      sousThematiques: sousThematiques.get(ficheId) ?? [],
+      pilotes: pilotes.get(ficheId) ?? [],
+      structures: structures.get(ficheId) ?? [],
+      plans: plansData.get(ficheId) ?? [],
+      axes: axesData.get(ficheId) ?? [],
+      effetsAttendus: effetsAttendus.get(ficheId) ?? [],
+      financeurs: financeurs.get(ficheId) ?? [],
+      indicateurs: indicateurs.get(ficheId) ?? [],
+      createdAt: fiche.createdAt,
+      modifiedAt: fiche.modifiedAt,
+      // Detail-only fields
+      objectifs: fiche.objectifs,
+      ressources: fiche.ressources,
+      calendrier: fiche.calendrier,
+      cibles: fiche.cibles,
+      piliersEci: fiche.piliersEci,
+      participationCitoyenne: fiche.participationCitoyenne,
+      participationCitoyenneType: fiche.participationCitoyenneType,
+      tempsDeMiseEnOeuvre: tempsMiseEnOeuvre,
+      etapes: etapes.get(ficheId) ?? [],
+      mesures: mesures.get(ficheId) ?? [],
+      budgets: budgets.get(ficheId) ?? [],
+      partenaires: partenaires.get(ficheId) ?? [],
+      services: services.get(ficheId) ?? [],
+      referents: referents.get(ficheId) ?? [],
+      fichesLiees,
+    };
+  }
+
+  // --- Relation helpers returning Map<ficheId, data[]> ---
+
+  private async getThematiques(ficheIds: number[]) {
+    const db = this.databaseService.db;
+    const rows = await db
+      .select({
+        ficheId: ficheActionThematiqueTable.ficheId,
+        id: thematiqueTable.id,
+        nom: thematiqueTable.nom,
+      })
+      .from(ficheActionThematiqueTable)
+      .innerJoin(
+        thematiqueTable,
+        eq(thematiqueTable.id, ficheActionThematiqueTable.thematiqueId)
+      )
+      .where(inArray(ficheActionThematiqueTable.ficheId, ficheIds));
+
+    return this.groupByFicheId(rows, (r) => ({ id: r.id, nom: r.nom }));
+  }
+
+  private async getSousThematiques(ficheIds: number[]) {
+    const db = this.databaseService.db;
+    const rows = await db
+      .select({
+        ficheId: ficheActionSousThematiqueTable.ficheId,
+        id: sousThematiqueTable.id,
+        nom: sousThematiqueTable.nom,
+      })
+      .from(ficheActionSousThematiqueTable)
+      .innerJoin(
+        sousThematiqueTable,
+        eq(sousThematiqueTable.id, ficheActionSousThematiqueTable.thematiqueId)
+      )
+      .where(inArray(ficheActionSousThematiqueTable.ficheId, ficheIds));
+
+    return this.groupByFicheId(rows, (r) => ({ id: r.id, nom: r.nom }));
+  }
+
+  private async getPilotes(ficheIds: number[]) {
+    const db = this.databaseService.db;
+    const rows = await db
+      .select({
+        ficheId: ficheActionPiloteTable.ficheId,
+        nom: personneTagTable.nom,
+      })
+      .from(ficheActionPiloteTable)
+      .leftJoin(
+        personneTagTable,
+        eq(personneTagTable.id, ficheActionPiloteTable.tagId)
+      )
+      .where(inArray(ficheActionPiloteTable.ficheId, ficheIds));
+
+    return this.groupByFicheId(rows, (r) => ({ nom: r.nom }));
+  }
+
+  private async getStructures(ficheIds: number[]) {
+    const db = this.databaseService.db;
+    const rows = await db
+      .select({
+        ficheId: ficheActionStructureTagTable.ficheId,
+        id: structureTagTable.id,
+        nom: structureTagTable.nom,
+      })
+      .from(ficheActionStructureTagTable)
+      .innerJoin(
+        structureTagTable,
+        eq(structureTagTable.id, ficheActionStructureTagTable.structureTagId)
+      )
+      .where(inArray(ficheActionStructureTagTable.ficheId, ficheIds));
+
+    return this.groupByFicheId(rows, (r) => ({ id: r.id, nom: r.nom }));
+  }
+
+  private async getPlans(ficheIds: number[]) {
+    const db = this.databaseService.db;
+
+    // Get all axe-to-fiche relations with their plan info
+    const rows = await db
+      .select({
+        ficheId: ficheActionAxeTable.ficheId,
+        axeId: axeTable.id,
+        axeNom: axeTable.nom,
+        planId: axeTable.plan,
+      })
+      .from(ficheActionAxeTable)
+      .innerJoin(axeTable, eq(axeTable.id, ficheActionAxeTable.axeId))
+      .where(inArray(ficheActionAxeTable.ficheId, ficheIds));
+
+    // Collect unique plan IDs to fetch their names
+    const planIds = new Set<number>();
+    for (const row of rows) {
+      planIds.add(row.planId ?? row.axeId);
+    }
+
+    // Fetch plan names
+    const planNames = new Map<number, string | null>();
+    if (planIds.size > 0) {
+      const planRows = await db
+        .select({ id: axeTable.id, nom: axeTable.nom })
+        .from(axeTable)
+        .where(inArray(axeTable.id, [...planIds]));
+      for (const p of planRows) {
+        planNames.set(p.id, p.nom);
+      }
+    }
+
+    // Deduplicate plans per fiche
+    const result = new Map<number, { id: number; nom: string | null }[]>();
+    for (const row of rows) {
+      const ficheId = row.ficheId;
+      const resolvedPlanId = row.planId ?? row.axeId;
+      const list = result.get(ficheId) ?? [];
+      if (!list.some((p) => p.id === resolvedPlanId)) {
+        list.push({
+          id: resolvedPlanId,
+          nom: planNames.get(resolvedPlanId) ?? null,
+        });
+      }
+      result.set(ficheId, list);
+    }
+    return result;
+  }
+
+  private async getAxes(ficheIds: number[]) {
+    const db = this.databaseService.db;
+
+    const rows = await db
+      .select({
+        ficheId: ficheActionAxeTable.ficheId,
+        id: axeTable.id,
+        nom: axeTable.nom,
+        planId: axeTable.plan,
+      })
+      .from(ficheActionAxeTable)
+      .innerJoin(axeTable, eq(axeTable.id, ficheActionAxeTable.axeId))
+      .where(inArray(ficheActionAxeTable.ficheId, ficheIds));
+
+    return this.groupByFicheId(rows, (r) => ({
+      id: r.id,
+      nom: r.nom,
+      planId: r.planId,
+    }));
+  }
+
+  private async getEffetsAttendus(ficheIds: number[]) {
+    const db = this.databaseService.db;
+    const rows = await db
+      .select({
+        ficheId: ficheActionEffetAttenduTable.ficheId,
+        id: effetAttenduTable.id,
+        nom: effetAttenduTable.nom,
+      })
+      .from(ficheActionEffetAttenduTable)
+      .innerJoin(
+        effetAttenduTable,
+        eq(effetAttenduTable.id, ficheActionEffetAttenduTable.effetAttenduId)
+      )
+      .where(inArray(ficheActionEffetAttenduTable.ficheId, ficheIds));
+
+    return this.groupByFicheId(rows, (r) => ({ id: r.id, nom: r.nom }));
+  }
+
+  private async getFinanceurs(ficheIds: number[]) {
+    const db = this.databaseService.db;
+    const rows = await db
+      .select({
+        ficheId: ficheActionFinanceurTagTable.ficheId,
+        id: financeurTagTable.id,
+        nom: financeurTagTable.nom,
+        montantTtc: ficheActionFinanceurTagTable.montantTtc,
+      })
+      .from(ficheActionFinanceurTagTable)
+      .innerJoin(
+        financeurTagTable,
+        eq(financeurTagTable.id, ficheActionFinanceurTagTable.financeurTagId)
+      )
+      .where(inArray(ficheActionFinanceurTagTable.ficheId, ficheIds));
+
+    return this.groupByFicheId(rows, (r) => ({
+      id: r.id,
+      nom: r.nom,
+      montantTtc: r.montantTtc,
+    }));
+  }
+
+  private async getIndicateurs(ficheIds: number[]) {
+    const db = this.databaseService.db;
+    const rows = await db
+      .select({
+        ficheId: ficheActionIndicateurTable.ficheId,
+        id: indicateurDefinitionTable.id,
+        nom: indicateurDefinitionTable.titre,
+        unite: indicateurDefinitionTable.unite,
+      })
+      .from(ficheActionIndicateurTable)
+      .innerJoin(
+        indicateurDefinitionTable,
+        eq(
+          indicateurDefinitionTable.id,
+          ficheActionIndicateurTable.indicateurId
+        )
+      )
+      .where(inArray(ficheActionIndicateurTable.ficheId, ficheIds));
+
+    return this.groupByFicheId(rows, (r) => ({
+      id: r.id,
+      nom: r.nom,
+      unite: r.unite,
+    }));
+  }
+
+  // --- Detail-only relations ---
+
+  private async getEtapes(ficheIds: number[]) {
+    const db = this.databaseService.db;
+    const rows = await db
+      .select({
+        ficheId: ficheActionEtapeTable.ficheId,
+        id: ficheActionEtapeTable.id,
+        nom: ficheActionEtapeTable.nom,
+        realise: ficheActionEtapeTable.realise,
+        ordre: ficheActionEtapeTable.ordre,
+      })
+      .from(ficheActionEtapeTable)
+      .where(inArray(ficheActionEtapeTable.ficheId, ficheIds))
+      .orderBy(ficheActionEtapeTable.ordre);
+
+    return this.groupByFicheId(rows, (r) => ({
+      id: r.id,
+      nom: r.nom,
+      realise: r.realise,
+      ordre: r.ordre,
+    }));
+  }
+
+  private async getMesures(ficheIds: number[]) {
+    const db = this.databaseService.db;
+    const rows = await db
+      .select({
+        ficheId: ficheActionActionTable.ficheId,
+        id: ficheActionActionTable.actionId,
+      })
+      .from(ficheActionActionTable)
+      .where(inArray(ficheActionActionTable.ficheId, ficheIds));
+
+    return this.groupByFicheId(rows, (r) => ({ id: r.id }));
+  }
+
+  private async getBudgets(ficheIds: number[]) {
+    const db = this.databaseService.db;
+    const rows = await db
+      .select({
+        ficheId: ficheActionBudgetTable.ficheId,
+        id: ficheActionBudgetTable.id,
+        type: ficheActionBudgetTable.type,
+        unite: ficheActionBudgetTable.unite,
+        annee: ficheActionBudgetTable.annee,
+        budgetPrevisionnel: ficheActionBudgetTable.budgetPrevisionnel,
+        budgetReel: ficheActionBudgetTable.budgetReel,
+        estEtale: ficheActionBudgetTable.estEtale,
+      })
+      .from(ficheActionBudgetTable)
+      .where(inArray(ficheActionBudgetTable.ficheId, ficheIds));
+
+    return this.groupByFicheId(rows, (r) => ({
+      id: r.id,
+      type: r.type,
+      unite: r.unite,
+      annee: r.annee,
+      budgetPrevisionnel: r.budgetPrevisionnel,
+      budgetReel: r.budgetReel,
+      estEtale: r.estEtale,
+    }));
+  }
+
+  private async getPartenaires(ficheIds: number[]) {
+    const db = this.databaseService.db;
+    const rows = await db
+      .select({
+        ficheId: ficheActionPartenaireTagTable.ficheId,
+        id: partenaireTagTable.id,
+        nom: partenaireTagTable.nom,
+      })
+      .from(ficheActionPartenaireTagTable)
+      .innerJoin(
+        partenaireTagTable,
+        eq(partenaireTagTable.id, ficheActionPartenaireTagTable.partenaireTagId)
+      )
+      .where(inArray(ficheActionPartenaireTagTable.ficheId, ficheIds));
+
+    return this.groupByFicheId(rows, (r) => ({ id: r.id, nom: r.nom }));
+  }
+
+  private async getServices(ficheIds: number[]) {
+    const db = this.databaseService.db;
+    const rows = await db
+      .select({
+        ficheId: ficheActionServiceTagTable.ficheId,
+        id: serviceTagTable.id,
+        nom: serviceTagTable.nom,
+      })
+      .from(ficheActionServiceTagTable)
+      .innerJoin(
+        serviceTagTable,
+        eq(serviceTagTable.id, ficheActionServiceTagTable.serviceTagId)
+      )
+      .where(inArray(ficheActionServiceTagTable.ficheId, ficheIds));
+
+    return this.groupByFicheId(rows, (r) => ({ id: r.id, nom: r.nom }));
+  }
+
+  private async getReferents(ficheIds: number[]) {
+    const db = this.databaseService.db;
+    const rows = await db
+      .select({
+        ficheId: ficheActionReferentTable.ficheId,
+        nom: personneTagTable.nom,
+      })
+      .from(ficheActionReferentTable)
+      .leftJoin(
+        personneTagTable,
+        eq(personneTagTable.id, ficheActionReferentTable.tagId)
+      )
+      .where(inArray(ficheActionReferentTable.ficheId, ficheIds));
+
+    return this.groupByFicheId(rows, (r) => ({ nom: r.nom }));
+  }
+
+  private async getFichesLiees(ficheId: number, collectiviteId: number) {
+    const db = this.databaseService.db;
+
+    const rows = await db
+      .select({
+        linkedFicheId: sql<number>`
+          CASE
+            WHEN ${ficheActionLienTable.ficheUne} = ${ficheId}
+            THEN ${ficheActionLienTable.ficheDeux}
+            ELSE ${ficheActionLienTable.ficheUne}
+          END
+        `.as('linked_fiche_id'),
+      })
+      .from(ficheActionLienTable)
+      .where(
+        or(
+          eq(ficheActionLienTable.ficheUne, ficheId),
+          eq(ficheActionLienTable.ficheDeux, ficheId)
+        )
+      );
+
+    if (rows.length === 0) return [];
+
+    const linkedIds = rows.map((r) => r.linkedFicheId);
+
+    // Only return non-restricted, non-deleted linked fiches
+    const linkedFiches = await db
+      .select({
+        id: ficheActionTable.id,
+        titre: ficheActionTable.titre,
+      })
+      .from(ficheActionTable)
+      .where(
+        and(
+          inArray(ficheActionTable.id, linkedIds),
+          eq(ficheActionTable.collectiviteId, collectiviteId),
+          eq(ficheActionTable.restreint, false),
+          eq(ficheActionTable.deleted, false)
+        )
+      );
+
+    return linkedFiches;
+  }
+
+  private async getTempsMiseEnOeuvre(id: number): Promise<string | null> {
+    const db = this.databaseService.db;
+    const [result] = await db
+      .select({ nom: tempsDeMiseEnOeuvreTable.nom })
+      .from(tempsDeMiseEnOeuvreTable)
+      .where(eq(tempsDeMiseEnOeuvreTable.id, id))
+      .limit(1);
+    return result?.nom ?? null;
+  }
+
+  // --- Utility ---
+
+  private groupByFicheId<
+    T extends { ficheId: number | null },
+    R,
+  >(rows: T[], mapper: (row: T) => R): Map<number, R[]> {
+    const map = new Map<number, R[]>();
+    for (const row of rows) {
+      if (row.ficheId === null) continue;
+      const list = map.get(row.ficheId) ?? [];
+      list.push(mapper(row));
+      map.set(row.ficheId, list);
+    }
+    return map;
+  }
+}

--- a/apps/backend/src/plans/partner-api/partner-permission.guard.ts
+++ b/apps/backend/src/plans/partner-api/partner-permission.guard.ts
@@ -1,0 +1,42 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+  Logger,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { REQUEST_JWT_PAYLOAD_PARAM } from '../../users/guards/auth.guard';
+import { AuthUser } from '../../users/models/auth.models';
+
+export const PARTNER_PLANS_READ_PERMISSION = 'partner.plans.read';
+
+@Injectable()
+export class PartnerPermissionGuard implements CanActivate {
+  private readonly logger = new Logger(PartnerPermissionGuard.name);
+
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest();
+    const user: AuthUser | undefined = request[REQUEST_JWT_PAYLOAD_PARAM];
+
+    if (!user) {
+      throw new UnauthorizedException('Missing authentication');
+    }
+
+    const permissions = user.jwtPayload.permissions;
+
+    if (
+      !permissions ||
+      !permissions.includes(PARTNER_PLANS_READ_PERMISSION)
+    ) {
+      this.logger.warn(
+        `Access denied: missing permission ${PARTNER_PLANS_READ_PERMISSION}`
+      );
+      throw new ForbiddenException(
+        `Permission ${PARTNER_PLANS_READ_PERMISSION} is required`
+      );
+    }
+
+    return true;
+  }
+}

--- a/apps/backend/src/plans/partner-api/partner-plans.controller.ts
+++ b/apps/backend/src/plans/partner-api/partner-plans.controller.ts
@@ -1,0 +1,67 @@
+import { Controller, Get, Param, UseGuards } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { TokenInfo } from '../../users/decorators/token-info.decorators';
+import type { AuthUser } from '../../users/models/auth.models';
+import { ApiUsageEnum } from '../../utils/api/api-usage-type.enum';
+import { ApiUsage } from '../../utils/api/api-usage.decorator';
+import {
+  CollectiviteIdParamDto,
+  PlanIdParamDto,
+} from './dto/partner-query.dto';
+import {
+  GetPlanResponseDto,
+  ListPlansResponseDto,
+} from './dto/partner-plan.dto';
+import { PartnerPermissionGuard } from './partner-permission.guard';
+import { PartnerPlansService } from './partner-plans.service';
+
+@ApiTags('API Partenaires - Plans')
+@ApiBearerAuth()
+@UseGuards(PartnerPermissionGuard)
+@Controller('collectivites/:collectiviteId/plans')
+export class PartnerPlansController {
+  constructor(private readonly partnerPlansService: PartnerPlansService) {}
+
+  @ApiUsage([ApiUsageEnum.EXTERNAL_API])
+  @Get()
+  @ApiOperation({
+    summary: "Liste les plans d'action d'une collectivité.",
+  })
+  @ApiResponse({
+    status: 200,
+    description: "Liste des plans de la collectivité.",
+    type: ListPlansResponseDto,
+  })
+  async listPlans(
+    @Param() params: CollectiviteIdParamDto,
+    @TokenInfo() _tokenInfo: AuthUser
+  ) {
+    return this.partnerPlansService.listPlans(params.collectiviteId);
+  }
+
+  @ApiUsage([ApiUsageEnum.EXTERNAL_API])
+  @Get(':planId')
+  @ApiOperation({
+    summary:
+      "Détail d'un plan avec arborescence complète des axes et ficheIds.",
+  })
+  @ApiResponse({
+    status: 200,
+    description: "Détail du plan avec arborescence.",
+    type: GetPlanResponseDto,
+  })
+  async getPlan(
+    @Param() params: PlanIdParamDto,
+    @TokenInfo() _tokenInfo: AuthUser
+  ) {
+    return this.partnerPlansService.getPlan(
+      params.collectiviteId,
+      params.planId
+    );
+  }
+}

--- a/apps/backend/src/plans/partner-api/partner-plans.e2e-spec.ts
+++ b/apps/backend/src/plans/partner-api/partner-plans.e2e-spec.ts
@@ -1,0 +1,189 @@
+import { INestApplication } from '@nestjs/common';
+import {
+  getAuthUser,
+  getServiceRoleUser,
+  getTestApp,
+} from '@tet/backend/test';
+import { GenerateTokenRequest } from '@tet/backend/users/apikeys/generate-token.request';
+import { GenerateTokenResponse } from '@tet/backend/users/apikeys/generate-token.response';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
+import { default as request } from 'supertest';
+
+describe('Partner API - Plans', () => {
+  let app: INestApplication;
+  let router: TrpcRouter;
+  let yoloDodoUser: AuthenticatedUser;
+  let partnerToken: string;
+  let limitedToken: string;
+  let apiKeyClientId: string;
+  let limitedApiKeyClientId: string;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    router = app.get(TrpcRouter);
+    yoloDodoUser = await getAuthUser();
+
+    const caller = router.createCaller({ user: getServiceRoleUser() });
+
+    // Create API key with partner.plans.read permission
+    const apiKey = await caller.users.apikeys.create({
+      userId: yoloDodoUser.id,
+      permissions: ['partner.plans.read'],
+    });
+    apiKeyClientId = apiKey.clientId;
+
+    const tokenResponse = await request(app.getHttpServer())
+      .post('/oauth/token')
+      .send({
+        grant_type: 'client_credentials',
+        client_id: apiKey.clientId,
+        client_secret: apiKey.clientSecret,
+      } satisfies GenerateTokenRequest)
+      .expect(201);
+
+    partnerToken = (tokenResponse.body as GenerateTokenResponse).access_token;
+
+    // Create API key WITHOUT partner.plans.read permission
+    const limitedApiKey = await caller.users.apikeys.create({
+      userId: yoloDodoUser.id,
+      permissions: ['indicateurs.valeurs.read'],
+    });
+    limitedApiKeyClientId = limitedApiKey.clientId;
+
+    const limitedTokenResponse = await request(app.getHttpServer())
+      .post('/oauth/token')
+      .send({
+        grant_type: 'client_credentials',
+        client_id: limitedApiKey.clientId,
+        client_secret: limitedApiKey.clientSecret,
+      } satisfies GenerateTokenRequest)
+      .expect(201);
+
+    limitedToken = (limitedTokenResponse.body as GenerateTokenResponse)
+      .access_token;
+  });
+
+  afterAll(async () => {
+    const caller = router.createCaller({ user: getServiceRoleUser() });
+    await caller.users.apikeys.delete({ clientId: apiKeyClientId });
+    await caller.users.apikeys.delete({ clientId: limitedApiKeyClientId });
+    await app.close();
+  });
+
+  describe('GET /collectivites/:collectiviteId/plans', () => {
+    test('Sans auth → 401', async () => {
+      await request(app.getHttpServer())
+        .get('/collectivites/1/plans')
+        .expect(401);
+    });
+
+    test('Avec token sans permission partner.plans.read → 403', async () => {
+      await request(app.getHttpServer())
+        .get('/collectivites/1/plans')
+        .set('Authorization', `Bearer ${limitedToken}`)
+        .expect(403);
+    });
+
+    test('Liste plans → 200 + shape correcte', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/collectivites/1/plans')
+        .set('Authorization', `Bearer ${partnerToken}`)
+        .expect(200);
+
+      expect(response.body).toHaveProperty('plans');
+      expect(Array.isArray(response.body.plans)).toBe(true);
+
+      if (response.body.plans.length > 0) {
+        const plan = response.body.plans[0];
+        expect(plan).toHaveProperty('id');
+        expect(plan).toHaveProperty('nom');
+        expect(plan).toHaveProperty('collectiviteId');
+        expect(plan).toHaveProperty('nbAxes');
+        expect(plan).toHaveProperty('nbFiches');
+        expect(plan).toHaveProperty('createdAt');
+        expect(plan).toHaveProperty('modifiedAt');
+      }
+    });
+
+    test('Collectivité sans plans → 200 + plans vide', async () => {
+      // Use a collectivite that likely has no plans (high ID)
+      const response = await request(app.getHttpServer())
+        .get('/collectivites/99999/plans')
+        .set('Authorization', `Bearer ${partnerToken}`)
+        .expect(200);
+
+      expect(response.body).toEqual({ plans: [] });
+    });
+  });
+
+  describe('GET /collectivites/:collectiviteId/plans/:planId', () => {
+    test('Sans auth → 401', async () => {
+      await request(app.getHttpServer())
+        .get('/collectivites/1/plans/1')
+        .expect(401);
+    });
+
+    test('Avec token sans permission → 403', async () => {
+      await request(app.getHttpServer())
+        .get('/collectivites/1/plans/1')
+        .set('Authorization', `Bearer ${limitedToken}`)
+        .expect(403);
+    });
+
+    test('Plan inexistant → 404', async () => {
+      await request(app.getHttpServer())
+        .get('/collectivites/1/plans/999999')
+        .set('Authorization', `Bearer ${partnerToken}`)
+        .expect(404);
+    });
+
+    test('Plan hors collectivité → 404', async () => {
+      // Get a real plan from collectivite 1
+      const listResponse = await request(app.getHttpServer())
+        .get('/collectivites/1/plans')
+        .set('Authorization', `Bearer ${partnerToken}`)
+        .expect(200);
+
+      if (listResponse.body.plans.length === 0) return;
+
+      const planId = listResponse.body.plans[0].id;
+
+      // Same plan should not be accessible via a different collectivite
+      await request(app.getHttpServer())
+        .get(`/collectivites/99999/plans/${planId}`)
+        .set('Authorization', `Bearer ${partnerToken}`)
+        .expect(404);
+    });
+
+    test('Plan détaillé avec arbre → 200 + shape correcte', async () => {
+      // First get a valid plan ID
+      const listResponse = await request(app.getHttpServer())
+        .get('/collectivites/1/plans')
+        .set('Authorization', `Bearer ${partnerToken}`)
+        .expect(200);
+
+      if (listResponse.body.plans.length === 0) {
+        // Skip if no plans exist
+        return;
+      }
+
+      const planId = listResponse.body.plans[0].id;
+
+      const response = await request(app.getHttpServer())
+        .get(`/collectivites/1/plans/${planId}`)
+        .set('Authorization', `Bearer ${partnerToken}`)
+        .expect(200);
+
+      expect(response.body).toHaveProperty('id', planId);
+      expect(response.body).toHaveProperty('nom');
+      expect(response.body).toHaveProperty('collectiviteId', 1);
+      expect(response.body).toHaveProperty('ficheIds');
+      expect(Array.isArray(response.body.ficheIds)).toBe(true);
+      expect(response.body).toHaveProperty('axes');
+      expect(Array.isArray(response.body.axes)).toBe(true);
+      expect(response.body).toHaveProperty('createdAt');
+      expect(response.body).toHaveProperty('modifiedAt');
+    });
+  });
+});

--- a/apps/backend/src/plans/partner-api/partner-plans.service.ts
+++ b/apps/backend/src/plans/partner-api/partner-plans.service.ts
@@ -1,0 +1,242 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { and, asc, count, countDistinct, eq, inArray, isNotNull, isNull, or, sql } from 'drizzle-orm';
+import { axeTable } from '../fiches/shared/models/axe.table';
+import { ficheActionAxeTable } from '../fiches/shared/models/fiche-action-axe.table';
+import { ficheActionTable } from '../fiches/shared/models/fiche-action.table';
+import { planActionTypeTable } from '../fiches/shared/models/plan-action-type.table';
+
+export type AxeTreeNode = {
+  id: number;
+  nom: string | null;
+  axes: AxeTreeNode[];
+  ficheIds: number[];
+};
+
+@Injectable()
+export class PartnerPlansService {
+  constructor(private readonly databaseService: DatabaseService) {}
+
+  async listPlans(collectiviteId: number) {
+    const db = this.databaseService.db;
+
+    // Plans are root axes (parent IS NULL)
+    const plans = await db
+      .select({
+        id: axeTable.id,
+        nom: axeTable.nom,
+        collectiviteId: axeTable.collectiviteId,
+        typeId: axeTable.typeId,
+        createdAt: axeTable.createdAt,
+        modifiedAt: axeTable.modifiedAt,
+      })
+      .from(axeTable)
+      .where(
+        and(
+          eq(axeTable.collectiviteId, collectiviteId),
+          isNull(axeTable.parent)
+        )
+      )
+      .orderBy(asc(axeTable.nom), asc(axeTable.id));
+
+    if (plans.length === 0) {
+      return { plans: [] };
+    }
+
+    const planIds = plans.map((p) => p.id);
+
+    // Get plan types
+    const typeIds = plans
+      .map((p) => p.typeId)
+      .filter((id): id is number => id !== null);
+    const types =
+      typeIds.length > 0
+        ? await db
+            .select({
+              id: planActionTypeTable.id,
+              type: planActionTypeTable.type,
+              categorie: planActionTypeTable.categorie,
+            })
+            .from(planActionTypeTable)
+            .where(inArray(planActionTypeTable.id, typeIds))
+        : [];
+
+    const typeMap = new Map(types.map((t) => [t.id, t]));
+
+    // Count axes per plan (excluding the root axe itself)
+    const axeCountsResult = await db
+      .select({
+        planId: axeTable.plan,
+        nbAxes: count(axeTable.id),
+      })
+      .from(axeTable)
+      .where(
+        and(inArray(axeTable.plan, planIds), isNotNull(axeTable.parent))
+      )
+      .groupBy(axeTable.plan);
+
+    const axeCountMap = new Map(
+      axeCountsResult.map((r) => [r.planId, Number(r.nbAxes)])
+    );
+
+    // Count non-restricted fiches per plan
+    const ficheCountsResult = await db
+      .select({
+        planId:
+          sql<number>`COALESCE(${axeTable.plan}, ${axeTable.id})`.as(
+            'plan_id'
+          ),
+        nbFiches: countDistinct(ficheActionTable.id),
+      })
+      .from(ficheActionAxeTable)
+      .innerJoin(axeTable, eq(axeTable.id, ficheActionAxeTable.axeId))
+      .innerJoin(
+        ficheActionTable,
+        eq(ficheActionTable.id, ficheActionAxeTable.ficheId)
+      )
+      .where(
+        and(
+          or(inArray(axeTable.plan, planIds), inArray(axeTable.id, planIds)),
+          eq(ficheActionTable.restreint, false),
+          eq(ficheActionTable.deleted, false)
+        )
+      )
+      .groupBy(sql`COALESCE(${axeTable.plan}, ${axeTable.id})`);
+
+    const ficheCountMap = new Map(
+      ficheCountsResult.map((r) => [r.planId, Number(r.nbFiches)])
+    );
+
+    return {
+      plans: plans.map((plan) => ({
+        id: plan.id,
+        nom: plan.nom,
+        type: plan.typeId ? typeMap.get(plan.typeId) ?? null : null,
+        collectiviteId: plan.collectiviteId,
+        nbAxes: axeCountMap.get(plan.id) ?? 0,
+        nbFiches: ficheCountMap.get(plan.id) ?? 0,
+        createdAt: plan.createdAt,
+        modifiedAt: plan.modifiedAt,
+      })),
+    };
+  }
+
+  async getPlan(collectiviteId: number, planId: number) {
+    const db = this.databaseService.db;
+
+    // Get the root plan axe
+    const [plan] = await db
+      .select({
+        id: axeTable.id,
+        nom: axeTable.nom,
+        collectiviteId: axeTable.collectiviteId,
+        typeId: axeTable.typeId,
+        createdAt: axeTable.createdAt,
+        modifiedAt: axeTable.modifiedAt,
+      })
+      .from(axeTable)
+      .where(
+        and(
+          eq(axeTable.id, planId),
+          eq(axeTable.collectiviteId, collectiviteId),
+          isNull(axeTable.parent)
+        )
+      )
+      .limit(1);
+
+    if (!plan) {
+      throw new NotFoundException(`Plan ${planId} not found`);
+    }
+
+    // Get the plan type
+    let type = null;
+    if (plan.typeId) {
+      const [typeResult] = await db
+        .select({
+          id: planActionTypeTable.id,
+          type: planActionTypeTable.type,
+          categorie: planActionTypeTable.categorie,
+        })
+        .from(planActionTypeTable)
+        .where(eq(planActionTypeTable.id, plan.typeId))
+        .limit(1);
+      type = typeResult ?? null;
+    }
+
+    // Get all descendant axes
+    const allAxes = await db
+      .select({
+        id: axeTable.id,
+        nom: axeTable.nom,
+        parent: axeTable.parent,
+      })
+      .from(axeTable)
+      .where(
+        and(
+          eq(axeTable.collectiviteId, collectiviteId),
+          or(eq(axeTable.plan, planId), eq(axeTable.id, planId))
+        )
+      )
+      .orderBy(asc(axeTable.nom), asc(axeTable.id));
+
+    // Get ficheIds per axe (only non-restricted, non-deleted)
+    const axeIds = allAxes.map((a) => a.id);
+    const fichesPerAxe =
+      axeIds.length > 0
+        ? await db
+            .select({
+              axeId: ficheActionAxeTable.axeId,
+              ficheId: ficheActionAxeTable.ficheId,
+            })
+            .from(ficheActionAxeTable)
+            .innerJoin(
+              ficheActionTable,
+              eq(ficheActionTable.id, ficheActionAxeTable.ficheId)
+            )
+            .where(
+              and(
+                inArray(ficheActionAxeTable.axeId, axeIds),
+                eq(ficheActionTable.restreint, false),
+                eq(ficheActionTable.deleted, false)
+              )
+            )
+        : [];
+
+    const ficheIdsByAxe = new Map<number, number[]>();
+    for (const row of fichesPerAxe) {
+      const list = ficheIdsByAxe.get(row.axeId) ?? [];
+      list.push(row.ficheId);
+      ficheIdsByAxe.set(row.axeId, list);
+    }
+
+    // Build tree recursively
+    const childrenMap = new Map<number | null, typeof allAxes>();
+    for (const axe of allAxes) {
+      const parentId = axe.parent;
+      const list = childrenMap.get(parentId) ?? [];
+      list.push(axe);
+      childrenMap.set(parentId, list);
+    }
+
+    const buildTree = (parentId: number): AxeTreeNode[] => {
+      const children = childrenMap.get(parentId) ?? [];
+      return children.map((child) => ({
+        id: child.id,
+        nom: child.nom,
+        axes: buildTree(child.id),
+        ficheIds: ficheIdsByAxe.get(child.id) ?? [],
+      }));
+    };
+
+    return {
+      id: plan.id,
+      nom: plan.nom,
+      type,
+      collectiviteId: plan.collectiviteId,
+      ficheIds: ficheIdsByAxe.get(planId) ?? [],
+      axes: buildTree(planId),
+      createdAt: plan.createdAt,
+      modifiedAt: plan.modifiedAt,
+    };
+  }
+}

--- a/apps/backend/src/plans/plans-main.module.ts
+++ b/apps/backend/src/plans/plans-main.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { AxeModule } from './axes/axe.module';
 import { FichesModule } from './fiches/fiches.module';
+import { PartnerApiModule } from './partner-api/partner-api.module';
 import { PlanMainRouter } from './plans-main.router';
 import { PlanModule } from './plans/plans.module';
 import { ReportsModule } from './reports/reports.module';
@@ -13,6 +14,7 @@ import { PlansUtilsModule } from './utils/plans-utils.module';
     FichesModule,
     PlanModule,
     ReportsModule,
+    PartnerApiModule,
   ],
   providers: [PlanMainRouter],
   exports: [PlanMainRouter],

--- a/packages/domain/src/users/authorizations/permission-operation.enum.schema.ts
+++ b/packages/domain/src/users/authorizations/permission-operation.enum.schema.ts
@@ -60,6 +60,9 @@ export const PermissionOperations = [
 
   // Utilisateurs
   'users.authorizations.mutate_super_admin_role',
+
+  // API Partenaires
+  'partner.plans.read',
 ] as const;
 
 export const permissionOperationEnumSchema = z.enum(PermissionOperations);


### PR DESCRIPTION
## Contexte

  Dans le cadre du travail de rapprochement entre les plateformes de suivi de la transition écologique mené par l'API Collectivités, une demande de la plateforme MEC est de pouvoir lier ses "projets" au fiches actions et plans de TeT. Pour cela et suite aux retours fournis sur [la première proposition ici](https://github.com/betagouv/communs-de-la-transition-ecologique-des-collectivites/discussions/355), la solution la plus pragmatique semble d'exposer les plans et fiches action des collectivités à des partenaires de confiance (API Collectivités, MEC) via une API REST.

## Objectif

  Exposer une **API REST** dédiée aux partenaires, authentifiée par le système d'API keys existant (OAuth2 `client_credentials` → JWT Bearer), avec une permission dédiée `partner.plans.read`.

### Périmètre de visibilité

  - **Uniquement les fiches non-restreintes** (`restreint = false`, `deleted = false`)
  - **Données publiques uniquement** : pas de notes internes, documents, emails/téléphones, createdBy/modifiedBy

## Endpoints

  | Méthode | Route | Description |
  |---------|-------|-------------|
  | `GET` | `/collectivites/:collectiviteId/plans` | Liste des plans d'action avec compteurs (axes, fiches) |
  | `GET` | `/collectivites/:collectiviteId/plans/:planId` | Détail d'un plan avec arborescence complète des axes |
  | `GET` | `/collectivites/:collectiviteId/fiches` | Liste paginée des fiches avec relations publiques |
  | `GET` | `/collectivites/:collectiviteId/fiches/:ficheId` | Détail complet d'une fiche action |

### Filtres disponibles (fiches)

  - `planId` — filtrer par plan d'action
  - `statut` — filtrer par statut (ex: "En cours", "Réalisé")
  - `modifiedSince` — date ISO 8601 pour la synchronisation incrémentale
  - `page` / `limit` — pagination (défaut: 20, max: 100)

## Décisions de design

  1. **Guard dédié** (`PartnerPermissionGuard`) : vérifie `partner.plans.read` dans le JWT, sans passer par le `PermissionService` existant (qui requiert un membership collectivité — non applicable aux partenaires)

  2. **Queries Drizzle dédiées** : le `ListFichesService` existant (~2000 lignes) est fortement couplé au contexte utilisateur (filtres confidentiels, permissions par membership, etc.). Plutôt que de le complexifier davantage avec des cas partenaires, les services Partner ont leurs propres queries allégées ne chargeant que les relations publiques

  3. **Terminologie TeT native** : les endpoints utilisent le vocabulaire TeT (plan / axe / fiche), pas un schéma commun intermédiaire. La traduction vers un éventuel schéma commun sera de la responsabilité du consommateur

  4. **Scope par collectivité** : pas de listing cross-collectivités, cohérent avec le modèle d'autorisation existant

  5. **Permission ajoutée à l'enum** : `partner.plans.read` ajouté à `PermissionOperations` dans `@tet/domain` pour être utilisable dans le système d'API keys existant

## Sécurité

  - Toutes les queries filtrent systématiquement `restreint = false` et `deleted_at IS NULL`
  - Une fiche restreinte demandée par ID retourne 404 (pas 403) pour ne pas leaker son existence
  - Aucune donnée sensible exposée (pas de notes, documents, informations de contact)
  - Auth obligatoire via Bearer token + permission spécifique

## Fichiers

### Créés (12 fichiers)

  apps/backend/src/plans/partner-api/
  ├── partner-api.module.ts
  ├── partner-plans.controller.ts
  ├── partner-plans.service.ts
  ├── partner-fiches.controller.ts
  ├── partner-fiches.service.ts
  ├── partner-permission.guard.ts
  ├── dto/
  │   ├── partner-plan.dto.ts
  │   ├── partner-fiche.dto.ts
  │   └── partner-query.dto.ts
  ├── partner-plans.e2e-spec.ts
  └── partner-fiches.e2e-spec.ts

### Modifiés
  - `apps/backend/src/plans/plans-main.module.ts` — import du `PartnerApiModule`
  - `packages/domain/src/users/authorizations/permission-operation.enum.schema.ts` — ajout `partner.plans.read`

## Tests

  20 tests E2E couvrant :
  - Authentification (401 sans token)
  - Autorisation (403 sans la permission `partner.plans.read`)
  - Shape des réponses (plans, fiches, pagination)
  - Filtrage (planId, statut, modifiedSince)
  - Pagination
  - Exclusion des fiches restreintes
  - 404 sur fiche restreinte demandée par ID
  - 404 sur ressource inexistante
  - Cleanup des API keys en afterAll

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * API Partenaires complète pour consulter plans et fiches (endpoints list/detail, pagination, filtres, réponses détaillées).

* **Sécurité**
  * Contrôle d'accès par permission dédiée "partner.plans.read" via une garde d'autorisation.

* **Tests**
  * Suites e2e couvrant authentification, autorisations, pagination, filtres et formes de réponse.

* **Chores**
  * Schémas de validation et DTOs pour listes, détails, paramètres et pagination; module et contrôleurs/services intégrés.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->