### PR TITLE
fix(security): empêche le phishing via le mail d'invitation (pentest V3)

### DIFF
--- a/.github/actions/app-env/action.yml
+++ b/.github/actions/app-env/action.yml
@@ -51,7 +51,7 @@ runs:
         echo "NEXT_PUBLIC_GIT_COMMIT_TIMESTAMP=${{ steps.setup.outputs.git_commit_timestamp }}" >> $file
         echo "NEXT_PUBLIC_APPLICATION_VERSION=${{ steps.setup.outputs.application_version }}" >> $file
         echo "NEXT_PUBLIC_ENV_NAME=${{ inputs.environment }}" >> $file
-        echo "=${{ fromJSON(inputs.json_vars).APP_URL }}" >> $file
+        echo "NEXT_PUBLIC_APP_URL=${{ fromJSON(inputs.json_vars).APP_URL }}" >> $file
         echo "NEXT_PUBLIC_AUTH_URL=${{ fromJSON(inputs.json_vars).AUTH_URL }}" >> $file
         echo "NEXT_PUBLIC_PANIER_URL=${{ fromJSON(inputs.json_vars).PANIER_URL }}" >> $file
         echo "NEXT_PUBLIC_AXEPTIO_ID=${{ fromJSON(inputs.json_vars).AXEPTIO_ID }}" >> $file

--- a/apps/app/src/collectivites/membres/invite-membre/use-send-invitation.ts
+++ b/apps/app/src/collectivites/membres/invite-membre/use-send-invitation.ts
@@ -1,7 +1,3 @@
-import {
-  makeCollectiviteAccueilUrl,
-  makeInvitationLandingPath,
-} from '@/app/app/paths';
 import { useToastContext } from '@/app/utils/toast/toast-context';
 import { useMutation } from '@tanstack/react-query';
 import { useCurrentCollectivite } from '@tet/api/collectivites';
@@ -12,7 +8,12 @@ export type SendInvitationArgs = {
 };
 
 /**
- * Envoi le mail d'invitation à rejoindre une collectivité donnée
+ * Envoi le mail d'invitation à rejoindre une collectivité donnée.
+ *
+ * Depuis le correctif TET-7331 (pentest V3), seuls les identifiants
+ * (`invitationId` ou `collectiviteId`) sont transmis : l'URL et le contenu du
+ * mail sont reconstruits côté serveur à partir d'`APP_URL` pour empêcher tout
+ * détournement du lien.
  */
 export const useSendInvitation = () => {
   const { setToast } = useToastContext();
@@ -24,31 +25,32 @@ export const useSendInvitation = () => {
       email: rawEmail,
     }: SendInvitationArgs) => {
       const email = rawEmail.toLowerCase();
-      const url =
-        window.location.origin +
-        (invitationId
-          ? makeInvitationLandingPath(invitationId, email)
-          : makeCollectiviteAccueilUrl({
-              collectiviteId,
-            }));
-      const urlType = invitationId ? 'invitation' : 'rattachement';
 
-      // envoi le mail d'invitation
       const invitePath = `${process.env.NEXT_PUBLIC_AUTH_URL}/invite`;
       const { prenom, nom, email: emailFrom } = user;
+      const body = invitationId
+        ? {
+            urlType: 'invitation' as const,
+            invitationId,
+            to: email,
+            from: { prenom, nom, email: emailFrom },
+            collectivite: collectiviteNom,
+          }
+        : {
+            urlType: 'rattachement' as const,
+            collectiviteId,
+            to: email,
+            from: { prenom, nom, email: emailFrom },
+            collectivite: collectiviteNom,
+          };
+
       return fetch(invitePath, {
         method: 'POST',
         credentials: 'include',
         headers: {
           'content-type': 'application/json',
         },
-        body: JSON.stringify({
-          to: email,
-          from: { prenom, nom, email: emailFrom },
-          collectivite: collectiviteNom,
-          url,
-          urlType,
-        }),
+        body: JSON.stringify(body),
       });
     },
     onSuccess: async (data, variables) => {

--- a/apps/auth/app/invite/route.ts
+++ b/apps/auth/app/invite/route.ts
@@ -1,29 +1,74 @@
+import { NextRequest } from 'next/server';
+import { z } from 'zod';
 import {
   authError,
   getDbUserFromRequest,
 } from '../../src/supabase/getDbUserFromRequest';
 import { sendEmail } from '../../src/utils/sendEmail';
-import { NextRequest } from 'next/server';
-import { z } from 'zod';
 
-// schéma des données attendues
-const invitationSchema = z.object({
+// SÉCURITÉ (pentest V3 / ORHUS-302) :
+// Le contenu et le lien du mail d'invitation doivent être générés strictement
+// côté serveur. Auparavant, le client envoyait l'URL du bouton et le nom de la
+// collectivité en clair, ce qui permettait à un utilisateur authentifié de
+// déclencher l'envoi d'un mail aux couleurs de l'ADEME depuis l'adresse
+// officielle, contenant un lien arbitraire (phishing). Le schéma ci-dessous
+// n'accepte plus que les identifiants nécessaires ; l'URL est construite à
+// partir de `APP_URL`, et toutes les valeurs interpolées dans le template HTML
+// sont échappées.
+
+const APP_URL = (process.env.APP_URL ?? process.env.NEXT_PUBLIC_APP_URL ?? '')
+  // on retire un éventuel `/` final pour produire des URL propres
+  .replace(/\/+$/, '');
+
+// Restreint les noms/prénoms à un jeu de caractères usuel (lettres latines,
+// accents, espace, tiret, apostrophe, point). Empêche l'injection de balises.
+const safeNameSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(100)
+  .regex(
+    /^[\p{L}\p{M}\s'.-]+$/u,
+    "Caractères non autorisés dans le nom ou prénom"
+  );
+
+// Nom de collectivité : même esprit, on autorise en plus chiffres, parenthèses
+// et virgule (ex: « CC de la Basse-Zorn », « CA Grand Paris Sud (91) »).
+const collectiviteNameSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(200)
+  .regex(
+    /^[\p{L}\p{M}\p{N}\s'(),.-]+$/u,
+    'Caractères non autorisés dans le nom de la collectivité'
+  );
+
+const baseInvitationSchema = z.object({
   /** Adresse à laquelle envoyer l'invitation */
   to: z.email(),
   /** Utilisateur envoyant l'invitation */
   from: z.object({
-    prenom: z.string(),
-    nom: z.string(),
+    prenom: safeNameSchema,
+    nom: safeNameSchema,
     email: z.email(),
   }),
   /** Collectivité à laquelle est attachée l'invitation */
-  collectivite: z.string(),
-  /** Lien pour activer l'invitation ou accéder à la collectivité (dans le cas
-   * du rattachement d'un utilisateur existant) */
-  url: z.string(),
-  /** Indique si il s'agit d'une invitation ou d'un rattachement */
-  urlType: z.enum(['invitation', 'rattachement']),
+  collectivite: collectiviteNameSchema,
 });
+
+const invitationSchema = z.discriminatedUnion('urlType', [
+  baseInvitationSchema.extend({
+    urlType: z.literal('invitation'),
+    /** Identifiant de l'invitation côté backend (UUID). */
+    invitationId: z.uuid(),
+  }),
+  baseInvitationSchema.extend({
+    urlType: z.literal('rattachement'),
+    /** Collectivité à laquelle on rattache un utilisateur existant. */
+    collectiviteId: z.number().int().positive(),
+  }),
+]);
 
 type Invitation = z.infer<typeof invitationSchema>;
 
@@ -37,13 +82,22 @@ export async function POST(request: NextRequest) {
     return authError;
   }
 
+  if (!APP_URL) {
+    console.error('POST invite: APP_URL non configurée côté serveur');
+    return Response.json(
+      { error: 'Configuration serveur incomplète' },
+      { status: 500 }
+    );
+  }
+
   // vérifie les paramètres
-  const invitation = (await request.json()) as Invitation;
-  const verifyArgs = invitationSchema.safeParse(invitation);
+  const body = (await request.json()) as unknown;
+  const verifyArgs = invitationSchema.safeParse(body);
   if (!verifyArgs.success) {
     console.error('POST invite error', verifyArgs.error);
-    return Response.json({ error: 'Arguments non valides' }, { status: 500 });
+    return Response.json({ error: 'Arguments non valides' }, { status: 400 });
   }
+  const invitation = verifyArgs.data;
 
   // génère et envoi le mail
   const { to, from, collectivite } = invitation;
@@ -62,23 +116,48 @@ export async function OPTIONS() {
   return Response.json({});
 }
 
+// Construit l'URL du bouton à partir d'`APP_URL` (verrouillée côté serveur),
+// jamais d'une URL fournie par le client.
+const buildInvitationUrl = (invitation: Invitation): string => {
+  if (invitation.urlType === 'invitation') {
+    return `${APP_URL}/invitation/${invitation.invitationId}/${encodeURIComponent(
+      invitation.to
+    )}`;
+  }
+  return `${APP_URL}/collectivite/${invitation.collectiviteId}/accueil`;
+};
+
+const escapeHtml = (value: string): string =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
 // formatage du mail
-const mailTemplate = ({ from, collectivite, url, urlType }: Invitation) => {
+const mailTemplate = (invitation: Invitation) => {
+  const { from, collectivite, urlType } = invitation;
   const { email, nom, prenom } = from;
+  const url = buildInvitationUrl(invitation);
+  const ctaLabel =
+    urlType === 'invitation'
+      ? 'Je rejoins la collectivité'
+      : 'Je lance Territoires en transitions !';
 
   return `<html>
 <body>
     <h2>Territoires en Transitions</h2>
     <p>Bonjour,</p>
 
-  <p>${prenom} ${nom} (${email}) vous invite à contribuer pour ${collectivite} sur Territoires en Transitions.</p>
-  <a href="${url}"
+  <p>${escapeHtml(prenom)} ${escapeHtml(nom)} (${escapeHtml(
+    email
+  )}) vous invite à contribuer pour ${escapeHtml(
+    collectivite
+  )} sur Territoires en Transitions.</p>
+  <a href="${escapeHtml(url)}"
     style="font-size: 1rem; font-weight: 700; border: 1px solid #6A6AF4; border-radius: 8px; text-align: center; padding: 1rem 2rem; margin: 1rem; display: block; max-width: fit-content; background-color: #6A6AF4; color: white; text-decoration: none;"
-    >${
-      urlType === 'invitation'
-        ? 'Je rejoins la collectivité'
-        : 'Je lance Territoires en transitions !'
-    }</a
+    >${ctaLabel}</a
   >
 
   ${


### PR DESCRIPTION
## Contexte

Le rapport ORHUS-302 (mai 2026) a identifié une vulnérabilité **élevée (V3)** sur l'endpoint `POST /invite` (Next.js, `apps/auth`). Cet endpoint :

1. Acceptait **l'URL du bouton « Accéder à l'invitation » en clair** depuis le client (champ `url`).
2. Acceptait également en clair le nom de la collectivité et les nom/prénom/email de l'expéditeur, **interpolés sans échappement** dans le template HTML.
3. Envoyait le mail depuis l'adresse officielle `notifications@territoiresentransitions.fr` via SMTP Brevo.

Conséquence : un utilisateur authentifié pouvait déclencher un envoi de mail aux couleurs de l'ADEME contenant un lien arbitraire. La preuve d'exploit consistait à pointer le bouton vers `https://orhus.fr`. Risques : campagnes de phishing depuis le domaine légitime, atteinte à l'image de marque, dégradation de la réputation du domaine SMTP.

🔗 Ticket Notion : [TET-7331 — V3 Phishing via `/invite`](https://www.notion.so/36e6523d57d781de85c5e66000ac58e4)

## Correctif (R6 du rapport)

### Côté serveur (`apps/auth/app/invite/route.ts`)

- **Plus aucune URL acceptée du client.** Le schéma Zod est désormais un `discriminatedUnion('urlType')` qui exige soit un `invitationId` (UUID), soit un `collectiviteId` (entier positif). L'URL du bouton est reconstruite côté serveur à partir d'`APP_URL` (variable d'environnement serveur, fallback `NEXT_PUBLIC_APP_URL`) et du chemin canonique correspondant.
- **HTML escape systématique.** Une fonction `escapeHtml` est appliquée à toutes les valeurs interpolées (nom, prénom, email, nom de collectivité, URL du bouton).
- **Schéma resserré.** Les noms/prénoms et le nom de collectivité passent par des regex Unicode (`\p{L}\p{M}\p{N}…`) qui rejettent toute balise HTML, JavaScript, caractère de contrôle. Bornes de longueur ajoutées (100/200 chars).
- Erreurs de validation : `500` → `400` (Bad Request, plus juste).

### Côté client (`apps/app/.../use-send-invitation.ts`)

- N'envoie plus l'URL construite dans le navigateur ; transmet directement `invitationId` (cas invitation) ou `collectiviteId` (cas rattachement).

## Validation

- Lint : OK.
- Build `auth` : OK.
- Build `app` : OK.
- Tentative manuelle d'exploit : envoyer `{ urlType: 'invitation', invitationId: 'xxx', url: 'https://attaquant.tld', collectivite: '<script>alert(1)</script>' }` → Zod rejette (`url` n'est plus dans le schéma, `collectivite` rejette les `<>`).
- Envoi légitime depuis l'UI : `invitationId` ou `collectiviteId` transmis, URL reconstruite côté serveur — comportement utilisateur inchangé.

## Test plan

- [ ] CI verte
- [ ] Vérifier sur staging : inviter un nouvel utilisateur → email reçu, lien correctement formé vers l'URL `https://app.territoiresentransitions.fr/invitation/<uuid>/<email>`.
- [ ] Rattacher un membre existant → email reçu, lien vers `/collectivite/<id>/accueil`.
- [ ] Tenter un appel direct à `/invite` avec un champ `url` arbitraire → réponse 400.
- [ ] Tenter un payload `collectivite: "<img src=x onerror=alert(1)>"` → réponse 400.

## Suite

Le rapport ne mentionne pas d'autres endpoints similaires, mais une revue rapide a identifié `signup`/`rejoindre-une-collectivite` qui acceptent un `redirect_to` en query string — à valider dans un autre ticket si nécessaire.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Correction de la génération de variables d'environnement pour les applications.

* **Chores**
  * Renforcement de la sécurité des invitations via validation stricte et échappement des données côté serveur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->