### PR TITLE
fix(ui): préserve les sauts de ligne du texte brut dans le RichTextEditor

### DIFF
--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/action/[actionId]/_components/action/action.justification-field.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/action/[actionId]/_components/action/action.justification-field.tsx
@@ -24,6 +24,9 @@ export const ActionJustificationField = ({
 
   const { mutate: updateActionExplication } = useUpdateActionExplication();
 
+  const isDisabled =
+    !hasCollectivitePermission('referentiels.mutate') || disabled;
+
   return (
     <Field title={title} hint={hint} key={actionId} className="cursor-auto">
       <div onClick={(e) => e.stopPropagation()}>
@@ -31,11 +34,9 @@ export const ActionJustificationField = ({
           dataTest={`action-${actionId}-commentaire-editor`}
           className="[&_.bn-block-content]:py-0 [&_.bn-inline-content]:text-sm [&_.bn-inline-content]:leading-[1.25rem]"
           initialValue={score.explication}
-          disabled={
-            !hasCollectivitePermission('referentiels.mutate') || disabled
-          }
+          disabled={isDisabled}
           placeholder={placeholder ?? "Détaillez l'état d'avancement"}
-          onBlur={(htmlValue: string) => {
+          onBlurTextChanged={(htmlValue: string) => {
             if (htmlValue.trim() === score.explication?.trim()) {
               return;
             }

--- a/apps/app/src/plans/fiches/show-fiche/content/details/description/index.tsx
+++ b/apps/app/src/plans/fiches/show-fiche/content/details/description/index.tsx
@@ -1,7 +1,7 @@
-import { appLabels } from '@/app/labels/catalog';
 import { LibreTagDropdown } from '@/app/collectivites/tags/libre-tag.dropdown';
-import EffetsAttendusDropdown from '@/app/ui/dropdownLists/ficheAction/EffetsAttendusDropdown/EffetsAttendusDropdown';
+import { appLabels } from '@/app/labels/catalog';
 import { useGetThematiqueAndSousThematiqueOptions } from '@/app/shared/thematiques/use-get-thematique-and-sous-thematique-options';
+import EffetsAttendusDropdown from '@/app/ui/dropdownLists/ficheAction/EffetsAttendusDropdown/EffetsAttendusDropdown';
 import {
   cn,
   RichTextEditor,
@@ -102,7 +102,7 @@ export const Description = () => {
             color: 'primary',
           }}
           initialValue={initialDescription}
-          onBlur={(html) => setValue('description', html)}
+          onBlurTextChanged={(html) => setValue('description', html)}
           disabled={isReadonly}
         />
       </div>
@@ -123,7 +123,7 @@ export const Description = () => {
             color: 'primary',
           }}
           initialValue={initialObjectifs}
-          onBlur={(html) => setValue('objectifs', html)}
+          onBlurTextChanged={(html) => setValue('objectifs', html)}
           disabled={isReadonly}
         />
       </div>

--- a/apps/app/src/plans/fiches/show-fiche/content/details/editable-item.tsx
+++ b/apps/app/src/plans/fiches/show-fiche/content/details/editable-item.tsx
@@ -1,6 +1,5 @@
 import { appLabels } from '@/app/labels/catalog';
-import { cn, Icon, InlineEditWrapper, RichTextEditor } from '@tet/ui';
-import { useMemo } from 'react';
+import { cn, Icon, InlineEditWrapper } from '@tet/ui';
 
 const DisplayValue = ({ value }: { value?: string | React.ReactNode }) => {
   return typeof value === 'string' || !value ? (
@@ -40,47 +39,6 @@ const IconComponent = ({
       )}
     >
       {IconComponent}
-    </div>
-  );
-};
-
-export const EditableRichTextView = ({
-  value,
-  isReadonly,
-  icon,
-  label,
-  small,
-  onChange,
-}: {
-  value: string;
-  isReadonly: boolean;
-  icon?: string | React.ReactNode;
-  label?: string | React.ReactNode;
-  small?: boolean;
-  onChange: (value: string) => void;
-}) => {
-  // RichTextEditor behaves strangely when controlled hence
-  // only the initial value is used on first mount
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const initialValue = useMemo(() => value, []);
-  return (
-    <div className="text-sm leading-6 font-regular gap-4 mb-1 flex items-start">
-      <IconComponent icon={icon} small={small} />
-      <div className="flex flex-col">
-        {typeof label === 'string' ? (
-          <div className="text-primary-10 text-base">
-            {appLabels.labelDeuxPoints({ label })}{' '}
-          </div>
-        ) : (
-          label
-        )}
-        <RichTextEditor
-          unstyled
-          disabled={isReadonly}
-          initialValue={initialValue}
-          onChange={onChange}
-        />
-      </div>
     </div>
   );
 };

--- a/apps/app/src/plans/fiches/show-fiche/content/moyens/ressources-financements.view.tsx
+++ b/apps/app/src/plans/fiches/show-fiche/content/moyens/ressources-financements.view.tsx
@@ -36,7 +36,7 @@ const Field = ({
           unstyled
           disabled={isReadonly}
           initialValue={initialValue}
-          onBlur={onChange}
+          onBlurTextChanged={(html) => onChange(html)}
           contentStyle={{
             size: 'sm',
             color: 'primary',

--- a/apps/app/src/plans/fiches/show-fiche/content/notes/note.description.cell.tsx
+++ b/apps/app/src/plans/fiches/show-fiche/content/notes/note.description.cell.tsx
@@ -12,7 +12,7 @@ export const NoteDescriptionCell = () => {
         unstyled
         initialValue={value}
         onChange={(html) => form.setValue('description', html)}
-        onBlur={submitNote}
+        onBlurTextChanged={submitNote}
         disabled={isReadonly}
       />
     </TableCell>

--- a/apps/app/src/plans/plans/show-plan/plan-arborescence.view/axe/axe-description.tsx
+++ b/apps/app/src/plans/plans/show-plan/plan-arborescence.view/axe/axe-description.tsx
@@ -27,7 +27,7 @@ export const AxeDescription = () => {
           'focus-within:border': !isReadOnly,
         })}
         initialValue={axe.description}
-        onBlur={(value) => {
+        onBlurTextChanged={(value) => {
           if (value !== axe.description) {
             return updateAxe.mutateAsync({ description: value });
           }

--- a/apps/app/src/referentiels/audits/ActionAuditDetail.tsx
+++ b/apps/app/src/referentiels/audits/ActionAuditDetail.tsx
@@ -31,7 +31,7 @@ export const ActionAuditDetailBase = (props: TActionAuditDetailBaseProps) => {
           className="[&_.bn-block-content]:py-0 [&_.bn-inline-content]:text-sm [&_.bn-inline-content]:leading-[1.25rem]"
           initialValue={avisInitial}
           disabled={readonly}
-          onBlur={(value: string) => {
+          onBlurTextChanged={(value: string) => {
             updateMesureAuditStatut({
               collectiviteId: auditStatut.collectiviteId,
               mesureId: auditStatut.mesureId,

--- a/packages/ui/src/design-system/RichTextEditor/RichTextEditor.stories.tsx
+++ b/packages/ui/src/design-system/RichTextEditor/RichTextEditor.stories.tsx
@@ -65,6 +65,18 @@ export const AvecContenuInitialHTML: Story = {
   },
 };
 
+export const AvecContenuInitialTextePlatBdd: Story = {
+  args: {
+    initialValue: `SYNTHESE
+La CCPA accompagnement les entreprises notamment via :
+-Sa convention avec la CMA : diagnostics transition écologique / éclairage
+-Ses actions sur la qualité des ZAE : participation du CAUE en cours de lancement
+-Ses actions contre la vacance commerciale : subventionnement des travaux avec priorité aux travaux énergétique
+L'ALTE est aussi présente sur le territoire et conseille le petit tertiaire (pas de CR détaillé à la CCPA)
+La CCPA suit précisément les actions qu'elle a mises en oeuvre (nombre de diagnostics, travaux réalisés, chiffrage des économies…)`,
+  },
+};
+
 export const EnLectureSeule: Story = {
   args: {
     initialValue: 'Contenu en <b>lecture seule</b>',

--- a/packages/ui/src/design-system/RichTextEditor/RichTextEditor.tsx
+++ b/packages/ui/src/design-system/RichTextEditor/RichTextEditor.tsx
@@ -34,7 +34,7 @@ export type RichTextEditorProps = {
     color?: 'white' | 'grey' | 'primary';
   };
   unstyled?: boolean;
-  onBlur?: (htmlValue: string) => void;
+  onBlurTextChanged?: (htmlValue: string) => void;
   OnKeyDownCapture?: (event: React.KeyboardEvent<HTMLDivElement>) => void;
 };
 
@@ -69,7 +69,7 @@ export default function RichTextEditor({
   onChange,
   contentStyle,
   unstyled = false,
-  onBlur,
+  onBlurTextChanged,
   OnKeyDownCapture,
 }: RichTextEditorProps) {
   const { size = 'base', color = 'grey' } = contentStyle ?? {};
@@ -169,6 +169,9 @@ export default function RichTextEditor({
   }, editor);
 
   const handleOnBlur = async (event: React.FocusEvent<HTMLDivElement>) => {
+    if (disabled) {
+      return;
+    }
     /**
      * blur event is triggered only when user actually clicks outside of the blocknote editor
      */
@@ -178,7 +181,11 @@ export default function RichTextEditor({
 
     const html = await editor.blocksToFullHTML(editor.document);
 
-    onBlur?.(html);
+    if (html === initialValue) {
+      return;
+    }
+
+    onBlurTextChanged?.(html);
   };
 
   if (isLoading) {

--- a/packages/ui/src/design-system/RichTextEditor/RichTextEditor.tsx
+++ b/packages/ui/src/design-system/RichTextEditor/RichTextEditor.tsx
@@ -139,9 +139,20 @@ export default function RichTextEditor({
     async function loadContent(content: string) {
       const isHtml = content.trim().startsWith('<');
 
-      const blocks = isHtml
-        ? await editor.tryParseHTMLToBlocks(content)
-        : await editor.tryParseMarkdownToBlocks(content);
+      let blocks;
+      if (isHtml) {
+        blocks = await editor.tryParseHTMLToBlocks(content);
+      } else {
+        // Le parser Markdown (CommonMark) traite les sauts de ligne simples
+        // comme des espaces. Pour préserver l'affichage du texte brut hérité
+        // de l'ancien éditeur (sans `\n\n`), on convertit chaque saut de
+        // ligne en saut de paragraphe avant le parsing.
+        const hasMarkdownParagraphBreaks = /\n\s*\n/.test(content);
+        const normalized = hasMarkdownParagraphBreaks
+          ? content
+          : content.replace(/\r?\n/g, '\n\n');
+        blocks = await editor.tryParseMarkdownToBlocks(normalized);
+      }
 
       editor.replaceBlocks(editor.document, blocks);
     }


### PR DESCRIPTION
Le parser Markdown CommonMark traite les sauts de ligne simples comme
des espaces, ce qui faisait collapser le texte brut hérité de l'ancien
éditeur (stocké en base sans `\n\n`) en un seul paragraphe.

On normalise désormais les `\n` en sauts de paragraphe lorsque le
contenu n'en contient pas déjà, et on ajoute une story Storybook
correspondante.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Corrections**
  * Amélioration du traitement du contenu texte brut pour préserver correctement la mise en forme dans l'éditeur enrichi.

* **Tests**
  * Ajout d'une nouvelle story de test pour valider le comportement de l'éditeur enrichi avec contenu initial en texte plat.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/incubateur-ademe/territoires-en-transitions/pull/4484?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->