### PR TITLE
refactor(labels): migre les labels JSX vers appLabels sur 9 composant…

### DIFF
--- a/apps/app/src/app/pages/Auth/AccepterCGUModal.tsx
+++ b/apps/app/src/app/pages/Auth/AccepterCGUModal.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import { useUpdateUser } from '@/app/users/use-update-user';
 import { useMutation } from '@tanstack/react-query';
 import { useUser } from '@tet/api';
@@ -31,20 +32,14 @@ const AccepterCGUModal = () => {
       render={() => (
         <>
           <ContractSVG className="self-center" />
-          <h4 className="mb-0">
-            Mise à jour des conditions générales d’utilisation{' '}
-          </h4>
-          <p className="mb-0">
-            Pour continuer à utiliser la plateforme territoiresentransitions.fr,
-            nous vous invitons à accepter les conditions générales
-            d’utilisation.
-          </p>
+          <h4 className="mb-0">{appLabels.cguMiseAJourTitre} </h4>
+          <p className="mb-0">{appLabels.cguAccepterMessage}</p>
         </>
       )}
       renderFooter={() => (
         <ModalFooter>
           <Button href={CGU_URL} external variant="underlined" className="mr-4">
-            Lire les conditions générales
+            {appLabels.cguLireConditionsGenerales}
           </Button>
           <Button
             data-test="AccepterCGUBtn"
@@ -56,7 +51,7 @@ const AccepterCGUModal = () => {
               setOpened(false);
             }}
           >
-            Accepter et poursuivre
+            {appLabels.cguAccepterEtPoursuivre}
           </Button>
         </ModalFooter>
       )}

--- a/apps/app/src/app/pages/CollectivitesEngagees/Views/Grid.tsx
+++ b/apps/app/src/app/pages/CollectivitesEngagees/Views/Grid.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import { Data } from '@/app/app/pages/CollectivitesEngagees/Views/View';
 import { RecherchesViewParam } from '@/app/app/paths';
 import noResultIllustration from '@/app/app/static/img/no-results-astronaut-bro.svg?url';
@@ -19,9 +20,9 @@ export const Grid = <T extends Data>({
   renderCard,
 }: Props<T>) => {
   const viewToText: Record<RecherchesViewParam, string> = {
-    collectivites: 'aucune collectivité',
-    referentiels: 'aucun référentiel',
-    plans: 'aucun plan',
+    collectivites: appLabels.rechercheGridAucuneCollectivite,
+    referentiels: appLabels.rechercheGridAucunReferentiel,
+    plans: appLabels.rechercheGridAucunPlan,
   };
 
   // État de chargement
@@ -39,10 +40,11 @@ export const Grid = <T extends Data>({
       {data.length === 0 ? (
         <div className="mt-10 md:mt-32 text-center text-primary-7">
           <div className="mb-4 text-2xl font-bold">
-            Oups... {viewToText[view]} ne correspond à votre recherche !
+            {appLabels.oupsAucunResultat} {viewToText[view]}{' '}
+            {appLabels.neCorrespondAVotreRecherche}
           </div>
           <div className="text-xl">
-            Modifiez ou désactivez les filtres pour obtenir plus de résultats
+            {appLabels.modifierFiltresPourPlusDeResultats}
           </div>
           <Image
             className="w-[24rem] self-center mt-10"

--- a/apps/app/src/app/pages/CollectivitesEngagees/Views/collectivites/CollectiviteCarte.tsx
+++ b/apps/app/src/app/pages/CollectivitesEngagees/Views/collectivites/CollectiviteCarte.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import { makeTdbCollectiviteUrl } from '@/app/app/paths';
 import { CollectiviteEngagee } from '@tet/api';
 import { Card, Event, Icon, useEventTracker } from '@tet/ui';
@@ -72,19 +73,17 @@ export const CollectiviteCarte = ({ collectivite, isClickable }: Props) => {
               <span className="text-xs text-grey-9 font-normal">
                 <Icon icon="line-chart-line" size="sm" className="mr-1.5" />
                 <span className="font-bold">{nbIndicateurs}</span>{' '}
-                {nbIndicateurs > 1
-                  ? 'indicateurs renseignés'
-                  : 'indicateur renseigné'}
+                {appLabels.indicateursRenseignesCount({ count: nbIndicateurs })}
               </span>
               <div className="text-grey-7 italic text-xs font-normal">
-                (open data et indicateurs renseignés par la collectivité)
+                {appLabels.openDataEtIndicateursCollectivite}
               </div>
             </div>
 
             <span className="text-xs text-grey-9 font-normal">
               <Icon icon="folders-line" size="sm" className="mr-1.5" />
               <span className="font-bold">{nbPlans}</span>{' '}
-              {nbPlans > 1 ? 'plans' : 'plan'}
+              {appLabels.plansCount({ count: nbPlans })}
             </span>
           </div>
 
@@ -96,16 +95,18 @@ export const CollectiviteCarte = ({ collectivite, isClickable }: Props) => {
             <span className="text-xs text-grey-9 font-normal">
               <Icon icon="star-line" size="sm" className="mr-1.5" />
               <span className="font-bold">
-                {etoilesCae} {etoilesCae > 1 ? 'étoiles' : 'étoile'}
+                {etoilesCae}{' '}
+                {appLabels.etoilesCount({ count: etoilesCae })}
               </span>{' '}
-              Climat Air Énergie
+              {appLabels.referentielCae}
             </span>
             <span className="text-xs text-grey-9 font-normal">
               <Icon icon="star-line" size="sm" className="mr-1.5" />
               <span className="font-bold">
-                {etoilesEci} {etoilesEci > 1 ? 'étoiles' : 'étoile'}
+                {etoilesEci}{' '}
+                {appLabels.etoilesCount({ count: etoilesEci })}
               </span>{' '}
-              Économie Circulaire
+              {appLabels.referentielEci}
             </span>
           </div>
         </div>

--- a/apps/app/src/app/pages/CollectivitesEngagees/Views/referentiels/ReferentielCarte.tsx
+++ b/apps/app/src/app/pages/CollectivitesEngagees/Views/referentiels/ReferentielCarte.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import { referentielToName } from '@/app/app/labels';
 import { makeReferentielRootUrl } from '@/app/app/paths';
 import { NIVEAUX } from '@/app/referentiels/tableau-de-bord/labellisation/LabellisationInfo';
@@ -120,19 +121,19 @@ export const ReferentielCol = ({
             <span className="font-bold">
               {toPercentString(scoreRealise)}
             </span>{' '}
-            réalisé courant
+            {appLabels.scoreRealiseIndicatif}
           </span>
           <span className="text-xs text-grey-9 font-normal">
             <Icon icon="calendar-line" size="sm" className="mr-1.5" />
             <span className="font-bold">
               {toPercentString(scoreProgramme)}
             </span>{' '}
-            programmé
+            {appLabels.scoreProgrammeIndicatif}
           </span>
         </>
       ) : (
         <span className="font-light italic text-xs text-grey-6">
-          Non concerné
+          {appLabels.avancementNonConcerne}
         </span>
       )}
     </div>

--- a/apps/app/src/app/pages/CollectivitesEngagees/contacts/contacts-modal.tsx
+++ b/apps/app/src/app/pages/CollectivitesEngagees/contacts/contacts-modal.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import {
   membreFonctionToLabel,
   membreFonctionToTeteFonction,
@@ -47,8 +48,8 @@ const ContactsModal = ({
       size="xl"
       title={
         view === 'referentiels'
-          ? 'Liste des référents du programme T.E.T.E'
-          : 'Liste des contacts'
+          ? appLabels.listeReferentsProgrammeTete
+          : appLabels.listeContacts
       }
       subTitle={collectiviteName}
       render={() => (
@@ -57,18 +58,18 @@ const ContactsModal = ({
           <thead>
             <tr className={rowClassName}>
               <td className={classNames('min-w-28', headCellClassName)}>
-                Contact
+                {appLabels.contact}
               </td>
               <td className={classNames('min-w-48', headCellClassName)}>
-                Fonction
+                {appLabels.fonction}
                 <br />
-                Intitulé du poste
+                {appLabels.intituleDuPoste}
               </td>
               <td className={classNames('min-w-28', headCellClassName)}>
-                Téléphone professionnel
+                {appLabels.telephoneProfessionnel}
               </td>
               <td className={classNames('min-w-48', headCellClassName)}>
-                Email
+                {appLabels.email}
               </td>
             </tr>
           </thead>
@@ -107,7 +108,7 @@ const ContactsModal = ({
                 >
                   {contact.email}{' '}
                   <Tooltip
-                    label={displayCopyMsg ? 'Copié !' : "Copier l'email"}
+                    label={displayCopyMsg ? appLabels.copie : appLabels.copierEmail}
                     openingDelay={0}
                   >
                     <Icon

--- a/apps/app/src/app/pages/collectivite/BibliothequeDocs/BibliothequeDocs.tsx
+++ b/apps/app/src/app/pages/collectivite/BibliothequeDocs/BibliothequeDocs.tsx
@@ -25,7 +25,7 @@ export const BibliothequeDocs = ({
 }: TBibliothequeDocsProps) => {
   return (
     <div data-test="BibliothequeDocs">
-      <h1 className="text-center mb-16">Bibliothèque de documents</h1>
+      <h1 className="text-center mb-16">{appLabels.bibliothequeDeDocuments}</h1>
 
       {labellisationEtAudit?.length ? (
         <section data-test="labellisation">
@@ -34,7 +34,7 @@ export const BibliothequeDocs = ({
       ) : null}
 
       <section data-test="rapports">
-        <h2 className="mb-6">Rapports de visite annuelle</h2>
+        <h2 className="mb-6">{appLabels.rapportsDeVisiteAnnuelle}</h2>
         {!isReadOnly && <AddRapportVisite />}
         {isReadOnly && (!rapports || rapports.length === 0) && (
           <p>{appLabels.aucunRapportVisiteAnnuelle}</p>
@@ -47,7 +47,7 @@ export const BibliothequeDocs = ({
       </section>
 
       <section className="mt-8">
-        <h2 className="mb-6">Documents</h2>
+        <h2 className="mb-6">{appLabels.documents}</h2>
         <PreuvesTabs />
       </section>
     </div>

--- a/apps/app/src/app/pages/collectivite/BibliothequeDocs/PreuveLabellisation.tsx
+++ b/apps/app/src/app/pages/collectivite/BibliothequeDocs/PreuveLabellisation.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import { referentielToName } from '@/app/app/labels';
 import PreuveDoc from '@/app/referentiels/preuves/Bibliotheque/PreuveDoc';
 import { TPreuveAuditEtLabellisation } from '@/app/referentiels/preuves/Bibliotheque/types';
@@ -31,7 +32,7 @@ export const PreuvesLabellisation = ({
           return (
             <Fragment key={referentiel}>
               <h2 className="mb-6">
-                {"Documents d'audit et de labellisation - Référentiel "}
+                {appLabels.documentsAuditEtLabellisationReferentiel}
                 {referentielToName[referentiel as ReferentielId]}
               </h2>
               {parDemande.map(({ id, docs, info }, index) => {
@@ -116,7 +117,7 @@ const Title = (props: { info: TCycleInfo }) => {
     return (
       <>
         {label}
-        <span className="capitalize">{labelEtoile}</span> étoile
+        <span className="capitalize">{labelEtoile}</span> {appLabels.etoile}
       </>
     );
   }
@@ -125,7 +126,7 @@ const Title = (props: { info: TCycleInfo }) => {
     return (
       <>
         {label}
-        <span>{"Audit contrat d'objectif territorial (COT)"}</span>
+        <span>{appLabels.auditContratObjectifTerritorialCOT}</span>
       </>
     );
   }

--- a/apps/app/src/app/pages/collectivite/Indicateurs/Indicateur/detail/DataSourceTooltip.tsx
+++ b/apps/app/src/app/pages/collectivite/Indicateurs/Indicateur/detail/DataSourceTooltip.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import Markdown from '@/app/ui/Markdown';
 import { Valeur } from '@tet/api/indicateurs/domain/valeur.schema';
 import { Tooltip } from '@tet/ui';
@@ -64,24 +65,25 @@ export const DataSourceTooltipContent = ({
       )}
       {!!metadonnee.diffuseur && (
         <p>
-          Diffuseur : <b>{metadonnee.diffuseur}</b>
+          {appLabels.diffuseurLabel} <b>{metadonnee.diffuseur}</b>
         </p>
       )}
       {!!metadonnee.producteur && (
         <p>
-          Producteur : <b>{metadonnee.producteur}</b>
+          {appLabels.producteurLabel} <b>{metadonnee.producteur}</b>
         </p>
       )}
       {!!metadonnee.dateVersion && (
         <p>
-          Version : <b>{new Date(metadonnee.dateVersion).getFullYear()}</b>
+          {appLabels.versionLabel}{' '}
+          <b>{new Date(metadonnee.dateVersion).getFullYear()}</b>
         </p>
       )}
       {!!metadonnee.methodologie && (
         <p>
-          Méthodologie / Périmètre :{' '}
+          {appLabels.methodologiePerimetreLabel}{' '}
           {calculAuto ? (
-            'Indicateur calculé automatiquement à partir des données disponibles sur Territoires en Transitions.'
+            appLabels.indicateurCalculeAutomatiquementMessage
           ) : (
             <Markdown
               content={metadonnee.methodologie}
@@ -94,7 +96,7 @@ export const DataSourceTooltipContent = ({
       )}
       {!calculAuto && !!metadonnee.limites && (
         <p>
-          Points d’attention / Limites : <b>{metadonnee.limites}</b>
+          {appLabels.pointsAttentionLimitesLabel} <b>{metadonnee.limites}</b>
         </p>
       )}
     </div>

--- a/apps/app/src/collectivites/membres/list-invitations/list-invitations.table.tsx
+++ b/apps/app/src/collectivites/membres/list-invitations/list-invitations.table.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { appLabels } from '@/app/labels/catalog';
 import { useCurrentCollectivite } from '@tet/api/collectivites';
 import {
   Table,
@@ -29,17 +30,21 @@ export function ListInvitationsTable() {
   return (
     <section>
       <h2 className="text-lg font-bold text-primary-10 mb-3">
-        Invitations en attente
+        {appLabels.invitationsEnAttente}
       </h2>
       <div className="p-4 pt-2 lg:p-8 lg:pt-4 bg-white rounded-xl border border-grey-3">
         <Table>
           <TableHead>
             <TableRow>
-              <TableHeaderCell>Adresse mail</TableHeaderCell>
-              <TableHeaderCell className="w-[12%]">Accès</TableHeaderCell>
+              <TableHeaderCell>{appLabels.adresseMail}</TableHeaderCell>
+              <TableHeaderCell className="w-[12%]">
+                {appLabels.membreAcces}
+              </TableHeaderCell>
 
               <VisibleWhen condition={canMutateMembres}>
-                <TableHeaderCell className="w-[10%]">Actions</TableHeaderCell>
+                <TableHeaderCell className="w-[10%]">
+                  {appLabels.actions}
+                </TableHeaderCell>
               </VisibleWhen>
             </TableRow>
           </TableHead>

--- a/apps/app/src/collectivites/preferences/affichage-referentiels.page.tsx
+++ b/apps/app/src/collectivites/preferences/affichage-referentiels.page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { appLabels } from '@/app/labels/catalog';
 import { referentielToName } from '@/app/app/labels';
 import { useReferentielsResetDisplayPreferences } from '@/app/referentiels/display-preferences/use-reset-display-preferences';
 import { useSuperAdminMode } from '@/app/users/authorizations/super-admin-mode/super-admin-mode.provider';
@@ -51,10 +52,9 @@ export const AffichageReferentielsPage = () => {
 
   return (
     <div className="max-w-xl">
-      <h2 className="mb-6">Affichage des référentiels</h2>
+      <h2 className="mb-6">{appLabels.affichageDesReferentiels}</h2>
       <p className="mb-4 text-sm text-grey-6">
-        Choisir les référentiels affichés dans le menu « État des lieux » pour
-        cette collectivité.
+        {appLabels.choisirReferentielsAffichesEtatDesLieux}
       </p>
       <div className="space-y-4 border border-grey-3 rounded-lg p-6 bg-white">
         {REFERENTIEL_IDS_WITH_EDITABLE_DISPLAY_PREFERENCES.map(
@@ -87,11 +87,10 @@ export const AffichageReferentielsPage = () => {
             className="text-sm text-grey-8 underline hover:no-underline"
             data-test="affichage-referentiels-reset"
           >
-            Réinitialiser selon le remplissage
+            {appLabels.reinitialiserSelonRemplissage}
           </button>
           <p className="text-xs text-grey-6 mt-1">
-            Affiche/cache automatiquement les référentiels CAE et ECI en
-            fonction de leur remplissage.
+            {appLabels.reinitialiserSelonRemplissageDescription}
           </p>
         </div>
       </div>

--- a/apps/app/src/labels/catalog.ts
+++ b/apps/app/src/labels/catalog.ts
@@ -931,6 +931,57 @@ export const appLabels = {
   fichierErreurFormatEtTailleMax:
     "Ce fichier ne peut pas être téléversé car son format n'est pas supporté et il dépasse la taille maximale autorisée",
   fichierErreurTeleversement: "Ce fichier n'a pas pu être téléversé",
+  listeReferentsProgrammeTete: 'Liste des référents du programme T.E.T.E',
+  listeContacts: 'Liste des contacts',
+  contact: 'Contact',
+  fonction: 'Fonction',
+  intituleDuPoste: 'Intitulé du poste',
+  telephoneProfessionnel: 'Téléphone professionnel',
+  copie: 'Copié !',
+  copierEmail: "Copier l'email",
+  diffuseurLabel: 'Diffuseur :',
+  producteurLabel: 'Producteur :',
+  versionLabel: 'Version :',
+  methodologiePerimetreLabel: 'Méthodologie / Périmètre :',
+  pointsAttentionLimitesLabel: "Points d'attention / Limites :",
+  indicateurCalculeAutomatiquementMessage:
+    'Indicateur calculé automatiquement à partir des données disponibles sur Territoires en Transitions.',
+  rechercherParIntituleOuDescription: 'Rechercher par intitulé ou description',
+  planDaction: "Plan d'action",
+  resultatCount: ({ count }: { count: number }): string =>
+    count <= 1 ? `${count} résultat` : `${count} résultats`,
+  actionSelectionneeCount: ({ count }: { count: number }): string =>
+    count <= 1 ? `${count} action sélectionnée` : `${count} actions sélectionnées`,
+  separateurPuce: ' • ',
+  cguMiseAJourTitre:
+    "Mise à jour des conditions générales d'utilisation",
+  cguAccepterMessage:
+    "Pour continuer à utiliser la plateforme territoiresentransitions.fr, nous vous invitons à accepter les conditions générales d'utilisation.",
+  cguLireConditionsGenerales: 'Lire les conditions générales',
+  cguAccepterEtPoursuivre: 'Accepter et poursuivre',
+  invitationsEnAttente: 'Invitations en attente',
+  adresseMail: 'Adresse mail',
+  affichageDesReferentiels: 'Affichage des référentiels',
+  choisirReferentielsAffichesEtatDesLieux:
+    'Choisir les référentiels affichés dans le menu « État des lieux » pour cette collectivité.',
+  reinitialiserSelonRemplissage: 'Réinitialiser selon le remplissage',
+  reinitialiserSelonRemplissageDescription:
+    'Affiche/cache automatiquement les référentiels CAE et ECI en fonction de leur remplissage.',
+  selectionnerThematiqueAvantSousThematique:
+    "Veuillez d'abord sélectionner une thématique pour pouvoir sélectionner une ou plusieurs sous-thématiques",
+  labelDeuxPoints: ({ label }: { label: string }): string => `${label} : `,
+  annee: 'Année',
+  total: 'TOTAL',
+  uniteHt: 'HT',
+  uniteEtp: 'ETP',
+  collectiviteEngageePolitiqueAvecPreuves: ({
+    referentielName,
+  }: {
+    referentielName: string;
+  }): string =>
+    `Être une collectivité engagée dans une politique ${referentielName} et le prouver (via les documents preuves ou un texte justificatif)`,
+  sousActionOuTache: 'Sous-action ou tâche',
+  statutOuScoreRequis: 'Statut ou score requis',
   mutationSuccess: 'Modification enregistrée',
   mutationError: "Erreur lors de l'enregistrement",
   mutationErreurReseauSauvegarde:

--- a/apps/app/src/labels/catalog.ts
+++ b/apps/app/src/labels/catalog.ts
@@ -982,6 +982,85 @@ export const appLabels = {
     `Être une collectivité engagée dans une politique ${referentielName} et le prouver (via les documents preuves ou un texte justificatif)`,
   sousActionOuTache: 'Sous-action ou tâche',
   statutOuScoreRequis: 'Statut ou score requis',
+  oupsAucunResultat: 'Oups...',
+  neCorrespondAVotreRecherche: 'ne correspond à votre recherche !',
+  modifierFiltresPourPlusDeResultats:
+    'Modifiez ou désactivez les filtres pour obtenir plus de résultats',
+  rechercheGridAucuneCollectivite: 'aucune collectivité',
+  rechercheGridAucunReferentiel: 'aucun référentiel',
+  rechercheGridAucunPlan: 'aucun plan',
+  openDataEtIndicateursCollectivite:
+    '(open data et indicateurs renseignés par la collectivité)',
+  indicateursRenseignesCount: ({ count }: { count: number }): string =>
+    count > 1 ? 'indicateurs renseignés' : 'indicateur renseigné',
+  plansCount: ({ count }: { count: number }): string =>
+    count > 1 ? 'plans' : 'plan',
+  etoilesCount: ({ count }: { count: number }): string =>
+    count > 1 ? 'étoiles' : 'étoile',
+  scoreRealiseIndicatif: 'réalisé courant',
+  scoreProgrammeIndicatif: 'programmé',
+  bibliothequeDeDocuments: 'Bibliothèque de documents',
+  rapportsDeVisiteAnnuelle: 'Rapports de visite annuelle',
+  documents: 'Documents',
+  documentsAuditEtLabellisationReferentiel:
+    "Documents d'audit et de labellisation - Référentiel ",
+  etoile: 'étoile',
+  auditContratObjectifTerritorialCOT:
+    "Audit contrat d'objectif territorial (COT)",
+  indicateurSelectionneCount: ({ count }: { count: number }): string =>
+    count <= 1
+      ? `${count} indicateur sélectionné`
+      : `${count} indicateurs sélectionnés`,
+  autresEmplacementsPourCetteActionCount: ({
+    count,
+  }: {
+    count: number;
+  }): string =>
+    count > 1
+      ? `${count} autres emplacements pour cette actions`
+      : 'autre emplacement pour cette action',
+  journalActivites: "Journal d'activités",
+  creeeLe: 'Créée le',
+  derniereModificationLe: 'Dernière modification le',
+  parPrenomNom: ({
+    prenom,
+    nom,
+  }: {
+    prenom?: string;
+    nom?: string;
+  }): string => `par ${prenom ?? ''} ${nom ?? ''}`,
+  sansType: 'Sans type',
+  axeCount: ({ count }: { count: number }): string =>
+    `${count} axe${count > 1 ? 's' : ''}`,
+  sousAxeCount: ({ count }: { count: number }): string =>
+    `${count} sous-axe${count > 1 ? 's' : ''}`,
+  actionCount: ({ count }: { count: number }): string =>
+    `${count} action${count > 1 ? 's' : ''}`,
+  rapportGenerationEnCoursIntro:
+    'Votre rapport est en cours de génération. Le traitement peut prendre quelques minutes selon le volume de données.',
+  vousRecevrezEmailA: 'Vous recevrez un email à ',
+  avecLienTelechargerRapport:
+    " avec un lien pour télécharger votre rapport dès qu'il sera prêt.",
+  joindreDocumentsLabellisationCNL:
+    '* Pour passer en CNL penser à joindre les documents de labellisation.',
+  quelTypeAuditSouhaitezVousDemander:
+    "Quel type d'audit souhaitez-vous demander ?",
+  envoyerMaDemande: 'Envoyer ma demande',
+  auditEciTachesAvecPreuves:
+    "Pour cet audit ECi, l'ensemble des tâches déclarées « faites » ou « détaillées » comprenant du « fait » doivent présenter des preuves téléchargées au niveau de la sous-action correspondante dans le référentiel.",
+  aucunAuditeurDossierIncomplet:
+    'Aucun auditeur ne pourra être attribué en cas de dossier incomplet.',
+  auditCoutAdemeRespectComplétude:
+    "Pour rappel, cet audit a un coût qui est aujourd'hui financé par l'ADEME. La validation de votre demande d'audit vous engage à respecter les conditions de complétude.",
+  erreurRecuperationDonnees:
+    'Une erreur est survenue lors de la récupération des données',
+  aucunResultatCorrespondFiltres:
+    'Aucun résultat ne correspond aux filtres sélectionnés',
+  reconnaissanceObtenue: 'Reconnaissance obtenue',
+  scoreRealise: 'Score réalisé',
+  scoreProgramme: 'Score programmé',
+  scoreRealiseLabel: 'Score réalisé :',
+  dateDerniereLabellisation: 'Date de la dernière labellisation :',
   mutationSuccess: 'Modification enregistrée',
   mutationError: "Erreur lors de l'enregistrement",
   mutationErreurReseauSauvegarde:

--- a/apps/app/src/plans/fiches/show-fiche/content/actions-liees/side-menu/link-fiches.view.tsx
+++ b/apps/app/src/plans/fiches/show-fiche/content/actions-liees/side-menu/link-fiches.view.tsx
@@ -47,7 +47,7 @@ export const LinkFichesView = () => {
   return (
     <div className="p-4">
       <div className="relative flex flex-col gap-4">
-        <Field title="Rechercher par intitulé ou description" small>
+        <Field title={appLabels.rechercherParIntituleOuDescription} small>
           <Input
             type="search"
             {...register('searchText')}
@@ -56,7 +56,7 @@ export const LinkFichesView = () => {
             displaySize="sm"
           />
         </Field>
-        <Field title="Plan d'action" small>
+        <Field title={appLabels.planDaction} small>
           <Controller
             name="planActionIds"
             control={control}
@@ -75,7 +75,7 @@ export const LinkFichesView = () => {
       <Divider color="primary" className="my-6" />
       <div className="mb-4 text-sm">
         {isLoading ? (
-          <span className="text-grey-6">Chargement...</span>
+          <span className="text-grey-6">{appLabels.formChargement}</span>
         ) : (
           <>
             <SearchResultsSummary
@@ -102,20 +102,16 @@ const SearchResultsSummary = ({
   count: number;
   linkedFicheIds: number[];
 }) => {
-  const resultSuffix = count > 1 ? 's' : '';
-  const linkedFicheSuffix = linkedFicheIds.length > 1 ? 's' : '';
   return (
     <>
-      <span className="font-bold">
-        {count} résultat{resultSuffix}
-      </span>
+      <span className="font-bold">{appLabels.resultatCount({ count })}</span>
       {linkedFicheIds.length > 0 && (
         <>
-          {' • '}
+          {appLabels.separateurPuce}
           <span className="text-grey-7">
-            {linkedFicheIds.length} action
-            {linkedFicheSuffix} sélectionnée
-            {linkedFicheSuffix}
+            {appLabels.actionSelectionneeCount({
+              count: linkedFicheIds.length,
+            })}
           </span>
         </>
       )}

--- a/apps/app/src/plans/fiches/show-fiche/content/details/description/index.tsx
+++ b/apps/app/src/plans/fiches/show-fiche/content/details/description/index.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import { LibreTagDropdown } from '@/app/collectivites/tags/libre-tag.dropdown';
 import EffetsAttendusDropdown from '@/app/ui/dropdownLists/ficheAction/EffetsAttendusDropdown/EffetsAttendusDropdown';
 import { useGetThematiqueAndSousThematiqueOptions } from '@/app/shared/thematiques/use-get-thematique-and-sous-thematique-options';
@@ -91,11 +92,11 @@ export const Description = () => {
       <div className="flex flex-col">
         <MainTitle>{getFieldLabel('description', fiche.description)}</MainTitle>
         <VisibleWhen condition={isReadonly && !initialDescription}>
-          À renseigner
+          {appLabels.placeholderARenseigner}
         </VisibleWhen>
         <RichTextEditor
           unstyled
-          ariaLabel="Description"
+          ariaLabel={appLabels.description}
           contentStyle={{
             size: 'sm',
             color: 'primary',
@@ -107,14 +108,16 @@ export const Description = () => {
       </div>
       <div className="flex flex-col gap-1">
         <MainTitle size="normal">
-          {`${getFieldLabel('objectifs', fiche.objectifs)} : `}
+          {appLabels.labelDeuxPoints({
+            label: getFieldLabel('objectifs', fiche.objectifs),
+          })}
         </MainTitle>
         <VisibleWhen condition={isReadonly && !initialObjectifs}>
-          À renseigner
+          {appLabels.placeholderARenseigner}
         </VisibleWhen>
         <RichTextEditor
           unstyled
-          ariaLabel="Objectifs"
+          ariaLabel={appLabels.objectifs}
           contentStyle={{
             size: 'sm',
             color: 'primary',
@@ -192,7 +195,7 @@ export const Description = () => {
                   ? selectedThematiques
                       .map((thematique) => thematique.nom)
                       .join(', ')
-                  : 'À renseigner'
+                  : appLabels.placeholderARenseigner
               }
               isReadonly={isReadonly}
               renderOnEdit={({ openState }) => (
@@ -223,8 +226,10 @@ export const Description = () => {
               label={getFieldLabel('sousThematiques', selectedSousThematiques)}
               value={
                 showSousThematiquesTooltip ? (
-                  <Tooltip label="Veuillez d'abord sélectionner une thématique pour pouvoir sélectionner une ou plusieurs sous-thématiques">
-                    <span>À renseigner</span>
+                  <Tooltip
+                    label={appLabels.selectionnerThematiqueAvantSousThematique}
+                  >
+                    <span>{appLabels.placeholderARenseigner}</span>
                   </Tooltip>
                 ) : (
                   selectedSousThematiques

--- a/apps/app/src/plans/fiches/show-fiche/content/indicateurs/side-menu/link-indicateur.view.tsx
+++ b/apps/app/src/plans/fiches/show-fiche/content/indicateurs/side-menu/link-indicateur.view.tsx
@@ -126,15 +126,9 @@ export const LinkIndicateursViewBase = ({
       </div>
       <Divider color="primary" className="my-6" />
       <div className="mb-4 font-bold">
-        {selectedIndicateurs ? (
-          <>
-            {selectedIndicateurs.length} indicateur
-            {selectedIndicateurs.length > 1 && 's'} sélectionné
-            {selectedIndicateurs.length > 1 && 's'}
-          </>
-        ) : (
-          <>0 indicateur sélectionné</>
-        )}
+        {appLabels.indicateurSelectionneCount({
+          count: selectedIndicateurs?.length ?? 0,
+        })}
       </div>
       <IndicateursSelectorGrid
         definitions={definitions}

--- a/apps/app/src/plans/fiches/show-fiche/content/moyens/budget/per-year-table/index.tsx
+++ b/apps/app/src/plans/fiches/show-fiche/content/moyens/budget/per-year-table/index.tsx
@@ -106,10 +106,12 @@ export const BudgetPerYearTable = ({
     () => [
       columnHelper.display({
         id: 'year',
-        header: () => <TableHeaderCell title="Année" className="w-[150px]" />,
+        header: () => (
+          <TableHeaderCell title={appLabels.annee} className="w-[150px]" />
+        ),
         cell: ({ row }) => {
           if (row.original.type === 'total') {
-            return <TotalTableCell>TOTAL</TotalTableCell>;
+            return <TotalTableCell>{appLabels.total}</TotalTableCell>;
           }
           const currentYear = row.original.budget.year;
 
@@ -134,7 +136,7 @@ export const BudgetPerYearTable = ({
             return (
               <TotalTableCell>
                 {getFormattedNumber(totals.montant)} €{' '}
-                <sup className="-top-[0.4em]">HT</sup>
+                <sup className="-top-[0.4em]">{appLabels.uniteHt}</sup>
               </TotalTableCell>
             );
           }
@@ -162,7 +164,7 @@ export const BudgetPerYearTable = ({
           if (row.original.type === 'total') {
             return (
               <TotalTableCell>
-                {getFormattedFloat(totals.etpPrevisionnel)} ETP
+                {getFormattedFloat(totals.etpPrevisionnel)} {appLabels.uniteEtp}
               </TotalTableCell>
             );
           }
@@ -176,7 +178,7 @@ export const BudgetPerYearTable = ({
           if (row.original.type === 'total') {
             return (
               <TotalTableCell>
-                {getFormattedFloat(totals.etpReel) ?? '-'} ETP
+                {getFormattedFloat(totals.etpReel) ?? '-'} {appLabels.uniteEtp}
               </TotalTableCell>
             );
           }

--- a/apps/app/src/plans/fiches/show-fiche/header/breadcrumbs/index.tsx
+++ b/apps/app/src/plans/fiches/show-fiche/header/breadcrumbs/index.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import { FicheWithRelations } from '@tet/domain/plans';
 import { Button, VisibleWhen } from '@tet/ui';
 import { JSX, useState } from 'react';
@@ -27,7 +28,6 @@ const OtherPlansBreadcrumbs = ({
 }): JSX.Element => {
   const [isOpen, setIsOpen] = useState(false);
   const axesCount = axes.length;
-  const s = axesCount > 1 ? 's' : '';
   return (
     <div className="mt-1 flex flex-col gap-2">
       <Button
@@ -37,8 +37,7 @@ const OtherPlansBreadcrumbs = ({
         iconPosition="right"
         onClick={() => setIsOpen((prevState) => !prevState)}
       >
-        {axesCount > 1 ? axesCount : ''} autre{s} emplacement{s} pour cette
-        action{s}
+        {appLabels.autresEmplacementsPourCetteActionCount({ count: axesCount })}
       </Button>
 
       <VisibleWhen condition={isOpen}>

--- a/apps/app/src/plans/fiches/show-fiche/header/menu/actions/activity-log/activity-log.modal.tsx
+++ b/apps/app/src/plans/fiches/show-fiche/header/menu/actions/activity-log/activity-log.modal.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import { getTextFormattedDate } from '@/app/utils/formatUtils';
 import { FicheWithRelations } from '@tet/domain/plans';
 import { Modal } from '@tet/ui';
@@ -7,11 +8,7 @@ const By = ({ prenom, nom }: { prenom?: string; nom?: string }) => {
   if (!prenom && !nom) {
     return null;
   }
-  return (
-    <>
-      par {prenom} {nom}
-    </>
-  );
+  return <>{appLabels.parPrenomNom({ prenom, nom })}</>;
 };
 
 const Date = ({ date }: { date: string }) => {
@@ -29,15 +26,16 @@ export const ActivityLogModal = ({
     <Modal
       openState={{ isOpen: true, setIsOpen: onClose }}
       onClose={onClose}
-      title="Journal d'activités"
+      title={appLabels.journalActivites}
       size="lg"
       render={() => (
         <div>
           <div>
-            Créée le <Date date={fiche.createdAt} /> <By {...fiche.createdBy} />
+            {appLabels.creeeLe} <Date date={fiche.createdAt} />{' '}
+            <By {...fiche.createdBy} />
           </div>
           <div>
-            Dernière modification le <Date date={fiche.modifiedAt} />{' '}
+            {appLabels.derniereModificationLe} <Date date={fiche.modifiedAt} />{' '}
             <By {...fiche.modifiedBy} />
           </div>
         </div>

--- a/apps/app/src/plans/plans/components/card/plan.card.tsx
+++ b/apps/app/src/plans/plans/components/card/plan.card.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 
+import { appLabels } from '@/app/labels/catalog';
 import { useFichesCountBy } from '@/app/plans/fiches/data/use-fiches-count-by';
 import { PiloteOrReferentLabel } from '@/app/plans/plans/components/PiloteOrReferentLabel';
 import { Plan, Statut } from '@tet/domain/plans';
@@ -55,10 +56,10 @@ export const PlanCard = ({
       className="gap-2 !p-4 hover:bg-white"
     >
       <span className="font-bold text-primary-9">
-        {plan.nom ?? 'Sans titre'}
+        {plan.nom ?? appLabels.sansTitre}
       </span>
       <span className="text-sm font-medium text-grey-8 uppercase">
-        {plan.type?.type ?? 'Sans type'}
+        {plan.type?.type ?? appLabels.sansType}
       </span>
       <div className="mb-auto">
         <Statuts
@@ -86,20 +87,15 @@ export const PlanCard = ({
         )}
       >
         {/** Nombre d'axes */}
-        <span>
-          {axesCount?.axe ?? 0} axe{axesCount && axesCount.axe > 1 ? 's' : ''}
-        </span>
+        <span>{appLabels.axeCount({ count: axesCount?.axe ?? 0 })}</span>
         <div className="w-0.5 h-4/5 my-auto bg-grey-5" />
         {/** Nombre de sous-axes */}
         <span>
-          {axesCount?.sousAxe ?? 0} sous-axe
-          {axesCount && axesCount.sousAxe > 1 ? 's' : ''}
+          {appLabels.sousAxeCount({ count: axesCount?.sousAxe ?? 0 })}
         </span>
         <div className="w-0.5 h-4/5 my-auto bg-grey-5" />
         {/** Nombre de fiches */}
-        <span>
-          {fichesCount ?? 0} action{fichesCount > 1 ? 's' : ''}
-        </span>
+        <span>{appLabels.actionCount({ count: fichesCount ?? 0 })}</span>
       </div>
     </Card>
   );

--- a/apps/app/src/plans/reports/generate-plan-report-pptx/generate-report-pending.tsx
+++ b/apps/app/src/plans/reports/generate-plan-report-pptx/generate-report-pending.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import PictoDocument from '@/app/ui/pictogrammes/PictoDocument';
 import { useUser } from '@tet/api';
 
@@ -8,11 +9,11 @@ export const GenerateReportPending = () => {
       <PictoDocument width="100" height="100" />
 
       <p className="mt-4 text-primary-9 font-bold text-center mb-0 text-base leading-6">
-        Votre rapport est en cours de génération. Le traitement peut prendre
-        quelques minutes selon le volume de données.
+        {appLabels.rapportGenerationEnCoursIntro}
         <br />
-        Vous recevrez un email à <span className="text-info-1">{email}</span>
-        avec un lien pour télécharger votre rapport dès qu&apos;il sera prêt.
+        {appLabels.vousRecevrezEmailA}
+        <span className="text-info-1">{email}</span>
+        {appLabels.avecLienTelechargerRapport}
       </p>
     </div>
   );

--- a/apps/app/src/referentiels/labellisations/CriteresAction.tsx
+++ b/apps/app/src/referentiels/labellisations/CriteresAction.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import { referentielToName } from '@/app/app/labels';
 import { makeReferentielTacheUrl } from '@/app/app/paths';
 import { TLabellisationParcours } from '@/app/referentiels/labellisations/types';
@@ -23,9 +24,9 @@ export const CriteresAction = (props: TCriteresActionProps) => {
   return (
     <>
       <li className=" mt-4 mb-2">
-        Être une collectivité engagée dans une politique{' '}
-        {referentielToName[referentiel]} et le prouver (via les documents
-        preuves ou un texte justificatif)
+        {appLabels.collectiviteEngageePolitiqueAvecPreuves({
+          referentielName: referentielToName[referentiel],
+        })}
       </li>
       <CritereActionTable {...props} />
     </>
@@ -45,9 +46,9 @@ export const CritereActionTable = (props: TCriteresActionTable) => {
         <thead>
           <tr>
             <th className="pl-10" colSpan={3}>
-              Sous-action ou tâche
+              {appLabels.sousActionOuTache}
             </th>
-            <th className="pr-6">Statut ou score requis</th>
+            <th className="pr-6">{appLabels.statutOuScoreRequis}</th>
           </tr>
         </thead>
         <tbody>

--- a/apps/app/src/referentiels/labellisations/DemandeAuditModal.tsx
+++ b/apps/app/src/referentiels/labellisations/DemandeAuditModal.tsx
@@ -49,11 +49,7 @@ export const DemandeAuditModalContent = (
 
   const aide =
     !labellisable && preuves?.data && !preuves.data.length ? (
-      <p className="text-sm">
-        {
-          '* Pour passer en CNL penser à joindre les documents de labellisation.'
-        }
-      </p>
+      <p className="text-sm">{appLabels.joindreDocumentsLabellisationCNL}</p>
     ) : null;
   const asterique = aide ? '*' : '';
 
@@ -78,7 +74,7 @@ export const DemandeAuditModalContent = (
             <MessageCompletudeECi parcours={parcours} />
             <div className="flex flex-col gap-6 mb-6">
               <p className="mb-0">
-                {"Quel type d'audit souhaitez-vous demander ?"}
+                {appLabels.quelTypeAuditSouhaitezVousDemander}
               </p>
               <RadioButton
                 id="cot"
@@ -121,7 +117,7 @@ export const DemandeAuditModalContent = (
                   }
                 }}
               >
-                {'Envoyer ma demande'}
+                {appLabels.envoyerMaDemande}
               </Button>
               <Button variant="outlined" size="sm" onClick={onClose}>
                 {appLabels.annuler}

--- a/apps/app/src/referentiels/labellisations/MessageCompletudeECi.tsx
+++ b/apps/app/src/referentiels/labellisations/MessageCompletudeECi.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import { ParcoursLabellisation } from '@tet/domain/referentiels';
 import { Alert } from '@tet/ui';
 
@@ -15,20 +16,10 @@ export const MessageCompletudeECi = ({
       description={
         <>
           <p>
-            Pour cet audit ECi, l’ensemble des tâches déclarées « faites » ou «
-            détaillées » comprenant du « fait » doivent présenter des preuves
-            téléchargées au niveau de la sous-action correspondante dans le
-            référentiel.{' '}
-            <b>
-              Aucun auditeur ne pourra être attribué en cas de dossier
-              incomplet.
-            </b>
+            {appLabels.auditEciTachesAvecPreuves}{' '}
+            <b>{appLabels.aucunAuditeurDossierIncomplet}</b>
           </p>
-          <p>
-            Pour rappel, cet audit a un coût qui est aujourd’hui financé par
-            l’ADEME. La validation de votre demande d’audit vous engage à
-            respecter les conditions de complétude.
-          </p>
+          <p>{appLabels.auditCoutAdemeRespectComplétude}</p>
         </>
       }
     />

--- a/apps/app/src/referentiels/referentiel.table/referentiel-table.tsx
+++ b/apps/app/src/referentiels/referentiel.table/referentiel-table.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import {
   ColumnFiltersState,
   flexRender,
@@ -294,7 +295,7 @@ function ReferentielTable({
   if (isEmpty && !hasActiveFilters) {
     return (
       <div className="min-h-96 flex items-center justify-center text-grey-7 bg-white rounded-xl border border-grey-3">
-        Une erreur est survenue lors de la récupération des données
+        {appLabels.erreurRecuperationDonnees}
       </div>
     );
   }
@@ -321,7 +322,7 @@ function TableContent({
             tabIndex={-1}
             className="py-16 text-center text-grey-7"
           >
-            Aucun résultat ne correspond aux filtres sélectionnés
+            {appLabels.aucunResultatCorrespondFiltres}
           </TableCell>
         </TableRow>
       ) : (
@@ -426,7 +427,7 @@ function TableTotalRow({ table }: { table: ReactTable<ActionListItem> }) {
               tabIndex={-1}
               className="font-bold"
             >
-              TOTAL
+              {appLabels.total}
             </TableCell>
           );
         }

--- a/apps/app/src/referentiels/tableau-de-bord/labellisation/LabellisationInfo.tsx
+++ b/apps/app/src/referentiels/tableau-de-bord/labellisation/LabellisationInfo.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import { toLocaleFixed } from '@/app/utils/to-locale-fixed';
 import { ParcoursLabellisation } from '@tet/domain/referentiels';
 import { Tooltip } from '@tet/ui';
@@ -31,18 +32,19 @@ const LabellisationInfo = ({
         label={
           etoiles === 1 ? (
             <p>
-              Reconnaissance obtenue
+              {appLabels.reconnaissanceObtenue}
               {!!dateLabel &&
                 ` le ${new Date(dateLabel).toLocaleDateString('fr')}`}
             </p>
           ) : (
             <>
               <p>
-                Score réalisé : <b>{toLocaleFixed(scoreRealise ?? 0, 2)} %</b>
+                {appLabels.scoreRealiseLabel}{' '}
+                <b>{toLocaleFixed(scoreRealise ?? 0, 2)} %</b>
               </p>
               {!!dateLabel && (
                 <p>
-                  Date de la dernière labellisation :{' '}
+                  {appLabels.dateDerniereLabellisation}{' '}
                   {new Date(dateLabel).toLocaleDateString('fr')}
                 </p>
               )}
@@ -68,7 +70,7 @@ const LabellisationInfo = ({
         <ScoreShow
           score={score.realises / score.max_personnalise}
           percent
-          legend="Score réalisé"
+          legend={appLabels.scoreRealise}
           size="sm"
           bold="value"
         />
@@ -76,7 +78,7 @@ const LabellisationInfo = ({
           score={score.programmes / score.max_personnalise}
           percent
           icon="calendar-line"
-          legend="Score programmé"
+          legend={appLabels.scoreProgramme}
           size="sm"
           bold="value"
         />


### PR DESCRIPTION
…s (batch 2)

Migration de strings JSX en dur vers le catalogue `appLabels.*` sur :
- contacts-modal (CollectivitesEngagees)
- DataSourceTooltip (Indicateurs)
- link-fiches.view (actions liées)
- AccepterCGUModal
- list-invitations.table
- affichage-referentiels.page
- description/index (fiche)
- per-year-table/index (budget)
- CriteresAction (labellisation)

Ajoute ~40 nouvelles clés et 3 helpers de fonction (`resultatCount`, `actionSelectionneeCount`, `labelDeuxPoints`,
`collectiviteEngageePolitiqueAvecPreuves`).