### PR TITLE
fix(plans): permet aux contributeurs pilotes de créer et modifier des…

### DIFF
--- a/apps/app/src/plans/fiches/data/use-get-fiche.ts
+++ b/apps/app/src/plans/fiches/data/use-get-fiche.ts
@@ -7,9 +7,11 @@ export type Fiche = RouterOutput['plans']['fiches']['get'];
 export function useGetFiche({
   id,
   initialData,
+  enabled,
 }: {
   id: number;
   initialData?: FicheWithRelations;
+  enabled?: boolean;
 }) {
   const trpc = useTRPC();
   return useQuery(
@@ -19,6 +21,7 @@ export function useGetFiche({
       },
       {
         initialData,
+        enabled,
       }
     )
   );

--- a/apps/app/src/plans/fiches/show-fiche/content/sous-actions/sous-actions.view.tsx
+++ b/apps/app/src/plans/fiches/show-fiche/content/sous-actions/sous-actions.view.tsx
@@ -8,15 +8,21 @@ import { ContentLayout } from '../content-layout';
 export const SousActionsView = () => {
   const { hasCollectivitePermission } = useCurrentCollectivite();
 
-  const { fiche, sousActions } = useFicheContext();
+  const { fiche, isReadonly, sousActions } = useFicheContext();
 
   const { mutate: createSousAction, isPending: isLoadingCreate } =
     useCreateSousAction(fiche.id);
 
   const isEmpty = sousActions.count === 0;
 
-  const canMutate = hasCollectivitePermission('plans.fiches.update');
-  const canCreate = hasCollectivitePermission('plans.fiches.create');
+  // Un utilisateur qui peut modifier la fiche parente peut gérer ses
+  // sous-actions (création et édition inline), même sans les permissions
+  // collectivité globales (cas du contributeur pilote de la fiche parente).
+  const canEditParentFiche = !isReadonly;
+  const canMutate =
+    hasCollectivitePermission('plans.fiches.update') || canEditParentFiche;
+  const canCreate =
+    hasCollectivitePermission('plans.fiches.create') || canEditParentFiche;
 
   return (
     <ContentLayout.Root>

--- a/apps/app/src/plans/sous-actions/data/use-can-edit-sous-action.ts
+++ b/apps/app/src/plans/sous-actions/data/use-can-edit-sous-action.ts
@@ -1,0 +1,30 @@
+import { useGetFiche } from '@/app/plans/fiches/data/use-get-fiche';
+import { isFicheEditableByCollectiviteUser } from '@/app/plans/fiches/share-fiche/share-fiche.utils';
+import { useUser } from '@tet/api';
+import { useCurrentCollectivite } from '@tet/api/collectivites';
+import { FicheWithRelations } from '@tet/domain/plans';
+
+/**
+ * Une sous-action est éditable par l'utilisateur s'il peut éditer la fiche
+ * parente (cas du contributeur pilote de la fiche parente) ou s'il peut
+ * éditer la sous-action elle-même (permission directe ou rôle de pilote sur
+ * la sous-action).
+ */
+export const useCanEditSousAction = (sousAction: FicheWithRelations) => {
+  const collectivite = useCurrentCollectivite();
+  const { id: userId } = useUser();
+
+  const { data: parentFiche } = useGetFiche({
+    id: sousAction.parentId ?? 0,
+    enabled: sousAction.parentId != null,
+  });
+
+  const canEditParent =
+    !!parentFiche &&
+    isFicheEditableByCollectiviteUser(parentFiche, collectivite, userId);
+
+  return (
+    canEditParent ||
+    isFicheEditableByCollectiviteUser(sousAction, collectivite, userId)
+  );
+};

--- a/apps/app/src/plans/sous-actions/list/table/sous-action.date.cell.tsx
+++ b/apps/app/src/plans/sous-actions/list/table/sous-action.date.cell.tsx
@@ -1,11 +1,9 @@
 import { format, isEqual, isValid } from 'date-fns';
 import { useState } from 'react';
 
-import { isFicheEditableByCollectiviteUser } from '@/app/plans/fiches/share-fiche/share-fiche.utils';
-import { useUser } from '@tet/api';
-import { useCurrentCollectivite } from '@tet/api/collectivites';
 import { FicheWithRelations, isFicheOnTime } from '@tet/domain/plans';
 import { cn, Icon, Input, TableCell } from '@tet/ui';
+import { useCanEditSousAction } from '../../data/use-can-edit-sous-action';
 import { useUpdateSousAction } from '../../data/use-update-sous-action';
 
 type Props = {
@@ -13,15 +11,7 @@ type Props = {
 };
 
 export const SousActionDateCell = ({ sousAction }: Props) => {
-  const collectivite = useCurrentCollectivite();
-
-  const { id: userId } = useUser();
-
-  const canUpdate = isFicheEditableByCollectiviteUser(
-    sousAction,
-    collectivite,
-    userId
-  );
+  const canUpdate = useCanEditSousAction(sousAction);
 
   const initialDate = sousAction.dateFin ?? '';
 

--- a/apps/app/src/plans/sous-actions/list/table/sous-action.description.cell.tsx
+++ b/apps/app/src/plans/sous-actions/list/table/sous-action.description.cell.tsx
@@ -1,11 +1,9 @@
 import { useState } from 'react';
 
-import { isFicheEditableByCollectiviteUser } from '@/app/plans/fiches/share-fiche/share-fiche.utils';
-import { useUser } from '@tet/api';
-import { useCurrentCollectivite } from '@tet/api/collectivites';
 import { FicheWithRelations } from '@tet/domain/plans';
 import { cn, TableCell, TableCellTextarea } from '@tet/ui';
 import { isEqual } from 'es-toolkit';
+import { useCanEditSousAction } from '../../data/use-can-edit-sous-action';
 import { useUpdateSousAction } from '../../data/use-update-sous-action';
 
 const getTitle = (
@@ -23,15 +21,7 @@ type Props = {
 };
 
 export const SousActionDescriptionCell = ({ sousAction }: Props) => {
-  const collectivite = useCurrentCollectivite();
-
-  const { id: userId } = useUser();
-
-  const canUpdate = isFicheEditableByCollectiviteUser(
-    sousAction,
-    collectivite,
-    userId
-  );
+  const canUpdate = useCanEditSousAction(sousAction);
 
   const [value, setValue] = useState(sousAction.description);
 

--- a/apps/app/src/plans/sous-actions/list/table/sous-action.pilotes.cell.tsx
+++ b/apps/app/src/plans/sous-actions/list/table/sous-action.pilotes.cell.tsx
@@ -1,11 +1,9 @@
-import { isFicheEditableByCollectiviteUser } from '@/app/plans/fiches/share-fiche/share-fiche.utils';
 import PersonnesDropdown from '@/app/ui/dropdownLists/PersonnesDropdown/PersonnesDropdown';
 import { getPersonneStringId } from '@/app/ui/dropdownLists/PersonnesDropdown/utils';
 import ListWithTooltip from '@/app/ui/lists/ListWithTooltip';
-import { useUser } from '@tet/api';
-import { useCurrentCollectivite } from '@tet/api/collectivites';
 import { FicheWithRelations } from '@tet/domain/plans';
 import { TableCell } from '@tet/ui';
+import { useCanEditSousAction } from '../../data/use-can-edit-sous-action';
 import { useUpdateSousAction } from '../../data/use-update-sous-action';
 
 type Props = {
@@ -13,15 +11,7 @@ type Props = {
 };
 
 export const SousActionPilotesCell = ({ sousAction }: Props) => {
-  const collectivite = useCurrentCollectivite();
-
-  const { id: userId } = useUser();
-
-  const canUpdate = isFicheEditableByCollectiviteUser(
-    sousAction,
-    collectivite,
-    userId
-  );
+  const canUpdate = useCanEditSousAction(sousAction);
 
   const { mutate: updateSousAction } = useUpdateSousAction();
 

--- a/apps/app/src/plans/sous-actions/list/table/sous-action.statut.cell.tsx
+++ b/apps/app/src/plans/sous-actions/list/table/sous-action.statut.cell.tsx
@@ -1,10 +1,8 @@
 import BadgeStatut from '@/app/app/pages/collectivite/PlansActions/components/BadgeStatut';
-import { isFicheEditableByCollectiviteUser } from '@/app/plans/fiches/share-fiche/share-fiche.utils';
 import StatutsSelectDropdown from '@/app/ui/dropdownLists/ficheAction/statuts/StatutsSelectDropdown';
-import { useUser } from '@tet/api';
-import { useCurrentCollectivite } from '@tet/api/collectivites';
 import { FicheWithRelations } from '@tet/domain/plans';
 import { TableCell } from '@tet/ui';
+import { useCanEditSousAction } from '../../data/use-can-edit-sous-action';
 import { useUpdateSousAction } from '../../data/use-update-sous-action';
 
 type Props = {
@@ -12,15 +10,7 @@ type Props = {
 };
 
 export const SousActionStatutCell = ({ sousAction }: Props) => {
-  const collectivite = useCurrentCollectivite();
-
-  const { id: userId } = useUser();
-
-  const canUpdate = isFicheEditableByCollectiviteUser(
-    sousAction,
-    collectivite,
-    userId
-  );
+  const canUpdate = useCanEditSousAction(sousAction);
 
   const { mutate: updateSousAction } = useUpdateSousAction();
 

--- a/apps/app/src/plans/sous-actions/list/table/sous-action.title.cell.tsx
+++ b/apps/app/src/plans/sous-actions/list/table/sous-action.title.cell.tsx
@@ -1,12 +1,10 @@
 import { useState } from 'react';
 
 import { generateTitle } from '@/app/utils/generate-title';
-import { isFicheEditableByCollectiviteUser } from '@/app/plans/fiches/share-fiche/share-fiche.utils';
-import { useUser } from '@tet/api';
-import { useCurrentCollectivite } from '@tet/api/collectivites';
 import { FicheWithRelations } from '@tet/domain/plans';
 import { cn, TableCell, TableCellTextarea } from '@tet/ui';
 import { isEqual } from 'es-toolkit';
+import { useCanEditSousAction } from '../../data/use-can-edit-sous-action';
 import { useUpdateSousAction } from '../../data/use-update-sous-action';
 
 type Props = {
@@ -14,15 +12,7 @@ type Props = {
 };
 
 export const SousActionTitleCell = ({ sousAction }: Props) => {
-  const collectivite = useCurrentCollectivite();
-
-  const { id: userId } = useUser();
-
-  const canUpdate = isFicheEditableByCollectiviteUser(
-    sousAction,
-    collectivite,
-    userId
-  );
+  const canUpdate = useCanEditSousAction(sousAction);
 
   const [value, setValue] = useState(sousAction.titre);
 

--- a/apps/backend/src/plans/fiches/create-fiche/create-fiche.router.e2e-spec.ts
+++ b/apps/backend/src/plans/fiches/create-fiche/create-fiche.router.e2e-spec.ts
@@ -1,4 +1,5 @@
 import { addTestCollectiviteAndUser } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { ficheActionPiloteTable } from '@tet/backend/plans/fiches/shared/models/fiche-action-pilote.table';
 import {
   getAuthUser,
   getAuthUserFromUserCredentials,
@@ -153,6 +154,172 @@ describe('Create Fiche Action', () => {
         })
       ).rejects.toThrow(
         `Droits insuffisants, l'utilisateur ${user.id} n'a pas l'autorisation plans.fiches.create sur la ressource Collectivité ${collectivite.id}`
+      );
+    });
+
+    test('Contributeur pilote can create a sous-action under a fiche they pilot', async () => {
+      const { user, cleanup } = await addTestUser(db, {
+        collectiviteId: collectivite.id,
+        role: CollectiviteRole.EDITION_FICHES_INDICATEURS,
+      });
+
+      onTestFinished(async () => {
+        await cleanup();
+      });
+
+      const editorCaller = router.createCaller({ user: editorUser });
+      const parentFiche = await editorCaller.plans.fiches.create({
+        fiche: {
+          titre: 'Fiche parente pilotée par le contributeur',
+          collectiviteId: collectivite.id,
+        },
+      });
+      const parentFicheId = parentFiche.id;
+      assert(parentFicheId);
+
+      await db.db.insert(ficheActionPiloteTable).values({
+        ficheId: parentFicheId,
+        userId: user.id,
+      });
+
+      const contributeurUser = getAuthUserFromUserCredentials(user);
+      const contributeurCaller = router.createCaller({
+        user: contributeurUser,
+      });
+
+      const sousAction = await contributeurCaller.plans.fiches.create({
+        fiche: {
+          titre: 'Sous-action créée par le contributeur',
+          collectiviteId: collectivite.id,
+          parentId: parentFicheId,
+        },
+      });
+      const sousActionId = sousAction.id;
+      expect(sousActionId).toBeDefined();
+
+      onTestFinished(async () => {
+        await editorCaller.plans.fiches.delete({
+          ficheId: sousActionId,
+          deleteMode: 'hard',
+        });
+        await editorCaller.plans.fiches.delete({
+          ficheId: parentFicheId,
+          deleteMode: 'hard',
+        });
+      });
+
+      expect(sousAction).toEqual(
+        expect.objectContaining({
+          id: sousActionId,
+          parentId: parentFicheId,
+          collectiviteId: collectivite.id,
+        })
+      );
+    });
+
+    test('Contributeur non-pilote cannot create a sous-action under a fiche they do not pilot', async () => {
+      const { user, cleanup } = await addTestUser(db, {
+        collectiviteId: collectivite.id,
+        role: CollectiviteRole.EDITION_FICHES_INDICATEURS,
+      });
+
+      onTestFinished(async () => {
+        await cleanup();
+      });
+
+      const editorCaller = router.createCaller({ user: editorUser });
+      const parentFiche = await editorCaller.plans.fiches.create({
+        fiche: {
+          titre: 'Fiche parente non pilotée par le contributeur',
+          collectiviteId: collectivite.id,
+        },
+      });
+      const parentFicheId = parentFiche.id;
+      assert(parentFicheId);
+
+      onTestFinished(async () => {
+        await editorCaller.plans.fiches.delete({
+          ficheId: parentFicheId,
+          deleteMode: 'hard',
+        });
+      });
+
+      const contributeurUser = getAuthUserFromUserCredentials(user);
+      const contributeurCaller = router.createCaller({
+        user: contributeurUser,
+      });
+
+      await expect(
+        contributeurCaller.plans.fiches.create({
+          fiche: {
+            titre: 'Sous-action non autorisée',
+            collectiviteId: collectivite.id,
+            parentId: parentFicheId,
+          },
+        })
+      ).rejects.toThrow(
+        `Droits insuffisants, l'utilisateur ${user.id} n'a pas l'autorisation plans.fiches.update sur la ressource Collectivité ${collectivite.id}`
+      );
+    });
+
+    test('Cannot create a sous-action in a different collectivite than its parent fiche', async () => {
+      const { user, cleanup } = await addTestUser(db, {
+        collectiviteId: collectivite.id,
+        role: CollectiviteRole.EDITION_FICHES_INDICATEURS,
+      });
+
+      const otherCollectiviteAndUser = await addTestCollectiviteAndUser(db, {
+        user: {
+          role: CollectiviteRole.ADMIN,
+        },
+      });
+      const otherCollectivite = otherCollectiviteAndUser.collectivite;
+
+      onTestFinished(async () => {
+        await cleanup();
+        await otherCollectiviteAndUser.cleanup();
+      });
+
+      const editorCaller = router.createCaller({ user: editorUser });
+      const parentFiche = await editorCaller.plans.fiches.create({
+        fiche: {
+          titre: 'Fiche parente dans la collectivité principale',
+          collectiviteId: collectivite.id,
+        },
+      });
+      const parentFicheId = parentFiche.id;
+      assert(parentFicheId);
+
+      await db.db.insert(ficheActionPiloteTable).values({
+        ficheId: parentFicheId,
+        userId: user.id,
+      });
+
+      onTestFinished(async () => {
+        await editorCaller.plans.fiches.delete({
+          ficheId: parentFicheId,
+          deleteMode: 'hard',
+        });
+      });
+
+      const contributeurUser = getAuthUserFromUserCredentials(user);
+      const contributeurCaller = router.createCaller({
+        user: contributeurUser,
+      });
+
+      // Le contributeur pilote la fiche parente (dans la collectivité principale),
+      // mais tente de créer une sous-action dans une autre collectivité :
+      // la création doit être refusée.
+      await expect(
+        contributeurCaller.plans.fiches.create({
+          fiche: {
+            titre: 'Sous-action avec mauvaise collectivité',
+            collectiviteId: otherCollectivite.id,
+            parentId: parentFicheId,
+          },
+        })
+      ).rejects.toThrow(
+        `La sous-action doit appartenir à la même collectivité que la fiche parente ${parentFicheId}`
       );
     });
   });

--- a/apps/backend/src/plans/fiches/create-fiche/create-fiche.service.ts
+++ b/apps/backend/src/plans/fiches/create-fiche/create-fiche.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { ForbiddenException, Injectable, Logger } from '@nestjs/common';
+import FicheActionPermissionsService from '@tet/backend/plans/fiches/fiche-action-permissions.service';
 import { ficheActionTable } from '@tet/backend/plans/fiches/shared/models/fiche-action.table';
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
@@ -17,6 +18,7 @@ export class CreateFicheService {
   constructor(
     private readonly databaseService: DatabaseService,
     private readonly permissionService: PermissionService,
+    private readonly ficheActionPermissionsService: FicheActionPermissionsService,
     private readonly updateFicheService: UpdateFicheService
   ) {}
 
@@ -37,14 +39,44 @@ export class CreateFicheService {
     );
 
     if (user) {
-      await this.permissionService.isAllowed(
-        user,
-        PermissionOperationEnum['PLANS.FICHES.CREATE'],
-        ResourceType.COLLECTIVITE,
-        fiche.collectiviteId,
-        false,
-        tx
-      );
+      if (fiche.parentId) {
+        // Pour une sous-action, il suffit d'avoir le droit de modifier la
+        // fiche parente (ce qui inclut les contributeurs pilotes de la fiche
+        // parente via la permission `plans.fiches.update_piloted_by_me`).
+        // Lève une ForbiddenException si l'utilisateur ne peut pas écrire
+        // la fiche parente.
+        await this.ficheActionPermissionsService.canWriteFiche(
+          fiche.parentId,
+          user,
+          tx
+        );
+        // La sous-action doit appartenir à la même collectivité que sa fiche
+        // parente, sinon le droit accordé sur la parente permettrait de créer
+        // une fiche dans une autre collectivité en contournant
+        // `plans.fiches.create`.
+        const parentFiche =
+          await this.ficheActionPermissionsService.getFicheFromId(
+            fiche.parentId,
+            tx
+          );
+        if (
+          parentFiche &&
+          parentFiche.collectiviteId !== fiche.collectiviteId
+        ) {
+          throw new ForbiddenException(
+            `La sous-action doit appartenir à la même collectivité que la fiche parente ${fiche.parentId}`
+          );
+        }
+      } else {
+        await this.permissionService.isAllowed(
+          user,
+          PermissionOperationEnum['PLANS.FICHES.CREATE'],
+          ResourceType.COLLECTIVITE,
+          fiche.collectiviteId,
+          false,
+          tx
+        );
+      }
     }
     const validation = ficheSchemaCreate.safeParse(fiche);
     if (!validation.success) {

--- a/apps/backend/src/plans/fiches/delete-fiche/delete-fiche.router.e2e-spec.ts
+++ b/apps/backend/src/plans/fiches/delete-fiche/delete-fiche.router.e2e-spec.ts
@@ -1,4 +1,5 @@
 import { addTestCollectiviteAndUser } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { ficheActionPiloteTable } from '@tet/backend/plans/fiches/shared/models/fiche-action-pilote.table';
 import {
   getAuthUser,
   getAuthUserFromUserCredentials,
@@ -238,6 +239,157 @@ describe('Delete Fiche Action', () => {
       // Attempt to delete should fail with ForbiddenException
       await expect(
         caller.plans.fiches.delete({ ficheId: testFicheId })
+      ).rejects.toThrow(
+        `Droits insuffisants, l'utilisateur ${user.id} n'a pas l'autorisation plans.fiches.delete sur la ressource Collectivité ${collectivite.id}`
+      );
+    });
+
+    test('Contributeur pilote of a parent fiche can delete its sous-action', async () => {
+      const { user, cleanup } = await addTestUser(db, {
+        collectiviteId: collectivite.id,
+        role: CollectiviteRole.EDITION_FICHES_INDICATEURS,
+      });
+
+      const editorCaller = router.createCaller({ user: editorUser });
+
+      // Crée une fiche parente et une sous-action rattachée à cette parente.
+      const parentFiche = await editorCaller.plans.fiches.create({
+        fiche: {
+          titre: 'Fiche parente pilotée par le contributeur (delete)',
+          collectiviteId: collectivite.id,
+        },
+      });
+      const parentFicheId = parentFiche.id;
+      assert(parentFicheId);
+
+      const sousAction = await editorCaller.plans.fiches.create({
+        fiche: {
+          titre: 'Sous-action à supprimer par le pilote parent',
+          collectiviteId: collectivite.id,
+          parentId: parentFicheId,
+        },
+      });
+      const sousActionId = sousAction.id;
+      expect(sousActionId).toBeDefined();
+
+      // Fait du contributeur un pilote de la fiche parente.
+      await db.db.insert(ficheActionPiloteTable).values({
+        ficheId: parentFicheId,
+        userId: user.id,
+      });
+
+      // Nettoyage idempotent en base pour absorber les tests qui suppriment
+      // eux-mêmes la sous-action.
+      onTestFinished(async () => {
+        await db.db
+          .delete(ficheActionTable)
+          .where(inArray(ficheActionTable.id, [sousActionId, parentFicheId]));
+        await cleanup();
+      });
+
+      const contributeurCaller = router.createCaller({
+        user: getAuthUserFromUserCredentials(user),
+      });
+
+      const result = await contributeurCaller.plans.fiches.delete({
+        ficheId: sousActionId,
+        deleteMode: 'hard',
+      });
+      expect(result).toEqual({ success: true });
+
+      // La sous-action doit avoir été supprimée en base.
+      const rows = await db.db
+        .select({ id: ficheActionTable.id })
+        .from(ficheActionTable)
+        .where(eq(ficheActionTable.id, sousActionId));
+      expect(rows.length).toEqual(0);
+    });
+
+    test('Contributeur non-pilote cannot delete a sous-action whose parent they do not pilot', async () => {
+      const { user, cleanup } = await addTestUser(db, {
+        collectiviteId: collectivite.id,
+        role: CollectiviteRole.EDITION_FICHES_INDICATEURS,
+      });
+
+      const editorCaller = router.createCaller({ user: editorUser });
+
+      const { ficheId: parentFicheId, ficheCleanup: parentCleanup } =
+        await createFicheAndCleanupFunction({
+          caller: editorCaller,
+          ficheInput: {
+            titre: 'Fiche parente non pilotée par le contributeur (delete)',
+            collectiviteId: collectivite.id,
+          },
+        });
+      const { ficheId: sousActionId, ficheCleanup: sousActionCleanup } =
+        await createFicheAndCleanupFunction({
+          caller: editorCaller,
+          ficheInput: {
+            titre: 'Sous-action non supprimable par un contributeur non pilote',
+            collectiviteId: collectivite.id,
+            parentId: parentFicheId,
+          },
+        });
+
+      onTestFinished(async () => {
+        await sousActionCleanup();
+        await parentCleanup();
+        await cleanup();
+      });
+
+      const contributeurCaller = router.createCaller({
+        user: getAuthUserFromUserCredentials(user),
+      });
+
+      await expect(
+        contributeurCaller.plans.fiches.delete({
+          ficheId: sousActionId,
+          deleteMode: 'hard',
+        })
+      ).rejects.toThrow(
+        `Droits insuffisants, l'utilisateur ${user.id} n'a pas l'autorisation plans.fiches.delete sur la ressource Collectivité ${collectivite.id}`
+      );
+    });
+
+    test('Contributeur pilote of a fiche itself cannot delete it (only sous-actions of piloted parents)', async () => {
+      const { user, cleanup } = await addTestUser(db, {
+        collectiviteId: collectivite.id,
+        role: CollectiviteRole.EDITION_FICHES_INDICATEURS,
+      });
+
+      const editorCaller = router.createCaller({ user: editorUser });
+
+      const { ficheId: topLevelFicheId, ficheCleanup: topLevelCleanup } =
+        await createFicheAndCleanupFunction({
+          caller: editorCaller,
+          ficheInput: {
+            titre: 'Fiche de premier niveau pilotée par le contributeur',
+            collectiviteId: collectivite.id,
+          },
+        });
+
+      // Contributeur est pilote de la fiche de premier niveau (pas de parent).
+      await db.db.insert(ficheActionPiloteTable).values({
+        ficheId: topLevelFicheId,
+        userId: user.id,
+      });
+
+      onTestFinished(async () => {
+        await topLevelCleanup();
+        await cleanup();
+      });
+
+      const contributeurCaller = router.createCaller({
+        user: getAuthUserFromUserCredentials(user),
+      });
+
+      // Le fallback parent-pilote ne s'applique qu'aux sous-actions : la
+      // suppression d'une fiche racine par son pilote reste refusée.
+      await expect(
+        contributeurCaller.plans.fiches.delete({
+          ficheId: topLevelFicheId,
+          deleteMode: 'hard',
+        })
       ).rejects.toThrow(
         `Droits insuffisants, l'utilisateur ${user.id} n'a pas l'autorisation plans.fiches.delete sur la ressource Collectivité ${collectivite.id}`
       );

--- a/apps/backend/src/plans/fiches/fiche-action-permissions.service.ts
+++ b/apps/backend/src/plans/fiches/fiche-action-permissions.service.ts
@@ -213,7 +213,7 @@ export default class FicheActionPermissionsService {
 
   async canDeleteFiche(
     ficheId: number,
-    user: AuthUser,
+    user: AuthenticatedUser,
     doNotThrow?: boolean
   ): Promise<boolean> {
     const fiche = await this.getFicheFromId(ficheId);
@@ -221,9 +221,49 @@ export default class FicheActionPermissionsService {
       throw new NotFoundException(`Action non trouvée pour l'id ${ficheId}`);
     }
 
-    // Check direct permissions first
     const operation = PermissionOperationEnum['PLANS.FICHES.DELETE'];
-    return await this.permissionService.isAllowed(
+
+    // Vérifie d'abord la permission directe de suppression au niveau
+    // collectivité.
+    const hasDirectDeletePermission = await this.permissionService.isAllowed(
+      user,
+      operation,
+      ResourceType.COLLECTIVITE,
+      fiche.collectiviteId,
+      true
+    );
+    if (hasDirectDeletePermission) {
+      return true;
+    }
+
+    // Fallback : un contributeur pilote de la fiche parente peut supprimer
+    // ses sous-actions, par symétrie avec `canWriteFiche`.
+    if (fiche.parentId) {
+      const userPermissionsResult =
+        await this.getUserPermissionsService.getUserRolesAndPermissions({
+          userId: user.id,
+        });
+      if (userPermissionsResult.success) {
+        const userPermissions = userPermissionsResult.data;
+        if (
+          hasPermission(userPermissions, 'plans.fiches.update_piloted_by_me', {
+            collectiviteId: fiche.collectiviteId,
+          })
+        ) {
+          const parentPiloteUserIds = await this.getPiloteUserIdsForFiche(
+            fiche.parentId
+          );
+          if (parentPiloteUserIds.includes(user.id)) {
+            return true;
+          }
+        }
+      }
+    }
+
+    // Ni permission directe, ni fallback parent-pilote : on redonne la main
+    // à `permissionService.isAllowed` avec le `doNotThrow` d'origine pour
+    // conserver le message d'erreur habituel.
+    return this.permissionService.isAllowed(
       user,
       operation,
       ResourceType.COLLECTIVITE,
@@ -273,6 +313,16 @@ export default class FicheActionPermissionsService {
       const piloteUserIds = await this.getPiloteUserIdsForFiche(ficheId, tx);
       if (piloteUserIds.includes(user.id)) {
         return FicheAccessModeEnum.DIRECT;
+      }
+      // Un pilote de la fiche parente peut modifier ses sous-actions.
+      if (fiche.parentId) {
+        const parentPiloteUserIds = await this.getPiloteUserIdsForFiche(
+          fiche.parentId,
+          tx
+        );
+        if (parentPiloteUserIds.includes(user.id)) {
+          return FicheAccessModeEnum.DIRECT;
+        }
       }
     }
 

--- a/apps/backend/src/plans/fiches/update-fiche/update-fiche.router.e2e-spec.ts
+++ b/apps/backend/src/plans/fiches/update-fiche/update-fiche.router.e2e-spec.ts
@@ -13,7 +13,7 @@ import { addTestUser } from '@tet/backend/users/users/users.test-fixture';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { CibleEnum, PiliersEciEnum, StatutEnum } from '@tet/domain/plans';
 import { CollectiviteRole } from '@tet/domain/users';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { describe, expect, onTestFinished } from 'vitest';
 import {
   actionsFixture,
@@ -891,6 +891,62 @@ describe('UpdateFicheService', () => {
         ficheId: ficheId,
         ficheFields: { pilotes: [] },
       });
+    });
+
+    test('Contributeur pilote of a parent fiche can update its sous-action', async () => {
+      const { user, cleanup } = await addTestUser(db, {
+        collectiviteId: collectiviteId,
+        role: CollectiviteRole.EDITION_FICHES_INDICATEURS,
+      });
+
+      const adminCaller = fichesRouter.createCaller({ user: yoloDodo });
+
+      // Ajoute le contributeur comme pilote de la fiche parente
+      await db.db.insert(ficheActionPiloteTable).values({
+        ficheId: ficheId,
+        userId: user.id,
+      });
+
+      // Crée une sous-action rattachée à la fiche parente
+      const sousAction = await adminCaller.create({
+        fiche: {
+          titre: 'Sous-action à modifier',
+          collectiviteId,
+          parentId: ficheId,
+        },
+      });
+      const sousActionId = sousAction.id;
+      expect(sousActionId).toBeDefined();
+
+      onTestFinished(async () => {
+        await db.db
+          .delete(ficheActionTable)
+          .where(eq(ficheActionTable.id, sousActionId));
+        await db.db
+          .delete(ficheActionPiloteTable)
+          .where(
+            and(
+              eq(ficheActionPiloteTable.ficheId, ficheId),
+              eq(ficheActionPiloteTable.userId, user.id)
+            )
+          );
+        await cleanup();
+      });
+
+      const contributeurUser = getAuthUserFromUserCredentials(user);
+      const contributeurCaller = fichesRouter.createCaller({
+        user: contributeurUser,
+      });
+
+      // Le contributeur n'est pas pilote de la sous-action elle-même,
+      // mais doit pouvoir la modifier car il pilote la fiche parente.
+      await contributeurCaller.update({
+        ficheId: sousActionId,
+        ficheFields: { titre: 'Sous-action modifiée par pilote parent' },
+      });
+
+      const fiche = await contributeurCaller.get({ id: sousActionId });
+      expect(fiche.titre).toBe('Sous-action modifiée par pilote parent');
     });
   });
 

--- a/e2e/tests/plans/fiches/show-fiche/contributeur.spec.ts
+++ b/e2e/tests/plans/fiches/show-fiche/contributeur.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from '@playwright/test';
 import { testWithFiches } from 'tests/plans/fiches/fiches.fixture';
+import { SousActionsPom } from './sous-actions.pom';
 
 const test = testWithFiches;
 
@@ -219,5 +220,239 @@ test.describe('Contributeur — restrictions sur la fiche action', () => {
     await expect(
       page.getByRole('checkbox', { name: 'Détailler par année' }).first()
     ).toBeVisible();
+  });
+
+  test('un contributeur pilote peut ajouter une sous-action à une fiche dont il est pilote', async ({
+    page,
+    collectivites,
+    fiches,
+  }) => {
+    const { collectivite, user: adminUser } =
+      await collectivites.addCollectiviteAndUser({
+        userArgs: { role: 'admin', autoLogin: true },
+      });
+
+    const [ficheId] = await fiches.create(adminUser, [
+      {
+        titre: 'Fiche parente pilotée par le contributeur',
+        collectiviteId: collectivite.data.id,
+        statut: 'En cours',
+      },
+    ]);
+
+    const contributeur = await collectivite.addUser({
+      role: 'edition_fiches_indicateurs',
+    });
+
+    await fiches.bulkEdit(adminUser, {
+      collectiviteId: collectivite.data.id,
+      ficheIds: [ficheId],
+      pilotes: {
+        add: [{ userId: contributeur.data.id }],
+      },
+    });
+
+    await contributeur.login();
+
+    const sousActionsPom = new SousActionsPom(page);
+    await sousActionsPom.goto(collectivite.data.id, ficheId);
+
+    // État initial : aucune sous-action, bouton d'ajout visible dans la carte vide
+    await expect(sousActionsPom.emptyStateHeading).toBeVisible();
+    await expect(sousActionsPom.addSousActionButton).toBeVisible();
+
+    await sousActionsPom.clickAddSousAction();
+
+    // Après création, une sous-action « Sans titre » apparaît et la carte vide disparaît
+    await expect(sousActionsPom.emptyStateHeading).toBeHidden();
+    await expect(
+      page.getByRole('row').filter({ hasText: 'Sans titre' })
+    ).toHaveCount(1);
+  });
+
+  test("un contributeur non pilote ne voit pas le bouton d'ajout de sous-action", async ({
+    page,
+    collectivites,
+    fiches,
+  }) => {
+    const { collectivite, user: adminUser } =
+      await collectivites.addCollectiviteAndUser({
+        userArgs: { role: 'admin', autoLogin: true },
+      });
+
+    const [ficheId] = await fiches.create(adminUser, [
+      {
+        titre: 'Fiche non pilotée par le contributeur',
+        collectiviteId: collectivite.data.id,
+        statut: 'En cours',
+      },
+    ]);
+
+    const contributeur = await collectivite.addUser({
+      role: 'edition_fiches_indicateurs',
+    });
+    await contributeur.login();
+
+    const sousActionsPom = new SousActionsPom(page);
+    await sousActionsPom.goto(collectivite.data.id, ficheId);
+
+    await expect(sousActionsPom.emptyStateHeading).toBeVisible();
+    await expect(sousActionsPom.addSousActionButton).toHaveCount(0);
+  });
+
+  test('un contributeur pilote peut modifier le titre d’une sous-action', async ({
+    page,
+    collectivites,
+    fiches,
+  }) => {
+    const { collectivite, user: adminUser } =
+      await collectivites.addCollectiviteAndUser({
+        userArgs: { role: 'admin', autoLogin: true },
+      });
+
+    const [ficheId] = await fiches.create(adminUser, [
+      {
+        titre: 'Fiche parente avec sous-action',
+        collectiviteId: collectivite.data.id,
+        statut: 'En cours',
+      },
+    ]);
+
+    const titreInitial = 'Sous-action à modifier';
+    await fiches.create(adminUser, [
+      {
+        titre: titreInitial,
+        collectiviteId: collectivite.data.id,
+        parentId: ficheId,
+      },
+    ]);
+
+    const contributeur = await collectivite.addUser({
+      role: 'edition_fiches_indicateurs',
+    });
+
+    await fiches.bulkEdit(adminUser, {
+      collectiviteId: collectivite.data.id,
+      ficheIds: [ficheId],
+      pilotes: {
+        add: [{ userId: contributeur.data.id }],
+      },
+    });
+
+    await contributeur.login();
+
+    const sousActionsPom = new SousActionsPom(page);
+    await sousActionsPom.goto(collectivite.data.id, ficheId);
+
+    await expect(
+      page.getByRole('row').filter({ hasText: titreInitial })
+    ).toHaveCount(1);
+
+    const nouveauTitre = 'Sous-action modifiée par le pilote parent';
+    await sousActionsPom.editTitle(titreInitial, nouveauTitre);
+
+    await expect(
+      page.getByRole('row').filter({ hasText: nouveauTitre })
+    ).toHaveCount(1);
+    await expect(
+      page.getByRole('row').filter({ hasText: titreInitial })
+    ).toHaveCount(0);
+  });
+
+  test('un contributeur pilote peut supprimer une sous-action', async ({
+    page,
+    collectivites,
+    fiches,
+  }) => {
+    const { collectivite, user: adminUser } =
+      await collectivites.addCollectiviteAndUser({
+        userArgs: { role: 'admin', autoLogin: true },
+      });
+
+    const [ficheId] = await fiches.create(adminUser, [
+      {
+        titre: 'Fiche parente avec sous-action à supprimer',
+        collectiviteId: collectivite.data.id,
+        statut: 'En cours',
+      },
+    ]);
+
+    const titreSousAction = 'Sous-action à supprimer';
+    await fiches.create(adminUser, [
+      {
+        titre: titreSousAction,
+        collectiviteId: collectivite.data.id,
+        parentId: ficheId,
+      },
+    ]);
+
+    const contributeur = await collectivite.addUser({
+      role: 'edition_fiches_indicateurs',
+    });
+
+    await fiches.bulkEdit(adminUser, {
+      collectiviteId: collectivite.data.id,
+      ficheIds: [ficheId],
+      pilotes: {
+        add: [{ userId: contributeur.data.id }],
+      },
+    });
+
+    await contributeur.login();
+
+    const sousActionsPom = new SousActionsPom(page);
+    await sousActionsPom.goto(collectivite.data.id, ficheId);
+
+    await expect(
+      page.getByRole('row').filter({ hasText: titreSousAction })
+    ).toHaveCount(1);
+
+    await sousActionsPom.deleteSousAction(titreSousAction);
+
+    await expect(
+      page.getByRole('row').filter({ hasText: titreSousAction })
+    ).toHaveCount(0);
+    await expect(sousActionsPom.emptyStateHeading).toBeVisible();
+  });
+
+  test("un contributeur non pilote ne voit pas le bouton de suppression d'une sous-action", async ({
+    page,
+    collectivites,
+    fiches,
+  }) => {
+    const { collectivite, user: adminUser } =
+      await collectivites.addCollectiviteAndUser({
+        userArgs: { role: 'admin', autoLogin: true },
+      });
+
+    const [ficheId] = await fiches.create(adminUser, [
+      {
+        titre: 'Fiche non pilotée par le contributeur (delete)',
+        collectiviteId: collectivite.data.id,
+        statut: 'En cours',
+      },
+    ]);
+
+    const titreSousAction = 'Sous-action non supprimable par contributeur';
+    await fiches.create(adminUser, [
+      {
+        titre: titreSousAction,
+        collectiviteId: collectivite.data.id,
+        parentId: ficheId,
+      },
+    ]);
+
+    const contributeur = await collectivite.addUser({
+      role: 'edition_fiches_indicateurs',
+    });
+    await contributeur.login();
+
+    const sousActionsPom = new SousActionsPom(page);
+    await sousActionsPom.goto(collectivite.data.id, ficheId);
+
+    await expect(
+      page.getByRole('row').filter({ hasText: titreSousAction })
+    ).toHaveCount(1);
+    await expect(sousActionsPom.deleteButton(titreSousAction)).toHaveCount(0);
   });
 });

--- a/e2e/tests/plans/fiches/show-fiche/sous-actions.pom.ts
+++ b/e2e/tests/plans/fiches/show-fiche/sous-actions.pom.ts
@@ -1,0 +1,75 @@
+import { expect, Locator, Page } from '@playwright/test';
+
+export class SousActionsPom {
+  readonly page: Page;
+  readonly sousActionsTab: Locator;
+  readonly addSousActionButton: Locator;
+  readonly titleTextarea: Locator;
+  readonly emptyStateHeading: Locator;
+  readonly confirmDeleteButton: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.sousActionsTab = page.getByRole('tab', { name: /Sous-actions/ });
+    this.addSousActionButton = page.getByRole('button', {
+      name: /Ajouter une sous-action/,
+    });
+    this.titleTextarea = page.getByPlaceholder('Saisir un titre');
+    this.emptyStateHeading = page.getByRole('heading', {
+      name: /Aucune sous-action/,
+    });
+    this.confirmDeleteButton = page
+      .getByRole('dialog', { name: /Supprimer la sous-action/ })
+      .getByRole('button', { name: 'Valider' });
+  }
+
+  /**
+   * Cible le bouton poubelle (colonne « actions ») de la ligne correspondant
+   * à la sous-action identifiée par son titre. On vise l'attribut `title`
+   * car c'est un bouton icône, non identifiable par son nom accessible.
+   */
+  deleteButton(currentTitle: string): Locator {
+    return this.page
+      .getByRole('row')
+      .filter({ hasText: currentTitle })
+      .getByTitle('Supprimer la sous-action');
+  }
+
+  async deleteSousAction(currentTitle: string) {
+    await this.deleteButton(currentTitle).click();
+    await expect(this.confirmDeleteButton).toBeVisible();
+    await this.confirmDeleteButton.click();
+    await expect(this.confirmDeleteButton).toBeHidden();
+  }
+
+  async goto(collectiviteId: number, ficheId: number) {
+    await this.page.goto(
+      `/collectivite/${collectiviteId}/actions/${ficheId}/sous-actions`
+    );
+  }
+
+  async clickAddSousAction() {
+    await this.addSousActionButton.click();
+  }
+
+  /**
+   * Cible la cellule titre (première colonne) d'une sous-action via le texte
+   * actuellement affiché.
+   */
+  titleCell(currentTitle: string): Locator {
+    return this.page
+      .getByRole('row')
+      .filter({ hasText: currentTitle })
+      .getByRole('cell')
+      .first();
+  }
+
+  async editTitle(currentTitle: string, newTitle: string) {
+    await this.titleCell(currentTitle).click();
+    await expect(this.titleTextarea).toBeVisible();
+    await this.titleTextarea.fill(newTitle);
+    // `Enter` ferme l'édition et déclenche la sauvegarde
+    await this.titleTextarea.press('Enter');
+    await expect(this.titleTextarea).toBeHidden();
+  }
+}


### PR DESCRIPTION
… sous-action

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notes de version

* **New Features**
  * Les responsables des actions parent peuvent désormais créer et modifier les sous-actions directement, sans avoir besoin de permissions globales de création ou modification au niveau de la collectivité.
  * Le système respecte maintenant le statut lecture seule de l'action parent, empêchant les modifications de sous-actions lorsque l'action parent est verrouillée.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->