### PR TITLE
Supprimer la prop titleClassname de Field

### DIFF
--- a/apps/app/src/collectivites/personnalisations/filters/personnalisation-filters.menu.tsx
+++ b/apps/app/src/collectivites/personnalisations/filters/personnalisation-filters.menu.tsx
@@ -29,7 +29,7 @@ export function PersonnalisationFiltersMenu() {
         startContent: (
           <div className="flex flex-col gap-4 p-2 text-sm">
             {enabledReferentielsCount > 1 && (
-              <Field title="Référentiels" titleClassName="text-primary-9">
+              <Field title="Référentiels">
                 <ReferentielsDropdown
                   values={filters.referentielIds}
                   onChange={(selectedReferentielIds) =>
@@ -38,7 +38,7 @@ export function PersonnalisationFiltersMenu() {
                 />
               </Field>
             )}
-            <Field title="Thématiques" titleClassName="text-primary-9">
+            <Field title="Thématiques">
               <PersonnalisationThematiquesDropdown
                 collectiviteId={collectiviteId}
                 values={filters.thematiqueIds}

--- a/packages/ui/src/design-system/Field/Field.tsx
+++ b/packages/ui/src/design-system/Field/Field.tsx
@@ -18,8 +18,6 @@ export type FieldProps = {
   children: React.ReactNode;
   /** Pour surcharger les styles du container */
   className?: string;
-  /** Pour surcharger les styles du titre */
-  titleClassName?: string;
   /** Complément d'informations */
   hint?: string;
   /** Pour lier le libellé et le champ qu'il contient */
@@ -33,7 +31,6 @@ export const Field = ({
   fieldId,
   title,
   className,
-  titleClassName,
   hint,
   htmlFor,
   state = 'default',
@@ -58,14 +55,10 @@ export const Field = ({
           {/** Title */}
           {title !== undefined && (
             <div
-              className={cn(
-                'text-primary-9',
-                {
-                  'text-grey-5': state === 'disabled',
-                  'text-sm': small,
-                },
-                titleClassName
-              )}
+              className={cn('text-primary-9', {
+                'text-grey-5': state === 'disabled',
+                'text-sm': small,
+              })}
             >
               {title}
             </div>


### PR DESCRIPTION
Supprimer la prop titleClassname de Field ajoutée récemment car Field a été update avec la bonne couleur de label

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Les titres de champs affichent désormais une présentation standardisée. La structure des champs de formulaire a été simplifiée avec une gestion unifiée des styles pour tous les états et tailles, assurant une apparence cohérente sans options de personnalisation individuelles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->