### PR TITLE
fix: corrige la consommation des invitations (TET-6849)

### DIFF
--- a/apps/app/app/(authed)/finaliser-mon-inscription/page.tsx
+++ b/apps/app/app/(authed)/finaliser-mon-inscription/page.tsx
@@ -1,26 +1,40 @@
 'use client';
 import { getRejoindreCollectivitePath } from '@tet/api';
-import { EmptyCard } from '@tet/ui';
-import { useRouter } from 'next/navigation';
+import { Alert, EmptyCard } from '@tet/ui';
+import { useRouter, useSearchParams } from 'next/navigation';
 import PictoCarte from './carte.svg';
 
 export default function Page() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const hasInvitationError = searchParams.get('error') === 'invitation';
 
   return (
-    <EmptyCard
-      picto={(props) => <PictoCarte {...props} />}
-      title="Merci pour votre inscription !"
-      description="Dernière étape pour accéder à l'ensemble des fonctionnalités de Territoires en Transitions : rejoindre une collectivité."
-      actions={[
-        {
-          children: 'Rejoindre une collectivité',
-          onClick: () =>
-            router.push(getRejoindreCollectivitePath(document.location.origin)),
-          size: 'md',
-        },
-      ]}
-      size="xl"
-    />
+    <>
+      {hasInvitationError && (
+        <Alert
+          state="error"
+          title="L'invitation n'a pas pu être traitée"
+          description="Le lien d'invitation est invalide ou a expiré. Veuillez demander une nouvelle invitation à l'administrateur de votre collectivité, ou rejoignez une collectivité manuellement."
+          className="mb-6"
+        />
+      )}
+      <EmptyCard
+        picto={(props) => <PictoCarte {...props} />}
+        title="Merci pour votre inscription !"
+        description="Dernière étape pour accéder à l'ensemble des fonctionnalités de Territoires en Transitions : rejoindre une collectivité."
+        actions={[
+          {
+            children: 'Rejoindre une collectivité',
+            onClick: () =>
+              router.push(
+                getRejoindreCollectivitePath(document.location.origin)
+              ),
+            size: 'md',
+          },
+        ]}
+        size="xl"
+      />
+    </>
   );
 }

--- a/apps/app/app/(public)/invitation/[invitationId]/[invitationEmail]/route.ts
+++ b/apps/app/app/(public)/invitation/[invitationId]/[invitationEmail]/route.ts
@@ -1,4 +1,4 @@
-import { signUpPath } from '@/app/app/paths';
+import { signInPath, signUpPath } from '@/app/app/paths';
 import { getAuthUrl, getRequestUrl } from '@tet/api';
 import { getAuthUser } from '@tet/api/utils/supabase/auth-user.server';
 import { trpcInServerFunction } from '@tet/api/utils/trpc/trpc-server-client';
@@ -27,6 +27,24 @@ export async function GET(
     redirect(authUrl.toString(), RedirectType.replace);
   }
 
+  // Si l'utilisateur est connecté avec un email différent de celui de l'invitation,
+  // on le redirige vers la page de connexion avec le bon email pré-rempli
+  if (
+    user.email &&
+    invitationEmail &&
+    user.email.toLowerCase() !== decodeURIComponent(invitationEmail).toLowerCase()
+  ) {
+    const url = getRequestUrl(request);
+
+    const searchParams = new URLSearchParams({
+      email: decodeURIComponent(invitationEmail),
+      redirect_to: url.href,
+    });
+
+    const authUrl = getAuthUrl(signInPath, searchParams, url.hostname);
+    redirect(authUrl.toString(), RedirectType.replace);
+  }
+
   // Else consume invitation and redirect to the home page
   try {
     await trpcInServerFunction.collectivites.membres.invitations.consume.mutate(
@@ -38,6 +56,12 @@ export async function GET(
     console.error(
       `Error consuming invitation ${invitationId}`,
       JSON.stringify(error)
+    );
+
+    // Redirige vers la page de finalisation avec un message d'erreur
+    redirect(
+      `/finaliser-mon-inscription?error=invitation`,
+      RedirectType.replace
     );
   }
 

--- a/apps/backend/src/collectivites/membres/mutate-invitations/invitation.router.e2e-spec.ts
+++ b/apps/backend/src/collectivites/membres/mutate-invitations/invitation.router.e2e-spec.ts
@@ -8,6 +8,7 @@ import {
   getTestDatabase,
   getTestRouter,
 } from '@tet/backend/test';
+import { onTestFinished } from 'vitest';
 import { utilisateurVerifieTable } from '@tet/backend/users/authorizations/roles/utilisateur-verifie.table';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { addTestUser } from '@tet/backend/users/users/users.test-fixture';
@@ -295,6 +296,107 @@ describe('Test les invitations', () => {
       .where(eq(ficheActionPiloteTable.userId, adminUserId));
 
     expect(pilotes.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test(`Refuse de consommer une invitation inexistante`, async () => {
+    const caller = router.createCaller({ user: adminUser });
+
+    await expect(() =>
+      caller.collectivites.membres.invitations.consume({
+        invitationId: crypto.randomUUID(),
+      })
+    ).rejects.toThrow(/n'existe pas/);
+  });
+
+  test(`Consomme une invitation malgré une casse différente entre JWT et email en base`, async () => {
+    const { user: invitee, cleanup: cleanupInvitee } = await addTestUser(
+      databaseService,
+      { collectiviteId: undefined, verified: false }
+    );
+    onTestFinished(cleanupInvitee);
+
+    const [invitationRow] = await databaseService.db
+      .insert(invitationTable)
+      .values({
+        role: CollectiviteRole.LECTURE,
+        email: 'CaseSensitive.Local@test.fr',
+        collectiviteId: collectivite.id,
+        createdBy: adminUserId,
+      })
+      .returning();
+
+    onTestFinished(async () => {
+      await databaseService.db
+        .delete(utilisateurCollectiviteAccessTable)
+        .where(
+          and(
+            eq(utilisateurCollectiviteAccessTable.userId, invitee.id),
+            eq(
+              utilisateurCollectiviteAccessTable.collectiviteId,
+              collectivite.id
+            )
+          )
+        );
+      await databaseService.db
+        .delete(invitationTable)
+        .where(eq(invitationTable.id, invitationRow.id));
+    });
+
+    const inviteeCaller = router.createCaller({
+      user: getAuthUserFromUserCredentials({
+        id: invitee.id,
+        email: 'casesensitive.local@test.fr',
+      }),
+    });
+
+    await inviteeCaller.collectivites.membres.invitations.consume({
+      invitationId: invitationRow.id,
+    });
+
+    const access = await databaseService.db
+      .select()
+      .from(utilisateurCollectiviteAccessTable)
+      .where(
+        and(
+          eq(utilisateurCollectiviteAccessTable.userId, invitee.id),
+          eq(utilisateurCollectiviteAccessTable.collectiviteId, collectivite.id)
+        )
+      );
+
+    expect(access.length).toBe(1);
+  });
+
+  test(`Refuse de consommer une invitation avec un email différent`, async () => {
+    const { user: wrongUser, cleanup: cleanupWrongUser } = await addTestUser(
+      databaseService
+    );
+    onTestFinished(cleanupWrongUser);
+
+    const [invitationRow] = await databaseService.db
+      .insert(invitationTable)
+      .values({
+        role: CollectiviteRole.LECTURE,
+        email: 'only-for-invited@test.fr',
+        collectiviteId: collectivite.id,
+        createdBy: adminUserId,
+      })
+      .returning();
+
+    onTestFinished(async () => {
+      await databaseService.db
+        .delete(invitationTable)
+        .where(eq(invitationTable.id, invitationRow.id));
+    });
+
+    const wrongCaller = router.createCaller({
+      user: getAuthUserFromUserCredentials(wrongUser),
+    });
+
+    await expect(() =>
+      wrongCaller.collectivites.membres.invitations.consume({
+        invitationId: invitationRow.id,
+      })
+    ).rejects.toThrow(/ne peut être consommée que par/);
   });
 
   test(`Supprime une invitation en attente`, async () => {

--- a/apps/backend/src/collectivites/membres/mutate-invitations/invitation.service.ts
+++ b/apps/backend/src/collectivites/membres/mutate-invitations/invitation.service.ts
@@ -2,6 +2,7 @@ import {
   Injectable,
   InternalServerErrorException,
   Logger,
+  NotFoundException,
 } from '@nestjs/common';
 import { ListMembresService } from '@tet/backend/collectivites/membres/list-membres/list-membres.service';
 import { PersonneTagService } from '@tet/backend/collectivites/tags/personnes/personne-tag.service';
@@ -166,7 +167,15 @@ export class InvitationService {
       .from(invitationTable)
       .where(eq(invitationTable.id, invitationId))
       .limit(1);
-    if (user.jwtPayload.email !== invitation.email) {
+
+    if (!invitation) {
+      this.logger.error(`L'invitation ${invitationId} n'existe pas`);
+      throw new NotFoundException(`L'invitation ${invitationId} n'existe pas`);
+    }
+
+    if (
+      user.jwtPayload.email?.toLowerCase() !== invitation.email.toLowerCase()
+    ) {
       this.logger.error(
         `L'email de l'invitation ${invitation.email} ne correspond pas à l'email du token ${user.jwtPayload.email}`
       );

--- a/e2e/tests/collectivite/membres/invite-membre.spec.ts
+++ b/e2e/tests/collectivite/membres/invite-membre.spec.ts
@@ -1,9 +1,9 @@
-import { Browser, expect } from '@playwright/test';
+import { Browser, BrowserContext, expect, Page } from '@playwright/test';
 import { utilisateurCollectiviteAccessTable } from '@tet/backend/users/authorizations/utilisateur-collectivite-access.table';
 import { authUsersTable } from '@tet/backend/users/models/auth-users.table';
 import { dcpTable } from '@tet/backend/users/models/dcp.table';
 import { CollectiviteRole } from '@tet/domain/users';
-import { and, eq } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm';
 import { test } from 'tests/main.fixture';
 import { databaseService } from 'tests/shared/database.service';
 import {
@@ -11,6 +11,7 @@ import {
   getInvitationEmailFromMailpit,
   getOtpFromMailpit,
 } from 'tests/shared/mailpit.utils';
+import { SupabaseClient } from 'tests/shared/supabase-client.utils';
 import { SignupUserPom } from '../../users/users/signup-user/signup-user.pom';
 import { InviteMembrePom } from './invite-membre.pom';
 
@@ -22,6 +23,37 @@ const generateTestEmail = () => {
 
 // Mot de passe suffisamment robuste pour obtenir un score zxcvbn de 4
 const STRONG_PASSWORD = 'kX9#mP2$qR7!bN4@wZ';
+
+/** Évite 127.0.0.1 vs localhost : les cookies de session ne sont pas partagés. */
+function invitationUrlPathForPlaywright(fullUrlFromMail: string): string {
+  const u = new URL(fullUrlFromMail);
+  return `${u.pathname}${u.search}`;
+}
+
+async function authenticateBrowserContext(
+  browserContext: BrowserContext,
+  email: string,
+  password: string
+) {
+  const supabaseClient = new SupabaseClient();
+  const { cookie } = await supabaseClient.authenticateUser(email, password);
+  await supabaseClient.addAuthCookie(browserContext, cookie);
+}
+
+async function openInvitationLinkInAuthenticatedContext(
+  browser: Browser,
+  invitationUrlFromMail: string,
+  email: string,
+  password: string
+): Promise<{ context: BrowserContext; page: Page }> {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  await authenticateBrowserContext(context, email, password);
+  await page.goto(invitationUrlPathForPlaywright(invitationUrlFromMail), {
+    waitUntil: 'load',
+  });
+  return { context, page };
+}
 
 test.describe('Invitation de membre', () => {
   test('invite un nouvel utilisateur (n’existe pas encore) : email reçu, signup, membre visible', async ({
@@ -54,7 +86,7 @@ test.describe('Invitation de membre', () => {
     const inviteePage = await inviteeContext.newPage();
 
     try {
-      await inviteePage.goto(invitationEmail.url);
+      await inviteePage.goto(invitationUrlPathForPlaywright(invitationEmail.url));
 
       // Redirigé vers la page de signup de l’auth
       const signupPom = new SignupUserPom(inviteePage);
@@ -145,5 +177,284 @@ test.describe('Invitation de membre', () => {
     expect(invitationEmail.url).toMatch(/\/collectivite\/|recherches/);
 
     await clearMailpitMailbox(existingEmail);
+  });
+
+  test('lien valide, utilisateur déjà connecté avec le bon email : consommation au clic', async ({
+    collectivites,
+    page,
+    context,
+  }) => {
+    test.setTimeout(60_000);
+
+    const inviteEmail = generateTestEmail();
+
+    const { collectivite } = await collectivites.addCollectiviteAndUser({
+      userArgs: { autoLogin: true, role: CollectiviteRole.ADMIN },
+    });
+
+    const pom = new InviteMembrePom(page);
+    await pom.gotoUsersPage(collectivite.data.id);
+    await pom.inviteMembre(inviteEmail, CollectiviteRole.LECTURE);
+
+    const invitationEmail = await getInvitationEmailFromMailpit(inviteEmail);
+
+    const browser = context.browser() as Browser;
+    expect(browser, 'Browser context required for invitee flow').toBeDefined();
+    const inviteeContext = await browser.newContext();
+    const inviteePage = await inviteeContext.newPage();
+
+    try {
+      const signupPom = new SignupUserPom(inviteePage);
+      await signupPom.gotoSignup();
+      await signupPom.fillStep1(inviteEmail, STRONG_PASSWORD);
+      const otp = await getOtpFromMailpit(inviteEmail);
+      await signupPom.fillStep2(otp);
+      await signupPom.fillStep3({
+        nom: 'Connecté',
+        prenom: 'AvantLien',
+        telephone: '0698765430',
+      });
+
+      await expect(
+        inviteePage.getByRole('heading', {
+          name: 'Merci pour votre inscription !',
+        })
+      ).toBeVisible({ timeout: 15000 });
+
+      await inviteePage.goto(invitationUrlPathForPlaywright(invitationEmail.url), {
+        waitUntil: 'load',
+      });
+      await expect(inviteePage).not.toHaveURL(/error=invitation/, {
+        timeout: 15000,
+      });
+
+      await inviteePage.goto(`/collectivite/${collectivite.data.id}/users`);
+      await expect(
+        inviteePage.locator(`[data-test="MembreRow-${inviteEmail}"]`)
+      ).toBeVisible({ timeout: 10000 });
+    } finally {
+      await inviteeContext.close();
+    }
+
+    await test.step('cleanup: delete created user', async () => {
+      const { db } = databaseService;
+      const [createdUser] = await db
+        .select({ id: authUsersTable.id })
+        .from(authUsersTable)
+        .where(eq(authUsersTable.email, inviteEmail));
+
+      await db
+        .delete(utilisateurCollectiviteAccessTable)
+        .where(
+          and(
+            eq(utilisateurCollectiviteAccessTable.userId, createdUser.id),
+            eq(
+              utilisateurCollectiviteAccessTable.collectiviteId,
+              collectivite.data.id
+            )
+          )
+        );
+      await db.delete(dcpTable).where(eq(dcpTable.id, createdUser.id));
+      await db
+        .delete(authUsersTable)
+        .where(eq(authUsersTable.id, createdUser.id));
+    });
+
+    await clearMailpitMailbox(inviteEmail);
+  });
+
+  test('lien d’invitation : utilisateur connecté avec un autre email → redirection vers la connexion', async ({
+    collectivites,
+    users,
+    page,
+    context,
+  }) => {
+    test.setTimeout(60_000);
+
+    const inviteEmail = generateTestEmail();
+
+    const { collectivite } = await collectivites.addCollectiviteAndUser({
+      userArgs: { autoLogin: true, role: CollectiviteRole.ADMIN },
+    });
+
+    const pom = new InviteMembrePom(page);
+    await pom.gotoUsersPage(collectivite.data.id);
+    await pom.inviteMembre(inviteEmail, CollectiviteRole.LECTURE);
+
+    const invitationEmail = await getInvitationEmailFromMailpit(inviteEmail);
+
+    const wrongUser = await users.addUser({
+      collectiviteId: undefined,
+      role: CollectiviteRole.EDITION,
+    });
+
+    const browser = context.browser() as Browser;
+    const { context: wrongContext, page: wrongPage } =
+      await openInvitationLinkInAuthenticatedContext(
+        browser,
+        invitationEmail.url,
+        wrongUser.data.email,
+        wrongUser.data.password
+      );
+
+    try {
+      await expect(wrongPage).toHaveURL(/\/login/, { timeout: 15000 });
+      const loginUrl = new URL(wrongPage.url());
+      expect(loginUrl.searchParams.get('email')).toBe(inviteEmail);
+      expect(loginUrl.searchParams.get('redirect_to')).toContain('/invitation/');
+    } finally {
+      await wrongContext.close();
+    }
+
+    await clearMailpitMailbox(inviteEmail);
+  });
+
+  test('lien avec id d’invitation invalide → erreur sur finaliser-mon-inscription', async ({
+    users,
+    context,
+  }) => {
+    test.setTimeout(60_000);
+
+    const loggedInUser = await users.addUser({
+      collectiviteId: undefined,
+      role: CollectiviteRole.EDITION,
+    });
+
+    const browser = context.browser() as Browser;
+    const invalidInvitationId = crypto.randomUUID();
+    const invitationPath = `/invitation/${invalidInvitationId}/${encodeURIComponent(loggedInUser.data.email)}`;
+
+    const guestContext = await browser.newContext();
+    const guestPage = await guestContext.newPage();
+
+    try {
+      await authenticateBrowserContext(
+        guestContext,
+        loggedInUser.data.email,
+        loggedInUser.data.password
+      );
+      await guestPage.goto(invitationPath, { waitUntil: 'load' });
+
+      await expect(guestPage).toHaveURL(/error=invitation/, { timeout: 20000 });
+      await expect(
+        guestPage.getByText("L'invitation n'a pas pu être traitée")
+      ).toBeVisible();
+    } finally {
+      await guestContext.close();
+    }
+  });
+
+  test('invitation avec casse différente entre JWT et base : consommation OK', async ({
+    collectivites,
+    page,
+    context,
+  }) => {
+    test.setTimeout(60_000);
+
+    const localPart = `case${Date.now()}${Math.random().toString(36).slice(2, 6)}`;
+    const inviteEmail = `${localPart}@test-e2e.fr`;
+    const upperEmail = `${localPart.toUpperCase()}@test-e2e.fr`;
+
+    const { collectivite } = await collectivites.addCollectiviteAndUser({
+      userArgs: { autoLogin: true, role: CollectiviteRole.ADMIN },
+    });
+
+    const pom = new InviteMembrePom(page);
+    await pom.gotoUsersPage(collectivite.data.id);
+    await pom.inviteMembre(inviteEmail, CollectiviteRole.LECTURE);
+
+    const invitationEmailInfo = await getInvitationEmailFromMailpit(inviteEmail);
+    const invitationId = invitationEmailInfo.url.match(
+      /\/invitation\/([0-9a-f-]{36})\//i
+    )?.[1];
+    expect(invitationId).toBeTruthy();
+    if (!invitationId) {
+      return;
+    }
+
+    const { db } = databaseService;
+    await db.execute(
+      sql`UPDATE utilisateur.invitation SET email = ${upperEmail} WHERE id = ${invitationId}`
+    );
+
+    const browser = context.browser() as Browser;
+    const inviteeContext = await browser.newContext();
+    const inviteePage = await inviteeContext.newPage();
+
+    try {
+      const signupPom = new SignupUserPom(inviteePage);
+      await signupPom.gotoSignup();
+      await signupPom.fillStep1(inviteEmail, STRONG_PASSWORD);
+      const otp = await getOtpFromMailpit(inviteEmail);
+      await signupPom.fillStep2(otp);
+      await signupPom.fillStep3({
+        nom: 'CasSe',
+        prenom: 'Test',
+        telephone: '0698765431',
+      });
+
+      await expect(inviteePage).toHaveURL(/\/finaliser-mon-inscription/, {
+        timeout: 15000,
+      });
+
+      const invitationPath = `/invitation/${invitationId}/${encodeURIComponent(upperEmail)}`;
+      await inviteePage.goto(invitationPath, { waitUntil: 'load' });
+
+      await expect(inviteePage).not.toHaveURL(/error=invitation/, {
+        timeout: 15000,
+      });
+
+      const [userRow] = await db
+        .select({ id: authUsersTable.id })
+        .from(authUsersTable)
+        .where(eq(authUsersTable.email, inviteEmail))
+        .limit(1);
+      expect(userRow).toBeDefined();
+
+      const [accessRow] = await db
+        .select({ id: utilisateurCollectiviteAccessTable.id })
+        .from(utilisateurCollectiviteAccessTable)
+        .where(
+          and(
+            eq(utilisateurCollectiviteAccessTable.userId, userRow.id),
+            eq(
+              utilisateurCollectiviteAccessTable.collectiviteId,
+              collectivite.data.id
+            )
+          )
+        )
+        .limit(1);
+      expect(accessRow).toBeDefined();
+    } finally {
+      await inviteeContext.close();
+    }
+
+    await test.step('cleanup: delete created user', async () => {
+      const [createdUser] = await db
+        .select({ id: authUsersTable.id })
+        .from(authUsersTable)
+        .where(eq(authUsersTable.email, inviteEmail));
+
+      await db
+        .delete(utilisateurCollectiviteAccessTable)
+        .where(
+          and(
+            eq(utilisateurCollectiviteAccessTable.userId, createdUser.id),
+            eq(
+              utilisateurCollectiviteAccessTable.collectiviteId,
+              collectivite.data.id
+            )
+          )
+        );
+      await db.execute(
+        sql`DELETE FROM utilisateur.invitation WHERE id = ${invitationId}`
+      );
+      await db.delete(dcpTable).where(eq(dcpTable.id, createdUser.id));
+      await db
+        .delete(authUsersTable)
+        .where(eq(authUsersTable.id, createdUser.id));
+    });
+
+    await clearMailpitMailbox(inviteEmail);
   });
 });


### PR DESCRIPTION
## Summary

Corrige le bug où le clic sur un lien d'invitation amène sur la modale "Rejoindre une collectivité" au lieu de rattacher automatiquement l'utilisateur.

**Causes identifiées et corrigées :**

- **Crash silencieux si invitation introuvable** : `consumeInvitation` crashait avec un `TypeError` si l'ID d'invitation était invalide (ex: URL corrompue par les redirections email Brevo/Sendinblue). L'erreur était avalée silencieusement et l'utilisateur redirigé vers `/` sans rattachement → ajout d'un null check avec `NotFoundException`
- **Comparaison d'email sensible à la casse** : `user.jwtPayload.email !== invitation.email` échouait si la casse différait (ex: `Mateo.Saguin@strasbourg.eu` vs `mateo.saguin@strasbourg.eu`) → comparaison avec `.toLowerCase()`
- **Utilisateur connecté avec le mauvais email** : si l'utilisateur était déjà connecté avec un compte différent de celui de l'invitation, la consommation échouait silencieusement → détection et redirection vers la page de connexion avec le bon email pré-rempli
- **Aucun feedback en cas d'erreur** : l'utilisateur était redirigé vers `/` sans explication → redirection vers `/finaliser-mon-inscription?error=invitation` avec un message d'alerte explicite

## Fichiers modifiés

- `apps/backend/.../invitation.service.ts` : null check + email case-insensitive
- `apps/app/.../invitation/[invitationId]/[invitationEmail]/route.ts` : détection mauvais email + error redirect
- `apps/app/.../finaliser-mon-inscription/page.tsx` : affichage alerte d'erreur

## Test plan

- [ ] Tester le clic sur un lien d'invitation valide (utilisateur non connecté) → doit créer le compte puis rattacher automatiquement
- [ ] Tester le clic sur un lien d'invitation valide (utilisateur connecté avec le bon email) → doit rattacher automatiquement
- [ ] Tester le clic sur un lien d'invitation (utilisateur connecté avec un email différent) → doit rediriger vers la page de connexion avec le bon email
- [ ] Tester un lien d'invitation avec un ID invalide → doit afficher un message d'erreur sur la page finaliser-mon-inscription
- [ ] Tester un lien d'invitation avec des emails de casse différente → doit fonctionner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Affichage d’une alerte si le lien d’invitation est invalide ou expiré lors de la finalisation d’inscription.
  * Redirection vers la page de connexion lorsque l’e‑mail connecté diffère de celui de l’invitation, avec champ e‑mail prérempli et retour vers le lien d’invitation.
  * Acception des adresses e‑mail indépendamment de la casse lors de la consommation d’une invitation.
  * Amélioration de la navigation vers les liens d’invitation (normalisation d’URL pour les environnements de test).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/incubateur-ademe/territoires-en-transitions/pull/4369)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->