### PR TITLE
fix(referentiels): corrige la valeur par défaut de l'avancement detaille

### DIFF
--- a/apps/app/src/referentiels/actions/avancement-detaille/avancement-detaille.modal.tsx
+++ b/apps/app/src/referentiels/actions/avancement-detaille/avancement-detaille.modal.tsx
@@ -45,7 +45,9 @@ const AvancementDetailleModal = ({ actionDefinition, openState }: Props) => {
   useEffect(() => {
     if (!isLoading && statut && !actionStatutUpdate) {
       const avancementDetaille =
-        statut.avancementDetaille || AVANCEMENT_DETAILLE_PAR_STATUT.detaille;
+        statut.avancement === 'detaille'
+          ? statut.avancementDetaille || AVANCEMENT_DETAILLE_PAR_STATUT.detaille
+          : AVANCEMENT_DETAILLE_PAR_STATUT.detaille;
       setActionStatutUpdate({
         ...omit(statut, ['modifiedAt', 'modifiedBy']),
         avancementDetaille: avancementDetaille,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Correction du comportement d'initialisation de l'avancement détaillé dans la modal : la valeur détaillée est maintenant reprise uniquement lorsque le statut indique un avancement "détaillé", sinon elle est forcée à la valeur par défaut, garantissant des mises à jour de statut cohérentes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->