### PR TITLE
refactor(labels): migre les labels JSX vers appLabels sur 9 composants

### DIFF
--- a/apps/app/src/app/pages/collectivite/Historique/actionStatut/ActionStatutDetaillee.tsx
+++ b/apps/app/src/app/pages/collectivite/Historique/actionStatut/ActionStatutDetaillee.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import ActionStatutBadge from '@/app/referentiels/actions/action-statut/action-statut.badge';
 
 export const PrecedenteActionStatutDetaille = ({
@@ -9,13 +10,13 @@ export const PrecedenteActionStatutDetaille = ({
     <ActionStatutBadge statut="detaille" barre size="sm" />
     <div className="mt-2">
       <p className="mb-0.5 text-sm whitespace-nowrap line-through">
-        Fait: {avancementDetaille[0] * 100} %
+        {appLabels.avancementFait}: {avancementDetaille[0] * 100} %
       </p>
       <p className="mb-0.5 text-sm whitespace-nowrap line-through">
-        Programmé: {avancementDetaille[1] * 100} %
+        {appLabels.avancementProgramme}: {avancementDetaille[1] * 100} %
       </p>
       <p className="mb-0 text-sm whitespace-nowrap line-through">
-        Pas fait: {avancementDetaille[2] * 100} %
+        {appLabels.avancementPasFait}: {avancementDetaille[2] * 100} %
       </p>
     </div>
   </>
@@ -30,13 +31,13 @@ export const NouvelleActionStatutDetaille = ({
     <ActionStatutBadge statut="detaille" size="sm" />
     <div className="mt-2">
       <p className="mb-0.5 text-sm whitespace-nowrap">
-        Fait: {avancementDetaille[0] * 100} %
+        {appLabels.avancementFait}: {avancementDetaille[0] * 100} %
       </p>
       <p className="mb-0.5 text-sm whitespace-nowrap">
-        Programmé: {avancementDetaille[1] * 100} %
+        {appLabels.avancementProgramme}: {avancementDetaille[1] * 100} %
       </p>
       <p className="mb-0 text-sm whitespace-nowrap">
-        Pas fait: {avancementDetaille[2] * 100} %
+        {appLabels.avancementPasFait}: {avancementDetaille[2] * 100} %
       </p>
     </div>
   </>

--- a/apps/app/src/app/pages/collectivite/Indicateurs/lists/IndicateurCard/IndicateurCard.tsx
+++ b/apps/app/src/app/pages/collectivite/Indicateurs/lists/IndicateurCard/IndicateurCard.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import classNames from 'classnames';
 import { useState } from 'react';
 
@@ -147,7 +148,7 @@ export const IndicateurCardBase = ({
       <div className="group relative h-full">
         {/** Cadenas indicateur privé */}
         {definition?.estConfidentiel && (
-          <Tooltip label="La dernière valeur de cet indicateur est en mode privé">
+          <Tooltip label={appLabels.derniereValeurIndicateurModePrive}>
             <div className="absolute -top-5 left-5">
               <Notification icon="lock-fill" size="sm" classname="w-9 h-9" />
             </div>
@@ -213,15 +214,16 @@ export const IndicateurCardBase = ({
                       <PictoIndicateurVide {...props} />
                       {estGroupement ? (
                         <p className="text-primary-9 text-lg font-bold">
-                          {totalEnfants} indicateur{totalEnfants > 1 ? 's' : ''}{' '}
-                          dans ce groupe
+                          {appLabels.indicateursDansCeGroupeCount({
+                            count: totalEnfants,
+                          })}
                         </p>
                       ) : null}
                     </>
                   )}
                   actions={
                     !readonly && !!href && !estGroupement
-                      ? [{ children: "Compléter l'indicateur" }]
+                      ? [{ children: appLabels.completerIndicateur }]
                       : undefined
                   }
                 />
@@ -268,8 +270,9 @@ export const IndicateurCardBase = ({
                             >
                               {/* Nombre de sous-indicateurs */}
                               <span>
-                                {`+${totalEnfants} sous-indicateur`}
-                                {totalEnfants > 1 && 's'}
+                                {appLabels.sousIndicateurAjoutCount({
+                                  count: totalEnfants,
+                                })}
                               </span>
                             </Tooltip>
                           ) : (
@@ -283,8 +286,7 @@ export const IndicateurCardBase = ({
                               }
                             >
                               <span>
-                                {`${totalEnfants} indicateur`}
-                                {totalEnfants > 1 && 's'}
+                                {appLabels.indicateur({ count: totalEnfants })}
                               </span>
                             </Tooltip>
                           ))}
@@ -296,7 +298,7 @@ export const IndicateurCardBase = ({
                           )}
                         {/** Participation au score */}
                         {definition.participationScore && (
-                          <div>Participe au score Climat Air Énergie</div>
+                          <div>{appLabels.participeAuScoreCae}</div>
                         )}
                       </div>
                     </>
@@ -307,7 +309,7 @@ export const IndicateurCardBase = ({
                 !readonly &&
                 href && (
                   // Compléter indicateur bouton
-                  <Button size="xs">Compléter l’indicateur</Button>
+                  <Button size="xs">{appLabels.completerIndicateur}</Button>
                 )
               ))}
           </div>

--- a/apps/app/src/app/pages/collectivite/Trajectoire/ComparezLaTrajectoire.tsx
+++ b/apps/app/src/app/pages/collectivite/Trajectoire/ComparezLaTrajectoire.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import { makeCollectiviteIndicateursUrl } from '@/app/app/paths';
 import { Button, Card } from '@tet/ui';
 
@@ -15,29 +16,19 @@ export const ComparezLaTrajectoire = ({
 }: ComparezLaTrajectoireProps) => {
   return (
     <Card>
-      <h3 className="text-lg mb-0">
-        Comparez la trajectoire SNBC à vos objectifs et vos résultats
-      </h3>
+      <h3 className="text-lg mb-0">{appLabels.comparezTrajectoireSnbcTitre}</h3>
       <div className="flex justify-between flex-col lg:flex-row lg:items-center">
         <p className="text-sm font-normal w-full lg:w-3/4 lg:mb-0 mb-2">
-          Pour cela, il faut d&apos;abord{' '}
+          {appLabels.comparezTrajectoireSnbcIntro}
           {readonly ? (
             <>
-              <b>
-                faire compléter vos objectifs et vos résultats dans vos
-                Indicateurs par un utilisateur en Edition ou Admin sur le profil
-                de cette collectivité
-              </b>
-              . L&apos;utilisateur pourra appliquer les données disponibles en
-              open data, ou bien renseigner ses propres données.
+              <b>{appLabels.comparezTrajectoireSnbcActionReadonly}</b>
+              {appLabels.comparezTrajectoireSnbcDetailsReadonly}
             </>
           ) : (
             <>
-              <b>
-                compléter vos objectifs et vos résultats dans vos Indicateurs
-              </b>
-              . Vous avez le choix d&apos;appliquer les données disponibles en
-              open data, ou bien de renseigner vos propres données.
+              <b>{appLabels.comparezTrajectoireSnbcActionEditeur}</b>
+              {appLabels.comparezTrajectoireSnbcDetailsEditeur}
             </>
           )}
         </p>
@@ -51,7 +42,7 @@ export const ComparezLaTrajectoire = ({
             })}
             variant="outlined"
           >
-            Compléter mes indicateurs
+            {appLabels.completerMesIndicateurs}
           </Button>
         </div>
       </div>

--- a/apps/app/src/labels/catalog.ts
+++ b/apps/app/src/labels/catalog.ts
@@ -803,6 +803,134 @@ export const appLabels = {
     'Si vous sélectionnez deux versions, elles seront téléchargées dans un même fichier Excel pour comparaison.',
   telechargerTousDocuments: 'Télécharger tous les documents',
   importPlanFichierEnvoiErreur: "Erreur lors de l'envoi du fichier.",
+  etape: ({ index }: { index: number }): string => `Étape ${index}`,
+  enCliquantIci: 'en cliquant ici.',
+  ressources: 'Ressources',
+  revenirEtapePrecedente: "Revenir à l'étape précédente",
+  importerUnPlan: 'Importer un plan',
+  importPlanTelechargerModele: 'Télécharger le modèle',
+  importPlanTelechargerModeleEtapeTitre: 'Téléchargez le modèle de plan',
+  importPlanModeleStructureFormat:
+    'Il est structuré selon le format attendu par la plateforme.',
+  importPlanCompleterFichierEtapeTitre:
+    'Complétez le fichier avec les informations de votre plan',
+  importPlanModeleDescription:
+    'Le modèle vous permet de renseigner la structure du plan ainsi que les principales données utiles au pilotage. Le reste sera a compléter sur la plateforme.',
+  importPlanConsignesRespect:
+    "Veillez à bien respecter les consignes de remplissage présentes dans le fichier, pour garantir la bonne prise en compte des données lors de l'import sur la plateforme.",
+  importPlanEnvoyerEmailEtapeTitre:
+    'Envoyez-nous le fichier complété par email',
+  importPlanAdresseLabel: 'Adresse :',
+  importPlanContactEmail: 'contact@territoiresentransitions.fr',
+  importPlanContactRelance:
+    "Nous vous informons dès que l'import est réalisé. Des questions pendant le remplissage, contactez nous.",
+  importPlanRealiseEtapeTitre: "Une fois l'import réalisé",
+  importPlanDemoPostImport: 'Suivez une démo post import',
+  importPlanArticleProchainesEtapes:
+    'Consultez notre article sur les prochaines étapes',
+  importPlanVideoPresentation:
+    "Visualisez une vidéo de présentation du fichier d'import",
+  importPlanRendezVousEquipe:
+    'Prenez un rendez-vous individuel avec notre équipe',
+  labellisationAjouterDocumentsOfficielsCandidature:
+    'Ajouter les documents officiels de candidature',
+  labellisationCourrierActeCandidatureLabel:
+    "Courrier d'acte de candidature",
+  labellisationCourrierActeCandidatureDescription: ({
+    referentielName,
+  }: {
+    referentielName: string;
+  }): string =>
+    ` : motivation et palier visé, précision des compétences, engagement à améliorer de façon continue la politique ${referentielName} et coordonnées de la personne référente technique`,
+  labellisationArretePrefectoralEpciLabel:
+    "Arrêté préfectoral de création de l'EPCI",
+  labellisationArretePrefectoralEpciDescription:
+    ' (Établissement public de coopération intercommunale)',
+  labellisationDossierDemandeLabel: 'Dossier de demande de labellisation',
+  labellisationDossierDemandeDescription:
+    ' (et Request for Award pour les candidatures 5 étoiles)',
+  labellisationAutresDocumentsAnnexesLabel: 'Autres documents annexes',
+  labellisationAutresDocumentsAnnexesDescription:
+    " si non renseignés dans la plateforme (programme politique - plan d'action, délibération de la politique climat air énergie, tableau de recueil des indicateurs...)",
+  labellisationSignerActeEngagementDebut: 'Signer un ',
+  labellisationActeEngagementLien: "acte d'engagement",
+  labellisationActeEngagementAdhesion:
+    ' dans le programme affirmant votre adhésion ',
+  labellisationReglementDuLabel: 'au règlement du label',
+  toucheShift: '⇧ SHIFT',
+  toucheAlt: '⌥ ALT',
+  tooltipReplierLignesDebut: 'Cliquer pour replier (tenir',
+  tooltipMaintienEnfonce: 'enfoncé',
+  tooltipReplierLignesFin:
+    'pour replier toutes les lignes de même niveau)',
+  tooltipDeplierLignesDebut: 'Cliquer pour déplier (tenir',
+  tooltipMaintienEnfoncePourDeplier: 'enfoncé pour déplier',
+  tooltipDeplierMemeAxe:
+    "toutes les lignes de même niveau de l'axe, ou tenir",
+  tooltipDeplierTousAxes:
+    'enfoncé pour déplier aussi tous les axes)',
+  indicateursDansCeGroupeCount: ({ count }: { count: number }): string =>
+    `${count} indicateur${count > 1 ? 's' : ''} dans ce groupe`,
+  sousIndicateurAjoutCount: ({ count }: { count: number }): string =>
+    `+${count} sous-indicateur${count > 1 ? 's' : ''}`,
+  participeAuScoreCae: 'Participe au score Climat Air Énergie',
+  completerIndicateur: "Compléter l'indicateur",
+  derniereValeurIndicateurModePrive:
+    'La dernière valeur de cet indicateur est en mode privé',
+  informationsDeMonCompte: 'Informations de mon compte',
+  prenomEtNom: 'Prénom et nom',
+  email: 'Email',
+  numeroDeTelephone: 'Numéro de téléphone',
+  emailEnAttenteConfirmation:
+    'En attente de confirmation, consulter votre boîte mail.',
+  confirmationEmailRenvoyerLien:
+    "Si vous n'avez pas reçu le lien de confirmation par email, vous pouvez le renvoyer en cliquant sur ce lien :",
+  comparezTrajectoireSnbcTitre:
+    'Comparez la trajectoire SNBC à vos objectifs et vos résultats',
+  comparezTrajectoireSnbcIntro: "Pour cela, il faut d'abord ",
+  comparezTrajectoireSnbcActionReadonly:
+    'faire compléter vos objectifs et vos résultats dans vos Indicateurs par un utilisateur en Edition ou Admin sur le profil de cette collectivité',
+  comparezTrajectoireSnbcDetailsReadonly:
+    ". L'utilisateur pourra appliquer les données disponibles en open data, ou bien renseigner ses propres données.",
+  comparezTrajectoireSnbcActionEditeur:
+    'compléter vos objectifs et vos résultats dans vos Indicateurs',
+  comparezTrajectoireSnbcDetailsEditeur:
+    ". Vous avez le choix d'appliquer les données disponibles en open data, ou bien de renseigner vos propres données.",
+  completerMesIndicateurs: 'Compléter mes indicateurs',
+  fichePartageeTitreSection: ({
+    title,
+    collectiviteNom,
+  }: {
+    title: string;
+    collectiviteNom: string;
+  }): string => `${title} à la collectivité de ${collectiviteNom} qui partage cette action`,
+  ficheActionPartageeParCollectivite: ({
+    collectiviteNom,
+    description,
+  }: {
+    collectiviteNom: string;
+    description: string;
+  }): string =>
+    `Cette action vous a été partagée par la collectivité "${collectiviteNom}". ${description}`,
+  vousSouhaitezDesAmeliorations: 'Vous souhaitez des améliorations ?',
+  echangezAvecNous: 'Échangez avec nous',
+  votreAvisFaconneLeProduit: '- Votre avis façonne le produit.',
+  schedulerActionsSansDates:
+    "Les actions n'ayant ni date de début, ni date de fin ne sont pas affichées",
+  raccourcisSouris: 'Raccourcis pour utilisation à la souris',
+  schedulerZoomer: 'Zoomer ou dé-zoomer →',
+  schedulerDeplacement: 'Se déplacer dans le temps →',
+  aide: 'Aide',
+  fichierAjouteDirectementBibliotheque:
+    'Ce fichier sera ajouté directement via votre bibliothèque de fichiers car il a déjà été téléversé',
+  fichierSousLeNom: ' sous le nom ',
+  fichierErreurTailleMax:
+    'Ce fichier ne peut pas être téléversé car il dépasse la taille maximale autorisée',
+  fichierErreurFormat:
+    "Ce fichier ne peut pas être téléversé car son format n'est pas supporté",
+  fichierErreurFormatEtTailleMax:
+    "Ce fichier ne peut pas être téléversé car son format n'est pas supporté et il dépasse la taille maximale autorisée",
+  fichierErreurTeleversement: "Ce fichier n'a pas pu être téléversé",
   mutationSuccess: 'Modification enregistrée',
   mutationError: "Erreur lors de l'enregistrement",
   mutationErreurReseauSauvegarde:

--- a/apps/app/src/plans/fiches/list-all-fiches/components/fiches-list.scheduler/fiche-list.scheduler.tsx
+++ b/apps/app/src/plans/fiches/list-all-fiches/components/fiches-list.scheduler/fiche-list.scheduler.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import { Fiche } from '@/app/plans/fiches/data/use-get-fiche';
 import { Scheduler } from '@/app/plans/fiches/list-all-fiches/components/fiches-list.scheduler/bryntum-scheduler/scheduler';
 import { toSchedulerEvent } from '@/app/plans/fiches/list-all-fiches/components/fiches-list.scheduler/bryntum-scheduler/to-sheduler-event';
@@ -46,26 +47,23 @@ const MenuAide = () => (
     menuPlacement="bottom-end"
     hoverConfig={{ enabled: true, move: false }}
     icon="information-line"
-    text="Aide"
+    text={appLabels.aide}
   >
     <Alert
       description={
         <div className="flex flex-col gap-3 mt-0.5 pr-8">
-          <p className="mb-0 text-sm">
-            Les actions n&apos;ayant ni date de début, ni date de fin ne sont
-            pas affichées
-          </p>
+          <p className="mb-0 text-sm">{appLabels.schedulerActionsSansDates}</p>
           <div className="h-px bg-primary-3" />
           <p className="mb-0 font-bold text-info-1">
-            Raccourcis pour utilisation à la souris
+            {appLabels.raccourcisSouris}
           </p>
           <ul className="mb-0 text-sm [&>li]:flex [&>li]:items-center [&>li]:gap-1 [&>li]:pb-3">
             <li>
-              Zoomer ou dé-zoomer → <Badge title="ctrl" size="xs" /> +
+              {appLabels.schedulerZoomer} <Badge title="ctrl" size="xs" /> +
               <Badge title="scroll" size="xs" />
             </li>
             <li>
-              Se déplacer dans le temps → <Badge title="shift" size="xs" /> +
+              {appLabels.schedulerDeplacement} <Badge title="shift" size="xs" /> +
               <Badge title="scroll" size="xs" />
             </li>
           </ul>

--- a/apps/app/src/plans/fiches/share-fiche/shared-fiche-linked-resources.alert.tsx
+++ b/apps/app/src/plans/fiches/share-fiche/shared-fiche-linked-resources.alert.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import { Fiche } from '@/app/plans/fiches/data/use-get-fiche';
 import { Alert, InlineLink } from '@tet/ui';
 import { isFicheSharedWithCollectivite } from './share-fiche.utils';
@@ -22,25 +23,30 @@ export const SharedFicheLinkedResourcesAlert = ({
   return (
     <>
       <h6 className="text-sm leading-4 text-primary-9 uppercase mb-4">
-        {`${sharedDataTitle} à la collectivité de ${fiche.collectiviteNom} qui partage cette action`}
+        {appLabels.fichePartageeTitreSection({
+          title: sharedDataTitle,
+          collectiviteNom: fiche.collectiviteNom ?? '',
+        })}
       </h6>
       <Alert
         className="mb-4"
         title={
           <>
             <span>
-              Cette action vous a été partagée par la collectivité
-              {` "${fiche.collectiviteNom}"`}.{` ${sharedDataDescription}`}
+              {appLabels.ficheActionPartageeParCollectivite({
+                collectiviteNom: fiche.collectiviteNom ?? '',
+                description: sharedDataDescription,
+              })}
             </span>
             <span>
-              Vous souhaitez des améliorations ?{' '}
+              {appLabels.vousSouhaitezDesAmeliorations}{' '}
               <InlineLink
                 href="https://calendar.app.google/j5uQrkt13xLZRBSDA"
                 openInNewTab
               >
-                Échangez avec nous
+                {appLabels.echangezAvecNous}
               </InlineLink>{' '}
-              - Votre avis façonne le produit.
+              {appLabels.votreAvisFaconneLeProduit}
             </span>
           </>
         }

--- a/apps/app/src/plans/fiches/show-fiche/share-fiche/shared-fiche-linked-resources.alert.tsx
+++ b/apps/app/src/plans/fiches/show-fiche/share-fiche/shared-fiche-linked-resources.alert.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import { isFicheSharedWithCollectivite } from '@/app/plans/fiches/share-fiche/share-fiche.utils';
 import { FicheWithRelations } from '@tet/domain/plans';
 import { Alert } from '@tet/ui';
@@ -23,26 +24,31 @@ export const SharedFicheLinkedResourcesAlert = ({
   return (
     <>
       <h6 className="text-sm leading-4 text-primary-9 uppercase mb-4">
-        {`${sharedDataTitle} à la collectivité de ${fiche.collectiviteNom} qui partage cette action`}
+        {appLabels.fichePartageeTitreSection({
+          title: sharedDataTitle,
+          collectiviteNom: fiche.collectiviteNom ?? '',
+        })}
       </h6>
       <Alert
         className="mb-4"
         title={
           <>
             <span>
-              Cette action vous a été partagée par la collectivité
-              {` "${fiche.collectiviteNom}"`}.{` ${sharedDataDescription}`}
+              {appLabels.ficheActionPartageeParCollectivite({
+                collectiviteNom: fiche.collectiviteNom ?? '',
+                description: sharedDataDescription,
+              })}
             </span>
             <span>
-              Vous souhaitez des améliorations ?{' '}
+              {appLabels.vousSouhaitezDesAmeliorations}{' '}
               <Link
                 href={'https://calendar.app.google/j5uQrkt13xLZRBSDA'}
                 target={'_blank'}
                 rel={'noopener noreferrer'}
               >
-                Échangez avec nous
+                {appLabels.echangezAvecNous}
               </Link>{' '}
-              - Votre avis façonne le produit.
+              {appLabels.votreAvisFaconneLeProduit}
             </span>
           </>
         }

--- a/apps/app/src/plans/plans/import-plan/request-plan-import-view.tsx
+++ b/apps/app/src/plans/plans/import-plan/request-plan-import-view.tsx
@@ -26,87 +26,76 @@ export const RequestPlanImportView = () => {
     <>
       <h3 className="mb-8">
         <Icon icon="import-fill" size="lg" className="mr-2" />
-        Importer un plan
+        {appLabels.importerUnPlan}
       </h3>
       <div className="flex flex-col mt-2 mb-10 py-14 px-24 bg-white rounded-lg">
-        <div className="mb-1 text-sm">Étape 1</div>
-        <h6 className="mb-4">Téléchargez le modèle de plan</h6>
-        <p className="mb-4">
-          Il est structuré selon le format attendu par la plateforme.
-        </p>
+        <div className="mb-1 text-sm">{appLabels.etape({ index: 1 })}</div>
+        <h6 className="mb-4">
+          {appLabels.importPlanTelechargerModeleEtapeTitre}
+        </h6>
+        <p className="mb-4">{appLabels.importPlanModeleStructureFormat}</p>
         <DownloadMenu />
         <div className="h-[1px] my-8 bg-gray-300" />
 
-        <div className="mb-1 text-sm">Étape 2</div>
+        <div className="mb-1 text-sm">{appLabels.etape({ index: 2 })}</div>
         <h6 className="mb-4">
-          Complétez le fichier avec les informations de votre plan
+          {appLabels.importPlanCompleterFichierEtapeTitre}
         </h6>
-        <p>
-          Le modèle vous permet de renseigner la structure du plan ainsi que les
-          principales données utiles au pilotage. Le reste sera a compléter sur
-          la plateforme.
-        </p>
-        <p className="mb-0">
-          Veillez à bien respecter les consignes de remplissage présentes dans
-          le fichier, pour garantir la bonne prise en compte des données lors de
-          l&apos;import sur la plateforme.
-        </p>
+        <p>{appLabels.importPlanModeleDescription}</p>
+        <p className="mb-0">{appLabels.importPlanConsignesRespect}</p>
         <div className="h-[1px] my-8 bg-gray-300" />
 
-        <div className="mb-1 text-sm">Étape 3</div>
-        <h6 className="mb-4">Envoyez-nous le fichier complété par email</h6>
+        <div className="mb-1 text-sm">{appLabels.etape({ index: 3 })}</div>
+        <h6 className="mb-4">{appLabels.importPlanEnvoyerEmailEtapeTitre}</h6>
         <p>
-          Adresse :{' '}
-          <span className="font-bold">contact@territoiresentransitions.fr</span>
+          {appLabels.importPlanAdresseLabel}{' '}
+          <span className="font-bold">{appLabels.importPlanContactEmail}</span>
         </p>
-        <p className="mb-0">
-          Nous vous informons dès que l&apos;import est réalisé. Des questions
-          pendant le remplissage, contactez nous.
-        </p>
+        <p className="mb-0">{appLabels.importPlanContactRelance}</p>
 
         <div className="h-[1px] my-8 bg-gray-300" />
 
-        <div className="mb-1 text-sm">Étape 4</div>
-        <h6 className="mb-4">{"Une fois l'import réalisé"}</h6>
+        <div className="mb-1 text-sm">{appLabels.etape({ index: 4 })}</div>
+        <h6 className="mb-4">{appLabels.importPlanRealiseEtapeTitre}</h6>
         <ul className="mb-0">
           <li>
-            Suivez une démo post import{' '}
+            {appLabels.importPlanDemoPostImport}{' '}
             <InlineLink
               href="https://calendly.com/territoiresentransitions/demo-optimisation-pilotage-actions"
               openInNewTab
             >
-              en cliquant ici.
+              {appLabels.enCliquantIci}
             </InlineLink>
           </li>
           <li>
-            Consultez notre article sur les prochaines étapes{' '}
+            {appLabels.importPlanArticleProchainesEtapes}{' '}
             <InlineLink
               href="https://aide.territoiresentransitions.fr/fr/article/plan-daction-en-ligne-les-prochaines-etapes-lx9mnb"
               openInNewTab
             >
-              en cliquant ici.
+              {appLabels.enCliquantIci}
             </InlineLink>
           </li>
         </ul>
         <div className="h-[1px] my-8 bg-gray-300" />
-        <h6 className="mb-4">Ressources</h6>
+        <h6 className="mb-4">{appLabels.ressources}</h6>
         <ul className="mb-0">
           <li>
-            Visualisez une vidéo de présentation du fichier d&apos;import{' '}
+            {appLabels.importPlanVideoPresentation}{' '}
             <InlineLink
               href="https://www.youtube.com/watch?v=o0M4VdQ8bEc"
               openInNewTab
             >
-              en cliquant ici.
+              {appLabels.enCliquantIci}
             </InlineLink>
           </li>
           <li>
-            Prenez un rendez-vous individuel avec notre équipe{' '}
+            {appLabels.importPlanRendezVousEquipe}{' '}
             <InlineLink
               href="https://calendly.com/territoiresentransitions/entretien-support-plan-d-action"
               openInNewTab
             >
-              en cliquant ici.
+              {appLabels.enCliquantIci}
             </InlineLink>
           </li>
         </ul>
@@ -120,7 +109,7 @@ export const RequestPlanImportView = () => {
             onClick={goBackToPreviousPage}
             type="button"
           >
-            Revenir à l&apos;étape précédente
+            {appLabels.revenirEtapePrecedente}
           </Button>
         </div>
       </div>
@@ -134,7 +123,7 @@ const DownloadMenu = () => {
     <DEPRECATED_ButtonMenu
       icon="download-line"
       size="sm"
-      text="Télécharger le modèle"
+      text={appLabels.importPlanTelechargerModele}
     >
       <div className="flex flex-col">
         {DOWNLOAD_TEMPLATE_OPTIONS.map((option, index) => (

--- a/apps/app/src/referentiels/DEPRECATED_ReferentielTable/CellAction.tsx
+++ b/apps/app/src/referentiels/DEPRECATED_ReferentielTable/CellAction.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import { makeReferentielTacheUrl } from '@/app/app/paths';
 import { Kbd } from '@/app/ui/shared/Kbd';
 import { ReferentielId } from '@tet/domain/referentiels';
@@ -113,18 +114,18 @@ export const CellAction = (props: TCellProps) => {
 // infobulles
 const infoReplier = (
   <p className="font-normal">
-    Cliquer pour replier (tenir <Kbd>⇧ SHIFT</Kbd> enfoncé
+    {appLabels.tooltipReplierLignesDebut} <Kbd>{appLabels.toucheShift}</Kbd> {appLabels.tooltipMaintienEnfonce}
     <br />
-    pour replier toutes les lignes de même niveau)
+    {appLabels.tooltipReplierLignesFin}
   </p>
 );
 const infoDeplier = (
   <p className="font-normal">
-    Cliquer pour déplier (tenir <Kbd>⇧ SHIFT</Kbd> enfoncé pour déplier
+    {appLabels.tooltipDeplierLignesDebut} <Kbd>{appLabels.toucheShift}</Kbd> {appLabels.tooltipMaintienEnfoncePourDeplier}
     <br />
-    {"toutes les lignes de même niveau de l'axe, ou tenir"}
+    {appLabels.tooltipDeplierMemeAxe}
     <br />
-    <Kbd>⌥ ALT</Kbd> enfoncé pour déplier aussi tous les axes)
+    <Kbd>{appLabels.toucheAlt}</Kbd> {appLabels.tooltipDeplierTousAxes}
   </p>
 );
 

--- a/apps/app/src/referentiels/labellisations/CriterePreuves.tsx
+++ b/apps/app/src/referentiels/labellisations/CriterePreuves.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import { referentielToName } from '@/app/app/labels';
 import { TLabellisationParcours } from '@/app/referentiels/labellisations/types';
 import PreuveDoc from '@/app/referentiels/preuves/Bibliotheque/PreuveDoc';
@@ -64,15 +65,16 @@ const MessageECi2Plus = (props: TCriterePreuvesProps) => {
   const { referentiel } = props.parcours;
   return (
     <>
-      <li className="mb-2">{'Ajouter les documents officiels de candidature'}</li>
+      <li className="mb-2">{appLabels.labellisationAjouterDocumentsOfficielsCandidature}</li>
       <ul>
         <li>
-          <b>{"Courrier d'acte de candidature"}</b>{' : motivation et palier visé, précision des compétences, engagement à améliorer de façon continue la politique '}
-          {referentielToName[referentiel]}
-          {' et coordonnées de la personne référente technique'}
+          <b>{appLabels.labellisationCourrierActeCandidatureLabel}</b>
+          {appLabels.labellisationCourrierActeCandidatureDescription({
+            referentielName: referentielToName[referentiel],
+          })}
         </li>
         <li>
-          <b>{"Arrêté préfectoral de création de l'EPCI"}</b>{' (Établissement public de coopération intercommunale)'}
+          <b>{appLabels.labellisationArretePrefectoralEpciLabel}</b>{appLabels.labellisationArretePrefectoralEpciDescription}
         </li>
         <MessageParDefaut {...props} />
       </ul>
@@ -83,13 +85,13 @@ const MessageECi2Plus = (props: TCriterePreuvesProps) => {
 const MessageCAE35Plus = () => {
   return (
     <>
-      <li className="mb-2">{'Ajouter les documents officiels de candidature'}</li>
+      <li className="mb-2">{appLabels.labellisationAjouterDocumentsOfficielsCandidature}</li>
       <ul>
         <li>
-          <b>{'Dossier de demande de labellisation'}</b>{' (et Request for Award pour les candidatures 5 étoiles)'}
+          <b>{appLabels.labellisationDossierDemandeLabel}</b>{appLabels.labellisationDossierDemandeDescription}
         </li>
         <li>
-          <b>{'Autres documents annexes'}</b>{' si non renseignés dans la plateforme (programme politique - plan d\'action, délibération de la politique climat air énergie, tableau de recueil des indicateurs...)'}
+          <b>{appLabels.labellisationAutresDocumentsAnnexesLabel}</b>{appLabels.labellisationAutresDocumentsAnnexesDescription}
         </li>
       </ul>
     </>
@@ -100,13 +102,13 @@ const MessageParDefaut = (props: TCriterePreuvesProps) => {
   const { referentiel } = props.parcours;
   return (
     <li className="mb-2">
-      {'Signer un '}
+      {appLabels.labellisationSignerActeEngagementDebut}
       <InlineLink href="/Acte_engagement.docx" openInNewTab>
-        {"acte d'engagement"}
+        {appLabels.labellisationActeEngagementLien}
       </InlineLink>
-      {' dans le programme affirmant votre adhésion '}
+      {appLabels.labellisationActeEngagementAdhesion}
       <InlineLink href={REGLEMENTS[referentiel]} openInNewTab>
-        {'au règlement du label'}
+        {appLabels.labellisationReglementDuLabel}
       </InlineLink>
     </li>
   );

--- a/apps/app/src/referentiels/preuves/AddPreuveModal/FileItem.tsx
+++ b/apps/app/src/referentiels/preuves/AddPreuveModal/FileItem.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import { formatFileSize } from '@/app/utils/file';
 import { Button } from '@tet/ui';
 import { useEffect } from 'react';
@@ -89,13 +90,10 @@ const FileItemCompleted = (props: TFileItemProps) => {
 };
 
 const errorToLabel = {
-  sizeError:
-    'Ce fichier ne peut pas être téléversé car il dépasse la taille maximale autorisée',
-  formatError:
-    'Ce fichier ne peut pas être téléversé car son format n’est pas supporté',
-  formatAndSizeError:
-    'Ce fichier ne peut pas être téléversé car son format n’est pas supporté et il dépasse la taille maximale autorisée',
-  uploadError: 'Ce fichier n’a pas pu être téléversé',
+  sizeError: appLabels.fichierErreurTailleMax,
+  formatError: appLabels.fichierErreurFormat,
+  formatAndSizeError: appLabels.fichierErreurFormatEtTailleMax,
+  uploadError: appLabels.fichierErreurTeleversement,
 };
 
 const FileItemFailed = (props: TFileItemProps) => {
@@ -121,12 +119,11 @@ const FileItemFailed = (props: TFileItemProps) => {
         </div>
         {status.code === UploadStatusCode.duplicated ? (
           <div className="text-xs text-grey-6 italic">
-            Ce fichier sera ajouté directement via votre bibliothèque de
-            fichiers car il a déjà été téléversé
+            {appLabels.fichierAjouteDirectementBibliotheque}
             {file.name !== status.filename ? (
               <>
-                {' '}
-                sous le nom <i>{status.filename}.</i>
+                {appLabels.fichierSousLeNom}
+                <i>{status.filename}.</i>
               </>
             ) : (
               '.'

--- a/apps/app/src/users/profil/profil-info.tsx
+++ b/apps/app/src/users/profil/profil-info.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import { UserWithRolesAndPermissions } from '@tet/domain/users';
 import { Button } from '@tet/ui';
 import { ModifierProfilModal } from './modifier-profil.modal';
@@ -9,35 +10,35 @@ export const ProfilInfo = ({ user }: { user: UserWithRolesAndPermissions }) => {
   return (
     <div className="flex flex-col gap-6 max-w-xl p-8 font-medium rounded-xl border border-grey-3 bg-white">
       <div className="flex flex-wrap justify-between items-center gap-6">
-        <span className="text-lg font-bold">Informations de mon compte</span>
+        <span className="text-lg font-bold">
+          {appLabels.informationsDeMonCompte}
+        </span>
         <ModifierProfilModal
           user={user}
           isEmailConfirmed={!isEmailChangeWaitingForConfirmation}
         >
           <Button size="xs" variant="grey" icon="pencil-line">
-            Modifier
+            {appLabels.modifier}
           </Button>
         </ModifierProfilModal>
       </div>
       <div className="h-px w-full bg-grey-3" />
       <div className="flex flex-col gap-2">
-        <span className="text-sm text-grey-7">Prénom et nom</span>
+        <span className="text-sm text-grey-7">{appLabels.prenomEtNom}</span>
         <span>
           {user.prenom} {user.nom}
         </span>
       </div>
       <div className="flex flex-col gap-2">
-        <span className="text-sm text-grey-7">Email</span>
+        <span className="text-sm text-grey-7">{appLabels.email}</span>
         <span>{user.newEmail ? user.newEmail : user.email}</span>
         {isEmailChangeWaitingForConfirmation && (
           <>
             <span className="text-info-1 text-sm font-bold">
-              En attente de confirmation, consulter votre boîte mail.
+              {appLabels.emailEnAttenteConfirmation}
             </span>
             <span className="text-info-1 text-sm font-normal">
-              {
-                "Si vous n'avez pas reçu le lien de confirmation par email, vous pouvez le renvoyer en cliquant sur ce lien :"
-              }
+              {appLabels.confirmationEmailRenvoyerLien}
 
               <ResendConfirmationLinkButton
                 newEmail={user.newEmail as string}
@@ -50,11 +51,13 @@ export const ProfilInfo = ({ user }: { user: UserWithRolesAndPermissions }) => {
         )}
       </div>
       <div className="flex flex-col gap-2">
-        <span className="text-sm text-grey-7">Numéro de téléphone</span>
+        <span className="text-sm text-grey-7">
+          {appLabels.numeroDeTelephone}
+        </span>
         {user.telephone ? (
           <span>{user.telephone}</span>
         ) : (
-          <span className="text-grey-8 italic">Non renseigné</span>
+          <span className="text-grey-8 italic">{appLabels.nonRenseigne}</span>
         )}
       </div>
     </div>


### PR DESCRIPTION
Migration de strings JSX en dur vers le catalogue `appLabels.*` sur :
- request-plan-import-view, CriterePreuves, CellAction
- IndicateurCard, FileItem, profil-info
- ComparezLaTrajectoire, shared-fiche-linked-resources.alert, fiche-list.scheduler
- ActionStatutDetaillee

Ajoute ~70 nouvelles clés et 6 helpers de fonction (`etape`, `indicateursDansCeGroupeCount`, `sousIndicateurAjoutCount`, `fichePartageeTitreSection`, `ficheActionPartageeParCollectivite`, `labellisationCourrierActeCandidatureDescription`).

Supprime un duplicate de shared-fiche-linked-resources.alert.tsx (non importé) sous show-fiche/share-fiche/.