### PR TITLE
fix(security): bloque l'injection SQL sur la recherche de collectivités (pentest V1)

### DIFF
--- a/apps/backend/src/collectivites/recherches/filters.request.spec.ts
+++ b/apps/backend/src/collectivites/recherches/filters.request.spec.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from 'vitest';
+import { filtersRequestSchema } from './filters.request';
+
+const baseInput = {
+  typesPlan: [],
+  regions: [],
+  departments: [],
+  typesCollectivite: [],
+  population: [],
+  referentiel: [],
+  niveauDeLabellisation: [],
+  realiseCourant: [],
+  tauxDeRemplissage: [],
+  nbCards: 10,
+};
+
+describe('filtersRequestSchema', () => {
+  describe('valeurs légitimes', () => {
+    it('accepte un payload vide', () => {
+      expect(filtersRequestSchema.safeParse(baseInput).success).toBe(true);
+    });
+
+    it('accepte des codes région INSEE', () => {
+      const result = filtersRequestSchema.safeParse({
+        ...baseInput,
+        regions: ['27', '11', '75', '01'],
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepte les codes département dont les codes corses', () => {
+      const result = filtersRequestSchema.safeParse({
+        ...baseInput,
+        departments: ['51', '31', '2A', '2B', '971'],
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepte les identifiants de tranche `filtre_intervalle`', () => {
+      const result = filtersRequestSchema.safeParse({
+        ...baseInput,
+        population: ['<20000', '20000-50000'],
+        realiseCourant: ['50-64', '35-49'],
+        tauxDeRemplissage: ['80-99'],
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepte les types de collectivité (enum + syndicat)', () => {
+      const result = filtersRequestSchema.safeParse({
+        ...baseInput,
+        typesCollectivite: ['syndicat', 'commune', 'epci'],
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepte les niveaux de labellisation 0-5', () => {
+      const result = filtersRequestSchema.safeParse({
+        ...baseInput,
+        niveauDeLabellisation: ['0', '1', '2', '3', '4', '5'],
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepte les référentiels connus', () => {
+      const result = filtersRequestSchema.safeParse({
+        ...baseInput,
+        referentiel: ['eci', 'cae', 'te', 'te-test'],
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  // Régression du pentest ORHUS-302 V1 (Injection SQL via le paramètre
+  // `regions` du formulaire de recherche de collectivités). Chaque entrée
+  // utilisateur de type tableau de chaînes doit refuser tout caractère qui
+  // permettrait d'échapper d'une liste `IN (...)`.
+  describe('protection contre les injections SQL (pentest V1)', () => {
+    const sqlInjectionPayloads = [
+      "27'); DROP TABLE collectivite; --",
+      "27' UNION SELECT password FROM users; --",
+      "27' OR 1=1 --",
+      "'; SELECT * FROM dcp; --",
+      '27; DROP TABLE collectivite',
+      '27, (SELECT 1)',
+      '27/**/UNION/**/SELECT',
+    ];
+
+    it.each(sqlInjectionPayloads)(
+      'rejette le payload `%s` dans `regions`',
+      (payload) => {
+        const result = filtersRequestSchema.safeParse({
+          ...baseInput,
+          regions: [payload],
+        });
+        expect(result.success).toBe(false);
+      }
+    );
+
+    it.each(sqlInjectionPayloads)(
+      'rejette le payload `%s` dans `departments`',
+      (payload) => {
+        const result = filtersRequestSchema.safeParse({
+          ...baseInput,
+          departments: [payload],
+        });
+        expect(result.success).toBe(false);
+      }
+    );
+
+    it.each(sqlInjectionPayloads)(
+      'rejette le payload `%s` dans `population`',
+      (payload) => {
+        const result = filtersRequestSchema.safeParse({
+          ...baseInput,
+          population: [payload],
+        });
+        expect(result.success).toBe(false);
+      }
+    );
+
+    it.each(sqlInjectionPayloads)(
+      'rejette le payload `%s` dans `typesCollectivite`',
+      (payload) => {
+        const result = filtersRequestSchema.safeParse({
+          ...baseInput,
+          typesCollectivite: [payload],
+        });
+        expect(result.success).toBe(false);
+      }
+    );
+
+    it.each(sqlInjectionPayloads)(
+      'rejette le payload `%s` dans `realiseCourant`',
+      (payload) => {
+        const result = filtersRequestSchema.safeParse({
+          ...baseInput,
+          realiseCourant: [payload],
+        });
+        expect(result.success).toBe(false);
+      }
+    );
+
+    it.each(sqlInjectionPayloads)(
+      'rejette le payload `%s` dans `tauxDeRemplissage`',
+      (payload) => {
+        const result = filtersRequestSchema.safeParse({
+          ...baseInput,
+          tauxDeRemplissage: [payload],
+        });
+        expect(result.success).toBe(false);
+      }
+    );
+
+    it.each(sqlInjectionPayloads)(
+      'rejette le payload `%s` dans `niveauDeLabellisation`',
+      (payload) => {
+        const result = filtersRequestSchema.safeParse({
+          ...baseInput,
+          niveauDeLabellisation: [payload],
+        });
+        expect(result.success).toBe(false);
+      }
+    );
+
+    it.each(sqlInjectionPayloads)(
+      'rejette le payload `%s` dans `referentiel`',
+      (payload) => {
+        const result = filtersRequestSchema.safeParse({
+          ...baseInput,
+          referentiel: [payload],
+        });
+        expect(result.success).toBe(false);
+      }
+    );
+  });
+
+  describe('bornes des champs numériques', () => {
+    it("limite `nbCards` à un entier strictement positif", () => {
+      expect(
+        filtersRequestSchema.safeParse({ ...baseInput, nbCards: 0 }).success
+      ).toBe(false);
+      expect(
+        filtersRequestSchema.safeParse({ ...baseInput, nbCards: -10 }).success
+      ).toBe(false);
+      expect(
+        filtersRequestSchema.safeParse({ ...baseInput, nbCards: 1.5 }).success
+      ).toBe(false);
+    });
+
+    it('rejette une page négative ou nulle', () => {
+      expect(
+        filtersRequestSchema.safeParse({ ...baseInput, page: 0 }).success
+      ).toBe(false);
+      expect(
+        filtersRequestSchema.safeParse({ ...baseInput, page: -1 }).success
+      ).toBe(false);
+    });
+  });
+});

--- a/apps/backend/src/collectivites/recherches/filters.request.ts
+++ b/apps/backend/src/collectivites/recherches/filters.request.ts
@@ -1,19 +1,52 @@
 import { z } from 'zod';
 
+// Codes INSEE région : 2-3 chiffres (métropole + DROM).
+const regionCodeSchema = z
+  .string()
+  .regex(/^[0-9]{1,3}$/, 'Code région invalide');
+
+// Codes INSEE département : 1-3 chiffres ou 2A/2B (Corse).
+const departmentCodeSchema = z
+  .string()
+  .regex(/^(?:[0-9]{1,3}|2[AB])$/i, 'Code département invalide');
+
+// Identifiants de tranche stockés dans `filtre_intervalle.id`
+// (ex: `<20000`, `20000-50000`, `50-64`, `80-99`).
+const filterIntervalleIdSchema = z
+  .string()
+  .regex(/^[A-Za-z0-9_<>=-]+$/, 'Identifiant de tranche invalide');
+
+// Types de collectivité (enum `collectiviteTypeEnum` + alias `syndicat`).
+const typeCollectiviteSchema = z
+  .string()
+  .regex(/^[a-z_]+$/, 'Type de collectivité invalide');
+
+// Niveau de labellisation : 0 à 5 étoiles.
+const niveauLabelSchema = z
+  .string()
+  .regex(/^[0-5]$/, 'Niveau de labellisation invalide');
+
+// Référentiel : `eci`, `cae`, `te`, `te-test`.
+const referentielSchema = z
+  .string()
+  .regex(/^[a-z-]+$/, 'Référentiel invalide');
+
+// Tri : `nom`, `completude`, `score`.
+const trierParSchema = z.string().regex(/^[a-z]+$/, 'Tri invalide');
+
 export const filtersRequestSchema = z.object({
-  typesPlan : z.number().array(),
-  nom : z.string().optional(),
-  regions : z.string().array(),
-  departments : z.string().array(),
-  typesCollectivite: z.string().array(),
-  population : z.string().array(),
-  referentiel : z.string().array(),
-  niveauDeLabellisation : z.string().array(),
-  realiseCourant : z.string().array(),
-  tauxDeRemplissage : z.string().array(),
-  trierPar : z.string().array().optional(),
-  page : z.number().optional(),
-  nbCards : z.number()
+  typesPlan: z.number().int().array(),
+  nom: z.string().max(200).optional(),
+  regions: regionCodeSchema.array(),
+  departments: departmentCodeSchema.array(),
+  typesCollectivite: typeCollectiviteSchema.array(),
+  population: filterIntervalleIdSchema.array(),
+  referentiel: referentielSchema.array(),
+  niveauDeLabellisation: niveauLabelSchema.array(),
+  realiseCourant: filterIntervalleIdSchema.array(),
+  tauxDeRemplissage: filterIntervalleIdSchema.array(),
+  trierPar: trierParSchema.array().optional(),
+  page: z.number().int().min(1).optional(),
+  nbCards: z.number().int().min(1).max(1000),
 });
 export type FiltersRequest = z.infer<typeof filtersRequestSchema>;
-

--- a/apps/backend/src/collectivites/recherches/recherches.service.ts
+++ b/apps/backend/src/collectivites/recherches/recherches.service.ts
@@ -43,6 +43,15 @@ export default class RecherchesService {
 
   constructor(private readonly databaseService: DatabaseService) {}
 
+  // SÉCURITÉ : ce service construit ses requêtes par concaténation puis les
+  // exécute via `sql.raw(...)`. La protection contre les injections SQL repose
+  // intégralement sur la validation stricte effectuée par
+  // `filtersRequestSchema` (cf. filters.request.ts), qui restreint chaque
+  // entrée utilisateur à un jeu de caractères sûr (chiffres, codes INSEE,
+  // identifiants de tranche, etc.). Toute relaxation de ce schéma rouvrirait
+  // la faille. La migration vers des requêtes Drizzle paramétrées reste à
+  // faire (R2 du pentest ORHUS-302).
+
   /**
    * Get view for "Collectivités" tab
    * @param filters


### PR DESCRIPTION
## Contexte

Le rapport de pentest ORHUS-302 (mai 2026) a identifié une **injection SQL critique** (V1) sur l'endpoint `collectivites.recherches.collectivites` (formulaire de recherche de collectivités).

À l'exception du paramètre `nom` (protégé par `.replace(/'/g, "''")`), les autres filtres — en particulier `regions` — étaient concaténés tels quels dans une requête exécutée via `sql.raw(...)`, sans paramétrisation. L'auditeur a pu **exfiltrer en une requête l'intégralité des 13 405 collectivités** en injectant une charge dans `regions`.

🔗 Ticket Notion : [V1 - Critique - Injection SQL via `regions`](https://www.notion.so/36e6523d57d7811f97c1eaddd525784b)

## Périmètre touché

`apps/backend/src/collectivites/recherches/recherches.service.ts` construit ses requêtes par concaténation de chaînes puis les exécute via `sql.raw(...)`. Les filtres `regions`, `departments`, `population`, `typesCollectivite`, `realiseCourant`, `tauxDeRemplissage`, `niveauDeLabellisation` et `referentiel` sont tous injectés sans échappement dans des clauses `IN (...)`.

## Approche du correctif

J'ai resserré la validation **Zod** au niveau du `filtersRequestSchema` pour restreindre chaque entrée à un jeu de caractères sûr. Les payloads d'injection sont désormais rejetés au niveau du routeur tRPC, avant d'atteindre la construction SQL.

| Champ | Regex appliquée | Valeurs légitimes |
|-------|----------------|------------------|
| `regions` | `^[0-9]{1,3}$` | Codes INSEE région (`27`, `75`, `11`…) |
| `departments` | `^(?:[0-9]{1,3}|2[AB])$` | Codes INSEE département + Corse |
| `population` / `realiseCourant` / `tauxDeRemplissage` | `^[A-Za-z0-9_<>=-]+$` | IDs de tranche `filtre_intervalle` (`<20000`, `50-64`…) |
| `typesCollectivite` | `^[a-z_]+$` | Enum + `syndicat` |
| `niveauDeLabellisation` | `^[0-5]$` | Étoiles 0-5 |
| `referentiel` | `^[a-z-]+$` | `eci`, `cae`, `te`, `te-test` |
| `trierPar` | `^[a-z]+$` | `nom`, `completude`, `score` |
| `nom` | `max(200)` | Texte libre (déjà échappé côté service) |
| `nbCards` / `page` | entiers strictement positifs | — |

Le service `RecherchesService` est annoté pour rendre explicite la dépendance entre la sécurité et le schéma Zod, en attendant la migration vers des requêtes Drizzle paramétrées (recommandation R2 du pentest, à traiter dans un autre ticket).

## Validation

- Tests unitaires ajoutés : `filters.request.spec.ts` couvre les valeurs légitimes et 56 cas de payloads d'injection (7 payloads × 8 champs sensibles), tous correctement rejetés. **65 tests passent**.
- Les e2e existants `recherches.router.e2e-spec.ts` passent toujours, à l'exception d'un test « Référentiels filtre étoiles tous référentiels cochés (Tous) » qui **échoue déjà sur main** (flake antérieur, hors scope de cette PR).
- L'UI alimente ces filtres via des dropdowns contrôlées (codes INSEE, tranches `filtre_intervalle`, enum types) — la nouvelle validation n'introduit aucune régression utilisateur observable.

## Test plan

- [x] CI verte (hors flake e2e pré-existant)
- [x] Vérification manuelle sur le staging : ouvrir la page « Collectivités engagées », appliquer les filtres région, département, population, type, niveau de labellisation, réalisé courant, taux de remplissage — les résultats doivent rester identiques
- [ ] Tentative d'exploit (avec un compte autorisé) : envoyer `{ "regions": ["27'); DROP TABLE collectivite; --"] }` via l'endpoint tRPC, doit retourner une 400 Zod

## Suite

Un ticket de suivi reste à traiter pour la recommandation R2 du pentest : migrer `recherches.service.ts` vers Drizzle paramétré (`sql\`...\`` + `sql.join`) pour éliminer le pattern `sql.raw(...)` lui-même.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Ajout de tests complets pour valider les filtres de recherche et détecter les tentatives d'injection.

* **Améliorations**
  * Renforcement de la validation des critères de recherche avec des contraintes strictes sur les formats et les limites numériques.

* **Documentation**
  * Ajout de commentaires détaillant le traitement sécurisé des requêtes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/incubateur-ademe/territoires-en-transitions/pull/4495?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->