### PR TITLE
feat(referentiels): vérifie le bon enregistrement des explications d'action quand on fait suivant/précédent

### DIFF
--- a/e2e/tests/referentiels/scores/accordion-header-click.spec.ts
+++ b/e2e/tests/referentiels/scores/accordion-header-click.spec.ts
@@ -130,7 +130,7 @@ test.describe("Clic sur le header d'une sous-action pour déplier/replier", () =
     await expect(expandButton).toHaveAttribute('aria-expanded', 'false');
 
     const commentaireEditor =
-      referentielScoresPom.getActionCommentaireLocator('cae_1.1.1.1');
+      referentielScoresPom.getActionExplicationLocator('cae_1.1.1.1');
     await commentaireEditor.click();
 
     // L'éditeur doit avoir le focus

--- a/e2e/tests/referentiels/scores/referentiel-scores.pom.ts
+++ b/e2e/tests/referentiels/scores/referentiel-scores.pom.ts
@@ -155,10 +155,37 @@ export class ReferentielScoresPom {
     return `[data-test="Tache-${tacheIdentifiant}"]`;
   }
 
-  getActionCommentaireLocator(actionId: string) {
+  getActionExplicationLocator(actionId: string) {
     return this.page.locator(
       `[data-test="action-${actionId}-commentaire-editor"]`
     );
+  }
+
+  async expectActionExplicationEditorVisible(actionId: string) {
+    await expect(this.getActionExplicationLocator(actionId)).toBeVisible();
+  }
+
+  async fillActionExplication(actionId: string, text: string) {
+    const contentEditable = this.getActionExplicationLocator(actionId);
+    await contentEditable.click();
+    await contentEditable.pressSequentially(text);
+  }
+
+  waitForUpdateCommentaireResponse() {
+    return this.page.waitForResponse(
+      (res) =>
+        res.request().method() === 'POST' &&
+        res.url().includes('referentiels.actions.updateCommentaire') &&
+        res.ok()
+    );
+  }
+
+  getMesureSuivanteLink() {
+    return this.page.getByRole('link', { name: 'Mesure suivante' });
+  }
+
+  getMesurePrecedenteLink() {
+    return this.page.getByRole('link', { name: 'Mesure précédente' });
   }
 
   getSousActionAvancementSelectLocator(sousActionIdentifiant: string) {

--- a/e2e/tests/referentiels/scores/update-action-explication-navigation.spec.ts
+++ b/e2e/tests/referentiels/scores/update-action-explication-navigation.spec.ts
@@ -1,0 +1,64 @@
+import { expect } from '@playwright/test';
+import { testWithReferentiels as test } from '../referentiels.fixture';
+
+const MESURE_111_ID = 'cae_1.1.1';
+const MESURE_111_HEADING = '1.1.1 Définir la vision, les';
+
+test.describe('Explication mesure — cache après navigation', () => {
+  test.beforeEach(async ({ page, collectivites }) => {
+    const { collectivite, user } = await collectivites.addCollectiviteAndUser({
+      userArgs: { autoLogin: true },
+      collectiviteArgs: { isCOT: true },
+    });
+    await user.precomputeReferentielSnapshot(collectivite.data.id, 'cae');
+    await page.goto('/');
+  });
+
+  test("L'explication modifiée reste visible après mesure suivante puis mesure précédente", async ({
+    page,
+    referentielScoresPom,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    referentiels,
+  }) => {
+    const explicationText = `explication-nav-e2e-${Date.now()}`;
+
+    await referentielScoresPom.goto('cae');
+    await referentielScoresPom.goToActionPage(
+      '1 - Planification',
+      '1.1 Stratégie globale',
+      MESURE_111_HEADING
+    );
+
+    await expect(
+      page.getByText("Explications sur l'état d'avancement")
+    ).toBeVisible();
+    await referentielScoresPom.expectActionExplicationEditorVisible(
+      MESURE_111_ID
+    );
+
+    const nextLink = referentielScoresPom.getMesureSuivanteLink();
+    await expect(nextLink).toBeVisible();
+    await expect(nextLink).toHaveAttribute('href', /\/action\/cae_1\.1\./);
+
+    await referentielScoresPom.fillActionExplication(
+      MESURE_111_ID,
+      explicationText
+    );
+
+    const saveDone = referentielScoresPom.waitForUpdateCommentaireResponse();
+    await nextLink.click();
+    await saveDone;
+
+    await expect(page).not.toHaveURL(/\/action\/cae_1\.1\.1(?:[/?#]|$)/);
+    await expect(referentielScoresPom.getMesurePrecedenteLink()).toBeVisible();
+
+    await referentielScoresPom.getMesurePrecedenteLink().click();
+    await expect(
+      page.getByRole('heading', { name: MESURE_111_HEADING })
+    ).toBeVisible();
+
+    await expect(
+      referentielScoresPom.getActionExplicationLocator(MESURE_111_ID)
+    ).toContainText(explicationText);
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Ajout d’un test e2e vérifiant que le texte d’une explication reste enregistré après navigation avant/arrière entre mesures.
  * Ajout d’aides de test pour éditer l’explication, vérifier sa visibilité, attendre la sauvegarde et faciliter la navigation “mesure suivante / précédente”.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->