### PR TITLE
Création du cronjob pour vérifier la page des stats

### DIFF
--- a/.github/workflows/keep-alive-streamlit.yml
+++ b/.github/workflows/keep-alive-streamlit.yml
@@ -1,0 +1,25 @@
+name: Keep Streamlit app alive
+
+on:
+  schedule:
+    - cron: '17 */2 * * *'
+  workflow_dispatch:
+permissions:
+   contents: read
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: pnpm install
+        uses: ./.github/actions/pnpm-install
+        with:
+          bryntum_access_token: ${{ secrets.BRYNTUM_ACCESS_TOKEN }}
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Visit Streamlit app and wake if sleeping
+        run: node --experimental-strip-types .github/workflows/scripts/keep-alive-streamlit.ts

--- a/.github/workflows/scripts/keep-alive-streamlit.ts
+++ b/.github/workflows/scripts/keep-alive-streamlit.ts
@@ -1,0 +1,21 @@
+import { chromium } from '@playwright/test';
+import { STREAMLIT_IFRAME_SRC } from '../../../apps/site/app/stats/streamlit.utils.ts';
+
+const browser = await chromium.launch();
+const page = await browser.newPage();
+
+await page.goto(STREAMLIT_IFRAME_SRC, { waitUntil: 'networkidle', timeout: 60_000 });
+
+const wakeButton = page.getByRole('button', { name: /get this app back up/i });
+
+if (await wakeButton.isVisible()) {
+  console.log('App asleep — clicking wake button');
+  await wakeButton.click();
+  console.log('Waiting for app to reach networkidle after wake');
+  await page.waitForLoadState('networkidle', { timeout: 120_000 });
+  console.log('App woken up successfully');
+} else {
+  console.log('App already active');
+}
+
+await browser.close();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Mise en place d’un processus automatisé (exécutable selon un calendrier et manuellement) qui ouvre une session navigateur pour vérifier et réveiller automatiquement l’application Streamlit si elle est en sommeil, améliorant sa disponibilité continue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->