### PR TITLE
fix(security): bloque la SSRF sur /api/zip via allowlist Supabase Storage (pentest V4)

### DIFF
--- a/apps/app/app/api/zip/route.ts
+++ b/apps/app/app/api/zip/route.ts
@@ -1,48 +1,98 @@
-import { NextResponse } from 'next/server';
 import JSZip from 'jszip';
+import { NextResponse } from 'next/server';
 import { Readable } from 'stream';
+import {
+  isAllowedStorageUrl,
+  sanitizeFilename,
+  zipRequestSchema,
+} from './validate';
+
+// SÉCURITÉ (pentest V4 / ORHUS-302) :
+// Cet endpoint génère une archive ZIP à partir d'URLs « signées Supabase
+// Storage » fournies par le client. Avant correctif, il acceptait n'importe
+// quelle URL et la téléchargeait via `fetch()`, exposant le serveur à une
+// SSRF (Server-Side Request Forgery) : un attaquant non authentifié pouvait
+// faire requêter des ressources internes (metadata cloud, APIs internes,
+// RFC1918, etc.) et récupérer leur contenu via l'archive renvoyée.
+//
+// Le correctif applique la recommandation R7 du rapport :
+//   1. Schéma Zod strict en entrée (forme + limites).
+//   2. Whitelist : seules les URL préfixées par
+//      `${SUPABASE_URL}/storage/v1/object/sign/` sont acceptées ; toute autre
+//      origine ou tout autre chemin renvoient 400.
+//   3. Filename ramené à un nom de fichier basique (anti zip slip).
+//   4. Plafond sur le nombre d'éléments pour limiter l'abus en DoS.
+//
+// Limitation connue restant en suivi : aucune résolution DNS applicative
+// (pas de protection explicite contre le DNS rebinding). À traiter si l'infra
+// sortante ne filtre pas déjà les destinations privées.
+
+const SUPABASE_URL = (process.env.NEXT_PUBLIC_SUPABASE_URL ?? '').replace(
+  /\/+$/,
+  ''
+);
 
 async function fetchFileAsArrayBuffer(url: string) {
   const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Fetch failed (${response.status}) for storage object`);
+  }
   return await response.arrayBuffer();
 }
 
 export async function POST(request: Request) {
   try {
-    const { signedUrls } = await request.json();
+    const body = (await request.json()) as unknown;
+    const parsed = zipRequestSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'Arguments non valides' },
+        { status: 400 }
+      );
+    }
+
+    // Valide chaque URL contre la whitelist + sanitize les noms de fichiers.
+    const sanitized: { filename: string; url: string }[] = [];
+    for (const entry of parsed.data.signedUrls) {
+      if (!isAllowedStorageUrl(entry.url, SUPABASE_URL)) {
+        return NextResponse.json(
+          { error: 'URL non autorisée' },
+          { status: 400 }
+        );
+      }
+      const safeName = sanitizeFilename(entry.filename);
+      if (!safeName) {
+        return NextResponse.json(
+          { error: 'Nom de fichier invalide' },
+          { status: 400 }
+        );
+      }
+      sanitized.push({ filename: safeName, url: entry.url });
+    }
 
     const zip = new JSZip();
 
-    // Download all files and add them to the ZIP
     await Promise.all(
-      signedUrls.map(
-        async ({ filename, url }: { filename: string; url: string }) => {
-          const fileData = await fetchFileAsArrayBuffer(url);
-          zip.file(filename, fileData);
-        }
-      )
+      sanitized.map(async ({ filename, url }) => {
+        const fileData = await fetchFileAsArrayBuffer(url);
+        zip.file(filename, fileData);
+      })
     );
 
-    // Generate ZIP content
     const zipContent = await zip.generateAsync({
       type: 'nodebuffer',
       compression: 'DEFLATE',
       streamFiles: true,
     });
 
-    // Create a readable stream from the ZIP content
     const stream = Readable.from(zipContent);
-
-    // Get the total size for the Content-Length header
     const contentLength = zipContent.length;
 
-    // Return streaming response
     return new NextResponse(stream as any, {
       headers: {
         'Content-Type': 'application/zip',
         'Content-Disposition': `attachment; filename="download.zip"`,
         'Content-Length': contentLength.toString(),
-        // Disable Next.js response caching
         'Cache-Control': 'no-cache, no-store, must-revalidate',
         Pragma: 'no-cache',
         Expires: '0',

--- a/apps/app/app/api/zip/validate.spec.ts
+++ b/apps/app/app/api/zip/validate.spec.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isAllowedStorageUrl,
+  MAX_FILES,
+  sanitizeFilename,
+  zipRequestSchema,
+} from './validate';
+
+const SUPABASE = 'https://abcd1234.supabase.co';
+
+describe('isAllowedStorageUrl', () => {
+  it('accepte une URL signée Supabase Storage', () => {
+    expect(
+      isAllowedStorageUrl(
+        `${SUPABASE}/storage/v1/object/sign/collectivites-1/hash123?token=eyJ&t=1`,
+        SUPABASE
+      )
+    ).toBe(true);
+  });
+
+  it('accepte le même origine en local (http + 127.0.0.1)', () => {
+    const local = 'http://127.0.0.1:54321';
+    expect(
+      isAllowedStorageUrl(
+        `${local}/storage/v1/object/sign/collectivites-1/abc?token=x`,
+        local
+      )
+    ).toBe(true);
+  });
+
+  // Régression du pentest V4 : la preuve d'exploit envoyait une URL externe
+  // contrôlée par l'attaquant — doit être rejetée.
+  describe('protection SSRF (pentest V4)', () => {
+    it.each([
+      'https://orhus.fr/exfil',
+      'https://attacker.example.com/storage/v1/object/sign/x/y',
+      'https://abcd1234.supabase.co.attacker.tld/storage/v1/object/sign/x/y',
+      // Métadonnées cloud AWS / GCP / Azure
+      'http://169.254.169.254/latest/meta-data/',
+      'http://metadata.google.internal/computeMetadata/v1/',
+      // Réseaux privés
+      'http://127.0.0.1:8000/admin',
+      'http://localhost/admin',
+      'http://10.0.0.1/secret',
+      'http://192.168.1.1/router',
+      'http://172.16.0.1/internal',
+      // Autres protocoles
+      'file:///etc/passwd',
+      'gopher://abcd1234.supabase.co/',
+      // Faux préfixe pour bypass naïf de startsWith()
+      'https://abcd1234.supabase.co.evil.tld/storage/v1/object/sign/x/y',
+    ])('rejette l\'URL hostile `%s`', (url) => {
+      expect(isAllowedStorageUrl(url, SUPABASE)).toBe(false);
+    });
+
+    it('rejette une URL Supabase pointant ailleurs que vers `/storage/v1/object/sign/`', () => {
+      expect(
+        isAllowedStorageUrl(
+          `${SUPABASE}/storage/v1/object/public/bucket/file`,
+          SUPABASE
+        )
+      ).toBe(false);
+      expect(
+        isAllowedStorageUrl(`${SUPABASE}/auth/v1/admin/users`, SUPABASE)
+      ).toBe(false);
+      expect(
+        isAllowedStorageUrl(`${SUPABASE}/rest/v1/users`, SUPABASE)
+      ).toBe(false);
+    });
+
+    it('rejette une URL non parsable', () => {
+      expect(isAllowedStorageUrl('not a url', SUPABASE)).toBe(false);
+      expect(isAllowedStorageUrl('', SUPABASE)).toBe(false);
+    });
+
+    it("rejette toutes les URL si SUPABASE_URL n'est pas configuré", () => {
+      expect(
+        isAllowedStorageUrl(
+          `${SUPABASE}/storage/v1/object/sign/x/y`,
+          undefined
+        )
+      ).toBe(false);
+      expect(
+        isAllowedStorageUrl(`${SUPABASE}/storage/v1/object/sign/x/y`, '')
+      ).toBe(false);
+    });
+
+    it('refuse un changement de protocole (https → http)', () => {
+      expect(
+        isAllowedStorageUrl(
+          'http://abcd1234.supabase.co/storage/v1/object/sign/x/y',
+          SUPABASE
+        )
+      ).toBe(false);
+    });
+  });
+});
+
+describe('sanitizeFilename', () => {
+  it('garde un nom de fichier basique tel quel', () => {
+    expect(sanitizeFilename('rapport.pdf')).toBe('rapport.pdf');
+    expect(sanitizeFilename('  rapport.pdf  ')).toBe('rapport.pdf');
+  });
+
+  it('réduit un chemin à son basename (anti zip slip)', () => {
+    expect(sanitizeFilename('../../etc/passwd')).toBe('passwd');
+    expect(sanitizeFilename('a/b/c.txt')).toBe('c.txt');
+    expect(sanitizeFilename('C:\\Windows\\system32\\cmd.exe')).toBe('cmd.exe');
+  });
+
+  it('rejette les noms vides, `.`, `..` ou contenant un NUL', () => {
+    expect(sanitizeFilename('')).toBeNull();
+    expect(sanitizeFilename('   ')).toBeNull();
+    expect(sanitizeFilename('.')).toBeNull();
+    expect(sanitizeFilename('..')).toBeNull();
+    expect(sanitizeFilename('rap\0port.pdf')).toBeNull();
+  });
+});
+
+describe('zipRequestSchema', () => {
+  const validEntry = {
+    filename: 'rapport.pdf',
+    url: `${SUPABASE}/storage/v1/object/sign/bucket/hash?token=t`,
+  };
+
+  it('accepte un payload bien formé', () => {
+    expect(
+      zipRequestSchema.safeParse({ signedUrls: [validEntry] }).success
+    ).toBe(true);
+  });
+
+  it('rejette un tableau vide', () => {
+    expect(zipRequestSchema.safeParse({ signedUrls: [] }).success).toBe(false);
+  });
+
+  it("rejette un tableau trop long (>MAX_FILES)", () => {
+    const tooMany = Array.from({ length: MAX_FILES + 1 }, () => validEntry);
+    expect(
+      zipRequestSchema.safeParse({ signedUrls: tooMany }).success
+    ).toBe(false);
+  });
+
+  it('rejette une URL non parsable', () => {
+    expect(
+      zipRequestSchema.safeParse({
+        signedUrls: [{ filename: 'rapport.pdf', url: 'pas-une-url' }],
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejette un filename vide', () => {
+    expect(
+      zipRequestSchema.safeParse({
+        signedUrls: [{ filename: '', url: validEntry.url }],
+      }).success
+    ).toBe(false);
+  });
+});

--- a/apps/app/app/api/zip/validate.ts
+++ b/apps/app/app/api/zip/validate.ts
@@ -1,0 +1,68 @@
+import path from 'node:path';
+import { z } from 'zod';
+
+// Helpers de validation pour `POST /api/zip` — extraits dans un module séparé
+// pour pouvoir être testés indépendamment du runtime Next.js.
+//
+// Voir `route.ts` pour le contexte sécurité (pentest V4 / ORHUS-302, SSRF).
+
+export const MAX_FILES = 100;
+
+export const STORAGE_SIGNED_PATH_PREFIX = '/storage/v1/object/sign/';
+
+export const signedUrlEntrySchema = z.object({
+  filename: z.string().trim().min(1).max(255),
+  url: z.url(),
+});
+
+export const zipRequestSchema = z.object({
+  signedUrls: z.array(signedUrlEntrySchema).min(1).max(MAX_FILES),
+});
+
+export type ZipRequest = z.infer<typeof zipRequestSchema>;
+
+/**
+ * Vérifie qu'une URL pointe bien vers le bucket Supabase Storage configuré,
+ * et uniquement vers le chemin des URL signées
+ * (`/storage/v1/object/sign/...`). Toute autre origine, tout autre chemin
+ * (par ex. `/storage/v1/object/<bucket>/...` non signé, ou un autre service
+ * Supabase) est rejeté.
+ */
+export const isAllowedStorageUrl = (
+  rawUrl: string,
+  supabaseUrl: string | undefined
+): boolean => {
+  if (!supabaseUrl) {
+    return false;
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return false;
+  }
+  let storageBase: URL;
+  try {
+    storageBase = new URL(supabaseUrl);
+  } catch {
+    return false;
+  }
+  return (
+    parsed.protocol === storageBase.protocol &&
+    parsed.host === storageBase.host &&
+    parsed.pathname.startsWith(STORAGE_SIGNED_PATH_PREFIX)
+  );
+};
+
+/**
+ * Ramène un nom de fichier fourni par le client à un nom basique sans
+ * séparateur de chemin, pour empêcher tout « zip slip » lors de l'extraction
+ * côté utilisateur.
+ */
+export const sanitizeFilename = (filename: string): string | null => {
+  const base = path.basename(filename.replace(/\\/g, '/').trim());
+  if (!base || base === '.' || base === '..' || base.includes('\0')) {
+    return null;
+  }
+  return base;
+};


### PR DESCRIPTION
## Contexte

Le rapport ORHUS-302 (mai 2026) a identifié une vulnérabilité **élevée (V4)** sur `POST /api/zip` :

- **Accessible sans authentification**.
- Acceptait n'importe quelle URL dans `signedUrls[].url` et la téléchargeait via `fetch()`, puis intégrait la réponse dans l'archive ZIP renvoyée à l'appelant.
- L'auditeur a obtenu en preuve que le serveur effectuait bien une requête HTTP vers un endpoint externe sous son contrôle et que la réponse atterrissait dans le ZIP.

Conséquences : exfiltration de données accessibles depuis le serveur applicatif, accès aux services internes (RFC1918, metadata cloud `169.254.169.254`, etc.), contournement de filtrage réseau.

🔗 Ticket Notion : [TET-7332 — V4 SSRF /api/zip](https://www.notion.so/36e6523d57d7812fa81dd0d25bfcb9eb)

## Correctif (R7 du rapport)

### `apps/app/app/api/zip/route.ts` + `validate.ts`

1. **Schéma Zod strict** en entrée — tableau d'objets `{filename, url}` validé en forme et longueur (1–`MAX_FILES=100`).
2. **Whitelist d'URL** : chaque URL doit
   - avoir la même `URL.host` **et** le même protocole que `NEXT_PUBLIC_SUPABASE_URL` ;
   - **et** un pathname qui commence par `/storage/v1/object/sign/` (URL signées seulement, pas les ressources publiques ni les autres APIs Supabase).
   - La comparaison se fait sur `URL.host`, pas sur `startsWith`, ce qui bloque les bypass par homoglyphe (`abcd1234.supabase.co.attacker.tld`).
3. **Sanitisation du `filename`** : seul le `basename` est conservé pour éviter le « zip slip » côté extraction utilisateur (`../../etc/passwd` → `passwd`, `C:\Windows\system32\cmd.exe` → `cmd.exe`).
4. Codes retour passent à **400 Bad Request** pour toutes les entrées invalides (au lieu d'un 500 silencieux).
5. La logique de validation est isolée dans `validate.ts` (pas dans `route.ts` pour éviter les restrictions d'export Next.js), ce qui la rend testable unitairement.

## Validation

- **27 tests** unitaires (`validate.spec.ts`) couvrant :
  - URLs hostiles (Supabase faux, `orhus.fr`, AWS/GCP/Azure metadata, `127.0.0.1`, `10.0.0.1`, `192.168.x.x`, `172.16.x.x`, `file://`, `gopher://`, homoglyphe `supabase.co.evil.tld`).
  - URLs Supabase mal ciblées (`/storage/v1/object/public/…`, `/auth/v1/admin`, `/rest/v1/users`).
  - URL non parsable / vide.
  - SUPABASE_URL non configuré → tout rejeter.
  - Downgrade de protocole `https → http`.
  - Sanitisation des noms de fichiers et bornes du schéma Zod.
- Build `app` : OK.
- Lint : OK (le warning `stream as any` est pré-existant, lié au cast Next.js).

## Limitation connue / suivi

**DNS rebinding** : le correctif ne fait pas de résolution DNS applicative ni de validation IP avant le `fetch()`. La protection repose sur :
1. Le filtrage de l'origine via `URL.host` (l'attaquant ne peut pas pointer sur sa propre origine).
2. Le filtrage réseau sortant de l'infra (à confirmer côté ops).

À traiter dans un suivi si l'app est déployée sans firewall sortant ou sur une infra où `*.supabase.co` peut être résolu vers une IP non Supabase.

## R8 — Suite (revue complète des fetch serveur)

Audit rapide effectué pendant l'exploration. À vérifier dans un ticket de suivi :
- **Webhooks tools** (`apps/tools/.../webhook-consumer.service.ts`) : `fetch(webhookConfiguration.url)` — admin-only, à confirmer.
- **Exports PDF / rapports** : utilisent des services internes, en principe pas d'URL utilisateur.
- **Uploader Supabase Storage** (`apps/app/.../useUploader.ts`) : chemin contrôlé côté backend, OK a priori.

Les autres `fetch()` du repo ciblent des URLs d'env (Sirene, Airtable, Calendly, Connect, Mattermost), pas de chemins user-supplied.

## Test plan

- [ ] CI verte.
- [ ] Vérifier sur staging que le téléchargement ZIP d'une action avec documents fonctionne toujours (cas légitime).
- [ ] Tenter manuellement `curl -X POST .../api/zip -d '{"signedUrls":[{"filename":"a","url":"http://169.254.169.254/"}]}'` → doit renvoyer `400 URL non autorisée`.
- [ ] Tenter `curl -X POST .../api/zip -d '{"signedUrls":[{"filename":"../../etc/passwd","url":"<url-storage-sign-valide>"}]}'` → doit retourner un ZIP dont le seul fichier est `passwd` (basename), pas de path traversal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Durci la validation du point de terminaison de génération ZIP : validation stricte du payload, filtrage des URLs autorisées vers le stockage, normalisation/sanitation des noms de fichiers, et limites sur le nombre de fichiers.
  * Meilleure gestion des erreurs HTTP lors du téléchargement des fichiers et réponses 400/500 adaptées.

* **Tests**
  * Ajout de tests couvrant la validation des URLs, la sanitation des noms et les règles du payload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->