### PR TITLE
Fix de la gestion du modified_by dans l'historisation des updates de FA

### DIFF
--- a/data_layer/sqitch/deploy/plan_action/fix_save_fiche_action_modified_by.sql
+++ b/data_layer/sqitch/deploy/plan_action/fix_save_fiche_action_modified_by.sql
@@ -1,0 +1,133 @@
+-- Deploy tet:plan_action/fix_save_fiche_action_modified_by to pg
+-- requires: migrate_calendrier_to_description
+
+BEGIN;
+
+-- Corrige la branche INSERT de `historique.save_fiche_action()` qui utilisait
+-- `auth.uid()` au lieu du `modified_by` effectivement écrit sur la fiche.
+-- En pratique, les écritures via le backend tRPC passent par une connexion
+-- service_role : `auth.uid()` y est NULL alors que la colonne `modified_by`
+-- est correctement renseignée par l'application. L'historique perdait donc
+-- l'auteur de la modification au premier changement après >1h de debounce.
+--
+-- On aligne cette branche INSERT sur la branche UPDATE qui, elle, utilise
+-- déjà `new.modified_by` directement : la colonne `public.fiche_action.modified_by`
+-- est l'unique source de vérité de l'auteur, l'historique la reflète.
+--
+-- Corps repris de `migrate_calendrier_to_description.sql` (état courant en
+-- prod), seule la valeur de `modified_by` à l'INSERT change.
+create or replace function historique.save_fiche_action()
+ returns trigger
+ language plpgsql
+ security definer
+as $function$
+declare
+    updated integer;
+    id_fiche integer;
+    previous_fiche integer;
+begin
+    id_fiche = coalesce(new.id, old.id);
+    update historique.fiche_action
+    set
+        titre = new.titre,
+        description = new.description,
+        piliers_eci = new.piliers_eci::text[],
+        objectifs = new.objectifs,
+        resultats_attendus = new.resultats_attendus::text[],
+        cibles = new.cibles::text[],
+        ressources = new.ressources,
+        financements = new.financements,
+        budget_previsionnel = new.budget_previsionnel,
+        statut = new.statut::text,
+        niveau_priorite = new.niveau_priorite::text,
+        date_debut = new.date_debut,
+        date_fin_provisoire = new.date_fin_provisoire,
+        amelioration_continue = new.amelioration_continue,
+        maj_termine = new.maj_termine,
+        modified_at = new.modified_at,
+        modified_by = new.modified_by,
+        restreint = new.restreint,
+        deleted = new is null
+    where id in (select id
+                 from historique.fiche_action
+                 where fiche_id = id_fiche
+                   and modified_at > new.modified_at - interval '1 hour'
+                 order by modified_at desc
+                 limit 1)
+    returning id into updated;
+
+    if updated is null
+    then
+        insert into historique.fiche_action
+        values (default,
+                id_fiche,
+                new.titre,
+                old.titre,
+                new.description,
+                old.description,
+                new.piliers_eci::text[],
+                old.piliers_eci::text[],
+                new.objectifs,
+                old.objectifs,
+                new.resultats_attendus::text[],
+                old.resultats_attendus::text[],
+                new.cibles::text[],
+                old.cibles::text[],
+                new.ressources,
+                old.ressources,
+                new.financements,
+                old.financements,
+                new.budget_previsionnel,
+                old.budget_previsionnel,
+                new.statut::text,
+                old.statut::text,
+                new.niveau_priorite::text,
+                old.niveau_priorite::text,
+                new.date_debut,
+                old.date_debut,
+                new.date_fin_provisoire,
+                old.date_fin_provisoire,
+                new.amelioration_continue,
+                old.amelioration_continue,
+                new.maj_termine,
+                old.maj_termine,
+                new.collectivite_id,
+                new.created_at,
+                new.modified_at,
+                old.modified_at,
+                new.modified_by,
+                old.modified_by,
+                new.restreint,
+                old.restreint,
+                new is null)
+        returning id into updated;
+
+        select id
+        from historique.fiche_action faa
+        where fiche_id = id_fiche
+        and id <> updated
+        order by faa.modified_at desc
+        limit 1 into previous_fiche;
+
+        if previous_fiche is not null then
+            insert into historique.fiche_action_pilote (fiche_historise_id, user_id, tag_nom, previous)
+            select updated, fap.user_id, fap.tag_nom, true
+            from historique.fiche_action_pilote fap
+            where fap.fiche_historise_id = previous_fiche;
+        end if;
+
+    else
+        delete from historique.fiche_action_pilote where fiche_historise_id = updated and previous = false;
+    end if;
+
+    insert into historique.fiche_action_pilote (fiche_historise_id, user_id, tag_nom, previous)
+    select updated, fap.user_id, pt.nom, false
+    from public.fiche_action_pilote fap
+    left join personne_tag pt on fap.tag_id = pt.id
+    where fiche_id = id_fiche;
+
+    return new;
+end ;
+$function$;
+
+COMMIT;

--- a/data_layer/sqitch/revert/plan_action/fix_save_fiche_action_modified_by.sql
+++ b/data_layer/sqitch/revert/plan_action/fix_save_fiche_action_modified_by.sql
@@ -1,0 +1,122 @@
+-- Revert tet:plan_action/fix_save_fiche_action_modified_by from pg
+
+BEGIN;
+
+-- Restaure la version de `historique.save_fiche_action()` issue de
+-- `migrate_calendrier_to_description.sql` (avec le bug `auth.uid()` à la
+-- place de `new.modified_by` dans la branche INSERT).
+create or replace function historique.save_fiche_action()
+ returns trigger
+ language plpgsql
+ security definer
+as $function$
+declare
+    updated integer;
+    id_fiche integer;
+    previous_fiche integer;
+begin
+    id_fiche = coalesce(new.id, old.id);
+    update historique.fiche_action
+    set
+        titre = new.titre,
+        description = new.description,
+        piliers_eci = new.piliers_eci::text[],
+        objectifs = new.objectifs,
+        resultats_attendus = new.resultats_attendus::text[],
+        cibles = new.cibles::text[],
+        ressources = new.ressources,
+        financements = new.financements,
+        budget_previsionnel = new.budget_previsionnel,
+        statut = new.statut::text,
+        niveau_priorite = new.niveau_priorite::text,
+        date_debut = new.date_debut,
+        date_fin_provisoire = new.date_fin_provisoire,
+        amelioration_continue = new.amelioration_continue,
+        maj_termine = new.maj_termine,
+        modified_at = new.modified_at,
+        modified_by = new.modified_by,
+        restreint = new.restreint,
+        deleted = new is null
+    where id in (select id
+                 from historique.fiche_action
+                 where fiche_id = id_fiche
+                   and modified_at > new.modified_at - interval '1 hour'
+                 order by modified_at desc
+                 limit 1)
+    returning id into updated;
+
+    if updated is null
+    then
+        insert into historique.fiche_action
+        values (default,
+                id_fiche,
+                new.titre,
+                old.titre,
+                new.description,
+                old.description,
+                new.piliers_eci::text[],
+                old.piliers_eci::text[],
+                new.objectifs,
+                old.objectifs,
+                new.resultats_attendus::text[],
+                old.resultats_attendus::text[],
+                new.cibles::text[],
+                old.cibles::text[],
+                new.ressources,
+                old.ressources,
+                new.financements,
+                old.financements,
+                new.budget_previsionnel,
+                old.budget_previsionnel,
+                new.statut::text,
+                old.statut::text,
+                new.niveau_priorite::text,
+                old.niveau_priorite::text,
+                new.date_debut,
+                old.date_debut,
+                new.date_fin_provisoire,
+                old.date_fin_provisoire,
+                new.amelioration_continue,
+                old.amelioration_continue,
+                new.maj_termine,
+                old.maj_termine,
+                new.collectivite_id,
+                new.created_at,
+                new.modified_at,
+                old.modified_at,
+                auth.uid(),
+                old.modified_by,
+                new.restreint,
+                old.restreint,
+                new is null)
+        returning id into updated;
+
+        select id
+        from historique.fiche_action faa
+        where fiche_id = id_fiche
+        and id <> updated
+        order by faa.modified_at desc
+        limit 1 into previous_fiche;
+
+        if previous_fiche is not null then
+            insert into historique.fiche_action_pilote (fiche_historise_id, user_id, tag_nom, previous)
+            select updated, fap.user_id, fap.tag_nom, true
+            from historique.fiche_action_pilote fap
+            where fap.fiche_historise_id = previous_fiche;
+        end if;
+
+    else
+        delete from historique.fiche_action_pilote where fiche_historise_id = updated and previous = false;
+    end if;
+
+    insert into historique.fiche_action_pilote (fiche_historise_id, user_id, tag_nom, previous)
+    select updated, fap.user_id, pt.nom, false
+    from public.fiche_action_pilote fap
+    left join personne_tag pt on fap.tag_id = pt.id
+    where fiche_id = id_fiche;
+
+    return new;
+end ;
+$function$;
+
+COMMIT;

--- a/data_layer/sqitch/sqitch.plan
+++ b/data_layer/sqitch/sqitch.plan
@@ -980,3 +980,4 @@ utils/banner_info 2026-04-27T10:00:00Z Thibaut Dusanter <thibaut.dusanter@gmail.
 referentiel/update_te_hierarchie 2026-04-28T00:00:00Z Thibaut Dusanter <thibaut.dusanter@gmail.com> # Met à jour la hiérarchie des référentiels te et te-test pour utiliser tache au lieu d'exemple
 
 plan_action/drop_plan_action_chemin_view 2026-05-05T08:32:55Z Gaël Servaud <gaelservaud@Host-001.lan> # Supprime la vue plan_action_chemin remplacée par une CTE récursive dans le backend
+plan_action/fix_save_fiche_action_modified_by [migrate_calendrier_to_description] 2026-05-06T15:03:56Z Gaël Servaud <gaelservaud@Host-005.lan> # Corrige save_fiche_action() pour historiser le modified_by écrit sur la fiche au lieu de auth.uid()

--- a/data_layer/sqitch/verify/plan_action/fix_save_fiche_action_modified_by.sql
+++ b/data_layer/sqitch/verify/plan_action/fix_save_fiche_action_modified_by.sql
@@ -1,0 +1,23 @@
+-- Verify tet:plan_action/fix_save_fiche_action_modified_by on pg
+
+BEGIN;
+
+select has_function_privilege('historique.save_fiche_action()', 'execute');
+
+-- La branche INSERT doit utiliser `new.modified_by` et plus `auth.uid()`.
+-- On vérifie qu'aucun `auth.uid()` ne subsiste dans le corps de la fonction.
+do $$
+begin
+    if exists (
+        select 1
+        from pg_proc p
+        join pg_namespace n on n.oid = p.pronamespace
+        where n.nspname = 'historique'
+          and p.proname = 'save_fiche_action'
+          and pg_get_functiondef(p.oid) like '%auth.uid()%'
+    ) then
+        raise exception 'historique.save_fiche_action() contient encore auth.uid() — le fix n''a pas été appliqué';
+    end if;
+end$$;
+
+ROLLBACK;

--- a/data_layer/tests/plan_action/fiche_action_historique.sql
+++ b/data_layer/tests/plan_action/fiche_action_historique.sql
@@ -1,0 +1,83 @@
+begin;
+select plan(4);
+
+-- Repro du bug d'historisation de `fiche_action.modified_by`.
+--
+-- Le backend tRPC met à jour les fiches via une connexion service_role :
+-- `auth.uid()` y vaut NULL alors que `modified_by` est explicitement écrit
+-- avec l'id de l'utilisateur applicatif (cf. update-fiche.service.ts).
+--
+-- La fonction `historique.save_fiche_action()` insère `auth.uid()` au lieu
+-- de `new.modified_by` dans la branche INSERT (premier changement après >1h).
+-- Conséquence observée en prod : `public.fiche_action.modified_by` est correct
+-- mais `historique.fiche_action.modified_by` est NULL.
+
+create temp table test_fiche (id integer) on commit drop;
+
+-- On part d'un état d'historique propre pour la fiche testée.
+delete from historique.fiche_action_pilote;
+delete from historique.fiche_action;
+
+-- Cas 1 — INSERT d'une nouvelle fiche par le backend (service_role)
+-- avec un `modified_by` explicite.
+select test.identify_as_service_role();
+
+with inserted as (
+    insert into fiche_action (titre, collectivite_id, modified_by, modified_at)
+    values ('Fiche test historisation - insert',
+            1,
+            '3f407fc6-3634-45ff-a988-301e9088096a', -- yili@didi.com
+            now())
+    returning id
+)
+insert into test_fiche (id) select id from inserted;
+
+select is(
+    (select modified_by from fiche_action where id = (select id from test_fiche)),
+    '3f407fc6-3634-45ff-a988-301e9088096a'::uuid,
+    'public.fiche_action.modified_by reflète bien l''id écrit par le backend'
+);
+
+select is(
+    (select modified_by
+       from historique.fiche_action
+      where fiche_id = (select id from test_fiche)
+      order by modified_at desc
+      limit 1),
+    '3f407fc6-3634-45ff-a988-301e9088096a'::uuid,
+    'historique.fiche_action.modified_by doit refléter le modified_by écrit '
+    'sur la fiche, pas auth.uid() (cf. save_fiche_action() ligne 152)'
+);
+
+-- Cas 2 — UPDATE après >1h, qui retombe dans la branche INSERT
+-- de `historique.save_fiche_action()` (debounce expiré).
+-- On simule le passage du temps en reculant le `modified_at` de l'historique.
+update historique.fiche_action
+   set modified_at = now() - interval '2 hours'
+ where fiche_id = (select id from test_fiche);
+
+update fiche_action
+   set titre = 'Fiche test historisation - update',
+       modified_by = '17440546-f389-4d4f-bfdb-b0c94a1bd0f9', -- yolo@dodo.com
+       modified_at = now()
+ where id = (select id from test_fiche);
+
+select is(
+    (select modified_by from fiche_action where id = (select id from test_fiche)),
+    '17440546-f389-4d4f-bfdb-b0c94a1bd0f9'::uuid,
+    'public.fiche_action.modified_by est bien mis à jour par l''update backend'
+);
+
+select is(
+    (select modified_by
+       from historique.fiche_action
+      where fiche_id = (select id from test_fiche)
+      order by modified_at desc
+      limit 1),
+    '17440546-f389-4d4f-bfdb-b0c94a1bd0f9'::uuid,
+    'historique.fiche_action.modified_by doit refléter le modified_by de la '
+    'modif courante, même quand on retombe dans la branche INSERT (>1h)'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notes de Version

* **Correctifs de bugs**
  * Correction du suivi de l'historique des modifications apportées aux actions de fiche pour une traçabilité précise et fiable des enregistrements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->