### PR TITLE
Utilise trpc pour supprimer une annexe d'une FA

### DIFF
--- a/apps/app/src/referentiels/preuves/Bibliotheque/useEditPreuve.ts
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/useEditPreuve.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useSupabase, useTRPC } from '@tet/api';
+import { useSupabase, useTRPC, useTRPCClient } from '@tet/api';
 import { invalidateQueries } from '../useAddPreuves';
 import { TEditHandlers, TPreuve } from './types';
 import { useEditFilenameState, useEditState } from './useEditState';
@@ -72,18 +72,27 @@ type PreuveTableName =
   | 'preuve_rapport';
 
 const tableOfType = ({ preuve_type }: Pick<TPreuve, 'preuve_type'>) =>
-  (preuve_type as string) === 'annexe'
+  preuve_type === 'annexe'
     ? 'annexe'
-    : (`preuve_${preuve_type}` as Exclude<PreuveTableName,'annexe'>);
+    : (`preuve_${preuve_type}` as Exclude<PreuveTableName, 'annexe'>);
 
 // renvoie une fonction de suppression d'une preuve
 const useRemovePreuve = () => {
   const supabase = useSupabase();
+  const trpcClient = useTRPCClient();
   const queryClient = useQueryClient();
   const trpc = useTRPC();
   return useMutation({
     mutationFn: async (preuve: TPreuve) => {
       const { id } = preuve;
+      if (preuve.preuve_type === 'annexe') {
+        if (id == null) {
+          throw new Error('annexe sans identifiant');
+        }
+        return trpcClient.plans.fiches.removeAnnexe.mutate({
+          annexeId: id,
+        });
+      }
       return supabase.from(tableOfType(preuve)).delete().match({ id });
     },
 
@@ -91,7 +100,7 @@ const useRemovePreuve = () => {
       invalidateQueries(queryClient, variables.collectivite_id, {
         invalidateParcours: false,
       });
-      if ((variables.preuve_type as string) === 'annexe') {
+      if (variables.preuve_type === 'annexe') {
         queryClient.invalidateQueries({
           queryKey: trpc.plans.fiches.ficheAnnexes.pathKey(),
         });
@@ -137,7 +146,7 @@ export const useUpdatePreuveLien = () => {
       invalidateQueries(queryClient, variables.collectivite_id, {
         invalidateParcours: false,
       });
-      if ((variables.preuve_type as string) === 'annexe') {
+      if (variables.preuve_type === 'annexe') {
         queryClient.invalidateQueries({
           queryKey: trpc.plans.fiches.ficheAnnexes.pathKey(),
         });
@@ -164,7 +173,7 @@ const useUpdatePreuveCommentaire = () => {
       invalidateQueries(queryClient, variables.collectivite_id, {
         invalidateParcours: false,
       });
-      if ((variables.preuve_type as string) === 'annexe') {
+      if (variables.preuve_type === 'annexe') {
         queryClient.invalidateQueries({
           queryKey: trpc.plans.fiches.ficheAnnexes.pathKey(),
         });

--- a/apps/backend/src/plans/fiches/fiches.module.ts
+++ b/apps/backend/src/plans/fiches/fiches.module.ts
@@ -21,6 +21,9 @@ import { PlansUtilsModule } from '../utils/plans-utils.module';
 import { AddAnnexeRepository } from './add-annexe/add-annexe.repository';
 import { AddAnnexeRouter } from './add-annexe/add-annexe.router';
 import { AddAnnexeService } from './add-annexe/add-annexe.service';
+import { RemoveAnnexeRepository } from './remove-annexe/remove-annexe.repository';
+import { RemoveAnnexeRouter } from './remove-annexe/remove-annexe.router';
+import { RemoveAnnexeService } from './remove-annexe/remove-annexe.service';
 import { BulkEditRouter } from './bulk-edit/bulk-edit.router';
 import { BulkEditService } from './bulk-edit/bulk-edit.service';
 import { CountByRouter } from './count-by/count-by.router';
@@ -89,6 +92,9 @@ import UpdateFicheService from './update-fiche/update-fiche.service';
     AddAnnexeRepository,
     AddAnnexeService,
     AddAnnexeRouter,
+    RemoveAnnexeRepository,
+    RemoveAnnexeService,
+    RemoveAnnexeRouter,
     FicheAnnexesRepository,
     FicheAnnexesService,
     FicheAnnexesRouter,
@@ -120,6 +126,7 @@ import UpdateFicheService from './update-fiche/update-fiche.service';
     CreateFicheRouter,
     AddAnnexeService,
     AddAnnexeRouter,
+    RemoveAnnexeRouter,
     FicheAnnexesService,
     FicheAnnexesRouter,
 

--- a/apps/backend/src/plans/fiches/fiches.router.ts
+++ b/apps/backend/src/plans/fiches/fiches.router.ts
@@ -10,6 +10,7 @@ import { FicheActionEtapeRouter } from './fiche-action-etape/fiche-action-etape.
 import { FicheActionPdfExportRouter } from './fiche-action-pdf-export/fiche-action-pdf-export.router';
 import { FicheAnnexesRouter } from './fiche-annexes/fiche-annexes.router';
 import { ListFichesRouter } from './list-fiches/list-fiches.router';
+import { RemoveAnnexeRouter } from './remove-annexe/remove-annexe.router';
 import { UpdateFicheRouter } from './update-fiche/update-fiche.router';
 
 @Injectable()
@@ -21,6 +22,7 @@ export class FichesRouter {
     private readonly updateFicheRouter: UpdateFicheRouter,
     private readonly createFicheRouter: CreateFicheRouter,
     private readonly addAnnexeRouter: AddAnnexeRouter,
+    private readonly removeAnnexeRouter: RemoveAnnexeRouter,
     private readonly deleteFicheRouter: DeleteFicheRouter,
     private readonly countByRouter: CountByRouter,
     private readonly bulkEditRouter: BulkEditRouter,
@@ -34,6 +36,7 @@ export class FichesRouter {
     this.ficheAnnexesRouter.router,
     this.createFicheRouter.router,
     this.addAnnexeRouter.router,
+    this.removeAnnexeRouter.router,
     this.updateFicheRouter.router,
     this.deleteFicheRouter.router,
 

--- a/apps/backend/src/plans/fiches/remove-annexe/remove-annexe.errors.ts
+++ b/apps/backend/src/plans/fiches/remove-annexe/remove-annexe.errors.ts
@@ -1,0 +1,3 @@
+import { CommonError } from '@tet/backend/utils/trpc/common-errors';
+
+export type RemoveAnnexeError = CommonError;

--- a/apps/backend/src/plans/fiches/remove-annexe/remove-annexe.input.ts
+++ b/apps/backend/src/plans/fiches/remove-annexe/remove-annexe.input.ts
@@ -1,0 +1,7 @@
+import z from 'zod';
+
+export const removeAnnexeInputSchema = z.object({
+  annexeId: z.number().int().positive(),
+});
+
+export type RemoveAnnexeInput = z.infer<typeof removeAnnexeInputSchema>;

--- a/apps/backend/src/plans/fiches/remove-annexe/remove-annexe.repository.ts
+++ b/apps/backend/src/plans/fiches/remove-annexe/remove-annexe.repository.ts
@@ -1,0 +1,50 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { annexeTable } from '@tet/backend/collectivites/documents/models/annexe.table';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { failure, Result, success } from '@tet/backend/utils/result.type';
+import { CommonErrorEnum } from '@tet/backend/utils/trpc/common-errors';
+import { getErrorMessage } from '@tet/domain/utils';
+import type { InferSelectModel } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
+import { RemoveAnnexeError } from './remove-annexe.errors';
+
+type AnnexeRow = InferSelectModel<typeof annexeTable>;
+
+@Injectable()
+export class RemoveAnnexeRepository {
+  private readonly logger = new Logger(RemoveAnnexeRepository.name);
+
+  constructor(private readonly databaseService: DatabaseService) {}
+
+  async findById(annexeId: number): Promise<AnnexeRow | undefined> {
+    const [row] = await this.databaseService.db
+      .select()
+      .from(annexeTable)
+      .where(eq(annexeTable.id, annexeId))
+      .limit(1);
+    return row;
+  }
+
+  async deleteById(annexeId: number): Promise<Result<{ id: number }, RemoveAnnexeError>> {
+    try {
+      const [deleted] = await this.databaseService.db
+        .delete(annexeTable)
+        .where(eq(annexeTable.id, annexeId))
+        .returning({ id: annexeTable.id });
+
+      if (!deleted) {
+        return failure(CommonErrorEnum.NOT_FOUND);
+      }
+
+      return success(deleted);
+    } catch (error) {
+      this.logger.error(
+        `Erreur lors de la suppression de l'annexe ${annexeId}: ${getErrorMessage(error)}`
+      );
+      return failure(
+        CommonErrorEnum.DATABASE_ERROR,
+        error instanceof Error ? error : new Error(getErrorMessage(error))
+      );
+    }
+  }
+}

--- a/apps/backend/src/plans/fiches/remove-annexe/remove-annexe.router.e2e-spec.ts
+++ b/apps/backend/src/plans/fiches/remove-annexe/remove-annexe.router.e2e-spec.ts
@@ -1,0 +1,113 @@
+import { INestApplication } from '@nestjs/common';
+import { addTestCollectiviteAndUsers } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import {
+  getAuthUserFromUserCredentials,
+  getTestApp,
+  getTestDatabase,
+  getTestRouter,
+  signInWith,
+} from '@tet/backend/test';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { addTestUser } from '@tet/backend/users/users/users.test-fixture';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
+import { Collectivite } from '@tet/domain/collectivites';
+import { CollectiviteRole } from '@tet/domain/users';
+import { createFiche } from '../fiches.test-fixture';
+
+describe('RemoveAnnexeRouter', () => {
+  let app: INestApplication;
+  let router: TrpcRouter;
+  let db: DatabaseService;
+
+  let collectivite: Collectivite;
+  let editorUser: AuthenticatedUser;
+  let visiteurUser: AuthenticatedUser;
+  let editorAuthToken: string;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    router = await getTestRouter(app);
+    db = await getTestDatabase(app);
+
+    const testCollectiviteAndUsersResult = await addTestCollectiviteAndUsers(
+      db,
+      {
+        users: [
+          {
+            role: CollectiviteRole.EDITION,
+          },
+        ],
+      }
+    );
+
+    collectivite = testCollectiviteAndUsersResult.collectivite;
+    const editorFixture = testCollectiviteAndUsersResult.users[0];
+    editorUser = getAuthUserFromUserCredentials(editorFixture);
+
+    const signIn = await signInWith({
+      email: editorFixture.email,
+      password: editorFixture.password,
+    });
+    editorAuthToken = signIn.data.session?.access_token ?? '';
+    if (!editorAuthToken) {
+      throw new Error('token éditeur manquant');
+    }
+
+    const visiteurResult = await addTestUser(db);
+    visiteurUser = getAuthUserFromUserCredentials(visiteurResult.user);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  test('un éditeur peut supprimer une annexe (lien)', async () => {
+    const caller = router.createCaller({ user: editorUser });
+    const ficheId = await createFiche({
+      caller,
+      ficheInput: {
+        titre: 'Fiche annexe à supprimer',
+        collectiviteId: collectivite.id,
+      },
+    });
+
+    const annexe = await caller.plans.fiches.addAnnexe({
+      ficheId,
+      commentaire: '',
+      lien: { url: 'https://example.com/doc', titre: 'Lien exemple' },
+    });
+
+    const result = await caller.plans.fiches.removeAnnexe({
+      annexeId: annexe.id,
+    });
+
+    expect(result.id).toBe(annexe.id);
+
+    await expect(
+      caller.plans.fiches.removeAnnexe({ annexeId: annexe.id })
+    ).rejects.toThrowError(/n'existe pas|not found/i);
+  });
+
+  test("un visiteur ne peut pas supprimer d'annexe", async () => {
+    const editorCaller = router.createCaller({ user: editorUser });
+    const ficheId = await createFiche({
+      caller: editorCaller,
+      ficheInput: {
+        titre: 'Fiche avec annexe protégée',
+        collectiviteId: collectivite.id,
+      },
+    });
+
+    const annexe = await editorCaller.plans.fiches.addAnnexe({
+      ficheId,
+      lien: { url: 'https://example.com', titre: 'X' },
+    });
+
+    const visiteurCaller = router.createCaller({ user: visiteurUser });
+
+    await expect(
+      visiteurCaller.plans.fiches.removeAnnexe({ annexeId: annexe.id })
+    ).rejects.toThrowError(/Droits insuffisants/i);
+  });
+});

--- a/apps/backend/src/plans/fiches/remove-annexe/remove-annexe.router.ts
+++ b/apps/backend/src/plans/fiches/remove-annexe/remove-annexe.router.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { createTrpcErrorHandler } from '@tet/backend/utils/trpc/trpc-error-handler';
+import { TrpcService } from '@tet/backend/utils/trpc/trpc.service';
+import z from 'zod';
+import { removeAnnexeInputSchema } from './remove-annexe.input';
+import { RemoveAnnexeService } from './remove-annexe.service';
+
+@Injectable()
+export class RemoveAnnexeRouter {
+  constructor(
+    private readonly trpc: TrpcService,
+    private readonly removeAnnexeService: RemoveAnnexeService
+  ) {}
+
+  private readonly getResultDataOrThrowError = createTrpcErrorHandler();
+
+  router = this.trpc.router({
+    removeAnnexe: this.trpc.authedProcedure
+      .input(removeAnnexeInputSchema)
+      .output(z.object({ id: z.number() }))
+      .mutation(async ({ input, ctx: { user } }) => {
+        const result = await this.removeAnnexeService.removeAnnexe(input, user);
+        return this.getResultDataOrThrowError(result);
+      }),
+  });
+}

--- a/apps/backend/src/plans/fiches/remove-annexe/remove-annexe.service.ts
+++ b/apps/backend/src/plans/fiches/remove-annexe/remove-annexe.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@nestjs/common';
+import FicheActionPermissionsService from '@tet/backend/plans/fiches/fiche-action-permissions.service';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { failure, Result } from '@tet/backend/utils/result.type';
+import { CommonErrorEnum } from '@tet/backend/utils/trpc/common-errors';
+import { RemoveAnnexeError } from './remove-annexe.errors';
+import { RemoveAnnexeInput } from './remove-annexe.input';
+import { RemoveAnnexeRepository } from './remove-annexe.repository';
+
+@Injectable()
+export class RemoveAnnexeService {
+  constructor(
+    private readonly ficheActionPermissionsService: FicheActionPermissionsService,
+    private readonly removeAnnexeRepository: RemoveAnnexeRepository
+  ) {}
+
+  async removeAnnexe(
+    input: RemoveAnnexeInput,
+    user: AuthenticatedUser
+  ): Promise<Result<{ id: number }, RemoveAnnexeError>> {
+    const { annexeId } = input;
+
+    const annexe = await this.removeAnnexeRepository.findById(annexeId);
+    if (!annexe) {
+      return failure(CommonErrorEnum.NOT_FOUND);
+    }
+
+    const accessMode = await this.ficheActionPermissionsService.canWriteFiche(
+      annexe.ficheId,
+      user,
+      undefined,
+      true
+    );
+    if (accessMode === null) {
+      return failure(CommonErrorEnum.UNAUTHORIZED);
+    }
+
+    return this.removeAnnexeRepository.deleteById(annexeId);
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notes de mise à jour

* **Nouvelles fonctionnalités**
  * Les utilisateurs autorisés peuvent désormais supprimer les annexes de leurs fiches directement depuis l'interface.

* **Tests**
  * Suite de tests end-to-end ajoutée pour valider la suppression d'annexes et les contrôles de permissions d'accès.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/incubateur-ademe/territoires-en-transitions/pull/4446)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->