### PR TITLE
refac(security): ne pas utiliser sql.raw pour éviter les injections

### DIFF
--- a/apps/backend/src/collectivites/membres/mutate-invitations/invitation.service.ts
+++ b/apps/backend/src/collectivites/membres/mutate-invitations/invitation.service.ts
@@ -234,15 +234,10 @@ export class InvitationService {
               utilisateurCollectiviteAccessTable.collectiviteId,
             ],
             set: {
-              isActive: sql.raw(
-                `excluded.${utilisateurCollectiviteAccessTable.isActive.name}`
-              ),
-              role: sql.raw(
-                `excluded.${utilisateurCollectiviteAccessTable.role.name}`
-              ),
-              invitationId: sql.raw(
-                `excluded.${utilisateurCollectiviteAccessTable.invitationId.name}`
-              ),
+              isActive: sql`excluded.${utilisateurCollectiviteAccessTable.isActive.name}`,
+              role: sql`excluded.${utilisateurCollectiviteAccessTable.role.name}`,
+              invitationId: sql`
+                excluded.${utilisateurCollectiviteAccessTable.invitationId.name}`,
             },
           });
 

--- a/apps/backend/src/collectivites/personnalisations/set-personnalisation-reponse/set-personnalisation-reponse.repository.ts
+++ b/apps/backend/src/collectivites/personnalisations/set-personnalisation-reponse/set-personnalisation-reponse.repository.ts
@@ -129,7 +129,7 @@ export class SetPersonnalisationReponseRepository {
               reponseBinaireTable.questionId,
             ],
             set: {
-              reponse: sql.raw(`excluded.${reponseBinaireTable.reponse.name}`),
+              reponse: sql`excluded.${reponseBinaireTable.reponse.name}`,
               modifiedAt: sql`CURRENT_TIMESTAMP`,
             },
           })
@@ -183,9 +183,7 @@ export class SetPersonnalisationReponseRepository {
               reponseProportionTable.questionId,
             ],
             set: {
-              reponse: sql.raw(
-                `excluded.${reponseProportionTable.reponse.name}`
-              ),
+              reponse: sql`excluded.${reponseProportionTable.reponse.name}`,
               modifiedAt: sql`CURRENT_TIMESTAMP`,
             },
           })
@@ -233,7 +231,7 @@ export class SetPersonnalisationReponseRepository {
               reponseChoixTable.questionId,
             ],
             set: {
-              reponse: sql.raw(`excluded.${reponseChoixTable.reponse.name}`),
+              reponse: sql`excluded.${reponseChoixTable.reponse.name}`,
               modifiedAt: sql`CURRENT_TIMESTAMP`,
             },
           })
@@ -312,8 +310,8 @@ export class SetPersonnalisationReponseRepository {
             justificationTable.questionId,
           ],
           set: {
-            texte: sql.raw(`excluded.${justificationTable.texte.name}`),
-            modifiedBy: sql.raw(`excluded.${justificationTable.modifiedBy.name}`),
+            texte: sql`excluded.${justificationTable.texte.name}`,
+            modifiedBy: sql`excluded.${justificationTable.modifiedBy.name}`,
             modifiedAt: sql`CURRENT_TIMESTAMP`,
           },
         })

--- a/apps/backend/src/collectivites/tableau-de-bord/tableau-de-bord-collectivite.service.ts
+++ b/apps/backend/src/collectivites/tableau-de-bord/tableau-de-bord-collectivite.service.ts
@@ -109,8 +109,8 @@ export default class TableauDeBordCollectiviteService {
       .onConflictDoUpdate({
         target: [tableauDeBordModuleTable.id],
         set: {
-          titre: sql.raw(`excluded.${tableauDeBordModuleTable.titre.name}`),
-          options: sql.raw(`excluded.${tableauDeBordModuleTable.options.name}`),
+          titre: sql`excluded.${tableauDeBordModuleTable.titre.name}`,
+          options: sql`excluded.${tableauDeBordModuleTable.options.name}`,
         },
       })
       .returning();

--- a/apps/backend/src/indicateurs/valeurs/crud-valeurs.service.ts
+++ b/apps/backend/src/indicateurs/valeurs/crud-valeurs.service.ts
@@ -720,27 +720,13 @@ export default class CrudValeursService {
               ],
               targetWhere: isNotNull(indicateurValeurTable.metadonneeId),
               set: {
-                resultat: sql.raw(
-                  `excluded.${indicateurValeurTable.resultat.name}`
-                ),
-                resultatCommentaire: sql.raw(
-                  `excluded.${indicateurValeurTable.resultatCommentaire.name}`
-                ),
-                objectif: sql.raw(
-                  `excluded.${indicateurValeurTable.objectif.name}`
-                ),
-                objectifCommentaire: sql.raw(
-                  `excluded.${indicateurValeurTable.objectifCommentaire.name}`
-                ),
-                calculAuto: sql.raw(
-                  `excluded.${indicateurValeurTable.calculAuto.name}`
-                ),
-                calculAutoIdentifiantsManquants: sql.raw(
-                  `excluded.${indicateurValeurTable.calculAutoIdentifiantsManquants.name}`
-                ),
-                modifiedBy: sql.raw(
-                  `excluded.${indicateurValeurTable.modifiedBy.name}`
-                ),
+                resultat: sql`excluded.${indicateurValeurTable.resultat.name}`,
+                resultatCommentaire: sql`excluded.${indicateurValeurTable.resultatCommentaire.name}`,
+                objectif: sql`excluded.${indicateurValeurTable.objectif.name}`,
+                objectifCommentaire: sql`excluded.${indicateurValeurTable.objectifCommentaire.name}`,
+                calculAuto: sql`excluded.${indicateurValeurTable.calculAuto.name}`,
+                calculAutoIdentifiantsManquants: sql`excluded.${indicateurValeurTable.calculAutoIdentifiantsManquants.name}`,
+                modifiedBy: sql`excluded.${indicateurValeurTable.modifiedBy.name}`,
               },
             })
             .returning();
@@ -848,27 +834,13 @@ export default class CrudValeursService {
                 ],
                 targetWhere: isNull(indicateurValeurTable.metadonneeId),
                 set: {
-                  resultat: sql.raw(
-                    `excluded.${indicateurValeurTable.resultat.name}`
-                  ),
-                  resultatCommentaire: sql.raw(
-                    `excluded.${indicateurValeurTable.resultatCommentaire.name}`
-                  ),
-                  objectif: sql.raw(
-                    `excluded.${indicateurValeurTable.objectif.name}`
-                  ),
-                  objectifCommentaire: sql.raw(
-                    `excluded.${indicateurValeurTable.objectifCommentaire.name}`
-                  ),
-                  calculAuto: sql.raw(
-                    `excluded.${indicateurValeurTable.calculAuto.name}`
-                  ),
-                  calculAutoIdentifiantsManquants: sql.raw(
-                    `excluded.${indicateurValeurTable.calculAutoIdentifiantsManquants.name}`
-                  ),
-                  modifiedBy: sql.raw(
-                    `excluded.${indicateurValeurTable.modifiedBy.name}`
-                  ),
+                  resultat: sql`excluded.${indicateurValeurTable.resultat.name}`,
+                  resultatCommentaire: sql`excluded.${indicateurValeurTable.resultatCommentaire.name}`,
+                  objectif: sql`excluded.${indicateurValeurTable.objectif.name}`,
+                  objectifCommentaire: sql`excluded.${indicateurValeurTable.objectifCommentaire.name}`,
+                  calculAuto: sql`excluded.${indicateurValeurTable.calculAuto.name}`,
+                  calculAutoIdentifiantsManquants: sql`excluded.${indicateurValeurTable.calculAutoIdentifiantsManquants.name}`,
+                  modifiedBy: sql`excluded.${indicateurValeurTable.modifiedBy.name}`,
                 },
               })
               .returning();

--- a/apps/backend/src/referentiels/snapshots/snapshots.service.ts
+++ b/apps/backend/src/referentiels/snapshots/snapshots.service.ts
@@ -190,25 +190,15 @@ export class SnapshotsService {
           snapshotTable.ref,
         ],
         set: {
-          date: sql.raw(`excluded.${snapshotTable.date.name}`),
-          pointFait: sql.raw(`excluded.${snapshotTable.pointFait.name}`),
-          pointPotentiel: sql.raw(
-            `excluded.${snapshotTable.pointPotentiel.name}`
-          ),
-          pointProgramme: sql.raw(
-            `excluded.${snapshotTable.pointProgramme.name}`
-          ),
-          pointPasFait: sql.raw(`excluded.${snapshotTable.pointPasFait.name}`),
-          scoresPayload: sql.raw(
-            `excluded.${snapshotTable.scoresPayload.name}`
-          ),
-          personnalisationReponses: sql.raw(
-            `excluded.${snapshotTable.personnalisationReponses.name}`
-          ),
-          referentielVersion: sql.raw(
-            `excluded.${snapshotTable.referentielVersion.name}`
-          ),
-          modifiedBy: sql.raw(`excluded.${snapshotTable.modifiedBy.name}`),
+          date: sql`excluded.${snapshotTable.date.name}`,
+          pointFait: sql`excluded.${snapshotTable.pointFait.name}`,
+          pointPotentiel: sql`excluded.${snapshotTable.pointPotentiel.name}`,
+          pointProgramme: sql`excluded.${snapshotTable.pointProgramme.name}`,
+          pointPasFait: sql`excluded.${snapshotTable.pointPasFait.name}`,
+          scoresPayload: sql`excluded.${snapshotTable.scoresPayload.name}`,
+          personnalisationReponses: sql`excluded.${snapshotTable.personnalisationReponses.name}`,
+          referentielVersion: sql`excluded.${snapshotTable.referentielVersion.name}`,
+          modifiedBy: sql`excluded.${snapshotTable.modifiedBy.name}`,
         },
       })
       .returning()
@@ -276,25 +266,15 @@ export class SnapshotsService {
         target: [snapshotTable.collectiviteId, snapshotTable.referentielId],
         targetWhere: eq(snapshotTable.jalon, SnapshotJalonEnum.COURANT),
         set: {
-          date: sql.raw(`excluded.${snapshotTable.date.name}`),
-          pointFait: sql.raw(`excluded.${snapshotTable.pointFait.name}`),
-          pointPotentiel: sql.raw(
-            `excluded.${snapshotTable.pointPotentiel.name}`
-          ),
-          pointProgramme: sql.raw(
-            `excluded.${snapshotTable.pointProgramme.name}`
-          ),
-          pointPasFait: sql.raw(`excluded.${snapshotTable.pointPasFait.name}`),
-          scoresPayload: sql.raw(
-            `excluded.${snapshotTable.scoresPayload.name}`
-          ),
-          personnalisationReponses: sql.raw(
-            `excluded.${snapshotTable.personnalisationReponses.name}`
-          ),
-          referentielVersion: sql.raw(
-            `excluded.${snapshotTable.referentielVersion.name}`
-          ),
-          modifiedBy: sql.raw(`excluded.${snapshotTable.modifiedBy.name}`),
+          date: sql`excluded.${snapshotTable.date.name}`,
+          pointFait: sql`excluded.${snapshotTable.pointFait.name}`,
+          pointPotentiel: sql`excluded.${snapshotTable.pointPotentiel.name}`,
+          pointProgramme: sql`excluded.${snapshotTable.pointProgramme.name}`,
+          pointPasFait: sql`excluded.${snapshotTable.pointPasFait.name}`,
+          scoresPayload: sql`excluded.${snapshotTable.scoresPayload.name}`,
+          personnalisationReponses: sql`excluded.${snapshotTable.personnalisationReponses.name}`,
+          referentielVersion: sql`excluded.${snapshotTable.referentielVersion.name}`,
+          modifiedBy: sql`excluded.${snapshotTable.modifiedBy.name}`,
         },
       })
       .returning()

--- a/apps/backend/src/referentiels/update-action-commentaire/update-action-commentaire.service.ts
+++ b/apps/backend/src/referentiels/update-action-commentaire/update-action-commentaire.service.ts
@@ -82,12 +82,8 @@ export class UpdateActionCommentaireService {
                 actionCommentaireTable.actionId,
               ],
               set: {
-                commentaire: sql.raw(
-                  `excluded.${actionCommentaireTable.commentaire.name}`
-                ),
-                modifiedBy: sql.raw(
-                  `excluded.${actionCommentaireTable.modifiedBy.name}`
-                ),
+                commentaire: sql`excluded.${actionCommentaireTable.commentaire.name}`,
+                modifiedBy: sql`excluded.${actionCommentaireTable.modifiedBy.name}`,
               },
             })
             .returning()

--- a/apps/backend/src/referentiels/update-action-statut/update-action-statut.service.ts
+++ b/apps/backend/src/referentiels/update-action-statut/update-action-statut.service.ts
@@ -146,9 +146,7 @@ export class UpdateActionStatutService {
           )
           .orderBy(actionStatutTable.actionId)
           .for('update');
-        const oldValuesMap = new Map(
-          oldValues.map((ov) => [ov.actionId, ov])
-        );
+        const oldValuesMap = new Map(oldValues.map((ov) => [ov.actionId, ov]));
 
         // Upsert action statuts with .returning() to get modified_at
         const upsertedRows = await tx
@@ -165,18 +163,10 @@ export class UpdateActionStatutService {
               actionStatutTable.actionId,
             ],
             set: {
-              avancement: sql.raw(
-                `excluded.${actionStatutTable.avancement.name}`
-              ),
-              avancementDetaille: sql.raw(
-                `excluded.${actionStatutTable.avancementDetaille.name}`
-              ),
-              concerne: sql.raw(
-                `excluded.${actionStatutTable.concerne.name}`
-              ),
-              modifiedBy: sql.raw(
-                `excluded.${actionStatutTable.modifiedBy.name}`
-              ),
+              avancement: sql`excluded.${actionStatutTable.avancement.name}`,
+              avancementDetaille: sql`excluded.${actionStatutTable.avancementDetaille.name}`,
+              concerne: sql`excluded.${actionStatutTable.concerne.name}`,
+              modifiedBy: sql`excluded.${actionStatutTable.modifiedBy.name}`,
             },
           })
           .returning();

--- a/apps/backend/src/users/authorizations/update-user-role/update-user-role.service.ts
+++ b/apps/backend/src/users/authorizations/update-user-role/update-user-role.service.ts
@@ -82,7 +82,7 @@ export class UpdateUserRoleService {
       .onConflictDoUpdate({
         target: [utilisateurVerifieTable.userId],
         set: {
-          verifie: sql.raw(`excluded.${utilisateurVerifieTable.verifie.name}`),
+          verifie: sql`excluded.${utilisateurVerifieTable.verifie.name}`,
         },
       });
   }

--- a/apps/backend/src/utils/database/conflict.utils.ts
+++ b/apps/backend/src/utils/database/conflict.utils.ts
@@ -20,7 +20,7 @@ export const buildConflictUpdateColumns = <
   const cls = getTableColumns(table);
   return columns.reduce((acc, column) => {
     const colName = cls[column].name;
-    acc[column] = sql.raw(`excluded.${colName}`);
+    acc[column] = sql`excluded.${colName}`;
     return acc;
   }, {} as Record<Q, SQL>);
 };

--- a/apps/tools/src/migrations/banatic2025/import-banatic-2025-collectivite-competences/index.ts
+++ b/apps/tools/src/migrations/banatic2025/import-banatic-2025-collectivite-competences/index.ts
@@ -184,9 +184,7 @@ const insertCompetencesForCollectivite = async (
         collectiviteBanatic2025CompetenceTable.competenceCode,
       ],
       set: {
-        exercice: sql.raw(
-          `excluded.${collectiviteBanatic2025CompetenceTable.exercice.name}`
-        ),
+        exercice: sql`excluded.${collectiviteBanatic2025CompetenceTable.exercice.name}`,
       },
     });
   return pairs.length;


### PR DESCRIPTION
Pas d'injection en tant que tel ici, mais autant supprimer la pratique de notre codebase au maximum

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notes de Version

* **Refactor**
  * Amélioration de la robustesse et de la maintenabilité du code de gestion de base de données à travers plusieurs services métier (gestion des invitations, personnalisations, tableaux de bord, indicateurs, snapshots, commentaires, statuts, autorisations utilisateur et imports). Ces changements optimisent les opérations d'upsert et renforcent la cohérence technique sans impact sur les fonctionnalités visibles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/incubateur-ademe/territoires-en-transitions/pull/4499?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->