### PR TITLE
Plus d'accès aux collectivités sans être vérifié

### DIFF
--- a/apps/auth/app/(authed)/rejoindre-une-collectivite/CollectiviteSelectionnee.tsx
+++ b/apps/auth/app/(authed)/rejoindre-une-collectivite/CollectiviteSelectionnee.tsx
@@ -1,6 +1,4 @@
-import { useUser } from '@tet/api';
-import { hasRole, PlatformRole } from '@tet/domain/users';
-import { Alert, Button, Icon, useCopyToClipboard } from '@tet/ui';
+import { Alert, Icon, useCopyToClipboard } from '@tet/ui';
 import { CollectiviteInfo } from './useRejoindreUneCollectivite';
 
 type Props = {
@@ -10,11 +8,9 @@ type Props = {
 export const CollectiviteSelectionnee = ({ collectivite }: Props) => {
   const { copy } = useCopyToClipboard();
 
-  const user = useUser();
-
   if (!collectivite) return;
 
-  const { url, contacts } = collectivite;
+  const { contacts } = collectivite;
 
   return (
     <div className="mt-6">
@@ -52,12 +48,6 @@ export const CollectiviteSelectionnee = ({ collectivite }: Props) => {
             ))}
           </tbody>
         </table>
-      )}
-
-      {hasRole(user, PlatformRole.VERIFIED) && (
-        <Button target="_blank" href={url} variant="outlined" className="mt-6">
-          En attendant l’accès, visitez le profil de cette collectivité
-        </Button>
       )}
     </div>
   );


### PR DESCRIPTION
Supprime le bouton d'accès à la collectivité en mode visite pour un utilisateur vérifié sans collectivité

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * L'interface de sélection de collectivité a été simplifiée et optimisée. Les vérifications de rôle utilisateur et les restrictions d'accès associées ont été supprimées du composant. Le bouton "En attendant l'accès" n'est plus affiché aux utilisateurs. Le tableau de contacts reste disponible et entièrement fonctionnel pour tous, offrant une expérience plus fluide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->