### PR TITLE
Ajout d'index sur les tables d'historique

### DIFF
--- a/apps/backend/src/plans/fiches/list-fiches/list-fiches-budget.repository.ts
+++ b/apps/backend/src/plans/fiches/list-fiches/list-fiches-budget.repository.ts
@@ -34,6 +34,10 @@ export class ListFichesBudgetRepository {
 
     const ficheIds = ficheIdsRows.map((row) => row.ficheId);
 
+    if (ficheIds.length === 0) {
+      return [];
+    }
+
     const ficheBudgetsQuery = this.listFicheBudgetsByFicheId({ ficheIds }, { tx });
 
     const query = (tx ?? this.databaseService.db)

--- a/apps/backend/src/plans/fiches/list-fiches/list-fiches.service.ts
+++ b/apps/backend/src/plans/fiches/list-fiches/list-fiches.service.ts
@@ -972,6 +972,10 @@ export default class ListFichesService {
     const ficheIds = ficheIdQueryResult.map((fiche) => fiche.id);
     const count = ficheIdQueryResult[0]?.count ?? 0;
 
+    if (ficheIds.length === 0) {
+      return { data: [], count };
+    }
+
     const ficheActionPartenaireTags = this.getFicheActionPartenaireTagsQuery(
       ficheIds,
       tx

--- a/data_layer/sqitch/deploy/historique/fiche_action_indexes.sql
+++ b/data_layer/sqitch/deploy/historique/fiche_action_indexes.sql
@@ -1,0 +1,18 @@
+-- Deploy tet:historique/fiche_action_indexes to pg
+-- requires: plan_action/historique
+
+-- Pas de BEGIN/COMMIT ici : `CREATE INDEX CONCURRENTLY` ne peut pas tourner
+-- dans un bloc transactionnel. Sqitch sur PostgreSQL n'enveloppe pas le
+-- script en transaction par défaut, chaque statement est donc en autocommit.
+--
+-- Le trigger save_history sur public.fiche_action lit historique.fiche_action
+-- (par fiche_id + modified_at) et historique.fiche_action_pilote (par
+-- fiche_historise_id) à chaque INSERT/UPDATE/DELETE. Sans ces index, chaque
+-- save fait des seq scans complets sur les deux tables, ce qui dégrade les
+-- saves de fiches au fur et à mesure que l'historique grossit.
+
+create index concurrently if not exists fiche_action_fiche_id_modified_at_idx
+  on historique.fiche_action (fiche_id, modified_at desc);
+
+create index concurrently if not exists fiche_action_pilote_fiche_historise_id_idx
+  on historique.fiche_action_pilote (fiche_historise_id);

--- a/data_layer/sqitch/revert/historique/fiche_action_indexes.sql
+++ b/data_layer/sqitch/revert/historique/fiche_action_indexes.sql
@@ -1,0 +1,7 @@
+-- Revert tet:historique/fiche_action_indexes from pg
+
+-- Pas de BEGIN/COMMIT : `DROP INDEX CONCURRENTLY` ne peut pas tourner dans
+-- un bloc transactionnel, comme son pendant CREATE.
+
+drop index concurrently if exists historique.fiche_action_pilote_fiche_historise_id_idx;
+drop index concurrently if exists historique.fiche_action_fiche_id_modified_at_idx;

--- a/data_layer/sqitch/sqitch.plan
+++ b/data_layer/sqitch/sqitch.plan
@@ -972,3 +972,4 @@ utilisateur/drop_claim_collectivite 2026-04-27T09:50:00Z Frederic Arnoux <freder
 
 plan_action/ajout_created_columns_tags 2026-03-06T00:00:00Z Frederic Arnoux <frederic.arnoux@beta.gouv.fr> # Ajoute les colonnes created_at/created_by aux tables de tags
 plan_action/drop_private_plan_action_functions 2026-03-09T00:00:00Z Frederic Arnoux <frederic.arnoux@beta.gouv.fr> # Supprime les fonctions privées ajouter_* du plan d'action
+historique/fiche_action_indexes [plan_action/historique] 2026-04-29T07:46:13Z Gaël Servaud <gaelservaud@Host-001.lan> # Ajoute des index sur historique.fiche_action et historique.fiche_action_pilote pour eviter les seq scans declenches par le trigger save_history sur fiche_action

--- a/data_layer/sqitch/verify/historique/fiche_action_indexes.sql
+++ b/data_layer/sqitch/verify/historique/fiche_action_indexes.sql
@@ -1,0 +1,15 @@
+-- Verify tet:historique/fiche_action_indexes on pg
+
+BEGIN;
+
+select 1 / count(*)
+  from pg_indexes
+ where schemaname = 'historique'
+   and indexname = 'fiche_action_fiche_id_modified_at_idx';
+
+select 1 / count(*)
+  from pg_indexes
+ where schemaname = 'historique'
+   and indexname = 'fiche_action_pilote_fiche_historise_id_idx';
+
+ROLLBACK;


### PR DESCRIPTION
## Contexte

  Les saves de fiches étaient lents en prod (mean 4 sec, max 10 min sur les `update fiche_action`). Le
  trigger `historique.save_fiche_action` faisait des seq scans complets sur `historique.fiche_action` et
  `historique.fiche_action_pilote` à chaque save, faute d'index sur les colonnes filtrées (`fiche_id` et
  `fiche_historise_id`).

  ## Solution

  Ajout de deux index via migration sqitch `historique/fiche_action_indexes` :

  - `historique.fiche_action (fiche_id, modified_at DESC)`
  - `historique.fiche_action_pilote (fiche_historise_id)`

  ## Mesures préprod

  Test de charge : 20 workers × 50 UPDATEs sur la même fiche, soit 1 000 saves concurrents
  | Métrique                          | Avant       | Après       | Gain  |
  | --------------------------------- | ----------- | ----------- | ----- |
  | Wall-clock du run                 | 152 sec     | 2,5 sec     | ÷61   |
  | Throughput                        | 6,6 saves/s | 400 saves/s | ×60   |
  | Mean par UPDATE                   | 2 687 ms    | 13,6 ms     | ÷197  |
  | Seq scans `fiche_action`          | 992         | 0           | –     |
  | Seq scans `fiche_action_pilote`   | 991         | 0           | –     |
  | Lignes lues en seq                | 657 M       | 0           | –     |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Optimisations de Performance**
  * Les listes de fiches et de budgets cessent immédiatement quand aucun identifiant n’est trouvé, retournant un tableau vide tout en conservant le comptage, évitant des requêtes inutiles.
* **Chores**
  * Ajout de migrations pour créer des index non bloquants sur les historiques afin d’accélérer les lectures, avec scripts de vérification.
* **Revert**
  * Ajout d’un script de revert pour supprimer proprement ces index si nécessaire.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->