### PR TITLE
fix: rendre le header des sous-actions cliquable pour déplier/replier

### DIFF
--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/action/[actionId]/_components/subaction/subaction-card.actions.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/action/[actionId]/_components/subaction/subaction-card.actions.tsx
@@ -32,7 +32,10 @@ const SubactionCardActions = ({ action }: Props) => {
 
   return (
     <>
-      <div className="flex flex-wrap mt-1 mb-2">
+      <div
+        className="flex flex-wrap mt-1 mb-2"
+        onClickCapture={(e) => e.stopPropagation()}
+      >
         {/* Score indicatif */}
         {haveScoreIndicatif &&
           !isScoreIndicatifLoading &&

--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/action/[actionId]/_components/subaction/subaction-card.header.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/action/[actionId]/_components/subaction/subaction-card.header.tsx
@@ -72,7 +72,10 @@ export const SubactionCardHeader = ({
                     aria-label={`Déplier la sous-action ${subAction.identifiant}`}
                   />
                 </VisibleWhen>
-                <div className="flex items-center">
+                <div
+                  className="flex items-center"
+                  onClick={(e) => e.stopPropagation()}
+                >
                   <SubActionStatutDropdown actionDefinition={subAction} />
 
                   {isSubAction && (

--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/action/[actionId]/_components/subaction/subaction-card.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/action/[actionId]/_components/subaction/subaction-card.tsx
@@ -7,8 +7,7 @@ import {
 } from '@/app/referentiels/referentiel-hooks';
 import { useStickyHeaderHeight } from '@/app/ui/layout/HeaderSticky';
 import { useIsVisitor } from '@/app/users/authorizations/use-is-visitor';
-import { AccordionControlled, Button } from '@tet/ui';
-import classNames from 'classnames';
+import { AccordionControlled, Button, cn } from '@tet/ui';
 import { ActionJustificationField } from '../action/action.justification-field';
 import { pluralize } from '../pluralize';
 import ScoreIndicatifLibelle from '../score-indicatif/score-indicatif.libelle';
@@ -31,7 +30,7 @@ const OpenPanelButton = ({
     size="xs"
     icon="layout-right-line"
     iconPosition="right"
-    className={classNames(
+    className={cn(
       'px-2 py-1 font-medium rounded-md border-[1px] text-xs flex gap-1 items-center justify-center text-nowrap',
       isActive
         ? 'bg-primary-9 border-primary-9 text-white'
@@ -59,8 +58,13 @@ const SubactionHeader = ({
 
   return (
     <div
+      role="button"
+      tabIndex={0}
+      aria-expanded={isExpanded}
+      aria-label={`Sous-action ${subAction.identifiant}`}
+      onClick={toggleExpand}
       style={{ top: stickyHeaderHeight }}
-      className={classNames('sticky z-10 p-4 rounded-t-lg', {
+      className={cn('sticky z-10 p-4 rounded-t-lg cursor-pointer', {
         'bg-primary-1 hover:bg-primary-1': isExpanded,
         'bg-grey-1': !isExpanded,
       })}
@@ -111,7 +115,7 @@ const SubactionContent = ({
   hideTasksStatus: boolean;
 }) => (
   <div
-    className={classNames('flex flex-col gap-4', {
+    className={cn('flex flex-col gap-4', {
       'p-4': showJustifications,
     })}
   >
@@ -163,7 +167,7 @@ const SubActionCard = ({
     <div
       id={subAction.id}
       data-test={`SousAction-${subAction.identifiant}`}
-      className={classNames(
+      className={cn(
         'border border-grey-3 rounded-lg bg-grey-1 transition-colors',
         { 'hover:bg-grey-2': !isExpanded }
       )}

--- a/e2e/tests/referentiels/scores/accordion-header-click.spec.ts
+++ b/e2e/tests/referentiels/scores/accordion-header-click.spec.ts
@@ -1,0 +1,127 @@
+import { expect } from '@playwright/test';
+import { testWithReferentiels as test } from '../referentiels.fixture';
+
+test.describe("Clic sur le header d'une sous-action pour déplier/replier", () => {
+  test.beforeEach(async ({ page, collectivites }) => {
+    const { collectivite, user } = await collectivites.addCollectiviteAndUser({
+      userArgs: { autoLogin: true },
+      collectiviteArgs: { isCOT: true },
+    });
+    await user.precomputeReferentielSnapshot(collectivite.data.id, 'cae');
+    await page.goto('/');
+  });
+
+  test('Cliquer sur le header (hors bouton flèche) déplie la sous-action', async ({
+    page,
+    referentielScoresPom,
+    referentiels: _,
+  }) => {
+    await referentielScoresPom.goto('cae');
+    await referentielScoresPom.goToActionPage(
+      '1 - Planification',
+      '1.1 Stratégie globale',
+      '1.1.1 Définir la vision, les'
+    );
+
+    const expandButton = referentielScoresPom.getSousActionExpandLocator(
+      '1.1.1.1'
+    );
+    await expect(expandButton).toHaveAttribute('aria-expanded', 'false');
+
+    // Clic sur le titre de la sous-action (pas sur la flèche)
+    const header = page.locator(
+      '[data-test="SousActionHeader-1.1.1.1"]'
+    );
+    await header
+      .locator('.text-primary-9.text-base.font-bold')
+      .click();
+
+    await expect(expandButton).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  test('Cliquer sur le header replie une sous-action déjà dépliée', async ({
+    page,
+    referentielScoresPom,
+    referentiels: _,
+  }) => {
+    await referentielScoresPom.goto('cae');
+    await referentielScoresPom.goToActionPage(
+      '1 - Planification',
+      '1.1 Stratégie globale',
+      '1.1.1 Définir la vision, les'
+    );
+
+    // D'abord déplier via le bouton flèche
+    await referentielScoresPom.expandSousAction('1.1.1.1');
+    const expandButton = referentielScoresPom.getSousActionExpandLocator(
+      '1.1.1.1'
+    );
+    await expect(expandButton).toHaveAttribute('aria-expanded', 'true');
+
+    // Puis cliquer sur le titre pour replier
+    const header = page.locator(
+      '[data-test="SousActionHeader-1.1.1.1"]'
+    );
+    await header
+      .locator('.text-primary-9.text-base.font-bold')
+      .click();
+
+    await expect(expandButton).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  test('Le bouton documents ouvre le side panel sans déplier la sous-action', async ({
+    page,
+    referentielScoresPom,
+    referentiels: _,
+  }) => {
+    await referentielScoresPom.goto('cae');
+    await referentielScoresPom.goToActionPage(
+      '1 - Planification',
+      '1.1 Stratégie globale',
+      '1.1.1 Définir la vision, les'
+    );
+
+    const expandButton = referentielScoresPom.getSousActionExpandLocator(
+      '1.1.1.1'
+    );
+    await expect(expandButton).toHaveAttribute('aria-expanded', 'false');
+
+    // Cliquer sur le bouton documents
+    const sousAction = page.locator('[id="cae_1.1.1.1"]');
+    await sousAction.getByRole('button', { name: /document/i }).click();
+
+    // Le side panel documents doit s'ouvrir
+    await expect(page).toHaveURL(/panel=documents/);
+
+    // La sous-action ne doit pas se déplier
+    await expect(expandButton).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  test('Le bouton commentaires ouvre le side panel sans déplier la sous-action', async ({
+    page,
+    referentielScoresPom,
+    referentiels: _,
+  }) => {
+    await referentielScoresPom.goto('cae');
+    await referentielScoresPom.goToActionPage(
+      '1 - Planification',
+      '1.1 Stratégie globale',
+      '1.1.1 Définir la vision, les'
+    );
+
+    const expandButton = referentielScoresPom.getSousActionExpandLocator(
+      '1.1.1.1'
+    );
+    await expect(expandButton).toHaveAttribute('aria-expanded', 'false');
+
+    // Cliquer sur le bouton commentaires
+    const sousAction = page.locator('[id="cae_1.1.1.1"]');
+    await sousAction.getByRole('button', { name: /commentaire/i }).click();
+
+    // Le side panel commentaires doit s'ouvrir
+    await expect(page).toHaveURL(/panel=comments/);
+
+    // La sous-action ne doit pas se déplier
+    await expect(expandButton).toHaveAttribute('aria-expanded', 'false');
+  });
+});


### PR DESCRIPTION
Le clic sur n'importe quelle zone du header toggle l'accordion, sans interférer avec les boutons documents/commentaires qui ouvrent le side panel, ni avec le dropdown de statut.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notes de version

* **Corrections de bogues**
  * Correction du comportement de l'accordéon des sous-actions pour empêcher la fermeture accidentelle lors de l'interaction avec les boutons et menus déroulants.
  * Amélioration de la gestion des événements de clic pour une meilleure stabilité.

* **Tests**
  * Ajout de tests automatisés pour valider le fonctionnement de l'accordéon et des panneaux latéraux dans la section des scores.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->