### PR TITLE
fix(referentiels): applique les filtres pilote dans useListActions (TET-7318)

### DIFF
--- a/apps/app/src/referentiels/actions/use-list-actions.spec.ts
+++ b/apps/app/src/referentiels/actions/use-list-actions.spec.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { ActionListItem, filterActions } from './use-list-actions';
+
+const action = (
+  overrides: Partial<ActionListItem> & Pick<ActionListItem, 'actionId'>
+): ActionListItem =>
+  ({
+    actionType: 'action',
+    pilotes: [],
+    services: [],
+    ...overrides,
+  } as unknown as ActionListItem);
+
+describe('filterActions', () => {
+  const axe = action({ actionId: 'cae_1', actionType: 'axe' });
+  const pilotedByUser = action({
+    actionId: 'cae_1.1',
+    pilotes: [{ userId: 'u1', tagId: null, nom: 'Alice', collectiviteId: 1 }],
+  });
+  const pilotedByTag = action({
+    actionId: 'cae_1.2',
+    pilotes: [{ userId: null, tagId: 42, nom: 'Equipe', collectiviteId: 1 }],
+  });
+  const withService = action({
+    actionId: 'cae_1.3',
+    services: [{ id: 7, nom: 'Direction', collectiviteId: 1 }],
+  });
+  const noPilote = action({ actionId: 'cae_1.4' });
+
+  const all = [axe, pilotedByUser, pilotedByTag, withService, noPilote];
+
+  it('returns everything when no filters are applied', () => {
+    expect(filterActions(all, {})).toEqual(all);
+  });
+
+  it('filtre par utilisateurPiloteIds', () => {
+    expect(
+      filterActions(all, { utilisateurPiloteIds: ['u1'] })
+    ).toEqual([pilotedByUser]);
+  });
+
+  it('filtre par personnePiloteIds', () => {
+    expect(filterActions(all, { personnePiloteIds: [42] })).toEqual([
+      pilotedByTag,
+    ]);
+  });
+
+  it('filtre par servicePiloteIds', () => {
+    expect(filterActions(all, { servicePiloteIds: [7] })).toEqual([
+      withService,
+    ]);
+  });
+
+  it("exclut les actions sans pilote quand un filtre pilote est appliqué", () => {
+    const result = filterActions(all, { utilisateurPiloteIds: ['u1'] });
+    expect(result).not.toContain(axe);
+    expect(result).not.toContain(noPilote);
+  });
+
+  it('applique la sémantique AND entre plusieurs ids de pilote', () => {
+    const piloteParDeux = action({
+      actionId: 'cae_2.1',
+      pilotes: [
+        { userId: 'u1', tagId: null, nom: 'Alice', collectiviteId: 1 },
+        { userId: 'u2', tagId: null, nom: 'Bob', collectiviteId: 1 },
+      ],
+    });
+    const result = filterActions([pilotedByUser, piloteParDeux], {
+      utilisateurPiloteIds: ['u1', 'u2'],
+    });
+    expect(result).toEqual([piloteParDeux]);
+  });
+
+  it('combine filtres pilote et actionTypes', () => {
+    const result = filterActions(all, {
+      actionTypes: ['action'],
+      utilisateurPiloteIds: ['u1'],
+    });
+    expect(result).toEqual([pilotedByUser]);
+  });
+});

--- a/apps/app/src/referentiels/actions/use-list-actions.ts
+++ b/apps/app/src/referentiels/actions/use-list-actions.ts
@@ -9,6 +9,15 @@ import { useListActionsGroupedById } from './use-list-actions-grouped-by-id';
 export type ActionListItem =
   RouterOutput['referentiels']['actions']['listActionsGroupedById'][ActionId];
 
+type ActionListFilters = Pick<
+  ListActionsInput,
+  | 'actionIds'
+  | 'actionTypes'
+  | 'utilisateurPiloteIds'
+  | 'personnePiloteIds'
+  | 'servicePiloteIds'
+>;
+
 export function useListActions(
   {
     collectiviteId,
@@ -16,6 +25,9 @@ export function useListActions(
     actionIds = [],
     actionTypes = [],
     includeDesactive = false,
+    utilisateurPiloteIds = [],
+    personnePiloteIds = [],
+    servicePiloteIds = [],
   }: ListActionsInput & { includeDesactive?: boolean },
   { enabled }: { enabled?: boolean } = { enabled: true }
 ) {
@@ -41,16 +53,50 @@ export function useListActions(
     Object.values(queryResult.data ?? {})
   );
 
-  let data = combinedDataAcrossReferentiels;
-  if (actionIds.length > 0) {
-    data = data.filter((action) => actionIds.includes(action.actionId));
-  }
-  if (actionTypes.length > 0) {
-    data = data.filter((action) => actionTypes.includes(action.actionType));
-  }
+  const data = filterActions(combinedDataAcrossReferentiels, {
+    actionIds,
+    actionTypes,
+    utilisateurPiloteIds,
+    personnePiloteIds,
+    servicePiloteIds,
+  });
 
   return {
     data,
     isPending,
   };
+}
+
+export function filterActions(
+  actions: ActionListItem[],
+  filters: ActionListFilters
+): ActionListItem[] {
+  let data = actions;
+  if (filters.actionIds?.length) {
+    const ids = filters.actionIds;
+    data = data.filter((action) => ids.includes(action.actionId));
+  }
+  if (filters.actionTypes?.length) {
+    const types = filters.actionTypes;
+    data = data.filter((action) => types.includes(action.actionType));
+  }
+  if (filters.utilisateurPiloteIds?.length) {
+    const ids = filters.utilisateurPiloteIds;
+    data = data.filter((action) =>
+      ids.every((id) => action.pilotes?.some((p) => p.userId === id))
+    );
+  }
+  if (filters.personnePiloteIds?.length) {
+    const ids = filters.personnePiloteIds;
+    data = data.filter((action) =>
+      ids.every((id) => action.pilotes?.some((p) => p.tagId === id))
+    );
+  }
+  if (filters.servicePiloteIds?.length) {
+    const ids = filters.servicePiloteIds;
+    data = data.filter((action) =>
+      ids.every((id) => action.services?.some((s) => s.id === id))
+    );
+  }
+  return data;
 }


### PR DESCRIPTION
## Contexte

Ticket Notion : [TET-7318 — Erreur du nombre de mesures dont la personne est pilote](https://www.notion.so/36c6523d57d78145b5d9c68e90f4f959) (criticité **Bloquant**).

Deux symptômes remontés :

1. Le module **« Mon suivi perso » → Mesures dont je suis pilote** affichait *1467 autres mesures* pour un utilisateur (toutes les mesures du CAE).
2. Sur les pages de référentiels, le filtre **« Personne pilote »** ou **« Service pilote »** ne filtrait rien et listait toutes les mesures.

## Cause racine

Le refactor introduit par `fb8a80692` (« feat(referentiels): vue tabulaire éditable ») a remplacé l'endpoint backend `listActions` (qui filtrait par pilote/service côté SQL) par `listActionsGroupedById` (qui retourne tout le référentiel). Le hook client `useListActions` a été réécrit en oubliant `utilisateurPiloteIds`, `personnePiloteIds` et `servicePiloteIds` — qui étaient silencieusement ignorés.

Conséquence directe :
- `MesuresModule` passait `module.options.filtre = { utilisateurPiloteIds: [userId], ... }` mais récupérait *toutes* les mesures du référentiel.
- Le composant `Filters` de la progression du référentiel transmettait bien `utilisateurPiloteIds` / `personnePiloteIds` / `servicePiloteIds`, mais ils n'étaient jamais appliqués.

## Correctif

Les données retournées par `listActionsGroupedById` incluent déjà `pilotes` et `services` par action — on les exploite pour filtrer **côté client** dans `useListActions`, en conservant la sémantique AND par groupe utilisée précédemment côté SQL (l'action doit avoir *tous* les ids du filtre).

La logique de filtre est extraite dans une fonction pure `filterActions` testable.

## Test plan

- [x] Tests unitaires `apps/app/src/referentiels/actions/use-list-actions.spec.ts` (7 tests)
- [x] `nx typecheck app`
- [x] Vérifier sur staging : ouvrir « Mon suivi perso → Mesures dont je suis pilote » et constater que le compteur correspond bien aux mesures pilotées
- [x] Vérifier sur staging : sur une page de référentiel, appliquer le filtre « Personne pilote » et constater que la liste se restreint aux mesures de cette personne
- [x] Vérifier sur staging : même chose pour le filtre « Service pilote »

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notes de version

* **New Features**
  * Ajout de capacités de filtrage avancées pour les actions : possibilité de filtrer par utilisateurs pilotes, personnes pilotes et services pilotes.

* **Tests**
  * Ajout de couverture de tests complète pour la fonctionnalité de filtrage des actions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/incubateur-ademe/territoires-en-transitions/pull/4489?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->