### PR TITLE
Allège un test pour éviter un timeout

### DIFF
--- a/apps/backend/src/referentiels/reset-display-preferences/reset-display-preferences.router.e2e-spec.ts
+++ b/apps/backend/src/referentiels/reset-display-preferences/reset-display-preferences.router.e2e-spec.ts
@@ -16,10 +16,8 @@ import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
 import { Collectivite } from '@tet/domain/collectivites';
 import { ReferentielIdEnum } from '@tet/domain/referentiels';
 import { CollectiviteRole } from '@tet/domain/users';
-import {
-  cleanupReferentielActionStatutsAndLabellisations,
-  updateAllNeedReferentielStatutsToCompleteReferentiel,
-} from '../update-action-statut/referentiel-action-statut.test-fixture';
+import { cleanupReferentielActionStatutsAndLabellisations } from '../update-action-statut/referentiel-action-statut.test-fixture';
+import { seedCollectiviteReferentielDisplayActivity } from './reset-display-preferences.test-fixture';
 
 describe('ResetDisplayPreferencesRouter', () => {
   let router: TrpcRouter;
@@ -30,9 +28,9 @@ describe('ResetDisplayPreferencesRouter', () => {
   let editorUser: AuthenticatedUser;
 
   beforeAll(async () => {
-    router = await getTestRouter();
-    authUser = await getAuthUser();
     app = await getTestApp();
+    router = await getTestRouter(app);
+    authUser = await getAuthUser();
     databaseService = await getTestDatabase(app);
 
     const testCollectiviteAndUserResult = await addTestCollectiviteAndUser(
@@ -100,14 +98,14 @@ describe('ResetDisplayPreferencesRouter', () => {
     });
   });
 
-  test('ECI is displayed if it has been filled and support user resets display preferences', async () => {
+  test('ECI is displayed when collectivite has enough ECI activity and support user resets display preferences', async () => {
     const editorUserCaller = router.createCaller({ user: editorUser });
     const trpcClient = createTRPCClientFromCaller(editorUserCaller);
-    await updateAllNeedReferentielStatutsToCompleteReferentiel(
+    await seedCollectiviteReferentielDisplayActivity({
       trpcClient,
-      collectivite.id,
-      ReferentielIdEnum.ECI
-    );
+      collectiviteId: collectivite.id,
+      referentiel: ReferentielIdEnum.ECI,
+    });
     const caller = router.createCaller({ user: authUser });
     const { cleanup } = await addAndEnableUserSuperAdminMode({
       app,

--- a/apps/backend/src/referentiels/reset-display-preferences/reset-display-preferences.test-fixture.ts
+++ b/apps/backend/src/referentiels/reset-display-preferences/reset-display-preferences.test-fixture.ts
@@ -1,0 +1,48 @@
+import { AppRouter } from '@tet/backend/utils/trpc/trpc.router';
+import {
+  ReferentielId,
+  StatutAvancementEnum,
+} from '@tet/domain/referentiels';
+import { TRPCClient } from '@trpc/client';
+import assert from 'assert';
+import { getActionStatusCreateForAction } from '../update-action-statut/referentiel-action-statut.test-fixture';
+import { ACTION_STATUT_COUNT_THRESHOLD1 } from './compute-referentiel-display.rules';
+
+/**
+ * Seed enough referentiel activity on a collectivite to trigger display criteria
+ * (e.g. >= 50 statuts + recent modified_at) via a single updateStatuts batch.
+ */
+export async function seedCollectiviteReferentielDisplayActivity({
+  trpcClient,
+  collectiviteId,
+  referentiel,
+}: {
+  trpcClient: TRPCClient<AppRouter>;
+  collectiviteId: number;
+  referentiel: ReferentielId;
+}): Promise<void> {
+  const scoreSnapshot =
+    await trpcClient.referentiels.snapshots.getCurrent.query({
+      referentielId: referentiel,
+      collectiviteId,
+    });
+
+  const actionStatusesToCreate = getActionStatusCreateForAction(
+    scoreSnapshot.scoresPayload.scores,
+    StatutAvancementEnum.FAIT
+  )
+    .map((actionStatus) => ({
+      ...actionStatus,
+      collectiviteId,
+    }))
+    .slice(0, ACTION_STATUT_COUNT_THRESHOLD1);
+
+  assert(
+    actionStatusesToCreate.length >= ACTION_STATUT_COUNT_THRESHOLD1,
+    `Expected at least ${ACTION_STATUT_COUNT_THRESHOLD1} actionable ${referentiel} actions, got ${actionStatusesToCreate.length}`
+  );
+
+  await trpcClient.referentiels.actions.updateStatuts.mutate({
+    actionStatuts: actionStatusesToCreate,
+  });
+}


### PR DESCRIPTION
Le test sur les conditions d'affichage d'un référentiel faisait un remplissage complet de celui-ci, ce qui n'était pas nécessaire.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Tests e2e améliorés pour la gestion des préférences d'affichage avec une configuration plus efficace des prérequis.
  * Nouvelle fixture de test créée pour optimiser la préparation des données d'activité pour les tests.

* **Chores**
  * Réorganisation interne du code de test pour une meilleure structure et maintenabilité.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/incubateur-ademe/territoires-en-transitions/pull/4454?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->