### PR TITLE
fix(referentiels): réserve la génération d'archive de preuves aux auditeurs

### DIFF
--- a/apps/backend/src/referentiels/preuves-archive/preuves-archive.full-pipeline.e2e-spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/preuves-archive.full-pipeline.e2e-spec.ts
@@ -7,6 +7,7 @@ import { preuveLabellisationTable } from '@tet/backend/collectivites/documents/m
 import { storageObjectTable } from '@tet/backend/collectivites/documents/models/storage-object.table';
 import { collectiviteBucketTable } from '@tet/backend/collectivites/shared/models/collectivite-bucket.table';
 import { auditTable } from '@tet/backend/referentiels/labellisations/audit.table';
+import { addAuditeurPermission } from '@tet/backend/referentiels/labellisations/labellisations.test-fixture';
 import { labellisationDemandeTable } from '@tet/backend/referentiels/labellisations/labellisation-demande.table';
 import {
   getAuthUserFromUserCredentials,
@@ -55,6 +56,7 @@ describe('Archive de preuves - pipeline complet (ZIP réel)', () => {
   let collectivite: Collectivite;
   let adminUser: AuthenticatedUser;
   let cleanupCollectivite: () => Promise<void>;
+  let auditeurCleanup: (() => Promise<void>) | null = null;
   let capturedZipDir: string;
   let capturedZipPath: string | null = null;
 
@@ -137,6 +139,9 @@ describe('Archive de preuves - pipeline complet (ZIP réel)', () => {
           like(storageObjectTable.name, `%${collectivite.id}`)
         )
       );
+    if (auditeurCleanup) {
+      await auditeurCleanup();
+    }
     await db.db
       .delete(auditTable)
       .where(eq(auditTable.collectiviteId, collectivite.id));
@@ -169,6 +174,12 @@ describe('Archive de preuves - pipeline complet (ZIP réel)', () => {
       .returning();
     const demandeId = demande.id;
     const auditId = audit.id;
+
+    ({ cleanup: auditeurCleanup } = await addAuditeurPermission({
+      databaseService: db,
+      auditId,
+      userId: adminUser.id,
+    }));
 
     const { archiveId } = await caller.referentiels.preuvesArchive.request({
       collectiviteId: collectivite.id,

--- a/apps/backend/src/referentiels/preuves-archive/preuves-archive.repository.ts
+++ b/apps/backend/src/referentiels/preuves-archive/preuves-archive.repository.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { auditeurTable } from '@tet/backend/referentiels/labellisations/auditeur.table';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { failure, success, type Result } from '@tet/backend/utils/result.type';
 import { getErrorMessage } from '@tet/domain/utils';
@@ -142,6 +143,36 @@ export class PreuvesArchiveRepository {
     } catch (error) {
       this.logger.error(
         `Lecture du job d'archive ${input.id}: ${getErrorMessage(error)}`
+      );
+      return failure(
+        PreuvesArchiveErrorEnum.GET_ARCHIVE_ERROR,
+        error instanceof Error ? error : new Error(getErrorMessage(error))
+      );
+    }
+  }
+
+  async getAuditeurMembership(input: {
+    auditId: number;
+    userId: string;
+  }): Promise<Result<boolean, PreuvesArchiveError>> {
+    try {
+      const [row] = await this.db
+        .select({ auditId: auditeurTable.auditId })
+        .from(auditeurTable)
+        .where(
+          and(
+            eq(auditeurTable.auditId, input.auditId),
+            eq(auditeurTable.auditeur, input.userId)
+          )
+        )
+        .limit(1);
+
+      return success(row !== undefined);
+    } catch (error) {
+      this.logger.error(
+        `Lecture du rôle auditeur (user ${input.userId}, audit ${input.auditId}): ${getErrorMessage(
+          error
+        )}`
       );
       return failure(
         PreuvesArchiveErrorEnum.GET_ARCHIVE_ERROR,

--- a/apps/backend/src/referentiels/preuves-archive/preuves-archive.router.e2e-spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/preuves-archive.router.e2e-spec.ts
@@ -15,6 +15,7 @@ import { randomUUID } from 'crypto';
 import { eq } from 'drizzle-orm';
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import { auditTable } from '@tet/backend/referentiels/labellisations/audit.table';
+import { addAuditeurPermission } from '@tet/backend/referentiels/labellisations/labellisations.test-fixture';
 import { DocumentStorageService } from '@tet/backend/utils/supabase/document-storage.service';
 import { GeneratePreuvesArchiveWorker } from './generate-preuves-archive/generate-preuves-archive.worker';
 import {
@@ -32,6 +33,8 @@ describe('Archive de preuves - tRPC', () => {
   let collectivite: Collectivite;
   let adminUser: AuthenticatedUser;
   let unauthorizedUser: AuthenticatedUser;
+  let readerNonAuditeur: AuthenticatedUser;
+  let auditeurCleanup: () => Promise<void>;
 
   beforeAll(async () => {
     app = await getTestApp({
@@ -66,15 +69,31 @@ describe('Archive de preuves - tRPC', () => {
       unauthorizedUserResult.user
     );
 
-    await db.db
+    const readerNonAuditeurResult = await addTestUser(db, {
+      collectiviteId: collectivite.id,
+      role: CollectiviteRole.ADMIN,
+    });
+    readerNonAuditeur = getAuthUserFromUserCredentials(
+      readerNonAuditeurResult.user
+    );
+
+    const [audit] = await db.db
       .insert(auditTable)
-      .values({ collectiviteId: collectivite.id, referentielId: 'cae' });
+      .values({ collectiviteId: collectivite.id, referentielId: 'cae' })
+      .returning();
+
+    ({ cleanup: auditeurCleanup } = await addAuditeurPermission({
+      databaseService: db,
+      auditId: audit.id,
+      userId: adminUser.id,
+    }));
   });
 
   afterAll(async () => {
     await db.db
       .delete(auditPreuvesArchiveTable)
       .where(eq(auditPreuvesArchiveTable.collectiviteId, collectivite.id));
+    await auditeurCleanup();
     await db.db
       .delete(auditTable)
       .where(eq(auditTable.collectiviteId, collectivite.id));
@@ -138,6 +157,17 @@ describe('Archive de preuves - tRPC', () => {
   describe("Archive de preuves - Cas d'erreur", () => {
     test('request échoue pour un utilisateur sans droits sur la collectivité', async () => {
       const caller = router.createCaller({ user: unauthorizedUser });
+
+      await expect(
+        caller.referentiels.preuvesArchive.request({
+          collectiviteId: collectivite.id,
+          referentielId: 'cae',
+        })
+      ).rejects.toThrow("Vous n'avez pas les permissions nécessaires");
+    });
+
+    test("request refuse un utilisateur ayant referentiels.read mais non-auditeur de l'audit en cours", async () => {
+      const caller = router.createCaller({ user: readerNonAuditeur });
 
       await expect(
         caller.referentiels.preuvesArchive.request({

--- a/apps/backend/src/referentiels/preuves-archive/request-preuves-archive/request-preuves-archive.service.spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/request-preuves-archive/request-preuves-archive.service.spec.ts
@@ -45,9 +45,11 @@ type CurrentAuditResult =
 function buildService({
   isAllowed = true,
   currentAudit = success({ id: 10 }),
+  isAuditeur = true,
 }: {
   isAllowed?: boolean;
   currentAudit?: CurrentAuditResult;
+  isAuditeur?: boolean;
 } = {}): RequestPreuvesArchiveService {
   const permissions = {
     isAllowed: vi.fn().mockResolvedValue(isAllowed),
@@ -58,6 +60,7 @@ function buildService({
   } as unknown;
 
   const repository = {
+    getAuditeurMembership: vi.fn().mockResolvedValue(success(isAuditeur)),
     createOrGetInFlight: vi.fn().mockResolvedValue(success(makeArchive())),
   } as unknown;
 
@@ -88,6 +91,21 @@ describe('RequestPreuvesArchiveService', () => {
         PreuvesArchiveErrorEnum.AUDIT_NOT_FOUND,
         new Error(
           'Aucun audit en cours pour la collectivité 1 et le référentiel cae'
+        )
+      )
+    );
+  });
+
+  it("échoue avec UNAUTHORIZED quand l'utilisateur n'est pas auditeur de l'audit en cours", async () => {
+    const service = buildService({ isAuditeur: false });
+
+    const result = await service.request(requestInput);
+
+    expect(result).toEqual(
+      failure(
+        PreuvesArchiveErrorEnum.UNAUTHORIZED,
+        new Error(
+          "L'utilisateur owner-id n'est pas auditeur de l'audit 10 en cours pour la collectivité 1"
         )
       )
     );

--- a/apps/backend/src/referentiels/preuves-archive/request-preuves-archive/request-preuves-archive.service.ts
+++ b/apps/backend/src/referentiels/preuves-archive/request-preuves-archive/request-preuves-archive.service.ts
@@ -77,12 +77,29 @@ export class RequestPreuvesArchiveService {
     if (!auditIdResult.success) {
       return auditIdResult;
     }
+    const auditId = auditIdResult.data;
+
+    const auditeurMembership = await this.repository.getAuditeurMembership({
+      auditId,
+      userId: user.id,
+    });
+    if (!auditeurMembership.success) {
+      return auditeurMembership;
+    }
+    if (!auditeurMembership.data) {
+      return failure(
+        PreuvesArchiveErrorEnum.UNAUTHORIZED,
+        new Error(
+          `L'utilisateur ${user.id} n'est pas auditeur de l'audit ${auditId} en cours pour la collectivité ${collectiviteId}`
+        )
+      );
+    }
 
     const expiresAt = new Date(Date.now() + ARCHIVE_TTL_MS).toISOString();
     const createResult = await this.repository.createOrGetInFlight({
       collectiviteId,
       referentielId,
-      auditId: auditIdResult.data,
+      auditId,
       requestedBy: user.id,
       expiresAt,
     });


### PR DESCRIPTION
## Nature
fix (durcissement d'autorisation). PR1 d'une stack ; mergeable seule, base `main`.

## Plan
[doc/plans/2026-05-21-001-feat-generation-archive-preuves-auditeur-plan.md](../blob/fix/preuves-archive-authz-auditeur/doc/plans/2026-05-21-001-feat-generation-archive-preuves-auditeur-plan.md) — PR1 de la stack (inclus dans ce commit).

## Problème corrigé (mode de défaillance)
L'endpoint `referentiels.preuvesArchive.request` (mergé récemment) n'exigeait que `referentiels.read` + un audit en cours. Un membre côté audité (ex. admin de la collectivité), **non-auditeur**, pouvait donc générer l'archive ZIP de toutes les preuves de l'audit. La règle métier veut que seuls les **auditeurs de l'audit en cours** la génèrent.

## Solution
- `PreuvesArchiveRepository.getAuditeurMembership({auditId, userId})` : lecture de `audit_auditeur` (Drizzle dans le repo, pas dans le service), `Result<boolean>`.
- Garde dans `RequestPreuvesArchiveService.request` : après résolution de l'audit en cours, refuse (`UNAUTHORIZED`) si l'utilisateur n'est pas auditeur — **avant** toute création de ligne (fail-closed).

## Tests
- **Régression e2e** (`preuves-archive.router.e2e-spec.ts`) : un admin **non-auditeur** ayant `referentiels.read` est refusé — test écrit d'abord, **rouge sur le code pré-fix** (l'archive était générée), vert après. La fixture inscrit l'utilisateur des cas de succès comme auditeur.
- **Unitaire** (`request-preuves-archive.service.spec.ts`) : refus `UNAUTHORIZED` sur le chemin non-auditeur.

## Surface de review
- **Attention humaine** : `request-preuves-archive.service.ts` (la garde, ordre des checks), `preuves-archive.repository.ts` (`getAuditeurMembership`).
- **Tests** : les deux specs ci-dessus.
- **Mécanique** : `doc/plans/…`.

## Hypothèses
- Un auditeur possède `referentiels.read` (la garde exige les deux ; `read` est une baseline que les auditeurs satisfont). `get` (lecture d'état) reste sur `referentiels.read` + scope `requestedBy = user.id` (anti-énumération existant).

## Zones low-confidence
- L'`get` ne re-vérifie pas l'appartenance auditeur : sans risque aujourd'hui (seul un auditeur peut créer), mais l'invariant repose sur la création. Cas limite : révocation d'auditeur post-création (fenêtre bornée par le TTL). Voir review sécurité (P3).

## Recherche anti-duplication
Cherché `isAuditeur`/`auditeurTable`/`audit_auditeur` : la lecture d'appartenance auditeur est **déjà dupliquée** dans `users/authorizations`, `export-score`, `labellisations`. Aucune méthode `is-auditeur(auditId,userId)` réutilisable propre ; la relocalisation dans `GetLabellisationService` (god-service) déclenche une dépendance circulaire `action-statut` pgEnum → gardée dans le repo preuves-archive.

## Reviewers automatiques
`security-sentinel` (→ P3 only : garde bien placée, fail-closed, pas d'IDOR) + `kieran-typescript-reviewer` (→ P1 traités : renommage `getAuditeurMembership`, code d'erreur `GET_ARCHIVE_ERROR`).

## Post-Deploy Monitoring & Validation
- **À surveiller** : logs backend `RequestPreuvesArchiveService` / erreurs tRPC `UNAUTHORIZED` sur `referentiels.preuvesArchive.request`.
- **Signal sain** : les auditeurs génèrent leurs archives ; les non-auditeurs reçoivent un refus propre (pas de 500).
- **Signal d'échec / rollback** : pic de `GET_ARCHIVE_ERROR` (erreur DB sur la lecture auditeur) ou auditeurs légitimes refusés à tort → revert de la garde.
- **Fenêtre / owner** : 48 h après déploiement, équipe référentiels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)