### PR TITLE
Fix/reselection fichier import plan

### DIFF
--- a/e2e/tests/plans/plans/import-plan/import-plan.pom.ts
+++ b/e2e/tests/plans/plans/import-plan/import-plan.pom.ts
@@ -1,0 +1,39 @@
+import { expect, Locator, Page } from '@playwright/test';
+
+const EXCEL_MIME_TYPE =
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+
+export class ImportPlanPom {
+  readonly title: Locator;
+  readonly fileInput: Locator;
+
+  constructor(public readonly page: Page) {
+    this.page = page;
+    this.title = page.getByRole('heading', {
+      name: 'Importer un plan',
+      level: 2,
+    });
+    this.fileInput = page.locator('input[type="file"]');
+  }
+
+  async goto() {
+    await this.page.goto('/plans/import', { waitUntil: 'domcontentloaded' });
+    await expect(this.title).toBeVisible();
+  }
+
+  async selectFile(fileName: string) {
+    await this.fileInput.setInputFiles({
+      name: fileName,
+      mimeType: EXCEL_MIME_TYPE,
+      buffer: Buffer.from('contenu-de-test'),
+    });
+  }
+
+  async expectFileRegistered(fileName: string) {
+    await expect(this.page.getByText(fileName)).toBeVisible();
+  }
+
+  async expectNativeInputCleared() {
+    await expect(this.fileInput).toHaveValue('');
+  }
+}

--- a/e2e/tests/plans/plans/import-plan/import-plan.spec.ts
+++ b/e2e/tests/plans/plans/import-plan/import-plan.spec.ts
@@ -1,0 +1,27 @@
+import { test } from 'tests/main.fixture';
+
+test.describe("Import d'un plan", () => {
+  test(
+    'réinitialise la valeur native du champ fichier après sélection, ' +
+      'pour permettre de re-sélectionner un fichier du même nom après un échec',
+    async ({ collectivites, importPlanPom }) => {
+      await collectivites.addCollectiviteAndUser({
+        userArgs: {
+          autoLogin: true,
+          isSupport: true,
+          isSuperAdminRoleEnabled: true,
+        },
+      });
+
+      await importPlanPom.goto();
+      await importPlanPom.selectFile('plan-a-importer.xlsx');
+
+      // Le fichier reste enregistré dans le formulaire (état react-hook-form)...
+      await importPlanPom.expectFileRegistered('plan-a-importer.xlsx');
+      // ...mais la valeur native de l'input est vidée, condition sans laquelle
+      // re-sélectionner un fichier du même nom ne déclencherait aucun nouvel
+      // évènement `change`.
+      await importPlanPom.expectNativeInputCleared();
+    }
+  );
+});

--- a/e2e/tests/plans/plans/plans.fixture.ts
+++ b/e2e/tests/plans/plans/plans.fixture.ts
@@ -8,6 +8,7 @@ import { UserFixture } from 'tests/users/users.fixture';
 import { EditAxePom } from '../axes/edit-axe.pom';
 import { CreatePlanPom } from './create-plan/create-plan.pom';
 import { EditPlanPom } from './edit-plan/edit-plan.pom';
+import { ImportPlanPom } from './import-plan/import-plan.pom';
 
 class PlansFactory extends FixtureFactory {
   constructor() {
@@ -50,6 +51,7 @@ export const testWithPlans = testWithFiches.extend<{
   createPlanPom: CreatePlanPom;
   editPlanPom: EditPlanPom;
   editAxePom: EditAxePom;
+  importPlanPom: ImportPlanPom;
 }>({
   plans: async ({ collectivites }, use) => {
     const plans = new PlansFactory();
@@ -67,5 +69,8 @@ export const testWithPlans = testWithFiches.extend<{
   editAxePom: async ({ page }, use) => {
     const showPlanPom = new EditAxePom(page);
     await use(showPlanPom);
+  },
+  importPlanPom: async ({ page }, use) => {
+    await use(new ImportPlanPom(page));
   },
 });

--- a/packages/ui/src/design-system/Input/InputFile.tsx
+++ b/packages/ui/src/design-system/Input/InputFile.tsx
@@ -28,6 +28,7 @@ export const InputFile = forwardRef(
       state,
       containerClassname,
       onDropFiles,
+      onChange,
       ...remainingProps
     }: InputFileProps,
     ref?: Ref<HTMLInputElement>
@@ -84,6 +85,14 @@ export const InputFile = forwardRef(
           type="file"
           className="invisible w-0 h-0"
           {...remainingProps}
+          onChange={(e) => {
+            onChange?.(e);
+            // Réinitialise la valeur native après chaque sélection : sans
+            // cela, re-sélectionner un fichier portant le même nom (cas du
+            // fichier corrigé après un échec) ne déclenche aucun nouvel
+            // évènement `change`.
+            e.target.value = '';
+          }}
         />
         <label
           htmlFor="input-file"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notes de version

* **Tests**
  * Ajout de tests e2e pour la fonctionnalité d'import de plan.

* **Corrections de bugs**
  * Amélioration du comportement de sélection de fichier : permet maintenant de resélectionner un fichier portant le même nom sans perdre l'enregistrement du formulaire.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/incubateur-ademe/territoires-en-transitions/pull/4458?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->