### PR TITLE
Explication sous-mesure hors du header de la sous-mesure

### DIFF
--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/action/[actionId]/_components/subaction/subaction-card.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/action/[actionId]/_components/subaction/subaction-card.tsx
@@ -46,12 +46,10 @@ const SubactionHeader = ({
   subAction,
   isExpanded,
   toggleExpand,
-  showJustifications,
 }: {
   subAction: ActionDefinitionSummary;
   isExpanded: boolean;
   toggleExpand: () => void;
-  showJustifications: boolean;
 }) => {
   const preuvesCount = useActionPreuvesCount(subAction.id);
   const isVisitor = useIsVisitor();
@@ -101,12 +99,6 @@ const SubactionHeader = ({
       <ScoreIndicatifLibelle actionId={subAction.id} />
 
       <SubactionCardActions action={subAction} />
-      {showJustifications && (
-        <ActionJustificationField
-          actionId={subAction.id}
-          placeholder="Explications sur l'etat d'avancement"
-        />
-      )}
     </div>
   );
 };
@@ -120,7 +112,7 @@ const SubactionContent = ({
   tasks: ActionDefinitionSummary[];
   hideTasksStatus: boolean;
 }) => (
-  <div className="flex flex-col gap-4">
+  <div className={cn('flex flex-col gap-4 p-4')}>
     {(subAction.description || subAction.haveExemples) && (
       <SubActionDescription subAction={subAction} className="text-sm" />
     )}
@@ -171,12 +163,27 @@ const SubActionCard = ({
         expanded={isExpanded}
         setExpanded={onToggleExpanded}
         renderHeader={({ isExpanded: expanded, toggleExpand }) => (
-          <SubactionHeader
-            subAction={subAction}
-            isExpanded={expanded}
-            toggleExpand={toggleExpand}
-            showJustifications={showJustifications}
-          />
+          <>
+            <SubactionHeader
+              subAction={subAction}
+              isExpanded={expanded}
+              toggleExpand={toggleExpand}
+            />
+            <div
+              className={cn('px-4 pb-4 bg-white cursor-pointer', {
+                'bg-primary-1': isExpanded,
+                'rounded-lg': !isExpanded,
+              })}
+              onClick={toggleExpand}
+            >
+              {showJustifications && (
+                <ActionJustificationField
+                  actionId={subAction.id}
+                  placeholder="Explications sur l'etat d'avancement"
+                />
+              )}
+            </div>
+          </>
         )}
         content={
           <SubactionContent

--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/action/[actionId]/_components/subaction/subaction-card.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/action/[actionId]/_components/subaction/subaction-card.tsx
@@ -177,10 +177,7 @@ const SubActionCard = ({
               onClick={toggleExpand}
             >
               {showJustifications && (
-                <ActionJustificationField
-                  actionId={subAction.id}
-                  placeholder="Explications sur l'etat d'avancement"
-                />
+                <ActionJustificationField actionId={subAction.id} />
               )}
             </div>
           </>


### PR DESCRIPTION
Déplace l'explication d'une sous-mesure hors du header afin qu'elle ne masque pas les tâches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactoring**
  * Réorganisation de la structure de l'en-tête des sous-actions : le rendu du champ de justification a été déplacé pour améliorer le comportement d'expansion et le contrôle des interactions.

* **Style**
  * Ajustement des espacements et ajout de padding dans le conteneur du contenu des sous-actions pour une présentation plus cohérente.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->