### PR TITLE
ci: étend le keep-alive Streamlit aux apps stats et impact

### DIFF
--- a/.github/workflows/scripts/keep-alive-streamlit.ts
+++ b/.github/workflows/scripts/keep-alive-streamlit.ts
@@ -1,26 +1,62 @@
-import { chromium } from '@playwright/test';
-import { STREAMLIT_IFRAME_SRC } from '../../../apps/site/app/stats/streamlit.utils.ts';
+import { chromium, expect, type FrameLocator, type Page } from '@playwright/test';
+import { STREAMLIT_IMPACT_IFRAME_SRC } from '../../../apps/site/app/impact/streamlit.utils.ts';
+import { STREAMLIT_STATS_IFRAME_SRC } from '../../../apps/site/app/stats/streamlit.utils.ts';
+
+const LOAD_TIMEOUT_MS = 180_000;
+
+/** Mirrors Streamlit's own e2e `wait_for_app_loaded` / `wait_for_app_run` checks. */
+async function waitForStreamlitReady(
+  frame: FrameLocator,
+  timeout = LOAD_TIMEOUT_MS,
+) {
+  await frame.locator('[data-testid="stAppViewContainer"]').waitFor({
+    state: 'attached',
+    timeout,
+  });
+
+  const connectedApp = frame
+    .locator('[data-testid="stApp"][data-test-connection-state="CONNECTED"]')
+    .or(
+      frame.locator(
+        '[data-testid="stApp"][data-test-connection-state="STATIC_CONNECTED"]',
+      ),
+    );
+  await connectedApp.waitFor({ state: 'attached', timeout });
+
+  await frame
+    .locator('[data-testid="stApp"][data-test-script-state="notRunning"]')
+    .waitFor({ state: 'attached', timeout });
+
+  await expect(frame.getByTestId('stSkeleton')).toHaveCount(0, { timeout });
+}
+
+async function keepAliveStreamlit(page: Page, iframeSrc: string, label: string) {
+  await page.goto(iframeSrc, {
+    waitUntil: 'domcontentloaded',
+    timeout: 60_000,
+  });
+
+  const frame = page.frameLocator('iframe[title="streamlitApp"]');
+  const wakeButton = frame.getByRole('button', {
+    name: /get this app back up/i,
+  });
+
+  if (await wakeButton.isVisible()) {
+    console.log(`[${label}] App asleep — clicking wake button`);
+    await wakeButton.click();
+    await wakeButton.waitFor({ state: 'hidden', timeout: LOAD_TIMEOUT_MS });
+  }
+
+  await waitForStreamlitReady(frame);
+  console.log(`[${label}] App ready`);
+}
 
 const browser = await chromium.launch();
 const page = await browser.newPage();
 
-await page.goto(STREAMLIT_IFRAME_SRC, {
-  waitUntil: 'domcontentloaded',
-  timeout: 60_000,
-});
-
-const frame = page.frameLocator('iframe[title="streamlitApp"]');
-const wakeButton = frame.getByRole('button', { name: /get this app back up/i });
-const readyText = frame.getByText(
-  'Déployer la transition écologique sur la totalité du territoire'
-);
-
-if (await wakeButton.isVisible()) {
-  console.log('App asleep — clicking wake button');
-  await wakeButton.click();
+try {
+  await keepAliveStreamlit(page, STREAMLIT_STATS_IFRAME_SRC, 'stats');
+  await keepAliveStreamlit(page, STREAMLIT_IMPACT_IFRAME_SRC, 'impact');
+} finally {
+  await browser.close();
 }
-
-await readyText.waitFor({ state: 'visible', timeout: 180_000 });
-console.log('App ready');
-
-await browser.close();


### PR DESCRIPTION
## Summary

- Le workflow planifié réveille désormais les deux embeds Streamlit (statistiques publiques et matrice d'impact).
- La détection de chargement s'appuie sur les signaux internes Streamlit (`stApp` connecté, script `notRunning`, absence de skeletons) au lieu d'un texte fixe sur la page.

## Test plan

- [ ] Lancer manuellement le workflow « Keep Streamlit app alive » (`workflow_dispatch`) et vérifier que les logs `[stats]` et `[impact]` se terminent par `App ready`.
- [ ] Confirmer que les pages `/stats` et `/impact` du site affichent bien les iframes après exécution du job.