### PR TITLE
feat(referentiels): génération asynchrone d'archive ZIP des preuves d'audit (backend)

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -15,5 +15,11 @@
       "import": "./dist/*.js",
       "default": "./dist/*.js"
     }
+  },
+  "dependencies": {
+    "archiver": "^7.0.0"
+  },
+  "devDependencies": {
+    "@types/archiver": "^7.0.0"
   }
 }

--- a/apps/backend/src/referentiels/labellisations/get-labellisation.service.ts
+++ b/apps/backend/src/referentiels/labellisations/get-labellisation.service.ts
@@ -184,6 +184,35 @@ export class GetLabellisationService {
     }
   }
 
+  async getCurrentAudit(
+    collectiviteId: number,
+    referentielId: ReferentielId,
+    tx?: Transaction
+  ): Promise<Result<LabellisationAudit, GetDemandeOrAuditError>> {
+    try {
+      const audit = await (tx ?? this.db)
+        .select()
+        .from(auditTable)
+        .where(
+          and(
+            eq(auditTable.collectiviteId, collectiviteId),
+            eq(auditTable.referentielId, referentielId),
+            not(auditTable.clos)
+          )
+        )
+        .orderBy(auditTable.dateDebut)
+        .limit(1);
+
+      if (!audit.length) {
+        return { success: false, error: 'NOT_FOUND' };
+      }
+      return { success: true, data: audit[0] };
+    } catch (error) {
+      this.logger.error(error);
+      return { success: false, error: 'DATABASE_ERROR' };
+    }
+  }
+
   /**
    * A bit weird to automatically create an empty audit / demande if not exists
    * But for retrocompatibility with current behavior.

--- a/apps/backend/src/referentiels/preuves-archive/build-archive/build-archive-manifests.spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/build-archive/build-archive-manifests.spec.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+import { buildArchiveManifests } from './build-archive-manifests';
+import type { ArchiveFolderArborescence } from '../generate-preuves-archive/generate-archive-folder-arborescence';
+
+function emptyArborescence(
+  overrides: Partial<ArchiveFolderArborescence> = {}
+): ArchiveFolderArborescence {
+  return {
+    files: [],
+    linkFolders: [],
+    skippedFiles: [],
+    ...overrides,
+  };
+}
+
+describe('buildArchiveManifests', () => {
+  it("retourne un tableau vide quand il n'y a rien à émettre", () => {
+    const entries = buildArchiveManifests({
+      arborescence: emptyArborescence(),
+      failedDownloads: [],
+    });
+
+    expect(entries).toEqual([]);
+  });
+
+  it('émet un `liens.csv` par dossier non vide, ignore les dossiers vides', () => {
+    const entries = buildArchiveManifests({
+      arborescence: emptyArborescence({
+        linkFolders: [
+          {
+            folderSegments: ['mesures', 'axe-1'],
+            liens: [
+              { titre: 'Site officiel', url: 'https://x', commentaire: '' },
+            ],
+          },
+          {
+            folderSegments: ['cycle-labellisation', 'audit'],
+            liens: [],
+          },
+        ],
+      }),
+      failedDownloads: [],
+    });
+
+    expect(entries.map((entry) => entry.name)).toEqual([
+      'mesures/axe-1/liens.csv',
+    ]);
+  });
+
+  it("agrège skippedFiles et failedDownloads dans `_manifeste/fichiers-manquants.txt`", () => {
+    const entries = buildArchiveManifests({
+      arborescence: emptyArborescence({
+        skippedFiles: [
+          {
+            filename: 'gros.pdf',
+            emplacement: 'mesures/axe-1',
+            raison: 'Fichier trop volumineux',
+          },
+        ],
+      }),
+      failedDownloads: ['mesures/axe-1/perdu.pdf (téléchargement échoué)'],
+    });
+
+    expect(entries).toEqual([
+      {
+        name: '_manifeste/fichiers-manquants.txt',
+        content:
+          'mesures/axe-1/gros.pdf — Fichier trop volumineux\n' +
+          'mesures/axe-1/perdu.pdf (téléchargement échoué)\n',
+      },
+    ]);
+  });
+
+  it("n'émet pas de manifeste vide quand aucune raison de manquant", () => {
+    const entries = buildArchiveManifests({
+      arborescence: emptyArborescence({
+        linkFolders: [
+          {
+            folderSegments: ['mesures'],
+            liens: [{ titre: 'X', url: 'https://x', commentaire: '' }],
+          },
+        ],
+      }),
+      failedDownloads: [],
+    });
+
+    expect(entries.map((entry) => entry.name)).toEqual(['mesures/liens.csv']);
+  });
+
+  it('concatène liens et manquants dans cet ordre', () => {
+    const entries = buildArchiveManifests({
+      arborescence: emptyArborescence({
+        linkFolders: [
+          {
+            folderSegments: ['mesures'],
+            liens: [{ titre: 'X', url: 'https://x', commentaire: '' }],
+          },
+        ],
+        skippedFiles: [
+          { filename: 'a.pdf', emplacement: 'mesures', raison: 'skip' },
+        ],
+      }),
+      failedDownloads: [],
+    });
+
+    expect(entries.map((entry) => entry.name)).toEqual([
+      'mesures/liens.csv',
+      '_manifeste/fichiers-manquants.txt',
+    ]);
+  });
+});

--- a/apps/backend/src/referentiels/preuves-archive/build-archive/build-archive-manifests.ts
+++ b/apps/backend/src/referentiels/preuves-archive/build-archive/build-archive-manifests.ts
@@ -1,0 +1,56 @@
+import { type ArchiveFolderArborescence } from '../generate-preuves-archive/generate-archive-folder-arborescence';
+import { buildArchivePath } from './build-archive-path';
+import { buildLiensCsv } from './build-liens-csv';
+
+// Le dossier `_manifeste/` à la racine écarte tout risque de collision avec un
+// fichier user homonyme (qui serait écrasé sans dédoublonnage côté manifestes).
+const MANIFESTE_FOLDER = '_manifeste';
+const FICHIERS_MANQUANTS_FILENAME = 'fichiers-manquants.txt';
+const LIENS_CSV_FILENAME = 'liens.csv';
+
+export interface ArchiveManifestEntry {
+  name: string;
+  content: string;
+}
+
+export interface BuildArchiveManifestsInput {
+  arborescence: ArchiveFolderArborescence;
+  failedDownloads: string[];
+}
+
+export function buildArchiveManifests({
+  arborescence,
+  failedDownloads,
+}: BuildArchiveManifestsInput): ArchiveManifestEntry[] {
+  const liensCsv = arborescence.linkFolders
+    .filter((folder) => folder.liens.length > 0)
+    .map((folder) => ({
+      name: buildArchivePath([
+        ...folder.folderSegments,
+        LIENS_CSV_FILENAME,
+      ]),
+      content: buildLiensCsv(folder.liens),
+    }));
+
+  const fichiersManquantsLignes = [
+    ...arborescence.skippedFiles.map(
+      (skipped) =>
+        `${skipped.emplacement}/${skipped.filename} — ${skipped.raison}`
+    ),
+    ...failedDownloads,
+  ];
+  const fichiersManquants: ArchiveManifestEntry[] =
+    fichiersManquantsLignes.length > 0
+      ? [
+          {
+            name: buildArchivePath([
+              MANIFESTE_FOLDER,
+              FICHIERS_MANQUANTS_FILENAME,
+            ]),
+            content: `${fichiersManquantsLignes.join('\n')}\n`,
+          },
+        ]
+      : [];
+
+  return [...liensCsv, ...fichiersManquants];
+}

--- a/apps/backend/src/referentiels/preuves-archive/build-archive/build-archive-path.spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/build-archive/build-archive-path.spec.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import { buildArchivePath, sanitizeSegment } from './build-archive-path';
+
+describe('sanitizeSegment', () => {
+  it('laisse passer un nom de fichier normal', () => {
+    expect(sanitizeSegment('rapport annuel.pdf')).toBe('rapport annuel.pdf');
+  });
+
+  it('neutralise un segment de traversée « .. »', () => {
+    expect(sanitizeSegment('..')).toBe('_');
+  });
+
+  it('neutralise un segment « . »', () => {
+    expect(sanitizeSegment('.')).toBe('_');
+  });
+
+  it('neutralise un segment vide', () => {
+    expect(sanitizeSegment('')).toBe('_');
+    expect(sanitizeSegment('   ')).toBe('_');
+  });
+
+  it('remplace les séparateurs de chemin par un underscore', () => {
+    expect(sanitizeSegment('a/b')).toBe('a_b');
+    expect(sanitizeSegment('a\\b')).toBe('a_b');
+  });
+
+  it('supprime les caractères NUL et de contrôle', () => {
+    expect(sanitizeSegment('a\x00b')).toBe('ab');
+    expect(sanitizeSegment('a\tb\rc\nd')).toBe('abcd');
+  });
+
+  it('retire les points et espaces en fin de segment (Windows)', () => {
+    expect(sanitizeSegment('dossier.')).toBe('dossier');
+    expect(sanitizeSegment('dossier ')).toBe('dossier');
+    expect(sanitizeSegment('dossier. . ')).toBe('dossier');
+  });
+
+  it('préfixe les noms réservés Windows', () => {
+    expect(sanitizeSegment('CON')).toBe('_CON');
+    expect(sanitizeSegment('nul')).toBe('_nul');
+    expect(sanitizeSegment('COM1')).toBe('_COM1');
+    expect(sanitizeSegment('LPT9.txt')).toBe('_LPT9.txt');
+  });
+
+  it('normalise en forme NFC', () => {
+    // « é » décomposé (e + accent combinant U+0301) → « é » composé U+00E9
+    expect(sanitizeSegment('éte.pdf')).toBe('éte.pdf');
+  });
+
+  it('tronque à 255 octets en préservant l’extension', () => {
+    const longName = 'a'.repeat(300) + '.pdf';
+    const result = sanitizeSegment(longName);
+    expect(Buffer.byteLength(result, 'utf8')).toBeLessThanOrEqual(255);
+    expect(result.endsWith('.pdf')).toBe(true);
+  });
+
+  it('tronque en comptant les octets, pas les caractères', () => {
+    const longName = 'é'.repeat(200) + '.pdf'; // « é » = 2 octets en UTF-8
+    const result = sanitizeSegment(longName);
+    expect(Buffer.byteLength(result, 'utf8')).toBeLessThanOrEqual(255);
+    expect(result.endsWith('.pdf')).toBe(true);
+  });
+});
+
+describe('buildArchivePath', () => {
+  it('joint les segments assainis par des « / »', () => {
+    expect(buildArchivePath(['mesures', 'axe 1', 'preuve.pdf'])).toBe(
+      'mesures/axe 1/preuve.pdf'
+    );
+  });
+
+  it('assainit chaque segment, y compris les répertoires', () => {
+    expect(buildArchivePath(['mesures', '..', 'preuve.pdf'])).toBe(
+      'mesures/_/preuve.pdf'
+    );
+    expect(buildArchivePath(['a/b', 'c'])).toBe('a_b/c');
+  });
+
+  it('ne produit jamais de chemin absolu', () => {
+    expect(buildArchivePath(['/etc', 'passwd']).startsWith('/')).toBe(false);
+  });
+
+  it('neutralise une tentative de Zip Slip complète', () => {
+    const path = buildArchivePath(['..', '..', 'etc', 'passwd']);
+    expect(path).toBe('_/_/etc/passwd');
+    expect(path.includes('..')).toBe(false);
+  });
+
+  it('neutralise un segment vide au lieu de produire « // »', () => {
+    expect(buildArchivePath(['mesures', '', 'preuve.pdf'])).toBe(
+      'mesures/_/preuve.pdf'
+    );
+  });
+
+  it('rejette une liste de segments vide', () => {
+    expect(() => buildArchivePath([])).toThrow();
+  });
+});

--- a/apps/backend/src/referentiels/preuves-archive/build-archive/build-archive-path.ts
+++ b/apps/backend/src/referentiels/preuves-archive/build-archive/build-archive-path.ts
@@ -1,0 +1,74 @@
+const MAX_SEGMENT_BYTES = 255;
+
+const WINDOWS_RESERVED_NAMES = new Set<string>([
+  'con',
+  'prn',
+  'aux',
+  'nul',
+  ...Array.from({ length: 9 }, (_, i) => `com${i + 1}`),
+  ...Array.from({ length: 9 }, (_, i) => `lpt${i + 1}`),
+]);
+
+const SEPARATOR_CODEPOINTS = new Set<number>([0x2f, 0x5c]);
+
+function stripControlAndSeparators(input: string): string {
+  return Array.from(input)
+    .flatMap((char) => {
+      const codePoint = char.codePointAt(0) ?? 0;
+      if (codePoint <= 0x1f || codePoint === 0x7f) {
+        return [];
+      }
+      return [SEPARATOR_CODEPOINTS.has(codePoint) ? '_' : char];
+    })
+    .join('');
+}
+
+function truncateToBytes(value: string, maxBytes: number): string {
+  let result = value;
+  while (Buffer.byteLength(result, 'utf8') > maxBytes && result.length > 0) {
+    result = result.slice(0, -1);
+  }
+  return result;
+}
+
+function truncateSegment(segment: string): string {
+  if (Buffer.byteLength(segment, 'utf8') <= MAX_SEGMENT_BYTES) {
+    return segment;
+  }
+  const lastDot = segment.lastIndexOf('.');
+  if (lastDot <= 0) {
+    return truncateToBytes(segment, MAX_SEGMENT_BYTES);
+  }
+  const extension = segment.slice(lastDot);
+  const extensionBytes = Buffer.byteLength(extension, 'utf8');
+  if (extensionBytes >= MAX_SEGMENT_BYTES) {
+    return truncateToBytes(segment, MAX_SEGMENT_BYTES);
+  }
+  const name = segment.slice(0, lastDot);
+  return truncateToBytes(name, MAX_SEGMENT_BYTES - extensionBytes) + extension;
+}
+
+export function sanitizeSegment(raw: string): string {
+  let segment = stripControlAndSeparators(raw.normalize('NFC'));
+  segment = segment.trim();
+  // Points et espaces de fin : problématiques sous Windows.
+  segment = segment.replace(/[. ]+$/, '');
+
+  if (segment === '' || segment === '.' || segment === '..') {
+    return '_';
+  }
+
+  const baseName = (segment.split('.')[0] ?? '').toLowerCase();
+  if (WINDOWS_RESERVED_NAMES.has(baseName)) {
+    segment = `_${segment}`;
+  }
+
+  return truncateSegment(segment);
+}
+
+export function buildArchivePath(segments: string[]): string {
+  if (segments.length === 0) {
+    throw new Error('buildArchivePath: au moins un segment est requis');
+  }
+  return segments.map(sanitizeSegment).join('/');
+}

--- a/apps/backend/src/referentiels/preuves-archive/build-archive/build-archive.service.ts
+++ b/apps/backend/src/referentiels/preuves-archive/build-archive/build-archive.service.ts
@@ -1,0 +1,159 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { failure, success, type Result } from '@tet/backend/utils/result.type';
+import { getErrorMessage } from '@tet/domain/utils';
+import archiver, { type Archiver } from 'archiver';
+import { createWriteStream } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pipeline } from 'node:stream/promises';
+import { DocumentStorageService } from '@tet/backend/utils/supabase/document-storage.service';
+import { type ArchiveFolderArborescence } from '../generate-preuves-archive/generate-archive-folder-arborescence';
+import {
+  ARCHIVE_ZIP_CONTENT_TYPE,
+  PREUVES_ARCHIVES_BUCKET,
+} from '../preuves-archive.constants';
+import {
+  PreuvesArchiveErrorEnum,
+  type PreuvesArchiveError,
+} from '../preuves-archive.errors';
+import { buildArchiveManifests } from './build-archive-manifests';
+import { mapWithConcurrency } from './map-with-concurrency';
+import {
+  prepareArchiveEntries,
+  type PreparedFileEntry,
+} from './prepare-archive-entries';
+
+const DOWNLOAD_CONCURRENCY = 8;
+
+export interface BuildAndUploadInput {
+  archiveId: string;
+  arborescence: ArchiveFolderArborescence;
+  storagePath: string;
+  onProgress?: (processedFiles: number) => void;
+}
+
+type DownloadOutcome =
+  | { kind: 'appended' }
+  | { kind: 'failed'; message: string };
+
+interface AssembleZipInput {
+  arborescence: ArchiveFolderArborescence;
+  tempZipPath: string;
+  onProgress?: (processedFiles: number) => void;
+}
+
+@Injectable()
+export class BuildArchiveService {
+  private readonly logger = new Logger(BuildArchiveService.name);
+
+  constructor(private readonly documentStorage: DocumentStorageService) {}
+
+  async buildAndUpload(
+    input: BuildAndUploadInput
+  ): Promise<Result<{ totalFiles: number }, PreuvesArchiveError>> {
+    const { archiveId, arborescence, storagePath, onProgress } = input;
+
+    let tempDir: string | null = null;
+    try {
+      tempDir = await mkdtemp(join(tmpdir(), 'preuves-archive-'));
+      const tempZipPath = join(tempDir, `${archiveId}.zip`);
+
+      const assembleResult = await this.assembleZip({
+        arborescence,
+        tempZipPath,
+        onProgress,
+      });
+      if (!assembleResult.success) {
+        return assembleResult;
+      }
+
+      const uploadResult = await this.documentStorage.storeDocument({
+        bucketId: PREUVES_ARCHIVES_BUCKET,
+        key: storagePath,
+        sourceFilePath: tempZipPath,
+        contentType: ARCHIVE_ZIP_CONTENT_TYPE,
+      });
+      if (!uploadResult.success) {
+        return failure(
+          PreuvesArchiveErrorEnum.CREATE_ARCHIVE_ERROR,
+          uploadResult.cause
+        );
+      }
+
+      return success({ totalFiles: assembleResult.data.totalFiles });
+    } catch (error) {
+      this.logger.error(
+        `Construction de l'archive ${archiveId} échouée: ${getErrorMessage(
+          error
+        )}`
+      );
+      return failure(
+        PreuvesArchiveErrorEnum.CREATE_ARCHIVE_ERROR,
+        error instanceof Error ? error : new Error(getErrorMessage(error))
+      );
+    } finally {
+      if (tempDir !== null) {
+        await rm(tempDir, { recursive: true, force: true }).catch((error) =>
+          this.logger.warn(
+            `Nettoyage du dossier temporaire ${tempDir} échoué: ${getErrorMessage(
+              error
+            )}`
+          )
+        );
+      }
+    }
+  }
+
+  private async assembleZip({
+    arborescence,
+    tempZipPath,
+    onProgress,
+  }: AssembleZipInput): Promise<Result<{ totalFiles: number }, PreuvesArchiveError>> {
+    const archive = archiver('zip', { store: true });
+    const output = createWriteStream(tempZipPath);
+    const writeFinished = pipeline(archive, output);
+
+    const preparedEntries = prepareArchiveEntries(arborescence.files);
+
+    const outcomes = await mapWithConcurrency(
+      preparedEntries,
+      DOWNLOAD_CONCURRENCY,
+      (entry) => this.downloadAndAppendEntry({ entry, archive }),
+      (processed) => onProgress?.(processed)
+    );
+    const failedDownloads = outcomes.flatMap((outcome) =>
+      outcome.kind === 'failed' ? [outcome.message] : []
+    );
+
+    buildArchiveManifests({ arborescence, failedDownloads }).forEach((entry) =>
+      archive.append(entry.content, { name: entry.name })
+    );
+
+    await archive.finalize();
+    await writeFinished;
+
+    return success({ totalFiles: preparedEntries.length });
+  }
+
+  private async downloadAndAppendEntry({
+    entry,
+    archive,
+  }: {
+    entry: PreparedFileEntry;
+    archive: Archiver;
+  }): Promise<DownloadOutcome> {
+    const streamResult = await this.documentStorage.getDocumentStream({
+      bucketId: entry.bucketId,
+      key: entry.hash,
+    });
+    if (!streamResult.success) {
+      return {
+        kind: 'failed',
+        message: `${entry.emplacement}/${entry.filename} (téléchargement échoué)`,
+      };
+    }
+    archive.append(streamResult.data, { name: entry.entryPath });
+    return { kind: 'appended' };
+  }
+}

--- a/apps/backend/src/referentiels/preuves-archive/build-archive/build-liens-csv.spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/build-archive/build-liens-csv.spec.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { buildLiensCsv } from './build-liens-csv';
+
+const HEADER = 'Titre,URL,Commentaire';
+
+describe('buildLiensCsv', () => {
+  it('produit un en-tete seul pour une liste vide', () => {
+    expect(buildLiensCsv([])).toBe(`${HEADER}\n`);
+  });
+
+  it('ecrit une ligne par lien', () => {
+    const csv = buildLiensCsv([
+      { titre: 'Site officiel', url: 'https://exemple.fr', commentaire: 'a jour' },
+    ]);
+    expect(csv).toBe(
+      `${HEADER}\nSite officiel,https://exemple.fr,a jour\n`
+    );
+  });
+
+  it('entoure de guillemets les champs contenant une virgule', () => {
+    const csv = buildLiensCsv([
+      { titre: 'Rapport, version 2', url: 'https://x.fr', commentaire: '' },
+    ]);
+    expect(csv).toBe(`${HEADER}\n"Rapport, version 2",https://x.fr,\n`);
+  });
+
+  it('double les guillemets internes', () => {
+    const csv = buildLiensCsv([
+      { titre: 'Le "grand" rapport', url: 'https://x.fr', commentaire: '' },
+    ]);
+    expect(csv).toBe(`${HEADER}\n"Le ""grand"" rapport",https://x.fr,\n`);
+  });
+
+  it('entoure de guillemets les champs contenant un saut de ligne', () => {
+    const csv = buildLiensCsv([
+      { titre: 'ligne1\nligne2', url: 'https://x.fr', commentaire: '' },
+    ]);
+    expect(csv).toBe(`${HEADER}\n"ligne1\nligne2",https://x.fr,\n`);
+  });
+
+  it('neutralise les injections de formule (= + - @) sur titre et commentaire', () => {
+    const csv = buildLiensCsv([
+      { titre: '=SUM(A1)', url: 'https://x.fr', commentaire: '@cmd' },
+    ]);
+    expect(csv).toBe(`${HEADER}\n'=SUM(A1),https://x.fr,'@cmd\n`);
+  });
+
+  it('neutralise une injection de formule commencant par - ou tabulation', () => {
+    const csv = buildLiensCsv([
+      { titre: '-2+3', url: 'https://x.fr', commentaire: '\tcmd' },
+    ]);
+    expect(csv).toBe(`${HEADER}\n'-2+3,https://x.fr,'\tcmd\n`);
+  });
+
+  it("remplace les URLs aux schemes non sûrs par un placeholder (javascript:/data:/etc)", () => {
+    const csv = buildLiensCsv([
+      { titre: 'XSS', url: 'javascript:alert(1)', commentaire: '' },
+      { titre: 'Data URI', url: 'data:text/html,xxx', commentaire: '' },
+      { titre: 'OK', url: 'https://example.com', commentaire: '' },
+    ]);
+    expect(csv).toBe(
+      `${HEADER}\nXSS,[URL non sûre],\nData URI,[URL non sûre],\nOK,https://example.com,\n`
+    );
+  });
+
+  it('neutralise la formule puis applique l’echappement CSV', () => {
+    const csv = buildLiensCsv([
+      { titre: '=SUM(A1,A2)', url: 'https://x.fr', commentaire: '' },
+    ]);
+    expect(csv).toBe(`${HEADER}\n"'=SUM(A1,A2)",https://x.fr,\n`);
+  });
+});

--- a/apps/backend/src/referentiels/preuves-archive/build-archive/build-liens-csv.ts
+++ b/apps/backend/src/referentiels/preuves-archive/build-archive/build-liens-csv.ts
@@ -1,0 +1,51 @@
+export interface LienPreuve {
+  titre: string;
+  url: string;
+  commentaire: string;
+}
+
+const CSV_HEADER = ['Titre', 'URL', 'Commentaire'] as const;
+
+const FORMULA_TRIGGERS = new Set<string>(['=', '+', '-', '@', '\t', '\r']);
+
+const ALLOWED_URL_SCHEMES = ['http://', 'https://'];
+
+const UNSAFE_URL_PLACEHOLDER = '[URL non sûre]';
+
+function neutralizeFormula(value: string): string {
+  const firstChar = value[0];
+  return firstChar !== undefined && FORMULA_TRIGGERS.has(firstChar)
+    ? `'${value}`
+    : value;
+}
+
+function sanitizeUrl(url: string): string {
+  const trimmed = url.trim();
+  if (trimmed === '') {
+    return '';
+  }
+  const lower = trimmed.toLowerCase();
+  return ALLOWED_URL_SCHEMES.some((scheme) => lower.startsWith(scheme))
+    ? trimmed
+    : UNSAFE_URL_PLACEHOLDER;
+}
+
+function escapeCsvField(value: string): string {
+  const neutralized = neutralizeFormula(value);
+  if (/["\r\n,]/.test(neutralized)) {
+    return `"${neutralized.replace(/"/g, '""')}"`;
+  }
+  return neutralized;
+}
+
+export function buildLiensCsv(liens: LienPreuve[]): string {
+  const lines = [
+    CSV_HEADER.join(','),
+    ...liens.map((lien) =>
+      [lien.titre, sanitizeUrl(lien.url), lien.commentaire]
+        .map(escapeCsvField)
+        .join(',')
+    ),
+  ];
+  return `${lines.join('\n')}\n`;
+}

--- a/apps/backend/src/referentiels/preuves-archive/build-archive/map-with-concurrency.spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/build-archive/map-with-concurrency.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { mapWithConcurrency } from './map-with-concurrency';
+
+const tick = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe('mapWithConcurrency', () => {
+  it('rend les résultats dans l’ordre des items malgré des durées variables', async () => {
+    const results = await mapWithConcurrency(
+      [30, 10, 20],
+      2,
+      async (ms) => {
+        await tick(ms);
+        return ms * 2;
+      }
+    );
+    expect(results).toEqual([60, 20, 40]);
+  });
+
+  it('ne dépasse jamais la concurrence demandée', async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+
+    await mapWithConcurrency([1, 2, 3, 4, 5, 6], 2, async () => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await tick(5);
+      inFlight -= 1;
+    });
+
+    expect(maxInFlight).toBe(2);
+  });
+
+  it('reporte le nombre cumulé de tâches terminées', async () => {
+    const completed: number[] = [];
+
+    await mapWithConcurrency(
+      [1, 2, 3],
+      3,
+      async () => undefined,
+      (count) => completed.push(count)
+    );
+
+    expect(completed).toEqual([1, 2, 3]);
+  });
+
+  it('retourne un tableau vide pour une liste vide sans lancer de worker', async () => {
+    let called = false;
+    const results = await mapWithConcurrency([], 4, async () => {
+      called = true;
+      return 1;
+    });
+    expect(results).toEqual([]);
+    expect(called).toBe(false);
+  });
+});

--- a/apps/backend/src/referentiels/preuves-archive/build-archive/map-with-concurrency.ts
+++ b/apps/backend/src/referentiels/preuves-archive/build-archive/map-with-concurrency.ts
@@ -1,0 +1,27 @@
+// Fenêtre glissante : `concurrency` workers tirent l'élément suivant dès qu'ils
+// se libèrent, plutôt que d'attendre la fin d'un lot complet (où un fichier lent
+// bloque tout le lot). Les résultats sont rendus dans l'ordre des `items`.
+export async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  task: (item: T) => Promise<R>,
+  onSettled?: (completedCount: number) => void
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+  let completedCount = 0;
+
+  async function runWorker(): Promise<void> {
+    while (nextIndex < items.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      results[index] = await task(items[index]);
+      completedCount += 1;
+      onSettled?.(completedCount);
+    }
+  }
+
+  const workerCount = Math.min(Math.max(concurrency, 1), items.length);
+  await Promise.all(Array.from({ length: workerCount }, runWorker));
+  return results;
+}

--- a/apps/backend/src/referentiels/preuves-archive/build-archive/prepare-archive-entries.spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/build-archive/prepare-archive-entries.spec.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import type { ArchiveFile } from '../generate-preuves-archive/generate-archive-folder-arborescence';
+import { prepareArchiveEntries } from './prepare-archive-entries';
+
+function makeFile(
+  overrides: Partial<ArchiveFile> = {}
+): ArchiveFile {
+  return {
+    folderSegments: ['mesures', 'axe-1'],
+    filename: 'document.pdf',
+    bucketId: 'preuves',
+    hash: 'abc123',
+    filesize: 1024,
+    ...overrides,
+  };
+}
+
+describe('prepareArchiveEntries', () => {
+  it('mappe un fichier unique sans suffixe', () => {
+    const entries = prepareArchiveEntries([makeFile()]);
+
+    expect(entries).toEqual([
+      {
+        entryPath: 'mesures/axe-1/document.pdf',
+        bucketId: 'preuves',
+        hash: 'abc123',
+        filename: 'document.pdf',
+        emplacement: 'mesures/axe-1',
+      },
+    ]);
+  });
+
+  it("suffixe `(2)`, `(3)`... pour les doublons de chemin", () => {
+    const files = [
+      makeFile({ hash: 'a' }),
+      makeFile({ hash: 'b' }),
+      makeFile({ hash: 'c' }),
+    ];
+
+    const entries = prepareArchiveEntries(files);
+
+    expect(entries.map((entry) => entry.entryPath)).toEqual([
+      'mesures/axe-1/document.pdf',
+      'mesures/axe-1/document (2).pdf',
+      'mesures/axe-1/document (3).pdf',
+    ]);
+  });
+
+  it('insère le suffixe avant la dernière extension', () => {
+    const files = [
+      makeFile({ filename: 'rapport.tar.gz', hash: 'a' }),
+      makeFile({ filename: 'rapport.tar.gz', hash: 'b' }),
+    ];
+
+    const entries = prepareArchiveEntries(files);
+
+    expect(entries[1].entryPath).toBe('mesures/axe-1/rapport.tar (2).gz');
+  });
+
+  it("ajoute le suffixe en fin pour un fichier sans extension", () => {
+    const files = [
+      makeFile({ filename: 'README', hash: 'a' }),
+      makeFile({ filename: 'README', hash: 'b' }),
+    ];
+
+    const entries = prepareArchiveEntries(files);
+
+    expect(entries[1].entryPath).toBe('mesures/axe-1/README (2)');
+  });
+
+  it("ajoute le suffixe en fin pour un fichier commençant par un point", () => {
+    const files = [
+      makeFile({ filename: '.env', hash: 'a' }),
+      makeFile({ filename: '.env', hash: 'b' }),
+    ];
+
+    const entries = prepareArchiveEntries(files);
+
+    expect(entries[1].entryPath).toBe('mesures/axe-1/.env (2)');
+  });
+
+  it("ne déduplique pas entre dossiers distincts", () => {
+    const files = [
+      makeFile({ folderSegments: ['mesures', 'axe-1'], hash: 'a' }),
+      makeFile({ folderSegments: ['mesures', 'axe-2'], hash: 'b' }),
+    ];
+
+    const entries = prepareArchiveEntries(files);
+
+    expect(entries.map((entry) => entry.entryPath)).toEqual([
+      'mesures/axe-1/document.pdf',
+      'mesures/axe-2/document.pdf',
+    ]);
+  });
+
+  it('expose `emplacement` joint par `/`', () => {
+    const entries = prepareArchiveEntries([
+      makeFile({ folderSegments: ['cycle-labellisation', 'audit'] }),
+    ]);
+
+    expect(entries[0].emplacement).toBe('cycle-labellisation/audit');
+  });
+});

--- a/apps/backend/src/referentiels/preuves-archive/build-archive/prepare-archive-entries.ts
+++ b/apps/backend/src/referentiels/preuves-archive/build-archive/prepare-archive-entries.ts
@@ -1,0 +1,48 @@
+import type { ArchiveFile } from '../generate-preuves-archive/generate-archive-folder-arborescence';
+import { buildArchivePath } from './build-archive-path';
+
+export interface PreparedFileEntry {
+  entryPath: string;
+  bucketId: string;
+  hash: string;
+  filename: string;
+  emplacement: string;
+}
+
+export function prepareArchiveEntries(
+  files: ArchiveFile[]
+): PreparedFileEntry[] {
+  const seenPaths = new Map<string, number>();
+
+  return files.map((file) => {
+    const basePath = buildArchivePath([...file.folderSegments, file.filename]);
+    const occurrence = seenPaths.get(basePath) ?? 0;
+    seenPaths.set(basePath, occurrence + 1);
+
+    const entryPath =
+      occurrence === 0
+        ? basePath
+        : buildArchivePath([
+            ...file.folderSegments,
+            suffixBasename(file.filename, occurrence + 1),
+          ]);
+
+    return {
+      entryPath,
+      bucketId: file.bucketId,
+      hash: file.hash,
+      filename: file.filename,
+      emplacement: file.folderSegments.join('/'),
+    };
+  });
+}
+
+function suffixBasename(filename: string, occurrence: number): string {
+  const lastDot = filename.lastIndexOf('.');
+  if (lastDot <= 0) {
+    return `${filename} (${occurrence})`;
+  }
+  const name = filename.slice(0, lastDot);
+  const extension = filename.slice(lastDot);
+  return `${name} (${occurrence})${extension}`;
+}

--- a/apps/backend/src/referentiels/preuves-archive/generate-preuves-archive/generate-archive-folder-arborescence.spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/generate-preuves-archive/generate-archive-folder-arborescence.spec.ts
@@ -1,0 +1,307 @@
+import { ActionTypeEnum } from '@tet/domain/referentiels';
+import { describe, expect, it } from 'vitest';
+import type { PreuvesByOrigin, PreuvesSource } from '../list-audit-preuves/list-audit-preuves.service';
+import type {
+  CollectedFilePreuve,
+  CollectedLinkPreuve,
+} from '../list-audit-preuves/collect-preuves.repository';
+import {
+  generateArchiveFolderArborescence,
+  type GenerateArchiveFolderArborescenceInput,
+  type ReferentielTreeNode,
+} from './generate-archive-folder-arborescence';
+
+const referentielTree: ReferentielTreeNode = {
+  actionId: 'cae',
+  actionType: ActionTypeEnum.REFERENTIEL,
+  identifiant: '',
+  nom: 'CAE',
+  actionsEnfant: [
+    {
+      actionId: 'cae_1',
+      actionType: ActionTypeEnum.AXE,
+      identifiant: '1',
+      nom: 'Axe un',
+      actionsEnfant: [
+        {
+          actionId: 'cae_1.1',
+          actionType: ActionTypeEnum.SOUS_AXE,
+          identifiant: '1.1',
+          nom: 'Sous-axe un',
+          actionsEnfant: [
+            {
+              actionId: 'cae_1.1.1',
+              actionType: ActionTypeEnum.ACTION,
+              identifiant: '1.1.1',
+              nom: 'Mesure un',
+              actionsEnfant: [
+                {
+                  actionId: 'cae_1.1.1.1',
+                  actionType: ActionTypeEnum.SOUS_ACTION,
+                  identifiant: '1.1.1.1',
+                  nom: 'Sous-action',
+                  actionsEnfant: [],
+                },
+              ],
+            },
+            {
+              actionId: 'cae_1.1.2',
+              actionType: ActionTypeEnum.ACTION,
+              identifiant: '1.1.2',
+              nom: 'Mesure deux',
+              actionsEnfant: [],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+function makeFile(
+  overrides: Partial<CollectedFilePreuve> = {}
+): CollectedFilePreuve {
+  return {
+    bucketId: 'bucket-1',
+    hash: 'hash-1',
+    filename: 'doc.pdf',
+    filesize: 1024,
+    actionId: null,
+    ...overrides,
+  };
+}
+
+function makeLink(
+  overrides: Partial<CollectedLinkPreuve> = {}
+): CollectedLinkPreuve {
+  return {
+    url: 'https://example.org',
+    titre: 'Un lien',
+    commentaire: '',
+    actionId: null,
+    ...overrides,
+  };
+}
+
+const empty: PreuvesSource = { files: [], links: [] };
+
+function buildInput(
+  preuves: Partial<PreuvesByOrigin> = {}
+): GenerateArchiveFolderArborescenceInput {
+  return {
+    preuves: {
+      mesure: empty,
+      demande: empty,
+      audit: empty,
+      ...preuves,
+    },
+    referentielTree,
+  };
+}
+
+describe('generateArchiveFolderArborescence', () => {
+  it('range les preuves de mesure dans mesures/<axe>/<sous-axe>/<mesure>/', () => {
+    const result = generateArchiveFolderArborescence(
+      buildInput({
+        mesure: {
+          files: [makeFile({ actionId: 'cae_1.1.1', filename: 'a.pdf' })],
+          links: [],
+        },
+      })
+    );
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.files).toEqual([
+      {
+        folderSegments: [
+          'mesures',
+          '1 Axe un',
+          '1.1 Sous-axe un',
+          '1.1.1 Mesure un',
+        ],
+        filename: 'a.pdf',
+        bucketId: 'bucket-1',
+        hash: 'hash-1',
+        filesize: 1024,
+      },
+    ]);
+  });
+
+  it('range les preuves de cycle dans cycle-labellisation/demande et /audit', () => {
+    const result = generateArchiveFolderArborescence(
+      buildInput({
+        demande: { files: [makeFile({ filename: 'demande.pdf' })], links: [] },
+        audit: { files: [makeFile({ filename: 'audit.pdf' })], links: [] },
+      })
+    );
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(
+      result.data.files.map((file) => ({
+        filename: file.filename,
+        folderSegments: file.folderSegments,
+      }))
+    ).toEqual([
+      {
+        filename: 'demande.pdf',
+        folderSegments: ['cycle-labellisation', 'demande'],
+      },
+      {
+        filename: 'audit.pdf',
+        folderSegments: ['cycle-labellisation', 'audit'],
+      },
+    ]);
+  });
+
+  it('remonte une preuve de sous-action dans le dossier de sa mesure ancetre', () => {
+    const result = generateArchiveFolderArborescence(
+      buildInput({
+        mesure: {
+          files: [makeFile({ actionId: 'cae_1.1.1.1', filename: 'sa.pdf' })],
+          links: [],
+        },
+      })
+    );
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.files[0].folderSegments).toEqual([
+      'mesures',
+      '1 Axe un',
+      '1.1 Sous-axe un',
+      '1.1.1 Mesure un',
+    ]);
+  });
+
+  it('ignore un fichier trop volumineux et le consigne', () => {
+    const result = generateArchiveFolderArborescence(
+      buildInput({
+        mesure: {
+          files: [
+            makeFile({
+              actionId: 'cae_1.1.1',
+              filename: 'gros.zip',
+              filesize: 200 * 1024 * 1024,
+            }),
+            makeFile({ actionId: 'cae_1.1.1', filename: 'ok.pdf' }),
+          ],
+          links: [],
+        },
+      })
+    );
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.files.map((file) => file.filename)).toEqual(['ok.pdf']);
+    expect(result.data.skippedFiles).toHaveLength(1);
+    expect(result.data.skippedFiles[0]).toMatchObject({
+      filename: 'gros.zip',
+      emplacement: 'mesures/1 Axe un/1.1 Sous-axe un/1.1.1 Mesure un',
+    });
+  });
+
+  it('ignore un fichier introuvable dans le stockage', () => {
+    const result = generateArchiveFolderArborescence(
+      buildInput({
+        mesure: {
+          files: [
+            makeFile({
+              actionId: 'cae_1.1.1',
+              filename: 'sans-taille.pdf',
+              filesize: null,
+            }),
+          ],
+          links: [],
+        },
+      })
+    );
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.files).toEqual([]);
+    expect(result.data.skippedFiles[0]).toMatchObject({
+      filename: 'sans-taille.pdf',
+      raison: 'Fichier introuvable dans le stockage',
+    });
+  });
+
+  it('rejette au-dela de 500 fichiers', () => {
+    const files = Array.from({ length: 501 }, (_, index) =>
+      makeFile({ actionId: 'cae_1.1.1', filename: `f-${index}.pdf` })
+    );
+
+    const result = generateArchiveFolderArborescence(
+      buildInput({ mesure: { files, links: [] } })
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error).toBe('COLLECT_PREUVES_ERROR');
+  });
+
+  it('rejette au-dela de 2 Go au total', () => {
+    const files = Array.from({ length: 30 }, (_, index) =>
+      makeFile({
+        actionId: 'cae_1.1.1',
+        filename: `f-${index}.pdf`,
+        filesize: 80 * 1024 * 1024,
+      })
+    );
+
+    const result = generateArchiveFolderArborescence(
+      buildInput({ mesure: { files, links: [] } })
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error).toBe('COLLECT_PREUVES_ERROR');
+  });
+
+  it('regroupe les preuves-lien par dossier', () => {
+    const result = generateArchiveFolderArborescence(
+      buildInput({
+        mesure: {
+          files: [makeFile({ actionId: 'cae_1.1.1', filename: 'doc.pdf' })],
+          links: [
+            makeLink({ actionId: 'cae_1.1.1', titre: 'Lien A' }),
+            makeLink({ actionId: 'cae_1.1.1', titre: 'Lien B' }),
+          ],
+        },
+        audit: {
+          files: [],
+          links: [makeLink({ titre: 'Lien audit', commentaire: null })],
+        },
+      })
+    );
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.files).toHaveLength(1);
+    expect(result.data.linkFolders).toEqual([
+      {
+        folderSegments: [
+          'mesures',
+          '1 Axe un',
+          '1.1 Sous-axe un',
+          '1.1.1 Mesure un',
+        ],
+        liens: [
+          { titre: 'Lien A', url: 'https://example.org', commentaire: '' },
+          { titre: 'Lien B', url: 'https://example.org', commentaire: '' },
+        ],
+      },
+      {
+        folderSegments: ['cycle-labellisation', 'audit'],
+        liens: [
+          {
+            titre: 'Lien audit',
+            url: 'https://example.org',
+            commentaire: '',
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/apps/backend/src/referentiels/preuves-archive/generate-preuves-archive/generate-archive-folder-arborescence.ts
+++ b/apps/backend/src/referentiels/preuves-archive/generate-preuves-archive/generate-archive-folder-arborescence.ts
@@ -1,0 +1,254 @@
+import { failure, success, type Result } from '@tet/backend/utils/result.type';
+import { ActionTypeEnum } from '@tet/domain/referentiels';
+import { groupBy } from 'es-toolkit';
+import type { PreuvesByOrigin } from '../list-audit-preuves/list-audit-preuves.service';
+import {
+  PreuvesArchiveErrorEnum,
+  type PreuvesArchiveError,
+} from '../preuves-archive.errors';
+import type {
+  CollectedFilePreuve,
+  CollectedLinkPreuve,
+} from '../list-audit-preuves/collect-preuves.repository';
+import type { LienPreuve } from '../build-archive/build-liens-csv';
+
+const MAX_FILE_SIZE_BYTES = 100 * 1024 * 1024;
+const MAX_FILE_COUNT = 500;
+const MAX_TOTAL_SIZE_BYTES = 2 * 1024 * 1024 * 1024;
+
+const MESURES_FOLDER = 'mesures';
+const CYCLE_FOLDER = 'cycle-labellisation';
+const DEMANDE_FOLDER = 'demande';
+const AUDIT_FOLDER = 'audit';
+
+export interface ArchiveFile {
+  folderSegments: string[];
+  filename: string;
+  bucketId: string;
+  hash: string;
+  filesize: number;
+}
+
+export interface ArchiveLinkFolder {
+  folderSegments: string[];
+  liens: LienPreuve[];
+}
+
+export interface SkippedFile {
+  filename: string;
+  emplacement: string;
+  raison: string;
+}
+
+export interface ArchiveFolderArborescence {
+  files: ArchiveFile[];
+  linkFolders: ArchiveLinkFolder[];
+  skippedFiles: SkippedFile[];
+}
+
+export interface ReferentielTreeNode {
+  actionId: string;
+  actionType?: string;
+  identifiant?: string | null;
+  nom?: string | null;
+  actionsEnfant?: ReferentielTreeNode[];
+}
+
+export interface GenerateArchiveFolderArborescenceInput {
+  preuves: PreuvesByOrigin;
+  referentielTree: ReferentielTreeNode;
+}
+
+interface MesureFolder {
+  actionId: string;
+  folderSegments: string[];
+}
+
+type FileWithFolder = {
+  file: CollectedFilePreuve;
+  folderSegments: string[];
+};
+
+type LinkWithFolder = {
+  link: CollectedLinkPreuve;
+  folderSegments: string[];
+};
+
+type FileTriage =
+  | { kind: 'collected'; file: ArchiveFile }
+  | { kind: 'skipped'; entry: SkippedFile };
+
+function triageFile({ file, folderSegments }: FileWithFolder): FileTriage {
+  const emplacement = folderSegments.join('/');
+  const filename = file.filename ?? file.hash;
+
+  if (file.filesize === null || file.bucketId === null) {
+    return {
+      kind: 'skipped',
+      entry: {
+        filename,
+        emplacement,
+        raison: 'Fichier introuvable dans le stockage',
+      },
+    };
+  }
+
+  if (file.filesize > MAX_FILE_SIZE_BYTES) {
+    return {
+      kind: 'skipped',
+      entry: {
+        filename,
+        emplacement,
+        raison: `Fichier trop volumineux (${file.filesize} octets, limite ${MAX_FILE_SIZE_BYTES})`,
+      },
+    };
+  }
+
+  return {
+    kind: 'collected',
+    file: {
+      folderSegments,
+      filename,
+      bucketId: file.bucketId,
+      hash: file.hash,
+      filesize: file.filesize,
+    },
+  };
+}
+
+function checkArchiveLimits(
+  files: ArchiveFile[]
+): Result<undefined, PreuvesArchiveError> {
+  if (files.length > MAX_FILE_COUNT) {
+    return failure(
+      PreuvesArchiveErrorEnum.COLLECT_PREUVES_ERROR,
+      new Error(
+        `Trop de fichiers à archiver (${files.length}, limite ${MAX_FILE_COUNT})`
+      )
+    );
+  }
+
+  const totalSize = files.reduce((sum, file) => sum + file.filesize, 0);
+  if (totalSize > MAX_TOTAL_SIZE_BYTES) {
+    return failure(
+      PreuvesArchiveErrorEnum.COLLECT_PREUVES_ERROR,
+      new Error(
+        `Archive trop volumineuse (${totalSize} octets, limite ${MAX_TOTAL_SIZE_BYTES})`
+      )
+    );
+  }
+
+  return success(undefined);
+}
+
+function groupLinksByFolder(links: LinkWithFolder[]): ArchiveLinkFolder[] {
+  const grouped = groupBy(links, ({ folderSegments }) =>
+    folderSegments.join('/')
+  );
+  return Object.values(grouped).map((items) => ({
+    folderSegments: items[0].folderSegments,
+    liens: items.map(({ link }) => ({
+      titre: link.titre ?? '',
+      url: link.url,
+      commentaire: link.commentaire ?? '',
+    })),
+  }));
+}
+
+function nodeLabel(node: ReferentielTreeNode): string {
+  return [node.identifiant, node.nom]
+    .filter((part): part is string => Boolean(part))
+    .join(' ');
+}
+
+function collectMesureFolders(
+  node: ReferentielTreeNode,
+  ancestors: string[]
+): MesureFolder[] {
+  const path =
+    node.actionType === ActionTypeEnum.REFERENTIEL
+      ? ancestors
+      : [...ancestors, nodeLabel(node)];
+
+  if (node.actionType === ActionTypeEnum.ACTION) {
+    return [
+      { actionId: node.actionId, folderSegments: [MESURES_FOLDER, ...path] },
+    ];
+  }
+
+  return (node.actionsEnfant ?? []).flatMap((child) =>
+    collectMesureFolders(child, path)
+  );
+}
+
+function mesureFolderSegments(
+  actionId: string | null,
+  mesureFolders: MesureFolder[]
+): string[] {
+  if (actionId === null) {
+    return [MESURES_FOLDER];
+  }
+  const match = mesureFolders.find(
+    (mesure) =>
+      mesure.actionId === actionId ||
+      actionId.startsWith(`${mesure.actionId}.`)
+  );
+  return match ? match.folderSegments : [MESURES_FOLDER];
+}
+
+export function generateArchiveFolderArborescence(
+  input: GenerateArchiveFolderArborescenceInput
+): Result<ArchiveFolderArborescence, PreuvesArchiveError> {
+  const { preuves, referentielTree } = input;
+
+  const mesureFolders = collectMesureFolders(referentielTree, []);
+
+  const mesureFiles = preuves.mesure.files.map((file) => ({
+    file,
+    folderSegments: mesureFolderSegments(file.actionId, mesureFolders),
+  }));
+  const demandeFiles = preuves.demande.files.map((file) => ({
+    file,
+    folderSegments: [CYCLE_FOLDER, DEMANDE_FOLDER],
+  }));
+  const auditFiles = preuves.audit.files.map((file) => ({
+    file,
+    folderSegments: [CYCLE_FOLDER, AUDIT_FOLDER],
+  }));
+
+  const mesureLinks = preuves.mesure.links.map((link) => ({
+    link,
+    folderSegments: mesureFolderSegments(link.actionId, mesureFolders),
+  }));
+  const demandeLinks = preuves.demande.links.map((link) => ({
+    link,
+    folderSegments: [CYCLE_FOLDER, DEMANDE_FOLDER],
+  }));
+  const auditLinks = preuves.audit.links.map((link) => ({
+    link,
+    folderSegments: [CYCLE_FOLDER, AUDIT_FOLDER],
+  }));
+
+  const triaged = [...mesureFiles, ...demandeFiles, ...auditFiles].map(triageFile);
+  const collectedFiles = triaged.flatMap((entry) =>
+    entry.kind === 'collected' ? [entry.file] : []
+  );
+  const skippedFiles = triaged.flatMap((entry) =>
+    entry.kind === 'skipped' ? [entry.entry] : []
+  );
+
+  const limits = checkArchiveLimits(collectedFiles);
+  if (!limits.success) {
+    return limits;
+  }
+
+  return success({
+    files: collectedFiles,
+    linkFolders: groupLinksByFolder([
+      ...mesureLinks,
+      ...demandeLinks,
+      ...auditLinks,
+    ]),
+    skippedFiles,
+  });
+}

--- a/apps/backend/src/referentiels/preuves-archive/generate-preuves-archive/generate-preuves-archive.service.spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/generate-preuves-archive/generate-preuves-archive.service.spec.ts
@@ -1,0 +1,199 @@
+import { failure, success } from '@tet/backend/utils/result.type';
+import { ActionTypeEnum, type ReferentielId } from '@tet/domain/referentiels';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  AuditPreuvesArchiveStatusEnum,
+  type AuditPreuvesArchive,
+} from '../models/audit-preuves-archive.table';
+import { GeneratePreuvesArchiveService } from './generate-preuves-archive.service';
+
+const archiveId = '00000000-0000-0000-0000-000000000001';
+const collectiviteId = 1;
+const auditId = 10;
+const demandeId = 20;
+const requesterId = 'user-id';
+const referentielId: ReferentielId = 'cae';
+
+const referentielTree = {
+  itemsTree: {
+    actionId: 'cae',
+    actionType: ActionTypeEnum.REFERENTIEL,
+    identifiant: '',
+    nom: 'CAE',
+    actionsEnfant: [],
+  },
+};
+
+function makeArchive(
+  overrides: Partial<AuditPreuvesArchive> = {}
+): AuditPreuvesArchive {
+  return {
+    id: archiveId,
+    collectiviteId,
+    referentielId,
+    auditId,
+    requestedBy: requesterId,
+    status: AuditPreuvesArchiveStatusEnum.PENDING,
+    totalFiles: 0,
+    processedFiles: 0,
+    storagePath: null,
+    errorMessage: null,
+    createdAt: '2026-05-19T00:00:00.000Z',
+    modifiedAt: '2026-05-19T00:00:00.000Z',
+    expiresAt: '2026-05-26T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function buildService({
+  initialArchive = makeArchive(),
+  canReadReferentiel = true,
+  buildSucceeds = true,
+  getByIdRawSucceeds = true,
+}: {
+  initialArchive?: AuditPreuvesArchive;
+  canReadReferentiel?: boolean;
+  buildSucceeds?: boolean;
+  getByIdRawSucceeds?: boolean;
+} = {}): {
+  service: GeneratePreuvesArchiveService;
+  repository: {
+    getByIdRaw: ReturnType<typeof vi.fn>;
+    transitionToProcessing: ReturnType<typeof vi.fn>;
+    markCompleted: ReturnType<typeof vi.fn>;
+    markFailed: ReturnType<typeof vi.fn>;
+    updateProgress: ReturnType<typeof vi.fn>;
+  };
+} {
+  const repository = {
+    getByIdRaw: vi
+      .fn()
+      .mockResolvedValue(
+        getByIdRawSucceeds
+          ? success(initialArchive)
+          : failure('ARCHIVE_NOT_FOUND', new Error('not found'))
+      ),
+    transitionToProcessing: vi
+      .fn()
+      .mockResolvedValue(success({ ...initialArchive, status: AuditPreuvesArchiveStatusEnum.PROCESSING })),
+    markCompleted: vi
+      .fn()
+      .mockResolvedValue(success({ ...initialArchive, status: AuditPreuvesArchiveStatusEnum.COMPLETED })),
+    markFailed: vi
+      .fn()
+      .mockResolvedValue(success({ ...initialArchive, status: AuditPreuvesArchiveStatusEnum.FAILED })),
+    updateProgress: vi.fn().mockResolvedValue(success(initialArchive)),
+  };
+
+  const listAuditPreuves = {
+    list: vi.fn().mockResolvedValue(
+      success({
+        mesure: { files: [], links: [] },
+        demande: { files: [], links: [] },
+        audit: { files: [], links: [] },
+      })
+    ),
+  } as unknown;
+
+  const getReferentielService = {
+    getReferentielTree: vi.fn().mockResolvedValue(referentielTree),
+  } as unknown;
+
+  const buildAndUpload = vi
+    .fn()
+    .mockResolvedValue(
+      buildSucceeds
+        ? success({ totalFiles: 0 })
+        : failure('CREATE_ARCHIVE_ERROR', new Error('upload KO'))
+    );
+  const buildArchiveService = { buildAndUpload } as unknown;
+
+  const getLabellisationService = {
+    getAudit: vi.fn().mockResolvedValue(success({ id: auditId, demandeId })),
+  } as unknown;
+
+  const isAllowed = vi.fn().mockResolvedValue(canReadReferentiel);
+  const permissions = { isAllowed } as unknown;
+
+  const service = new GeneratePreuvesArchiveService(
+    repository as never,
+    listAuditPreuves as never,
+    getReferentielService as never,
+    buildArchiveService as never,
+    getLabellisationService as never,
+    permissions as never
+  );
+
+  return { service, repository };
+}
+
+// Le happy-path (processing → completed, vrai ZIP) est prouvé de bout en bout
+// par preuves-archive.full-pipeline.e2e-spec. Ce spec ne couvre que les cas
+// d'erreur et le no-op, dont le mapping retryable est propre au service.
+describe('GeneratePreuvesArchiveService.generate', () => {
+  it("no-op si l'archive est déjà completed (ré-livraison stalled)", async () => {
+    const { service, repository } = buildService({
+      initialArchive: makeArchive({ status: AuditPreuvesArchiveStatusEnum.COMPLETED }),
+    });
+
+    const result = await service.generate(archiveId);
+
+    expect(result).toEqual({ success: true, data: undefined });
+    expect(repository.transitionToProcessing).not.toHaveBeenCalled();
+    expect(repository.markCompleted).not.toHaveBeenCalled();
+  });
+
+  it('échec non-retryable si archive introuvable, sans écrire failed', async () => {
+    const { service, repository } = buildService({ getByIdRawSucceeds: false });
+
+    const result = await service.generate(archiveId);
+
+    expect(result).toEqual({
+      success: false,
+      error: { message: expect.stringContaining('introuvable'), retryable: false },
+    });
+    expect(repository.markFailed).not.toHaveBeenCalled();
+  });
+
+  it("échec non-retryable si l'utilisateur a perdu referentiels.read, sans écrire failed", async () => {
+    const { service, repository } = buildService({ canReadReferentiel: false });
+
+    const result = await service.generate(archiveId);
+
+    expect(result).toEqual({
+      success: false,
+      error: {
+        message: expect.stringContaining("n'a plus le droit referentiels.read"),
+        retryable: false,
+      },
+    });
+    expect(repository.markFailed).not.toHaveBeenCalled();
+    expect(repository.markCompleted).not.toHaveBeenCalled();
+  });
+
+  it('échec retryable si buildAndUpload échoue, sans écrire failed (BullMQ retentera)', async () => {
+    const { service, repository } = buildService({ buildSucceeds: false });
+
+    const result = await service.generate(archiveId);
+
+    expect(result).toEqual({
+      success: false,
+      error: {
+        message: expect.stringContaining("Construction de l'archive échouée"),
+        retryable: true,
+      },
+    });
+    expect(repository.markFailed).not.toHaveBeenCalled();
+    expect(repository.markCompleted).not.toHaveBeenCalled();
+  });
+});
+
+describe('GeneratePreuvesArchiveService.markFailed', () => {
+  it('délègue au repository pour marquer la ligne failed', async () => {
+    const { service, repository } = buildService();
+
+    await service.markFailed(archiveId, 'boom');
+
+    expect(repository.markFailed).toHaveBeenCalledWith(archiveId, 'boom');
+  });
+});

--- a/apps/backend/src/referentiels/preuves-archive/generate-preuves-archive/generate-preuves-archive.service.ts
+++ b/apps/backend/src/referentiels/preuves-archive/generate-preuves-archive/generate-preuves-archive.service.ts
@@ -1,0 +1,317 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { GetLabellisationService } from '@tet/backend/referentiels/labellisations/get-labellisation.service';
+import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
+import {
+  AuthRole,
+  type AuthenticatedUser,
+} from '@tet/backend/users/models/auth.models';
+import { failure, success, type Result } from '@tet/backend/utils/result.type';
+import {
+  referentielIdEnumSchema,
+  type ReferentielId,
+} from '@tet/domain/referentiels';
+import { ResourceType } from '@tet/domain/users';
+import { getErrorMessage } from '@tet/domain/utils';
+import { GetReferentielService } from '../../get-referentiel/get-referentiel.service';
+import { BuildArchiveService } from '../build-archive/build-archive.service';
+import { ListAuditPreuvesService } from '../list-audit-preuves/list-audit-preuves.service';
+import {
+  AuditPreuvesArchiveStatusEnum,
+  type AuditPreuvesArchive,
+} from '../models/audit-preuves-archive.table';
+import { PreuvesArchiveRepository } from '../preuves-archive.repository';
+import {
+  generateArchiveFolderArborescence,
+  type ArchiveFolderArborescence,
+  type ReferentielTreeNode,
+} from './generate-archive-folder-arborescence';
+
+interface JobContext {
+  user: AuthenticatedUser;
+  demandeId: number;
+  referentielId: ReferentielId;
+}
+
+/**
+ * `retryable` distingue une panne d'infra transitoire (Supabase/réseau/disque,
+ * que BullMQ doit relancer) d'une erreur logique définitive (permission révoquée,
+ * référentiel invalide, audit/archive introuvable, qu'il est inutile de retenter).
+ * Le worker traduit ce flag en `Error` (retry) ou `UnrecoverableError` (terminal).
+ */
+export interface GenerateArchiveFailure {
+  message: string;
+  retryable: boolean;
+}
+
+type GenerateArchiveResult = Result<undefined, GenerateArchiveFailure>;
+
+function retryableFailure(
+  message: string
+): Result<never, GenerateArchiveFailure> {
+  return failure({ message, retryable: true });
+}
+
+function nonRetryableFailure(
+  message: string
+): Result<never, GenerateArchiveFailure> {
+  return failure({ message, retryable: false });
+}
+
+function buildRequesterUser(userId: string): AuthenticatedUser {
+  return {
+    id: userId,
+    role: AuthRole.AUTHENTICATED,
+    isAnonymous: false,
+    jwtPayload: { role: AuthRole.AUTHENTICATED },
+  };
+}
+
+function parseReferentielId(
+  raw: string
+): Result<ReferentielId, GenerateArchiveFailure> {
+  const parsed = referentielIdEnumSchema.safeParse(raw);
+  if (!parsed.success) {
+    return nonRetryableFailure(`Référentiel ${raw} invalide`);
+  }
+  return success(parsed.data);
+}
+
+@Injectable()
+export class GeneratePreuvesArchiveService {
+  private readonly logger = new Logger(GeneratePreuvesArchiveService.name);
+
+  constructor(
+    private readonly repository: PreuvesArchiveRepository,
+    private readonly listAuditPreuvesService: ListAuditPreuvesService,
+    private readonly getReferentielService: GetReferentielService,
+    private readonly buildArchiveService: BuildArchiveService,
+    private readonly getLabellisationService: GetLabellisationService,
+    private readonly permissions: PermissionService
+  ) {}
+
+  /**
+   * Ne marque jamais la ligne `failed` : c'est `markFailed` (appelé par le
+   * worker au dernier échec uniquement) qui le fait, sinon la ligne clignoterait
+   * `failed` entre deux retries. Sur succès la ligne passe `completed` ici.
+   */
+  async generate(archiveId: string): Promise<GenerateArchiveResult> {
+    const archiveResult = await this.repository.getByIdRaw(archiveId);
+    if (!archiveResult.success) {
+      return nonRetryableFailure(`Archive ${archiveId} introuvable`);
+    }
+    const archive = archiveResult.data;
+
+    // Ré-livraison stalled d'un job déjà terminé : no-op, pas de second upload.
+    if (archive.status === AuditPreuvesArchiveStatusEnum.COMPLETED) {
+      this.logger.log(
+        `Archive ${archiveId} déjà completed — ré-livraison ignorée`
+      );
+      return success(undefined);
+    }
+
+    this.logger.log(`Génération de l'archive de preuves ${archiveId}`);
+
+    const transition = await this.repository.transitionToProcessing(archiveId);
+    if (!transition.success) {
+      return retryableFailure(
+        `Passage en statut processing échoué pour ${archiveId}: ${transition.error}`
+      );
+    }
+
+    const contextResult = await this.resolveJobContext(archive);
+    if (!contextResult.success) {
+      return contextResult;
+    }
+
+    const arborescenceResult = await this.buildArborescence(
+      archive,
+      contextResult.data
+    );
+    if (!arborescenceResult.success) {
+      return arborescenceResult;
+    }
+
+    return this.uploadAndComplete(archiveId, arborescenceResult.data);
+  }
+
+  /**
+   * Marque la ligne `failed` une fois les tentatives BullMQ épuisées (ou sur
+   * crash worker stalled). Libère l'index unique partiel pour que l'utilisateur
+   * puisse relancer.
+   */
+  async markFailed(archiveId: string, message: string): Promise<void> {
+    const result = await this.repository.markFailed(archiveId, message);
+    if (!result.success) {
+      this.logger.error(
+        `Marquage failed échoué pour ${archiveId}: ${result.error}`
+      );
+    }
+  }
+
+  private async resolveJobContext(
+    archive: AuditPreuvesArchive
+  ): Promise<Result<JobContext, GenerateArchiveFailure>> {
+    const user = buildRequesterUser(archive.requestedBy);
+
+    const stillAllowed = await this.permissions.isAllowed(
+      user,
+      'referentiels.read',
+      ResourceType.COLLECTIVITE,
+      archive.collectiviteId,
+      true
+    );
+    if (!stillAllowed) {
+      return nonRetryableFailure(
+        `L'utilisateur ${archive.requestedBy} n'a plus le droit referentiels.read sur la collectivité ${archive.collectiviteId}`
+      );
+    }
+
+    const demandeIdResult = await this.resolveDemandeId(archive.auditId);
+    if (!demandeIdResult.success) {
+      return demandeIdResult;
+    }
+
+    const referentielIdResult = parseReferentielId(archive.referentielId);
+    if (!referentielIdResult.success) {
+      return referentielIdResult;
+    }
+
+    return success({
+      user,
+      demandeId: demandeIdResult.data,
+      referentielId: referentielIdResult.data,
+    });
+  }
+
+  private async resolveDemandeId(
+    auditId: number
+  ): Promise<Result<number, GenerateArchiveFailure>> {
+    try {
+      const auditDetails = await this.getLabellisationService.getAudit(auditId);
+      if (!auditDetails.success) {
+        return nonRetryableFailure(`Audit ${auditId} introuvable`);
+      }
+      const demandeId = auditDetails.data.demandeId;
+      if (demandeId == null) {
+        return nonRetryableFailure(
+          `Aucune demande de labellisation rattachée à l'audit ${auditId}`
+        );
+      }
+      return success(demandeId);
+    } catch (error) {
+      // L'accès DB peut tomber transitoirement : laisser BullMQ relancer.
+      return retryableFailure(
+        `Résolution de la demande échouée: ${getErrorMessage(error)}`
+      );
+    }
+  }
+
+  private async buildArborescence(
+    archive: AuditPreuvesArchive,
+    context: JobContext
+  ): Promise<Result<ArchiveFolderArborescence, GenerateArchiveFailure>> {
+    const preuvesResult = await this.listAuditPreuvesService.list({
+      collectiviteId: archive.collectiviteId,
+      auditId: archive.auditId,
+      demandeId: context.demandeId,
+      user: context.user,
+    });
+    if (!preuvesResult.success) {
+      return retryableFailure(
+        `Liste des preuves échouée: ${preuvesResult.error}`
+      );
+    }
+
+    const treeResult = await this.fetchReferentielTree(context.referentielId);
+    if (!treeResult.success) {
+      return treeResult;
+    }
+
+    const arborescenceResult = generateArchiveFolderArborescence({
+      preuves: preuvesResult.data,
+      referentielTree: treeResult.data,
+    });
+    if (!arborescenceResult.success) {
+      // Arbre/préuves cohérents mais arborescence impossible : défaut de données.
+      return nonRetryableFailure(
+        `Construction de l'arborescence échouée: ${arborescenceResult.error}`
+      );
+    }
+    return success(arborescenceResult.data);
+  }
+
+  private async fetchReferentielTree(
+    referentielId: ReferentielId
+  ): Promise<Result<ReferentielTreeNode, GenerateArchiveFailure>> {
+    try {
+      const tree = await this.getReferentielService.getReferentielTree(
+        referentielId
+      );
+      return success(tree.itemsTree);
+    } catch (error) {
+      return retryableFailure(
+        `Récupération de l'arbre du référentiel échouée: ${getErrorMessage(error)}`
+      );
+    }
+  }
+
+  private async uploadAndComplete(
+    archiveId: string,
+    arborescence: ArchiveFolderArborescence
+  ): Promise<GenerateArchiveResult> {
+    const totalFiles = arborescence.files.length;
+    const totalResult = await this.repository.updateProgress(archiveId, {
+      processedFiles: 0,
+      totalFiles,
+    });
+    if (!totalResult.success) {
+      this.logger.warn(
+        `Publication de total_files échouée pour ${archiveId}: ${totalResult.error}`
+      );
+    }
+
+    const storagePath = `${archiveId}.zip`;
+    const buildResult = await this.buildArchiveService.buildAndUpload({
+      archiveId,
+      arborescence,
+      storagePath,
+      onProgress: (processedFiles) => {
+        void this.persistProgress(archiveId, processedFiles, totalFiles);
+      },
+    });
+    if (!buildResult.success) {
+      return retryableFailure(
+        `Construction de l'archive échouée: ${buildResult.error}`
+      );
+    }
+
+    const completedResult = await this.repository.markCompleted(
+      archiveId,
+      storagePath
+    );
+    if (!completedResult.success) {
+      return retryableFailure(
+        `Passage en statut completed échoué pour ${archiveId}: ${completedResult.error}`
+      );
+    }
+
+    this.logger.log(`Archive de preuves ${archiveId} générée avec succès`);
+    return success(undefined);
+  }
+
+  private async persistProgress(
+    archiveId: string,
+    processedFiles: number,
+    totalFiles: number
+  ): Promise<void> {
+    const result = await this.repository.updateProgress(archiveId, {
+      processedFiles,
+      totalFiles,
+    });
+    if (!result.success) {
+      this.logger.warn(
+        `Mise à jour de la progression échouée pour ${archiveId}: ${result.error}`
+      );
+    }
+  }
+}

--- a/apps/backend/src/referentiels/preuves-archive/generate-preuves-archive/generate-preuves-archive.worker.spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/generate-preuves-archive/generate-preuves-archive.worker.spec.ts
@@ -1,0 +1,103 @@
+import { failure, success } from '@tet/backend/utils/result.type';
+import { Job, UnrecoverableError } from 'bullmq';
+import { describe, expect, it, vi } from 'vitest';
+import type { PreuvesArchiveJobData } from '../preuves-archive.queue';
+import { GeneratePreuvesArchiveWorker } from './generate-preuves-archive.worker';
+
+const archiveId = '00000000-0000-0000-0000-000000000001';
+
+function makeJob(overrides: {
+  attemptsMade?: number;
+  attempts?: number;
+}): Job<PreuvesArchiveJobData> {
+  return {
+    data: { archiveId },
+    attemptsMade: overrides.attemptsMade ?? 1,
+    opts: { attempts: overrides.attempts ?? 3 },
+  } as unknown as Job<PreuvesArchiveJobData>;
+}
+
+function buildWorker(generate: () => unknown): {
+  worker: GeneratePreuvesArchiveWorker;
+} {
+  const service = {
+    generate: vi.fn().mockResolvedValue(generate()),
+    markFailed: vi.fn().mockResolvedValue(undefined),
+  };
+  const worker = new GeneratePreuvesArchiveWorker(service as never);
+  return { worker };
+}
+
+describe('GeneratePreuvesArchiveWorker.process', () => {
+  it('ne throw pas quand generate réussit (job réussi pour BullMQ)', async () => {
+    const { worker } = buildWorker(() => success(undefined));
+
+    await expect(
+      worker.process(makeJob({ attemptsMade: 1 }))
+    ).resolves.toBeUndefined();
+  });
+
+  it('throw une Error sur échec retryable (BullMQ retentera avec backoff)', async () => {
+    const { worker } = buildWorker(() =>
+      failure({ message: 'Supabase 503', retryable: true })
+    );
+
+    const promise = worker.process(makeJob({ attemptsMade: 1 }));
+    await expect(promise).rejects.toThrow('Supabase 503');
+    await expect(promise).rejects.not.toBeInstanceOf(UnrecoverableError);
+  });
+
+  it('throw une UnrecoverableError sur échec non-retryable (pas de retry)', async () => {
+    const { worker } = buildWorker(() =>
+      failure({ message: 'permission révoquée', retryable: false })
+    );
+
+    await expect(
+      worker.process(makeJob({ attemptsMade: 1 }))
+    ).rejects.toBeInstanceOf(UnrecoverableError);
+  });
+});
+
+describe('GeneratePreuvesArchiveWorker.onJobFailed', () => {
+  it('ne marque PAS failed tant que des tentatives restent', async () => {
+    const service = { markFailed: vi.fn().mockResolvedValue(undefined) };
+    const localWorker = new GeneratePreuvesArchiveWorker(service as never);
+
+    await localWorker.onJobFailed(
+      makeJob({ attemptsMade: 1, attempts: 3 }),
+      new Error('transient')
+    );
+
+    expect(service.markFailed).not.toHaveBeenCalled();
+  });
+
+  it('marque failed quand les tentatives sont épuisées', async () => {
+    const service = { markFailed: vi.fn().mockResolvedValue(undefined) };
+    const localWorker = new GeneratePreuvesArchiveWorker(service as never);
+
+    await localWorker.onJobFailed(
+      makeJob({ attemptsMade: 3, attempts: 3 }),
+      new Error('boom')
+    );
+
+    expect(service.markFailed).toHaveBeenCalledWith(
+      archiveId,
+      expect.stringContaining('boom')
+    );
+  });
+
+  it('marque failed immédiatement sur UnrecoverableError, même si des tentatives restent', async () => {
+    const service = { markFailed: vi.fn().mockResolvedValue(undefined) };
+    const localWorker = new GeneratePreuvesArchiveWorker(service as never);
+
+    await localWorker.onJobFailed(
+      makeJob({ attemptsMade: 1, attempts: 3 }),
+      new UnrecoverableError('définitif')
+    );
+
+    expect(service.markFailed).toHaveBeenCalledWith(
+      archiveId,
+      expect.stringContaining('définitif')
+    );
+  });
+});

--- a/apps/backend/src/referentiels/preuves-archive/generate-preuves-archive/generate-preuves-archive.worker.ts
+++ b/apps/backend/src/referentiels/preuves-archive/generate-preuves-archive/generate-preuves-archive.worker.ts
@@ -1,0 +1,68 @@
+import { OnWorkerEvent, Processor, WorkerHost } from '@nestjs/bullmq';
+import { getErrorMessage } from '@tet/domain/utils';
+import { Job, UnrecoverableError } from 'bullmq';
+import {
+  PREUVES_ARCHIVE_LOCK_DURATION_MS,
+  PREUVES_ARCHIVE_QUEUE_NAME,
+  type PreuvesArchiveJobData,
+} from '../preuves-archive.queue';
+import { GeneratePreuvesArchiveService } from './generate-preuves-archive.service';
+
+/**
+ * Frontière BullMQ : seul endroit autorisé à `throw` (les services retournent
+ * des `Result`). BullMQ ne relance un job que si `process()` throw, et ne
+ * retente pas un `UnrecoverableError` — d'où la traduction du flag `retryable`.
+ */
+@Processor(PREUVES_ARCHIVE_QUEUE_NAME, {
+  lockDuration: PREUVES_ARCHIVE_LOCK_DURATION_MS,
+  concurrency: 1,
+})
+export class GeneratePreuvesArchiveWorker extends WorkerHost {
+  constructor(private readonly service: GeneratePreuvesArchiveService) {
+    super();
+  }
+
+  async process(job: Job<PreuvesArchiveJobData>): Promise<void> {
+    const result = await this.service.generate(job.data.archiveId);
+    if (result.success) {
+      return;
+    }
+    if (result.error.retryable) {
+      throw new Error(result.error.message);
+    }
+    throw new UnrecoverableError(result.error.message);
+  }
+
+  /**
+   * Le worker émet `failed` à CHAQUE tentative échouée, pas seulement à la
+   * dernière. On ne marque la ligne DB `failed` qu'au dernier échec — retries
+   * épuisés (`attemptsMade >= attempts`) ou erreur non-retryable
+   * (`UnrecoverableError`, qui court-circuite les retries restants) — sinon la
+   * ligne clignoterait `failed` entre deux retries. Marquer `failed` au terme
+   * libère l'index unique partiel et permet à l'utilisateur de relancer.
+   */
+  @OnWorkerEvent('failed')
+  async onJobFailed(
+    job: Job<PreuvesArchiveJobData>,
+    error: Error
+  ): Promise<void> {
+    if (!this.isTerminalFailure(job, error)) {
+      return;
+    }
+    await this.service.markFailed(
+      job.data.archiveId,
+      `Génération interrompue: ${getErrorMessage(error)}`
+    );
+  }
+
+  private isTerminalFailure(
+    job: Job<PreuvesArchiveJobData>,
+    error: Error
+  ): boolean {
+    if (error instanceof UnrecoverableError) {
+      return true;
+    }
+    const maxAttempts = job.opts.attempts ?? 1;
+    return job.attemptsMade >= maxAttempts;
+  }
+}

--- a/apps/backend/src/referentiels/preuves-archive/get-preuves-archive/get-preuves-archive.input.ts
+++ b/apps/backend/src/referentiels/preuves-archive/get-preuves-archive/get-preuves-archive.input.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const getPreuvesArchiveInputSchema = z.object({
+  archiveId: z.string().uuid(),
+});
+
+export type GetPreuvesArchiveInput = z.infer<
+  typeof getPreuvesArchiveInputSchema
+>;

--- a/apps/backend/src/referentiels/preuves-archive/get-preuves-archive/get-preuves-archive.output.ts
+++ b/apps/backend/src/referentiels/preuves-archive/get-preuves-archive/get-preuves-archive.output.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+import { auditPreuvesArchiveStatusSchema } from '../models/audit-preuves-archive.table';
+
+export const getPreuvesArchiveOutputSchema = z.object({
+  archiveId: z.string().uuid(),
+  status: auditPreuvesArchiveStatusSchema,
+  totalFiles: z.number().int().nonnegative(),
+  processedFiles: z.number().int().nonnegative(),
+  downloadUrl: z.string().nullable(),
+  errorMessage: z.string().nullable(),
+});
+
+export type GetPreuvesArchiveOutput = z.infer<
+  typeof getPreuvesArchiveOutputSchema
+>;

--- a/apps/backend/src/referentiels/preuves-archive/get-preuves-archive/get-preuves-archive.router.ts
+++ b/apps/backend/src/referentiels/preuves-archive/get-preuves-archive/get-preuves-archive.router.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@nestjs/common';
+import { createTrpcErrorHandler } from '@tet/backend/utils/trpc/trpc-error-handler';
+import { TrpcService } from '@tet/backend/utils/trpc/trpc.service';
+import { preuvesArchiveErrorConfig } from '../preuves-archive.trpc-errors';
+import { getPreuvesArchiveInputSchema } from './get-preuves-archive.input';
+import { getPreuvesArchiveOutputSchema } from './get-preuves-archive.output';
+import { GetPreuvesArchiveService } from './get-preuves-archive.service';
+
+@Injectable()
+export class GetPreuvesArchiveRouter {
+  constructor(
+    private readonly trpc: TrpcService,
+    private readonly getPreuvesArchiveService: GetPreuvesArchiveService
+  ) {}
+
+  private readonly getResultDataOrThrowError = createTrpcErrorHandler(
+    preuvesArchiveErrorConfig
+  );
+
+  router = this.trpc.router({
+    get: this.trpc.authedProcedure
+      .input(getPreuvesArchiveInputSchema)
+      .output(getPreuvesArchiveOutputSchema)
+      .query(async ({ input, ctx: { user } }) => {
+        const result = await this.getPreuvesArchiveService.get({
+          archiveId: input.archiveId,
+          user,
+        });
+        return this.getResultDataOrThrowError(result);
+      }),
+  });
+}

--- a/apps/backend/src/referentiels/preuves-archive/get-preuves-archive/get-preuves-archive.service.spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/get-preuves-archive/get-preuves-archive.service.spec.ts
@@ -1,0 +1,192 @@
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { failure, success, type Result } from '@tet/backend/utils/result.type';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  AuditPreuvesArchiveStatusEnum,
+  type AuditPreuvesArchive,
+} from '../models/audit-preuves-archive.table';
+import {
+  PreuvesArchiveErrorEnum,
+  type PreuvesArchiveError,
+} from '../preuves-archive.errors';
+import { GetPreuvesArchiveService } from './get-preuves-archive.service';
+
+const owner: AuthenticatedUser = { id: 'owner-id' } as AuthenticatedUser;
+
+function makeArchive(
+  overrides: Partial<AuditPreuvesArchive> = {}
+): AuditPreuvesArchive {
+  return {
+    id: 'archive-id',
+    collectiviteId: 1,
+    referentielId: 'cae',
+    auditId: 10,
+    requestedBy: owner.id,
+    status: AuditPreuvesArchiveStatusEnum.PENDING,
+    totalFiles: 0,
+    processedFiles: 0,
+    storagePath: null,
+    errorMessage: null,
+    createdAt: '2026-05-19T00:00:00.000Z',
+    modifiedAt: '2026-05-19T00:00:00.000Z',
+    expiresAt: '2026-05-26T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function buildService({
+  isAllowed = true,
+  getByIdResult = success(makeArchive()),
+  signedUrlResult = success({ signedUrl: 'https://signed.example/archive.zip' }),
+}: {
+  isAllowed?: boolean;
+  getByIdResult?: Result<AuditPreuvesArchive, PreuvesArchiveError>;
+  signedUrlResult?: Result<{ signedUrl: string }, PreuvesArchiveError>;
+} = {}): GetPreuvesArchiveService {
+  const permissions = {
+    isAllowed: vi.fn().mockResolvedValue(isAllowed),
+  } as unknown;
+
+  const repository = {
+    getByIdForUser: vi.fn().mockResolvedValue(getByIdResult),
+  } as unknown;
+
+  const documentStorage = {
+    createDocumentSignedUrl: vi.fn().mockResolvedValue(signedUrlResult),
+  } as unknown;
+
+  return new GetPreuvesArchiveService(
+    permissions as never,
+    repository as never,
+    documentStorage as never
+  );
+}
+
+describe('GetPreuvesArchiveService', () => {
+  it("renvoie NOT_FOUND quand getByIdForUser ne trouve pas la ligne (anti-énumération via filtre SQL `requestedBy`)", async () => {
+    const service = buildService({
+      getByIdResult: failure(
+        PreuvesArchiveErrorEnum.ARCHIVE_NOT_FOUND,
+        new Error('Archive archive-id non trouvée')
+      ),
+    });
+
+    const result = await service.get({
+      archiveId: 'archive-id',
+      user: owner,
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error).toBe(PreuvesArchiveErrorEnum.ARCHIVE_NOT_FOUND);
+  });
+
+  it("renvoie une downloadUrl fraîche quand le statut est completed", async () => {
+    const service = buildService({
+      getByIdResult: success(
+        makeArchive({
+          status: AuditPreuvesArchiveStatusEnum.COMPLETED,
+          storagePath: 'archive-id.zip',
+          totalFiles: 4,
+          processedFiles: 4,
+        })
+      ),
+    });
+
+    const result = await service.get({
+      archiveId: 'archive-id',
+      user: owner,
+    });
+
+    expect(result).toEqual(
+      success({
+        archiveId: 'archive-id',
+        status: AuditPreuvesArchiveStatusEnum.COMPLETED,
+        totalFiles: 4,
+        processedFiles: 4,
+        downloadUrl: 'https://signed.example/archive.zip',
+        errorMessage: null,
+      })
+    );
+  });
+
+  it("renvoie NOT_FOUND quand l'utilisateur a perdu referentiels.read sur la collectivité", async () => {
+    const service = buildService({
+      isAllowed: false,
+      getByIdResult: success(
+        makeArchive({
+          status: AuditPreuvesArchiveStatusEnum.COMPLETED,
+          storagePath: 'archive-id.zip',
+          totalFiles: 4,
+          processedFiles: 4,
+        })
+      ),
+    });
+
+    const result = await service.get({
+      archiveId: 'archive-id',
+      user: owner,
+    });
+
+    expect(result).toEqual(
+      failure(
+        PreuvesArchiveErrorEnum.ARCHIVE_NOT_FOUND,
+        new Error('Archive archive-id non trouvée')
+      )
+    );
+  });
+
+  it("ne signe pas une archive completed dont l'expires_at est dépassé", async () => {
+    const service = buildService({
+      getByIdResult: success(
+        makeArchive({
+          status: AuditPreuvesArchiveStatusEnum.COMPLETED,
+          storagePath: 'archive-id.zip',
+          totalFiles: 4,
+          processedFiles: 4,
+          expiresAt: '2020-01-01T00:00:00.000Z',
+        })
+      ),
+    });
+
+    const result = await service.get({
+      archiveId: 'archive-id',
+      user: owner,
+    });
+
+    expect(result).toEqual(
+      success({
+        archiveId: 'archive-id',
+        status: AuditPreuvesArchiveStatusEnum.COMPLETED,
+        totalFiles: 4,
+        processedFiles: 4,
+        downloadUrl: null,
+        errorMessage: null,
+      })
+    );
+  });
+
+  it("ne renvoie pas de downloadUrl tant que l'archive n'est pas completed", async () => {
+    const service = buildService({
+      getByIdResult: success(
+        makeArchive({ status: AuditPreuvesArchiveStatusEnum.PROCESSING, totalFiles: 4, processedFiles: 1 })
+      ),
+    });
+
+    const result = await service.get({
+      archiveId: 'archive-id',
+      user: owner,
+    });
+
+    expect(result).toEqual(
+      success({
+        archiveId: 'archive-id',
+        status: AuditPreuvesArchiveStatusEnum.PROCESSING,
+        totalFiles: 4,
+        processedFiles: 1,
+        downloadUrl: null,
+        errorMessage: null,
+      })
+    );
+  });
+});

--- a/apps/backend/src/referentiels/preuves-archive/get-preuves-archive/get-preuves-archive.service.ts
+++ b/apps/backend/src/referentiels/preuves-archive/get-preuves-archive/get-preuves-archive.service.ts
@@ -1,0 +1,101 @@
+import { Injectable } from '@nestjs/common';
+import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { failure, success, type Result } from '@tet/backend/utils/result.type';
+import { ResourceType } from '@tet/domain/users';
+import { DocumentStorageService } from '@tet/backend/utils/supabase/document-storage.service';
+import {
+  ARCHIVE_DOWNLOAD_TTL_SECONDS,
+  PREUVES_ARCHIVES_BUCKET,
+} from '../preuves-archive.constants';
+import {
+  PreuvesArchiveErrorEnum,
+  type PreuvesArchiveError,
+} from '../preuves-archive.errors';
+import type { GetPreuvesArchiveOutput } from './get-preuves-archive.output';
+import { PreuvesArchiveRepository } from '../preuves-archive.repository';
+import { AuditPreuvesArchiveStatusEnum } from '../models/audit-preuves-archive.table';
+
+export interface GetPreuvesArchiveServiceInput {
+  archiveId: string;
+  user: AuthenticatedUser;
+}
+
+// Message générique : le détail technique reste en DB pour les ops, jamais exposé au client.
+const FAILED_ARCHIVE_PUBLIC_MESSAGE =
+  "La génération de l'archive a échoué. Veuillez réessayer ou contactez le support.";
+
+@Injectable()
+export class GetPreuvesArchiveService {
+  constructor(
+    private readonly permissions: PermissionService,
+    private readonly repository: PreuvesArchiveRepository,
+    private readonly documentStorage: DocumentStorageService
+  ) {}
+
+  async get(
+    input: GetPreuvesArchiveServiceInput
+  ): Promise<Result<GetPreuvesArchiveOutput, PreuvesArchiveError>> {
+    const { archiveId, user } = input;
+
+    const archiveResult = await this.repository.getByIdForUser({
+      id: archiveId,
+      requestedBy: user.id,
+    });
+    if (!archiveResult.success) {
+      return archiveResult;
+    }
+    const archive = archiveResult.data;
+
+    // Anti-énumération : NOT_FOUND couvre la propriété, le droit perdu et l'expiration.
+    const archiveNotFound = failure(
+      PreuvesArchiveErrorEnum.ARCHIVE_NOT_FOUND,
+      new Error(`Archive ${archiveId} non trouvée`)
+    );
+
+    const stillAllowed = await this.permissions.isAllowed(
+      user,
+      'referentiels.read',
+      ResourceType.COLLECTIVITE,
+      archive.collectiviteId,
+      true
+    );
+    if (!stillAllowed) {
+      return archiveNotFound;
+    }
+
+    const isExpired = new Date(archive.expiresAt).getTime() <= Date.now();
+
+    let downloadUrl: string | null = null;
+    if (
+      archive.status === AuditPreuvesArchiveStatusEnum.COMPLETED &&
+      archive.storagePath !== null &&
+      !isExpired
+    ) {
+      const signedUrlResult = await this.documentStorage.createDocumentSignedUrl({
+        bucketId: PREUVES_ARCHIVES_BUCKET,
+        key: archive.storagePath,
+        expiresInSeconds: ARCHIVE_DOWNLOAD_TTL_SECONDS,
+      });
+      if (!signedUrlResult.success) {
+        return failure(
+          PreuvesArchiveErrorEnum.GET_ARCHIVE_ERROR,
+          signedUrlResult.cause
+        );
+      }
+      downloadUrl = signedUrlResult.data.signedUrl;
+    }
+
+    return success({
+      archiveId: archive.id,
+      status: archive.status,
+      totalFiles: archive.totalFiles,
+      processedFiles: archive.processedFiles,
+      downloadUrl,
+      errorMessage:
+        archive.status === AuditPreuvesArchiveStatusEnum.FAILED
+          ? FAILED_ARCHIVE_PUBLIC_MESSAGE
+          : null,
+    });
+  }
+}

--- a/apps/backend/src/referentiels/preuves-archive/list-audit-preuves/collect-preuves.repository.e2e-spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/list-audit-preuves/collect-preuves.repository.e2e-spec.ts
@@ -1,0 +1,150 @@
+import { INestApplication } from '@nestjs/common';
+import { addTestCollectiviteAndUser } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { bibliothequeFichierTable } from '@tet/backend/collectivites/documents/models/bibliotheque-fichier.table';
+import { preuveComplementaireTable } from '@tet/backend/collectivites/documents/models/preuve-complementaire.table';
+import { storageObjectTable } from '@tet/backend/collectivites/documents/models/storage-object.table';
+import { collectiviteBucketTable } from '@tet/backend/collectivites/shared/models/collectivite-bucket.table';
+import {
+  getAuthUserFromUserCredentials,
+  getTestApp,
+  getTestDatabase,
+} from '@tet/backend/test';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { Collectivite } from '@tet/domain/collectivites';
+import { CollectiviteRole } from '@tet/domain/users';
+import { and, eq, like } from 'drizzle-orm';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { PREUVES_ARCHIVES_BUCKET } from '../preuves-archive.constants';
+import { CollectPreuvesRepository } from './collect-preuves.repository';
+
+const ACTION_ID = 'cae_1.1.3';
+
+describe('CollectPreuvesRepository - filtre confidentiel (SQL réel)', () => {
+  let app: INestApplication;
+  let db: DatabaseService;
+  let repository: CollectPreuvesRepository;
+  let collectivite: Collectivite;
+  let adminUserId: string;
+  let cleanupCollectivite: () => Promise<void>;
+
+  let publicHash: string;
+  let confidentielHash: string;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    db = await getTestDatabase(app);
+    repository = app.get(CollectPreuvesRepository);
+
+    const fixture = await addTestCollectiviteAndUser(db, {
+      user: { role: CollectiviteRole.ADMIN },
+    });
+    collectivite = fixture.collectivite;
+    adminUserId = getAuthUserFromUserCredentials(fixture.user).id;
+    cleanupCollectivite = fixture.cleanup;
+
+    publicHash = `hash-public-${collectivite.id}`;
+    confidentielHash = `hash-confidentiel-${collectivite.id}`;
+
+    await db.db
+      .insert(collectiviteBucketTable)
+      .values({ bucketId: PREUVES_ARCHIVES_BUCKET, collectiviteId: collectivite.id });
+
+    const fichiers = await db.db
+      .insert(bibliothequeFichierTable)
+      .values([
+        {
+          collectiviteId: collectivite.id,
+          hash: publicHash,
+          filename: 'public.pdf',
+          confidentiel: false,
+        },
+        {
+          collectiviteId: collectivite.id,
+          hash: confidentielHash,
+          filename: 'secret.pdf',
+          confidentiel: true,
+        },
+      ])
+      .returning();
+
+    await db.db.insert(storageObjectTable).values(
+      fichiers.map((fichier) => ({
+        bucketId: PREUVES_ARCHIVES_BUCKET,
+        name: fichier.hash,
+        metadata: { size: 1024 },
+      }))
+    );
+
+    await db.db.insert(preuveComplementaireTable).values([
+      ...fichiers.map((fichier) => ({
+        collectiviteId: collectivite.id,
+        actionId: ACTION_ID,
+        fichierId: fichier.id,
+        modifiedBy: adminUserId,
+      })),
+      {
+        collectiviteId: collectivite.id,
+        actionId: ACTION_ID,
+        url: 'https://exemple.fr/lien-public',
+        titre: 'Lien public',
+        modifiedBy: adminUserId,
+      },
+    ]);
+  });
+
+  afterAll(async () => {
+    await db.db
+      .delete(preuveComplementaireTable)
+      .where(eq(preuveComplementaireTable.collectiviteId, collectivite.id));
+    await db.db
+      .delete(storageObjectTable)
+      .where(
+        and(
+          eq(storageObjectTable.bucketId, PREUVES_ARCHIVES_BUCKET),
+          like(storageObjectTable.name, `%${collectivite.id}`)
+        )
+      );
+    await db.db
+      .delete(bibliothequeFichierTable)
+      .where(eq(bibliothequeFichierTable.collectiviteId, collectivite.id));
+    await cleanupCollectivite();
+    await app.close();
+  });
+
+  test('canReadConfidentiel=true : expose le fichier public ET le confidentiel', async () => {
+    const result = await repository.getComplementairePreuves({
+      collectiviteId: collectivite.id,
+      canReadConfidentiel: true,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.files.map((file) => file.hash).sort()).toEqual(
+      [confidentielHash, publicHash].sort()
+    );
+  });
+
+  test('canReadConfidentiel=false : masque le confidentiel, garde le public', async () => {
+    const result = await repository.getComplementairePreuves({
+      collectiviteId: collectivite.id,
+      canReadConfidentiel: false,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.files.map((file) => file.hash)).toEqual([publicHash]);
+  });
+
+  test('un lien (sans fichier) reste visible même sans droit confidentiel', async () => {
+    const result = await repository.getComplementairePreuves({
+      collectiviteId: collectivite.id,
+      canReadConfidentiel: false,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.links.map((link) => link.url)).toEqual([
+      'https://exemple.fr/lien-public',
+    ]);
+  });
+});

--- a/apps/backend/src/referentiels/preuves-archive/list-audit-preuves/collect-preuves.repository.ts
+++ b/apps/backend/src/referentiels/preuves-archive/list-audit-preuves/collect-preuves.repository.ts
@@ -1,0 +1,357 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { bibliothequeFichierTable } from '@tet/backend/collectivites/documents/models/bibliotheque-fichier.table';
+import { preuveActionTable } from '@tet/backend/collectivites/documents/models/preuve-action.table';
+import { preuveAuditTable } from '@tet/backend/collectivites/documents/models/preuve-audit.table';
+import { preuveComplementaireTable } from '@tet/backend/collectivites/documents/models/preuve-complementaire.table';
+import { preuveLabellisationTable } from '@tet/backend/collectivites/documents/models/preuve-labellisation.table';
+import { preuveReglementaireTable } from '@tet/backend/collectivites/documents/models/preuve-reglementaire.table';
+import { storageObjectTable } from '@tet/backend/collectivites/documents/models/storage-object.table';
+import { collectiviteBucketTable } from '@tet/backend/collectivites/shared/models/collectivite-bucket.table';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { failure, success, type Result } from '@tet/backend/utils/result.type';
+import { getErrorMessage } from '@tet/domain/utils';
+import { and, eq, inArray, isNull, or, sql, type Column, type SQL } from 'drizzle-orm';
+import { z } from 'zod';
+import {
+  PreuvesArchiveErrorEnum,
+  type PreuvesArchiveError,
+} from '../preuves-archive.errors';
+
+const storageMetadataSchema = z.object({
+  size: z.union([z.number(), z.string()]),
+});
+
+export interface CollectedFilePreuve {
+  bucketId: string | null;
+  hash: string;
+  filename: string | null;
+  filesize: number | null;
+  actionId: string | null;
+}
+
+export interface CollectedLinkPreuve {
+  url: string;
+  titre: string | null;
+  commentaire: string | null;
+  actionId: string | null;
+}
+
+type CollectedPreuves = {
+  files: CollectedFilePreuve[];
+  links: CollectedLinkPreuve[];
+};
+
+@Injectable()
+export class CollectPreuvesRepository {
+  private readonly db = this.database.db;
+  private readonly logger = new Logger(CollectPreuvesRepository.name);
+
+  constructor(private readonly database: DatabaseService) {}
+
+  async getComplementairePreuves(input: {
+    collectiviteId: number;
+    canReadConfidentiel: boolean;
+  }): Promise<Result<CollectedPreuves, PreuvesArchiveError>> {
+    const { collectiviteId, canReadConfidentiel } = input;
+    try {
+      const rows = await this.db
+        .select({
+          actionId: preuveComplementaireTable.actionId,
+          fichierId: preuveComplementaireTable.fichierId,
+          url: preuveComplementaireTable.url,
+          titre: preuveComplementaireTable.titre,
+          commentaire: preuveComplementaireTable.commentaire,
+          bucketId: storageObjectTable.bucketId,
+          hash: bibliothequeFichierTable.hash,
+          filename: bibliothequeFichierTable.filename,
+          metadata: storageObjectTable.metadata,
+        })
+        .from(preuveComplementaireTable)
+        .leftJoin(
+          bibliothequeFichierTable,
+          and(
+            eq(preuveComplementaireTable.fichierId, bibliothequeFichierTable.id),
+            eq(bibliothequeFichierTable.collectiviteId, collectiviteId)
+          )
+        )
+        .leftJoin(
+          storageObjectTable,
+          and(
+            eq(storageObjectTable.name, bibliothequeFichierTable.hash),
+            this.storageObjectInCollectiviteBuckets(collectiviteId)
+          )
+        )
+        .where(
+          and(
+            eq(preuveComplementaireTable.collectiviteId, collectiviteId),
+            this.hideConfidentielFilter(
+              preuveComplementaireTable.fichierId,
+              canReadConfidentiel
+            )
+          )
+        );
+
+      return success(this.splitFilesAndLinks(rows));
+    } catch (error) {
+      this.logger.error(
+        `Collecte des preuves complémentaires: ${getErrorMessage(error)}`
+      );
+      return failure(
+        PreuvesArchiveErrorEnum.COLLECT_PREUVES_ERROR,
+        error instanceof Error ? error : new Error(getErrorMessage(error))
+      );
+    }
+  }
+
+  async getReglementairePreuves(input: {
+    collectiviteId: number;
+    canReadConfidentiel: boolean;
+  }): Promise<Result<CollectedPreuves, PreuvesArchiveError>> {
+    const { collectiviteId, canReadConfidentiel } = input;
+    try {
+      const rows = await this.db
+        .select({
+          actionId: preuveActionTable.actionId,
+          fichierId: preuveReglementaireTable.fichierId,
+          url: preuveReglementaireTable.url,
+          titre: preuveReglementaireTable.titre,
+          commentaire: preuveReglementaireTable.commentaire,
+          bucketId: storageObjectTable.bucketId,
+          hash: bibliothequeFichierTable.hash,
+          filename: bibliothequeFichierTable.filename,
+          metadata: storageObjectTable.metadata,
+        })
+        .from(preuveReglementaireTable)
+        .innerJoin(
+          preuveActionTable,
+          eq(preuveReglementaireTable.preuveId, preuveActionTable.preuveId)
+        )
+        .leftJoin(
+          bibliothequeFichierTable,
+          and(
+            eq(preuveReglementaireTable.fichierId, bibliothequeFichierTable.id),
+            eq(bibliothequeFichierTable.collectiviteId, collectiviteId)
+          )
+        )
+        .leftJoin(
+          storageObjectTable,
+          and(
+            eq(storageObjectTable.name, bibliothequeFichierTable.hash),
+            this.storageObjectInCollectiviteBuckets(collectiviteId)
+          )
+        )
+        .where(
+          and(
+            eq(preuveReglementaireTable.collectiviteId, collectiviteId),
+            this.hideConfidentielFilter(
+              preuveReglementaireTable.fichierId,
+              canReadConfidentiel
+            )
+          )
+        );
+
+      return success(this.splitFilesAndLinks(rows));
+    } catch (error) {
+      this.logger.error(
+        `Collecte des preuves réglementaires: ${getErrorMessage(error)}`
+      );
+      return failure(
+        PreuvesArchiveErrorEnum.COLLECT_PREUVES_ERROR,
+        error instanceof Error ? error : new Error(getErrorMessage(error))
+      );
+    }
+  }
+
+  async getLabellisationPreuves(input: {
+    collectiviteId: number;
+    demandeId: number;
+    canReadConfidentiel: boolean;
+  }): Promise<Result<CollectedPreuves, PreuvesArchiveError>> {
+    const { collectiviteId, demandeId, canReadConfidentiel } = input;
+    try {
+      const rows = await this.db
+        .select({
+          actionId: sql<string | null>`null`,
+          fichierId: preuveLabellisationTable.fichierId,
+          url: preuveLabellisationTable.url,
+          titre: preuveLabellisationTable.titre,
+          commentaire: preuveLabellisationTable.commentaire,
+          bucketId: storageObjectTable.bucketId,
+          hash: bibliothequeFichierTable.hash,
+          filename: bibliothequeFichierTable.filename,
+          metadata: storageObjectTable.metadata,
+        })
+        .from(preuveLabellisationTable)
+        .leftJoin(
+          bibliothequeFichierTable,
+          and(
+            eq(preuveLabellisationTable.fichierId, bibliothequeFichierTable.id),
+            eq(bibliothequeFichierTable.collectiviteId, collectiviteId)
+          )
+        )
+        .leftJoin(
+          storageObjectTable,
+          and(
+            eq(storageObjectTable.name, bibliothequeFichierTable.hash),
+            this.storageObjectInCollectiviteBuckets(collectiviteId)
+          )
+        )
+        .where(
+          and(
+            eq(preuveLabellisationTable.demandeId, demandeId),
+            eq(preuveLabellisationTable.collectiviteId, collectiviteId),
+            this.hideConfidentielFilter(
+              preuveLabellisationTable.fichierId,
+              canReadConfidentiel
+            )
+          )
+        );
+
+      return success(this.splitFilesAndLinks(rows));
+    } catch (error) {
+      this.logger.error(
+        `Collecte des preuves de labellisation: ${getErrorMessage(error)}`
+      );
+      return failure(
+        PreuvesArchiveErrorEnum.COLLECT_PREUVES_ERROR,
+        error instanceof Error ? error : new Error(getErrorMessage(error))
+      );
+    }
+  }
+
+  async getAuditPreuves(input: {
+    collectiviteId: number;
+    auditId: number;
+    canReadConfidentiel: boolean;
+  }): Promise<Result<CollectedPreuves, PreuvesArchiveError>> {
+    const { collectiviteId, auditId, canReadConfidentiel } = input;
+    try {
+      const rows = await this.db
+        .select({
+          actionId: sql<string | null>`null`,
+          fichierId: preuveAuditTable.fichierId,
+          url: preuveAuditTable.url,
+          titre: preuveAuditTable.titre,
+          commentaire: preuveAuditTable.commentaire,
+          bucketId: storageObjectTable.bucketId,
+          hash: bibliothequeFichierTable.hash,
+          filename: bibliothequeFichierTable.filename,
+          metadata: storageObjectTable.metadata,
+        })
+        .from(preuveAuditTable)
+        .leftJoin(
+          bibliothequeFichierTable,
+          and(
+            eq(preuveAuditTable.fichierId, bibliothequeFichierTable.id),
+            eq(bibliothequeFichierTable.collectiviteId, collectiviteId)
+          )
+        )
+        .leftJoin(
+          storageObjectTable,
+          and(
+            eq(storageObjectTable.name, bibliothequeFichierTable.hash),
+            this.storageObjectInCollectiviteBuckets(collectiviteId)
+          )
+        )
+        .where(
+          and(
+            eq(preuveAuditTable.auditId, auditId),
+            eq(preuveAuditTable.collectiviteId, collectiviteId),
+            this.hideConfidentielFilter(
+              preuveAuditTable.fichierId,
+              canReadConfidentiel
+            )
+          )
+        );
+
+      return success(this.splitFilesAndLinks(rows));
+    } catch (error) {
+      this.logger.error(
+        `Collecte des preuves d'audit: ${getErrorMessage(error)}`
+      );
+      return failure(
+        PreuvesArchiveErrorEnum.COLLECT_PREUVES_ERROR,
+        error instanceof Error ? error : new Error(getErrorMessage(error))
+      );
+    }
+  }
+
+  private storageObjectInCollectiviteBuckets(collectiviteId: number): SQL {
+    return inArray(
+      storageObjectTable.bucketId,
+      this.db
+        .select({ bucketId: collectiviteBucketTable.bucketId })
+        .from(collectiviteBucketTable)
+        .where(eq(collectiviteBucketTable.collectiviteId, collectiviteId))
+    );
+  }
+
+  // `confidentiel === null` traité comme confidentiel (fail-closed) ; les liens
+  // (sans fichier) ne portent jamais de confidentialité et restent visibles.
+  private hideConfidentielFilter(
+    fichierIdColumn: Column,
+    canReadConfidentiel: boolean
+  ): SQL | undefined {
+    if (canReadConfidentiel) {
+      return undefined;
+    }
+    return or(
+      isNull(fichierIdColumn),
+      eq(bibliothequeFichierTable.confidentiel, false)
+    );
+  }
+
+  private splitFilesAndLinks(
+    rows: Array<{
+      actionId: string | null;
+      fichierId: number | null;
+      url: string | null;
+      titre: string | null;
+      commentaire: string | null;
+      bucketId: string | null;
+      hash: string | null;
+      filename: string | null;
+      metadata: unknown;
+    }>
+  ): CollectedPreuves {
+    const files = rows
+      .filter(
+        (
+          row
+        ): row is typeof row & {
+          fichierId: number;
+          hash: string;
+        } => row.fichierId !== null && row.hash !== null
+      )
+      .map((row) => ({
+        bucketId: row.bucketId,
+        hash: row.hash,
+        filename: row.filename,
+        filesize: this.readFilesize(row.metadata),
+        actionId: row.actionId,
+      }));
+
+    const links = rows
+      .filter(
+        (row): row is typeof row & { url: string } =>
+          row.fichierId === null && row.url !== null && row.url !== ''
+      )
+      .map((row) => ({
+        url: row.url,
+        titre: row.titre,
+        commentaire: row.commentaire,
+        actionId: row.actionId,
+      }));
+
+    return { files, links };
+  }
+
+  private readFilesize(metadata: unknown): number | null {
+    const parsed = storageMetadataSchema.safeParse(metadata);
+    if (!parsed.success) {
+      return null;
+    }
+    const size = Number(parsed.data.size);
+    return Number.isFinite(size) ? size : null;
+  }
+}

--- a/apps/backend/src/referentiels/preuves-archive/list-audit-preuves/list-audit-preuves.service.spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/list-audit-preuves/list-audit-preuves.service.spec.ts
@@ -1,0 +1,144 @@
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { ResourceType } from '@tet/domain/users';
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  CollectedFilePreuve,
+  CollectedLinkPreuve,
+} from './collect-preuves.repository';
+import { ListAuditPreuvesService } from './list-audit-preuves.service';
+
+const user = { id: 'user-id' } as AuthenticatedUser;
+
+const baseInput = {
+  collectiviteId: 1,
+  auditId: 10,
+  demandeId: 20,
+  user,
+};
+
+const empty = { files: [], links: [] };
+
+type PreuvesPayload = {
+  files: CollectedFilePreuve[];
+  links: CollectedLinkPreuve[];
+};
+
+function buildService({
+  complementaire = empty,
+  reglementaire = empty,
+  labellisation = empty,
+  audit = empty,
+  canReadConfidentiel = true,
+}: {
+  complementaire?: PreuvesPayload;
+  reglementaire?: PreuvesPayload;
+  labellisation?: PreuvesPayload;
+  audit?: PreuvesPayload;
+  canReadConfidentiel?: boolean;
+} = {}): {
+  service: ListAuditPreuvesService;
+  permissionsIsAllowed: ReturnType<typeof vi.fn>;
+} {
+  const repository = {
+    getComplementairePreuves: vi
+      .fn()
+      .mockResolvedValue({ success: true, data: complementaire }),
+    getReglementairePreuves: vi
+      .fn()
+      .mockResolvedValue({ success: true, data: reglementaire }),
+    getLabellisationPreuves: vi
+      .fn()
+      .mockResolvedValue({ success: true, data: labellisation }),
+    getAuditPreuves: vi
+      .fn()
+      .mockResolvedValue({ success: true, data: audit }),
+  };
+
+  const permissionsIsAllowed = vi.fn().mockResolvedValue(canReadConfidentiel);
+  const permissions = { isAllowed: permissionsIsAllowed } as unknown;
+
+  const service = new ListAuditPreuvesService(
+    repository as never,
+    permissions as never
+  );
+
+  return { service, permissionsIsAllowed };
+}
+
+function makeFile(
+  overrides: Partial<CollectedFilePreuve> = {}
+): CollectedFilePreuve {
+  return {
+    bucketId: 'bucket-1',
+    hash: 'hash-1',
+    filename: 'doc.pdf',
+    filesize: 1024,
+    actionId: null,
+    ...overrides,
+  };
+}
+
+describe('ListAuditPreuvesService', () => {
+  it('interroge la permission `collectivites.documents.read_confidentiel` sur la collectivité', async () => {
+    const { service, permissionsIsAllowed } = buildService();
+
+    await service.list(baseInput);
+
+    expect(permissionsIsAllowed).toHaveBeenCalledWith(
+      user,
+      'collectivites.documents.read_confidentiel',
+      ResourceType.COLLECTIVITE,
+      1,
+      true
+    );
+  });
+
+  it('fusionne complémentaires et réglementaires sous le bucket `mesure`', async () => {
+    const { service } = buildService({
+      complementaire: {
+        files: [makeFile({ actionId: 'cae_1.1.1', filename: 'comp.pdf' })],
+        links: [],
+      },
+      reglementaire: {
+        files: [makeFile({ actionId: 'cae_1.1.1', filename: 'regl.pdf' })],
+        links: [],
+      },
+    });
+
+    const result = await service.list(baseInput);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.mesure.files.map((file) => file.filename)).toEqual([
+      'comp.pdf',
+      'regl.pdf',
+    ]);
+  });
+
+  it("propage l'échec d'une requête repository", async () => {
+    const repository = {
+      getComplementairePreuves: vi
+        .fn()
+        .mockResolvedValue({ success: false, error: 'COLLECT_PREUVES_ERROR' }),
+      getReglementairePreuves: vi
+        .fn()
+        .mockResolvedValue({ success: true, data: empty }),
+      getLabellisationPreuves: vi
+        .fn()
+        .mockResolvedValue({ success: true, data: empty }),
+      getAuditPreuves: vi
+        .fn()
+        .mockResolvedValue({ success: true, data: empty }),
+    } as unknown;
+    const service = new ListAuditPreuvesService(
+      repository as never,
+      { isAllowed: vi.fn().mockResolvedValue(true) } as never
+    );
+
+    const result = await service.list(baseInput);
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error).toBe('COLLECT_PREUVES_ERROR');
+  });
+});

--- a/apps/backend/src/referentiels/preuves-archive/list-audit-preuves/list-audit-preuves.service.ts
+++ b/apps/backend/src/referentiels/preuves-archive/list-audit-preuves/list-audit-preuves.service.ts
@@ -1,0 +1,103 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { failure, success, type Result } from '@tet/backend/utils/result.type';
+import { ResourceType } from '@tet/domain/users';
+import { getErrorMessage } from '@tet/domain/utils';
+import {
+  PreuvesArchiveErrorEnum,
+  type PreuvesArchiveError,
+} from '../preuves-archive.errors';
+import {
+  CollectPreuvesRepository,
+  type CollectedFilePreuve,
+  type CollectedLinkPreuve,
+} from './collect-preuves.repository';
+
+export interface PreuvesSource {
+  files: CollectedFilePreuve[];
+  links: CollectedLinkPreuve[];
+}
+
+export interface PreuvesByOrigin {
+  mesure: PreuvesSource;
+  demande: PreuvesSource;
+  audit: PreuvesSource;
+}
+
+export interface ListPreuvesForAuditInput {
+  collectiviteId: number;
+  demandeId: number;
+  auditId: number;
+  user: AuthenticatedUser;
+}
+
+@Injectable()
+export class ListAuditPreuvesService {
+  private readonly logger = new Logger(ListAuditPreuvesService.name);
+
+  constructor(
+    private readonly repository: CollectPreuvesRepository,
+    private readonly permissions: PermissionService
+  ) {}
+
+  async list(
+    input: ListPreuvesForAuditInput
+  ): Promise<Result<PreuvesByOrigin, PreuvesArchiveError>> {
+    const { collectiviteId, demandeId, auditId, user } = input;
+
+    try {
+      const canReadConfidentiel = await this.permissions.isAllowed(
+        user,
+        'collectivites.documents.read_confidentiel',
+        ResourceType.COLLECTIVITE,
+        collectiviteId,
+        true
+      );
+
+      const [complementaire, reglementaire, labellisation, audit] =
+        await Promise.all([
+          this.repository.getComplementairePreuves({
+            collectiviteId,
+            canReadConfidentiel,
+          }),
+          this.repository.getReglementairePreuves({
+            collectiviteId,
+            canReadConfidentiel,
+          }),
+          this.repository.getLabellisationPreuves({
+            collectiviteId,
+            demandeId,
+            canReadConfidentiel,
+          }),
+          this.repository.getAuditPreuves({
+            collectiviteId,
+            auditId,
+            canReadConfidentiel,
+          }),
+        ]);
+
+      if (!complementaire.success) return complementaire;
+      if (!reglementaire.success) return reglementaire;
+      if (!labellisation.success) return labellisation;
+      if (!audit.success) return audit;
+
+      return success({
+        mesure: {
+          files: [...complementaire.data.files, ...reglementaire.data.files],
+          links: [...complementaire.data.links, ...reglementaire.data.links],
+        },
+        demande: labellisation.data,
+        audit: audit.data,
+      });
+    } catch (error) {
+      this.logger.error(
+        `Liste des preuves de l'audit ${auditId}: ${getErrorMessage(error)}`
+      );
+      return failure(
+        PreuvesArchiveErrorEnum.COLLECT_PREUVES_ERROR,
+        error instanceof Error ? error : new Error(getErrorMessage(error))
+      );
+    }
+  }
+}

--- a/apps/backend/src/referentiels/preuves-archive/models/audit-preuves-archive.table.ts
+++ b/apps/backend/src/referentiels/preuves-archive/models/audit-preuves-archive.table.ts
@@ -1,0 +1,77 @@
+import { auditTable } from '@tet/backend/referentiels/labellisations/audit.table';
+import { authUsersTable } from '@tet/backend/users/models/auth-users.table';
+import { collectiviteTable } from '@tet/backend/collectivites/shared/models/collectivite.table';
+import {
+  createdAt,
+  modifiedAt,
+  TIMESTAMP_OPTIONS,
+} from '@tet/backend/utils/column.utils';
+import { InferSelectModel, sql } from 'drizzle-orm';
+import {
+  integer,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from 'drizzle-orm/pg-core';
+import { z } from 'zod';
+
+export enum AuditPreuvesArchiveStatusEnum {
+  PENDING = 'pending',
+  PROCESSING = 'processing',
+  COMPLETED = 'completed',
+  FAILED = 'failed',
+}
+
+const orderedAuditPreuvesArchiveStatus = [
+  AuditPreuvesArchiveStatusEnum.PENDING,
+  AuditPreuvesArchiveStatusEnum.PROCESSING,
+  AuditPreuvesArchiveStatusEnum.COMPLETED,
+  AuditPreuvesArchiveStatusEnum.FAILED,
+] as const;
+
+export const auditPreuvesArchiveStatusSchema = z.enum(
+  orderedAuditPreuvesArchiveStatus
+);
+
+export type AuditPreuvesArchiveStatus = z.infer<
+  typeof auditPreuvesArchiveStatusSchema
+>;
+
+export const auditPreuvesArchiveInFlightStatuses: readonly AuditPreuvesArchiveStatus[] =
+  [AuditPreuvesArchiveStatusEnum.PENDING, AuditPreuvesArchiveStatusEnum.PROCESSING];
+
+export const auditPreuvesArchiveTable = pgTable(
+  'audit_preuves_archive',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    collectiviteId: integer('collectivite_id')
+      .notNull()
+      .references(() => collectiviteTable.id, { onDelete: 'cascade' }),
+    referentielId: text('referentiel_id').notNull(),
+    auditId: integer('audit_id')
+      .notNull()
+      .references(() => auditTable.id, { onDelete: 'cascade' }),
+    requestedBy: uuid('requested_by')
+      .notNull()
+      .references(() => authUsersTable.id, { onDelete: 'cascade' }),
+    status: text('status').notNull().$type<AuditPreuvesArchiveStatus>(),
+    totalFiles: integer('total_files').notNull().default(0),
+    processedFiles: integer('processed_files').notNull().default(0),
+    storagePath: text('storage_path'),
+    errorMessage: text('error_message'),
+    createdAt,
+    modifiedAt,
+    expiresAt: timestamp('expires_at', TIMESTAMP_OPTIONS).notNull(),
+  },
+  (table) => [
+    uniqueIndex('audit_preuves_archive_in_flight_unique')
+      .on(table.auditId, table.requestedBy)
+      .where(sql`status IN ('pending', 'processing')`),
+  ]
+);
+
+export type AuditPreuvesArchive = InferSelectModel<
+  typeof auditPreuvesArchiveTable
+>;

--- a/apps/backend/src/referentiels/preuves-archive/preuves-archive.constants.ts
+++ b/apps/backend/src/referentiels/preuves-archive/preuves-archive.constants.ts
@@ -1,0 +1,6 @@
+export const PREUVES_ARCHIVES_BUCKET = 'preuves-archives';
+
+export const ARCHIVE_ZIP_CONTENT_TYPE = 'application/zip';
+
+/** TTL de la signed URL retournée par `get` : 24h pour laisser à l'utilisateur le temps de télécharger son archive. Régénérée à chaque appel de `get`. */
+export const ARCHIVE_DOWNLOAD_TTL_SECONDS = 24 * 60 * 60;

--- a/apps/backend/src/referentiels/preuves-archive/preuves-archive.errors.ts
+++ b/apps/backend/src/referentiels/preuves-archive/preuves-archive.errors.ts
@@ -1,0 +1,19 @@
+import { createErrorsEnum } from '@tet/backend/utils/trpc/trpc-error-handler';
+
+export const PreuvesArchiveSpecificErrors = [
+  'CREATE_ARCHIVE_ERROR',
+  'GET_ARCHIVE_ERROR',
+  'UPDATE_ARCHIVE_ERROR',
+  'ARCHIVE_NOT_FOUND',
+  'AUDIT_NOT_FOUND',
+  'ARCHIVE_STATUS_PARSE_ERROR',
+  'COLLECT_PREUVES_ERROR',
+] as const;
+
+export type PreuvesArchiveSpecificError =
+  (typeof PreuvesArchiveSpecificErrors)[number];
+
+export const PreuvesArchiveErrorEnum = createErrorsEnum(
+  PreuvesArchiveSpecificErrors
+);
+export type PreuvesArchiveError = keyof typeof PreuvesArchiveErrorEnum;

--- a/apps/backend/src/referentiels/preuves-archive/preuves-archive.full-pipeline.e2e-spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/preuves-archive.full-pipeline.e2e-spec.ts
@@ -1,0 +1,273 @@
+import { INestApplication } from '@nestjs/common';
+import { addTestCollectiviteAndUser } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { bibliothequeFichierTable } from '@tet/backend/collectivites/documents/models/bibliotheque-fichier.table';
+import { preuveAuditTable } from '@tet/backend/collectivites/documents/models/preuve-audit.table';
+import { preuveComplementaireTable } from '@tet/backend/collectivites/documents/models/preuve-complementaire.table';
+import { preuveLabellisationTable } from '@tet/backend/collectivites/documents/models/preuve-labellisation.table';
+import { storageObjectTable } from '@tet/backend/collectivites/documents/models/storage-object.table';
+import { collectiviteBucketTable } from '@tet/backend/collectivites/shared/models/collectivite-bucket.table';
+import { auditTable } from '@tet/backend/referentiels/labellisations/audit.table';
+import { labellisationDemandeTable } from '@tet/backend/referentiels/labellisations/labellisation-demande.table';
+import {
+  getAuthUserFromUserCredentials,
+  getTestApp,
+  getTestDatabase,
+} from '@tet/backend/test';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
+import { Collectivite } from '@tet/domain/collectivites';
+import { CollectiviteRole } from '@tet/domain/users';
+import { and, eq, sql } from 'drizzle-orm';
+import { execSync } from 'node:child_process';
+import { copyFile, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Readable } from 'node:stream';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { like } from 'drizzle-orm';
+import { DocumentStorageService } from '@tet/backend/utils/supabase/document-storage.service';
+import { GeneratePreuvesArchiveService } from './generate-preuves-archive/generate-preuves-archive.service';
+import { GeneratePreuvesArchiveWorker } from './generate-preuves-archive/generate-preuves-archive.worker';
+import { auditPreuvesArchiveTable } from './models/audit-preuves-archive.table';
+import { PREUVES_ARCHIVES_BUCKET } from './preuves-archive.constants';
+
+const MESURE_SOUS_ACTION_ID = 'cae_1.1.3.2';
+const COMPLEMENTAIRE_ACTION_ID = 'cae_1.1.3';
+
+// Réutilisation pragmatique du bucket `preuves-archives` (créé par la migration) :
+// `storage.buckets` est un schéma Supabase et créer un bucket de test ad-hoc
+// demande de connaître son schéma exact (owner, name, public, etc.). Le bucket
+// est partagé entre les `storage.objects` simulant les sources et l'upload de
+// l'archive — anodin ici puisque les I/O Supabase sont mockés.
+const BUCKET_ID = PREUVES_ARCHIVES_BUCKET;
+
+// Second bucket VIDE rattaché à la collectivité : reproduit une collectivité
+// fusionnée (plusieurs `collectivite_bucket`). Sans le fix, le LEFT JOIN sur
+// `collectivite_id` seul multiplie chaque preuve par bucket et liste les
+// fichiers présents comme « manquants ». Aucun objet n'y est stocké.
+const EMPTY_BUCKET_ID = 'preuves-archive-e2e-empty-bucket';
+
+describe('Archive de preuves - pipeline complet (ZIP réel)', () => {
+  let app: INestApplication;
+  let db: DatabaseService;
+  let router: TrpcRouter;
+  let collectivite: Collectivite;
+  let adminUser: AuthenticatedUser;
+  let cleanupCollectivite: () => Promise<void>;
+  let capturedZipDir: string;
+  let capturedZipPath: string | null = null;
+
+  beforeAll(async () => {
+    capturedZipDir = await mkdtemp(join(tmpdir(), 'preuves-archive-e2e-'));
+
+    app = await getTestApp({
+      overrides: (moduleBuilder) => {
+        moduleBuilder
+          .overrideProvider(GeneratePreuvesArchiveWorker)
+          .useValue({ onModuleInit: () => undefined });
+        moduleBuilder.overrideProvider(DocumentStorageService).useValue({
+          getDocumentStream: async ({ key }: { key: string }) => ({
+            success: true,
+            data: Readable.from(
+              Buffer.from(`fake content for hash ${key}\n`.repeat(8))
+            ),
+          }),
+          storeDocument: async ({
+            sourceFilePath,
+            key,
+          }: {
+            sourceFilePath: string;
+            key: string;
+          }) => {
+            capturedZipPath = join(capturedZipDir, key);
+            await copyFile(sourceFilePath, capturedZipPath);
+            return { success: true, data: { key } };
+          },
+          createDocumentSignedUrl: async () => ({
+            success: true,
+            data: { signedUrl: 'https://fake.test/archive.zip' },
+          }),
+        });
+      },
+    });
+    db = await getTestDatabase(app);
+    router = await app.get(TrpcRouter);
+
+    const fixture = await addTestCollectiviteAndUser(db, {
+      user: { role: CollectiviteRole.ADMIN },
+    });
+    collectivite = fixture.collectivite;
+    adminUser = getAuthUserFromUserCredentials(fixture.user);
+    cleanupCollectivite = fixture.cleanup;
+
+    await db.db
+      .insert(collectiviteBucketTable)
+      .values({ bucketId: BUCKET_ID, collectiviteId: collectivite.id });
+
+    await db.db.execute(
+      sql`INSERT INTO storage.buckets (id, name, public) VALUES (${EMPTY_BUCKET_ID}, ${'E2E empty bucket'}, false) ON CONFLICT (id) DO NOTHING`
+    );
+    await db.db
+      .insert(collectiviteBucketTable)
+      .values({ bucketId: EMPTY_BUCKET_ID, collectiviteId: collectivite.id });
+  });
+
+  afterAll(async () => {
+    await db.db
+      .delete(preuveAuditTable)
+      .where(eq(preuveAuditTable.collectiviteId, collectivite.id));
+    await db.db
+      .delete(preuveLabellisationTable)
+      .where(eq(preuveLabellisationTable.collectiviteId, collectivite.id));
+    await db.db
+      .delete(preuveComplementaireTable)
+      .where(eq(preuveComplementaireTable.collectiviteId, collectivite.id));
+    await db.db
+      .delete(auditPreuvesArchiveTable)
+      .where(eq(auditPreuvesArchiveTable.collectiviteId, collectivite.id));
+    // Nettoie uniquement les objects qu'on a seedés (suffixés par l'id de la
+    // collectivité) — le bucket `preuves-archives` peut contenir d'autres
+    // archives d'autres tests.
+    await db.db
+      .delete(storageObjectTable)
+      .where(
+        and(
+          eq(storageObjectTable.bucketId, BUCKET_ID),
+          like(storageObjectTable.name, `%${collectivite.id}`)
+        )
+      );
+    await db.db
+      .delete(auditTable)
+      .where(eq(auditTable.collectiviteId, collectivite.id));
+    await db.db
+      .delete(labellisationDemandeTable)
+      .where(eq(labellisationDemandeTable.collectiviteId, collectivite.id));
+    await cleanupCollectivite();
+    await db.db.execute(
+      sql`DELETE FROM storage.buckets WHERE id = ${EMPTY_BUCKET_ID}`
+    );
+
+    await rm(capturedZipDir, { recursive: true, force: true });
+    await app.close();
+  });
+
+  test("produit un ZIP avec l'arborescence attendue (3 fichiers + 1 lien CSV)", async () => {
+    const caller = router.createCaller({ user: adminUser });
+
+    const [demande] = await db.db
+      .insert(labellisationDemandeTable)
+      .values({ collectiviteId: collectivite.id, referentiel: 'cae' })
+      .returning();
+    const [audit] = await db.db
+      .insert(auditTable)
+      .values({
+        collectiviteId: collectivite.id,
+        referentielId: 'cae',
+        demandeId: demande.id,
+      })
+      .returning();
+    const demandeId = demande.id;
+    const auditId = audit.id;
+
+    const { archiveId } = await caller.referentiels.preuvesArchive.request({
+      collectiviteId: collectivite.id,
+      referentielId: 'cae',
+    });
+
+    const fichiers = await db.db
+      .insert(bibliothequeFichierTable)
+      .values([
+        {
+          collectiviteId: collectivite.id,
+          hash: `hash-mesure-${collectivite.id}`,
+          filename: 'preuve-mesure.pdf',
+          confidentiel: false,
+        },
+        {
+          collectiviteId: collectivite.id,
+          hash: `hash-demande-${collectivite.id}`,
+          filename: 'rapport-demande.pdf',
+          confidentiel: false,
+        },
+        {
+          collectiviteId: collectivite.id,
+          hash: `hash-audit-${collectivite.id}`,
+          filename: 'rapport-audit.pdf',
+          confidentiel: false,
+        },
+      ])
+      .returning();
+    const [fichierMesure, fichierDemande, fichierAudit] = fichiers;
+
+    await db.db.insert(storageObjectTable).values(
+      fichiers.map((fichier) => ({
+        bucketId: BUCKET_ID,
+        name: fichier.hash,
+        metadata: { size: 1024 },
+      }))
+    );
+
+    await db.db.insert(preuveComplementaireTable).values([
+      {
+        collectiviteId: collectivite.id,
+        actionId: MESURE_SOUS_ACTION_ID,
+        fichierId: fichierMesure.id,
+        modifiedBy: adminUser.id,
+      },
+      {
+        collectiviteId: collectivite.id,
+        actionId: COMPLEMENTAIRE_ACTION_ID,
+        url: 'https://exemple.fr/ressource',
+        titre: 'Une ressource externe',
+        modifiedBy: adminUser.id,
+      },
+    ]);
+    await db.db.insert(preuveLabellisationTable).values({
+      collectiviteId: collectivite.id,
+      demandeId,
+      fichierId: fichierDemande.id,
+      modifiedBy: adminUser.id,
+    });
+    await db.db.insert(preuveAuditTable).values({
+      collectiviteId: collectivite.id,
+      auditId,
+      fichierId: fichierAudit.id,
+      modifiedBy: adminUser.id,
+    });
+
+    const service = app.get(GeneratePreuvesArchiveService);
+    const generationResult = await service.generate(archiveId);
+    expect(generationResult).toEqual({ success: true });
+    expect(capturedZipPath).not.toBeNull();
+
+    const listing = execSync(`unzip -Z1 "${capturedZipPath}"`, {
+      encoding: 'utf8',
+    });
+    const entries = listing.trim().split('\n');
+
+    expect(entries).toContain('cycle-labellisation/demande/rapport-demande.pdf');
+    expect(entries).toContain('cycle-labellisation/audit/rapport-audit.pdf');
+    expect(
+      entries.some(
+        (entry) =>
+          entry.startsWith('mesures/') && entry.endsWith('/preuve-mesure.pdf')
+      )
+    ).toBe(true);
+    expect(
+      entries.some(
+        (entry) => entry.startsWith('mesures/') && entry.endsWith('/liens.csv')
+      )
+    ).toBe(true);
+
+    // Assertion de garde du scénario à 2 buckets monté plus haut (EMPTY_BUCKET_ID,
+    // cf. beforeAll). Avant le fix, le LEFT JOIN sur `collectivite_id` seul
+    // multipliait chaque preuve par le nombre de buckets rattachés ; la copie
+    // jointe au bucket vide n'avait pas d'objet storage et était donc comptée
+    // comme introuvable, générant à tort `_manifeste/fichiers-manquants.txt`.
+    // L'absence de ce manifeste est précisément ce qui prouve que le produit
+    // cartésien ne réapparaît pas : sans cette ligne, le setup EMPTY_BUCKET_ID
+    // ne valide plus rien.
+    expect(entries).not.toContain('_manifeste/fichiers-manquants.txt');
+  });
+});

--- a/apps/backend/src/referentiels/preuves-archive/preuves-archive.queue.ts
+++ b/apps/backend/src/referentiels/preuves-archive/preuves-archive.queue.ts
@@ -1,0 +1,22 @@
+import type { JobsOptions } from 'bullmq';
+
+export const PREUVES_ARCHIVE_QUEUE_NAME = 'preuves_archive_generation';
+
+/** Verrou large : la génération d'archive est longue (collecte + téléchargement + upload). */
+export const PREUVES_ARCHIVE_LOCK_DURATION_MS = 10 * 60 * 1000;
+
+/**
+ * Backoff exponentiel à partir de 30s (30s, 60s, 120s) : laisse passer les
+ * indisponibilités transitoires d'infra (Supabase 503, réseau, disque) sans
+ * pilonner. `attempts: 3` borne un job qui dure ~10 min et lit tout un bucket.
+ */
+export const PREUVES_ARCHIVE_JOB_OPTIONS: JobsOptions = {
+  attempts: 3,
+  backoff: { type: 'exponential', delay: 30_000 },
+  removeOnComplete: { age: 3600 },
+  removeOnFail: { age: 86400 },
+};
+
+export interface PreuvesArchiveJobData {
+  archiveId: string;
+}

--- a/apps/backend/src/referentiels/preuves-archive/preuves-archive.repository.ts
+++ b/apps/backend/src/referentiels/preuves-archive/preuves-archive.repository.ts
@@ -1,0 +1,299 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { failure, success, type Result } from '@tet/backend/utils/result.type';
+import { getErrorMessage } from '@tet/domain/utils';
+import { and, eq, inArray } from 'drizzle-orm';
+import {
+  AuditPreuvesArchive,
+  auditPreuvesArchiveStatusSchema,
+  AuditPreuvesArchiveStatus,
+  AuditPreuvesArchiveStatusEnum,
+  auditPreuvesArchiveTable,
+} from './models/audit-preuves-archive.table';
+import {
+  PreuvesArchiveErrorEnum,
+  type PreuvesArchiveError,
+} from './preuves-archive.errors';
+
+export interface CreateArchiveInput {
+  collectiviteId: number;
+  referentielId: string;
+  auditId: number;
+  requestedBy: string;
+  expiresAt: string;
+}
+
+export interface UpdateArchiveProgressInput {
+  processedFiles: number;
+  totalFiles?: number;
+}
+
+@Injectable()
+export class PreuvesArchiveRepository {
+  private readonly db = this.database.db;
+  private readonly logger = new Logger(PreuvesArchiveRepository.name);
+
+  constructor(private readonly database: DatabaseService) {}
+
+  async createOrGetInFlight(
+    input: CreateArchiveInput
+  ): Promise<Result<AuditPreuvesArchive, PreuvesArchiveError>> {
+    try {
+      const [created] = await this.db
+        .insert(auditPreuvesArchiveTable)
+        .values({
+          collectiviteId: input.collectiviteId,
+          referentielId: input.referentielId,
+          auditId: input.auditId,
+          requestedBy: input.requestedBy,
+          status: AuditPreuvesArchiveStatusEnum.PENDING,
+          expiresAt: input.expiresAt,
+        })
+        .onConflictDoNothing()
+        .returning();
+
+      if (created) {
+        return this.parseRow(created);
+      }
+
+      const [existing] = await this.db
+        .select()
+        .from(auditPreuvesArchiveTable)
+        .where(
+          and(
+            eq(auditPreuvesArchiveTable.auditId, input.auditId),
+            eq(auditPreuvesArchiveTable.requestedBy, input.requestedBy)
+          )
+        )
+        .limit(1);
+
+      if (!existing) {
+        return failure(
+          PreuvesArchiveErrorEnum.CREATE_ARCHIVE_ERROR,
+          new Error(
+            'Aucune ligne créée ni job in-flight trouvé après ON CONFLICT'
+          )
+        );
+      }
+
+      return this.parseRow(existing);
+    } catch (error) {
+      this.logger.error(`Création du job d'archive: ${getErrorMessage(error)}`);
+      return failure(
+        PreuvesArchiveErrorEnum.CREATE_ARCHIVE_ERROR,
+        error instanceof Error ? error : new Error(getErrorMessage(error))
+      );
+    }
+  }
+
+  async getByIdRaw(
+    id: string
+  ): Promise<Result<AuditPreuvesArchive, PreuvesArchiveError>> {
+    try {
+      const [row] = await this.db
+        .select()
+        .from(auditPreuvesArchiveTable)
+        .where(eq(auditPreuvesArchiveTable.id, id))
+        .limit(1);
+
+      if (!row) {
+        return failure(
+          PreuvesArchiveErrorEnum.ARCHIVE_NOT_FOUND,
+          new Error(`Archive ${id} non trouvée`)
+        );
+      }
+
+      return this.parseRow(row);
+    } catch (error) {
+      this.logger.error(
+        `Lecture du job d'archive ${id}: ${getErrorMessage(error)}`
+      );
+      return failure(
+        PreuvesArchiveErrorEnum.GET_ARCHIVE_ERROR,
+        error instanceof Error ? error : new Error(getErrorMessage(error))
+      );
+    }
+  }
+
+  async getByIdForUser(input: {
+    id: string;
+    requestedBy: string;
+  }): Promise<Result<AuditPreuvesArchive, PreuvesArchiveError>> {
+    try {
+      const [row] = await this.db
+        .select()
+        .from(auditPreuvesArchiveTable)
+        .where(
+          and(
+            eq(auditPreuvesArchiveTable.id, input.id),
+            eq(auditPreuvesArchiveTable.requestedBy, input.requestedBy)
+          )
+        )
+        .limit(1);
+
+      if (!row) {
+        return failure(
+          PreuvesArchiveErrorEnum.ARCHIVE_NOT_FOUND,
+          new Error(`Archive ${input.id} non trouvée`)
+        );
+      }
+
+      return this.parseRow(row);
+    } catch (error) {
+      this.logger.error(
+        `Lecture du job d'archive ${input.id}: ${getErrorMessage(error)}`
+      );
+      return failure(
+        PreuvesArchiveErrorEnum.GET_ARCHIVE_ERROR,
+        error instanceof Error ? error : new Error(getErrorMessage(error))
+      );
+    }
+  }
+
+  /**
+   * Compense l'enfilement BullMQ qui a échoué après `createOrGetInFlight` :
+   * supprime la ligne `pending` sinon elle bloque l'index unique partiel
+   * jusqu'à expiration TTL.
+   */
+  async deleteIfPending(id: string): Promise<Result<undefined, PreuvesArchiveError>> {
+    try {
+      await this.db
+        .delete(auditPreuvesArchiveTable)
+        .where(
+          and(
+            eq(auditPreuvesArchiveTable.id, id),
+            eq(auditPreuvesArchiveTable.status, AuditPreuvesArchiveStatusEnum.PENDING)
+          )
+        );
+      return success(undefined);
+    } catch (error) {
+      this.logger.error(
+        `Suppression de la ligne pending ${id}: ${getErrorMessage(error)}`
+      );
+      return failure(
+        PreuvesArchiveErrorEnum.UPDATE_ARCHIVE_ERROR,
+        error instanceof Error ? error : new Error(getErrorMessage(error))
+      );
+    }
+  }
+
+  async transitionToProcessing(
+    id: string
+  ): Promise<Result<AuditPreuvesArchive, PreuvesArchiveError>> {
+    return this.updateAndReturn(
+      id,
+      {
+        status: AuditPreuvesArchiveStatusEnum.PROCESSING,
+        errorMessage: null,
+        storagePath: null,
+        processedFiles: 0,
+        totalFiles: 0,
+        modifiedAt: new Date().toISOString(),
+      },
+      [
+        AuditPreuvesArchiveStatusEnum.PENDING,
+        AuditPreuvesArchiveStatusEnum.PROCESSING,
+        AuditPreuvesArchiveStatusEnum.FAILED,
+      ]
+    );
+  }
+
+  async markCompleted(
+    id: string,
+    storagePath: string
+  ): Promise<Result<AuditPreuvesArchive, PreuvesArchiveError>> {
+    return this.updateAndReturn(
+      id,
+      {
+        status: AuditPreuvesArchiveStatusEnum.COMPLETED,
+        storagePath,
+        modifiedAt: new Date().toISOString(),
+      },
+      [AuditPreuvesArchiveStatusEnum.PROCESSING]
+    );
+  }
+
+  async markFailed(
+    id: string,
+    errorMessage: string
+  ): Promise<Result<AuditPreuvesArchive, PreuvesArchiveError>> {
+    return this.updateAndReturn(
+      id,
+      {
+        status: AuditPreuvesArchiveStatusEnum.FAILED,
+        errorMessage,
+        modifiedAt: new Date().toISOString(),
+      },
+      [AuditPreuvesArchiveStatusEnum.PROCESSING]
+    );
+  }
+
+  private async updateAndReturn(
+    id: string,
+    patch: Partial<typeof auditPreuvesArchiveTable.$inferInsert>,
+    allowedFromStatuses?: AuditPreuvesArchiveStatus[]
+  ): Promise<Result<AuditPreuvesArchive, PreuvesArchiveError>> {
+    try {
+      const whereClause = allowedFromStatuses
+        ? and(
+            eq(auditPreuvesArchiveTable.id, id),
+            inArray(auditPreuvesArchiveTable.status, allowedFromStatuses)
+          )
+        : eq(auditPreuvesArchiveTable.id, id);
+
+      const [row] = await this.db
+        .update(auditPreuvesArchiveTable)
+        .set(patch)
+        .where(whereClause)
+        .returning();
+
+      if (!row) {
+        return failure(
+          PreuvesArchiveErrorEnum.ARCHIVE_NOT_FOUND,
+          new Error(`Archive ${id} non trouvée`)
+        );
+      }
+
+      return this.parseRow(row);
+    } catch (error) {
+      this.logger.error(
+        `Mise à jour du job ${id}: ${getErrorMessage(error)}`
+      );
+      return failure(
+        PreuvesArchiveErrorEnum.UPDATE_ARCHIVE_ERROR,
+        error instanceof Error ? error : new Error(getErrorMessage(error))
+      );
+    }
+  }
+
+  async updateProgress(
+    id: string,
+    input: UpdateArchiveProgressInput
+  ): Promise<Result<AuditPreuvesArchive, PreuvesArchiveError>> {
+    return this.updateAndReturn(
+      id,
+      {
+        processedFiles: input.processedFiles,
+        totalFiles: input.totalFiles,
+        modifiedAt: new Date().toISOString(),
+      },
+      [AuditPreuvesArchiveStatusEnum.PROCESSING]
+    );
+  }
+
+  // La colonne `status` est `text` en base alors que le schéma Drizzle annonce
+  // `AuditPreuvesArchiveStatus` : on valide au runtime pour rattraper une valeur
+  // divergente (migration manuelle, donnée héritée) au lieu de la caster aveuglément.
+  private parseRow(
+    row: AuditPreuvesArchive
+  ): Result<AuditPreuvesArchive, PreuvesArchiveError> {
+    const parsedStatus = auditPreuvesArchiveStatusSchema.safeParse(row.status);
+    if (!parsedStatus.success) {
+      return failure(
+        PreuvesArchiveErrorEnum.ARCHIVE_STATUS_PARSE_ERROR,
+        parsedStatus.error
+      );
+    }
+    return success({ ...row, status: parsedStatus.data });
+  }
+}

--- a/apps/backend/src/referentiels/preuves-archive/preuves-archive.router.e2e-spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/preuves-archive.router.e2e-spec.ts
@@ -1,0 +1,207 @@
+import { INestApplication } from '@nestjs/common';
+import { addTestCollectiviteAndUser } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import {
+  getAuthUserFromUserCredentials,
+  getTestApp,
+  getTestDatabase,
+} from '@tet/backend/test';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { addTestUser } from '@tet/backend/users/users/users.test-fixture';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
+import { Collectivite } from '@tet/domain/collectivites';
+import { CollectiviteRole } from '@tet/domain/users';
+import { randomUUID } from 'crypto';
+import { eq } from 'drizzle-orm';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { auditTable } from '@tet/backend/referentiels/labellisations/audit.table';
+import { DocumentStorageService } from '@tet/backend/utils/supabase/document-storage.service';
+import { GeneratePreuvesArchiveWorker } from './generate-preuves-archive/generate-preuves-archive.worker';
+import {
+  auditPreuvesArchiveTable,
+  AuditPreuvesArchiveStatusEnum,
+} from './models/audit-preuves-archive.table';
+
+const FAKE_SIGNED_URL = 'https://supabase.test/signed/archive.zip';
+
+describe('Archive de preuves - tRPC', () => {
+  let app: INestApplication;
+  let router: TrpcRouter;
+  let db: DatabaseService;
+
+  let collectivite: Collectivite;
+  let adminUser: AuthenticatedUser;
+  let unauthorizedUser: AuthenticatedUser;
+
+  beforeAll(async () => {
+    app = await getTestApp({
+      overrides: (moduleBuilder) => {
+        moduleBuilder
+          .overrideProvider(GeneratePreuvesArchiveWorker)
+          .useValue({ onModuleInit: () => undefined });
+        moduleBuilder.overrideProvider(DocumentStorageService).useValue({
+          createDocumentSignedUrl: async () => ({
+            success: true,
+            data: { signedUrl: FAKE_SIGNED_URL },
+          }),
+        });
+      },
+    });
+    router = await app.get(TrpcRouter);
+    db = await getTestDatabase(app);
+
+    const testCollectiviteAndUserResult = await addTestCollectiviteAndUser(db, {
+      user: {
+        role: CollectiviteRole.ADMIN,
+      },
+    });
+
+    collectivite = testCollectiviteAndUserResult.collectivite;
+    adminUser = getAuthUserFromUserCredentials(
+      testCollectiviteAndUserResult.user
+    );
+
+    const unauthorizedUserResult = await addTestUser(db, { verified: false });
+    unauthorizedUser = getAuthUserFromUserCredentials(
+      unauthorizedUserResult.user
+    );
+
+    await db.db
+      .insert(auditTable)
+      .values({ collectiviteId: collectivite.id, referentielId: 'cae' });
+  });
+
+  afterAll(async () => {
+    await db.db
+      .delete(auditPreuvesArchiveTable)
+      .where(eq(auditPreuvesArchiveTable.collectiviteId, collectivite.id));
+    await db.db
+      .delete(auditTable)
+      .where(eq(auditTable.collectiviteId, collectivite.id));
+    await app.close();
+  });
+
+  describe('Archive de preuves - Cas de succès', () => {
+    test('request déclenche une archive et renvoie un statut pending', async () => {
+      const caller = router.createCaller({ user: adminUser });
+
+      const result = await caller.referentiels.preuvesArchive.request({
+        collectiviteId: collectivite.id,
+        referentielId: 'cae',
+      });
+
+      expect(result.archiveId).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+      );
+      expect(result.status).toBe('pending');
+    });
+
+    test('request est idempotent : un second appel renvoie le même archiveId', async () => {
+      const caller = router.createCaller({ user: adminUser });
+
+      const first = await caller.referentiels.preuvesArchive.request({
+        collectiviteId: collectivite.id,
+        referentielId: 'cae',
+      });
+      const second = await caller.referentiels.preuvesArchive.request({
+        collectiviteId: collectivite.id,
+        referentielId: 'cae',
+      });
+
+      expect(second.archiveId).toBe(first.archiveId);
+    });
+
+    test("get renvoie l'état courant pending de l'archive", async () => {
+      const caller = router.createCaller({ user: adminUser });
+
+      const { archiveId } = await caller.referentiels.preuvesArchive.request({
+        collectiviteId: collectivite.id,
+        referentielId: 'cae',
+      });
+
+      const result = await caller.referentiels.preuvesArchive.get({
+        archiveId,
+      });
+
+      expect(result).toEqual({
+        archiveId,
+        status: 'pending',
+        totalFiles: 0,
+        processedFiles: 0,
+        downloadUrl: null,
+        errorMessage: null,
+      });
+    });
+
+  });
+
+  describe("Archive de preuves - Cas d'erreur", () => {
+    test('request échoue pour un utilisateur sans droits sur la collectivité', async () => {
+      const caller = router.createCaller({ user: unauthorizedUser });
+
+      await expect(
+        caller.referentiels.preuvesArchive.request({
+          collectiviteId: collectivite.id,
+          referentielId: 'cae',
+        })
+      ).rejects.toThrow("Vous n'avez pas les permissions nécessaires");
+    });
+
+    test('get renvoie NOT_FOUND pour une archive appartenant à un·e autre utilisateur·ice', async () => {
+      const adminCaller = router.createCaller({ user: adminUser });
+      const { archiveId } =
+        await adminCaller.referentiels.preuvesArchive.request({
+          collectiviteId: collectivite.id,
+          referentielId: 'cae',
+        });
+
+      const unauthorizedCaller = router.createCaller({
+        user: unauthorizedUser,
+      });
+
+      await expect(
+        unauthorizedCaller.referentiels.preuvesArchive.get({ archiveId })
+      ).rejects.toThrow("L'archive de preuves demandée n'existe pas");
+    });
+
+    test('get renvoie NOT_FOUND pour un archiveId inexistant', async () => {
+      const caller = router.createCaller({ user: adminUser });
+
+      await expect(
+        caller.referentiels.preuvesArchive.get({ archiveId: randomUUID() })
+      ).rejects.toThrow("L'archive de preuves demandée n'existe pas");
+    });
+
+    test("get retourne un message générique quand l'archive est failed (pas de fuite du détail interne)", async () => {
+      const caller = router.createCaller({ user: adminUser });
+
+      const { archiveId } = await caller.referentiels.preuvesArchive.request({
+        collectiviteId: collectivite.id,
+        referentielId: 'cae',
+      });
+
+      const internalDetail =
+        'Audit 42 introuvable: getAudit returned DATABASE_ERROR stack trace xxx';
+      await db.db
+        .update(auditPreuvesArchiveTable)
+        .set({
+          status: AuditPreuvesArchiveStatusEnum.FAILED,
+          errorMessage: internalDetail,
+          modifiedAt: new Date().toISOString(),
+        })
+        .where(eq(auditPreuvesArchiveTable.id, archiveId));
+
+      const result = await caller.referentiels.preuvesArchive.get({
+        archiveId,
+      });
+
+      expect(result).toMatchObject({
+        status: 'failed',
+        errorMessage:
+          "La génération de l'archive a échoué. Veuillez réessayer ou contactez le support.",
+        downloadUrl: null,
+      });
+      expect(result.errorMessage).not.toContain('getAudit');
+    });
+  });
+});

--- a/apps/backend/src/referentiels/preuves-archive/preuves-archive.trpc-errors.ts
+++ b/apps/backend/src/referentiels/preuves-archive/preuves-archive.trpc-errors.ts
@@ -1,0 +1,37 @@
+import { TrpcErrorHandlerConfig } from '@tet/backend/utils/trpc/trpc-error-handler';
+import type { PreuvesArchiveSpecificError } from './preuves-archive.errors';
+
+/** `ARCHIVE_NOT_FOUND` couvre aussi l'anti-énumération (archive d'un·e autre utilisateur·ice). */
+export const preuvesArchiveErrorConfig: TrpcErrorHandlerConfig<PreuvesArchiveSpecificError> =
+  {
+    specificErrors: {
+      CREATE_ARCHIVE_ERROR: {
+        code: 'INTERNAL_SERVER_ERROR',
+        message: "La création de l'archive de preuves a échoué",
+      },
+      GET_ARCHIVE_ERROR: {
+        code: 'INTERNAL_SERVER_ERROR',
+        message: "La lecture de l'archive de preuves a échoué",
+      },
+      UPDATE_ARCHIVE_ERROR: {
+        code: 'INTERNAL_SERVER_ERROR',
+        message: "La mise à jour de l'archive de preuves a échoué",
+      },
+      ARCHIVE_NOT_FOUND: {
+        code: 'NOT_FOUND',
+        message: "L'archive de preuves demandée n'existe pas",
+      },
+      AUDIT_NOT_FOUND: {
+        code: 'NOT_FOUND',
+        message: "Aucun audit en cours pour ce référentiel",
+      },
+      ARCHIVE_STATUS_PARSE_ERROR: {
+        code: 'INTERNAL_SERVER_ERROR',
+        message: "Le statut de l'archive de preuves est invalide",
+      },
+      COLLECT_PREUVES_ERROR: {
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'La collecte des preuves a échoué',
+      },
+    },
+  };

--- a/apps/backend/src/referentiels/preuves-archive/request-preuves-archive/request-preuves-archive.input.ts
+++ b/apps/backend/src/referentiels/preuves-archive/request-preuves-archive/request-preuves-archive.input.ts
@@ -1,0 +1,11 @@
+import { referentielIdEnumSchema } from '@tet/domain/referentiels';
+import { z } from 'zod';
+
+export const requestPreuvesArchiveInputSchema = z.object({
+  collectiviteId: z.number().int().positive(),
+  referentielId: referentielIdEnumSchema,
+});
+
+export type RequestPreuvesArchiveInput = z.infer<
+  typeof requestPreuvesArchiveInputSchema
+>;

--- a/apps/backend/src/referentiels/preuves-archive/request-preuves-archive/request-preuves-archive.output.ts
+++ b/apps/backend/src/referentiels/preuves-archive/request-preuves-archive/request-preuves-archive.output.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+import { auditPreuvesArchiveStatusSchema } from '../models/audit-preuves-archive.table';
+
+export const requestPreuvesArchiveOutputSchema = z.object({
+  archiveId: z.string().uuid(),
+  status: auditPreuvesArchiveStatusSchema,
+});
+
+export type RequestPreuvesArchiveOutput = z.infer<
+  typeof requestPreuvesArchiveOutputSchema
+>;

--- a/apps/backend/src/referentiels/preuves-archive/request-preuves-archive/request-preuves-archive.router.ts
+++ b/apps/backend/src/referentiels/preuves-archive/request-preuves-archive/request-preuves-archive.router.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@nestjs/common';
+import { createTrpcErrorHandler } from '@tet/backend/utils/trpc/trpc-error-handler';
+import { TrpcService } from '@tet/backend/utils/trpc/trpc.service';
+import { preuvesArchiveErrorConfig } from '../preuves-archive.trpc-errors';
+import { requestPreuvesArchiveInputSchema } from './request-preuves-archive.input';
+import { requestPreuvesArchiveOutputSchema } from './request-preuves-archive.output';
+import { RequestPreuvesArchiveService } from './request-preuves-archive.service';
+
+@Injectable()
+export class RequestPreuvesArchiveRouter {
+  constructor(
+    private readonly trpc: TrpcService,
+    private readonly requestPreuvesArchiveService: RequestPreuvesArchiveService
+  ) {}
+
+  private readonly getResultDataOrThrowError = createTrpcErrorHandler(
+    preuvesArchiveErrorConfig
+  );
+
+  router = this.trpc.router({
+    request: this.trpc.authedProcedure
+      .input(requestPreuvesArchiveInputSchema)
+      .output(requestPreuvesArchiveOutputSchema)
+      .mutation(async ({ input, ctx: { user } }) => {
+        const result = await this.requestPreuvesArchiveService.request({
+          ...input,
+          user,
+        });
+        return this.getResultDataOrThrowError(result);
+      }),
+  });
+}

--- a/apps/backend/src/referentiels/preuves-archive/request-preuves-archive/request-preuves-archive.service.spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/request-preuves-archive/request-preuves-archive.service.spec.ts
@@ -1,0 +1,95 @@
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { failure, success } from '@tet/backend/utils/result.type';
+import { ReferentielId } from '@tet/domain/referentiels';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  AuditPreuvesArchiveStatusEnum,
+  type AuditPreuvesArchive,
+} from '../models/audit-preuves-archive.table';
+import { PreuvesArchiveErrorEnum } from '../preuves-archive.errors';
+import { RequestPreuvesArchiveService } from './request-preuves-archive.service';
+
+const owner: AuthenticatedUser = { id: 'owner-id' } as AuthenticatedUser;
+
+const requestInput = {
+  collectiviteId: 1,
+  referentielId: 'cae' as ReferentielId,
+  user: owner,
+};
+
+function makeArchive(
+  overrides: Partial<AuditPreuvesArchive> = {}
+): AuditPreuvesArchive {
+  return {
+    id: 'archive-id',
+    collectiviteId: 1,
+    referentielId: 'cae',
+    auditId: 10,
+    requestedBy: owner.id,
+    status: AuditPreuvesArchiveStatusEnum.PENDING,
+    totalFiles: 0,
+    processedFiles: 0,
+    storagePath: null,
+    errorMessage: null,
+    createdAt: '2026-05-19T00:00:00.000Z',
+    modifiedAt: '2026-05-19T00:00:00.000Z',
+    expiresAt: '2026-05-26T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+type CurrentAuditResult =
+  | { success: true; data: { id: number } }
+  | { success: false; error: 'NOT_FOUND' | 'DATABASE_ERROR' };
+
+function buildService({
+  isAllowed = true,
+  currentAudit = success({ id: 10 }),
+}: {
+  isAllowed?: boolean;
+  currentAudit?: CurrentAuditResult;
+} = {}): RequestPreuvesArchiveService {
+  const permissions = {
+    isAllowed: vi.fn().mockResolvedValue(isAllowed),
+  } as unknown;
+
+  const getLabellisationService = {
+    getCurrentAudit: vi.fn().mockResolvedValue(currentAudit),
+  } as unknown;
+
+  const repository = {
+    createOrGetInFlight: vi.fn().mockResolvedValue(success(makeArchive())),
+  } as unknown;
+
+  const queue = {
+    add: vi.fn().mockResolvedValue(undefined),
+  } as unknown;
+
+  return new RequestPreuvesArchiveService(
+    permissions as never,
+    getLabellisationService as never,
+    repository as never,
+    queue as never
+  );
+}
+
+describe('RequestPreuvesArchiveService', () => {
+  // unauthorized et le happy-path sont prouvés en réel par le router e2e ; ce
+  // spec ne garde que le mapping d'erreur propre au service.
+  it("échoue avec AUDIT_NOT_FOUND quand aucun audit n'est en cours", async () => {
+    const service = buildService({
+      currentAudit: { success: false, error: 'NOT_FOUND' },
+    });
+
+    const result = await service.request(requestInput);
+
+    expect(result).toEqual(
+      failure(
+        PreuvesArchiveErrorEnum.AUDIT_NOT_FOUND,
+        new Error(
+          'Aucun audit en cours pour la collectivité 1 et le référentiel cae'
+        )
+      )
+    );
+  });
+});

--- a/apps/backend/src/referentiels/preuves-archive/request-preuves-archive/request-preuves-archive.service.ts
+++ b/apps/backend/src/referentiels/preuves-archive/request-preuves-archive/request-preuves-archive.service.ts
@@ -1,0 +1,151 @@
+import { InjectQueue } from '@nestjs/bullmq';
+import { Injectable, Logger } from '@nestjs/common';
+import { GetLabellisationService } from '@tet/backend/referentiels/labellisations/get-labellisation.service';
+import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { failure, success, type Result } from '@tet/backend/utils/result.type';
+import { ReferentielId } from '@tet/domain/referentiels';
+import { ResourceType } from '@tet/domain/users';
+import { getErrorMessage } from '@tet/domain/utils';
+import { Queue } from 'bullmq';
+import {
+  auditPreuvesArchiveInFlightStatuses,
+  type AuditPreuvesArchiveStatus,
+} from '../models/audit-preuves-archive.table';
+import {
+  PreuvesArchiveErrorEnum,
+  type PreuvesArchiveError,
+} from '../preuves-archive.errors';
+import {
+  PREUVES_ARCHIVE_QUEUE_NAME,
+  type PreuvesArchiveJobData,
+} from '../preuves-archive.queue';
+import { PreuvesArchiveRepository } from '../preuves-archive.repository';
+
+const ARCHIVE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+const GENERATE_ARCHIVE_JOB_NAME = 'generate-archive';
+
+export interface RequestPreuvesArchiveInput {
+  collectiviteId: number;
+  referentielId: ReferentielId;
+  user: AuthenticatedUser;
+}
+
+export interface RequestPreuvesArchiveResult {
+  archiveId: string;
+  status: AuditPreuvesArchiveStatus;
+}
+
+@Injectable()
+export class RequestPreuvesArchiveService {
+  private readonly logger = new Logger(RequestPreuvesArchiveService.name);
+
+  constructor(
+    private readonly permissions: PermissionService,
+    private readonly getLabellisationService: GetLabellisationService,
+    private readonly repository: PreuvesArchiveRepository,
+    @InjectQueue(PREUVES_ARCHIVE_QUEUE_NAME)
+    private readonly queue: Queue<PreuvesArchiveJobData>
+  ) {}
+
+  async request(
+    input: RequestPreuvesArchiveInput
+  ): Promise<Result<RequestPreuvesArchiveResult, PreuvesArchiveError>> {
+    const { collectiviteId, referentielId, user } = input;
+
+    const isAllowed = await this.permissions.isAllowed(
+      user,
+      'referentiels.read',
+      ResourceType.COLLECTIVITE,
+      collectiviteId,
+      true
+    );
+    if (!isAllowed) {
+      return failure(
+        PreuvesArchiveErrorEnum.UNAUTHORIZED,
+        new Error(
+          `L'utilisateur ${user.id} n'a pas le droit referentiels.read sur la collectivité ${collectiviteId}`
+        )
+      );
+    }
+
+    const auditIdResult = await this.resolveCurrentAuditId(
+      collectiviteId,
+      referentielId
+    );
+    if (!auditIdResult.success) {
+      return auditIdResult;
+    }
+
+    const expiresAt = new Date(Date.now() + ARCHIVE_TTL_MS).toISOString();
+    const createResult = await this.repository.createOrGetInFlight({
+      collectiviteId,
+      referentielId,
+      auditId: auditIdResult.data,
+      requestedBy: user.id,
+      expiresAt,
+    });
+    if (!createResult.success) {
+      return createResult;
+    }
+
+    const archive = createResult.data;
+
+    if (auditPreuvesArchiveInFlightStatuses.includes(archive.status)) {
+      try {
+        // attempts/backoff/removeOn* viennent de defaultJobOptions sur la queue.
+        await this.queue.add(
+          GENERATE_ARCHIVE_JOB_NAME,
+          { archiveId: archive.id },
+          { jobId: archive.id }
+        );
+      } catch (error) {
+        this.logger.error(
+          `Enfilement du job d'archive ${archive.id}: ${getErrorMessage(error)}`
+        );
+        // La ligne pending occuperait l'index unique partiel jusqu'à TTL — on la retire pour permettre un retry immédiat.
+        const cleanup = await this.repository.deleteIfPending(archive.id);
+        if (!cleanup.success) {
+          this.logger.error(
+            `Nettoyage de la ligne pending ${archive.id} après échec d'enfilement: ${cleanup.error}`
+          );
+        }
+        return failure(
+          PreuvesArchiveErrorEnum.CREATE_ARCHIVE_ERROR,
+          error instanceof Error ? error : new Error(getErrorMessage(error))
+        );
+      }
+    }
+
+    return success({ archiveId: archive.id, status: archive.status });
+  }
+
+  private async resolveCurrentAuditId(
+    collectiviteId: number,
+    referentielId: ReferentielId
+  ): Promise<Result<number, PreuvesArchiveError>> {
+    const audit = await this.getLabellisationService.getCurrentAudit(
+      collectiviteId,
+      referentielId
+    );
+    if (audit.success) {
+      return success(audit.data.id);
+    }
+
+    if (audit.error === 'NOT_FOUND') {
+      return failure(
+        PreuvesArchiveErrorEnum.AUDIT_NOT_FOUND,
+        new Error(
+          `Aucun audit en cours pour la collectivité ${collectiviteId} et le référentiel ${referentielId}`
+        )
+      );
+    }
+    return failure(
+      PreuvesArchiveErrorEnum.CREATE_ARCHIVE_ERROR,
+      new Error(
+        `Résolution de l'audit courant échouée (collectivité ${collectiviteId}, référentiel ${referentielId})`
+      )
+    );
+  }
+}

--- a/apps/backend/src/referentiels/referentiels.module.ts
+++ b/apps/backend/src/referentiels/referentiels.module.ts
@@ -1,3 +1,4 @@
+import { BullModule } from '@nestjs/bullmq';
 import { Module } from '@nestjs/common';
 import { IndicateursModule } from '@tet/backend/indicateurs/indicateurs.module';
 import { FichesModule } from '@tet/backend/plans/fiches/fiches.module';
@@ -55,6 +56,20 @@ import { CountPreuvesRouter } from './count-preuve/count-preuves.router';
 import { CountPreuvesService } from './count-preuve/count-preuves.service';
 import { ListActionsRouter } from './list-actions/list-actions.router';
 import { ListActionsService } from './list-actions/list-actions.service';
+import { BuildArchiveService } from './preuves-archive/build-archive/build-archive.service';
+import { GeneratePreuvesArchiveService } from './preuves-archive/generate-preuves-archive/generate-preuves-archive.service';
+import { GeneratePreuvesArchiveWorker } from './preuves-archive/generate-preuves-archive/generate-preuves-archive.worker';
+import { GetPreuvesArchiveRouter } from './preuves-archive/get-preuves-archive/get-preuves-archive.router';
+import { GetPreuvesArchiveService } from './preuves-archive/get-preuves-archive/get-preuves-archive.service';
+import { CollectPreuvesRepository } from './preuves-archive/list-audit-preuves/collect-preuves.repository';
+import { ListAuditPreuvesService } from './preuves-archive/list-audit-preuves/list-audit-preuves.service';
+import { PreuvesArchiveRepository } from './preuves-archive/preuves-archive.repository';
+import {
+  PREUVES_ARCHIVE_JOB_OPTIONS,
+  PREUVES_ARCHIVE_QUEUE_NAME,
+} from './preuves-archive/preuves-archive.queue';
+import { RequestPreuvesArchiveRouter } from './preuves-archive/request-preuves-archive/request-preuves-archive.router';
+import { RequestPreuvesArchiveService } from './preuves-archive/request-preuves-archive/request-preuves-archive.service';
 import { ReferentielsCoreModule } from './referentiels-core.module';
 import { ReferentielsRouter } from './referentiels.router';
 import { ResetDisplayPreferencesRouter } from './reset-display-preferences/reset-display-preferences.router';
@@ -77,6 +92,10 @@ import { UpdateActionStatutService } from './update-action-statut/update-action-
     IndicateursModule,
     FichesModule,
     ReferentielsCoreModule,
+    BullModule.registerQueue({
+      name: PREUVES_ARCHIVE_QUEUE_NAME,
+      defaultJobOptions: PREUVES_ARCHIVE_JOB_OPTIONS,
+    }),
   ],
   providers: [
     ActionStatutHistoryService,
@@ -92,6 +111,18 @@ import { UpdateActionStatutService } from './update-action-statut/update-action-
 
     CountPreuvesService,
     CountPreuvesRouter,
+
+    // Archive ZIP des preuves d'audit
+    PreuvesArchiveRepository,
+    CollectPreuvesRepository,
+    ListAuditPreuvesService,
+    BuildArchiveService,
+    RequestPreuvesArchiveService,
+    RequestPreuvesArchiveRouter,
+    GetPreuvesArchiveService,
+    GetPreuvesArchiveRouter,
+    GeneratePreuvesArchiveService,
+    GeneratePreuvesArchiveWorker,
 
     UpdateActionStatutHistoriqueRepository,
     ActionPersonnalisationsService,

--- a/apps/backend/src/referentiels/referentiels.router.ts
+++ b/apps/backend/src/referentiels/referentiels.router.ts
@@ -14,6 +14,8 @@ import { StartAuditRouter } from './labellisations/start-audit/start-audit.route
 import { ValidateAuditRouter } from './labellisations/validate-audit/validate-audit.router';
 import { CountPreuvesRouter } from './count-preuve/count-preuves.router';
 import { ListActionsRouter } from './list-actions/list-actions.router';
+import { GetPreuvesArchiveRouter } from './preuves-archive/get-preuves-archive/get-preuves-archive.router';
+import { RequestPreuvesArchiveRouter } from './preuves-archive/request-preuves-archive/request-preuves-archive.router';
 import { ResetDisplayPreferencesRouter } from './reset-display-preferences/reset-display-preferences.router';
 import { ActionPersonnalisationsRouter } from './action-personnalisations/action-personnalisations.router';
 import { SnapshotsRouter } from './snapshots/snapshots.router';
@@ -43,7 +45,9 @@ export class ReferentielsRouter {
     private readonly handleMesureAuditStatutRouter: HandleMesureAuditStatutRouter,
     private readonly getReferentielDefinitionRouter: GetReferentielDefinitionRouter,
     private readonly resetDisplayPreferencesRouter: ResetDisplayPreferencesRouter,
-    private readonly historiqueRouter: HistoriqueRouter
+    private readonly historiqueRouter: HistoriqueRouter,
+    private readonly requestPreuvesArchiveRouter: RequestPreuvesArchiveRouter,
+    private readonly getPreuvesArchiveRouter: GetPreuvesArchiveRouter
   ) {}
 
   router = this.trpc.router({
@@ -76,6 +80,11 @@ export class ReferentielsRouter {
     preferences: this.resetDisplayPreferencesRouter.router,
 
     historique: this.historiqueRouter.router,
+
+    preuvesArchive: this.trpc.mergeRouters(
+      this.requestPreuvesArchiveRouter.router,
+      this.getPreuvesArchiveRouter.router
+    ),
   });
 
   createCaller = this.trpc.createCallerFactory(this.router);

--- a/apps/backend/src/utils/supabase/document-storage.errors.ts
+++ b/apps/backend/src/utils/supabase/document-storage.errors.ts
@@ -1,0 +1,14 @@
+import { createErrorsEnum } from '@tet/backend/utils/trpc/trpc-error-handler';
+
+export const DocumentStorageSpecificErrors = [
+  'READ_DOCUMENT_ERROR',
+  'WRITE_DOCUMENT_ERROR',
+] as const;
+
+export type DocumentStorageSpecificError =
+  (typeof DocumentStorageSpecificErrors)[number];
+
+export const DocumentStorageErrorEnum = createErrorsEnum(
+  DocumentStorageSpecificErrors
+);
+export type DocumentStorageError = keyof typeof DocumentStorageErrorEnum;

--- a/apps/backend/src/utils/supabase/document-storage.service.ts
+++ b/apps/backend/src/utils/supabase/document-storage.service.ts
@@ -1,0 +1,151 @@
+import { Injectable, Logger } from '@nestjs/common';
+import SupabaseService from '@tet/backend/utils/database/supabase.service';
+import { failure, success, type Result } from '@tet/backend/utils/result.type';
+import { getErrorMessage } from '@tet/domain/utils';
+import { createReadStream } from 'node:fs';
+import { Readable } from 'node:stream';
+import { type ReadableStream as WebReadableStream } from 'node:stream/web';
+import {
+  DocumentStorageErrorEnum,
+  type DocumentStorageError,
+} from './document-storage.errors';
+
+// URL signée consommée immédiatement par `fetch()`, ne sort jamais du process.
+const STREAM_FETCH_TTL_SECONDS = 60;
+
+export interface GetDocumentStreamInput {
+  bucketId: string;
+  key: string;
+}
+
+export interface StoreDocumentInput {
+  bucketId: string;
+  key: string;
+  sourceFilePath: string;
+  contentType: string;
+}
+
+export interface CreateDocumentSignedUrlInput {
+  bucketId: string;
+  key: string;
+  expiresInSeconds: number;
+}
+
+@Injectable()
+export class DocumentStorageService {
+  private readonly logger = new Logger(DocumentStorageService.name);
+
+  constructor(private readonly supabase: SupabaseService) {}
+
+  /** `fetch` authentifié plutôt que `storage.download()`, qui bufferise l'objet entier en mémoire. */
+  async getDocumentStream(
+    input: GetDocumentStreamInput
+  ): Promise<Result<Readable, DocumentStorageError>> {
+    const { bucketId, key } = input;
+    try {
+      const { data, error } = await this.supabase.client.storage
+        .from(bucketId)
+        .createSignedUrl(key, STREAM_FETCH_TTL_SECONDS);
+
+      if (error || !data) {
+        this.logger.error(
+          `Signed URL introuvable pour ${bucketId}/${key}: ${
+            error?.message ?? 'objet absent'
+          }`
+        );
+        return failure(DocumentStorageErrorEnum.READ_DOCUMENT_ERROR);
+      }
+
+      const response = await fetch(data.signedUrl);
+      if (!response.ok || !response.body) {
+        this.logger.error(
+          `Téléchargement échoué pour ${bucketId}/${key}: HTTP ${response.status}`
+        );
+        return failure(DocumentStorageErrorEnum.READ_DOCUMENT_ERROR);
+      }
+
+      // `fetch` renvoie le `ReadableStream` de lib.dom ; `Readable.fromWeb`
+      // attend celui de node:stream/web — structurellement identiques, distincts
+      // au niveau des types. Conversion explicite à la frontière externe.
+      return success(
+        Readable.fromWeb(response.body as WebReadableStream<Uint8Array>)
+      );
+    } catch (error) {
+      this.logger.error(
+        `Erreur de lecture du document ${bucketId}/${key}: ${getErrorMessage(
+          error
+        )}`
+      );
+      return failure(
+        DocumentStorageErrorEnum.READ_DOCUMENT_ERROR,
+        error instanceof Error ? error : new Error(getErrorMessage(error))
+      );
+    }
+  }
+
+  async storeDocument(
+    input: StoreDocumentInput
+  ): Promise<Result<{ key: string }, DocumentStorageError>> {
+    const { bucketId, key, sourceFilePath, contentType } = input;
+    try {
+      const fileStream = createReadStream(sourceFilePath);
+      const uploadResult = await this.supabase.saveInStorage({
+        bucket: bucketId,
+        path: key,
+        file: fileStream,
+        mimeType: contentType,
+      });
+
+      if (!uploadResult.success) {
+        this.logger.error(
+          `Upload du document ${bucketId}/${key} échoué: ${uploadResult.error}`
+        );
+        return failure(DocumentStorageErrorEnum.WRITE_DOCUMENT_ERROR);
+      }
+
+      return success({ key: uploadResult.data.path });
+    } catch (error) {
+      this.logger.error(
+        `Erreur d'upload du document ${bucketId}/${key}: ${getErrorMessage(
+          error
+        )}`
+      );
+      return failure(
+        DocumentStorageErrorEnum.WRITE_DOCUMENT_ERROR,
+        error instanceof Error ? error : new Error(getErrorMessage(error))
+      );
+    }
+  }
+
+  async createDocumentSignedUrl(
+    input: CreateDocumentSignedUrlInput
+  ): Promise<Result<{ signedUrl: string }, DocumentStorageError>> {
+    const { bucketId, key, expiresInSeconds } = input;
+    try {
+      const { data, error } = await this.supabase.client.storage
+        .from(bucketId)
+        .createSignedUrl(key, expiresInSeconds);
+
+      if (error || !data) {
+        this.logger.error(
+          `Signed URL introuvable pour ${bucketId}/${key}: ${
+            error?.message ?? 'objet absent'
+          }`
+        );
+        return failure(DocumentStorageErrorEnum.READ_DOCUMENT_ERROR);
+      }
+
+      return success({ signedUrl: data.signedUrl });
+    } catch (error) {
+      this.logger.error(
+        `Erreur de génération de signed URL pour ${bucketId}/${key}: ${getErrorMessage(
+          error
+        )}`
+      );
+      return failure(
+        DocumentStorageErrorEnum.READ_DOCUMENT_ERROR,
+        error instanceof Error ? error : new Error(getErrorMessage(error))
+      );
+    }
+  }
+}

--- a/apps/backend/src/utils/utils.module.ts
+++ b/apps/backend/src/utils/utils.module.ts
@@ -5,6 +5,7 @@ import { WEBHOOK_NOTIFICATIONS_QUEUE_NAME } from './bullmq/queue-names.constants
 import { ContextStoreService } from './context/context.service';
 import { CsvService } from './csv/csv.service';
 import MattermostNotificationService from './mattermost-notification.service';
+import { DocumentStorageService } from './supabase/document-storage.service';
 import { VersionController } from './version/version.controller';
 import { WebhookService } from './webhooks/webhook.service';
 
@@ -22,6 +23,7 @@ import { WebhookService } from './webhooks/webhook.service';
     MattermostNotificationService,
     WebhookService,
     VersionService,
+    DocumentStorageService,
   ],
   exports: [
     ContextStoreService,
@@ -29,6 +31,7 @@ import { WebhookService } from './webhooks/webhook.service';
     MattermostNotificationService,
     WebhookService,
     VersionService,
+    DocumentStorageService,
   ],
   controllers: [VersionController],
 })

--- a/data_layer/sqitch/deploy/referentiel/audit_preuves_archive.sql
+++ b/data_layer/sqitch/deploy/referentiel/audit_preuves_archive.sql
@@ -1,0 +1,41 @@
+-- Deploy tet:referentiel/audit_preuves_archive to pg
+
+BEGIN;
+
+CREATE TABLE public.audit_preuves_archive (
+    id              uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+    collectivite_id integer     NOT NULL REFERENCES public.collectivite(id) ON DELETE CASCADE,
+    referentiel_id  text        NOT NULL,
+    audit_id        integer     NOT NULL REFERENCES labellisation.audit(id) ON DELETE CASCADE,
+    requested_by    uuid        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    status          text        NOT NULL CHECK (status IN ('pending', 'processing', 'completed', 'failed')),
+    total_files     integer     NOT NULL DEFAULT 0,
+    processed_files integer     NOT NULL DEFAULT 0,
+    storage_path    text        NULL,
+    error_message   text        NULL,
+    created_at      timestamptz NOT NULL DEFAULT now(),
+    modified_at     timestamptz NOT NULL DEFAULT now(),
+    expires_at      timestamptz NOT NULL
+);
+
+COMMENT ON TABLE public.audit_preuves_archive IS 'Job de génération asynchrone d''archive ZIP des preuves d''un audit.';
+COMMENT ON COLUMN public.audit_preuves_archive.referentiel_id IS 'Identifiant du référentiel de l''audit.';
+COMMENT ON COLUMN public.audit_preuves_archive.requested_by IS 'Utilisateur·ice ayant demandé la génération.';
+COMMENT ON COLUMN public.audit_preuves_archive.status IS 'pending | processing | completed | failed.';
+COMMENT ON COLUMN public.audit_preuves_archive.storage_path IS 'Chemin de l''objet ZIP dans le bucket privé ; NULL tant que le job n''est pas completed.';
+COMMENT ON COLUMN public.audit_preuves_archive.error_message IS 'Renseigné quand status = failed.';
+COMMENT ON COLUMN public.audit_preuves_archive.expires_at IS 'Date d''expiration de l''archive (created_at + 7 jours).';
+
+CREATE UNIQUE INDEX audit_preuves_archive_in_flight_unique
+    ON public.audit_preuves_archive (audit_id, requested_by)
+    WHERE status IN ('pending', 'processing');
+
+-- RLS sans policy : seul service_role accède à la table.
+ALTER TABLE public.audit_preuves_archive ENABLE ROW LEVEL SECURITY;
+
+-- Bucket privé : téléchargement via signed URL générée à la demande.
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('preuves-archives', 'preuves-archives', false)
+ON CONFLICT DO NOTHING;
+
+COMMIT;

--- a/data_layer/sqitch/revert/referentiel/audit_preuves_archive.sql
+++ b/data_layer/sqitch/revert/referentiel/audit_preuves_archive.sql
@@ -1,0 +1,9 @@
+-- Revert tet:referentiel/audit_preuves_archive from pg
+
+BEGIN;
+
+DELETE FROM storage.buckets WHERE id = 'preuves-archives';
+
+DROP TABLE IF EXISTS public.audit_preuves_archive CASCADE;
+
+COMMIT;

--- a/data_layer/sqitch/sqitch.plan
+++ b/data_layer/sqitch/sqitch.plan
@@ -989,3 +989,4 @@ referentiel/drop_comparaison_scores_audit_type_tabular_score [referentiel/drop_a
 
 collectivite/type_add_structure_sans_statut_juridique [collectivite/type_add_service_public] 2026-05-19T13:35:00Z Frederic Arnoux <frederic.arnoux@beta.gouv.fr> # Ajoute le type structure_sans_statut_juridique
 collectivite/structure_sans_statut_juridique_unique_nom [collectivite/type_add_structure_sans_statut_juridique] 2026-05-19T18:00:00Z Frederic Arnoux <frederic.arnoux@beta.gouv.fr> # Ajoute un index unique partiel sur le nom des structures sans statut juridique
+referentiel/audit_preuves_archive 2026-05-19T13:59:38Z Gaël Servaud <gaelservaud@Host-002.lan> # Crée la table audit_preuves_archive (génération asynchrone d archives de preuves)

--- a/data_layer/sqitch/verify/referentiel/audit_preuves_archive.sql
+++ b/data_layer/sqitch/verify/referentiel/audit_preuves_archive.sql
@@ -1,0 +1,154 @@
+-- Verify tet:referentiel/audit_preuves_archive on pg
+
+BEGIN;
+
+DO $$
+DECLARE
+    check_clause       text;
+    status_check       text;
+    fk_collectivite    text;
+    fk_audit           text;
+    fk_requested_by    text;
+    index_predicate    text;
+BEGIN
+    -- Table exists with the expected 13 columns
+    ASSERT (
+        SELECT COUNT(*) = 13
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'audit_preuves_archive'
+          AND column_name IN (
+              'id', 'collectivite_id', 'referentiel_id', 'audit_id',
+              'requested_by', 'status', 'total_files', 'processed_files',
+              'storage_path', 'error_message', 'created_at', 'modified_at',
+              'expires_at'
+          )
+    ), 'La table audit_preuves_archive doit contenir les 13 colonnes attendues';
+
+    -- NOT NULL on every column except storage_path and error_message
+    ASSERT (
+        SELECT COUNT(*) = 11
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'audit_preuves_archive'
+          AND is_nullable = 'NO'
+    ), 'Toutes les colonnes sauf storage_path et error_message doivent être NOT NULL';
+
+    ASSERT (
+        SELECT COUNT(*) = 2
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'audit_preuves_archive'
+          AND column_name IN ('storage_path', 'error_message')
+          AND is_nullable = 'YES'
+    ), 'Les colonnes storage_path et error_message doivent être NULLABLE';
+
+    -- CHECK constraint on status, with the exact 4 allowed values
+    SELECT cc.check_clause INTO status_check
+    FROM information_schema.check_constraints cc
+    JOIN information_schema.constraint_column_usage ccu
+        ON cc.constraint_name = ccu.constraint_name
+    WHERE ccu.table_schema = 'public'
+      AND ccu.table_name = 'audit_preuves_archive'
+      AND ccu.column_name = 'status'
+    LIMIT 1;
+
+    ASSERT status_check IS NOT NULL,
+        'La colonne status doit avoir une contrainte CHECK';
+    ASSERT status_check LIKE '%''pending''%'
+        AND status_check LIKE '%''processing''%'
+        AND status_check LIKE '%''completed''%'
+        AND status_check LIKE '%''failed''%',
+        'La contrainte CHECK sur status doit autoriser exactement pending|processing|completed|failed';
+
+    -- Foreign keys with ON DELETE CASCADE
+    SELECT rc.delete_rule INTO fk_collectivite
+    FROM information_schema.table_constraints tc
+    JOIN information_schema.referential_constraints rc
+        USING (constraint_schema, constraint_name)
+    JOIN information_schema.key_column_usage kcu
+        USING (constraint_schema, constraint_name)
+    WHERE tc.table_schema = 'public'
+      AND tc.table_name = 'audit_preuves_archive'
+      AND tc.constraint_type = 'FOREIGN KEY'
+      AND kcu.column_name = 'collectivite_id'
+    LIMIT 1;
+
+    ASSERT fk_collectivite = 'CASCADE',
+        'La FK collectivite_id doit avoir delete_rule = CASCADE';
+
+    SELECT rc.delete_rule INTO fk_audit
+    FROM information_schema.table_constraints tc
+    JOIN information_schema.referential_constraints rc
+        USING (constraint_schema, constraint_name)
+    JOIN information_schema.key_column_usage kcu
+        USING (constraint_schema, constraint_name)
+    WHERE tc.table_schema = 'public'
+      AND tc.table_name = 'audit_preuves_archive'
+      AND tc.constraint_type = 'FOREIGN KEY'
+      AND kcu.column_name = 'audit_id'
+    LIMIT 1;
+
+    ASSERT fk_audit = 'CASCADE',
+        'La FK audit_id doit avoir delete_rule = CASCADE';
+
+    SELECT rc.delete_rule INTO fk_requested_by
+    FROM information_schema.table_constraints tc
+    JOIN information_schema.referential_constraints rc
+        USING (constraint_schema, constraint_name)
+    JOIN information_schema.key_column_usage kcu
+        USING (constraint_schema, constraint_name)
+    WHERE tc.table_schema = 'public'
+      AND tc.table_name = 'audit_preuves_archive'
+      AND tc.constraint_type = 'FOREIGN KEY'
+      AND kcu.column_name = 'requested_by'
+    LIMIT 1;
+
+    ASSERT fk_requested_by = 'CASCADE',
+        'La FK requested_by doit avoir delete_rule = CASCADE';
+
+    -- Partial unique index on (audit_id, requested_by) WHERE status in-flight
+    SELECT pg_get_expr(i.indpred, i.indrelid) INTO index_predicate
+    FROM pg_index i
+    JOIN pg_class c ON c.oid = i.indexrelid
+    WHERE c.relname = 'audit_preuves_archive_in_flight_unique';
+
+    ASSERT index_predicate IS NOT NULL,
+        'L''index unique partiel audit_preuves_archive_in_flight_unique doit exister';
+    ASSERT index_predicate LIKE '%pending%'
+        AND index_predicate LIKE '%processing%',
+        'L''index partiel doit être restreint aux statuts pending et processing';
+    ASSERT (
+        SELECT i.indisunique
+        FROM pg_index i
+        JOIN pg_class c ON c.oid = i.indexrelid
+        WHERE c.relname = 'audit_preuves_archive_in_flight_unique'
+    ), 'L''index audit_preuves_archive_in_flight_unique doit être UNIQUE';
+
+    -- RLS is enabled
+    ASSERT (
+        SELECT relrowsecurity
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public'
+          AND c.relname = 'audit_preuves_archive'
+    ), 'RLS doit être activée sur audit_preuves_archive';
+
+    -- No policies defined (deny-by-default for non-service_role)
+    ASSERT (
+        SELECT COUNT(*) = 0
+        FROM pg_policies
+        WHERE schemaname = 'public'
+          AND tablename = 'audit_preuves_archive'
+    ), 'audit_preuves_archive ne doit avoir aucune policy (RLS deny-by-default, accès via service_role uniquement)';
+
+    -- Bucket privé dédié aux archives de preuves
+    ASSERT (
+        SELECT COUNT(*) = 1
+        FROM storage.buckets
+        WHERE id = 'preuves-archives'
+          AND public IS FALSE
+    ), 'Le bucket privé preuves-archives doit exister';
+END $$;
+
+ROLLBACK;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -734,7 +734,15 @@ importers:
 
   apps/auth: {}
 
-  apps/backend: {}
+  apps/backend:
+    dependencies:
+      archiver:
+        specifier: ^7.0.0
+        version: 7.0.1
+    devDependencies:
+      '@types/archiver':
+        specifier: ^7.0.0
+        version: 7.0.0
 
   apps/panier: {}
 
@@ -1498,7 +1506,6 @@ packages:
 
   '@bryntum/scheduler-lib@1.0.0':
     resolution: {integrity: sha512-3Bd95kUaPsEJL+M7X2G5iV+7eNeSEPiFDX/U6Aucy5VeZDIuFFW+YTq4NVCVrzfs2wxeh5IRwW7fJC2mKv/hFw==}
-    engines: {node: '>=0.10.0'}
 
   '@bryntum/scheduler-react@6.3.1':
     resolution: {integrity: sha512-tqdu0Zz2wk7ou7vmM4g1m6xSNYrrtiMaBxd8v/DInVRsVGM2ZO9F6X6jisjF29CzUGAak+nI6H+GH02AkXBPYw==}
@@ -6272,6 +6279,9 @@ packages:
   '@types/acorn@4.0.6':
     resolution: {integrity: sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==}
 
+  '@types/archiver@7.0.0':
+    resolution: {integrity: sha512-/3vwGwx9n+mCQdYZ2IKGGHEFL30I96UgBlk8EtRDDFQ9uxM1l4O5Ci6r00EMAkiDaTqD9DQ6nVrWRICnBPtzzg==}
+
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
@@ -6568,6 +6578,9 @@ packages:
 
   '@types/react@19.2.3':
     resolution: {integrity: sha512-k5dJVszUiNr1DSe8Cs+knKR6IrqhqdhpUwzqhkS8ecQTSf3THNtbfIp/umqHMpX2bv+9dkx3fwDv/86LcSfvSg==}
+
+  '@types/readdir-glob@1.1.5':
+    resolution: {integrity: sha512-raiuEPUYqXu+nvtY2Pe8s8FEmZ3x5yAH4VkLdihcPdalvsHltomrRC9BzuStrJ9yk06470hS0Crw0f1pXqD+Hg==}
 
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
@@ -7215,9 +7228,17 @@ packages:
     resolution: {integrity: sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==}
     engines: {node: '>= 10'}
 
+  archiver-utils@5.0.2:
+    resolution: {integrity: sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==}
+    engines: {node: '>= 14'}
+
   archiver@5.3.2:
     resolution: {integrity: sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==}
     engines: {node: '>= 10'}
+
+  archiver@7.0.1:
+    resolution: {integrity: sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==}
+    engines: {node: '>= 14'}
 
   archy@1.0.0:
     resolution: {integrity: sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==}
@@ -7582,6 +7603,10 @@ packages:
 
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+
+  buffer-crc32@1.0.0:
+    resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
+    engines: {node: '>=8.0.0'}
 
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
@@ -7986,6 +8011,10 @@ packages:
     resolution: {integrity: sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==}
     engines: {node: '>= 10'}
 
+  compress-commons@6.0.2:
+    resolution: {integrity: sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==}
+    engines: {node: '>= 14'}
+
   compressible@2.0.18:
     resolution: {integrity: sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==}
     engines: {node: '>= 0.6'}
@@ -8125,6 +8154,10 @@ packages:
   crc32-stream@4.0.3:
     resolution: {integrity: sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==}
     engines: {node: '>= 10'}
+
+  crc32-stream@6.0.0:
+    resolution: {integrity: sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==}
+    engines: {node: '>= 14'}
 
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
@@ -15801,6 +15834,10 @@ packages:
     resolution: {integrity: sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==}
     engines: {node: '>= 10'}
 
+  zip-stream@6.0.1:
+    resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
+    engines: {node: '>= 14'}
+
   zod-to-json-schema@3.24.5:
     resolution: {integrity: sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==}
     peerDependencies:
@@ -22670,6 +22707,10 @@ snapshots:
       '@types/estree': 1.0.8
     optional: true
 
+  '@types/archiver@7.0.0':
+    dependencies:
+      '@types/readdir-glob': 1.1.5
+
   '@types/aria-query@5.0.4': {}
 
   '@types/async-retry@1.4.9':
@@ -23010,6 +23051,10 @@ snapshots:
   '@types/react@19.2.3':
     dependencies:
       csstype: 3.1.3
+
+  '@types/readdir-glob@1.1.5':
+    dependencies:
+      '@types/node': 24.1.0
 
   '@types/resolve@1.20.2': {}
 
@@ -23790,6 +23835,16 @@ snapshots:
       normalize-path: 3.0.0
       readable-stream: 3.6.2
 
+  archiver-utils@5.0.2:
+    dependencies:
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      is-stream: 2.0.1
+      lazystream: 1.0.1
+      lodash: 4.17.21
+      normalize-path: 3.0.0
+      readable-stream: 4.7.0
+
   archiver@5.3.2:
     dependencies:
       archiver-utils: 2.1.0
@@ -23799,6 +23854,19 @@ snapshots:
       readdir-glob: 1.1.3
       tar-stream: 2.2.0
       zip-stream: 4.1.1
+
+  archiver@7.0.1:
+    dependencies:
+      archiver-utils: 5.0.2
+      async: 3.2.6
+      buffer-crc32: 1.0.0
+      readable-stream: 4.7.0
+      readdir-glob: 1.1.3
+      tar-stream: 3.1.7
+      zip-stream: 6.0.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
 
   archy@1.0.0: {}
 
@@ -24239,6 +24307,8 @@ snapshots:
 
   buffer-crc32@0.2.13: {}
 
+  buffer-crc32@1.0.0: {}
+
   buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
@@ -24633,6 +24703,14 @@ snapshots:
       normalize-path: 3.0.0
       readable-stream: 3.6.2
 
+  compress-commons@6.0.2:
+    dependencies:
+      crc-32: 1.2.2
+      crc32-stream: 6.0.0
+      is-stream: 2.0.1
+      normalize-path: 3.0.0
+      readable-stream: 4.7.0
+
   compressible@2.0.18:
     dependencies:
       mime-db: 1.54.0
@@ -24787,6 +24865,11 @@ snapshots:
     dependencies:
       crc-32: 1.2.2
       readable-stream: 3.6.2
+
+  crc32-stream@6.0.0:
+    dependencies:
+      crc-32: 1.2.2
+      readable-stream: 4.7.0
 
   create-require@1.1.1:
     optional: true
@@ -34553,6 +34636,12 @@ snapshots:
       archiver-utils: 3.0.4
       compress-commons: 4.1.2
       readable-stream: 3.6.2
+
+  zip-stream@6.0.1:
+    dependencies:
+      archiver-utils: 5.0.2
+      compress-commons: 6.0.2
+      readable-stream: 4.7.0
 
   zod-to-json-schema@3.24.5(zod@4.1.12):
     dependencies:


### PR DESCRIPTION
## Résumé

Génération asynchrone d'une archive ZIP de toutes les preuves d'un audit (backend uniquement). L'utilisateur·ice demande l'archive, elle est construite en tâche de fond, puis téléchargeable via une URL signée à durée limitée.

## Fonctionnement

- **tRPC** : `request` (déclenche/récupère un job idempotent) et `get` (statut, progression, URL de téléchargement).
- **Job BullMQ** : retries + backoff exponentiel, `UnrecoverableError` pour les échecs définitifs (permission révoquée, référentiel invalide…), ligne marquée `failed` au seul dernier échec.
- **Contenu** : preuves de mesure (complémentaires + réglementaires), de demande de labellisation et d'audit, rangées par arborescence du référentiel ; liens externes regroupés en `liens.csv` ; fichiers ignorés consignés dans `_manifeste/fichiers-manquants.txt`.

## Architecture (couches)

- Entrée tRPC → orchestration (worker + service) → collecte applicative → repositories → assemblage ZIP → stockage.
- `CollectPreuvesRepository` (lecture des preuves) et `PreuvesArchiveRepository` (cycle de vie du job) séparés par agrégat.
- Assemblage ZIP en **streaming**, téléchargements en **fenêtre glissante** (concurrence bornée).
- `DocumentStorageService` générique (`utils/supabase`), erreur découplée mappée au call-site (anti-corruption).

## Sécurité

- Filtre **confidentiel poussé en SQL**, fail-closed.
- **Scope collectivité** sur chaque requête de collecte.
- **Anti-énumération** sur `get` (NOT_FOUND couvre propriété/droit/expiration), message d'erreur générique (pas de fuite interne).
- Neutralisation d'**injection CSV** + allowlist de schémas URL.
- **Sanitization des noms** : zip-slip, séparateurs, caractères de contrôle, portabilité Windows, troncature 255 octets.

## Tests

- Unitaires sur les fonctions pures (arborescence, chemins, manifestes, CSV, concurrence).
- e2e : filtre confidentiel (SQL réel) et **pipeline complet** (DB réelle + ZIP réel).

## À faire avant merge (suivi)

- [ ] **RLS** sur le bucket `preuves-archives` (isolation par collectivité au niveau storage).
- [ ] **Index** sur `audit_preuves_archive.requested_by` (FK CASCADE).
- [ ] Décision sur la dérive de schéma `bibliotheque_fichier.confidentiel` (NOT NULL en base vs nullable côté Drizzle → branche défensive `isNull` morte).

## Hors scope

Frontend (UI de demande / suivi / téléchargement) : phase suivante.