### PR TITLE
tests(e2e): filet anti-régression sur les comportements de modale (préparation refacto DS #4449)

### DIFF
--- a/e2e/tests/collectivite/membres/invite-membre-modal-behavior.spec.ts
+++ b/e2e/tests/collectivite/membres/invite-membre-modal-behavior.spec.ts
@@ -1,0 +1,86 @@
+import { CollectiviteRole } from '@tet/domain/users';
+import { test } from 'tests/main.fixture';
+import { InviteMembrePom } from './invite-membre.pom';
+
+/**
+ * Tests anti-régression centrés sur les comportements de la modale "Inviter un
+ * membre" (Modal contrôlée via `openState`) : ouverture, fermeture par les
+ * différents canaux (bouton X, ESC, Annuler) et démontage de l'état du
+ * formulaire à la fermeture. Le happy path d'invitation est couvert par
+ * invite-membre.spec.ts.
+ */
+test.describe('Modale d’invitation d’un membre — comportements', () => {
+  test('Le bouton X ferme la modale', async ({ collectivites, page }) => {
+    const { collectivite } = await collectivites.addCollectiviteAndUser({
+      userArgs: { autoLogin: true, role: CollectiviteRole.ADMIN },
+    });
+
+    const pom = new InviteMembrePom(page);
+    await pom.gotoUsersPage(collectivite.data.id);
+    await pom.openInviteModal();
+
+    await pom.closeViaXButton();
+  });
+
+  test('La touche ESC ferme la modale', async ({ collectivites, page }) => {
+    const { collectivite } = await collectivites.addCollectiviteAndUser({
+      userArgs: { autoLogin: true, role: CollectiviteRole.ADMIN },
+    });
+
+    const pom = new InviteMembrePom(page);
+    await pom.gotoUsersPage(collectivite.data.id);
+    await pom.openInviteModal();
+
+    await pom.closeViaEscape();
+  });
+
+  test('Le bouton Annuler ferme la modale', async ({ collectivites, page }) => {
+    const { collectivite } = await collectivites.addCollectiviteAndUser({
+      userArgs: { autoLogin: true, role: CollectiviteRole.ADMIN },
+    });
+
+    const pom = new InviteMembrePom(page);
+    await pom.gotoUsersPage(collectivite.data.id);
+    await pom.openInviteModal();
+
+    await pom.closeViaCancelButton();
+  });
+
+  test('Réouvrir la modale après une saisie partielle présente un formulaire vide', async ({
+    collectivites,
+    page,
+  }) => {
+    const { collectivite } = await collectivites.addCollectiviteAndUser({
+      userArgs: { autoLogin: true, role: CollectiviteRole.ADMIN },
+    });
+
+    const pom = new InviteMembrePom(page);
+    await pom.gotoUsersPage(collectivite.data.id);
+
+    await pom.openInviteModal();
+    await pom.emailInput.fill('saisie-partielle@test-e2e.fr');
+    await pom.closeViaCancelButton();
+
+    await pom.openInviteModal();
+    await pom.expectEmailInputValue('');
+  });
+
+  test('Réouvrir après une fermeture par ESC présente un formulaire vide', async ({
+    collectivites,
+    page,
+  }) => {
+    const { collectivite } = await collectivites.addCollectiviteAndUser({
+      userArgs: { autoLogin: true, role: CollectiviteRole.ADMIN },
+    });
+
+    const pom = new InviteMembrePom(page);
+    await pom.gotoUsersPage(collectivite.data.id);
+
+    await pom.openInviteModal();
+    await pom.emailInput.fill('saisie-esc@test-e2e.fr');
+    await pom.closeViaEscape();
+
+    await pom.openInviteModal();
+    await pom.expectEmailInputValue('');
+  });
+});

--- a/e2e/tests/collectivite/membres/invite-membre.pom.ts
+++ b/e2e/tests/collectivite/membres/invite-membre.pom.ts
@@ -8,6 +8,8 @@ export class InviteMembrePom {
   readonly emailInput: Locator;
   readonly niveauDropdown: DropdownPom;
   readonly submitButton: Locator;
+  readonly cancelButton: Locator;
+  readonly closeButton: Locator;
 
   constructor(public readonly page: Page) {
     this.inviteButton = page.locator('[data-test="invite"]');
@@ -18,6 +20,8 @@ export class InviteMembrePom {
       page.locator('[data-test="niveau"]')
     );
     this.submitButton = this.modal.locator('[data-test="ok"]');
+    this.cancelButton = this.modal.getByRole('button', { name: 'Annuler' });
+    this.closeButton = this.modal.getByRole('button', { name: 'Fermer' });
   }
 
   /** Navigue vers la page des membres de la collectivité */
@@ -30,6 +34,25 @@ export class InviteMembrePom {
   async openInviteModal() {
     await this.inviteButton.click();
     await expect(this.modal).toBeVisible({ timeout: 10000 });
+  }
+
+  async closeViaXButton() {
+    await this.closeButton.click();
+    await expect(this.modal).toBeHidden();
+  }
+
+  async closeViaCancelButton() {
+    await this.cancelButton.click();
+    await expect(this.modal).toBeHidden();
+  }
+
+  async closeViaEscape() {
+    await this.page.keyboard.press('Escape');
+    await expect(this.modal).toBeHidden();
+  }
+
+  async expectEmailInputValue(expected: string) {
+    await expect(this.emailInput).toHaveValue(expected);
   }
 
   /** Remplit le formulaire d'invitation et soumet */

--- a/e2e/tests/users/users/update-user/update-user-modal-behavior.spec.ts
+++ b/e2e/tests/users/users/update-user/update-user-modal-behavior.spec.ts
@@ -1,0 +1,112 @@
+import { test } from 'tests/main.fixture';
+import { UpdateUserPom } from './update-user.pom';
+
+/**
+ * Tests anti-régression centrés sur les comportements complexes de la modale
+ * "Modifier mes informations" : validation du formulaire qui gate le bouton
+ * Valider, et réinitialisation de l'état du formulaire à la fermeture (via
+ * Annuler, bouton X, ESC) — comportements indépendants du happy path de mise
+ * à jour déjà couvert par update-user.spec.ts.
+ */
+test.describe('Modale de modification du profil — comportements', () => {
+  test('Annuler ferme la modale et restaure les valeurs initiales à la réouverture', async ({
+    collectivites,
+    page,
+  }) => {
+    const { user } = await collectivites.addCollectiviteAndUser({
+      userArgs: { autoLogin: true },
+    });
+
+    const pom = new UpdateUserPom(page);
+    await pom.goto();
+    await pom.openEditModal();
+
+    await pom.fillForm({ prenom: 'PrenomModifie', nom: 'NomModifie' });
+    await pom.closeEditModal();
+
+    await pom.openEditModal();
+    await pom.expectInputValue('prenom', user.data.prenom);
+    await pom.expectInputValue('nom', user.data.nom);
+  });
+
+  test('Bouton X ferme la modale et restaure les valeurs initiales à la réouverture', async ({
+    collectivites,
+    page,
+  }) => {
+    const { user } = await collectivites.addCollectiviteAndUser({
+      userArgs: { autoLogin: true },
+    });
+
+    const pom = new UpdateUserPom(page);
+    await pom.goto();
+    await pom.openEditModal();
+
+    await pom.fillForm({ telephone: '06 99 99 99 99' });
+    await pom.closeEditModalViaXButton();
+
+    await pom.openEditModal();
+    await pom.expectInputValue('telephone', user.data.telephone ?? '');
+  });
+
+  test('ESC ferme la modale et restaure les valeurs initiales à la réouverture', async ({
+    collectivites,
+    page,
+  }) => {
+    const { user } = await collectivites.addCollectiviteAndUser({
+      userArgs: { autoLogin: true },
+    });
+
+    const pom = new UpdateUserPom(page);
+    await pom.goto();
+    await pom.openEditModal();
+
+    await pom.fillForm({ prenom: 'AvantEsc' });
+    await pom.closeEditModalViaEscape();
+
+    await pom.openEditModal();
+    await pom.expectInputValue('prenom', user.data.prenom);
+  });
+
+  test('Le bouton Valider est désactivé tant que le formulaire est invalide', async ({
+    collectivites,
+    page,
+  }) => {
+    await collectivites.addCollectiviteAndUser({
+      userArgs: { autoLogin: true },
+    });
+
+    const pom = new UpdateUserPom(page);
+    await pom.goto();
+    await pom.openEditModal();
+
+    // Vider le champ nom (min 2 lettres requises) doit invalider le formulaire.
+    await pom.fillForm({ nom: '' });
+    await pom.expectSubmitDisabled();
+
+    // Restaurer une valeur valide doit réactiver le bouton.
+    await pom.fillForm({ nom: 'Dupont' });
+    await pom.expectSubmitEnabled();
+  });
+
+  test('Annuler restaure aussi les champs email et téléphone', async ({
+    collectivites,
+    page,
+  }) => {
+    const { user } = await collectivites.addCollectiviteAndUser({
+      userArgs: { autoLogin: true },
+    });
+
+    const pom = new UpdateUserPom(page);
+    await pom.goto();
+
+    await pom.openEditModal();
+    await pom.fillForm({
+      telephone: '06 00 00 00 00',
+    });
+    await pom.closeEditModal();
+
+    await pom.openEditModal();
+    await pom.expectInputValue('telephone', user.data.telephone ?? '');
+    await pom.expectInputValue('email', user.data.email);
+  });
+});

--- a/e2e/tests/users/users/update-user/update-user.pom.ts
+++ b/e2e/tests/users/users/update-user/update-user.pom.ts
@@ -10,6 +10,7 @@ export class UpdateUserPom {
   readonly telephoneInput: Locator;
   readonly modalSubmitButton: Locator;
   readonly modalCancelButton: Locator;
+  readonly modalCloseButton: Locator;
   readonly prenomNomDisplay: Locator;
   readonly emailDisplay: Locator;
   readonly telephoneDisplay: Locator;
@@ -32,6 +33,9 @@ export class UpdateUserPom {
     });
     this.modalCancelButton = this.modal.getByRole('button', {
       name: 'Annuler',
+    });
+    this.modalCloseButton = this.modal.getByRole('button', {
+      name: 'Fermer',
     });
     // Selector for prenom/nom: find the section with "Prénom et nom" label, then get the value span
     this.prenomNomDisplay = page
@@ -71,6 +75,32 @@ export class UpdateUserPom {
   async closeEditModal() {
     await this.modalCancelButton.click();
     await expect(this.modal).toBeHidden();
+  }
+
+  async closeEditModalViaXButton() {
+    await this.modalCloseButton.click();
+    await expect(this.modal).toBeHidden();
+  }
+
+  async closeEditModalViaEscape() {
+    await this.page.keyboard.press('Escape');
+    await expect(this.modal).toBeHidden();
+  }
+
+  async expectSubmitDisabled() {
+    await expect(this.modalSubmitButton).toBeDisabled();
+  }
+
+  async expectSubmitEnabled() {
+    await expect(this.modalSubmitButton).toBeEnabled();
+  }
+
+  async expectInputValue(
+    field: 'prenom' | 'nom' | 'email' | 'telephone',
+    expected: string
+  ) {
+    const input = this.modal.locator(`#${field}`);
+    await expect(input).toHaveValue(expected);
   }
 
   async fillForm(data: {


### PR DESCRIPTION
## Contexte

Filet anti-régression e2e en prévision de la refacto du composant Modal du Design System portée par la PR #4449 (`Modal` → `Modal.next` + `AlertModal`, API compositionnelle Radix).

Ces tests sont écrits **depuis `main`** et validés contre le composant Modal actuel. Une fois mergés et la PR #4449 rebasée, ils tourneront automatiquement contre la nouvelle implémentation et révéleront toute régression sur les chemins de fermeture et de réinitialisation des modales.

## Couverture

Deux modales représentatives des comportements complexes :

- **« Modifier mes informations »** (`update-user-modal-behavior.spec.ts`) — modale contrôlée avec formulaire `react-hook-form`, validation `zod`, `reset()` à la fermeture, gating du bouton `Valider`.
  - Fermeture via Annuler / bouton X / ESC restaure les valeurs initiales à la réouverture
  - Bouton `Valider` désactivé tant que le formulaire est invalide
- **« Inviter un membre »** (`invite-membre-modal-behavior.spec.ts`) — modale contrôlée via `openState`, démontage du contenu à la fermeture.
  - Fermeture via X / ESC / Annuler
  - Formulaire vide à la réouverture après une saisie partielle

## Choix techniques

- Sélecteurs par rôle ARIA (`getByRole('button', { name: 'Fermer' })`, `name: 'Annuler'`) pour rester compatibles avec l'ancien `Modal` (attribut `title`) **et** le futur `Modal.next` / `AlertModal` — pas de dépendance au `data-test="close-Modal"` qui disparaît dans la refacto.
- Helpers ajoutés aux POMs existants (`update-user.pom.ts`, `invite-membre.pom.ts`) pour la réutilisation : `closeViaXButton`, `closeViaEscape`, `expectSubmitDisabled/Enabled`, `expectInputValue`.
- Aucune modification de code applicatif.

## Test plan

- [ ] CI e2e passe sur cette branche (basée sur `main`)
- [ ] Une fois mergé dans `main`, rebaser PR #4449 et vérifier quels tests échouent → liste des régressions à corriger côté DS

---
_Generated by [Claude Code](https://claude.ai/code/session_01C753xiscVm4DKqMYXt2zdo)_