### PR TITLE
Ajoute le point trpc donnant la liste des fichiers de la collectivités

### DIFF
--- a/apps/app/src/referentiels/preuves/AddPreuveModal/useAddFileToLib.ts
+++ b/apps/app/src/referentiels/preuves/AddPreuveModal/useAddFileToLib.ts
@@ -10,7 +10,7 @@ export const useAddFileToLib = () => {
     trpc.collectivites.documents.create.mutationOptions({
       onSuccess: () => {
         queryClient.invalidateQueries({
-          queryKey: ['bibliotheque_fichier'],
+          queryKey: trpc.collectivites.documents.list.queryKey(),
         });
       },
     })

--- a/apps/app/src/referentiels/preuves/Bibliotheque/types.ts
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/types.ts
@@ -6,18 +6,22 @@ import { TEditState } from './useEditState';
 // un fichier de la bibliothèque
 export type TBibliothequeFichier = {
   id: number;
-  collectivite_id: number;
+  collectiviteId: number;
   hash: string;
   filename: string;
-  bucket_id: string;
-  filesize: number;
-  confidentiel: boolean;
+  bucketId: string;
+  fileId: string;
+  filesize: number | null;
+  confidentiel: boolean | null;
 };
 
-export type TFichier = Pick<
-  TBibliothequeFichier,
-  'bucket_id' | 'filename' | 'filesize' | 'hash' | 'confidentiel'
->;
+export type TFichier = {
+  bucket_id: string;
+  filename: string;
+  filesize: number | null;
+  hash: string;
+  confidentiel: boolean | null;
+};
 
 // champs propres aux fichiers
 export type TPreuveFichierFields = {

--- a/apps/app/src/referentiels/preuves/Bibliotheque/useEditPreuve.ts
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/useEditPreuve.ts
@@ -182,7 +182,7 @@ export const useUpdateBibliothequeFichier = () => {
           trpc,
         });
         queryClient.invalidateQueries({
-          queryKey: ['bibliotheque_fichier'],
+          queryKey: trpc.collectivites.documents.list.queryKey(),
         });
         queryClient.invalidateQueries({
           queryKey: trpc.plans.fiches.ficheAnnexes.pathKey(),

--- a/apps/app/src/referentiels/preuves/Bibliotheque/useFichiers.ts
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/useFichiers.ts
@@ -1,13 +1,10 @@
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
-import { DBClient, useSupabase } from '@tet/api';
+import { getTrpcClient, useTRPC } from '@tet/api';
 import { useCollectiviteId } from '@tet/api/collectivites';
-import { createClientWithoutCookieOptions } from '@tet/api/utils/supabase/browser-client';
-import { TBibliothequeFichier } from './types';
 
 export const NB_ITEMS_PER_PAGE = 5;
 
 export type TFilters = { search: string; page: number };
-type TFetchedData = { items: TBibliothequeFichier[]; total: number };
 
 /**
  * Donne la liste de tous les fichiers de la collectivité, éventuellement
@@ -15,44 +12,28 @@ type TFetchedData = { items: TBibliothequeFichier[]; total: number };
  * recherche
  */
 export const useFichiers = (filters: TFilters) => {
-  const collectivite_id = useCollectiviteId();
-  const supabase = useSupabase();
-
-  return useQuery({
-    queryKey: ['bibliotheque_fichier', collectivite_id, filters],
-    queryFn: () =>
-      collectivite_id ? fetch(supabase, collectivite_id, filters) : null,
-    placeholderData: keepPreviousData,
-  });
-};
-
-// charge les données
-const fetch = async (
-  supabase: DBClient,
-  collectivite_id: number,
-  filters: TFilters
-): Promise<TFetchedData> => {
+  const collectiviteId = useCollectiviteId();
+  const trpc = useTRPC();
   const { search, page } = filters;
 
-  // lit la liste des fichiers de la collectivité
-  const query = supabase
-    .from('bibliotheque_fichier')
-    .select('id,filename,filesize,hash,confidentiel', { count: 'exact' })
-    .eq('collectivite_id', collectivite_id)
-    .order('filename', { ascending: true })
-    .range(NB_ITEMS_PER_PAGE * (page - 1), NB_ITEMS_PER_PAGE * page - 1);
-
-  // éventuellement filtrée par nom de fichier
-  if (search) {
-    query.ilike('filename', `%${search}%`);
-  }
-
-  const { data, count, error } = await query;
-  if (error) {
-    throw new Error(error.message);
-  }
-
-  return { items: (data as TBibliothequeFichier[]) || [], total: count || 0 };
+  return useQuery(
+    trpc.collectivites.documents.list.queryOptions(
+      {
+        collectiviteId,
+        filenameContains: search || undefined,
+        page,
+        limit: NB_ITEMS_PER_PAGE,
+      },
+      {
+        enabled: !!collectiviteId,
+        placeholderData: keepPreviousData,
+        select: (data) => ({
+          items: data.data,
+          total: data.count,
+        }),
+      }
+    )
+  );
 };
 
 /**
@@ -63,20 +44,16 @@ export const getFilesPerHash = async (
   collectivite_id: number,
   hashes: string[]
 ) => {
-  // TODO: replace with `useSupabase()`
-  const supabase = createClientWithoutCookieOptions();
-
-  const query = supabase
-    .from('bibliotheque_fichier')
-    .select('id,filename,filesize,hash')
-    .eq('collectivite_id', collectivite_id)
-    .in('hash', hashes);
-
-  const { data, error } = await query;
-
-  if (error) {
-    return null;
+  if (!hashes.length) {
+    return [];
   }
 
-  return (data as TBibliothequeFichier[]) || null;
+  const trpcClient = getTrpcClient();
+  const data = await trpcClient.collectivites.documents.list.query({
+    collectiviteId: collectivite_id,
+    hashes,
+    page: 1,
+    limit: hashes.length,
+  });
+  return data.data;
 };

--- a/apps/app/src/referentiels/preuves/Bibliotheque/utils.ts
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/utils.ts
@@ -6,9 +6,8 @@ export const getFormattedTitle = (preuve: TPreuve) => {
   const { fichier, lien } = preuve;
   if (fichier) {
     const { filename, filesize } = fichier;
-    return `${filename} (${getExtension(
-      filename
-    )?.toUpperCase()}, ${formatFileSize(filesize)})`;
+    const sizeLabel = filesize != null ? `, ${formatFileSize(filesize)}` : '';
+    return `${filename} (${getExtension(filename)?.toUpperCase()}${sizeLabel})`;
   }
   if (lien) return lien.titre;
   return null;

--- a/apps/backend/src/collectivites/collectivites.module.ts
+++ b/apps/backend/src/collectivites/collectivites.module.ts
@@ -8,6 +8,8 @@ import { DocumentController } from '@tet/backend/collectivites/documents/documen
 import { EditPreuveDocumentRepository } from '@tet/backend/collectivites/documents/edit-preuve-document/edit-preuve-document.repository';
 import { EditPreuveDocumentRouter } from '@tet/backend/collectivites/documents/edit-preuve-document/edit-preuve-document.router';
 import { EditPreuveDocumentService } from '@tet/backend/collectivites/documents/edit-preuve-document/edit-preuve-document.service';
+import { ListDocumentsRouter } from '@tet/backend/collectivites/documents/list-documents/list-documents.router';
+import { ListDocumentsService } from '@tet/backend/collectivites/documents/list-documents/list-documents.service';
 import { StoreDocumentRouter } from '@tet/backend/collectivites/documents/store-document/store-document.router';
 import { StoreDocumentService } from '@tet/backend/collectivites/documents/store-document/store-document.service';
 import { UpdateDocumentRouter } from '@tet/backend/collectivites/documents/update-document/update-document.router';
@@ -82,6 +84,8 @@ import { TableauDeBordModule } from './tableau-de-bord/tableau-de-bord.module';
     EditPreuveDocumentRepository,
     EditPreuveDocumentService,
     EditPreuveDocumentRouter,
+    ListDocumentsService,
+    ListDocumentsRouter,
     DocumentsRouter,
     DocumentService,
     PersonneTagService,
@@ -131,6 +135,8 @@ import { TableauDeBordModule } from './tableau-de-bord/tableau-de-bord.module';
     StoreDocumentRouter,
     UpdateDocumentService,
     UpdateDocumentRouter,
+    ListDocumentsService,
+    ListDocumentsRouter,
     DocumentService,
     DocumentsRouter,
     ListCollectivitesService,

--- a/apps/backend/src/collectivites/documents/document.service.ts
+++ b/apps/backend/src/collectivites/documents/document.service.ts
@@ -79,16 +79,20 @@ export default class DocumentService {
         bucketId: collectiviteBucketTable.bucketId,
       })
       .from(bibliothequeFichierTable)
-      .leftJoin(
+      .innerJoin(
         collectiviteBucketTable,
-        eq(collectiviteBucketTable.collectiviteId, collectiviteId)
+        eq(
+          collectiviteBucketTable.collectiviteId,
+          bibliothequeFichierTable.collectiviteId
+        )
       )
       .where(
         and(
           eq(bibliothequeFichierTable.collectiviteId, collectiviteId),
           eq(bibliothequeFichierTable.hash, hashId)
         )
-      );
+      )
+      .limit(1);
     if (!fichier.length) {
       throw new NotFoundException(
         `Document non trouvé pour la collectivité ${collectiviteId} et le hash ${hashId}`
@@ -105,7 +109,7 @@ export default class DocumentService {
       collectiviteId
     );
 
-    const bucketId = document.bucketId || '';
+    const bucketId = document.bucketId;
     this.logger.log(`Downloading file ${hashId} from bucket ${bucketId}`);
 
     const { data, error } = await this.supabaseService.client.storage

--- a/apps/backend/src/collectivites/documents/documents.router.ts
+++ b/apps/backend/src/collectivites/documents/documents.router.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { TrpcService } from '@tet/backend/utils/trpc/trpc.service';
 import { EditPreuveDocumentRouter } from './edit-preuve-document/edit-preuve-document.router';
+import { ListDocumentsRouter } from './list-documents/list-documents.router';
 import { StoreDocumentRouter } from './store-document/store-document.router';
 import { UpdateDocumentRouter } from './update-document/update-document.router';
 
@@ -10,13 +11,15 @@ export class DocumentsRouter {
     private readonly trpc: TrpcService,
     private readonly storeDocumentRouter: StoreDocumentRouter,
     private readonly updateDocumentRouter: UpdateDocumentRouter,
-    private readonly editPreuveDocumentRouter: EditPreuveDocumentRouter
+    private readonly editPreuveDocumentRouter: EditPreuveDocumentRouter,
+    private readonly listDocumentsRouter: ListDocumentsRouter
   ) {}
 
   router = this.trpc.mergeRouters(
     this.storeDocumentRouter.router,
     this.updateDocumentRouter.router,
-    this.editPreuveDocumentRouter.router
+    this.editPreuveDocumentRouter.router,
+    this.listDocumentsRouter.router
   );
 
   createCaller = this.trpc.createCallerFactory(this.router);

--- a/apps/backend/src/collectivites/documents/documents.test-fixture.ts
+++ b/apps/backend/src/collectivites/documents/documents.test-fixture.ts
@@ -29,10 +29,15 @@ export async function uploadCreateTestDocument({
   const testPdfBuffer = fs.readFileSync(
     path.join(PDF_SAMPLES_DIR, sampleFileName)
   );
+  // ajoute un suffixe unique pour éviter les collisions de hash (contrainte unique collectiviteId+hash)
+  const uniqueSuffix = Buffer.from(
+    `${fileName}-${Date.now()}-${Math.random()}`
+  );
+  const uniqueBuffer = Buffer.concat([testPdfBuffer, uniqueSuffix]);
   const response = await testAgent
     .post(`/collectivites/${collectiviteId}/documents/upload`)
     .set('Authorization', `Bearer ${token}`)
-    .attach('file', testPdfBuffer, fileName)
+    .attach('file', uniqueBuffer, fileName)
     .field('confidentiel', JSON.stringify(confidentiel))
     .expect(201);
   const createdDocument: BibliothequeFichier = response.body;

--- a/apps/backend/src/collectivites/documents/list-documents/list-documents.input.ts
+++ b/apps/backend/src/collectivites/documents/list-documents/list-documents.input.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+export const listDocumentsInputSchema = z.object({
+  collectiviteId: z.number().int().positive(),
+  filenameContains: z.string().trim().optional(),
+  hashes: z.array(z.string()).max(100).optional(),
+  page: z.number().int().positive().default(1),
+  limit: z.number().int().positive().max(100).default(100),
+});
+
+export type ListDocumentsInput = z.infer<typeof listDocumentsInputSchema>;

--- a/apps/backend/src/collectivites/documents/list-documents/list-documents.output.ts
+++ b/apps/backend/src/collectivites/documents/list-documents/list-documents.output.ts
@@ -1,0 +1,22 @@
+import { bibliothequeFichierSchema } from '@tet/domain/collectivites';
+import { z } from 'zod';
+
+export const listDocumentsOutputItemSchema = bibliothequeFichierSchema.extend({
+  bucketId: z.string().uuid(),
+  fileId: z.string().uuid(),
+  filesize: z.number().int().nullable(),
+});
+
+export type ListDocumentsOutputItem = z.infer<
+  typeof listDocumentsOutputItemSchema
+>;
+
+export const listDocumentsOutputSchema = z.object({
+  count: z.number().int(),
+  pageCount: z.number().int(),
+  pageSize: z.number().int(),
+  page: z.number().int(),
+  data: listDocumentsOutputItemSchema.array(),
+});
+
+export type ListDocumentsOutput = z.infer<typeof listDocumentsOutputSchema>;

--- a/apps/backend/src/collectivites/documents/list-documents/list-documents.router.e2e-spec.ts
+++ b/apps/backend/src/collectivites/documents/list-documents/list-documents.router.e2e-spec.ts
@@ -1,0 +1,268 @@
+import { INestApplication } from '@nestjs/common';
+import { addTestCollectiviteAndUsers } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import {
+  deleteAllDocuments,
+  uploadCreateTestDocument,
+} from '@tet/backend/collectivites/documents/documents.test-fixture';
+import { getAuthUserFromUserCredentials, signInWith } from '@tet/backend/test';
+import { addTestUser } from '@tet/backend/users/users/users.test-fixture';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
+import { Collectivite } from '@tet/domain/collectivites';
+import { CollectiviteRole } from '@tet/domain/users';
+import request from 'supertest';
+import {
+  getTestApp,
+  getTestDatabase,
+  getTestRouter,
+} from '../../../../test/app-utils';
+
+describe('ListDocumentsRouter', () => {
+  let app: INestApplication;
+  let router: TrpcRouter;
+  let databaseService: DatabaseService;
+  let collectivite: Collectivite;
+  let adminToken: string;
+  let editorCaller: ReturnType<TrpcRouter['createCaller']>;
+  let lectureCaller: ReturnType<TrpcRouter['createCaller']>;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    router = await getTestRouter(app);
+    databaseService = await getTestDatabase(app);
+
+    const { collectivite: col, users } = await addTestCollectiviteAndUsers(
+      databaseService,
+      {
+        users: [
+          { role: CollectiviteRole.EDITION },
+          { role: CollectiviteRole.LECTURE },
+        ],
+      }
+    );
+
+    collectivite = col;
+    editorCaller = router.createCaller({
+      user: getAuthUserFromUserCredentials(users[0]),
+    });
+    lectureCaller = router.createCaller({
+      user: getAuthUserFromUserCredentials(users[1]),
+    });
+
+    const adminSignIn = await signInWith({
+      email: users[0].email,
+      password: users[0].password,
+    });
+    adminToken = adminSignIn.data.session?.access_token ?? '';
+    if (!adminToken) {
+      throw new Error('Échec login editor: token manquant');
+    }
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+
+  beforeEach(async () => {
+    await deleteAllDocuments({
+      databaseService,
+      collectiviteId: collectivite.id,
+    });
+  });
+
+  test('collectivité vide : retourne un tableau vide', async () => {
+    const result = await editorCaller.collectivites.documents.list({
+      collectiviteId: collectivite.id,
+    });
+
+    expect(result).toEqual({
+      data: [],
+      count: 0,
+      page: 1,
+      pageSize: 100,
+      pageCount: 0,
+    });
+  });
+
+  test('retourne le document avec tous les champs attendus', async () => {
+    const testAgent = request(app.getHttpServer());
+
+    const doc = await uploadCreateTestDocument({
+      collectiviteId: collectivite.id,
+      testAgent,
+      token: adminToken,
+      fileName: 'rapport.pdf',
+    });
+
+    const result = await editorCaller.collectivites.documents.list({
+      collectiviteId: collectivite.id,
+    });
+
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0]).toMatchObject({
+      id: expect.any(Number),
+      collectiviteId: collectivite.id,
+      hash: doc.hash,
+      filename: 'rapport.pdf',
+      confidentiel: false,
+      bucketId: expect.any(String),
+      fileId: expect.any(String),
+      filesize: expect.any(Number),
+    });
+    expect(result.count).toBe(1);
+  });
+
+  test('filtre par nom de fichier (sans tenir compte des accents)', async () => {
+    const testAgent = request(app.getHttpServer());
+
+    const docAccent = await uploadCreateTestDocument({
+      collectiviteId: collectivite.id,
+      testAgent,
+      token: adminToken,
+      fileName: 'café-etude.pdf',
+    });
+    // update du nom pour les besoins du test, car l'encodage des caractères
+    // lors de l'upload via supertest n'est pas garanti
+    await editorCaller.collectivites.documents.update({
+      collectiviteId: collectivite.id,
+      hash: docAccent.hash,
+      filename: 'café-etude.pdf',
+    });
+
+    await uploadCreateTestDocument({
+      collectiviteId: collectivite.id,
+      testAgent,
+      token: adminToken,
+      fileName: 'autre.doc',
+    });
+
+    const avecCafe = await editorCaller.collectivites.documents.list({
+      collectiviteId: collectivite.id,
+      filenameContains: 'cafe',
+    });
+
+    expect(avecCafe.data).toHaveLength(1);
+    expect(avecCafe.data[0].filename).toBe('café-etude.pdf');
+    expect(avecCafe.count).toBe(1);
+
+    const avecEtude = await editorCaller.collectivites.documents.list({
+      collectiviteId: collectivite.id,
+      filenameContains: 'étude',
+    });
+
+    expect(avecEtude.data).toHaveLength(1);
+    expect(avecEtude.data[0].filename).toBe('café-etude.pdf');
+
+    const aucunMatch = await editorCaller.collectivites.documents.list({
+      collectiviteId: collectivite.id,
+      filenameContains: 'absent',
+    });
+
+    expect(aucunMatch.data).toHaveLength(0);
+    expect(aucunMatch.count).toBe(0);
+  });
+
+  test('utilisateur avec le droit read_confidentiel voit le document confidentiel', async () => {
+    const testAgent = request(app.getHttpServer());
+
+    const doc = await uploadCreateTestDocument({
+      collectiviteId: collectivite.id,
+      testAgent,
+      token: adminToken,
+      fileName: 'secret.pdf',
+    });
+
+    await editorCaller.collectivites.documents.update({
+      collectiviteId: collectivite.id,
+      hash: doc.hash,
+      confidentiel: true,
+    });
+
+    const result = await lectureCaller.collectivites.documents.list({
+      collectiviteId: collectivite.id,
+    });
+
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].confidentiel).toBe(true);
+  });
+
+  test('filtre par liste de hashes', async () => {
+    const testAgent = request(app.getHttpServer());
+
+    const doc1 = await uploadCreateTestDocument({
+      collectiviteId: collectivite.id,
+      testAgent,
+      token: adminToken,
+      fileName: 'hash-a.pdf',
+    });
+    const doc2 = await uploadCreateTestDocument({
+      collectiviteId: collectivite.id,
+      testAgent,
+      token: adminToken,
+      fileName: 'hash-b.pdf',
+    });
+    await uploadCreateTestDocument({
+      collectiviteId: collectivite.id,
+      testAgent,
+      token: adminToken,
+      fileName: 'hash-c.pdf',
+    });
+
+    const result = await editorCaller.collectivites.documents.list({
+      collectiviteId: collectivite.id,
+      hashes: [doc1.hash, doc2.hash],
+    });
+
+    expect(result.data).toHaveLength(2);
+    expect(result.count).toBe(2);
+    const returnedHashes = result.data.map((d) => d.hash);
+    expect(returnedHashes).toContain(doc1.hash);
+    expect(returnedHashes).toContain(doc2.hash);
+
+    const aucunMatch = await editorCaller.collectivites.documents.list({
+      collectiviteId: collectivite.id,
+      hashes: ['hash-inexistant'],
+    });
+
+    expect(aucunMatch.data).toHaveLength(0);
+    expect(aucunMatch.count).toBe(0);
+  });
+
+  test('utilisateur vérifié sans rôle dans la collectivité ne voit pas les documents confidentiels mais voit les documents publiques', async () => {
+    const testAgent = request(app.getHttpServer());
+
+    const noAccessUserResult = await addTestUser(databaseService);
+    const noAccessAuthUser = getAuthUserFromUserCredentials(
+      noAccessUserResult.user
+    );
+
+    const docPublic = await uploadCreateTestDocument({
+      collectiviteId: collectivite.id,
+      testAgent,
+      token: adminToken,
+      fileName: 'public.pdf',
+    });
+
+    const docConfidentiel = await uploadCreateTestDocument({
+      collectiviteId: collectivite.id,
+      testAgent,
+      token: adminToken,
+      fileName: 'confidentiel.pdf',
+    });
+
+    await editorCaller.collectivites.documents.update({
+      collectiviteId: collectivite.id,
+      hash: docConfidentiel.hash,
+      confidentiel: true,
+    });
+
+    const noAccessCaller = router.createCaller({ user: noAccessAuthUser });
+    const result = await noAccessCaller.collectivites.documents.list({
+      collectiviteId: collectivite.id,
+    });
+
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].hash).toBe(docPublic.hash);
+    expect(result.data[0].confidentiel).toBe(false);
+  });
+});

--- a/apps/backend/src/collectivites/documents/list-documents/list-documents.router.ts
+++ b/apps/backend/src/collectivites/documents/list-documents/list-documents.router.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { createTrpcErrorHandler } from '@tet/backend/utils/trpc/trpc-error-handler';
+import { TrpcService } from '@tet/backend/utils/trpc/trpc.service';
+import { listDocumentsInputSchema } from './list-documents.input';
+import { listDocumentsOutputSchema } from './list-documents.output';
+import { ListDocumentsService } from './list-documents.service';
+
+@Injectable()
+export class ListDocumentsRouter {
+  constructor(
+    private readonly trpc: TrpcService,
+    private readonly service: ListDocumentsService
+  ) {}
+
+  private readonly getResultDataOrThrowError = createTrpcErrorHandler();
+
+  router = this.trpc.router({
+    list: this.trpc.authedProcedure
+      .input(listDocumentsInputSchema)
+      .output(listDocumentsOutputSchema)
+      .query(async ({ input, ctx }) => {
+        const result = await this.service.listDocuments(input, ctx.user);
+        return this.getResultDataOrThrowError(result);
+      }),
+  });
+}

--- a/apps/backend/src/collectivites/documents/list-documents/list-documents.service.ts
+++ b/apps/backend/src/collectivites/documents/list-documents/list-documents.service.ts
@@ -1,0 +1,129 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { collectiviteBucketTable } from '@tet/backend/collectivites/shared/models/collectivite-bucket.table';
+import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { failure, Result, success } from '@tet/backend/utils/result.type';
+import {
+  CommonError,
+  CommonErrorEnum,
+} from '@tet/backend/utils/trpc/common-errors';
+import { ResourceType } from '@tet/domain/users';
+import { and, asc, eq, inArray, isNull, or, SQL, sql } from 'drizzle-orm';
+import { bibliothequeFichierTable } from '../models/bibliotheque-fichier.table';
+import { storageObjectTable } from '../models/storage-object.table';
+import type { ListDocumentsInput } from './list-documents.input';
+import type { ListDocumentsOutput } from './list-documents.output';
+
+@Injectable()
+export class ListDocumentsService {
+  private readonly logger = new Logger(ListDocumentsService.name);
+
+  constructor(
+    private readonly databaseService: DatabaseService,
+    private readonly permissionService: PermissionService
+  ) {}
+
+  async listDocuments(
+    input: ListDocumentsInput,
+    user: AuthenticatedUser
+  ): Promise<Result<ListDocumentsOutput, CommonError>> {
+    const isAllowed = await this.permissionService.isAllowed(
+      user,
+      'collectivites.documents.read',
+      ResourceType.COLLECTIVITE,
+      input.collectiviteId,
+      true
+    );
+    if (!isAllowed) {
+      return failure(CommonErrorEnum.UNAUTHORIZED);
+    }
+
+    const canReadConfidentiel = await this.permissionService.isAllowed(
+      user,
+      'collectivites.documents.read_confidentiel',
+      ResourceType.COLLECTIVITE,
+      input.collectiviteId,
+      true
+    );
+
+    const conditions: (SQL | undefined)[] = [
+      eq(bibliothequeFichierTable.collectiviteId, input.collectiviteId),
+    ];
+    const filenameContains = input.filenameContains?.trim();
+    if (filenameContains) {
+      conditions.push(
+        sql`unaccent(${
+          bibliothequeFichierTable.filename
+        }) ilike unaccent(${`%${filenameContains}%`})`
+      );
+    }
+    if (input.hashes?.length) {
+      conditions.push(inArray(bibliothequeFichierTable.hash, input.hashes));
+    }
+    if (!canReadConfidentiel) {
+      conditions.push(
+        or(
+          isNull(bibliothequeFichierTable.confidentiel),
+          eq(bibliothequeFichierTable.confidentiel, false)
+        )
+      );
+    }
+
+    try {
+      const qb = this.databaseService.db
+        .select({
+          id: bibliothequeFichierTable.id,
+          collectiviteId: bibliothequeFichierTable.collectiviteId,
+          hash: bibliothequeFichierTable.hash,
+          filename: bibliothequeFichierTable.filename,
+          confidentiel: bibliothequeFichierTable.confidentiel,
+          bucketId: collectiviteBucketTable.bucketId,
+          fileId: storageObjectTable.id,
+          filesize: sql<
+            number | null
+          >`floor((${storageObjectTable.metadata}->>'size')::numeric)::integer`.as(
+            'filesize'
+          ),
+        })
+        .from(bibliothequeFichierTable)
+        .innerJoin(
+          collectiviteBucketTable,
+          eq(
+            collectiviteBucketTable.collectiviteId,
+            bibliothequeFichierTable.collectiviteId
+          )
+        )
+        .innerJoin(
+          storageObjectTable,
+          and(
+            eq(storageObjectTable.name, bibliothequeFichierTable.hash),
+            eq(storageObjectTable.bucketId, collectiviteBucketTable.bucketId)
+          )
+        )
+        .where(and(...conditions))
+        .$dynamic();
+
+      const page = await this.databaseService.withPagination(
+        qb,
+        sql`${asc(bibliothequeFichierTable.filename)}, ${asc(
+          bibliothequeFichierTable.id
+        )}`,
+        input.page,
+        input.limit
+      );
+
+      this.logger.log(
+        `${page.data.length} documents listés pour la collectivité ${input.collectiviteId} (${page.count} au total)`
+      );
+
+      return success(page as ListDocumentsOutput);
+    } catch (error) {
+      this.logger.error(
+        `Erreur lors du chargement des documents pour la collectivité ${input.collectiviteId}`,
+        error
+      );
+      return failure(CommonErrorEnum.DATABASE_ERROR);
+    }
+  }
+}

--- a/data_layer/sqitch/deploy/collectivite/add_constraint_collectivite_bucket.sql
+++ b/data_layer/sqitch/deploy/collectivite/add_constraint_collectivite_bucket.sql
@@ -1,0 +1,21 @@
+-- Deploy tet:collectivite/add_constraint_collectivite_bucket to pg
+
+BEGIN;
+
+DO
+$$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.table_constraints
+        WHERE table_schema = 'public'
+          AND table_name = 'collectivite_bucket'
+          AND constraint_name = 'collectivite_bucket_collectivite_id_key'
+    ) THEN
+        ALTER TABLE public.collectivite_bucket
+            ADD CONSTRAINT collectivite_bucket_collectivite_id_key UNIQUE (collectivite_id);
+    END IF;
+END
+$$;
+
+COMMIT;

--- a/data_layer/sqitch/revert/collectivite/add_constraint_collectivite_bucket.sql
+++ b/data_layer/sqitch/revert/collectivite/add_constraint_collectivite_bucket.sql
@@ -1,0 +1,8 @@
+-- Revert tet:collectivite/add_constraint_collectivite_bucket from pg
+
+BEGIN;
+
+ALTER TABLE public.collectivite_bucket
+    DROP CONSTRAINT IF EXISTS collectivite_bucket_collectivite_id_key;
+
+COMMIT;

--- a/data_layer/sqitch/sqitch.plan
+++ b/data_layer/sqitch/sqitch.plan
@@ -983,3 +983,4 @@ plan_action/drop_plan_action_chemin_view 2026-05-05T08:32:55Z Gaël Servaud <gae
 plan_action/fix_save_fiche_action_modified_by [migrate_calendrier_to_description] 2026-05-06T15:03:56Z Gaël Servaud <gaelservaud@Host-005.lan> # Corrige save_fiche_action() pour historiser le modified_by écrit sur la fiche au lieu de auth.uid()
 
 labellisation/drop_preuve_count 2026-05-12T14:05:12Z Marc Rutkowski <marc@attractive-media.fr> # Supprime la fonction preuve_count remplacée par le point tRPC referentiels.actions.countPreuves
+collectivite/add_constraint_collectivite_bucket 2026-04-30T13:48:56Z Marc Rutkowski <marc@attractive-media.fr> # Ajout d'une contrainte 1-1 entre collectivité et bucket

--- a/data_layer/sqitch/verify/collectivite/add_constraint_collectivite_bucket.sql
+++ b/data_layer/sqitch/verify/collectivite/add_constraint_collectivite_bucket.sql
@@ -1,0 +1,21 @@
+-- Verify tet:collectivite/add_constraint_collectivite_bucket on pg
+
+BEGIN;
+
+DO
+$$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.table_constraints
+        WHERE table_schema = 'public'
+          AND table_name = 'collectivite_bucket'
+          AND constraint_name = 'collectivite_bucket_collectivite_id_key'
+          AND constraint_type = 'UNIQUE'
+    ) THEN
+        RAISE EXCEPTION 'Unique constraint collectivite_bucket_collectivite_id_key does not exist';
+    END IF;
+END
+$$;
+
+ROLLBACK;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Ajout d’un endpoint de listing des documents avec filtre par nom et par hash, pagination et contrôle d’accès sur les documents confidentiels.

* **Améliorations**
  * Invalidation de cache alignée sur le client tRPC et affichage du titre de fichier ajusté quand la taille est absente.
  * Remplacement des requêtes directes par un appel tRPC pour la récupération des fichiers.

* **Tests**
  * Suite e2e couvrant le comportement du listing, filtres et permissions.

* **Chores**
  * Migration ajoutant une contrainte unique entre collectivité et bucket.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->