### PR TITLE
Tet 6574/inline edit select list size

### DIFF
--- a/apps/app/src/plans/sous-actions/list/table/sous-action.pilotes.cell.tsx
+++ b/apps/app/src/plans/sous-actions/list/table/sous-action.pilotes.cell.tsx
@@ -29,6 +29,7 @@ export const SousActionPilotesCell = ({ sousAction }: Props) => {
     <TableCell
       canEdit={canUpdate}
       edit={{
+        maxHeight: '24rem',
         renderOnEdit: ({ openState }) => (
           <div className="w-80">
             <PersonnesDropdown

--- a/packages/ui/src/design-system/inline-edit/inline-edit.wrapper.tsx
+++ b/packages/ui/src/design-system/inline-edit/inline-edit.wrapper.tsx
@@ -11,7 +11,7 @@ import {
   useFloating,
   useInteractions,
 } from '@floating-ui/react';
-import { cloneElement, HTMLAttributes, useState } from 'react';
+import { cloneElement, CSSProperties, HTMLAttributes, useState } from 'react';
 
 import { useOpenState } from '../../hooks/use-open-state';
 import { preset } from '../../tailwind-preset';
@@ -27,6 +27,7 @@ export type InlineEditWrapperProps = {
   onClose?: () => void;
   disabled?: boolean;
   floatingMatchReferenceHeight?: boolean;
+  maxHeight?: CSSProperties['maxHeight'];
 };
 
 /**
@@ -40,6 +41,7 @@ export const InlineEditWrapper = ({
   disabled,
   openState,
   floatingMatchReferenceHeight = true,
+  maxHeight,
 }: InlineEditWrapperProps) => {
   const { isOpen, setIsOpen } = useOpenState(openState);
 
@@ -52,7 +54,7 @@ export const InlineEditWrapper = ({
     setIsOpen(open);
   };
 
-  const [maxHeight, setMaxHeight] = useState(0);
+  const [internalMaxHeight, setInternalMaxHeight] = useState(0);
 
   const { refs, context, x, y, strategy } = useFloating({
     open: isOpen,
@@ -67,7 +69,7 @@ export const InlineEditWrapper = ({
       }),
       size({
         apply({ availableHeight }) {
-          setMaxHeight(availableHeight);
+          setInternalMaxHeight(availableHeight);
         },
       }),
     ],
@@ -114,7 +116,7 @@ export const InlineEditWrapper = ({
                         refs.reference?.current?.getBoundingClientRect().height
                       }px`
                     : undefined,
-                  maxHeight, // set by floating-ui size middleware to calculate available space within the viewport
+                  maxHeight: maxHeight ?? internalMaxHeight, // if maxHeight is not provided, use the value set by floating-ui size middleware to calculate available space within the viewport
                   zIndex: preset.theme.extend.zIndex.modal,
                 },
               })}


### PR DESCRIPTION
Prise en compte [du retour](https://www.notion.so/accelerateur-transition-ecologique-ademe/Retours-de-test-refonte-action-2ed6523d57d78004afffe40e93a955aa?source=copy_link#3176523d57d780269c62fd897ea58a30) de la FA suivant :

> Le selecteur de personne pilote des sous-actions fonctionne bizarrement
Le “selecteur actif” se “resize” en fonction du nombre de résultat de la “recherche” ce qui entraine un mouvement du “selecteur”. D’habitude le sélecteur reste sur la ligne sur laquelle tu ouvres le champ et le resize se fait par en bas, sans bouger le “sélecteur actif”

---

Ajout d'une hauteur max à l'inline edit wrapper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notes de version

* **Refactor**
  * Amélioration des composants d'édition en ligne permettant une meilleure configuration de la hauteur maximale des éléments, offrant une plus grande flexibilité dans l'adaptation de l'interface utilisateur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->