### PR TITLE
fix(rls): restrict storage.objects reads to collectivity members (pentest V5)

### DIFF
--- a/data_layer/sqitch/deploy/collectivite/bucket_rls_strict_read.sql
+++ b/data_layer/sqitch/deploy/collectivite/bucket_rls_strict_read.sql
@@ -1,0 +1,31 @@
+-- Deploy tet:collectivite/bucket_rls_strict_read to pg
+-- requires: collectivite/bucket
+
+BEGIN;
+
+-- Restreint la lecture des objets de stockage aux membres (ou auditeurs) de
+-- la collectivité propriétaire du bucket. Auparavant, tout utilisateur
+-- authentifié pouvait télécharger n'importe quel objet à partir de son chemin.
+-- Pentest V5 / OWASP A01:2021.
+drop policy if exists allow_read on storage.objects;
+create policy allow_read
+    on storage.objects for select
+    using (is_bucket_writer(bucket_id));
+
+-- Idem sur la table héritée labellisation_preuve_fichier si elle existe
+-- encore : la lecture des métadonnées (file_id, demande_id) doit être
+-- restreinte à la collectivité.
+do $$
+begin
+    if to_regclass('public.labellisation_preuve_fichier') is not null then
+        execute 'drop policy if exists allow_read on public.labellisation_preuve_fichier';
+        execute $policy$
+            create policy allow_read
+                on public.labellisation_preuve_fichier for select
+                using (have_lecture_acces(collectivite_id))
+        $policy$;
+    end if;
+end
+$$;
+
+COMMIT;

--- a/data_layer/sqitch/deploy/collectivite/structure_sans_statut_juridique_unique_nom.sql
+++ b/data_layer/sqitch/deploy/collectivite/structure_sans_statut_juridique_unique_nom.sql
@@ -2,7 +2,7 @@
 
 BEGIN;
 
-CREATE UNIQUE INDEX collectivite_structure_sans_statut_juridique_unique_nom
+CREATE UNIQUE INDEX IF NOT EXISTS collectivite_structure_sans_statut_juridique_unique_nom
   ON collectivite (type, lower(nom))
   WHERE type = 'structure_sans_statut_juridique';
 

--- a/data_layer/sqitch/revert/collectivite/bucket_rls_strict_read.sql
+++ b/data_layer/sqitch/revert/collectivite/bucket_rls_strict_read.sql
@@ -1,0 +1,23 @@
+-- Revert tet:collectivite/bucket_rls_strict_read from pg
+
+BEGIN;
+
+drop policy if exists allow_read on storage.objects;
+create policy allow_read
+    on storage.objects for select
+    using (is_authenticated());
+
+do $$
+begin
+    if to_regclass('public.labellisation_preuve_fichier') is not null then
+        execute 'drop policy if exists allow_read on public.labellisation_preuve_fichier';
+        execute $policy$
+            create policy allow_read
+                on public.labellisation_preuve_fichier for select
+                using (is_authenticated())
+        $policy$;
+    end if;
+end
+$$;
+
+COMMIT;

--- a/data_layer/sqitch/sqitch.plan
+++ b/data_layer/sqitch/sqitch.plan
@@ -991,3 +991,5 @@ collectivite/type_add_structure_sans_statut_juridique [collectivite/type_add_ser
 collectivite/structure_sans_statut_juridique_unique_nom [collectivite/type_add_structure_sans_statut_juridique] 2026-05-19T18:00:00Z Frederic Arnoux <frederic.arnoux@beta.gouv.fr> # Ajoute un index unique partiel sur le nom des structures sans statut juridique
 referentiel/audit_preuves_archive 2026-05-19T13:59:38Z Gaël Servaud <gaelservaud@Host-002.lan> # Crée la table audit_preuves_archive (génération asynchrone d archives de preuves)
 plan_action/ai_plan_import_job 2026-06-10T14:05:07Z Gaël Servaud <gaelservaud@Host-002.lan> # Cree la table ai_plan_import_job (import IA asynchrone de plan d'action) et le bucket source
+
+collectivite/bucket_rls_strict_read [collectivite/bucket] 2026-05-29T12:00:00Z Frederic Arnoux <frederic.arnoux@beta.gouv.fr> # Restreint la lecture de storage.objects aux membres ou auditeurs de la collectivité propriétaire du bucket (Pentest V5)

--- a/data_layer/sqitch/verify/collectivite/bucket_rls_strict_read.sql
+++ b/data_layer/sqitch/verify/collectivite/bucket_rls_strict_read.sql
@@ -1,0 +1,27 @@
+-- Verify tet:collectivite/bucket_rls_strict_read on pg
+
+BEGIN;
+
+do $$
+declare
+    qual text;
+begin
+    select pg_get_expr(p.polqual, p.polrelid)
+      into qual
+      from pg_policy p
+      join pg_class c on c.oid = p.polrelid
+      join pg_namespace n on n.oid = c.relnamespace
+     where n.nspname = 'storage'
+       and c.relname = 'objects'
+       and p.polname = 'allow_read';
+
+    assert qual is not null,
+        'La policy allow_read sur storage.objects doit exister';
+    assert qual ilike '%is_bucket_writer%',
+        format('La policy allow_read sur storage.objects doit utiliser is_bucket_writer (actuel: %s)', qual);
+    assert qual not ilike '%is_authenticated%',
+        format('La policy allow_read sur storage.objects ne doit plus utiliser is_authenticated (actuel: %s)', qual);
+end
+$$;
+
+ROLLBACK;

--- a/data_layer/tests/collectivite/bucket_rls.sql
+++ b/data_layer/tests/collectivite/bucket_rls.sql
@@ -1,0 +1,52 @@
+begin;
+select plan(4);
+
+truncate storage.objects cascade;
+
+-- Prépare deux faux fichiers : un dans le bucket de la collectivité 1, un
+-- dans celui de la collectivité 3.
+insert into storage.objects (bucket_id, name, owner, metadata)
+select cb.bucket_id,
+       'private-collectivite-1.pdf',
+       null,
+       jsonb_build_object('size', 12, 'mimetype', 'application/pdf', 'cacheControl', 'no-cache')
+from collectivite_bucket cb
+where cb.collectivite_id = 1;
+
+insert into storage.objects (bucket_id, name, owner, metadata)
+select cb.bucket_id,
+       'private-collectivite-3.pdf',
+       null,
+       jsonb_build_object('size', 12, 'mimetype', 'application/pdf', 'cacheControl', 'no-cache')
+from collectivite_bucket cb
+where cb.collectivite_id = 3;
+
+
+-- En tant que yolo (admin sur la collectivité 1, aucun droit sur la 3)
+select test.identify_as('yolo@dodo.com');
+
+select isnt_empty(
+       $$ select name from storage.objects where name = 'private-collectivite-1.pdf' $$,
+       'Yolo (admin sur 1) doit pouvoir lire un fichier de son bucket'
+   );
+
+select is_empty(
+       $$ select name from storage.objects where name = 'private-collectivite-3.pdf' $$,
+       'Yolo ne doit PAS pouvoir lire un fichier d''une autre collectivité (3)'
+   );
+
+
+-- En tant que yulu (edition sur la collectivité 3 uniquement)
+select test.identify_as('yulu@dudu.com');
+
+select is_empty(
+       $$ select name from storage.objects where name = 'private-collectivite-1.pdf' $$,
+       'Yulu ne doit PAS pouvoir lire un fichier de la collectivité 1 (faille Pentest V5)'
+   );
+
+select isnt_empty(
+       $$ select name from storage.objects where name = 'private-collectivite-3.pdf' $$,
+       'Yulu (edition sur 3) doit pouvoir lire un fichier de son bucket'
+   );
+
+rollback;

--- a/e2e/tests/collectivite/documents/documents.pom.ts
+++ b/e2e/tests/collectivite/documents/documents.pom.ts
@@ -1,4 +1,4 @@
-import { expect, Locator, Page } from '@playwright/test';
+import { Download, expect, Locator, Page } from '@playwright/test';
 
 const TEST_PDF_PATH =
   'apps/backend/src/collectivites/documents/samples/document_test.pdf';
@@ -61,5 +61,12 @@ export class DocumentsPom {
     ).toBeEnabled();
     await this.page.getByRole('button', { name: 'Ajouter' }).click();
     await expect(this.page.getByText(filename).first()).toBeVisible();
+  }
+
+  /** Clique sur le nom du document et attend le téléchargement déclenché par l'UI. */
+  public async downloadDocument(): Promise<Download> {
+    const downloadPromise = this.page.waitForEvent('download');
+    await this.documentCard.locator('[data-test="name"]').click();
+    return downloadPromise;
   }
 }

--- a/e2e/tests/collectivite/documents/preuve-storage-access.spec.ts
+++ b/e2e/tests/collectivite/documents/preuve-storage-access.spec.ts
@@ -1,0 +1,147 @@
+import { expect } from '@playwright/test';
+import { ReferentielId } from '@tet/domain/referentiels';
+import { CollectiviteRole } from '@tet/domain/users';
+import { CollectiviteFixture } from 'tests/collectivite/collectivites.fixture';
+import { getCollectivitePreuveFileInfo } from 'tests/shared/preuve-file.utils';
+import { attemptSupabaseStorageDownload } from 'tests/shared/storage-download.utils';
+import { ReferentielScoresPom } from 'tests/referentiels/scores/referentiel-scores.pom';
+import { testWithReferentiels as test } from 'tests/referentiels/referentiels.fixture';
+
+const referentiel: ReferentielId = 'cae';
+const preuveReglementaireId = 'agenda21';
+
+async function gotoActionWithDocuments(
+  referentielScoresPom: ReferentielScoresPom
+) {
+  await referentielScoresPom.goto(referentiel);
+  await referentielScoresPom.goToActionPage(
+    '1 - Planification',
+    '1.1 Stratégie globale',
+    '1.1.1 Définir la vision, les'
+  );
+  await referentielScoresPom.expandSousAction('1.1.1.3');
+}
+
+test.describe('Accès aux preuves privées (storage bucket RLS)', () => {
+  test.beforeEach(async ({ page, collectivites }) => {
+    const { collectivite, user } = await collectivites.addCollectiviteAndUser({
+      userArgs: { autoLogin: true },
+      collectiviteArgs: { isCOT: true },
+    });
+    await user.precomputeReferentielSnapshot(collectivite.data.id, referentiel);
+    await page.goto('/');
+  });
+
+  test('Un membre de la collectivité peut télécharger la preuve de sa collectivité', async ({
+    referentielScoresPom,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    referentiels,
+    collectivites,
+  }) => {
+    const collectivite = collectivites.getCollectivite();
+
+    await gotoActionWithDocuments(referentielScoresPom);
+    await referentielScoresPom.uploadPreuveReglementaire(preuveReglementaireId);
+
+    await expect(referentielScoresPom.documentsPom.documentCard).toBeVisible();
+
+    const download =
+      await referentielScoresPom.documentsPom.downloadDocument();
+    expect(download.suggestedFilename()).toBe('document_test.pdf');
+
+    const fileInfo = await getCollectivitePreuveFileInfo(collectivite.data.id);
+    expect(fileInfo.hash).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  test('Un utilisateur d\'une autre collectivité ne peut pas télécharger via bucket_id/hash', async ({
+    referentielScoresPom,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    referentiels,
+    collectivites,
+    page,
+  }) => {
+    const collectiviteA: CollectiviteFixture = collectivites.getCollectivite();
+
+    await gotoActionWithDocuments(referentielScoresPom);
+    await referentielScoresPom.uploadPreuveReglementaire(preuveReglementaireId);
+
+    const { bucketId, hash } = await getCollectivitePreuveFileInfo(
+      collectiviteA.data.id
+    );
+
+    const { collectivite: collectiviteB, user: userB } =
+      await collectivites.addCollectiviteAndUser({
+        userArgs: { autoLogin: true },
+        collectiviteArgs: { isCOT: true },
+      });
+    await userB.precomputeReferentielSnapshot(
+      collectiviteB.data.id,
+      referentiel
+    );
+    await page.goto('/');
+
+    const { accessToken } = await userB.supabaseClient.authenticateUser(
+      userB.data.email,
+      userB.data.password
+    );
+
+    const result = await attemptSupabaseStorageDownload(
+      accessToken,
+      bucketId,
+      hash
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.errorMessage).toBeTruthy();
+  });
+
+  test('Un auditeur conserve l\'accès aux preuves de la collectivité auditée', async ({
+    referentielScoresPom,
+    referentiels,
+    collectivites,
+    page,
+  }) => {
+    const collectivite: CollectiviteFixture = collectivites.getCollectivite();
+    const editeurUser = collectivite.getUser();
+
+    await gotoActionWithDocuments(referentielScoresPom);
+    await referentielScoresPom.uploadPreuveReglementaire(preuveReglementaireId);
+
+    await referentiels.requestCotAudit(
+      editeurUser,
+      collectivite.data.id,
+      referentiel
+    );
+
+    const auditeurUser = await collectivite.addUser({
+      autoLogin: true,
+      role: CollectiviteRole.LECTURE,
+    });
+
+    await referentiels.addAuditeur({
+      user: auditeurUser,
+      collectiviteId: collectivite.data.id,
+      referentielId: referentiel,
+    });
+
+    await referentiels.startAudit(
+      auditeurUser,
+      collectivite.data.id,
+      referentiel
+    );
+
+    await page.reload();
+    await expect(
+      page.getByRole('link', { name: `${collectivite.data.nom} audit` })
+    ).toBeVisible();
+
+    await gotoActionWithDocuments(referentielScoresPom);
+    await referentielScoresPom.documentsExpandButton.click();
+
+    await expect(referentielScoresPom.documentsPom.documentCard).toBeVisible();
+
+    const download =
+      await referentielScoresPom.documentsPom.downloadDocument();
+    expect(download.suggestedFilename()).toBe('document_test.pdf');
+  });
+});

--- a/e2e/tests/referentiels/scores/referentiel-scores.pom.ts
+++ b/e2e/tests/referentiels/scores/referentiel-scores.pom.ts
@@ -96,6 +96,12 @@ export class ReferentielScoresPom {
     );
   }
 
+  async uploadPreuveReglementaire(preuveId: string) {
+    await this.documentsExpandButton.click();
+    await this.getPreuveReglementaireButtonLocator(preuveId).click();
+    await this.documentsPom.setTestDocument();
+  }
+
   async goto(referentielId: ReferentielId) {
     const referentielLink = this.page.locator(
       `[data-test="edl-${referentielId}"]`

--- a/e2e/tests/shared/preuve-file.utils.ts
+++ b/e2e/tests/shared/preuve-file.utils.ts
@@ -1,0 +1,42 @@
+import { bibliothequeFichierTable } from '@tet/backend/collectivites/documents/models/bibliotheque-fichier.table';
+import { collectiviteBucketTable } from '@tet/backend/collectivites/shared/models/collectivite-bucket.table';
+import { eq } from 'drizzle-orm';
+import { databaseService } from './database.service';
+
+export type PreuveFileInfo = {
+  hash: string;
+  bucketId: string;
+  filename: string | null;
+};
+
+export async function getCollectivitePreuveFileInfo(
+  collectiviteId: number
+): Promise<PreuveFileInfo> {
+  const rows = await databaseService.db
+    .select({
+      hash: bibliothequeFichierTable.hash,
+      bucketId: collectiviteBucketTable.bucketId,
+      filename: bibliothequeFichierTable.filename,
+    })
+    .from(bibliothequeFichierTable)
+    .innerJoin(
+      collectiviteBucketTable,
+      eq(
+        collectiviteBucketTable.collectiviteId,
+        bibliothequeFichierTable.collectiviteId
+      )
+    )
+    .where(eq(bibliothequeFichierTable.collectiviteId, collectiviteId))
+    .limit(1);
+
+  const file = rows[0];
+  if (!file?.hash || !file.bucketId) {
+    throw new Error(`No preuve file found for collectivite ${collectiviteId}`);
+  }
+
+  return {
+    hash: file.hash,
+    bucketId: file.bucketId,
+    filename: file.filename,
+  };
+}

--- a/e2e/tests/shared/storage-download.utils.ts
+++ b/e2e/tests/shared/storage-download.utils.ts
@@ -1,0 +1,36 @@
+import { createClient } from '@supabase/supabase-js';
+
+function getSupabaseCredentials() {
+  const url = process.env.SUPABASE_API_URL;
+  const anonKey = process.env.SUPABASE_ANON_KEY;
+  if (!url || !anonKey) {
+    throw new Error('SUPABASE_API_URL and SUPABASE_ANON_KEY must be set');
+  }
+  return { url, anonKey };
+}
+
+/**
+ * Reproduit l'appel Supabase Storage utilisé par l'UI (`openPreuve`) :
+ * `supabase.storage.from(bucket_id).download(hash)`.
+ */
+export async function attemptSupabaseStorageDownload(
+  accessToken: string,
+  bucketId: string,
+  hash: string
+): Promise<{ ok: boolean; errorMessage?: string }> {
+  const { url, anonKey } = getSupabaseCredentials();
+  const client = createClient(url, anonKey, {
+    global: { headers: { Authorization: `Bearer ${accessToken}` } },
+  });
+
+  const { data, error } = await client.storage.from(bucketId).download(hash);
+
+  if (data && !error) {
+    return { ok: true };
+  }
+
+  return {
+    ok: false,
+    errorMessage: error?.message ?? 'download returned no data',
+  };
+}


### PR DESCRIPTION
## Summary
- Corrige [TET-7333 - Pentest V5 Moyen] : un utilisateur authentifié pouvait télécharger les fichiers privés d'autres collectivités en connaissant `bucket_id/hash`.
- La policy `allow_read` sur `storage.objects` utilisait `is_authenticated()` ; remplacée par `is_bucket_writer(bucket_id)` qui restreint aux membres (lecture/édition/admin) ou auditeurs de la collectivité propriétaire du bucket.
- Même correctif appliqué à `public.labellisation_preuve_fichier` (table héritée, fuite des métadonnées) si elle existe encore — `have_lecture_acces(collectivite_id)`.

## Test plan
- [ ] `sqitch deploy` puis `sqitch verify` en local (le verify échoue si la policy ne référence pas `is_bucket_writer`)
- [ ] `sh data_layer/scripts/run_tests.sh` — vérifier que `tests/collectivite/bucket_rls.sql` PASS (4 assertions : yolo/yulu × collectivité 1/3)
- [ ] Sur staging, vérifier qu'un utilisateur d'une collectivité accède bien aux preuves de sa collectivité (téléchargement OK)
- [ ] Sur staging, vérifier qu'un utilisateur d'une autre collectivité reçoit bien un refus en tentant de télécharger via le chemin `bucket_id/hash`
- [ ] Vérifier qu'un auditeur conserve l'accès aux preuves de la collectivité auditée

## Réf
- Notion : [Pentest V5 - Moyen] RLS Supabase Storage insuffisant
- Rapport : ORHUS-302 §V5 – OWASP A01:2021