### PR TITLE
fix(security): bloque le contrôle d'accès horizontal sur plans/axes/discussions (pentest V2)

### DIFF
--- a/apps/backend/src/collectivites/discussions/application/discussion-application.service.spec.ts
+++ b/apps/backend/src/collectivites/discussions/application/discussion-application.service.spec.ts
@@ -9,6 +9,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { DiscussionDomainService } from '../domain/discussion-domain-service';
 import { DiscussionErrorEnum } from '../domain/discussion.errors';
 import { ListDiscussionService } from '../domain/list-discussion-service';
+import { DiscussionRepository } from '../infrastructure/discussion-repository.interface';
 import {
   CreateDiscussionRequest,
   DeleteDiscussionMessageRequest,
@@ -22,7 +23,19 @@ describe('DiscussionApplicationService', () => {
   let mockListDiscussionService: Partial<ListDiscussionService>;
   let mockPermissionService: Partial<PermissionService>;
   let mockDatabaseService: Partial<DatabaseService>;
+  let mockDiscussionRepository: Partial<DiscussionRepository>;
   let mockLogger: Partial<Logger>;
+
+  // Fabrique une discussion "stub" pour les pré-checks (cf. assertDiscussionInCollectivite).
+  const makeDiscussion = (overrides: { id?: number; collectiviteId?: number } = {}) => ({
+    id: overrides.id ?? 1,
+    collectiviteId: overrides.collectiviteId ?? 1,
+    actionId: 'cae_1.1.1',
+    status: discussionStatus.OUVERT,
+    createdBy: 'user-123',
+    createdAt: '2025-01-01T00:00:00.000Z',
+    modifiedAt: '2025-01-01T00:00:00.000Z',
+  });
 
   const mockUser: AuthUser = {
     id: 'user-123',
@@ -59,6 +72,11 @@ describe('DiscussionApplicationService', () => {
       },
     } as any;
 
+    mockDiscussionRepository = {
+      findById: vi.fn(),
+      findDiscussionByMessageId: vi.fn(),
+    };
+
     mockLogger = {
       log: vi.fn(),
       error: vi.fn(),
@@ -82,6 +100,10 @@ describe('DiscussionApplicationService', () => {
         {
           provide: DatabaseService,
           useValue: mockDatabaseService as DatabaseService,
+        },
+        {
+          provide: 'DiscussionRepository',
+          useValue: mockDiscussionRepository as DiscussionRepository,
         },
         {
           provide: Logger,
@@ -168,6 +190,10 @@ describe('DiscussionApplicationService', () => {
       const mockResponse = { success: true as const, data: undefined };
 
       vi.mocked(mockPermissionService.isAllowed)?.mockResolvedValue(true);
+      vi.mocked(mockDiscussionRepository.findById)?.mockResolvedValue({
+        success: true,
+        data: makeDiscussion({ id: discussionId, collectiviteId }),
+      });
       vi.mocked(
         mockDiscussionDomainService.deleteDiscussionAndDiscussionMessage
       )?.mockResolvedValue(mockResponse);
@@ -335,6 +361,10 @@ describe('DiscussionApplicationService', () => {
       };
 
       vi.mocked(mockPermissionService.isAllowed)?.mockResolvedValue(true);
+      vi.mocked(mockDiscussionRepository.findById)?.mockResolvedValue({
+        success: true,
+        data: makeDiscussion({ id: discussionId, collectiviteId }),
+      });
       vi.mocked(
         mockDiscussionDomainService.updateDiscussion
       )?.mockResolvedValue(mockResponse);
@@ -391,6 +421,10 @@ describe('DiscussionApplicationService', () => {
       };
 
       vi.mocked(mockPermissionService.isAllowed)?.mockResolvedValue(true);
+      vi.mocked(mockDiscussionRepository.findById)?.mockResolvedValue({
+        success: true,
+        data: makeDiscussion({ id: discussionId, collectiviteId }),
+      });
       vi.mocked(
         mockDiscussionDomainService.updateDiscussion
       )?.mockResolvedValue(mockResponse);
@@ -429,6 +463,10 @@ describe('DiscussionApplicationService', () => {
       };
 
       vi.mocked(mockPermissionService.isAllowed)?.mockResolvedValue(true);
+      vi.mocked(mockDiscussionRepository.findById)?.mockResolvedValue({
+        success: true,
+        data: makeDiscussion({ id: discussionId, collectiviteId }),
+      });
       vi.mocked(
         mockDiscussionDomainService.updateDiscussion
       )?.mockResolvedValue(mockResponse);
@@ -482,6 +520,12 @@ describe('DiscussionApplicationService', () => {
 
       vi.mocked(mockPermissionService.isAllowed)?.mockResolvedValue(true);
       vi.mocked(
+        mockDiscussionRepository.findDiscussionByMessageId
+      )?.mockResolvedValue({
+        success: true,
+        data: makeDiscussion({ collectiviteId }),
+      });
+      vi.mocked(
         mockDiscussionDomainService.updateDiscussionMessage
       )?.mockResolvedValue(mockResponse);
 
@@ -532,6 +576,12 @@ describe('DiscussionApplicationService', () => {
 
       vi.mocked(mockPermissionService.isAllowed)?.mockResolvedValue(true);
       vi.mocked(
+        mockDiscussionRepository.findDiscussionByMessageId
+      )?.mockResolvedValue({
+        success: true,
+        data: makeDiscussion({ collectiviteId }),
+      });
+      vi.mocked(
         mockDiscussionDomainService.deleteDiscussionMessage
       )?.mockResolvedValue(mockResponse);
 
@@ -560,6 +610,153 @@ describe('DiscussionApplicationService', () => {
         error: DiscussionErrorEnum.UNAUTHORIZED,
       });
       expect(mockLogger.error).toHaveBeenCalled();
+      expect(
+        mockDiscussionDomainService.deleteDiscussionMessage
+      ).not.toHaveBeenCalled();
+    });
+  });
+
+  // Régression du pentest ORHUS-302 V2 (contrôle d'accès horizontal sur
+  // discussions). Un utilisateur autorisé sur sa collectivité ne doit pas
+  // pouvoir muter une discussion/message appartenant à une autre collectivité
+  // en passant uniquement leur identifiant dans le payload.
+  describe('contrôle d\'accès horizontal (pentest V2)', () => {
+    const attackerCollectiviteId = 1;
+    const victimCollectiviteId = 2;
+    const foreignDiscussionId = 999;
+    const foreignMessageId = 888;
+
+    test('createDiscussion → NOT_FOUND si la discussion existante appartient à une autre collectivité', async () => {
+      vi.mocked(mockPermissionService.isAllowed)?.mockResolvedValue(true);
+      vi.mocked(mockDiscussionRepository.findById)?.mockResolvedValue({
+        success: true,
+        data: makeDiscussion({
+          id: foreignDiscussionId,
+          collectiviteId: victimCollectiviteId,
+        }),
+      });
+
+      const result = await service.createDiscussion(
+        {
+          discussionId: foreignDiscussionId,
+          collectiviteId: attackerCollectiviteId,
+          actionId: 'cae_1.1.1',
+          message: 'tentative',
+        },
+        mockUser
+      );
+
+      expect(result).toEqual({
+        success: false,
+        error: DiscussionErrorEnum.NOT_FOUND,
+      });
+      expect(
+        mockDiscussionDomainService.createOrUpdateDiscussion
+      ).not.toHaveBeenCalled();
+    });
+
+    test('updateDiscussion → NOT_FOUND si la discussion appartient à une autre collectivité', async () => {
+      vi.mocked(mockPermissionService.isAllowed)?.mockResolvedValue(true);
+      vi.mocked(mockDiscussionRepository.findById)?.mockResolvedValue({
+        success: true,
+        data: makeDiscussion({
+          id: foreignDiscussionId,
+          collectiviteId: victimCollectiviteId,
+        }),
+      });
+
+      const result = await service.updateDiscussion(
+        {
+          discussionId: foreignDiscussionId,
+          collectiviteId: attackerCollectiviteId,
+          status: discussionStatus.FERME,
+        },
+        mockUser
+      );
+
+      expect(result).toEqual({
+        success: false,
+        error: DiscussionErrorEnum.NOT_FOUND,
+      });
+      expect(mockDiscussionDomainService.updateDiscussion).not.toHaveBeenCalled();
+    });
+
+    test('updateDiscussionMessage → NOT_FOUND si le message appartient à une autre collectivité', async () => {
+      vi.mocked(mockPermissionService.isAllowed)?.mockResolvedValue(true);
+      vi.mocked(
+        mockDiscussionRepository.findDiscussionByMessageId
+      )?.mockResolvedValue({
+        success: true,
+        data: makeDiscussion({ collectiviteId: victimCollectiviteId }),
+      });
+
+      const result = await service.updateDiscussionMessage(
+        {
+          messageId: foreignMessageId,
+          collectiviteId: attackerCollectiviteId,
+          message: 'pwned',
+        },
+        mockUser
+      );
+
+      expect(result).toEqual({
+        success: false,
+        error: DiscussionErrorEnum.NOT_FOUND,
+      });
+      expect(
+        mockDiscussionDomainService.updateDiscussionMessage
+      ).not.toHaveBeenCalled();
+    });
+
+    test('deleteDiscussionAndDiscussionMessage → NOT_FOUND si la discussion appartient à une autre collectivité', async () => {
+      vi.mocked(mockPermissionService.isAllowed)?.mockResolvedValue(true);
+      vi.mocked(mockDiscussionRepository.findById)?.mockResolvedValue({
+        success: true,
+        data: makeDiscussion({
+          id: foreignDiscussionId,
+          collectiviteId: victimCollectiviteId,
+        }),
+      });
+
+      const result = await service.deleteDiscussionAndDiscussionMessage(
+        {
+          discussionId: foreignDiscussionId,
+          collectiviteId: attackerCollectiviteId,
+        },
+        mockUser
+      );
+
+      expect(result).toEqual({
+        success: false,
+        error: DiscussionErrorEnum.NOT_FOUND,
+      });
+      expect(
+        mockDiscussionDomainService.deleteDiscussionAndDiscussionMessage
+      ).not.toHaveBeenCalled();
+    });
+
+    test('deleteDiscussionMessage → NOT_FOUND si le message appartient à une autre collectivité', async () => {
+      vi.mocked(mockPermissionService.isAllowed)?.mockResolvedValue(true);
+      vi.mocked(
+        mockDiscussionRepository.findDiscussionByMessageId
+      )?.mockResolvedValue({
+        success: true,
+        data: makeDiscussion({ collectiviteId: victimCollectiviteId }),
+      });
+
+      const result = await service.deleteDiscussionMessage(
+        {
+          messageId: foreignMessageId,
+          discussionId: foreignDiscussionId,
+          collectiviteId: attackerCollectiviteId,
+        },
+        mockUser
+      );
+
+      expect(result).toEqual({
+        success: false,
+        error: DiscussionErrorEnum.NOT_FOUND,
+      });
       expect(
         mockDiscussionDomainService.deleteDiscussionMessage
       ).not.toHaveBeenCalled();

--- a/apps/backend/src/collectivites/discussions/application/discussion-application.service.ts
+++ b/apps/backend/src/collectivites/discussions/application/discussion-application.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
 import { AuthUser } from '@tet/backend/users/models/auth.models';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
@@ -10,6 +10,7 @@ import {
   DiscussionErrorEnum,
 } from '../domain/discussion.errors';
 import { ListDiscussionService } from '../domain/list-discussion-service';
+import { type DiscussionRepository } from '../infrastructure/discussion-repository.interface';
 import { DiscussionResult } from '../infrastructure/discussion.results';
 import {
   CreateDiscussionData,
@@ -30,8 +31,48 @@ export class DiscussionApplicationService {
     private readonly listDiscussionService: ListDiscussionService,
     private readonly permissionService: PermissionService,
     private readonly databaseService: DatabaseService,
+    @Inject('DiscussionRepository')
+    private readonly discussionRepository: DiscussionRepository,
     private readonly logger: Logger
   ) {}
+
+  // SÉCURITÉ (pentest V2 / ORHUS-302) : ces helpers vérifient que la ressource
+  // existante (discussion ou message) appartient bien à la `collectiviteId`
+  // déclarée dans le payload avant toute mutation. Sans ce contrôle, un
+  // utilisateur ayant des droits sur sa propre collectivité pouvait manipuler
+  // les discussions/messages d'une autre collectivité en passant simplement
+  // leur identifiant.
+  private async assertDiscussionInCollectivite(
+    discussionId: number,
+    collectiviteId: number
+  ): Promise<DiscussionResult<void, DiscussionError>> {
+    const result = await this.discussionRepository.findById(discussionId);
+    if (!result.success) {
+      return result;
+    }
+    if (result.data.collectiviteId !== collectiviteId) {
+      // On renvoie volontairement un NOT_FOUND plutôt qu'un FORBIDDEN pour
+      // ne pas confirmer l'existence d'une discussion étrangère.
+      return { success: false, error: DiscussionErrorEnum.NOT_FOUND };
+    }
+    return { success: true, data: undefined };
+  }
+
+  private async assertMessageInCollectivite(
+    messageId: number,
+    collectiviteId: number
+  ): Promise<DiscussionResult<void, DiscussionError>> {
+    const result = await this.discussionRepository.findDiscussionByMessageId(
+      messageId
+    );
+    if (!result.success) {
+      return result;
+    }
+    if (result.data.collectiviteId !== collectiviteId) {
+      return { success: false, error: DiscussionErrorEnum.NOT_FOUND };
+    }
+    return { success: true, data: undefined };
+  }
 
   async createDiscussion(
     discussion: CreateDiscussionRequest,
@@ -52,6 +93,16 @@ export class DiscussionApplicationService {
         success: false,
         error: DiscussionErrorEnum.UNAUTHORIZED,
       };
+    }
+
+    if (discussion.discussionId) {
+      const check = await this.assertDiscussionInCollectivite(
+        discussion.discussionId,
+        discussion.collectiviteId
+      );
+      if (!check.success) {
+        return check;
+      }
     }
 
     this.logger.log(
@@ -91,6 +142,13 @@ export class DiscussionApplicationService {
         error: DiscussionErrorEnum.UNAUTHORIZED,
       };
     }
+    const ownershipCheck = await this.assertDiscussionInCollectivite(
+      discussionId,
+      collectiviteId
+    );
+    if (!ownershipCheck.success) {
+      return ownershipCheck;
+    }
     const discussionMessageResult =
       await this.discussionDomainService.deleteDiscussionAndDiscussionMessage(
         discussionId
@@ -119,6 +177,13 @@ export class DiscussionApplicationService {
         success: false,
         error: DiscussionErrorEnum.UNAUTHORIZED,
       };
+    }
+    const ownershipCheck = await this.assertMessageInCollectivite(
+      messageId,
+      collectiviteId
+    );
+    if (!ownershipCheck.success) {
+      return ownershipCheck;
     }
     const discussionMessageResult =
       await this.discussionDomainService.deleteDiscussionMessage(
@@ -202,6 +267,13 @@ export class DiscussionApplicationService {
         error: DiscussionErrorEnum.UNAUTHORIZED,
       };
     }
+    const ownershipCheck = await this.assertDiscussionInCollectivite(
+      discussionId,
+      collectiviteId
+    );
+    if (!ownershipCheck.success) {
+      return ownershipCheck;
+    }
     const result = await this.discussionDomainService.updateDiscussion(
       discussionId,
       status
@@ -229,6 +301,13 @@ export class DiscussionApplicationService {
         success: false,
         error: DiscussionErrorEnum.UNAUTHORIZED,
       };
+    }
+    const ownershipCheck = await this.assertMessageInCollectivite(
+      messageId,
+      collectiviteId
+    );
+    if (!ownershipCheck.success) {
+      return ownershipCheck;
     }
     const result = await this.discussionDomainService.updateDiscussionMessage(
       messageId,

--- a/apps/backend/src/collectivites/discussions/infrastructure/discussion-repository.interface.ts
+++ b/apps/backend/src/collectivites/discussions/infrastructure/discussion-repository.interface.ts
@@ -22,6 +22,9 @@ export interface DiscussionRepository {
     tx?: Transaction
   ) => Promise<DiscussionResult<CreateDiscussionMessageResponse>>;
   findById: (id: number) => Promise<DiscussionResult<Discussion>>;
+  findDiscussionByMessageId: (
+    messageId: number
+  ) => Promise<DiscussionResult<Discussion>>;
   findByCollectiviteIdAndReferentielId: (
     collectiviteId: number,
     referentielId: ReferentielId

--- a/apps/backend/src/collectivites/discussions/infrastructure/discussion.repository.impl.ts
+++ b/apps/backend/src/collectivites/discussions/infrastructure/discussion.repository.impl.ts
@@ -169,6 +169,41 @@ export class DiscussionRepositoryImpl implements DiscussionRepository {
     }
   }
 
+  async findDiscussionByMessageId(
+    messageId: number
+  ): Promise<DiscussionResult<Discussion>> {
+    try {
+      const result = await this.databaseService.db
+        .select(getTableColumns(discussionTable))
+        .from(discussionMessageTable)
+        .innerJoin(
+          discussionTable,
+          eq(discussionMessageTable.discussionId, discussionTable.id)
+        )
+        .where(eq(discussionMessageTable.id, messageId));
+
+      if (!result || result.length === 0) {
+        return {
+          success: false,
+          error: DiscussionErrorEnum.NOT_FOUND,
+        };
+      }
+      const [discussion] = result;
+      return {
+        success: true,
+        data: discussion,
+      };
+    } catch (error) {
+      this.logger.error(
+        `Error finding discussion by message id ${messageId}: ${error}`
+      );
+      return {
+        success: false,
+        error: DiscussionErrorEnum.DATABASE_ERROR,
+      };
+    }
+  }
+
   async countMessagesDiscussionsByDiscussionId(
     discussionId: number
   ): Promise<DiscussionResult<number>> {

--- a/apps/backend/src/plans/axes/upsert-axe/upsert-axe-base.repository.ts
+++ b/apps/backend/src/plans/axes/upsert-axe/upsert-axe-base.repository.ts
@@ -4,7 +4,7 @@ import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { Transaction } from '@tet/backend/utils/database/transaction.utils';
 import { Result } from '@tet/backend/utils/result.type';
 import { AxeLight } from '@tet/domain/plans';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 
 /**
  * Type d'erreur générique pour les opérations d'upsert
@@ -80,15 +80,26 @@ export abstract class UpsertAxeBaseRepository<
     tx?: Transaction
   ): Promise<Result<AxeLight, TError>> {
     try {
-      const { id, ...otherProps } = input;
+      // SÉCURITÉ (pentest V2 / ORHUS-302) : on n'accepte pas le `collectiviteId`
+      // du payload comme cible de l'update. La clause WHERE filtre sur le
+      // `collectiviteId` réel de la ressource et la SET ignore le champ pour
+      // garder le rattachement immuable. Cela bloque à la fois la modification
+      // d'un axe/plan d'une autre collectivité et son « hijack » (changement
+      // de `collectivite_id` vers la collectivité de l'attaquant).
+      const { id, collectiviteId, ...mutableProps } = input;
       const result = await (tx ?? this.databaseService.db)
         .update(axeTable)
         .set({
-          ...otherProps,
+          ...mutableProps,
           modifiedBy: userId,
           modifiedAt: new Date().toISOString(),
         })
-        .where(eq(axeTable.id, id))
+        .where(
+          and(
+            eq(axeTable.id, id),
+            eq(axeTable.collectiviteId, collectiviteId)
+          )
+        )
         .returning();
 
       if (!result || result.length === 0) {


### PR DESCRIPTION
## Contexte

Le rapport de pentest ORHUS-302 (mai 2026) a identifié un **défaut de contrôle d'accès horizontal** (V2, criticité élevée) sur plusieurs endpoints tRPC : un administrateur d'une collectivité A peut muter — et même **hijacker** — des ressources appartenant à une collectivité B en envoyant simplement l'identifiant de la ressource cible et son propre `collectiviteId`. Le serveur autorise l'opération en se basant uniquement sur le `collectiviteId` du payload, sans vérifier que la ressource concernée appartient bien à cette collectivité.

🔗 Ticket Notion : [TET-7330 — V2 Contrôle d'accès horizontal](https://www.notion.so/36e6523d57d781fba763d3a98803012e)

## Endpoints corrigés

### Plans / Axes (`plans.plans.update`, `plans.axes.update`)

Le repository d'upsert (`upsert-axe-base.repository.ts`) filtrait son UPDATE sur `id` uniquement et écrivait le `collectivite_id` reçu en payload dans la clause SET. Conséquence :

1. **Modification non autorisée** : l'attaquant pouvait modifier le nom/description/etc. d'un plan/axe appartenant à une autre collectivité.
2. **Hijack** : `SET collectivite_id = <attaquant>` rattachait silencieusement le plan/axe à la collectivité de l'attaquant ; la victime voyait son plan disparaître (c'est ce que le rapport décrit comme une « suppression complète »).

**Fix** :
- WHERE resserré sur `(id, collectiviteId)` → l'UPDATE n'affecte 0 ligne si la ressource appartient à une autre collectivité.
- `collectiviteId` retiré du SET → le rattachement à la collectivité est désormais immuable côté ORM.

### Discussions (`collectivites.discussions.*`)

`DiscussionApplicationService` vérifiait la permission sur le `collectiviteId` du payload, puis opérait sur la discussion ou le message via son id seul. Les **5 endpoints mutants** étaient touchés : `create` (cas avec `discussionId` fourni), `update`, `updateMessage`, `delete`, `deleteMessage`.

**Fix** :
- Deux helpers privés `assertDiscussionInCollectivite(discussionId, collectiviteId)` et `assertMessageInCollectivite(messageId, collectiviteId)` pré-chargent la ressource via le repository et renvoient `NOT_FOUND` si elle n'appartient pas à la collectivité revendiquée. On renvoie volontairement `NOT_FOUND` plutôt que `FORBIDDEN` pour ne pas confirmer l'existence d'une discussion étrangère.
- Nouvelle méthode repository `findDiscussionByMessageId` qui joint `discussion_message` → `discussion` pour récupérer le `collectivite_id` propriétaire d'un message.
- Helpers appelés systématiquement après le contrôle de permission, avant toute opération.

## Validation

- **20 tests** dans `discussion-application.service.spec.ts` (15 existants + **5 régressions V2** ajoutées) couvrant les 5 endpoints discussions face à un payload cross-collectivité.
- **21 tests** e2e `upsert-plan.router.e2e-spec.ts` ✅ — confirme qu'un update légitime fonctionne toujours.
- **9 tests** e2e `upsert-axe.router.e2e-spec.ts` ✅ — idem.
- **17 tests** `discussion-domain-service.spec.ts` + **13 tests** `discussion.router.spec.ts` ✅.
- Build backend OK.

## Suite

Recommandation **R5** du pentest (« revue complète du code pour vérifier les contrôles de cohérence sur l'ensemble des endpoints tRPC mutants ») reste à traiter en suivi. Endpoints suspects identifiés à investiguer (liste non exhaustive) :
- `collectivites.collectivite-preferences.update`
- `indicateurs.valeurs.upsert`
- Toutes les routes acceptant un `collectiviteId` en payload + un identifiant de ressource enfant

## Test plan

- [ ] CI verte
- [ ] Vérification manuelle staging : un admin d'une collectivité A tente d'updater un plan/axe d'une collectivité B (via DevTools / curl direct) → doit renvoyer `UPDATE_PLAN_ERROR` / `UPDATE_AXE_ERROR`.
- [ ] Un admin d'une collectivité A tente de poster/modifier/supprimer une discussion/message d'une collectivité B → doit renvoyer `NOT_FOUND`.
- [ ] Les opérations légitimes (update plan/axe/discussion dans sa propre collectivité) restent fonctionnelles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Renforcé les contrôles d'accès horizontal pour les discussions et messages afin de prévenir l'accès non autorisé aux ressources d'autres collectivités.
  * Amélioré la validation de sécurité pour les axes en garantissant que seuls les propriétaires autorisés peuvent les modifier.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/incubateur-ademe/territoires-en-transitions/pull/4496?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->