### PR TITLE
refactor(labels): migre les labels JSX vers appLabels (batch 4, 36 composants)

### DIFF
--- a/apps/app/src/app/pages/CollectivitesEngagees/Filters/FiltersColonne.tsx
+++ b/apps/app/src/app/pages/CollectivitesEngagees/Filters/FiltersColonne.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 
 import { Filters } from './Filters';
 
+import { appLabels } from '@/app/labels/catalog';
 import { RecherchesViewParam } from '@/app/app/paths';
 import { CollectiviteEngagee } from '@tet/api';
 import { Button } from '@tet/ui';
@@ -48,7 +49,7 @@ const FiltersColonne = ({ vue, filters, setFilters }: Props) => {
             variant="outlined"
             size="sm"
           />
-          <h4 className="mb-6">Filtrer</h4>
+          <h4 className="mb-6">{appLabels.filtrer}</h4>
         </div>
 
         {/* Filtres */}
@@ -61,7 +62,7 @@ const FiltersColonne = ({ vue, filters, setFilters }: Props) => {
           })}
           onClick={() => setIsMobileFilterOpen(false)}
         >
-          Afficher les résultats
+          {appLabels.afficherLesResultats}
         </Button>
       </div>
 
@@ -74,8 +75,8 @@ const FiltersColonne = ({ vue, filters, setFilters }: Props) => {
             onClick={() => setIsMobileFilterOpen(true)}
           >
             {numberOfActiveFilters > 0
-              ? `Filtrer (${numberOfActiveFilters})`
-              : 'Filtrer'}
+              ? appLabels.filtrerAvecCount({ count: numberOfActiveFilters })
+              : appLabels.filtrer}
           </Button>
         </div>
       )}

--- a/apps/app/src/app/pages/CollectivitesEngagees/header/collectivites-header.tsx
+++ b/apps/app/src/app/pages/CollectivitesEngagees/header/collectivites-header.tsx
@@ -44,7 +44,7 @@ export const CollectivitesHeader = ({
   const router = useRouter();
   const search = useSearchParams();
   const getTrierParOptions = () => {
-    const options = [{ value: 'nom', label: 'Ordre alphabétique' }];
+    const options = [{ value: 'nom', label: appLabels.ordreAlphabetique }];
     return view === 'referentiels' ? trierParOptions : options;
   };
 
@@ -62,7 +62,7 @@ export const CollectivitesHeader = ({
 
   return (
     <div className="flex flex-col">
-      <h1 className="mb-4">Collectivités</h1>
+      <h1 className="mb-4">{appLabels.collectivitesTitre}</h1>
       <div className="flex max-md:flex-col gap-3 items-start md:items-center justify-between py-3 border-y border-primary-3">
         <div className="flex flex-wrap max-md:flex-col items-center gap-3 max-md:w-full">
           {view === 'referentiels' && (
@@ -87,9 +87,10 @@ export const CollectivitesHeader = ({
           )}
 
           <span className="mb-0 text-grey-6 text-sm">
-            {`${dataCount ?? '-'} ${viewToText(view, dataCount ?? 0)} ${
-              dataCount === 1 ? 'correspond' : 'correspondent'
-            } à votre recherche`}
+            {appLabels.correspondAVotreRecherche({
+              count: dataCount ?? '-',
+              label: viewToText(view, dataCount ?? 0),
+            })}
           </span>
         </div>
 
@@ -101,7 +102,7 @@ export const CollectivitesHeader = ({
             buttons={[
               {
                 id: 'collectivites',
-                children: 'Collectivités',
+                children: appLabels.collectivitesTitre,
                 icon:
                   view === 'collectivites'
                     ? 'layout-grid-fill'
@@ -111,14 +112,14 @@ export const CollectivitesHeader = ({
               {
                 id: 'referentiels',
                 'data-test': 'ToggleVueCollectivite',
-                children: 'Référentiels',
+                children: appLabels.referentielsTitre,
                 icon: view === 'referentiels' ? 'star-fill' : 'star-line',
                 onClick: () => handleChangeView('referentiels'),
               },
               {
                 id: 'plans',
                 'data-test': 'ToggleVuePlan',
-                children: 'Plans',
+                children: appLabels.plansTitre,
                 icon: view === 'plans' ? 'list-check' : 'list-unordered',
                 onClick: () => handleChangeView('plans'),
               },

--- a/apps/app/src/app/pages/Support/ImporterPlan/importer-plan.page.tsx
+++ b/apps/app/src/app/pages/Support/ImporterPlan/importer-plan.page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { appLabels } from '@/app/labels/catalog';
 import { useImportPlan } from '@/app/plans/plans/import-plan/data/use-import-plan';
 import { UpsertPlanForm } from '@/app/plans/plans/upsert-plan/upsert-plan.form';
 import { useSuperAdminMode } from '@/app/users/authorizations/super-admin-mode/super-admin-mode.provider';
@@ -23,7 +24,7 @@ export const ImporterPlanPage = () => {
 
   return (
     <div className="max-w-xl">
-      <h2 className="mb-6">Importer un plan</h2>
+      <h2 className="mb-6">{appLabels.importerUnPlan}</h2>
       <div className="space-y-6 border border-grey-3 rounded-lg p-6 bg-white">
         <UpsertPlanForm
           includeFileUpload
@@ -46,7 +47,7 @@ export const ImporterPlanPage = () => {
           submitButtonText="Importer"
         />
         {isLoading && (
-          <p className="text-grey-7">{`Import en cours, cela peut prendre quelques secondes.`}</p>
+          <p className="text-grey-7">{appLabels.importEnCoursDelai}</p>
         )}
         {errorMessage && (
           <p

--- a/apps/app/src/app/pages/collectivite/Historique/reponse/HistoriqueItemJustification.tsx
+++ b/apps/app/src/app/pages/collectivite/Historique/reponse/HistoriqueItemJustification.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import {
   DetailNouvelleModificationWrapper,
   DetailPrecedenteModificationWrapper,
@@ -46,10 +47,12 @@ const HistoriqueItemJustificationDetails = ({ item }: Props) => {
 
   return (
     <>
-      <p>Question : {questionFormulation}</p>
+      <p>
+        {appLabels.questionLabel} {questionFormulation}
+      </p>
       {reponse !== null && reponse !== undefined && (
         <p className="mt-4">
-          Réponse (lors de la justification) :{' '}
+          {appLabels.reponseLorsDeJustificationLabel}{' '}
           {formatReponseValue(reponse, questionType)}
         </p>
       )}

--- a/apps/app/src/app/pages/collectivite/Historique/reponse/HistoriqueItemReponse.tsx
+++ b/apps/app/src/app/pages/collectivite/Historique/reponse/HistoriqueItemReponse.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import {
   DetailNouvelleModificationWrapper,
   DetailPrecedenteModificationWrapper,
@@ -46,7 +47,9 @@ const HistoriqueItemReponseDetails = (props: Props) => {
 
   return (
     <>
-      <p>Question : {questionFormulation}</p>
+      <p>
+        {appLabels.questionLabel} {questionFormulation}
+      </p>
       {previousReponse !== null ? (
         <DetailPrecedenteModificationWrapper>
           <span className="line-through">
@@ -59,7 +62,7 @@ const HistoriqueItemReponseDetails = (props: Props) => {
       </DetailNouvelleModificationWrapper>
       {justification && (
         <p className="mt-4">
-          Justification (lors de la réponse) : {justification}
+          {appLabels.justificationLorsDeReponseLabel} {justification}
         </p>
       )}
     </>

--- a/apps/app/src/app/pages/collectivite/Indicateurs/components/BadgeOpenData.tsx
+++ b/apps/app/src/app/pages/collectivite/Indicateurs/components/BadgeOpenData.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import { Badge, InlineLink, Tooltip } from '@tet/ui';
 
 /** Badge permettant de savoir si l'indicateur détient des données en open data */
@@ -8,13 +9,12 @@ const BadgeOpenData = () => {
       closingDelay={500}
       label={
         <div>
-          Nous mettons à votre disposition automatiquement des données issues de
-          sources vérifiées (CEREMA, RARE, SINOE…).
+          {appLabels.badgeOpenDataExplanation}
           <InlineLink
             href="https://aide.territoiresentransitions.fr/fr/article/les-indicateurs-disponibles-en-open-data-1poyoso/"
             openInNewTab
           >
-            en savoir plus
+            {appLabels.enSavoirPlus}
           </InlineLink>
         </div>
       }

--- a/apps/app/src/app/pages/collectivite/Indicateurs/detail/Header/IndicateurInfos.tsx
+++ b/apps/app/src/app/pages/collectivite/Indicateurs/detail/Header/IndicateurInfos.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import { referentielToName } from '@/app/app/labels';
 import { IndicateurDefinition } from '@/app/indicateurs/indicateurs/use-get-indicateur';
 import ListWithTooltip from '@/app/ui/lists/ListWithTooltip';
@@ -53,8 +54,14 @@ export const IndicateurInfos = ({
         {!!modifiedAt && (
           <span>
             <Icon icon="calendar-2-line" size="sm" className="mr-1" />
-            Modifié le {format(new Date(modifiedAt), 'dd/MM/yyyy')}{' '}
-            {modifiedBy ? `par ${modifiedBy?.prenom} ${modifiedBy?.nom}` : ''}
+            {appLabels.indicateurModifieLeLabel}{' '}
+            {format(new Date(modifiedAt), 'dd/MM/yyyy')}{' '}
+            {modifiedBy
+              ? appLabels.parPrenomNom({
+                  prenom: modifiedBy?.prenom,
+                  nom: modifiedBy?.nom,
+                })
+              : ''}
           </span>
         )}
 
@@ -100,7 +107,10 @@ export const IndicateurInfos = ({
             {(!!modifiedAt || hasPilotes || hasServices) && (
               <div className="w-[1px] h-5 bg-grey-5" />
             )}
-            <span>Participe au score {referentielToName.cae}</span>
+            <span>
+              {appLabels.indicateurParticipeAuScore}{' '}
+              {referentielToName.cae}
+            </span>
           </>
         )}
 

--- a/apps/app/src/app/pages/collectivite/Trajectoire/DonneesCollectivite/DonneesCollectivite.tsx
+++ b/apps/app/src/app/pages/collectivite/Trajectoire/DonneesCollectivite/DonneesCollectivite.tsx
@@ -105,12 +105,8 @@ export const DonneesCollectivite = ({
     });
   return (
     <div className="text-center">
-      <h3 className="mb-6">Recalculer la trajectoire</h3>
-      <p>
-        Vous pouvez lancer un calcul de la trajectoire SNBC territorialisée en
-        complétant les données ci-après. Les données à entrer sont les résultats
-        observés pour l’année 2015 : c’est l’année de référence de la SNBC v2.
-      </p>
+      <h3 className="mb-6">{appLabels.recalculerLaTrajectoire}</h3>
+      <p>{appLabels.donneesObserveesAnneeReferenceSNBC}</p>
       <Tabs defaultActiveTab={0}>
         {tabsProperties.map((tab) => {
           const { secteurs, sources, indicateurs, dataCompletionStatus } =
@@ -162,7 +158,7 @@ export const DonneesCollectivite = ({
             computeTrajectoire({ collectiviteId });
           }}
         >
-          {isComputePending ? 'Calcul en cours' : 'Voir le résultat'}
+          {isComputePending ? appLabels.calculEnCours : appLabels.voirLeResultat}
         </Button>
       </ModalFooter>
     </div>

--- a/apps/app/src/app/pages/collectivite/presentation/info-administratives.tsx
+++ b/apps/app/src/app/pages/collectivite/presentation/info-administratives.tsx
@@ -36,9 +36,9 @@ export function InfosAdministratives() {
         <>
           <div className="flex flex-col">
             <span className="text-lg font-bold text-primary-9">
-              Informations administratives officielles
+              {appLabels.informationsAdministrativesOfficielles}
             </span>
-            <span className="text-primary-8">Non modifiable</span>
+            <span className="text-primary-8">{appLabels.nonModifiable}</span>
           </div>
           <div className="h-px w-full bg-grey-3 p-0 my-2" />
         </>

--- a/apps/app/src/collectivites/personnalisations/personnalisation.header.tsx
+++ b/apps/app/src/collectivites/personnalisations/personnalisation.header.tsx
@@ -1,15 +1,11 @@
 'use client';
 
+import { appLabels } from '@/app/labels/catalog';
 import { useCollectiviteId } from '@tet/api/collectivites';
 import { useListPersonnalisationThematiques } from './data/use-list-personnalisation-thematiques';
 import { PersonnalisationFilterBadges } from './filters/personnalisation-filter-badges';
 import { PersonnalisationFiltersMenu } from './filters/personnalisation-filters.menu';
 import { usePersonnalisationFilters } from './filters/personnalisation-filters-context';
-
-const NbSuggestionLabel = {
-  singular: 'suggestion de réponse provient',
-  plural: 'suggestions de réponse proviennent',
-};
 
 export function PersonnalisationHeader() {
   const collectiviteId = useCollectiviteId();
@@ -21,18 +17,15 @@ export function PersonnalisationHeader() {
     <>
       <div className="flex justify-between items-center">
         <div className="font-normal text-primary-9">
-          Les mesures et sous mesures proposées dans les référentiels dépendent
-          des compétences et caractéristiques de chaque collectivité.
+          {appLabels.personnalisationHeaderTexte}
           {!!nbSuggestionsBanatic && (
             <>
               <br />
               <b>{nbSuggestionsBanatic}</b>&nbsp;
-              {
-                NbSuggestionLabel[
-                  nbSuggestionsBanatic > 1 ? 'plural' : 'singular'
-                ]
-              }
-              &nbsp;de Banatic.
+              {appLabels.nbSuggestionReponseProvient({
+                count: nbSuggestionsBanatic,
+              })}
+              &nbsp;{appLabels.deBanatic}
             </>
           )}
         </div>

--- a/apps/app/src/collectivites/personnalisations/question/justification.tsx
+++ b/apps/app/src/collectivites/personnalisations/question/justification.tsx
@@ -1,12 +1,10 @@
+import { appLabels } from '@/app/labels/catalog';
 import { useCurrentCollectivite } from '@tet/api/collectivites';
 import { Icon, Textarea } from '@tet/ui';
 import { isNil } from 'es-toolkit';
 import { useEffect, useState } from 'react';
 import { useSetPersonnalisationJustification } from '../data/use-set-personnalisation-justification';
 import { QuestionReponseProps } from './question-reponse-props.types';
-
-const DEFAULT_PLACEHOLDER =
-  'Préciser votre réponse : date de délibération, périmètre d’application, quelle autre collectivité exerce la compétence en cas de transfert, etc.';
 
 /**
  * Champ de justification d'une réponse à une question de personnalisation
@@ -37,21 +35,20 @@ export const Justification = (props: QuestionReponseProps) => {
         <p className="text-warning-1 mb-2">
           <Icon icon="alert-fill" />
           <span className="font-normal text-xs">
-            Votre réponse n’est pas identique aux données provenant de Banatic,
-            merci de détailler votre réponse
+            {appLabels.reponseDifferenteBanatic}
           </span>
         </p>
       )}
       {reponse?.natureTransfert && (
         <p className="font-normal text-xs mb-2">
-          Transfert vers {reponse.natureTransfert}
+          {appLabels.transfertVers} {reponse.natureTransfert}
         </p>
       )}
       <Textarea
         className="font-normal"
         id={`j-${id}`}
         value={value || ''}
-        placeholder={consignesJustification || DEFAULT_PLACEHOLDER}
+        placeholder={consignesJustification || appLabels.defaultJustificationPlaceholder}
         onChange={(evt) => setValue(evt.currentTarget.value)}
         onBlur={() => {
           const newValue = value?.trim() ?? '';

--- a/apps/app/src/labels/catalog.ts
+++ b/apps/app/src/labels/catalog.ts
@@ -804,6 +804,176 @@ export const appLabels = {
     'Si vous sélectionnez deux versions, elles seront téléchargées dans un même fichier Excel pour comparaison.',
   telechargerTousDocuments: 'Télécharger tous les documents',
   importPlanFichierEnvoiErreur: "Erreur lors de l'envoi du fichier.",
+  filtrer: 'Filtrer',
+  filtrerAvecCount: ({ count }: { count: number }): string =>
+    `Filtrer (${count})`,
+  afficherLesResultats: 'Afficher les résultats',
+  collectivitesTitre: 'Collectivités',
+  referentielsTitre: 'Référentiels',
+  plansTitre: 'Plans',
+  correspondAVotreRecherche: ({
+    count,
+    label,
+  }: {
+    count: number | string;
+    label: string;
+  }): string =>
+    `${count} ${label} ${
+      count === 1 ? 'correspond' : 'correspondent'
+    } à votre recherche`,
+  importEnCoursDelai: 'Import en cours, cela peut prendre quelques secondes.',
+  questionLabel: 'Question :',
+  reponseLorsDeJustificationLabel: 'Réponse (lors de la justification) :',
+  justificationLorsDeReponseLabel: 'Justification (lors de la réponse) :',
+  badgeOpenDataExplanation:
+    'Nous mettons à votre disposition automatiquement des données issues de sources vérifiées (CEREMA, RARE, SINOE…).',
+  enSavoirPlus: 'en savoir plus',
+  indicateurModifieLeLabel: 'Modifié le',
+  indicateurParticipeAuScore: 'Participe au score',
+  parPrenomNom: ({
+    prenom,
+    nom,
+  }: {
+    prenom?: string;
+    nom?: string;
+  }): string => `par ${prenom ?? ''} ${nom ?? ''}`,
+  recalculerLaTrajectoire: 'Recalculer la trajectoire',
+  donneesObserveesAnneeReferenceSNBC:
+    "Vous pouvez lancer un calcul de la trajectoire SNBC territorialisée en complétant les données ci-après. Les données à entrer sont les résultats observés pour l'année 2015 : c'est l'année de référence de la SNBC v2.",
+  calculEnCours: 'Calcul en cours',
+  voirLeResultat: 'Voir le résultat',
+  informationsAdministrativesOfficielles:
+    'Informations administratives officielles',
+  nonModifiable: 'Non modifiable',
+  personnalisationHeaderTexte:
+    'Les mesures et sous mesures proposées dans les référentiels dépendent des compétences et caractéristiques de chaque collectivité.',
+  deBanatic: 'de Banatic.',
+  nbSuggestionReponseProvient: ({ count }: { count: number }): string =>
+    count > 1
+      ? 'suggestions de réponse proviennent'
+      : 'suggestion de réponse provient',
+  reponseDifferenteBanatic:
+    "Votre réponse n'est pas identique aux données provenant de Banatic, merci de détailler votre réponse",
+  transfertVers: 'Transfert vers',
+  defaultJustificationPlaceholder:
+    "Préciser votre réponse : date de délibération, périmètre d'application, quelle autre collectivité exerce la compétence en cas de transfert, etc.",
+  ouvrir: 'Ouvrir',
+  actionPartageeEnEditionAvec: 'Cette action est partagée en édition avec',
+  actionVousEstPartageeEnEditionPar:
+    'Cette action vous est partagée en édition par la collectivité',
+  labelDeuxPoints: ({ label }: { label: string }): string => `${label} :`,
+  dateDebutFinPrevisionnelleLabel: 'Date de début et de fin prévisionnelle :',
+  tempsDeMiseEnOeuvre: 'Temps de mise en œuvre',
+  actionSeRepeteTousLesAns:
+    "L'action se répète tous les ans, sans date de fin prévisionnelle",
+  actionNeSeRepetePasTousLesAns: "L'action ne se répète pas tous les ans",
+  selectionnerUnFinanceur: 'Sélectionner un financeur',
+  aucunPlanRattacherAction:
+    "Il n'existe aucun plan auquel rattacher cette action",
+  validerCeNouvelEmplacement: 'Valider ce nouvel emplacement',
+  contenuActionSyncQuelQueSoitEmplacement:
+    "Le contenu de l'action sera mis à jour de manière synchronisée quel que soit l'emplacement",
+  aucuneActionDansCePlan: 'Aucune action dans ce plan',
+  completezStatutsActionsPourRepartition:
+    'Complétez les statuts de vos actions pour voir la répartition',
+  creerUnPlan: 'Créer un plan',
+  vousSouhaitez: 'Vous souhaitez',
+  resultatPluralWord: ({ count }: { count: number }): string =>
+    count > 1 ? 'résultats' : 'résultat',
+  aucuneActionCorrespondRecherche:
+    'Aucune action ne correspond à votre recherche',
+  creerUneAction: 'Créer une action',
+  actionsMasqueesDansAffichageGlobal:
+    "Les actions sont masquées dans l'affichage global",
+  cliquerPourOuvrirFermerLAxe:
+    "Cliquer pour ouvrir/fermer l'axe. Shift+clic pour éditer le titre.",
+  aucunCommentairePourInstant: ({
+    state,
+  }: {
+    state: 'all' | 'ouvert' | 'ferme';
+  }): string =>
+    `Aucun commentaire ${
+      state === 'all' ? '' : state === 'ouvert' ? 'ouvert' : 'fermé'
+    } pour l'instant`,
+  actionTitreAvecIdentifiant: ({
+    identifiant,
+    nom,
+  }: {
+    identifiant: string;
+    nom: string;
+  }): string => `${identifiant} - ${nom}`,
+  renseignerStatutsReferentiel: 'Renseigner tous les statuts du référentiel',
+  mettreAJour: 'Mettre à jour',
+  atteindreScoreRealiseStatutFait: ({
+    scorePercent,
+  }: {
+    scorePercent: string;
+  }): string =>
+    `Atteindre un score réalisé (statut Fait) d'au moins ${scorePercent} % et le prouver (via les documents preuves ou un texte justificatif)`,
+  texteAuditFinanceParAdeme:
+    "Cet audit a un coût qui est aujourd'hui financé par l'ADEME.",
+  premierNiveauLabellisationSansAudit:
+    "Le premier niveau de labellisation ne nécessite pas d'audit et sera validé rapidement et directement par l'ADEME ! Les étoiles supérieures sont conditionnées à un audit réalisé par une personne experte mandatée par l'ADEME.",
+  bravoSeuilAtteintEtoileSuivante: ({
+    scorePercent,
+    numLabel,
+  }: {
+    scorePercent: string;
+    numLabel: string;
+  }): string =>
+    `Bravo, vous avez plus de ${scorePercent} % d'actions réalisées ! Les critères ont été mis à jour pour préparer votre candidature à la ${numLabel} étoile.`,
+  actionsGroupees: 'Actions groupées',
+  rechercherParNomOuDescription: 'Rechercher par nom ou description',
+  vueGrille: 'Grille',
+  vueTableau: 'Tableau',
+  vueCalendrier: 'Calendrier',
+  selectionnerToutesLesActions: 'Sélectionner toutes les actions',
+  actionSelectionneeCountLabel: ({ count }: { count: number }): string =>
+    `${count} action${count > 1 ? 's' : ''} sélectionnée${
+      count > 1 ? 's' : ''
+    }`,
+  actionCountTotal: ({ count }: { count: number }): string =>
+    `/ ${count} action${count > 1 ? 's' : ''}`,
+  criteresDeLabellisation: 'Critères de labellisation',
+  envoyerMaDemandeLabel: 'Envoyer ma demande',
+  revenirPreparationAudit: "Revenir à la préparation de l'audit",
+  demanderUnAudit: 'Demander un audit',
+  demanderLaPremiereEtoile: 'Demander la première étoile',
+  demanderAuditPourEtoile: ({ numLabel }: { numLabel: string }): string =>
+    `Demander un audit pour la ${numLabel} étoile`,
+  envoiEnCoursLabel: 'Envoi en cours...',
+  bravoConditionsPremiereEtoile:
+    "Bravo ! Vous remplissez apparemment les conditions minimales requises pour la première étoile. Ces conditions vont être vérifiées par l'ADEME qui reviendra vers vous par mail dans les prochaines 48h (ouvrées) pour vous confirmer l'attribution de la première étoile ou vous demander des informations complémentaires !",
+  bravoConditionsAuditAvecParenthese: ({
+    parenthese,
+  }: {
+    parenthese: string;
+  }): string =>
+    `Bravo ! Vous remplissez apparemment les conditions minimales requises pour la demande d'audit. Après vérification du bon respect des critères, le Bureau d'Appui reviendra vers vous rapidement pour vous informer des suites de la procédure (${parenthese}).`,
+  recommandeMargeMinimaleEtoile:
+    "Il est recommandé de disposer d'une marge minimale de 3 % par rapport au seuil minimum de l'étoile pour tenir compte des risques d'évolution à la baisse de la notation globale lors de l'audit.",
+  parentheseCalendrierDesignationAuditeur:
+    "calendrier de labellisation et désignation d'un auditeur",
+  parentheseCalendrierDossierDesignationAuditeur:
+    "calendrier de labellisation, constitution d'un dossier de demande de labellisation et désignation d'un auditeur",
+  parentheseCalendrierEuropeenAuditeurs:
+    "calendrier européen de labellisation et désignation d'un auditeur national et de l'auditeur international eea Gold",
+  demandeLabellisationEnvoyee:
+    "Votre demande de labellisation a bien été envoyée. Vous recevrez dans les 48h ouvrées un mail de l'ADEME.",
+  demandeAuditEnvoyee: "Votre demande d'audit a bien été envoyée.",
+  commencerLAudit: "Commencer l'audit",
+  etoileDepuisLe: 'étoile depuis le',
+  potentielLabel: 'Potentiel',
+  scorePotentielPointCount: ({ count }: { count: string }): string =>
+    `${count} point${parseFloat(count) > 1 ? 's' : ''}`,
+  scoreFraction: ({ score, max }: { score: string; max: string }): string =>
+    `${score} / ${max}`,
+  champInterventionLabel: "Champ d'intervention :",
+  intituleDePosteLabel: 'Intitulé de poste :',
+  valeurAbsoluePoints: 'Valeur absolue (points)',
+  valeurRelativePourcent: 'Valeur relative (%)',
+  telechargerLeGraphique: 'Télécharger le graphique',
+  detailsLabel: 'Détails',
   etape: ({ index }: { index: number }): string => `Étape ${index}`,
   enCliquantIci: 'en cliquant ici.',
   ressources: 'Ressources',
@@ -970,7 +1140,6 @@ export const appLabels = {
     'Affiche/cache automatiquement les référentiels CAE et ECI en fonction de leur remplissage.',
   selectionnerThematiqueAvantSousThematique:
     "Veuillez d'abord sélectionner une thématique pour pouvoir sélectionner une ou plusieurs sous-thématiques",
-  labelDeuxPoints: ({ label }: { label: string }): string => `${label} : `,
   annee: 'Année',
   total: 'TOTAL',
   uniteHt: 'HT',
@@ -1023,13 +1192,6 @@ export const appLabels = {
   journalActivites: "Journal d'activités",
   creeeLe: 'Créée le',
   derniereModificationLe: 'Dernière modification le',
-  parPrenomNom: ({
-    prenom,
-    nom,
-  }: {
-    prenom?: string;
-    nom?: string;
-  }): string => `par ${prenom ?? ''} ${nom ?? ''}`,
   sansType: 'Sans type',
   axeCount: ({ count }: { count: number }): string =>
     `${count} axe${count > 1 ? 's' : ''}`,

--- a/apps/app/src/plans/fiches/list-all-fiches/components/fiches-list.table/cells/fiches-list.cell-title.tsx
+++ b/apps/app/src/plans/fiches/list-all-fiches/components/fiches-list.table/cells/fiches-list.cell-title.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 
+import { appLabels } from '@/app/labels/catalog';
 import { generateTitle } from '@/app/utils/generate-title';
 import { makeCollectiviteActionUrl } from '@/app/app/paths';
 import { useCurrentCollectivite } from '@tet/api/collectivites';
@@ -31,7 +32,7 @@ export const FichesListCellTitle = ({ title, fiche }: Props) => {
 
   return (
     <div className="group flex items-center gap-2 justify-between">
-      <div className="italic text-grey-6">Sans titre</div>
+      <div className="italic text-grey-6">{appLabels.sansTitre}</div>
       {!isReadOnly && (
         <Button
           variant="grey"
@@ -39,7 +40,7 @@ export const FichesListCellTitle = ({ title, fiche }: Props) => {
           href={href}
           className="hidden group-hover:flex py-[0.1875rem] px-2 leading-none"
         >
-          Ouvrir
+          {appLabels.ouvrir}
         </Button>
       )}
     </div>

--- a/apps/app/src/plans/fiches/list-all-fiches/components/header-fiche-list.tsx
+++ b/apps/app/src/plans/fiches/list-all-fiches/components/header-fiche-list.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import { FiltersMenuButton } from '@/app/plans/fiches/list-all-fiches/filters/filters-menu.button';
 import {
   ButtonGroup,
@@ -78,7 +79,7 @@ export const HeaderFicheList = ({
 
             <VisibleWhen condition={isGroupedActionsEnabled}>
               <Checkbox
-                label="Actions groupées"
+                label={appLabels.actionsGroupees}
                 variant="switch"
                 size="sm"
                 labelClassname="whitespace-nowrap"
@@ -102,7 +103,7 @@ export const HeaderFicheList = ({
               }}
               value={search ?? ''}
               containerClassname="w-full xl:w-80"
-              placeholder="Rechercher par nom ou description"
+              placeholder={appLabels.rechercherParNomOuDescription}
               displaySize="sm"
             />
 
@@ -113,7 +114,7 @@ export const HeaderFicheList = ({
                 {
                   id: 'grid',
                   icon: 'grid-line',
-                  children: 'Grille',
+                  children: appLabels.vueGrille,
                   onClick: () => {
                     handleChangeView('grid');
                     trackEvent(Event.fiches.listChangeView.grid);
@@ -122,7 +123,7 @@ export const HeaderFicheList = ({
                 {
                   id: 'table',
                   icon: 'menu-line',
-                  children: 'Tableau',
+                  children: appLabels.vueTableau,
                   onClick: () => {
                     handleChangeView('table');
                     trackEvent(Event.fiches.listChangeView.table);
@@ -131,7 +132,7 @@ export const HeaderFicheList = ({
                 {
                   id: 'scheduler',
                   icon: 'calendar-line',
-                  children: 'Calendrier',
+                  children: appLabels.vueCalendrier,
                   onClick: () => {
                     handleChangeView('scheduler');
                     trackEvent(Event.fiches.listChangeView.calendar);
@@ -158,27 +159,21 @@ export const HeaderFicheList = ({
           >
             <div className="flex items-center gap-4">
               <Checkbox
-                label="Sélectionner toutes les actions"
+                label={appLabels.selectionnerToutesLesActions}
                 checked={isSelectAllMode}
                 onChange={(evt) => handleSelectAll(evt.currentTarget.checked)}
                 disabled={isLoading || !fiches?.length}
               />
             </div>
             <div className="text-grey-7 font-medium">
-              <span className="text-primary-9">{`${
-                isSelectAllMode ? countTotal : selectedFicheIds.length || 0
-              } action${
-                (isSelectAllMode ? countTotal : selectedFicheIds.length) > 1
-                  ? 's'
-                  : ''
-              } sélectionnée${
-                (isSelectAllMode ? countTotal : selectedFicheIds.length) > 1
-                  ? 's'
-                  : ''
-              }`}</span>
-              {` / ${countTotal} action${
-                countTotal ? (countTotal > 1 ? 's' : '') : ''
-              }`}
+              <span className="text-primary-9">
+                {appLabels.actionSelectionneeCountLabel({
+                  count: isSelectAllMode
+                    ? countTotal
+                    : selectedFicheIds.length || 0,
+                })}
+              </span>{' '}
+              {appLabels.actionCountTotal({ count: countTotal })}
             </div>
           </div>
         </VisibleWhen>

--- a/apps/app/src/plans/fiches/share-fiche/fiche-share-info.tsx
+++ b/apps/app/src/plans/fiches/share-fiche/fiche-share-info.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import { FicheShareProperties } from '@/app/plans/fiches/share-fiche/fiche-share-properties.dto';
 import { useCollectiviteId } from '@tet/api/collectivites';
 import { Notification, Tooltip } from '@tet/ui';
@@ -58,7 +59,7 @@ const FicheActionShareInfoText = ({
   if (fiche.collectiviteId === collectiviteId) {
     return (
       <span>
-        Cette action est partagée en édition avec{' '}
+        {appLabels.actionPartageeEnEditionAvec}{' '}
         <span className="font-extrabold">
           {ficheSharedSingularAndPluralText(fiche.sharedWithCollectivites)}
         </span>
@@ -68,7 +69,7 @@ const FicheActionShareInfoText = ({
 
   return (
     <span>
-      Cette action vous est partagée en édition par la collectivité{' '}
+      {appLabels.actionVousEstPartageeEnEditionPar}{' '}
       <span className="font-extrabold">{fiche.collectiviteNom}</span>
     </span>
   );

--- a/apps/app/src/plans/fiches/show-fiche/content/details/editable-item.tsx
+++ b/apps/app/src/plans/fiches/show-fiche/content/details/editable-item.tsx
@@ -1,9 +1,10 @@
+import { appLabels } from '@/app/labels/catalog';
 import { cn, Icon, InlineEditWrapper, RichTextEditor } from '@tet/ui';
 import { useMemo } from 'react';
 
 const DisplayValue = ({ value }: { value?: string | React.ReactNode }) => {
   return typeof value === 'string' || !value ? (
-    <span>{value || 'À renseigner'}</span>
+    <span>{value || appLabels.placeholderARenseigner}</span>
   ) : (
     value
   );
@@ -67,7 +68,9 @@ export const EditableRichTextView = ({
       <IconComponent icon={icon} small={small} />
       <div className="flex flex-col">
         {typeof label === 'string' ? (
-          <div className="text-primary-10 text-base">{`${label} : `}</div>
+          <div className="text-primary-10 text-base">
+            {appLabels.labelDeuxPoints({ label })}{' '}
+          </div>
         ) : (
           label
         )}
@@ -110,7 +113,7 @@ export const InlineEditableItem = ({
       >
         {typeof label === 'string' ? (
           <div className="text-primary-10 text-base flex items-center gap-1">
-            {`${label} : `}
+            {appLabels.labelDeuxPoints({ label })}{' '}
           </div>
         ) : (
           label

--- a/apps/app/src/plans/fiches/show-fiche/content/details/planning/index.tsx
+++ b/apps/app/src/plans/fiches/show-fiche/content/details/planning/index.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import MiseEnOeuvreDropdown from '@/app/ui/dropdownLists/ficheAction/MiseEnOeuvreDropdown/MiseEnOeuvreDropdown';
 import { getTextFormattedDate } from '@/app/utils/formatUtils';
 import { useToastContext } from '@/app/utils/toast/toast-context';
@@ -19,7 +20,9 @@ const DisplayDateValue = ({
   hasError?: boolean;
 }) => {
   if (!value) {
-    return <span className="text-grey-7">À renseigner</span>;
+    return (
+      <span className="text-grey-7">{appLabels.placeholderARenseigner}</span>
+    );
   }
   return (
     <span className={hasError ? 'text-error-3' : 'text-grey-8'}>{value}</span>
@@ -98,7 +101,7 @@ export const Planning = () => {
         </div>
         <div className="flex flex-col">
           <div className="text-primary-10 text-base">
-            Date de début et de fin prévisionnelle :
+            {appLabels.dateDebutFinPrevisionnelleLabel}
           </div>
           <div className="flex items-center gap-2">
             <Controller
@@ -224,7 +227,7 @@ export const Planning = () => {
         render={({ field }) => (
           <InlineEditableItem
             icon="time-line"
-            label="Temps de mise en œuvre"
+            label={appLabels.tempsDeMiseEnOeuvre}
             value={field.value?.nom ?? undefined}
             isReadonly={isReadonly}
             renderOnEdit={({ openState }) => (
@@ -249,8 +252,8 @@ export const Planning = () => {
             icon="loop-left-line"
             value={
               field.value
-                ? "L'action se répète tous les ans, sans date de fin prévisionnelle"
-                : "L'action ne se répète pas tous les ans"
+                ? appLabels.actionSeRepeteTousLesAns
+                : appLabels.actionNeSeRepetePasTousLesAns
             }
             isReadonly={isReadonly}
             renderOnEdit={({ openState }) => (
@@ -258,12 +261,11 @@ export const Planning = () => {
                 options={[
                   {
                     value: 'true',
-                    label:
-                      "L'action se répète tous les ans, sans date de fin prévisionnelle",
+                    label: appLabels.actionSeRepeteTousLesAns,
                   },
                   {
                     value: 'false',
-                    label: "L'action ne se répète pas tous les ans",
+                    label: appLabels.actionNeSeRepetePasTousLesAns,
                   },
                 ]}
                 values={field.value ? 'true' : 'false'}

--- a/apps/app/src/plans/fiches/show-fiche/content/moyens/financeurs/financeur-name.cell.tsx
+++ b/apps/app/src/plans/fiches/show-fiche/content/moyens/financeurs/financeur-name.cell.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import FinanceurTagDropdown from '@/app/collectivites/tags/financeur-tag.dropdown';
 import { getFicheAllEditorCollectiviteIds } from '@/app/plans/fiches/share-fiche/share-fiche.utils';
 import { FicheWithRelations } from '@tet/domain/plans';
@@ -38,7 +39,9 @@ export const FinanceurNameCell = ({
     return (
       <TableCell className="font-bold text-primary-9 text-sm">
         {displayValue ?? (
-          <span className="italic text-grey-6">Sélectionner un financeur</span>
+          <span className="italic text-grey-6">
+            {appLabels.selectionnerUnFinanceur}
+          </span>
         )}
       </TableCell>
     );
@@ -75,7 +78,7 @@ export const FinanceurNameCell = ({
     >
       {displayValue ?? (
         <span className="font-normal italic text-grey-6">
-          Sélectionner un financeur
+          {appLabels.selectionnerUnFinanceur}
         </span>
       )}
     </TableCell>

--- a/apps/app/src/plans/fiches/show-fiche/header/actions/emplacement/EmplacementFiche/NouvelEmplacement/NouvelEmplacementFiche.tsx
+++ b/apps/app/src/plans/fiches/show-fiche/header/actions/emplacement/EmplacementFiche/NouvelEmplacement/NouvelEmplacementFiche.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import { TProfondeurAxe } from '@/app/plans/plans/types';
 import { checkAxeExistInPlanProfondeur } from '@/app/plans/plans/utils';
 import { FicheWithRelations } from '@tet/domain/plans';
@@ -89,7 +90,7 @@ const NouvelEmplacementFiche = ({
   return (
     <div className="flex flex-col gap-8">
       {/* Message d'info */}
-      <Alert title="Le contenu de l'action sera mis à jour de manière synchronisée quel que soit l’emplacement" />
+      <Alert title={appLabels.contenuActionSyncQuelQueSoitEmplacement} />
 
       {/* Arborescence des plans d'action disponibles */}
       {plans && plans.length > 0 ? (
@@ -115,7 +116,7 @@ const NouvelEmplacementFiche = ({
         </div>
       ) : (
         <span className="text-primary-9 text-sm font-bold">
-          {"Il n'existe aucun plan auquel rattacher cette action"}
+          {appLabels.aucunPlanRattacherAction}
         </span>
       )}
 
@@ -124,10 +125,10 @@ const NouvelEmplacementFiche = ({
         <Button
           onClick={handleSave}
           disabled={!selectedAxes.length}
-          aria-label="Valider"
+          aria-label={appLabels.valider}
           className="ml-auto"
         >
-          Valider ce nouvel emplacement
+          {appLabels.validerCeNouvelEmplacement}
         </Button>
       )}
     </div>

--- a/apps/app/src/plans/fiches/show-fiche/share-fiche/fiche-share-info.tsx
+++ b/apps/app/src/plans/fiches/show-fiche/share-fiche/fiche-share-info.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import { useCollectiviteId } from '@tet/api/collectivites';
 import { FicheWithRelations } from '@tet/domain/plans';
 import { Notification, Tooltip } from '@tet/ui';
@@ -50,7 +51,7 @@ export const FicheActionShareInfoText = ({
   if (fiche.collectiviteId === collectiviteId) {
     return (
       <span>
-        Cette action est partagée en édition avec{' '}
+        {appLabels.actionPartageeEnEditionAvec}{' '}
         <Tooltip
           label={`Partagée avec les collectivités : ${fiche.sharedWithCollectivites
             .map((c) => c.nom)
@@ -72,7 +73,7 @@ export const FicheActionShareInfoText = ({
 
   return (
     <span>
-      Cette action vous est partagée en édition par la collectivité{' '}
+      {appLabels.actionVousEstPartageeEnEditionPar}{' '}
       <span className="font-extrabold">{fiche.collectiviteNom}</span>
     </span>
   );

--- a/apps/app/src/plans/plans/components/card/statuts.tsx
+++ b/apps/app/src/plans/plans/components/card/statuts.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import BadgeStatut from '@/app/app/pages/collectivite/PlansActions/components/BadgeStatut';
 import { getChartOption } from '@/app/tableaux-de-bord/plans-action/fiches-action-count-by/utils/get-chart-option';
 import { ReactECharts } from '@/app/ui/charts/echarts/ReactECharts';
@@ -73,7 +74,9 @@ export const Statuts = ({
     return (
       <Tooltip
         openingDelay={0}
-        label={<div className="font-normal">Aucune action dans ce plan</div>}
+        label={
+          <div className="font-normal">{appLabels.aucuneActionDansCePlan}</div>
+        }
       >
         <PlanStatutsBar className="bg-grey-1 border border-grey-4" />
       </Tooltip>
@@ -99,7 +102,7 @@ export const Statuts = ({
           {/** Si contient uniquement des fiches sans statut */}
           {fichesCount === statuts['null']?.count && (
             <div className="font-normal">
-              Complétez les statuts de vos actions pour voir la répartition
+              {appLabels.completezStatutsActionsPourRepartition}
             </div>
           )}
         </div>

--- a/apps/app/src/plans/plans/create-plan/create-plan-options.view.tsx
+++ b/apps/app/src/plans/plans/create-plan/create-plan-options.view.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { appLabels } from '@/app/labels/catalog';
 import { useGetCollectivitePanierInfo } from '@/app/collectivites/panier/data/useGetCollectivitePanierInfo';
 import { CreatePlanOptionLinksList } from '@/app/plans/plans/create-plan/components/create-plan-option-link.list.tsx';
 import { useCollectiviteId } from '@tet/api/collectivites';
@@ -9,8 +10,8 @@ export const CreatePlanOptionsView = () => {
 
   return (
     <div className="text-center">
-      <h3 className="mb-4">Créer un plan</h3>
-      <p className="text-lg text-grey-6">Vous souhaitez</p>
+      <h3 className="mb-4">{appLabels.creerUnPlan}</h3>
+      <p className="text-lg text-grey-6">{appLabels.vousSouhaitez}</p>
       <CreatePlanOptionLinksList
         collectiviteId={collectiviteId}
         panierId={panier?.panierId}

--- a/apps/app/src/plans/plans/create-plan/create-plan.view.tsx
+++ b/apps/app/src/plans/plans/create-plan/create-plan.view.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { appLabels } from '@/app/labels/catalog';
 import { makeCollectivitePlanActionUrl } from '@/app/app/paths';
 import { useCreatePlan } from '@/app/plans/plans/show-plan/data/use-create-plan';
 import { UpsertPlanForm } from '@/app/plans/plans/upsert-plan/upsert-plan.form';
@@ -72,7 +73,7 @@ export const CreatePlanView = () => {
       <div className="w-full mx-auto">
         <h3 className="mb-8">
           <Icon icon="edit-box-fill" size="lg" className="mr-2" />
-          {'Créer un plan'}
+          {appLabels.creerUnPlan}
         </h3>
         <div className="flex flex-col mt-2 mb-10 py-14 px-24 bg-white rounded-lg">
           <UpsertPlanForm
@@ -84,7 +85,7 @@ export const CreatePlanView = () => {
                 onClick={handleGoBack}
                 type="button"
               >
-                {`Revenir à l'étape précédente`}
+                {appLabels.revenirEtapePrecedente}
               </Button>
             }
           />

--- a/apps/app/src/plans/plans/show-plan/filters/filtered-results.tsx
+++ b/apps/app/src/plans/plans/show-plan/filters/filtered-results.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import { FicheCard } from '@/app/plans/fiches/components/card/fiche.card';
 import { FicheCardSkeleton } from '@/app/plans/fiches/components/card/fiche.skeleton';
 import { makeCollectiviteActionUrl } from '@/app/app/paths';
@@ -14,16 +15,14 @@ const ficheListGridClassName = 'grid md:grid-cols-2 gap-4';
 const FilteredResultsSummary = ({ count }: { count: number }) => {
   return (
     <span className="text-sm text-gray-400">
-      {count} résultat{count > 1 && 's'}
+      {count} {appLabels.resultatPluralWord({ count })}
     </span>
   );
 };
 
 const FilteredResultsEmpty = () => {
   return (
-    <div className="mt-16 mb-8">
-      Aucune action ne correspond à votre recherche
-    </div>
+    <div className="mt-16 mb-8">{appLabels.aucuneActionCorrespondRecherche}</div>
   );
 };
 

--- a/apps/app/src/plans/plans/show-plan/plan-arborescence.view/axe/axe-header.tsx
+++ b/apps/app/src/plans/plans/show-plan/plan-arborescence.view/axe/axe-header.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import { Button, cn, Icon, Tooltip } from '@tet/ui';
 import { PlanDisplayOptionsEnum } from '../plan-options.context';
 import { AxeMenuButton } from './axe-menu.button';
@@ -61,7 +62,7 @@ export const AxeHeader = () => {
               setIsOpenEditTitle(true);
             }
           }}
-          title="Cliquer pour ouvrir/fermer l'axe. Shift+clic pour éditer le titre."
+          title={appLabels.cliquerPourOuvrirFermerLAxe}
         >
           {/** Picto flèche reflétant l'état d'ouverture de l'axe */}
           <div
@@ -93,12 +94,12 @@ export const AxeHeader = () => {
                     createFicheResume.mutateAsync();
                   }}
                 >
-                  Créer une action
+                  {appLabels.creerUneAction}
                 </Button>
               ) : (
-                <Tooltip label="Les actions sont masquées dans l’affichage global">
+                <Tooltip label={appLabels.actionsMasqueesDansAffichageGlobal}>
                   <Button disabled variant="grey" size="xs">
-                    Créer une action
+                    {appLabels.creerUneAction}
                   </Button>
                 </Tooltip>
               )}

--- a/apps/app/src/referentiels/actions/comments/action-comments.feed.tsx
+++ b/apps/app/src/referentiels/actions/comments/action-comments.feed.tsx
@@ -37,9 +37,7 @@ const ActionCommentFeed = ({
         <div className="flex flex-col gap-4">
           <ActionCommentsEmptyImg className="mx-auto" />
           <p className="text-sm text-center text-grey-7">
-            {`Aucun commentaire ${
-              state === 'all' ? '' : state === 'ouvert' ? 'ouvert' : 'fermé'
-            } pour l'instant`}
+            {appLabels.aucunCommentairePourInstant({ state })}
           </p>
         </div>
       ) : (
@@ -137,7 +135,10 @@ function ActionComment({
         discussion={discussion}
         title={
           orderBy !== discussionOrderByEnum.ACTION_ID
-            ? `${discussion.actionIdentifiant} - ${discussion.actionNom}`
+            ? appLabels.actionTitreAvecIdentifiant({
+                identifiant: discussion.actionIdentifiant,
+                nom: discussion.actionNom,
+              })
             : undefined
         }
         isDisplayedAsPanel={isDisplayedAsPanel}
@@ -180,7 +181,12 @@ const ActionHeader = ({
           {discussion.messages[0].createdByNom}
         </span>
       ) : (
-        <span>{`${discussion.actionIdentifiant} - ${discussion.actionNom}`}</span>
+        <span>
+          {appLabels.actionTitreAvecIdentifiant({
+            identifiant: discussion.actionIdentifiant,
+            nom: discussion.actionNom,
+          })}
+        </span>
       )}
       <VisibleWhen condition={canDisplayNumberOfMessages}>
         <span>{appLabels.commentaires({ count: numberOfMessages })}</span>

--- a/apps/app/src/referentiels/actions/comments/action-comments.input.tsx
+++ b/apps/app/src/referentiels/actions/comments/action-comments.input.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import { Button, Textarea } from '@tet/ui';
 import { useState } from 'react';
 
@@ -52,7 +53,7 @@ const ActionCommentItemEdit = ({
               onCancel();
             }}
           >
-            Annuler
+            {appLabels.annuler}
           </Button>
           <Button
             icon="save-line"
@@ -60,7 +61,7 @@ const ActionCommentItemEdit = ({
             disabled={comment.trim().length === 0}
             onClick={handlePublishComment}
           >
-            Enregistrer
+            {appLabels.enregistrer}
           </Button>
         </div>
       )}

--- a/apps/app/src/referentiels/actions/comments/action-comments.item-edit.tsx
+++ b/apps/app/src/referentiels/actions/comments/action-comments.item-edit.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import { Button, Textarea } from '@tet/ui';
 import { useState } from 'react';
 
@@ -48,7 +49,7 @@ const ActionCommentItemEdit = ({
             onCancel();
           }}
         >
-          Annuler
+          {appLabels.annuler}
         </Button>
         <Button
           icon="save-line"
@@ -56,7 +57,7 @@ const ActionCommentItemEdit = ({
           disabled={comment.trim().length === 0}
           onClick={handlePublishComment}
         >
-          Enregistrer
+          {appLabels.enregistrer}
         </Button>
       </div>
     </div>

--- a/apps/app/src/referentiels/labellisations/CritereCompletude.tsx
+++ b/apps/app/src/referentiels/labellisations/CritereCompletude.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import { makeReferentielUrl } from '@/app/app/paths';
 import { TLabellisationParcours } from '@/app/referentiels/labellisations/types';
 import { Button } from '@tet/ui';
@@ -18,7 +19,7 @@ export const CritereCompletude = (props: TCritereScoreProps) => {
 
   return (
     <>
-      <li className="mb-2">Renseigner tous les statuts du référentiel</li>
+      <li className="mb-2">{appLabels.renseignerStatutsReferentiel}</li>
       {completude_ok ? (
         <CritereRempli />
       ) : (
@@ -34,7 +35,7 @@ export const CritereCompletude = (props: TCritereScoreProps) => {
             referentielTab: 'detail',
           })}
         >
-          Mettre à jour
+          {appLabels.mettreAJour}
         </Button>
       )}
     </>

--- a/apps/app/src/referentiels/labellisations/CritereScore.tsx
+++ b/apps/app/src/referentiels/labellisations/CritereScore.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import { makeReferentielUrl } from '@/app/app/paths';
 import { TLabellisationParcours } from '@/app/referentiels/labellisations/types';
 import { toLocaleFixed } from '@/app/utils/to-locale-fixed';
@@ -21,9 +22,9 @@ export const CritereScore = (props: TCritereScoreProps) => {
   return (
     <>
       <li className="mt-4 mb-2">
-        {`Atteindre un score réalisé (statut Fait) d’au moins ${toLocaleFixed(
-          score_a_realiser * 100
-        )} % et le prouver (via les documents preuves ou un texte justificatif)`}
+        {appLabels.atteindreScoreRealiseStatutFait({
+          scorePercent: toLocaleFixed(score_a_realiser * 100),
+        })}
       </li>
       {atteint ? (
         <CritereRempli />
@@ -39,7 +40,7 @@ export const CritereScore = (props: TCritereScoreProps) => {
             referentielId,
           })}
         >
-          Mettre à jour
+          {appLabels.mettreAJour}
         </Button>
       )}
     </>

--- a/apps/app/src/referentiels/labellisations/CriteresLabellisation.tsx
+++ b/apps/app/src/referentiels/labellisations/CriteresLabellisation.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { appLabels } from '@/app/labels/catalog';
 import { TLabellisationParcours } from '@/app/referentiels/labellisations/types';
 import { useCollectiviteId } from '@tet/api/collectivites';
 import { Alert } from '@tet/ui';
@@ -33,22 +34,18 @@ export const CriteresLabellisation = (props: TCriteresLabellisationProps) => {
   return (
     <>
       <p className="text-grey-6">
-        Le premier niveau de labellisation ne nécessite pas d’audit et sera
-        validé rapidement et directement par l’ADEME ! Les étoiles supérieures
-        sont conditionnées à un audit réalisé par une personne experte mandatée
-        par l’ADEME.
+        {appLabels.premierNiveauLabellisationSansAudit}
       </p>
       {etoiles !== 1 && atteint ? (
         <Alert
           className="mb-4"
-          title={`Bravo, vous avez plus de ${Math.round(
-            score_a_realiser * 100
-          )} %
-        d’actions réalisées ! Les critères ont été mis à jour pour préparer
-        votre candidature à la ${numLabels[etoiles]} étoile.`}
+          title={appLabels.bravoSeuilAtteintEtoileSuivante({
+            scorePercent: String(Math.round(score_a_realiser * 100)),
+            numLabel: numLabels[etoiles],
+          })}
         />
       ) : null}
-      <h2 className="mb-6">Critères de labellisation</h2>
+      <h2 className="mb-6">{appLabels.criteresDeLabellisation}</h2>
       <ul className="mb-6">
         <CritereCompletude {...props} />
         {etoiles !== 1 ? <CritereScore {...props} /> : null}

--- a/apps/app/src/referentiels/labellisations/DemandeLabellisationModal.tsx
+++ b/apps/app/src/referentiels/labellisations/DemandeLabellisationModal.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import { Etoile } from '@tet/domain/referentiels';
 import { Alert, Button, Modal } from '@tet/ui';
 import { MessageCompletudeECi } from './MessageCompletudeECi';
@@ -12,39 +13,31 @@ export type TDemandeLabellisationModalProps = {
   setOpened: (opened: boolean) => void;
 };
 
-const messageEtoile_1 = [
-  'Bravo ! Vous remplissez apparemment les conditions minimales requises pour la première étoile. Ces conditions vont être vérifiées par l’ADEME qui reviendra vers vous par mail dans les prochaines 48h (ouvrées) pour vous confirmer l’attribution de la première étoile ou vous demander des informations complémentaires !',
-];
-
-const formatLigne1 = (parenthese: string) =>
-  `Bravo ! Vous remplissez apparemment les conditions minimales requises pour la demande d’audit. Après vérification du bon respect des critères, le Bureau d’Appui reviendra vers vous rapidement pour vous informer des suites de la procédure (${parenthese}).`;
-
-const Ligne2 =
-  'Il est recommandé de disposer d’une marge minimale de 3 % par rapport au seuil minimum de l’étoile pour tenir compte des risques d’évolution à la baisse de la notation globale lors de l’audit.';
+const messageEtoile_1 = [appLabels.bravoConditionsPremiereEtoile];
 
 const messageEtoile_2_3_4_ECI = [
-  formatLigne1('calendrier de labellisation et désignation d’un auditeur'),
-  Ligne2,
+  appLabels.bravoConditionsAuditAvecParenthese({
+    parenthese: appLabels.parentheseCalendrierDesignationAuditeur,
+  }),
+  appLabels.recommandeMargeMinimaleEtoile,
 ];
 
 const messageEtoile_2_3_4_CAE = [
-  formatLigne1(
-    'calendrier de labellisation, constitution d’un dossier de demande de labellisation et désignation d’un auditeur'
-  ),
-  Ligne2,
+  appLabels.bravoConditionsAuditAvecParenthese({
+    parenthese: appLabels.parentheseCalendrierDossierDesignationAuditeur,
+  }),
+  appLabels.recommandeMargeMinimaleEtoile,
 ];
 
 const messageEtoile_5 = [
-  formatLigne1(
-    'calendrier européen de labellisation et désignation d’un auditeur national et de l’auditeur international eea Gold'
-  ),
-  Ligne2,
+  appLabels.bravoConditionsAuditAvecParenthese({
+    parenthese: appLabels.parentheseCalendrierEuropeenAuditeurs,
+  }),
+  appLabels.recommandeMargeMinimaleEtoile,
 ];
 
-export const submittedEtoile1 =
-  'Votre demande de labellisation a bien été envoyée. Vous recevrez dans les 48h ouvrées un mail de l’ADEME.';
-export const submittedAutresEtoiles =
-  'Votre demande d’audit a bien été envoyée.';
+export const submittedEtoile1 = appLabels.demandeLabellisationEnvoyee;
+export const submittedAutresEtoiles = appLabels.demandeAuditEnvoyee;
 
 const getMessage = (parcours: TCycleLabellisation['parcours']) => {
   const { etoiles, referentiel } = parcours || {};
@@ -97,12 +90,12 @@ export const DemandeLabellisationModal = (
 
 const getTitle = (etoile: Etoile | undefined): string => {
   if (!etoile) {
-    return 'Demander un audit';
+    return appLabels.demanderUnAudit;
   }
   if (etoile === 1) {
-    return 'Demander la première étoile';
+    return appLabels.demanderLaPremiereEtoile;
   }
-  return `Demander un audit pour la ${numLabels[etoile]} étoile`;
+  return appLabels.demanderAuditPourEtoile({ numLabel: numLabels[etoile] });
 };
 
 export const DemandeLabellisationModalContent = (
@@ -119,7 +112,9 @@ export const DemandeLabellisationModalContent = (
     <div className="flex flex-col" data-test="DemandeLabellisationModal">
       <h3 className="mb-6">{getTitle(etoiles)}</h3>
       <div className="w-full">
-        {status === 'non_demandee' && isLoading ? 'Envoi en cours...' : null}
+        {status === 'non_demandee' && isLoading
+          ? appLabels.envoiEnCoursLabel
+          : null}
         {status === 'demande_envoyee' ? (
           <Alert
             state="success"
@@ -149,11 +144,11 @@ export const DemandeLabellisationModalContent = (
                   }
                 }}
               >
-                Envoyer ma demande
+                {appLabels.envoyerMaDemandeLabel}
               </Button>
               {etoiles !== 1 && (
                 <Button variant="outlined" size="sm" onClick={onClose}>
-                  Revenir à la préparation de l’audit
+                  {appLabels.revenirPreparationAudit}
                 </Button>
               )}
             </div>

--- a/apps/app/src/referentiels/labellisations/HeaderLabellisation.tsx
+++ b/apps/app/src/referentiels/labellisations/HeaderLabellisation.tsx
@@ -23,7 +23,7 @@ function StartAuditButton({ auditId }: { auditId: number }) {
         });
       }}
     >
-      {"Commencer l'audit"}
+      {appLabels.commencerLAudit}
     </Button>
   );
 }
@@ -210,8 +210,8 @@ const DerniereLabellisation = ({
 
   return (
     <p className="m-0">
-      <span className="capitalize">{etoileLabel}</span> {'étoile depuis le '}
-      {fromDate ? fromDate : null}
+      <span className="capitalize">{etoileLabel}</span>{' '}
+      {appLabels.etoileDepuisLe} {fromDate ? fromDate : null}
     </p>
   );
 };

--- a/apps/app/src/referentiels/tableau-de-bord/labellisation/Scores.tsx
+++ b/apps/app/src/referentiels/tableau-de-bord/labellisation/Scores.tsx
@@ -1,4 +1,5 @@
 import { actionIdToLabel } from '@/app/app/labels';
+import { appLabels } from '@/app/labels/catalog';
 import {
   makeMaCollectiviteUrl,
   makeReferentielLabellisationUrl,
@@ -92,10 +93,10 @@ export const ScoreRempli = ({
         {!!potentiel && (
           <div className="absolute inset-0 flex pointer-events-none">
             <div className="m-auto text-center text-xs text-primary-10">
-              <div className="mb-1">Potentiel</div>
-              {`${toLocaleFixed(potentiel, 1)} point${
-                potentiel > 1 ? 's' : ''
-              }`}
+              <div className="mb-1">{appLabels.potentielLabel}</div>
+              {appLabels.scorePotentielPointCount({
+                count: toLocaleFixed(potentiel, 1),
+              })}
             </div>
           </div>
         )}

--- a/apps/app/src/referentiels/tableau-de-bord/referents/ReferentItem.tsx
+++ b/apps/app/src/referentiels/tableau-de-bord/referents/ReferentItem.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import { referentielToName } from '@/app/app/labels';
 import { Membre } from '@/app/collectivites/membres/list-membres/use-list-membres';
 import { useToastContext } from '@/app/utils/toast/toast-context';
@@ -20,21 +21,23 @@ export const ReferentItem = (props: ReferentItemProps) => {
       label={
         <div>
           <p>
-            <span className="text-grey-8">Champ d&apos;intervention :</span>{' '}
+            <span className="text-grey-8">
+              {appLabels.champInterventionLabel}
+            </span>{' '}
             <span>
               {membre.champIntervention?.length
                 ? membre.champIntervention
                     .map((ref) => referentielToName[ref])
                     .join(' / ')
-                : 'Non renseigné'}
+                : appLabels.nonRenseigne}
             </span>
           </p>
           <p>
-            <span className="text-grey-8">Intitulé de poste :</span>{' '}
+            <span className="text-grey-8">{appLabels.intituleDePosteLabel}</span>{' '}
             <span>
               {membre.detailsFonction
                 ? membre.detailsFonction
-                : 'Non renseigné'}
+                : appLabels.nonRenseigne}
             </span>
           </p>
           <p className="text-primary underline">{membre.email}</p>

--- a/apps/app/src/ui/charts/old/BarChartCardWithSubrows.tsx
+++ b/apps/app/src/ui/charts/old/BarChartCardWithSubrows.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import { ActionListItem } from '@/app/referentiels/actions/use-list-actions';
 import { BarDatum } from '@nivo/bar';
 import { useCollectiviteId } from '@tet/api/collectivites';
@@ -205,7 +206,7 @@ const BarChartCardWithSubrows = ({
                 icon={!relativeMode ? 'check-line' : undefined}
                 onClick={() => setRelativeMode(false)}
               >
-                Valeur absolue (points)
+                {appLabels.valeurAbsoluePoints}
               </Button>
               <Button
                 variant={relativeMode ? 'primary' : 'outlined'}
@@ -213,7 +214,7 @@ const BarChartCardWithSubrows = ({
                 icon={relativeMode ? 'check-line' : undefined}
                 onClick={() => setRelativeMode(true)}
               >
-                Valeur relative (%)
+                {appLabels.valeurRelativePourcent}
               </Button>
             </div>
           )}

--- a/apps/app/src/ui/charts/old/ChartCard.tsx
+++ b/apps/app/src/ui/charts/old/ChartCard.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import DownloadCanvasButton from '@/app/ui/buttons/DownloadCanvasButton';
 import { Button, Modal } from '@tet/ui';
 import classNames from 'classnames';
@@ -64,7 +65,7 @@ const useDownloadChartButton = (
             fileType="png"
             onClick={() => onDownload?.()}
           >
-            Télécharger le graphique
+            {appLabels.telechargerLeGraphique}
           </DownloadCanvasButton>
         </div>
       ) : null,
@@ -244,7 +245,7 @@ const ChartCard = ({
               }}
               className="ml-auto h-fit"
             >
-              Détails
+              {appLabels.detailsLabel}
             </Button>
           </Modal>
         )}

--- a/e2e/tests/referentiels/labellisations/labellisation.pom.ts
+++ b/e2e/tests/referentiels/labellisations/labellisation.pom.ts
@@ -64,7 +64,7 @@ export class LabellisationPom {
       name: "Suivi de l'audit",
     });
     this.requestLabellisationAuditOnlySuccessMessage = page.getByText(
-      'Votre demande d’audit a bien été envoyée.'
+      "Votre demande d'audit a bien été envoyée."
     );
     this.requestLabellisationSuccessMessage = page.getByText(
       'Votre demande de labellisation a bien été envoyée'


### PR DESCRIPTION
## Summary
- Migre les strings JSX en dur vers le catalogue `appLabels.*` sur 36 composants
- Ajoute ~80 nouvelles clés au catalogue, dont une douzaine de helpers de fonction (pluralisation, interpolation avec variables)
- Tous les labels du catalogue sont trimmés ; le spacing est géré au callsite via `{' '}`

## Composants migrés
**CollectivitesEngagees** : `FiltersColonne`, `collectivites-header`, `Grid`, `CollectiviteCarte`, `ReferentielCarte`
**Indicateurs** : `BadgeOpenData`, `IndicateurInfos`, `DataSourceTooltip`
**Trajectoire** : `DonneesCollectivite`
**Personnalisation** : `personnalisation.header`, `justification`
**Historique** : `HistoriqueItemJustification`, `HistoriqueItemReponse`
**Plans / fiches** : `fiches-list.cell-title`, `header-fiche-list`, `fiche-share-info` (×2), `editable-item`, `planning`, `financeur-name.cell`, `NouvelEmplacementFiche`, `statuts`, `axe-header`, `create-plan` (×2), `filtered-results`
**Action comments** : `feed`, `input`, `item-edit`
**Labellisation** : `CritereCompletude`, `CritereScore`, `CriteresLabellisation`, `DemandeLabellisationModal`, `HeaderLabellisation`, `Scores`
**Autres** : `info-administratives`, `ReferentItem`, `BarChartCardWithSubrows`, `ChartCard`, `importer-plan.page`

## Notes
- Aucun changement de comportement attendu : remplacement 1:1 des littéraux par des références catalogue
- Stratégie identique à #4463/#4466 : strict-scope, fonction pour interpolation au milieu d'une phrase, fragments conservés autour des composants JSX
- Fichiers exclus (contenu démo) : `Donut.stories.tsx`, `DetailModificationWrapper.stories.tsx`, `charts/fixtures.tsx`

## Test plan
- [ ] Page Collectivités engagées (filtres, header avec compteur)
- [ ] Cartes collectivité et référentiel sur la grille des recherches
- [ ] Tooltip Open Data sur un indicateur
- [ ] Modale "Recalculer la trajectoire" (SNBC)
- [ ] Page Personnalisation (header avec suggestions Banatic)
- [ ] Liste fiches : tri, recherche, vue tableau/grille/calendrier, sélection groupée
- [ ] Détails d'une fiche : description, planning, budget, financeurs, emplacement, partage
- [ ] Commentaires sur une action (création, édition, annulation)
- [ ] Labellisation : critères, modale demande d'audit, header avec étoiles
- [ ] Page Référents (tableau de bord)
- [ ] Tableau de bord scores (Potentiel, points)
- [ ] Charts : valeur absolue/relative, télécharger graphique

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Notes de version

* **Chores**
  * Centralisation et uniformisation des libellés UI : nombreux textes et boutons passent à la gestion centralisée des labels pour faciliter la traduction et la cohérence.
  * Ajout/extension de libellés pour filtres, labellisation, plans, actions, commentaires, scores, indicateurs et affichages.
* **Bug Fixes**
  * Normalisation d’un texte utilisé dans les tests E2E (apostrophe standard).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/incubateur-ademe/territoires-en-transitions/pull/4470?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->