### PR TITLE
feat(ui): aligne la modale sur le design system DSTET

### DIFF
--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/users/_components/ConfirmerChangementNiveau.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/users/_components/ConfirmerChangementNiveau.tsx
@@ -20,12 +20,16 @@ export const ConfirmerChangementNiveau = (props: Props) => {
 
   return (
     <Modal
-      size="md"
+      size="sm"
       title="Modifier mes droits d'accès à la collectivité"
-      description="Souhaitez-vous vraiment modifier vos droits d'accès à cette
-    collectivité ? Si possible, nommez une nouvelle personne avec
-    l'accès admin."
       openState={{ isOpen, setIsOpen }}
+      render={() => (
+        <p className="mb-0">
+          {
+            "Souhaitez-vous vraiment modifier vos droits d'accès à cette collectivité ? Si possible, nommez une nouvelle personne avec l'accès admin."
+          }
+        </p>
+      )}
       renderFooter={({ close }) => (
         <ModalFooterOKCancel
           btnOKProps={{

--- a/apps/app/src/app/pages/collectivite/Indicateurs/detail/Header/DeleteModal.tsx
+++ b/apps/app/src/app/pages/collectivite/Indicateurs/detail/Header/DeleteModal.tsx
@@ -20,7 +20,9 @@ const DeleteModal = ({ definition, isLoading = false }: Props) => {
     <Modal
       title={appLabels.suppressionIndicateur}
       subTitle={definition.titre}
-      description={appLabels.suppressionIndicateurDescription}
+      render={() => (
+        <p className="mb-0">{appLabels.suppressionIndicateurDescription}</p>
+      )}
       renderFooter={({ close }) => (
         <ModalFooterOKCancel
           btnCancelProps={{

--- a/apps/app/src/app/pages/collectivite/Indicateurs/detail/Header/EditModal.tsx
+++ b/apps/app/src/app/pages/collectivite/Indicateurs/detail/Header/EditModal.tsx
@@ -60,8 +60,8 @@ const EditModal = ({ openState, definition }: Props) => {
       openState={openState}
       title={appLabels.modifierIndicateur}
       subTitle={definition.titre}
-      render={({ descriptionId }) => (
-        <FormSectionGrid formSectionId={descriptionId}>
+      render={() => (
+        <FormSectionGrid>
           {/* Personnes pilote */}
           <Field title={appLabels.personnePilote} className="col-span-2">
             <PersonneTagDropdown

--- a/apps/app/src/app/pages/collectivite/Indicateurs/detail/fiches-liees.modal.tsx
+++ b/apps/app/src/app/pages/collectivite/Indicateurs/detail/fiches-liees.modal.tsx
@@ -34,8 +34,8 @@ export const FichesLieesModal = ({
       openState={{ isOpen, setIsOpen }}
       title={appLabels.lierAction}
       size="lg"
-      render={({ descriptionId }) => (
-        <Field fieldId={descriptionId} title={appLabels.actions}>
+      render={() => (
+        <Field title={appLabels.actions}>
           <FichesActionsDropdown
             ficheCouranteId={currentFicheId}
             values={linkedFicheIdsState.map((id) => id.toString())}

--- a/apps/app/src/app/pages/collectivite/PlansActions/ActionsGroupees/ActionsGroupeesModale.tsx
+++ b/apps/app/src/app/pages/collectivite/PlansActions/ActionsGroupees/ActionsGroupeesModale.tsx
@@ -19,8 +19,8 @@ const ActionsGroupeesModale = ({
     <Modal
       {...props}
       subTitle={`pour toutes les actions sélectionnées`}
-      render={({ descriptionId }) => (
-        <FormSectionGrid formSectionId={descriptionId}>
+      render={() => (
+        <FormSectionGrid>
           {children}
         </FormSectionGrid>
       )}

--- a/apps/app/src/app/pages/collectivite/Referentiels/DownloadScore/download-score.modal.tsx
+++ b/apps/app/src/app/pages/collectivite/Referentiels/DownloadScore/download-score.modal.tsx
@@ -70,7 +70,7 @@ export const DownloadScoreModal = ({
     <>
       <Modal
         title={appLabels.telechargerEtatDesLieux}
-        size="md"
+        size="sm"
         openState={openState}
         render={() => (
           <div className="space-y-6">

--- a/apps/app/src/app/pages/collectivite/Referentiels/SaveScore/save-score.modal.tsx
+++ b/apps/app/src/app/pages/collectivite/Referentiels/SaveScore/save-score.modal.tsx
@@ -72,10 +72,10 @@ export const SaveScoreModal = ({
     <>
       <Modal
         title="Figer l'état des lieux"
-        size="md"
+        size="sm"
         openState={openState}
-        render={({ descriptionId }) => (
-          <div id={descriptionId} className="space-y-6">
+        render={() => (
+          <div className="space-y-6">
             {/*Info */}
             <Alert
               description="Vous pouvez figer les scores et textes renseignés dans le référentiel à la fin de l'état des lieux initial (ex: Etat-des-lieux-initial) ou à un autre moment clé (ex: pre-visite-annuelle), etc.

--- a/apps/app/src/collectivites/membres/remove-invitation/confirm-remove-invitation.modal.tsx
+++ b/apps/app/src/collectivites/membres/remove-invitation/confirm-remove-invitation.modal.tsx
@@ -16,11 +16,13 @@ export const ConfirmerSuppressionInvitation = (props: Props) => {
 
   return (
     <Modal
-      size="md"
+      size="sm"
       title={appLabels.annulerInvitation}
       subTitle={email}
-      description={appLabels.invitationDescription}
       openState={{ isOpen, setIsOpen }}
+      render={() => (
+        <p className="mb-0">{appLabels.invitationDescription}</p>
+      )}
       renderFooter={({ close }) => (
         <ModalFooterOKCancel
           btnOKProps={{

--- a/apps/app/src/collectivites/membres/remove-membre/confirm-remove-membre.modal.tsx
+++ b/apps/app/src/collectivites/membres/remove-membre/confirm-remove-membre.modal.tsx
@@ -20,15 +20,15 @@ export const ConfirmerSuppressionMembre = (props: Props) => {
 
   return (
     <Modal
-      size="md"
+      size="sm"
       title={
         isCurrentUser
           ? 'Retirer mon accès la collectivité'
           : "Retirer l'accès à la collectivité"
       }
       subTitle={membre.email}
-      description={getDescription(props)}
       openState={{ isOpen, setIsOpen }}
+      render={() => <p className="mb-0">{getDescription(props)}</p>}
       renderFooter={({ close }) => (
         <ModalFooterOKCancel
           btnOKProps={{

--- a/apps/app/src/plans/fiches/share-fiche/remove-sharing.modal.tsx
+++ b/apps/app/src/plans/fiches/share-fiche/remove-sharing.modal.tsx
@@ -38,9 +38,9 @@ export const RemoveSharingModal = ({
       title={appLabels.retirerPartage}
       subTitle={titre || appLabels.actionSansTitre}
       onClose={onClose}
-      render={({ descriptionId }) => (
+      render={() => (
         // Texte d'avertissement
-        <div id={descriptionId} data-test="supprimer-fiche-modale">
+        <div data-test="supprimer-fiche-modale">
           <Alert
             state="warning"
             title={appLabels.retirerPartageDescription({

--- a/apps/app/src/plans/fiches/shared/delete-fiche.modal.tsx
+++ b/apps/app/src/plans/fiches/shared/delete-fiche.modal.tsx
@@ -67,9 +67,8 @@ export const DeleteFicheModal = ({
       title={appLabels.supprimerAction}
       subTitle={titre || appLabels.actionSansTitre}
       onClose={onClose}
-      render={({ descriptionId }) => (
+      render={() => (
         <div
-          id={descriptionId}
           data-test="supprimer-fiche-modale"
           className="flex flex-col gap-2"
         >

--- a/apps/app/src/plans/fiches/show-fiche/content/details/description/impact/ModaleActionImpact.tsx
+++ b/apps/app/src/plans/fiches/show-fiche/content/details/description/impact/ModaleActionImpact.tsx
@@ -27,7 +27,6 @@ export const ModaleActionImpact = (props: ModaleActionImpactProps) => {
       size="lg"
       title={titre}
       subTitle={typologie?.nom}
-      textAlign="left"
       openState={{
         isOpen,
         setIsOpen: (opened) => {

--- a/apps/app/src/plans/fiches/show-fiche/content/documents/ModaleAjoutDocument.tsx
+++ b/apps/app/src/plans/fiches/show-fiche/content/documents/ModaleAjoutDocument.tsx
@@ -25,8 +25,8 @@ const ModaleAjoutDocument = ({
       openState={{ isOpen, setIsOpen }}
       title={appLabels.ajouterDocument}
       size="lg"
-      render={({ descriptionId, close }) => (
-        <div id={descriptionId}>
+      render={({ close }) => (
+        <div>
           <AddPreuveModal
             docType="annexe"
             onClose={close}

--- a/apps/app/src/plans/fiches/show-fiche/content/mesures-liees/mesures-liees.modal.tsx
+++ b/apps/app/src/plans/fiches/show-fiche/content/mesures-liees/mesures-liees.modal.tsx
@@ -38,8 +38,8 @@ export const MesuresLieesModal = ({
       title={appLabels.lierMesureReferentiels}
       size="lg"
       disableDismiss
-      render={({ descriptionId }) => (
-        <Field fieldId={descriptionId} title={appLabels.mesuresLiees}>
+      render={() => (
+        <Field title={appLabels.mesuresLiees}>
           <MesuresReferentielsDropdown
             values={editedMesureIds}
             onChange={({ values }) =>

--- a/apps/app/src/plans/fiches/show-fiche/content/moyens/budget/per-year-table/delete-budget.button.tsx
+++ b/apps/app/src/plans/fiches/show-fiche/content/moyens/budget/per-year-table/delete-budget.button.tsx
@@ -35,8 +35,8 @@ export const DeleteBudgetButton = ({
           title={appLabels.supprimerBudget}
           subTitle={appLabels.budgetAnnee({ year })}
           openState={{ isOpen, setIsOpen }}
-          render={({ descriptionId }) => (
-            <div id={descriptionId}>
+          render={() => (
+            <div>
               <p className="mb-0">{appLabels.supprimerBudgetDescription}</p>
             </div>
           )}

--- a/apps/app/src/plans/fiches/show-fiche/content/moyens/financeurs/delete-financeur.button.tsx
+++ b/apps/app/src/plans/fiches/show-fiche/content/moyens/financeurs/delete-financeur.button.tsx
@@ -34,8 +34,8 @@ export const DeleteFinanceurButton = ({
           title={appLabels.supprimerFinanceur}
           subTitle={financeurName}
           openState={{ isOpen, setIsOpen }}
-          render={({ descriptionId }) => (
-            <div id={descriptionId}>
+          render={() => (
+            <div>
               <p className="mb-0">{appLabels.supprimerFinanceurDescription}</p>
             </div>
           )}

--- a/apps/app/src/plans/fiches/show-fiche/content/notes/note-deletion.modal.tsx
+++ b/apps/app/src/plans/fiches/show-fiche/content/notes/note-deletion.modal.tsx
@@ -27,8 +27,8 @@ export const NoteDeletionModal = ({
             })
           : ''
       }`}
-      render={({ descriptionId }) => (
-        <div id={descriptionId}>
+      render={() => (
+        <div>
           <p className="mb-0">{appLabels.supprimerNoteConfirmation}</p>
         </div>
       )}

--- a/apps/app/src/plans/fiches/show-fiche/header/actions/emplacement/EmplacementFiche/ModaleEmplacement.tsx
+++ b/apps/app/src/plans/fiches/show-fiche/header/actions/emplacement/EmplacementFiche/ModaleEmplacement.tsx
@@ -27,8 +27,8 @@ export const ModaleEmplacement = ({
         setActiveTab(0);
         onClose();
       }}
-      render={({ descriptionId }) => (
-        <div id={descriptionId}>
+      render={() => (
+        <div>
           <Tabs defaultActiveTab={activeTab} onChange={setActiveTab}>
             <Tab label="Emplacement actuel">
               <EmplacementActuelFiche />

--- a/apps/app/src/plans/fiches/show-fiche/share-fiche/remove-sharing.modal.tsx
+++ b/apps/app/src/plans/fiches/show-fiche/share-fiche/remove-sharing.modal.tsx
@@ -37,9 +37,9 @@ const RemoveSharingModal = ({
     <Modal
       title="Retirer le partage"
       subTitle={titre || 'Action sans titre'}
-      render={({ descriptionId }) => (
+      render={() => (
         // Texte d'avertissement
-        <div id={descriptionId} data-test="supprimer-fiche-modale">
+        <div data-test="supprimer-fiche-modale">
           <Alert
             state="warning"
             title={`Cette action vous a été partagée par la collectivité "${collectiviteNom}". Sa suppression de votre collectivité n’affectera pas son existence dans la collectivité qui vous l’a partagée, où elle restera accessible.`}

--- a/apps/app/src/plans/plans/show-plan/actions/delete-axe-or-plan.modal.tsx
+++ b/apps/app/src/plans/plans/show-plan/actions/delete-axe-or-plan.modal.tsx
@@ -32,12 +32,9 @@ export const DeletePlanOrAxeModal = ({
   return (
     <Modal
       dataTest="SupprimerFicheModale"
-      size={axeHasFiche ? 'lg' : 'md'}
+      size={axeHasFiche ? 'lg' : 'sm'}
       title={appLabels.souhaitezVousSupprimer({ labelPlanOrAxe })}
       openState={openState}
-      description={
-        axeHasFiche ? undefined : appLabels.aucuneActionDans({ labelPlanOrAxe })
-      }
       render={
         axeHasFiche
           ? () => (
@@ -47,7 +44,11 @@ export const DeletePlanOrAxeModal = ({
                 description={appLabels.actionsLieesAutrePlan}
               />
             )
-          : undefined
+          : () => (
+              <p className="mb-0">
+                {appLabels.aucuneActionDans({ labelPlanOrAxe })}
+              </p>
+            )
       }
       renderFooter={({ close }) => (
         <ModalFooterOKCancel

--- a/apps/app/src/plans/plans/show-plan/actions/move-axe.modal.tsx
+++ b/apps/app/src/plans/plans/show-plan/actions/move-axe.modal.tsx
@@ -99,8 +99,8 @@ export const MoveAxeModal = ({
       size="xl"
       title="Déplacer cet axe"
       openState={openState}
-      render={({ descriptionId }) => (
-        <div id={descriptionId} className="flex flex-col gap-8">
+      render={() => (
+        <div className="flex flex-col gap-8">
           {/* Message d'info */}
           <Alert title="Sélectionnez l'emplacement de cet axe" />
 

--- a/apps/app/src/plans/plans/show-plan/actions/move-fiche.modal.tsx
+++ b/apps/app/src/plans/plans/show-plan/actions/move-fiche.modal.tsx
@@ -45,8 +45,8 @@ const MoveFicheModal = ({
       size="xl"
       onClose={handleClose}
       openState={openState}
-      render={({ descriptionId }) => (
-        <div id={descriptionId} className="flex flex-col gap-8">
+      render={() => (
+        <div className="flex flex-col gap-8">
           {/* Arborescence du plan courant */}
           <div className="border border-grey-3 rounded-lg grid grid-flow-col auto-cols-[16rem] overflow-x-auto divide-x-[0.5px] divide-primary-3 py-3">
             <ColonneTableauEmplacement

--- a/apps/app/src/plans/plans/show-plan/actions/update-fiche-visibility.modal.tsx
+++ b/apps/app/src/plans/plans/show-plan/actions/update-fiche-visibility.modal.tsx
@@ -24,17 +24,18 @@ const RestreindreFichesModal = ({
   return (
     <Modal
       openState={openState}
-      textAlign="left"
       title={
         isPrivate
           ? appLabels.rendreFichesPriveesQuestion
           : appLabels.rendreFichesPubliquesQuestion
       }
-      description={
-        isPrivate
-          ? appLabels.rendreFichesPriveesDescription
-          : appLabels.rendreFichesPubliquesDescription
-      }
+      render={() => (
+        <p className="mb-0">
+          {isPrivate
+            ? appLabels.rendreFichesPriveesDescription
+            : appLabels.rendreFichesPubliquesDescription}
+        </p>
+      )}
       renderFooter={({ close }) => (
         <ModalFooterOKCancel
           btnCancelProps={{

--- a/apps/app/src/plans/reports/generate-plan-report-pptx/generate-report.modal.tsx
+++ b/apps/app/src/plans/reports/generate-plan-report-pptx/generate-report.modal.tsx
@@ -32,15 +32,15 @@ export const GenerateReportPlanModal = ({
           ? 'Génération de votre rapport en cours'
           : 'Générer le rapport de mon plan au format PowerPoint'
       }
-      size="md"
+      size="sm"
       onClose={() => {
         setReportId(null);
       }}
       noCloseButton={isSubmittingGeneration}
       disableDismiss={isSubmittingGeneration}
       openState={openState}
-      render={({ descriptionId }) => (
-        <div id={descriptionId} className="space-y-6">
+      render={() => (
+        <div className="space-y-6">
           {reportId ? (
             <GenerateReportPending />
           ) : (

--- a/apps/app/src/plans/sous-actions/delete-sous-action.modal.tsx
+++ b/apps/app/src/plans/sous-actions/delete-sous-action.modal.tsx
@@ -20,8 +20,8 @@ export const DeleteSousActionModal = ({
       openState={openState}
       title={appLabels.supprimerSousAction}
       subTitle={sousAction.titre ?? undefined}
-      render={({ descriptionId }) => (
-        <div id={descriptionId} className="flex flex-col gap-6 text-center">
+      render={() => (
+        <div className="flex flex-col gap-6 text-center">
           {appLabels.confirmDeleteSousActionDescription}
         </div>
       )}

--- a/apps/app/src/referentiels/comparisons/deleteSnapshot/delete-snapshot.modal.tsx
+++ b/apps/app/src/referentiels/comparisons/deleteSnapshot/delete-snapshot.modal.tsx
@@ -27,7 +27,7 @@ export const DeleteSnapshotModal = ({
 
   return (
     <Modal
-      size="md"
+      size="sm"
       openState={openState}
       render={() => <DeleteSnapshotModalContent />}
       renderFooter={({ close }) => (

--- a/apps/app/src/referentiels/comparisons/updateSnapshotName/update-snapshot-name.modal.tsx
+++ b/apps/app/src/referentiels/comparisons/updateSnapshotName/update-snapshot-name.modal.tsx
@@ -42,10 +42,10 @@ export const UpdateSnapshotNameModal = ({
     <>
       <Modal
         title={appLabels.editerNomSauvegarde}
-        size="md"
+        size="sm"
         openState={openState}
-        render={({ descriptionId }) => (
-          <div id={descriptionId} className="space-y-6">
+        render={() => (
+          <div className="space-y-6">
             <Field title={appLabels.nomDeLaSauvegarde}>
               <div className="flex items-center border border-grey-4 rounded-lg bg-grey-1 focus-within:border-primary-5">
                 <span className="text-sm px-3 py-3 text-primary-7 border-r border-grey-4">

--- a/apps/app/src/referentiels/preuves/Bibliotheque/AlerteSuppression.tsx
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/AlerteSuppression.tsx
@@ -21,7 +21,7 @@ const AlerteSuppression = ({
         openState={{ isOpen, setIsOpen }}
         title={title}
         dataTest="confirm-suppr"
-        description={message}
+        render={message ? () => <p className="mb-0">{message}</p> : undefined}
         renderFooter={({ close }) => (
           <ModalFooterOKCancel
             btnCancelProps={{ onClick: close }}

--- a/apps/app/src/referentiels/tableau-de-bord/referents/ModaleReferents.tsx
+++ b/apps/app/src/referentiels/tableau-de-bord/referents/ModaleReferents.tsx
@@ -62,7 +62,7 @@ export const ModaleReferents = (props: ModaleReferentsProps) => {
     <Modal
       openState={{ isOpen, setIsOpen }}
       title={appLabels.referentAssocierReferents}
-      size="md"
+      size="sm"
       render={() => (
         <>
           <p>{appLabels.referentStatutDescription}</p>

--- a/apps/auth/components/Login/LoginModal.tsx
+++ b/apps/auth/components/Login/LoginModal.tsx
@@ -20,7 +20,7 @@ export const LoginModal = (props: LoginProps) => {
       dataTest="SignInPage"
       disableDismiss
       backdropBlur
-      size={mdDialog.includes(view) ? 'md' : 'lg'}
+      size={mdDialog.includes(view) ? 'sm' : 'lg'}
       title={getTitle(view)}
       openState={{ isOpen, setIsOpen }}
       onClose={onClose}

--- a/apps/auth/components/Signup/SignupModal.tsx
+++ b/apps/auth/components/Signup/SignupModal.tsx
@@ -20,7 +20,7 @@ export const SignupModal = (props: SignupProps) => {
       dataTest="SignUpPage"
       disableDismiss
       backdropBlur
-      size={mdDialog.includes(view) ? 'md' : 'lg'}
+      size={mdDialog.includes(view) ? 'sm' : 'lg'}
       title={getTitle(view)}
       subTitle={getSubTitle(view)}
       openState={{ isOpen, setIsOpen }}

--- a/apps/panier/components/ActionImpact/ModaleActionImpact.tsx
+++ b/apps/panier/components/ActionImpact/ModaleActionImpact.tsx
@@ -36,7 +36,6 @@ export const ModaleActionImpact = (props: ModaleActionImpactProps) => {
       size="lg"
       title={titre}
       subTitle={typologie?.nom}
-      textAlign="left"
       render={() => {
         return (
           <>

--- a/packages/design-tokens/src/design-tokens.ts
+++ b/packages/design-tokens/src/design-tokens.ts
@@ -60,7 +60,7 @@ export const designTokens = {
       10: '#161616',
     },
     'orange-1': '#F28E40',
-    overlay: 'hsla(240, 40%, 27%, 0.5)',
+    overlay: 'rgba(26, 42, 130, 0.5)',
   },
   fontFamily: {
     sans: ['Marianne', 'arial', 'sans-serif'],
@@ -109,6 +109,11 @@ export const designTokens = {
   },
   maxWidth: {
     '8xl': '90rem',
+    'modal-xs': '30rem',
+    'modal-sm': '40rem',
+    'modal-md': '50rem',
+    'modal-lg': '60rem',
+    'modal-xl': '75rem',
   },
   maxHeight: {
     '80vh': '80vh',

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -3,6 +3,10 @@
   "description": "frontend library containing shared components and design system",
   "private": true,
   "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
   "exports": {
     "./global.css": "./src/global.css",
     ".": {

--- a/packages/ui/src/design-system/Divider/Divider.tsx
+++ b/packages/ui/src/design-system/Divider/Divider.tsx
@@ -16,7 +16,7 @@ export const Divider = ({
       aria-orientation={orientation}
       className={cn(
         {
-          'border-grey-4': color === 'grey',
+          'border-grey-3': color === 'grey',
           'border-primary-3': color === 'primary',
         },
         {

--- a/packages/ui/src/design-system/Modal/Modal.behavior.test.tsx
+++ b/packages/ui/src/design-system/Modal/Modal.behavior.test.tsx
@@ -1,0 +1,196 @@
+import '@testing-library/jest-dom/vitest';
+
+import { uiLabels } from '@tet/ui/labels/catalog';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Modal } from './Modal';
+
+/**
+ * Le trigger doit être un élément hôte : `Modal` clone `children` et y injecte
+ * les props Floating UI (onClick, ref). Un composant qui ne les transmet pas
+ * n'ouvrirait jamais la modale.
+ */
+const trigger = <button type="button">Ouvrir</button>;
+
+const openByTrigger = () =>
+  fireEvent.click(screen.getByRole('button', { name: 'Ouvrir' }));
+
+const openState = () => ({ isOpen: true, setIsOpen: vi.fn() });
+
+describe('Modal — ouverture / fermeture', () => {
+  it('ne rend rien tant que la modale est fermée', () => {
+    render(<Modal title="Titre">{trigger}</Modal>);
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('ouvre la modale au clic sur le trigger', () => {
+    render(<Modal title="Titre">{trigger}</Modal>);
+    openByTrigger();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('affiche la modale quand openState.isOpen est vrai', () => {
+    render(<Modal title="Titre" openState={openState()} />);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('ferme via le bouton fermer et appelle onClose', () => {
+    const onClose = vi.fn();
+    render(
+      <Modal title="Titre" onClose={onClose}>
+        {trigger}
+      </Modal>
+    );
+    openByTrigger();
+    fireEvent.click(screen.getByRole('button', { name: uiLabels.fermer }));
+    expect(screen.queryByRole('dialog')).toBeNull();
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('ferme avec la touche Échap', () => {
+    render(<Modal title="Titre">{trigger}</Modal>);
+    openByTrigger();
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('ne ferme pas avec Échap quand disableDismiss est actif', () => {
+    render(
+      <Modal title="Titre" disableDismiss>
+        {trigger}
+      </Modal>
+    );
+    openByTrigger();
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it("n'affiche pas le bouton fermer avec noCloseButton", () => {
+    render(<Modal title="Titre" noCloseButton openState={openState()} />);
+    expect(screen.queryByRole('button', { name: uiLabels.fermer })).toBeNull();
+  });
+
+  it('la fonction close passée à render ferme la modale', () => {
+    render(
+      <Modal
+        title="Titre"
+        render={({ close }) => (
+          <button type="button" onClick={close}>
+            Valider
+          </button>
+        )}
+      >
+        {trigger}
+      </Modal>
+    );
+    openByTrigger();
+    fireEvent.click(screen.getByRole('button', { name: 'Valider' }));
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+});
+
+describe('Modal — accessibilité', () => {
+  it('a le rôle dialog et un aria-labelledby résolvant vers le titre', () => {
+    render(<Modal title="Mon titre" openState={openState()} />);
+    const dialog = screen.getByRole('dialog');
+    const labelId = dialog.getAttribute('aria-labelledby') ?? '';
+    expect(document.getElementById(labelId)).toHaveTextContent('Mon titre');
+  });
+
+  it("n'expose pas d'aria-labelledby quand la modale n'a pas de titre", () => {
+    render(
+      <Modal
+        openState={openState()}
+        render={() => <p className="mb-0">Sans titre</p>}
+      />
+    );
+    expect(screen.getByRole('dialog')).not.toHaveAttribute('aria-labelledby');
+  });
+
+  it('a un aria-describedby résolvant vers le corps rendu', () => {
+    render(
+      <Modal
+        title="Titre"
+        openState={openState()}
+        render={() => <p className="mb-0">Une description</p>}
+      />
+    );
+    const dialog = screen.getByRole('dialog');
+    const describedBy = dialog.getAttribute('aria-describedby') ?? '';
+    expect(document.getElementById(describedBy)).toHaveTextContent(
+      'Une description'
+    );
+  });
+
+  it("n'expose pas d'aria-describedby quand la modale n'a pas de corps", () => {
+    render(<Modal title="Titre" openState={openState()} />);
+    expect(screen.getByRole('dialog')).not.toHaveAttribute('aria-describedby');
+  });
+
+  it("place le focus dans la modale à l'ouverture", async () => {
+    render(<Modal title="Titre">{trigger}</Modal>);
+    openByTrigger();
+    const dialog = screen.getByRole('dialog');
+    await waitFor(() =>
+      expect(dialog.contains(document.activeElement)).toBe(true)
+    );
+  });
+
+  it('restaure le focus sur le trigger à la fermeture', async () => {
+    render(<Modal title="Titre">{trigger}</Modal>);
+    const triggerButton = screen.getByRole('button', { name: 'Ouvrir' });
+    fireEvent.click(triggerButton);
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
+    await waitFor(() => expect(document.activeElement).toBe(triggerButton));
+  });
+});
+
+describe('Modal — sections et dividers', () => {
+  it('rend le titre et le sous-titre quand ils sont fournis', () => {
+    render(
+      <Modal title="Titre" subTitle="Sous-titre" openState={openState()} />
+    );
+    expect(screen.getByRole('heading', { name: 'Titre' })).toBeInTheDocument();
+    expect(screen.getByText('Sous-titre')).toBeInTheDocument();
+  });
+
+  it('insère un divider entre header/body et entre body/footer', () => {
+    render(
+      <Modal
+        title="Titre"
+        openState={openState()}
+        render={() => <p>Corps</p>}
+        renderFooter={() => <button type="button">OK</button>}
+      />
+    );
+    expect(screen.getAllByRole('separator')).toHaveLength(2);
+  });
+
+  it('ne rend aucun divider pour une modale sans body ni footer', () => {
+    render(<Modal title="Titre" openState={openState()} />);
+    expect(screen.queryAllByRole('separator')).toHaveLength(0);
+  });
+
+  it('applique la classe de largeur correspondant à size', () => {
+    render(<Modal title="Titre" size="lg" openState={openState()} />);
+    expect(screen.getByRole('dialog')).toHaveClass('max-w-modal-lg');
+  });
+});
+
+describe('Modal — scrollableContent', () => {
+  it('rend le conteneur en overflow-hidden et le body scrollable', () => {
+    render(
+      <Modal
+        title="Titre"
+        scrollableContent
+        openState={openState()}
+        render={() => <p>Corps</p>}
+      />
+    );
+    expect(screen.getByRole('dialog')).toHaveClass('overflow-hidden');
+    expect(screen.getByText('Corps').parentElement).toHaveClass(
+      'overflow-y-auto'
+    );
+  });
+});

--- a/packages/ui/src/design-system/Modal/Modal.stories.tsx
+++ b/packages/ui/src/design-system/Modal/Modal.stories.tsx
@@ -14,6 +14,13 @@ export default meta;
 
 type Story = StoryObj<typeof Modal>;
 
+const loremIpsum =
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed felis magna, semper eget tortor sed, aliquet ornare risus. Sed egestas egestas porttitor. Sed quis pretium eros. Mauris a turpis eu elit efficitur vehicula. Nulla ac vulputate velit. Nulla quis neque nec sapien molestie imperdiet. Cras viverra lacus vulputate diam malesuada viverra.';
+
+const longLoremIpsum = loremIpsum.repeat(5);
+
+const renderLorem = () => <p className="mb-0">{loremIpsum}</p>;
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const OpenButton = forwardRef((props: any, ref) => (
   <Button {...props} ref={ref} variant="outlined">
@@ -24,11 +31,26 @@ OpenButton.displayName = 'OpenButton';
 
 export const Default: Story = {
   args: {
-    textAlign: 'left',
     title: 'Un titre simple',
     subTitle: 'Un sous titre',
-    description:
-      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed felis magna, semper eget tortor sed, aliquet ornare risus. Sed egestas egestas porttitor. Sed quis pretium eros. Mauris a turpis eu elit efficitur vehicula. Nulla ac vulputate velit. Nulla quis neque nec sapien molestie imperdiet. Cras viverra lacus vulputate diam malesuada viverra.',
+    render: renderLorem,
+  },
+  render: (args) => {
+    return (
+      <Modal {...args}>
+        <OpenButton text="Ouvrir la modale" />
+      </Modal>
+    );
+  },
+};
+
+export const TitreLong: Story = {
+  args: {
+    title:
+      'Un titre particulièrement long qui doit passer sur plusieurs lignes pour vérifier le comportement du line-height du header de la modale',
+    subTitle:
+      'Un sous-titre lui aussi suffisamment long pour repasser à la ligne et confirmer que les hauteurs de ligne du titre et du sous-titre restent correctes',
+    render: renderLorem,
   },
   render: (args) => {
     return (
@@ -49,14 +71,14 @@ export const AvecBackdropBlur: Story = {
 
 export const AvecFooter: Story = {
   args: {
-    textAlign: 'left',
     title: 'Un titre simple',
     subTitle: 'Un sous titre',
-    description:
-      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed felis magna, semper eget tortor sed, aliquet ornare risus. Sed egestas egestas porttitor. Sed quis pretium eros. Mauris a turpis eu elit efficitur vehicula. Nulla ac vulputate velit. Nulla quis neque nec sapien molestie imperdiet. Cras viverra lacus vulputate diam malesuada viverra.',
+    render: renderLorem,
     renderFooter: ({ close }) => (
       <ModalFooter>
-        <Button onClick={close}>Fermer</Button>
+        <Button size="xs" onClick={close}>
+          Fermer
+        </Button>
       </ModalFooter>
     ),
   },
@@ -71,21 +93,17 @@ export const AvecFooter: Story = {
 
 export const LongContent: Story = {
   args: {
-    textAlign: 'left',
     title: 'Un titre simple',
     subTitle: 'Un sous titre',
-    description:
-      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed felis magna, semper eget tortor sed, aliquet ornare risus. Sed egestas egestas porttitor. Sed quis pretium eros. Mauris a turpis eu elit efficitur vehicula. Nulla ac vulputate velit. Nulla quis neque nec sapien molestie imperdiet. Cras viverra lacus vulputate diam malesuada viverra. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed felis magna, semper eget tortor sed, aliquet ornare risus. Sed egestas egestas porttitor. Sed quis pretium eros. Mauris a turpis eu elit efficitur vehicula. Nulla ac vulputate velit. Nulla quis neque nec sapien molestie imperdiet. Cras viverra lacus vulputate diam malesuada viverra. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed felis magna, semper eget tortor sed, aliquet ornare risus. Sed egestas egestas porttitor. Sed quis pretium eros. Mauris a turpis eu elit efficitur vehicula. Nulla ac vulputate velit. Nulla quis neque nec sapien molestie imperdiet. Cras viverra lacus vulputate diam malesuada viverra. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed felis magna, semper eget tortor sed, aliquet ornare risus. Sed egestas egestas porttitor. Sed quis pretium eros. Mauris a turpis eu elit efficitur vehicula. Nulla ac vulputate velit. Nulla quis neque nec sapien molestie imperdiet. Cras viverra lacus vulputate diam malesuada viverra. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed felis magna, semper eget tortor sed, aliquet ornare risus. Sed egestas egestas porttitor. Sed quis pretium eros. Mauris a turpis eu elit efficitur vehicula. Nulla ac vulputate velit. Nulla quis neque nec sapien molestie imperdiet. Cras viverra lacus vulputate diam malesuada viverra.',
   },
   render: (args) => {
     return (
       <Modal
         {...args}
         render={({ close }) => (
-          <div className="flex flex-col p-8 border border-grey-5 text-grey-8 rounded-lg">
-            <p>Contenu de la fonction &quot;render&quot; ici avec un petit bouton.</p>
-            <p>Un autre paragraphe.</p>
-            <div className="flex gap-6 mt-2 ml-auto">
+          <div className="flex flex-col gap-4">
+            <p className="mb-0">{longLoremIpsum}</p>
+            <div className="flex gap-6 ml-auto">
               <Button variant="grey" onClick={() => close()}>
                 Annuler
               </Button>
@@ -111,7 +129,10 @@ export const WithRender: Story = {
         {...args}
         render={() => (
           <div className="flex flex-col p-8 border border-grey-5 text-grey-8 rounded-lg">
-            <p>Contenu de la fonction &quot;render&quot; ici avec un petit bouton.</p>
+            <p>
+              Contenu de la fonction &quot;render&quot; ici avec un petit
+              bouton.
+            </p>
             <p>Un autre paragraphe.</p>
             <Button className="ml-auto">Valider</Button>
           </div>
@@ -131,7 +152,9 @@ export const onlyRender: Story = {
         {...args}
         render={() => (
           <div className="p-8 border border-grey-5 text-grey-8 rounded-lg">
-            <span>Contenu de la fonction &quot;render&quot; ici dans les bordures.</span>
+            <span>
+              Contenu de la fonction &quot;render&quot; ici dans les bordures.
+            </span>
           </div>
         )}
       >
@@ -143,14 +166,15 @@ export const onlyRender: Story = {
 
 export const Size: Story = {
   args: {
-    textAlign: 'left',
     title: 'Un titre simple',
-    description:
-      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed felis magna, semper eget tortor sed, aliquet ornare risus. Sed egestas egestas porttitor. Sed quis pretium eros. Mauris a turpis eu elit efficitur vehicula. Nulla ac vulputate velit. Nulla quis neque nec sapien molestie imperdiet. Cras viverra lacus vulputate diam malesuada viverra.',
+    render: renderLorem,
   },
   render: (args) => {
     return (
       <div className="flex items-center gap-6">
+        <Modal {...args} size="xs">
+          <OpenButton text="xs" />
+        </Modal>
         <Modal {...args} size="sm">
           <OpenButton text="sm" />
         </Modal>
@@ -164,6 +188,31 @@ export const Size: Story = {
           <OpenButton text="xl" />
         </Modal>
       </div>
+    );
+  },
+};
+
+export const ScrollableContent: Story = {
+  args: {
+    title: 'Header et footer figés',
+    subTitle: 'Le contenu défile entre les deux',
+    scrollableContent: true,
+    renderFooter: ({ close }) => (
+      <ModalFooter>
+        <Button size="xs" onClick={close}>
+          Fermer
+        </Button>
+      </ModalFooter>
+    ),
+  },
+  render: (args) => {
+    return (
+      <Modal
+        {...args}
+        render={() => <p className="mb-0">{longLoremIpsum}</p>}
+      >
+        <OpenButton text="Ouvrir la modale" />
+      </Modal>
     );
   },
 };
@@ -187,113 +236,8 @@ const RenderControlled = (args: ComponentProps<typeof Modal>) => {
 
 export const Controlled: Story = {
   args: {
-    textAlign: 'left',
     title: 'Un titre simple',
-    description:
-      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed felis magna, semper eget tortor sed, aliquet ornare risus. Sed egestas egestas porttitor. Sed quis pretium eros. Mauris a turpis eu elit efficitur vehicula. Nulla ac vulputate velit. Nulla quis neque nec sapien molestie imperdiet. Cras viverra lacus vulputate diam malesuada viverra.',
+    render: renderLorem,
   },
   render: (args) => <RenderControlled {...args} />,
-};
-
-const RenderWithFooterAlwaysVisible = (
-  args: ComponentProps<typeof Modal>
-) => {
-  const [isOpen, setIsOpen] = useState(false);
-
-  return (
-    <>
-      <Modal
-        {...args}
-        openState={{
-          isOpen,
-          setIsOpen,
-        }}
-        footerIsAlwaysVisible
-      />
-      <OpenButton onClick={() => setIsOpen(!isOpen)} />
-    </>
-  );
-};
-
-export const WithFooterAlwaysVisible: Story = {
-  args: {
-    textAlign: 'left',
-    title:
-      'Une modale scrollable avec ses CTAs toujours visibles dans le footer',
-    render: () => (
-      <div className="flex flex-col p-8 border border-grey-5 text-grey-8 rounded-lg bg-slate-200">
-        <p>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed felis
-          magna, semper eget tortor sed, aliquet ornare risus. Sed egestas
-          egestas porttitor. Sed quis pretium eros. Mauris a turpis eu elit
-          efficitur vehicula. Nulla ac vulputate velit. Nulla quis neque nec
-          sapien molestie imperdiet. Cras viverra lacus vulputate diam malesuada
-          viverra.
-        </p>
-        <p>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed felis
-          magna, semper eget tortor sed, aliquet ornare risus. Sed egestas
-          egestas porttitor. Sed quis pretium eros. Mauris a turpis eu elit
-          efficitur vehicula. Nulla ac vulputate velit. Nulla quis neque nec
-          sapien molestie imperdiet. Cras viverra lacus vulputate diam malesuada
-          viverra.
-        </p>
-        <p>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed felis
-          magna, semper eget tortor sed, aliquet ornare risus. Sed egestas
-          egestas porttitor. Sed quis pretium eros. Mauris a turpis eu elit
-          efficitur vehicula. Nulla ac vulputate velit. Nulla quis neque nec
-          sapien molestie imperdiet. Cras viverra lacus vulputate diam malesuada
-          viverra.
-        </p>
-        <p>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed felis
-          magna, semper eget tortor sed, aliquet ornare risus. Sed egestas
-          egestas porttitor. Sed quis pretium eros. Mauris a turpis eu elit
-          efficitur vehicula. Nulla ac vulputate velit. Nulla quis neque nec
-          sapien molestie imperdiet. Cras viverra lacus vulputate diam malesuada
-          viverra.
-        </p>
-        <p>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed felis
-          magna, semper eget tortor sed, aliquet ornare risus. Sed egestas
-          egestas porttitor. Sed quis pretium eros. Mauris a turpis eu elit
-          efficitur vehicula. Nulla ac vulputate velit. Nulla quis neque nec
-          sapien molestie imperdiet. Cras viverra lacus vulputate diam malesuada
-          viverra.
-        </p>
-        <p>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed felis
-          magna, semper eget tortor sed, aliquet ornare risus. Sed egestas
-          egestas porttitor. Sed quis pretium eros. Mauris a turpis eu elit
-          efficitur vehicula. Nulla ac vulputate velit. Nulla quis neque nec
-          sapien molestie imperdiet. Cras viverra lacus vulputate diam malesuada
-          viverra.
-        </p>
-        <p>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed felis
-          magna, semper eget tortor sed, aliquet ornare risus. Sed egestas
-          egestas porttitor. Sed quis pretium eros. Mauris a turpis eu elit
-          efficitur vehicula. Nulla ac vulputate velit. Nulla quis neque nec
-          sapien molestie imperdiet. Cras viverra lacus vulputate diam malesuada
-          viverra.
-        </p>
-        <p>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed felis
-          magna, semper eget tortor sed, aliquet ornare risus. Sed egestas
-          egestas porttitor. Sed quis pretium eros. Mauris a turpis eu elit
-          efficitur vehicula. Nulla ac vulputate velit. Nulla quis neque nec
-          sapien molestie imperdiet. Cras viverra lacus vulputate diam malesuada
-          viverra.
-        </p>
-      </div>
-    ),
-    renderFooter: ({ close }) => (
-      <ModalFooter>
-        <Button onClick={close}>Fermer</Button>
-        <Button onClick={close}>Valider</Button>
-      </ModalFooter>
-    ),
-  },
-  render: (args) => <RenderWithFooterAlwaysVisible {...args} />,
 };

--- a/packages/ui/src/design-system/Modal/Modal.tsx
+++ b/packages/ui/src/design-system/Modal/Modal.tsx
@@ -11,22 +11,24 @@ import {
   useInteractions,
   useRole,
 } from '@floating-ui/react';
-import classNames from 'classnames';
 import { uiLabels } from '@tet/ui/labels/catalog';
 import { JSX, RefObject, cloneElement } from 'react';
 
 import { useOpenState } from '../../hooks/use-open-state';
 import { preset } from '../../tailwind-preset';
+import { cn } from '../../utils/cn';
 import { OpenState } from '../../utils/types';
 import { Button } from '../Button';
+import { Divider } from '../Divider';
 
-export type ModalSize = 'sm' | 'md' | 'lg' | 'xl';
+export type ModalSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 
 const sizeToClass: Record<ModalSize, string> = {
-  sm: 'max-w-sm',
-  md: 'max-w-[40rem]',
-  lg: 'max-w-4xl',
-  xl: 'max-w-[1200px]',
+  xs: 'max-w-modal-xs',
+  sm: 'max-w-modal-sm',
+  md: 'max-w-modal-md',
+  lg: 'max-w-modal-lg',
+  xl: 'max-w-modal-xl',
 };
 
 /**
@@ -38,8 +40,6 @@ export type RenderProps = {
   close: () => void;
   /** l'id à donner au titre pour l'accessibilité */
   labelId: string;
-  /** l'id à la description pour l'accessibilité */
-  descriptionId: string;
   /** Référence du container de la modale */
   ref: RefObject<HTMLElement | null>;
 };
@@ -56,15 +56,11 @@ export type ModalProps = {
   title?: string;
   /** Sous-titre de la modale, n'est pas affiché si non défini */
   subTitle?: string;
-  /** Description de la modale, n'est pas affichée si non définie. Elle est placée sous le titre */
-  description?: string;
-  /** Titre et description centrés par défaut */
-  textAlign?: 'left' | 'center' | 'right';
   /** Permet de contrôler l'ouverture de la modale */
   openState?: OpenState;
   /** fonction appelée lors de la fermeture de la modale */
   onClose?: () => void;
-  /** max-width prédéfinies, valeur par défaut "md" */
+  /** max-width prédéfinies, valeur par défaut "sm" */
   size?: ModalSize;
   /** désactive la fermeture lors du clic sur le fond */
   disableDismiss?: boolean;
@@ -76,8 +72,8 @@ export type ModalProps = {
   zIndex?: string | number;
   /** Id de test */
   dataTest?: string;
-  /** When true, ensures the modal's footer is always visible (content is made scrollable when needed)*/
-  footerIsAlwaysVisible?: boolean;
+  /** Fige le header et le footer, le body devient scrollable si le contenu dépasse la hauteur de l'écran */
+  scrollableContent?: boolean;
 };
 
 /*
@@ -89,17 +85,15 @@ export const Modal = ({
   children,
   title,
   subTitle,
-  description,
-  textAlign = 'center',
   openState,
   onClose,
-  size = 'md',
+  size = 'sm',
   disableDismiss,
   noCloseButton,
   renderFooter,
   backdropBlur,
   dataTest = 'Modal',
-  footerIsAlwaysVisible = false,
+  scrollableContent,
 }: ModalProps) => {
   const { isOpen, toggleIsOpen } = useOpenState(openState);
 
@@ -128,10 +122,9 @@ export const Modal = ({
     useDismiss(context, { enabled: !disableDismiss }),
   ]);
 
-  const footerClassName = footerIsAlwaysVisible ? 'sticky bottom-0' : '';
-  const contentClassName = classNames('flex flex-col gap-8 ', {
-    'h-full overflow-y-auto relative': footerIsAlwaysVisible,
-  });
+  const hasHeader = Boolean(title || subTitle);
+  const hasBody = Boolean(render);
+  const hasFooter = Boolean(renderFooter);
 
   return (
     <>
@@ -158,75 +151,76 @@ export const Modal = ({
                   data-test={dataTest}
                   {...getFloatingProps({
                     ref: refs.setFloating,
-                    'aria-labelledby': labelId,
-                    'aria-describedby': descriptionId,
-                    className: classNames(
+                    ...(title ? { 'aria-labelledby': labelId } : {}),
+                    ...(hasBody ? { 'aria-describedby': descriptionId } : {}),
+                    className: cn(
                       `
-                                  relative flex flex-col self-end gap-8 w-full mx-auto px-10 py-12
-                                  rounded-xl bg-white border border-grey-4 shadow-[0_4px_20px_0px_rgba(0,0,0,0.05)]
-                                  sm:self-center sm:w-[calc(100%-3rem)]
-                                  md:p-[4.5rem] md:pb-[2.5rem]
+                                  relative flex flex-col self-end gap-3 w-full mx-auto p-6 mt-8
+                                  rounded-md bg-white border border-grey-4 shadow-[0_4px_30px_0px_rgba(0,0,0,0.02)]
+                                  sm:self-center sm:w-[calc(100%-3rem)] sm:my-6
                                 `,
                       sizeToClass[size],
                       {
-                        'mt-8 sm:my-6': !footerIsAlwaysVisible,
-                        'max-h-[calc(100vh-2rem)]': footerIsAlwaysVisible,
+                        'overflow-hidden max-h-[calc(100vh-2rem)] sm:max-h-[calc(100vh-3rem)]':
+                          scrollableContent,
                       }
                     ),
                   })}
                 >
                   {!noCloseButton && (
-                    <Button
-                      data-html2canvas-ignore
-                      data-test={`close-${dataTest}`}
-                      title={uiLabels.fermer}
-                      onClick={handleOpenChange}
-                      icon="close-line"
-                      variant="grey"
-                      size="xs"
-                      className="!absolute max-md:top-4 top-8 max-md:right-4 right-8"
-                    />
+                    <div className="absolute top-6 right-6">
+                      <Button
+                        data-html2canvas-ignore
+                        data-test={`close-${dataTest}`}
+                        title={uiLabels.fermer}
+                        onClick={handleOpenChange}
+                        icon="close-line"
+                        variant="grey"
+                        size="xs"
+                      />
+                    </div>
                   )}
-                  {(title || subTitle || description) && (
+                  {hasHeader && (
                     <div
-                      className={classNames('flex flex-col gap-4', {
-                        'text-left': textAlign === 'left',
-                        'text-center': textAlign === 'center',
-                        'text-right': textAlign === 'right',
+                      className={cn('flex flex-col shrink-0', {
+                        'pr-9': !noCloseButton,
                       })}
                     >
                       {title && (
-                        <h3 id={labelId} className="mb-0 text-primary-10">
+                        <h3
+                          id={labelId}
+                          className="mb-0 text-2xl leading-9 text-primary-9"
+                        >
                           {title}
                         </h3>
                       )}
                       {subTitle && (
-                        <p className="mb-0 font-bold text-primary">
+                        <p className="mb-0 text-base font-medium text-grey-8">
                           {subTitle}
-                        </p>
-                      )}
-                      {description && (
-                        <p id={descriptionId} className="mb-0">
-                          {description}
                         </p>
                       )}
                     </div>
                   )}
-                  {render && (
-                    <div className={contentClassName}>
+                  {hasHeader && (hasBody || hasFooter) && <Divider />}
+                  {hasBody && (
+                    <div
+                      id={descriptionId}
+                      className={cn('flex flex-col gap-6', {
+                        'flex-1 min-h-0 overflow-y-auto': scrollableContent,
+                      })}
+                    >
                       {render?.({
                         close: handleOpenChange,
                         labelId,
-                        descriptionId,
                         ref: refs.floating,
                       })}
                     </div>
                   )}
-                  <div className={footerClassName}>
-                    {renderFooter?.({
+                  {hasBody && hasFooter && <Divider />}
+                  {hasFooter &&
+                    renderFooter?.({
                       close: handleOpenChange,
                     })}
-                  </div>
                 </div>
               </FloatingFocusManager>
             </FloatingOverlay>

--- a/packages/ui/src/design-system/Modal/ModalFooter.stories.tsx
+++ b/packages/ui/src/design-system/Modal/ModalFooter.stories.tsx
@@ -13,14 +13,21 @@ type Story = StoryObj<typeof ModalFooter>;
 export const Default: Story = {
   args: {
     variant: 'right',
-    children: [<Button key="cancel" variant="outlined">Cancel</Button>, <Button key="ok">OK</Button>],
+    children: [
+      <Button key="cancel" size="xs" variant="outlined">
+        Cancel
+      </Button>,
+      <Button key="ok" size="xs">
+        OK
+      </Button>,
+    ],
   },
 };
 
 export const Center: Story = {
   args: {
     variant: 'center',
-    children: <Button>OK</Button>,
+    children: <Button size="xs">OK</Button>,
   },
 };
 
@@ -29,11 +36,19 @@ export const Space: Story = {
     variant: 'space',
     children: [
       <ModalFooterSection key="section">
-        <Button variant="outlined">Non pertinent</Button>
-        <Button variant="outlined">En cours</Button>
-        <Button variant="outlined">Réalisé</Button>
+        <Button size="xs" variant="outlined">
+          Non pertinent
+        </Button>
+        <Button size="xs" variant="outlined">
+          En cours
+        </Button>
+        <Button size="xs" variant="outlined">
+          Réalisé
+        </Button>
       </ModalFooterSection>,
-      <Button key="add" icon="file-add-fill">Ajouter</Button>,
+      <Button key="add" size="xs" icon="file-add-fill">
+        Ajouter
+      </Button>,
     ],
   },
 };
@@ -42,6 +57,13 @@ export const AvecContenuOptionnel: Story = {
   args: {
     variant: 'right',
     content: [<p key="content">Contenu optionnel</p>],
-    children: [<Button key="cancel" variant="outlined">Cancel</Button>, <Button key="ok">OK</Button>],
+    children: [
+      <Button key="cancel" size="xs" variant="outlined">
+        Cancel
+      </Button>,
+      <Button key="ok" size="xs">
+        OK
+      </Button>,
+    ],
   },
 };

--- a/packages/ui/src/design-system/Modal/ModalFooter.tsx
+++ b/packages/ui/src/design-system/Modal/ModalFooter.tsx
@@ -1,4 +1,4 @@
-import classNames from 'classnames';
+import { cn } from '../../utils/cn';
 
 type ModalFooterVariant = 'center' | 'right' | 'space';
 
@@ -27,14 +27,9 @@ export const ModalFooter = ({
   variant = 'right',
 }: ModalFooterProps) => {
   return (
-    <div className="mt-4">
+    <div className="shrink-0">
       {content}
-      <div
-        className={classNames(
-          'flex gap-4 flex-wrap',
-          variantToClassnames[variant]
-        )}
-      >
+      <div className={cn('flex gap-4 flex-wrap', variantToClassnames[variant])}>
         {children}
       </div>
     </div>

--- a/packages/ui/src/design-system/Modal/ModalFooterOKCancel.tsx
+++ b/packages/ui/src/design-system/Modal/ModalFooterOKCancel.tsx
@@ -24,11 +24,16 @@ export const ModalFooterOKCancel = (props: ModalFooterOKCancelProps) => {
   return (
     <ModalFooter variant="right" {...remainingProps}>
       {btnCancelProps && (
-        <Button type="button" variant="outlined" {...btnCancelRemainingProps}>
+        <Button
+          type="button"
+          variant="outlined"
+          size="xs"
+          {...btnCancelRemainingProps}
+        >
           {cancel || uiLabels.annuler}
         </Button>
       )}
-      <Button type="submit" {...btnOKRemainingProps}>
+      <Button type="submit" size="xs" {...btnOKRemainingProps}>
         {ok || uiLabels.valider}
       </Button>
     </ModalFooter>

--- a/packages/ui/src/design-system/Modal/ModalFooterOKCancelWithSteps.tsx
+++ b/packages/ui/src/design-system/Modal/ModalFooterOKCancelWithSteps.tsx
@@ -31,7 +31,12 @@ export const ModalFooterOKCancelWithSteps = (
   return (
     <ModalFooter variant="right" {...remainingProps}>
       {btnCancelProps && (
-        <Button type="button" variant="outlined" {...btnCancelRemainingProps}>
+        <Button
+          type="button"
+          variant="outlined"
+          size="xs"
+          {...btnCancelRemainingProps}
+        >
           {cancel || uiLabels.annuler}
         </Button>
       )}
@@ -39,6 +44,7 @@ export const ModalFooterOKCancelWithSteps = (
         <Button
           type="button"
           variant="outlined"
+          size="xs"
           {...btnCancelRemainingProps}
           icon="arrow-left-line"
           iconPosition="left"
@@ -52,6 +58,7 @@ export const ModalFooterOKCancelWithSteps = (
       {currentStep < stepsCount && (
         <Button
           type="submit"
+          size="xs"
           {...btnOKRemainingProps}
           icon="arrow-right-line"
           iconPosition="right"
@@ -64,7 +71,7 @@ export const ModalFooterOKCancelWithSteps = (
         </Button>
       )}
       {currentStep === stepsCount && (
-        <Button type="submit" {...btnOKRemainingProps}>
+        <Button type="submit" size="xs" {...btnOKRemainingProps}>
           {ok || uiLabels.valider}
         </Button>
       )}

--- a/packages/ui/src/design-system/Select/Select.stories.tsx
+++ b/packages/ui/src/design-system/Select/Select.stories.tsx
@@ -417,7 +417,6 @@ const RenderCreateOptionInModal = () => {
   return (
     <Modal
       title="Select avec création dans une modale"
-      textAlign="left"
       render={() => (
         <div className="flex flex-col gap-6">
           <Field title="Pilotes">
@@ -443,7 +442,9 @@ const RenderCreateOptionInModal = () => {
                     )
                   ),
                 onDelete: (value) => {
-                  setOptions(getFlatOptions(options).filter((o) => o.value !== value));
+                  setOptions(
+                    getFlatOptions(options).filter((o) => o.value !== value)
+                  );
                   setValues(
                     values && values.length > 1
                       ? values.filter((v) => v !== value)

--- a/packages/ui/tsconfig.spec.json
+++ b/packages/ui/tsconfig.spec.json
@@ -12,7 +12,6 @@
     ]
   },
   "include": [
-    "vitest.config.mts",
     "src/**/*.test.ts",
     "src/**/*.spec.ts",
     "src/**/*.test.tsx",

--- a/packages/ui/vitest.config.mts
+++ b/packages/ui/vitest.config.mts
@@ -1,0 +1,23 @@
+/// <reference types='vitest' />
+import path from 'node:path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@tet/ui': path.resolve(__dirname, 'src'),
+    },
+  },
+  esbuild: {
+    jsx: 'automatic',
+  },
+  test: {
+    root: path.resolve(__dirname),
+    watch: false,
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: ['./vitest.setup.ts'],
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    reporters: ['default'],
+  },
+});

--- a/packages/ui/vitest.setup.ts
+++ b/packages/ui/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';


### PR DESCRIPTION
- échelle de tailles à 5 niveaux (xs/sm/md/lg/xl = 480/640/800/960/1200), défaut sm
- header réduit au titre + sous-titre, suppression de la prop description (migrée vers render)
- dividers entre header/body/footer, paddings et gaps conformes (24px, radius 6px)
- ombre et couleur d'overlay alignées sur le DS
- variante scrollableContent : header et footer figés, body scrollable
- boutons de footer en taille xs
- couleur du Divider passée en grey-3


Le champ description disparaît car il n'a pas vraiment d'intérêt par rapport au body d'une modale.
Je pense que cela montre plutôt que l'on aurait besoin d'un composant Alert qui permet de confirmer ou d'infirmer des opérations (au lieu d'une modale trop générique pour ça)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notes de Version

* **New Features**
  * Ajout de contenu scrollable pour les modales
  * Nouvelle taille de modale extra-petite (xs)

* **Bug Fixes**
  * Correction de la couleur du diviseur gris dans les composants

* **Style**
  * Ajustement de la taille de plusieurs modales pour une meilleure cohérence visuelle
  * Amélioration de la mise en page et des espacements des modales
  * Mise à jour des jetons de conception pour les tailles de modales

* **Tests**
  * Ajout de suite de tests complète pour les modales incluant accessibilité et interaction utilisateur

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/incubateur-ademe/territoires-en-transitions/pull/4461?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->