### PR TITLE
Fix event propagation in subaction card actions

### DIFF
--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/action/[actionId]/_components/subaction/subaction-card.actions.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/action/[actionId]/_components/subaction/subaction-card.actions.tsx
@@ -34,7 +34,7 @@ const SubactionCardActions = ({ action }: Props) => {
     <>
       <div
         className="flex flex-wrap mt-1 mb-2"
-        onClickCapture={(e) => e.stopPropagation()}
+        onClick={(e) => e.stopPropagation()}
       >
         {/* Score indicatif */}
         {haveScoreIndicatif &&

--- a/e2e/tests/referentiels/scores/score-indicatif-modal.spec.ts
+++ b/e2e/tests/referentiels/scores/score-indicatif-modal.spec.ts
@@ -1,0 +1,48 @@
+import { expect } from '@playwright/test';
+import { testWithReferentiels as test } from '../referentiels.fixture';
+
+test.describe("Modale de saisie des données d'indicateur du score indicatif", () => {
+  test.beforeEach(async ({ page, collectivites }) => {
+    const { collectivite, user } = await collectivites.addCollectiviteAndUser({
+      userArgs: { autoLogin: true },
+      collectiviteArgs: { isCOT: true },
+    });
+    await user.precomputeReferentielSnapshot(collectivite.data.id, 'cae');
+    await page.goto('/');
+  });
+
+  test("Cliquer sur \"Renseigner les données de l'indicateur\" ouvre la modale", async ({
+    page,
+    referentielScoresPom,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    referentiels,
+  }) => {
+    await referentielScoresPom.goto('cae');
+    await referentielScoresPom.goToActionPage(
+      '4 - Mobilité',
+      '4.1 Promotion et suivi de la mobilité',
+      '4.1.1 Promouvoir et suivre les pratiques'
+    );
+
+    // La tâche 4.1.1.6.2 est à l'intérieur de la sous-action 4.1.1.6
+    // qu'il faut déplier pour accéder aux tâches
+    await referentielScoresPom.expandSousAction('4.1.1.6');
+
+    const tache = page.locator(
+      referentielScoresPom.getTacheLocationExpression('4.1.1.6.2')
+    );
+    const renseignerButton = tache.getByRole('button', {
+      name: "Renseigner les données de l'indicateur",
+    });
+
+    await expect(renseignerButton).toBeVisible();
+
+    // Aucune modale ouverte avant le clic
+    await expect(page.getByRole('dialog')).toHaveCount(0);
+
+    await renseignerButton.click();
+
+    // La modale doit s'ouvrir après le clic
+    await expect(page.getByRole('dialog')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
Fixed event propagation issue in the subaction card actions component that was preventing the score indicatif modal from opening correctly.

## Key Changes
- Changed `onClickCapture` to `onClick` in the subaction card actions wrapper div to use the standard event bubbling phase instead of the capture phase
- Added e2e test to verify that clicking "Renseigner les données de l'indicateur" button opens the modal correctly

## Implementation Details
The issue was that `onClickCapture` with `stopPropagation()` was preventing click events from properly reaching child elements (specifically the "Renseigner les données de l'indicateur" button). By switching to the standard `onClick` handler, the event can properly bubble up from the button while still preventing propagation to parent elements when needed.

The new e2e test validates the complete user flow:
- Navigates to a referentiel action page
- Expands the necessary subaction to access the task
- Verifies the button is visible
- Confirms the modal opens when the button is clicked

https://claude.ai/code/session_01GhdyEjgwhEtebm7vDm6dfb