### PR TITLE
fix(collectivites): placer les CT de test (#) après les autres dans la liste

### DIFF
--- a/apps/backend/src/collectivites/import-collectivite-relations/import-collectivite-relations.router.e2e-spec.ts
+++ b/apps/backend/src/collectivites/import-collectivite-relations/import-collectivite-relations.router.e2e-spec.ts
@@ -1,15 +1,25 @@
-import { getAnonUser, getServiceRoleUser } from '@tet/backend/test';
+import {
+  getAnonUser,
+  getServiceRoleUser,
+  importCollectiviteRelationsUnderLock,
+} from '@tet/backend/test';
 import { AuthRole, AuthUser } from '@tet/backend/users/models/auth.models';
-import { getTestRouter } from '../../../test/app-utils';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { INestApplication } from '@nestjs/common';
+import { getTestApp, getTestDatabase, getTestRouter } from '../../../test/app-utils';
 import { TrpcRouter } from '../../utils/trpc/trpc.router';
 
 describe("Route d'import des relations entre collectivités", () => {
+  let app: INestApplication;
   let router: TrpcRouter;
+  let database: DatabaseService;
   let anonUser: AuthUser<AuthRole.ANON>;
   let serviceRoleUser: AuthUser<AuthRole.SERVICE_ROLE>;
 
   beforeAll(async () => {
-    router = await getTestRouter();
+    app = await getTestApp();
+    router = await getTestRouter(app);
+    database = await getTestDatabase(app);
     anonUser = getAnonUser();
     serviceRoleUser = getServiceRoleUser();
   });
@@ -35,14 +45,14 @@ describe("Route d'import des relations entre collectivités", () => {
 
   test('Relations correctement créées', async () => {
     const serviceRoleCaller = router.createCaller({ user: serviceRoleUser });
-    const importEpciCommunesRelationsResult =
-      await serviceRoleCaller.collectivites.relations.importEpciCommunesRelations();
-    expect(importEpciCommunesRelationsResult.processed).toBeGreaterThan(0);
-    expect(importEpciCommunesRelationsResult.created).toBeGreaterThan(0);
+    const { epci, syndicat } = await importCollectiviteRelationsUnderLock(
+      database,
+      serviceRoleCaller.collectivites.relations
+    );
 
-    const importSyndicatEpciRelationsResult =
-      await serviceRoleCaller.collectivites.relations.importSyndicatEpciRelations();
-    expect(importSyndicatEpciRelationsResult.processed).toBeGreaterThan(0);
-    expect(importSyndicatEpciRelationsResult.created).toBeGreaterThan(0);
+    expect(epci.processed).toBeGreaterThan(0);
+    expect(epci.created).toBeGreaterThan(0);
+    expect(syndicat.processed).toBeGreaterThan(0);
+    expect(syndicat.created).toBeGreaterThan(0);
   });
 });

--- a/apps/backend/src/collectivites/list-collectivites/list-collectivites.router.e2e-spec.ts
+++ b/apps/backend/src/collectivites/list-collectivites/list-collectivites.router.e2e-spec.ts
@@ -1,7 +1,17 @@
-import { getAnonUser, getServiceRoleUser } from '@tet/backend/test';
+import { INestApplication } from '@nestjs/common';
+import {
+  ensureCollectiviteRelationsImported,
+  getAnonUser,
+  getServiceRoleUser,
+} from '@tet/backend/test';
 import { AuthRole, AuthUser } from '@tet/backend/users/models/auth.models';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { inferProcedureInput } from '@trpc/server';
-import { getTestRouter } from '../../../test/app-utils';
+import {
+  getTestApp,
+  getTestDatabase,
+  getTestRouter,
+} from '../../../test/app-utils';
 import { AppRouter, TrpcRouter } from '../../utils/trpc/trpc.router';
 
 type Input = inferProcedureInput<
@@ -9,12 +19,16 @@ type Input = inferProcedureInput<
 >;
 
 describe('Route de recherche des collectivités', () => {
+  let app: INestApplication;
   let router: TrpcRouter;
+  let database: DatabaseService;
   let anonUser: AuthUser<AuthRole.ANON>;
   let serviceRoleUser: AuthUser<AuthRole.SERVICE_ROLE>;
 
   beforeAll(async () => {
-    router = await getTestRouter();
+    app = await getTestApp();
+    router = await getTestRouter(app);
+    database = await getTestDatabase(app);
     anonUser = getAnonUser();
     serviceRoleUser = getServiceRoleUser();
   });
@@ -40,6 +54,9 @@ describe('Route de recherche des collectivités', () => {
     }
 
     // Les collectivités de test (#…) sont triées après les autres
+    expect(result.length).toBeGreaterThan(0);
+    expect(result[0]?.nom?.startsWith('#') ?? false).toBe(false);
+
     let seenTestCollectivite = false;
     for (const collectivite of result) {
       const isTestCollectivite = collectivite.nom?.startsWith('#') ?? false;
@@ -107,87 +124,93 @@ describe('Route de recherche des collectivités', () => {
     expect(resultWithNonExistentText.length).toBe(0);
   });
 
-  test(`Requête avec siren et relations`, async () => {
-    const caller = router.createCaller({ user: anonUser });
-    const serviceRoleCaller = router.createCaller({ user: serviceRoleUser });
-
-    // Be sure that the relations have been created
-
-    await serviceRoleCaller.collectivites.relations.importEpciCommunesRelations();
-    await serviceRoleCaller.collectivites.relations.importSyndicatEpciRelations();
-
-    const resultWithRelations = await caller.collectivites.collectivites.list({
-      siren: '200073344',
-      fieldsMode: 'resume',
-      withRelations: true,
+  describe('avec relations importées', () => {
+    beforeAll(async () => {
+      const serviceRoleCaller = router.createCaller({ user: serviceRoleUser });
+      await ensureCollectiviteRelationsImported(
+        database,
+        serviceRoleCaller.collectivites.relations
+      );
     });
-    expect(resultWithRelations.length).toBe(1);
-    expect(resultWithRelations[0]).toEqual({
-      id: 5178,
-      nom: 'CA Rambouillet Territoires',
-      siren: '200073344',
-      communeCode: null,
-      natureInsee: 'CA',
-      type: 'epci',
-      activeCOT: false,
-      parents: [
+
+    test(`Requête avec siren et relations`, async () => {
+      const caller = router.createCaller({ user: anonUser });
+
+      const resultWithRelations = await caller.collectivites.collectivites.list(
         {
-          id: 5186,
-          nom: "SI d'évacuation et d'élimination des déchets de l'Ouest Yvelines (SIEED)",
-          siren: '257800300',
-          natureInsee: 'SMF',
-          type: 'epci',
-        },
-        {
-          id: 5189,
-          nom: 'SI de collecte et de traitement des ordures ménagères de la région de Rambouillet (SICTOM)',
-          siren: '257801290',
-          natureInsee: 'SMF',
-          type: 'epci',
-        },
-      ],
-      enfants: [
-        {
-          id: 3016,
-          nom: 'Ablis',
-          siren: null,
-          communeCode: '78003',
-          natureInsee: null,
-          type: 'commune',
-        },
-        {
-          id: 3080,
-          nom: 'Le Perray-en-Yvelines',
-          siren: null,
-          communeCode: '78486',
-          natureInsee: null,
-          type: 'commune',
-        },
-        {
-          id: 3042,
-          nom: 'Les Essarts-le-Roi',
-          siren: null,
-          communeCode: '78220',
-          natureInsee: null,
-          type: 'commune',
-        },
-        {
-          id: 3085,
-          nom: 'Rambouillet',
-          siren: null,
-          communeCode: '78517',
-          natureInsee: null,
-          type: 'commune',
-        },
-        {
-          id: 3087,
-          nom: 'Saint-Arnoult-en-Yvelines',
-          siren: null,
-          communeCode: '78537',
-          natureInsee: null,
-          type: 'commune',
-        },
-      ],
+          siren: '200073344',
+          fieldsMode: 'resume',
+          withRelations: true,
+        }
+      );
+      expect(resultWithRelations.length).toBe(1);
+      expect(resultWithRelations[0]).toEqual({
+        id: 5178,
+        nom: 'CA Rambouillet Territoires',
+        siren: '200073344',
+        communeCode: null,
+        natureInsee: 'CA',
+        type: 'epci',
+        activeCOT: false,
+        parents: [
+          {
+            id: 5186,
+            nom: "SI d'évacuation et d'élimination des déchets de l'Ouest Yvelines (SIEED)",
+            siren: '257800300',
+            natureInsee: 'SMF',
+            type: 'epci',
+          },
+          {
+            id: 5189,
+            nom: 'SI de collecte et de traitement des ordures ménagères de la région de Rambouillet (SICTOM)',
+            siren: '257801290',
+            natureInsee: 'SMF',
+            type: 'epci',
+          },
+        ],
+        enfants: [
+          {
+            id: 3016,
+            nom: 'Ablis',
+            siren: null,
+            communeCode: '78003',
+            natureInsee: null,
+            type: 'commune',
+          },
+          {
+            id: 3080,
+            nom: 'Le Perray-en-Yvelines',
+            siren: null,
+            communeCode: '78486',
+            natureInsee: null,
+            type: 'commune',
+          },
+          {
+            id: 3042,
+            nom: 'Les Essarts-le-Roi',
+            siren: null,
+            communeCode: '78220',
+            natureInsee: null,
+            type: 'commune',
+          },
+          {
+            id: 3085,
+            nom: 'Rambouillet',
+            siren: null,
+            communeCode: '78517',
+            natureInsee: null,
+            type: 'commune',
+          },
+          {
+            id: 3087,
+            nom: 'Saint-Arnoult-en-Yvelines',
+            siren: null,
+            communeCode: '78537',
+            natureInsee: null,
+            type: 'commune',
+          },
+        ],
+      });
     });
-  }, 10000);
+  });
 });

--- a/apps/backend/src/collectivites/list-collectivites/list-collectivites.router.e2e-spec.ts
+++ b/apps/backend/src/collectivites/list-collectivites/list-collectivites.router.e2e-spec.ts
@@ -39,6 +39,17 @@ describe('Route de recherche des collectivités', () => {
       expect(collectivite.id).toBeDefined();
     }
 
+    // Les collectivités de test (#…) sont triées après les autres
+    let seenTestCollectivite = false;
+    for (const collectivite of result) {
+      const isTestCollectivite = collectivite.nom?.startsWith('#') ?? false;
+      if (isTestCollectivite) {
+        seenTestCollectivite = true;
+      } else {
+        expect(seenTestCollectivite).toBe(false);
+      }
+    }
+
     // Retourne le nombre demandé
     const resultWithLimit = await caller.collectivites.collectivites.list({
       limit: 30,

--- a/apps/backend/src/collectivites/list-collectivites/list-collectivites.service.ts
+++ b/apps/backend/src/collectivites/list-collectivites/list-collectivites.service.ts
@@ -248,14 +248,50 @@ export default class ListCollectivitesService {
       request.where(and(...whereConditions));
     }
 
-    return this.db.withPagination(
-      request.$dynamic(),
-      input.text
-        ? desc(sql`similarity
-      (${collectiviteTable.nom}, ${input.text})`)
-        : asc(collectiviteTable.nom),
-      input.page,
-      input.limit
-    );
+    const orderByClause = input.text
+      ? [desc(sql`similarity(${collectiviteTable.nom}, ${input.text})`)]
+      : [
+          asc(
+            sql`CASE WHEN ${collectiviteTable.nom} LIKE '#%' THEN 1 ELSE 0 END`
+          ),
+          asc(collectiviteTable.nom),
+        ];
+
+    const dynamicRequest = request.$dynamic();
+    const page = input.page;
+    const pageSize = input.limit;
+
+    if (pageSize && pageSize > 0) {
+      const data = await dynamicRequest
+        .orderBy(...orderByClause)
+        .limit(pageSize)
+        .offset((page - 1) * pageSize);
+
+      const countQuery = db
+        .select({ count: sql<number>`count(*)::int` })
+        .from(collectiviteTable);
+      const [total] = await (whereConditions.length > 0
+        ? countQuery.where(and(...whereConditions))
+        : countQuery);
+      const count = Number(total?.count ?? 0);
+
+      return {
+        data,
+        count,
+        page,
+        pageSize,
+        pageCount: Math.ceil(count / pageSize),
+      };
+    }
+
+    const data = await dynamicRequest.orderBy(...orderByClause);
+
+    return {
+      data,
+      count: data.length,
+      page: 1,
+      pageSize: data.length,
+      pageCount: 1,
+    };
   }
 }

--- a/apps/backend/src/utils/database/database.service.ts
+++ b/apps/backend/src/utils/database/database.service.ts
@@ -1,8 +1,7 @@
 import { AuthUser } from '@tet/backend/users/models/auth.models';
 import { Injectable, Logger, OnApplicationShutdown } from '@nestjs/common';
 import { drizzle } from 'drizzle-orm/node-postgres';
-import { PgColumn, PgSelect } from 'drizzle-orm/pg-core';
-import { SQL, sql } from 'drizzle-orm/sql';
+import { sql } from 'drizzle-orm/sql';
 import { Pool } from 'pg';
 import ConfigurationService from '../config/configuration.service';
 import { DatabaseServiceInterface } from './database-service.interface';
@@ -88,55 +87,6 @@ export class DatabaseService
         }
       }, ...rest);
     }) as typeof this.db.transaction;
-  }
-
-  async withPagination<T extends PgSelect>(
-    qb: T,
-    orderByColumn: PgColumn | SQL | SQL.Aliased,
-    page: number,
-    pageSize?: number
-  ) {
-    if (pageSize && pageSize > 0) {
-      const result = await qb
-        .orderBy(orderByColumn)
-        .limit(pageSize)
-        .offset((page - 1) * pageSize);
-
-      // @ts-expect-error - config is protected and only accessible within class 'PgSelectQueryBuilderBase<THKT, TTableName, TSelection, TSelectMode, TNullabilityMap, TDynamic, TExcludedMethods, TResult, TSelectedFields>' and its subclasses
-      qb.config.fields = { count: sql<number>`count(*)` };
-      // @ts-expect-error - config is protected and only accessible within class 'PgSelectQueryBuilderBase<THKT, TTableName, TSelection, TSelectMode, TNullabilityMap, TDynamic, TExcludedMethods, TResult, TSelectedFields>' and its subclasses
-      qb.config.orderBy = [];
-      // @ts-expect-error - config is protected and only accessible within class 'PgSelectQueryBuilderBase<THKT, TTableName, TSelection, TSelectMode, TNullabilityMap, TDynamic, TExcludedMethods, TResult, TSelectedFields>' and its subclasses
-      qb.config.limit = undefined;
-      // @ts-expect-error - config is protected and only accessible within class 'PgSelectQueryBuilderBase<THKT, TTableName, TSelection, TSelectMode, TNullabilityMap, TDynamic, TExcludedMethods, TResult, TSelectedFields>' and its subclasses
-      qb.config.offset = undefined;
-      // @ts-expect-error - config is protected and only accessible within class 'PgSelectQueryBuilderBase<THKT, TTableName, TSelection, TSelectMode, TNullabilityMap, TDynamic, TExcludedMethods, TResult, TSelectedFields>' and its subclasses
-      qb.config.orderBy = [];
-      // @ts-expect-error - config is protected and only accessible within class 'PgSelectQueryBuilderBase<THKT, TTableName, TSelection, TSelectMode, TNullabilityMap, TDynamic, TExcludedMethods, TResult, TSelectedFields>' and its subclasses
-      qb.config.limit = undefined;
-      // @ts-expect-error - config is protected and only accessible within class 'PgSelectQueryBuilderBase<THKT, TTableName, TSelection, TSelectMode, TNullabilityMap, TDynamic, TExcludedMethods, TResult, TSelectedFields>' and its subclasses
-      qb.config.offset = undefined;
-
-      const [total] = await qb;
-
-      const count = parseInt(total.count);
-      return {
-        data: result,
-        count: count,
-        page: page,
-        pageSize: pageSize,
-        pageCount: Math.ceil(count / pageSize),
-      };
-    } else {
-      const result = await qb.orderBy(orderByColumn);
-      return {
-        data: result,
-        count: result.length,
-        page: 1,
-        pageSize: result.length,
-        pageCount: 1,
-      };
-    }
   }
 
   async onApplicationShutdown(signal: string) {

--- a/apps/backend/test/collectivites-utils.ts
+++ b/apps/backend/test/collectivites-utils.ts
@@ -1,6 +1,105 @@
+import { ImportCollectiviteRelationsResponse } from '@tet/backend/collectivites/import-collectivite-relations/import-collectivite-relations.response';
+import { collectiviteRelationsTable } from '@tet/backend/collectivites/shared/models/collectivite-relations.table';
 import { collectiviteTable } from '@tet/backend/collectivites/shared/models/collectivite.table';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
-import { eq } from 'drizzle-orm';
+import { count, eq } from 'drizzle-orm';
+
+/** Advisory lock id for coordinating relation imports across parallel vitest workers. */
+const COLLECTIVITE_RELATIONS_IMPORT_LOCK_ID = 2_422_003;
+
+/**
+ * EPCI–commune imports alone create tens of thousands of rows; below this threshold
+ * the table is considered empty for test purposes.
+ */
+const MIN_COLLECTIVITE_RELATIONS_FOR_TESTS = 5_000;
+
+export type CollectiviteRelationsImporter = {
+  importEpciCommunesRelations: () => Promise<ImportCollectiviteRelationsResponse>;
+  importSyndicatEpciRelations: () => Promise<ImportCollectiviteRelationsResponse>;
+};
+
+let ensureRelationsPromise: Promise<void> | null = null;
+
+async function countCollectiviteRelations(
+  database: DatabaseService
+): Promise<number> {
+  const [row] = await database.db
+    .select({ count: count() })
+    .from(collectiviteRelationsTable);
+  return Number(row?.count ?? 0);
+}
+
+export type ImportCollectiviteRelationsResults = {
+  epci: ImportCollectiviteRelationsResponse;
+  syndicat: ImportCollectiviteRelationsResponse;
+};
+
+async function runCollectiviteRelationsImport(
+  importRelations: CollectiviteRelationsImporter
+): Promise<ImportCollectiviteRelationsResults> {
+  const epci = await importRelations.importEpciCommunesRelations();
+  const syndicat = await importRelations.importSyndicatEpciRelations();
+  return { epci, syndicat };
+}
+
+async function withCollectiviteRelationsImportLock<T>(
+  database: DatabaseService,
+  fn: () => Promise<T>
+): Promise<T> {
+  const client = await database.db.$client.connect();
+  try {
+    await client.query('SELECT pg_advisory_lock($1)', [
+      COLLECTIVITE_RELATIONS_IMPORT_LOCK_ID,
+    ]);
+    return await fn();
+  } finally {
+    await client
+      .query('SELECT pg_advisory_unlock($1)', [
+        COLLECTIVITE_RELATIONS_IMPORT_LOCK_ID,
+      ])
+      .catch(() => undefined);
+    client.release();
+  }
+}
+
+/**
+ * Runs EPCI–commune and syndicat–EPCI imports while holding a session-level advisory
+ * lock so parallel test files do not bulk-insert at the same time.
+ */
+export async function importCollectiviteRelationsUnderLock(
+  database: DatabaseService,
+  importRelations: CollectiviteRelationsImporter
+): Promise<ImportCollectiviteRelationsResults> {
+  return withCollectiviteRelationsImportLock(database, () =>
+    runCollectiviteRelationsImport(importRelations)
+  );
+}
+
+/**
+ * Ensures collectivite relations exist for tests that consume them (e.g. list with
+ * `withRelations`). Skips the heavy CSV import when the table is already populated;
+ * coordinates concurrent workers via an advisory lock (count checked under lock).
+ */
+export async function ensureCollectiviteRelationsImported(
+  database: DatabaseService,
+  importRelations: CollectiviteRelationsImporter
+): Promise<void> {
+  if (!ensureRelationsPromise) {
+    ensureRelationsPromise = withCollectiviteRelationsImportLock(
+      database,
+      async () => {
+        if (
+          (await countCollectiviteRelations(database)) >=
+          MIN_COLLECTIVITE_RELATIONS_FOR_TESTS
+        ) {
+          return;
+        }
+        await runCollectiviteRelationsImport(importRelations);
+      }
+    );
+  }
+  return ensureRelationsPromise;
+}
 
 export const getCollectiviteIdBySiren = async (
   databaseService: DatabaseService,


### PR DESCRIPTION
## Summary

- Sans texte de recherche, les collectivités dont le nom commence par `#` (CT de test) sont triées après les autres dans `collectivites.list`, au lieu d’apparaître en tête du select « Rejoindre une collectivité ».
- Avec recherche, le tri par `similarity` est inchangé : les CT de test restent trouvables.
- La pagination est gérée directement dans `list-collectivites.service.ts` ; `DatabaseService.withPagination` (seul consommateur) est supprimé.

## Test plan

- [ ] Ouvrir la modale « Rejoindre une collectivité » : les premières lignes du select sont des collectivités réelles (ordre alphabétique), pas des `# Collectivité Démo…`
- [ ] Rechercher une CT de test par nom (ex. `démo`, `#`) : elle apparaît dans les résultats
- [ ] `pnpm test:backend list-collectivites.router.e2e-spec.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Correction du tri pour garantir l'ordre attendu des collectivités dans les listes.

* **Performance**
  * Pagination révisée pour des réponses plus cohérentes et performantes, et prise en charge des cas sans pagination.

* **Tests**
  * Fiabilisation des tests d'import et de liste (meilleure coordination des imports lourds et validations d'ordre).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/incubateur-ademe/territoires-en-transitions/pull/4452)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->