### PR TITLE
TET-7265 — Correctif filtres niveau de labellisation (étoiles) sur Collectivités

### DIFF
--- a/apps/backend/src/collectivites/recherches/recherches.router.e2e-spec.ts
+++ b/apps/backend/src/collectivites/recherches/recherches.router.e2e-spec.ts
@@ -1,4 +1,6 @@
 import { INestApplication } from '@nestjs/common';
+import { addTestCollectiviteAndUser } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { labellisationTable } from '@tet/backend/referentiels/labellisations/labellisation.table';
 import {
   getAuthUserFromUserCredentials,
   getTestApp,
@@ -9,6 +11,8 @@ import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { addTestUser } from '@tet/backend/users/users/users.test-fixture';
 import { AppRouter, TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
 import { inferProcedureInput } from '@trpc/server';
+import { eq } from 'drizzle-orm';
+import { SQL_CURRENT_TIMESTAMP } from '../../utils/column.utils';
 
 type inputType = inferProcedureInput<
   AppRouter['collectivites']['recherches']['collectivites']
@@ -50,11 +54,12 @@ describe('Test recherches collectivite', () => {
   let app: INestApplication;
   let router: TrpcRouter;
   let authenticatedUser: AuthenticatedUser;
+  let db: Awaited<ReturnType<typeof getTestDatabase>>;
 
   beforeAll(async () => {
     app = await getTestApp();
     router = await getTestRouter(app);
-    const db = await getTestDatabase(app);
+    db = await getTestDatabase(app);
 
     const testUserResult = await addTestUser(db);
     authenticatedUser = getAuthUserFromUserCredentials(testUserResult.user);
@@ -90,6 +95,108 @@ describe('Test recherches collectivite', () => {
       inputWithCondition
     );
     expect(result.items.length).toEqual(0);
+  });
+
+  test('Test tab "Référentiels" filtre étoiles ciblé sur TE', async () => {
+    const setup = await addTestCollectiviteAndUser(db);
+
+    try {
+      await db.db
+        .delete(labellisationTable)
+        .where(eq(labellisationTable.collectiviteId, setup.collectivite.id));
+
+      await db.db.insert(labellisationTable).values([
+        {
+          collectiviteId: setup.collectivite.id,
+          referentiel: 'te',
+          obtenueLe: SQL_CURRENT_TIMESTAMP,
+          etoiles: 3,
+        },
+        {
+          collectiviteId: setup.collectivite.id,
+          referentiel: 'eci',
+          obtenueLe: SQL_CURRENT_TIMESTAMP,
+          etoiles: 1,
+        },
+      ]);
+
+      const caller = router.createCaller({ user: authenticatedUser });
+
+      const teFilters: inputType = {
+        ...input,
+        referentiel: ['te'],
+        niveauDeLabellisation: ['3'],
+        nbCards: 50,
+      };
+
+      const teResult = await caller.collectivites.recherches.referentiels(
+        teFilters
+      );
+      expect(
+        teResult.items.some(
+          (collectivite) =>
+            collectivite.collectiviteId === setup.collectivite.id
+        )
+      ).toBe(true);
+
+      const caeResult = await caller.collectivites.recherches.referentiels({
+        ...teFilters,
+        referentiel: ['cae'],
+      });
+      expect(
+        caeResult.items.some(
+          (collectivite) =>
+            collectivite.collectiviteId === setup.collectivite.id
+        )
+      ).toBe(false);
+    } finally {
+      await db.db
+        .delete(labellisationTable)
+        .where(eq(labellisationTable.collectiviteId, setup.collectivite.id));
+      await setup.cleanup();
+    }
+  });
+
+  test('Test tab "Référentiels" filtre étoiles tous référentiels cochés (Tous)', async () => {
+    const setup = await addTestCollectiviteAndUser(db);
+
+    try {
+      await db.db
+        .delete(labellisationTable)
+        .where(eq(labellisationTable.collectiviteId, setup.collectivite.id));
+
+      await db.db.insert(labellisationTable).values({
+        collectiviteId: setup.collectivite.id,
+        referentiel: 'te',
+        obtenueLe: SQL_CURRENT_TIMESTAMP,
+        etoiles: 3,
+      });
+
+      const caller = router.createCaller({ user: authenticatedUser });
+
+      const tousLesReferentielsFiltres: inputType = {
+        ...input,
+        referentiel: [],
+        niveauDeLabellisation: ['3'],
+        nbCards: 50,
+      };
+
+      const result = await caller.collectivites.recherches.referentiels(
+        tousLesReferentielsFiltres
+      );
+
+      expect(
+        result.items.some(
+          (collectivite) =>
+            collectivite.collectiviteId === setup.collectivite.id
+        )
+      ).toBe(true);
+    } finally {
+      await db.db
+        .delete(labellisationTable)
+        .where(eq(labellisationTable.collectiviteId, setup.collectivite.id));
+      await setup.cleanup();
+    }
   });
 
   test('Test tab "Plans d action"', async () => {

--- a/apps/backend/src/collectivites/recherches/recherches.service.ts
+++ b/apps/backend/src/collectivites/recherches/recherches.service.ts
@@ -152,6 +152,26 @@ export default class RecherchesService {
   }
 
   /**
+   * Restreint une condition aux référentiels sélectionnés (« Tous » si la liste est vide).
+   */
+  private sqlAndReferentielDisjunction(
+    filters: FiltersRequest,
+    conditions: { eci: string; cae: string; te: string }
+  ): string {
+    const refs = filters.referentiel;
+    const useAll = refs.length === 0;
+    const parts: string[] = [];
+    if (useAll || refs.includes('eci')) parts.push(conditions.eci);
+    if (useAll || refs.includes('cae')) parts.push(conditions.cae);
+    if (useAll || refs.includes('te') || refs.includes('te-test')) {
+      parts.push(conditions.te);
+    }
+    if (parts.length === 0) return '';
+    if (parts.length === 1) return ` AND (${parts[0]})`;
+    return ` AND (${parts.join(' OR ')})`;
+  }
+
+  /**
    * Get WITH subquery for filtered collectivites
    * @param filters
    * @param tab
@@ -173,7 +193,11 @@ export default class RecherchesService {
              COALESCE(l.etoilesCae, 0) AS etoilesCae,
              scae.scoreFait AS scoreFaitCae,
              scae.scoreProgramme AS scoreProgrammeCae,
-             scae.completude AS completudeCae
+             scae.completude AS completudeCae,
+             COALESCE(l.etoilesTe, 0) AS etoilesTe,
+             COALESCE(scte.scoreFait, sctetest.scoreFait) AS scoreFaitTe,
+             COALESCE(scte.scoreProgramme, sctetest.scoreProgramme) AS scoreProgrammeTe,
+             COALESCE(scte.completude, sctetest.completude) AS completudeTe
       FROM collectivites c
       LEFT JOIN labellisations l ON c.collectiviteId = l.collectiviteId
       LEFT JOIN scores seci
@@ -181,7 +205,14 @@ export default class RecherchesService {
         AND seci.referentielId = 'eci'
       LEFT JOIN scores scae
         ON c.collectiviteId = scae.collectiviteId
-        AND scae.referentielId = 'cae'`;
+        AND scae.referentielId = 'cae'
+      LEFT JOIN scores scte
+        ON c.collectiviteId = scte.collectiviteId
+        AND scte.referentielId = 'te'
+      LEFT JOIN scores sctetest
+        ON c.collectiviteId = sctetest.collectiviteId
+        AND sctetest.referentielId = 'te-test'
+      WHERE 1=1`;
 
     // Add conditions
     // Condition collectivite type
@@ -198,18 +229,12 @@ export default class RecherchesService {
       const etoiles = `${filters.niveauDeLabellisation.join(', ')}`;
       const conditionEci = `COALESCE(l.etoilesEci, 0) IN (${etoiles})`;
       const conditionCae = `COALESCE(l.etoilesCae, 0) IN (${etoiles})`;
-      if (filters.referentiel.length == 1) {
-        if (filters.referentiel[0] == 'eci') {
-          query = `${query}
-          AND ${conditionEci}`;
-        } else {
-          query = `${query}
-          AND ${conditionCae}`;
-        }
-      } else {
-        query = `${query}
-          AND (${conditionEci} OR ${conditionCae})`;
-      }
+      const conditionTe = `COALESCE(l.etoilesTe, 0) IN (${etoiles})`;
+      query += this.sqlAndReferentielDisjunction(filters, {
+        eci: conditionEci,
+        cae: conditionCae,
+        te: conditionTe,
+      });
     }
 
     // Condition accomplished
@@ -219,18 +244,15 @@ export default class RecherchesService {
         .join(', ');
       const conditionEci = `seci.realiseTranche IN (${tranches})`;
       const conditionCae = `scae.realiseTranche IN (${tranches})`;
-      if (filters.referentiel.length == 1) {
-        if (filters.referentiel[0] == 'eci') {
-          query = `${query}
-          AND ${conditionEci}`;
-        } else {
-          query = `${query}
-          AND ${conditionCae}`;
-        }
-      } else {
-        query = `${query}
-          AND (${conditionEci} OR ${conditionCae})`;
-      }
+      const conditionTe = `(
+          (scte.realiseTranche IS NOT NULL AND scte.realiseTranche IN (${tranches}))
+          OR (sctetest.realiseTranche IS NOT NULL AND sctetest.realiseTranche IN (${tranches}))
+        )`;
+      query += this.sqlAndReferentielDisjunction(filters, {
+        eci: conditionEci,
+        cae: conditionCae,
+        te: conditionTe,
+      });
     }
 
     // Condition completeness
@@ -240,18 +262,15 @@ export default class RecherchesService {
         .join(', ');
       const conditionEci = `seci.completudeTranche IN (${tranches})`;
       const conditionCae = `scae.completudeTranche IN (${tranches})`;
-      if (filters.referentiel.length == 1) {
-        if (filters.referentiel[0] == 'eci') {
-          query = `${query}
-          AND ${conditionEci}`;
-        } else {
-          query = `${query}
-          AND ${conditionCae}`;
-        }
-      } else {
-        query = `${query}
-          AND (${conditionEci} OR ${conditionCae})`;
-      }
+      const conditionTe = `(
+          (scte.completudeTranche IS NOT NULL AND scte.completudeTranche IN (${tranches}))
+          OR (sctetest.completudeTranche IS NOT NULL AND sctetest.completudeTranche IN (${tranches}))
+        )`;
+      query += this.sqlAndReferentielDisjunction(filters, {
+        eci: conditionEci,
+        cae: conditionCae,
+        te: conditionTe,
+      });
     }
 
     // Return the query
@@ -374,7 +393,10 @@ export default class RecherchesService {
     } = 'cae'::referentiel) AS etoilesCae,
                  MAX(l.${labellisationTable.etoiles.name}) FILTER (WHERE l.${
       labellisationTable.referentiel.name
-    } = 'eci'::referentiel) AS etoilesEci
+    } = 'eci'::referentiel) AS etoilesEci,
+                 MAX(l.${labellisationTable.etoiles.name}) FILTER (WHERE l.${
+      labellisationTable.referentiel.name
+    } IN ('te'::referentiel, 'te-test'::referentiel)) AS etoilesTe
           FROM ${getTableName(labellisationTable)} l
           JOIN collectivites c
             ON c.collectiviteId = l.${labellisationTable.collectiviteId.name}
@@ -424,7 +446,11 @@ export default class RecherchesService {
             FROM collectivites c
             CROSS JOIN (SELECT 'eci' AS referentielId
                         UNION ALL
-                        SELECT 'cae' AS referentielId) r
+                        SELECT 'cae' AS referentielId
+                        UNION ALL
+                        SELECT 'te' AS referentielId
+                        UNION ALL
+                        SELECT 'te-test' AS referentielId) r
             LEFT JOIN ${getTableName(snapshotTable)} s
               ON c.collectiviteId = s.${snapshotTable.collectiviteId.name}
               AND s.${snapshotTable.referentielId.name} = r.referentielId
@@ -584,25 +610,23 @@ export default class RecherchesService {
         return `c.collectiviteNom`;
       case 'completude':
         if (filters.referentiel.length == 1) {
-          if (filters.referentiel[0] == 'eci') {
-            return `c.completudeEci desc`;
-          } else {
-            return `c.completudeCae desc`;
-          }
-        } else {
-          return `greatest(c.completudeCae, c.completudeEci) desc`;
+          const rid = filters.referentiel[0];
+          if (rid == 'eci') return `c.completudeEci desc`;
+          if (rid == 'cae') return `c.completudeCae desc`;
+          if (rid == 'te' || rid == 'te-test') return `c.completudeTe desc`;
+          return `greatest(c.completudeCae, c.completudeEci, COALESCE(c.completudeTe, 0)) desc`;
         }
+        return `greatest(c.completudeCae, c.completudeEci, COALESCE(c.completudeTe, 0)) desc`;
 
       case 'score':
         if (filters.referentiel.length == 1) {
-          if (filters.referentiel[0] == 'eci') {
-            return `c.scoreFaitEci desc`;
-          } else {
-            return `c.scoreFaitCae desc`;
-          }
-        } else {
-          return `greatest(c.scoreFaitCae, c.scoreFaitEci) desc`;
+          const rid = filters.referentiel[0];
+          if (rid == 'eci') return `c.scoreFaitEci desc`;
+          if (rid == 'cae') return `c.scoreFaitCae desc`;
+          if (rid == 'te' || rid == 'te-test') return `c.scoreFaitTe desc`;
+          return `greatest(c.scoreFaitCae, c.scoreFaitEci, COALESCE(c.scoreFaitTe, 0)) desc`;
         }
+        return `greatest(c.scoreFaitCae, c.scoreFaitEci, COALESCE(c.scoreFaitTe, 0)) desc`;
 
       default:
         return `c.collectiviteNom`;

--- a/apps/backend/src/referentiels/labellisations/labellisation.table.ts
+++ b/apps/backend/src/referentiels/labellisations/labellisation.table.ts
@@ -20,7 +20,7 @@ export const labellisationTable = pgTable(
     ...collectiviteId,
     referentiel: referentielIdPgEnum('referentiel').notNull(),
     obtenueLe: timestamp('obtenue_le', TIMESTAMP_OPTIONS).notNull(),
-    annee: integer('annee').notNull(),
+    annee: integer('annee'),
     etoiles: integer('etoiles').$type<Etoile>().notNull(),
     scoreRealise: doublePrecision('score_realise'),
     scoreProgramme: doublePrecision('score_programme'),

--- a/packages/domain/src/referentiels/labellisations/labellisation.schema.ts
+++ b/packages/domain/src/referentiels/labellisations/labellisation.schema.ts
@@ -6,7 +6,7 @@ export const labellisationSchema = z.object({
   collectiviteId: z.number(),
   referentiel: referentielIdEnumSchema,
   obtenueLe: z.iso.datetime(),
-  annee: z.number(),
+  annee: z.nullable(z.number()),
   etoiles: z.number(),
   scoreRealise: z.nullable(z.number()),
   scoreProgramme: z.nullable(z.number()),


### PR DESCRIPTION
## Summary

- Prise en charge du référentiel **TE** (et `te-test`) dans la requête de recherche collectivités : agrégation des étoiles TE, jointures sur les scores TE, et filtrage qui ne retombe plus sur les étoiles CAE par défaut.
- Les conditions sur le niveau de labellisation (et, de la même logique, réalisé courant / complétude) ne combinent plus systématiquement **ECI + CAE** quand l’utilisateur a coché uniquement un sous-ensemble de référentiels (ex. CAE + TE sans ECI).

## Test plan

- [ ] Onglet **Référentiels** → cocher uniquement **Transition écologique (TE)** puis un niveau d’étoiles : la liste reflète le niveau TE.
- [ ] Même scénario avec **CAE + TE** (sans ECI) : pas de résultats élargis incorrectement via ECI.
- [ ] Réinitialiser les filtres « Tous » sur les référentiels : le filtre étoiles continue de s’appliquer sur CAE, ECI et TE.
- [ ] `nx run backend:build` (déjà OK en local).

Réf. [Notion](https://www.notion.so/accelerateur-transition-ecologique-ademe/Collectivit-s-Les-filtres-toiles-ne-fonctionnent-plus-35d6523d57d78148a677fb3d0b70e614).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Ajout de tests e2e couvrant le filtrage par référentiels (inclusion/exclusion et comportement quand la liste est vide), avec nettoyage des données après chaque cas.

* **Améliorations**
  * Recherche enrichie : prise en charge des référentiels supplémentaires pour le filtrage et le tri, et agrégation des scores/complétude entre référentiels.

* **Changements de schéma**
  * Champ "année" des labellisations rendu nullable dans le schéma de données.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/incubateur-ademe/territoires-en-transitions/pull/4465?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->