### PR TITLE
fix(indicateurs): Préserve les favoris et la confidentialité lors d'u…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,6 @@ keyfile.json
 
 # Compound engineering plugin
 docs
+
+#AI
+.context

--- a/apps/app/src/app/pages/collectivite/Indicateurs/detail/Header/EditModal.tsx
+++ b/apps/app/src/app/pages/collectivite/Indicateurs/detail/Header/EditModal.tsx
@@ -55,6 +55,7 @@ const EditModal = ({ openState, definition }: Props) => {
 
   return (
     <Modal
+      dataTest="IndicateurEditModal"
       openState={openState}
       title="Modifier l'indicateur"
       subTitle={definition.titre}
@@ -74,7 +75,7 @@ const EditModal = ({ openState, definition }: Props) => {
           {/* Directions ou services pilote */}
           <Field title="Direction ou service pilote" className="col-span-2">
             <ServicesPilotesDropdown
-              placeholder="Sélectionnez ou créez un pilote"
+              placeholder="Sélectionnez ou créez une direction ou un service pilote"
               values={editedServices?.map((s) => s.id)}
               onChange={({ services }) => setEditedServices(services)}
             />

--- a/apps/app/src/app/pages/collectivite/Indicateurs/detail/Header/IndicateurToolbar.tsx
+++ b/apps/app/src/app/pages/collectivite/Indicateurs/detail/Header/IndicateurToolbar.tsx
@@ -53,6 +53,7 @@ const IndicateurToolbar = ({
           }
         >
           <Button
+            dataTest="IndicateurFavoriButton"
             icon={estFavori ? 'star-fill' : 'star-line'}
             size="xs"
             variant="grey"

--- a/apps/backend/src/indicateurs/definitions/mutate-definition/mutate-definition.input.ts
+++ b/apps/backend/src/indicateurs/definitions/mutate-definition/mutate-definition.input.ts
@@ -38,7 +38,7 @@ export const createIndicateurDefinitionInputSchema = z.object({
     .describe('Action à laquelle rattacher le nouvel indicateur'),
 });
 
-export type CreateIndicateurDefinitionInput = z.output<
+export type CreateIndicateurDefinitionInput = z.infer<
   typeof createIndicateurDefinitionInputSchema
 >;
 
@@ -51,8 +51,14 @@ export const updateIndicateurDefinitionInputSchema = z.object({
         collectiviteId: true,
         ficheId: true,
         thematiques: true,
+        estFavori: true,
+        estConfidentiel: true,
       }).shape,
 
+      // Redéfinis sans `.default(false)` pour que le service puisse distinguer
+      // "absent du payload" de "explicitement mis à false".
+      estFavori: z.boolean().optional(),
+      estConfidentiel: z.boolean().optional(),
       ficheIds: z.array(z.number()).optional(),
       pilotes: z.array(upsertIndicateurDefinitionPilotesInputSchema).optional(),
       services: z.array(zm.pick(serviceTagSchema, { id: true })).optional(),

--- a/apps/backend/src/indicateurs/definitions/mutate-definition/update-definition.router.e2e-spec.ts
+++ b/apps/backend/src/indicateurs/definitions/mutate-definition/update-definition.router.e2e-spec.ts
@@ -187,6 +187,91 @@ describe('UpdateIndicateurDefinitionRouter', () => {
       );
     });
 
+    test('should preserve estFavori and estConfidentiel when updating unrelated fields', async () => {
+      const caller = router.createCaller({ user: authenticatedUser });
+
+      const indicateurId = await createIndicateurPerso({
+        caller,
+        indicateurData: {
+          collectiviteId: collectivite.id,
+          titre: 'Test Preserve Favori On Partial Update',
+        },
+      });
+
+      await caller.indicateurs.indicateurs.update({
+        indicateurId,
+        collectiviteId: collectivite.id,
+        indicateurFields: {
+          estFavori: true,
+          estConfidentiel: true,
+        },
+      });
+
+      await caller.indicateurs.indicateurs.update({
+        indicateurId,
+        collectiviteId: collectivite.id,
+        indicateurFields: {
+          pilotes: [{ userId: authenticatedUser.id }],
+        },
+      });
+
+      const {
+        data: [updatedIndicateur],
+      } = await caller.indicateurs.indicateurs.list({
+        collectiviteId: collectivite.id,
+        filters: {
+          indicateurIds: [indicateurId],
+        },
+      });
+
+      expect(updatedIndicateur).toBeDefined();
+      expect(updatedIndicateur.estFavori).toBe(true);
+      expect(updatedIndicateur.estConfidentiel).toBe(true);
+    });
+
+    test('should reset estFavori and estConfidentiel when explicitly set to false', async () => {
+      const caller = router.createCaller({ user: authenticatedUser });
+
+      const indicateurId = await createIndicateurPerso({
+        caller,
+        indicateurData: {
+          collectiviteId: collectivite.id,
+          titre: 'Test Reset Favori On Explicit False',
+        },
+      });
+
+      await caller.indicateurs.indicateurs.update({
+        indicateurId,
+        collectiviteId: collectivite.id,
+        indicateurFields: {
+          estFavori: true,
+          estConfidentiel: true,
+        },
+      });
+
+      await caller.indicateurs.indicateurs.update({
+        indicateurId,
+        collectiviteId: collectivite.id,
+        indicateurFields: {
+          estFavori: false,
+          estConfidentiel: false,
+        },
+      });
+
+      const {
+        data: [updatedIndicateur],
+      } = await caller.indicateurs.indicateurs.list({
+        collectiviteId: collectivite.id,
+        filters: {
+          indicateurIds: [indicateurId],
+        },
+      });
+
+      expect(updatedIndicateur).toBeDefined();
+      expect(updatedIndicateur.estFavori).toBe(false);
+      expect(updatedIndicateur.estConfidentiel).toBe(false);
+    });
+
     test('should throw error when updating non-existent indicator', async () => {
       const updateData: UpdateIndicateurDefinitionInput = {
         indicateurId: 99999,

--- a/doc/solutions/logic-errors/zod-default-leaks-into-partial-update-schema.md
+++ b/doc/solutions/logic-errors/zod-default-leaks-into-partial-update-schema.md
@@ -1,0 +1,110 @@
+---
+title: "Zod `.default()` on a base schema silently overwrites fields in a `.partial()` update"
+category: logic-errors
+date: 2026-04-21
+tags:
+  - zod
+  - trpc
+  - partial-update
+  - schema-composition
+  - indicateurs
+severity: medium
+component: backend/indicateurs/definitions/mutate-definition
+symptoms:
+  - Toggling an indicateur as favori, then editing only the pilote, silently removes it from favoris
+  - Marking an indicateur as confidentiel, then any partial update, resets it to public
+  - Boolean fields omitted from an update payload get written to the database as `false` instead of being preserved
+root_cause: >
+  The update input schema spread its shape from a create schema whose boolean fields carried
+  `.default(false)`. Wrapping that shape in `.partial()` makes fields optional at the type level
+  but does NOT strip the `.default()` — Zod still fills `false` when the client omits the field,
+  so the service layer's `field !== undefined` guard sees `false` and writes it to the database.
+---
+
+# Zod `.default()` on a base schema silently overwrites fields in a `.partial()` update
+
+## Problem
+
+Partial updates to an indicateur via `indicateurs.indicateurs.update` silently reset `estFavori` and `estConfidentiel` to `false` whenever the client sent any update payload that didn't include those fields. Toggling a favori and then editing the pilote via the edit modal would make the favori disappear; enabling "mode privé" and then changing anything else would make it public again.
+
+## Symptoms
+
+- User marks an indicateur as favori → edits the pilote → the star icon goes off.
+- Confidentialité toggle state does not survive any other edit to the same indicateur.
+- The UI sends exactly what was edited (`{ pilotes: [...] }`), and `estFavori` / `estConfidentiel` are never mentioned in the payload, yet they are written to `false` in the database.
+
+## What Didn't Work
+
+- **Reading the service layer first.** The service at `apps/backend/src/indicateurs/definitions/mutate-definition/update-definition.service.ts` already guards every field with `if (field !== undefined)` before writing. It looked correct. The bug wasn't in the service — it was in what the service received from the validated input.
+- **Assuming `.partial()` strips defaults.** `.partial()` only changes whether a field is *required*, not whether it has a default. `z.boolean().optional().default(false)` still resolves to `false` when the input is `undefined`, even inside a `.partial()` wrapper.
+
+## Solution
+
+The update schema inherits field shapes from a create schema via `.shape` spread. In the create schema, the boolean fields legitimately default to `false` (a new indicateur without `estFavori` in the payload should be non-favori). The fix: explicitly `omit` those fields from the spread and redeclare them in the update schema *without* the default, so that omitting them produces `undefined` instead of `false`.
+
+```ts
+// apps/backend/src/indicateurs/definitions/mutate-definition/mutate-definition.input.ts
+
+export const updateIndicateurDefinitionInputSchema = z.object({
+  indicateurId: z.number(),
+  collectiviteId: z.number(),
+  indicateurFields: z
+    .object({
+      ...createIndicateurDefinitionInputSchema.omit({
+        collectiviteId: true,
+        ficheId: true,
+        thematiques: true,
+        estFavori: true,        // ← omit the defaulted field
+        estConfidentiel: true,  // ← omit the defaulted field
+      }).shape,
+
+      // Redéfinis sans `.default(false)` pour que le service puisse distinguer
+      // "absent du payload" de "explicitement mis à false".
+      estFavori: z.boolean().optional(),
+      estConfidentiel: z.boolean().optional(),
+      // ...
+    })
+    .partial(),
+});
+```
+
+After this change, the service's `if (estFavori !== undefined)` guard correctly skips writing the column when the client didn't send the field, preserving the stored value.
+
+## Why This Works
+
+`.default(false)` is a *transform* that fires at parse time whenever the input slot is `undefined`. `.partial()` changes the *requirement* of a field (optional vs. required) but leaves the default transform in place. So even with `.partial()`, any field with a default that is missing from the payload arrives at the handler as the default value — never as `undefined`.
+
+The service layer was written correctly for a world where "absent" meant `undefined`. The schema was silently turning "absent" into `false`. The two contracts need to agree: if the service distinguishes `undefined` from `false`, the schema must not erase that distinction.
+
+## Prevention
+
+**Keep `.default()` out of update/partial schemas.** When deriving an update schema from a create schema:
+
+- The create side owns "new object, fill in sensible defaults."
+- The update side owns "change what I sent, leave the rest alone."
+
+These are different contracts; they cannot share default behavior.
+
+**Practical rule for this codebase:** when a base schema with `.default(...)` fields is reused via `.shape` + `.partial()` for an update, `omit` every defaulted field and redeclare it without the default. Add a comment so the next reader knows why.
+
+**Test both directions.** A preserve-on-omit test is not enough; pair it with an explicit-reset test. Together they lock in the schema's two-way semantics:
+
+```ts
+// Preserve: absent fields stay as they were
+await caller.update({ indicateurFields: { estFavori: true } });
+await caller.update({ indicateurFields: { pilotes: [...] } });
+expect(row.estFavori).toBe(true);
+
+// Reset: explicit false actually resets
+await caller.update({ indicateurFields: { estFavori: true } });
+await caller.update({ indicateurFields: { estFavori: false } });
+expect(row.estFavori).toBe(false);
+```
+
+**Structural fix for future fields.** The `omit + redeclare` pattern is not self-enforcing — the next developer who adds a `.default()` field to the create schema will silently repeat this bug. A stronger refactor is to extract a shared no-defaults base schema that both create and update derive from explicitly (create adds defaults on top; update stays bare). Worth doing the next time this file is touched for a non-trivial change.
+
+## Related
+
+- Commit `1201e3d5b` — "Préserve les favoris et la confidentialité lors d'une mise à jour partielle d'un indicateur"
+- [Zod docs: `.default()`](https://zod.dev/?id=default)
+- [Zod docs: `.partial()`](https://zod.dev/?id=partial)

--- a/e2e/tests/indicateurs/indicateur-detail/indicateur-detail.pom.ts
+++ b/e2e/tests/indicateurs/indicateur-detail/indicateur-detail.pom.ts
@@ -1,0 +1,50 @@
+import { expect, Locator, Page } from '@playwright/test';
+
+export class IndicateurDetailPom {
+  readonly favoriButton: Locator;
+  readonly modifierButton: Locator;
+  readonly editModal: Locator;
+  readonly editModalValiderButton: Locator;
+  readonly piloteDropdown: Locator;
+
+  constructor(readonly page: Page) {
+    this.favoriButton = page.locator('[data-test="IndicateurFavoriButton"]');
+    this.modifierButton = page.getByRole('button', {
+      name: 'Modifier',
+    });
+    this.editModal = page.locator('[data-test="IndicateurEditModal"]');
+    this.editModalValiderButton = this.editModal.getByText('Valider');
+    this.piloteDropdown = this.editModal.getByPlaceholder(
+      'Sélectionnez ou créez un pilote'
+    );
+  }
+
+  async goto(collectiviteId: number, indicateurId: number) {
+    await this.page.goto(
+      `/collectivite/${collectiviteId}/indicateurs/perso/${indicateurId}`
+    );
+    await expect(this.favoriButton).toBeVisible();
+  }
+
+  async toggleFavori() {
+    await this.favoriButton.click();
+  }
+
+  async openEditModal() {
+    await this.modifierButton.click();
+    await expect(this.editModal).toBeVisible();
+  }
+
+  async saveEditModal() {
+    await this.editModalValiderButton.click();
+    await expect(this.editModal).toBeHidden();
+  }
+
+  async expectIsFavori() {
+    await expect(this.favoriButton).toHaveClass(/text-warning-1/);
+  }
+
+  async expectIsNotFavori() {
+    await expect(this.favoriButton).not.toHaveClass(/text-warning-1/);
+  }
+}

--- a/e2e/tests/indicateurs/indicateur-detail/indicateur-detail.spec.ts
+++ b/e2e/tests/indicateurs/indicateur-detail/indicateur-detail.spec.ts
@@ -1,0 +1,64 @@
+import { expect } from '@playwright/test';
+import { testWithIndicateurs as test } from '../indicateurs.fixture';
+
+test.describe("Détail d'un indicateur personnalisé", () => {
+  let collectiviteId: number;
+  let indicateurId: number;
+
+  test.beforeEach(
+    async ({ page, collectivites, indicateurs, indicateurDetailPom }) => {
+      const { collectivite, user } = await collectivites.addCollectiviteAndUser(
+        {
+          userArgs: { autoLogin: true },
+        }
+      );
+
+      collectiviteId = collectivite.data.id;
+
+      indicateurId = await indicateurs.create(user, {
+        collectiviteId,
+        titre: 'Indicateur favori test',
+        unite: 'kg',
+      });
+
+      // Marquer comme favori via l'API
+      await indicateurs.update(user, {
+        indicateurId,
+        collectiviteId,
+        indicateurFields: {
+          estFavori: true,
+        },
+      });
+
+      await page.goto('/');
+      await indicateurDetailPom.goto(collectiviteId, indicateurId);
+    }
+  );
+
+  test('Modifier le pilote préserve le favori', async ({
+    indicateurDetailPom,
+    users,
+  }) => {
+    const user = users.getUser();
+    // Vérifier que le favori est actif
+    await indicateurDetailPom.expectIsFavori();
+
+    // Ouvrir la modale d'édition et sélectionner un pilote
+    await indicateurDetailPom.openEditModal();
+
+    // Sélectionner le premier pilote disponible dans le dropdown
+    await indicateurDetailPom.piloteDropdown.click();
+    const userOption = indicateurDetailPom.page.getByTestId(user.data.id);
+    await expect(userOption).toBeVisible();
+    await userOption.click();
+
+    // Sauvegarder
+    await indicateurDetailPom.saveEditModal();
+
+    // Recharger la page pour vérifier la persistance
+    await indicateurDetailPom.goto(collectiviteId, indicateurId);
+
+    // Le favori doit toujours être actif
+    await indicateurDetailPom.expectIsFavori();
+  });
+});

--- a/e2e/tests/indicateurs/indicateurs.fixture.ts
+++ b/e2e/tests/indicateurs/indicateurs.fixture.ts
@@ -5,6 +5,7 @@ import { testWithCollectivites } from 'tests/collectivite/collectivites.fixture'
 import { databaseService } from 'tests/shared/database.service';
 import { FixtureFactory } from 'tests/shared/fixture-factory.interface';
 import { UserFixture } from 'tests/users/users.fixture';
+import { IndicateurDetailPom } from './indicateur-detail/indicateur-detail.pom';
 
 class IndicateursFactory extends FixtureFactory {
   constructor() {
@@ -24,6 +25,17 @@ class IndicateursFactory extends FixtureFactory {
     );
 
     return indicateurId;
+  }
+
+  /**
+   * Met à jour un indicateur
+   */
+  async update(
+    user: UserFixture,
+    indicateur: RouterInput['indicateurs']['indicateurs']['update']
+  ): Promise<void> {
+    const trpcClient = user.getTrpcClient();
+    await trpcClient.indicateurs.indicateurs.update.mutate(indicateur);
   }
 
   /**
@@ -53,10 +65,14 @@ class IndicateursFactory extends FixtureFactory {
 
 export const testWithIndicateurs = testWithCollectivites.extend<{
   indicateurs: IndicateursFactory;
+  indicateurDetailPom: IndicateurDetailPom;
 }>({
   indicateurs: async ({ collectivites }, use) => {
     const indicateurs = new IndicateursFactory();
     collectivites.registerCleanupFunc(indicateurs);
     await use(indicateurs);
+  },
+  indicateurDetailPom: async ({ page }, use) => {
+    await use(new IndicateurDetailPom(page));
   },
 });


### PR DESCRIPTION
…ne mise à jour partielle d'un indicateur

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notes de publication

* **Corrections de bugs**
  * Correction du problème de conservation des statuts "Favori" et "Confidentiel" lors de la modification d'un indicateur. Ces valeurs sont désormais correctement conservées pendant les mises à jour partielles.

* **Améliorations**
  * Amélioration du texte d'aide du champ de sélection des pilotes pour plus de clarté.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->