### PR TITLE
Ajoute la page publique matrice d'impact

### DIFF
--- a/apps/site/app/impact/page.tsx
+++ b/apps/site/app/impact/page.tsx
@@ -1,0 +1,32 @@
+import Section from '@/site/components/sections/Section';
+import { Metadata } from 'next';
+import { STREAMLIT_IMPACT_IFRAME_SRC } from './streamlit.utils';
+
+export const metadata: Metadata = {
+  title: 'Matrice d’impact',
+};
+
+export default function MatriceImpactPage() {
+  return (
+    <>
+      <Section containerClassName="bg-primary-1">
+        <h1>Matrice d&apos;impact</h1>
+        <p>
+          Visualisez les chiffres clés de la matrice d&apos;impact du service
+          numérique.
+        </p>
+      </Section>
+      <Section>
+        <div className="w-full h-[4100px]">
+          <iframe
+            title="Matrice d'impact Territoires en Transitions"
+            src={STREAMLIT_IMPACT_IFRAME_SRC}
+            className="w-full h-full border-0"
+            loading="lazy"
+            sandbox="allow-scripts allow-same-origin allow-forms"
+          />
+        </div>
+      </Section>
+    </>
+  );
+}

--- a/apps/site/app/impact/streamlit.utils.ts
+++ b/apps/site/app/impact/streamlit.utils.ts
@@ -1,0 +1,2 @@
+export const STREAMLIT_IMPACT_IFRAME_SRC =
+  'https://statpublicimpact-mzzpl2qqhn4utcnbfhaop6.streamlit.app/matrice_impact?embed=true&embed_options=light_theme';

--- a/apps/site/app/stats/page.tsx
+++ b/apps/site/app/stats/page.tsx
@@ -1,6 +1,6 @@
 import Section from '@/site/components/sections/Section';
 import { Metadata } from 'next';
-import { STREAMLIT_IFRAME_SRC } from './streamlit.utils';
+import { STREAMLIT_STATS_IFRAME_SRC } from './streamlit.utils';
 
 export const metadata: Metadata = {
   title: 'Statistiques publiques',
@@ -20,9 +20,10 @@ export default function StatistiquesPage() {
         <div className="w-full h-[8500px]">
           <iframe
             title="Tableau de bord des statistiques publiques Territoires en Transitions"
-            src={STREAMLIT_IFRAME_SRC}
+            src={STREAMLIT_STATS_IFRAME_SRC}
             className="w-full h-full border-0"
             loading="lazy"
+            sandbox="allow-scripts allow-same-origin allow-forms"
           />
         </div>
       </Section>

--- a/apps/site/app/stats/streamlit.utils.ts
+++ b/apps/site/app/stats/streamlit.utils.ts
@@ -1,2 +1,2 @@
-export const STREAMLIT_IFRAME_SRC =
+export const STREAMLIT_STATS_IFRAME_SRC =
   'https://statpublicimpact-mzzpl2qqhn4utcnbfhaop6.streamlit.app/?embed=true&embed_options=light_theme';

--- a/apps/site/proxy.ts
+++ b/apps/site/proxy.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { STREAMLIT_IFRAME_SRC } from './app/stats/streamlit.utils';
+import { STREAMLIT_IMPACT_IFRAME_SRC } from './app/impact/streamlit.utils';
+import { STREAMLIT_STATS_IFRAME_SRC } from './app/stats/streamlit.utils';
 
 /**
  * Middleware pour ajouter à chaque requête les en-têtes CSP
@@ -73,9 +74,10 @@ export function proxy(request: NextRequest) {
     base-uri 'self';
     form-action 'self';
     frame-ancestors 'none';
-    frame-src youtube.com www.youtube.com dailymotion.com www.dailymotion.com *.adform.net ${
-      googleWithFloodlight.frameSrc
-    } ${new URL(STREAMLIT_IFRAME_SRC).origin};
+    frame-src youtube.com www.youtube.com dailymotion.com www.dailymotion.com *.adform.net
+    ${googleWithFloodlight.frameSrc}
+    ${new URL(STREAMLIT_STATS_IFRAME_SRC).origin}
+    ${new URL(STREAMLIT_IMPACT_IFRAME_SRC).origin};
     block-all-mixed-content;
     upgrade-insecure-requests;
 `;


### PR DESCRIPTION
## Summary
- ajoute une nouvelle route publique `\/impact` sur le site
- reprend le format existant des stats publiques avec une iframe Streamlit plein écran
- configure le titre, le sous-titre et la source Streamlit de la matrice d'impact

## Test plan
- [ ] ouvrir `\/impact` en local et vérifier que la page charge
- [ ] vérifier l'affichage du titre "Matrice d'impact" et du sous-titre
- [ ] vérifier que l'iframe charge `\/matrice_impact` correctement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Nouvelle page « Matrice d'impact » avec titre dédié pour consulter les indicateurs.

* **Améliorations**
  * Intégration d'une visualisation interactive embarquée (iframe) avec chargement lazy pour meilleures performances.
  * Mise à jour de l'intégration des statistiques embarquées pour cohérence d'affichage.
  * Ajustements des conteneurs d'affichage pour améliorer l'expérience visuelle sur différents appareils.

* **Sécurité**
  * Renforcement des règles d'intégration d'iframes et mise à jour des origines autorisées pour les contenus embarqués (vidéo et visualisations).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/incubateur-ademe/territoires-en-transitions/pull/4440)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->