### PR TITLE
feat(app): interdit les labels JSX hardcodés (react/jsx-no-literals)

### DIFF
--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/actions/[actionId]/layout.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/actions/[actionId]/layout.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import { Fiche } from '@/app/plans/fiches/show-fiche';
 import { ScrollReset } from '@/app/utils/scroll-reset';
 import {
@@ -30,7 +31,7 @@ export default async function FicheDetailPage({
   );
 
   if (!fiche) {
-    return <div>Action non trouvée</div>;
+    return <div>{appLabels.actionNonTrouvee}</div>;
   }
   return (
     <>

--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/indicateurs/liste/layout.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/indicateurs/liste/layout.tsx
@@ -19,9 +19,7 @@ export default function Layout({ tabs }: { tabs: ReactNode }) {
   return (
     <>
       <PageHeader>
-        <PageHeader.Title>
-          appLabels.navListesIndicateurs
-        </PageHeader.Title>
+        <PageHeader.Title>{appLabels.listesIndicateurs}</PageHeader.Title>
         {canCreate && (
           <PageHeader.Actions>
             <Button

--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/layout.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/layout.tsx
@@ -2,6 +2,7 @@
 
 import { ReactNode } from 'react';
 
+import { appLabels } from '@/app/labels/catalog';
 import { useIsVisitor } from '@/app/users/authorizations/use-is-visitor';
 import { useCurrentCollectivite } from '@tet/api/collectivites';
 
@@ -18,7 +19,7 @@ export default function Layout({ children }: { children: ReactNode }) {
     return (
       <div className="flex-grow flex">
         <div className="m-auto text-grey-7">
-          Cette collectivité n’est pas accessible en mode visite.
+          {appLabels.collectiviteInaccessibleEnVisite}
         </div>
       </div>
     );

--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/ma-collectivite/layout.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/ma-collectivite/layout.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { appLabels } from '@/app/labels/catalog';
 import { PageHeader } from '@tet/ui';
 import {
   Tabs,
@@ -13,7 +14,7 @@ export default function Layout({ children }: PropsWithChildren) {
   return (
     <>
       <PageHeader>
-        <PageHeader.Title>Ma collectivité</PageHeader.Title>
+        <PageHeader.Title>{appLabels.maCollectivite}</PageHeader.Title>
       </PageHeader>
       <Tabs tabsListClassName="justify-start">
         <TabsList className="justify-start">

--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/plans/page.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/plans/page.tsx
@@ -1,5 +1,6 @@
 import { fetchCollectivitePanierInfo } from '@/app/collectivites/panier/data/fetchCollectivitePanierInfo';
 import { AllPlansView } from '@/app/plans/plans/list-all-plans/all-plans.view';
+import { appLabels } from '@/app/labels/catalog';
 import { createSupabaseServerClient } from '@tet/api/utils/supabase/server-client';
 import { z } from 'zod';
 
@@ -16,7 +17,7 @@ export default async function PlansListPage({
     .safeParse(unsafeCollectiviteId);
 
   if (!success) {
-    return <div>Invalid collectiviteId</div>;
+    return <div>{appLabels.collectiviteIdInvalide}</div>;
   }
 
   const supabaseClient = await createSupabaseServerClient();

--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/plans/tableau-de-bord/_components/modules.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/plans/tableau-de-bord/_components/modules.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { appLabels } from '@/app/labels/catalog';
 import { SuiviPlansModule } from '@/app/tableaux-de-bord/plans-action/suivi-plans/suivi-plans.module';
 import SpinnerLoader from '@/app/ui/shared/SpinnerLoader';
 import { ModulePlanActionList } from '@tet/domain/collectivites/tableau-de-bord';
@@ -22,7 +23,7 @@ const Modules = () => {
   if (isEmpty) {
     return (
       <div className="h-64 flex items-center justify-center text-error-1">
-        Une erreur est survenue
+        {appLabels.uneErreurEstSurvenue}
       </div>
     );
   }

--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/(overview)/@tabs/header.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/(overview)/@tabs/header.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { referentielToName } from '@/app/app/labels';
+import { appLabels } from '@/app/labels/catalog';
 import DownloadScoreButton from '@/app/app/pages/collectivite/Referentiels/DownloadScore/download-score.button';
 import SaveScoreButton from '@/app/app/pages/collectivite/Referentiels/SaveScore/save-score.button';
 import { useGetAction } from '@/app/referentiels/actions/use-get-action';
@@ -23,7 +24,7 @@ export const Header = ({ referentielId }: { referentielId: ReferentielId }) => {
   return (
     <PageHeader>
       <PageHeader.Title>
-        Référentiel {referentielToName[referentielId]}
+        {appLabels.referentiel} {referentielToName[referentielId]}
       </PageHeader.Title>
       <PageHeader.Actions>
         <div className="flex gap-x-4">

--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/action/[actionId]/_components/score-indicatif/score-indicatif.donnees.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/action/[actionId]/_components/score-indicatif/score-indicatif.donnees.tsx
@@ -6,6 +6,7 @@ import {
   makeCollectiviteIndicateursUrl,
 } from '@/app/app/paths';
 import { IndicateurDefinition } from '@/app/indicateurs/indicateurs/use-get-indicateur';
+import { appLabels } from '@/app/labels/catalog';
 import { useCollectiviteId } from '@tet/api/collectivites';
 import { Accordion, Button, ModalFooterOKCancel } from '@tet/ui';
 import { OpenState } from '@tet/ui/utils/types';
@@ -73,7 +74,7 @@ export const ScoreIndicatifDonnees = (props: ScoreIndicatifDonneesProps) => {
               href={indicateurURL}
               external
             >
-              Voir la fiche de l’indicateur
+              {appLabels.voirFicheIndicateur}
             </Button>
           ) : null
         }

--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/tableau-de-bord/personnel/_components/modules.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/tableau-de-bord/personnel/_components/modules.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import SpinnerLoader from '@/app/ui/shared/SpinnerLoader';
 import {
   ModuleFicheActionsSelect,
@@ -75,7 +76,7 @@ const Modules = () => {
   if (isEmpty) {
     return (
       <div className="h-64 flex items-center justify-center text-error-1">
-        Une erreur est survenue
+        {appLabels.uneErreurEstSurvenue}
       </div>
     );
   }

--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/tableau-de-bord/synthetique/page.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/tableau-de-bord/synthetique/page.tsx
@@ -5,6 +5,7 @@ import {
   makeReferentielRootUrl,
   makeTdbPlansEtActionsUrl,
 } from '@/app/app/paths';
+import { appLabels } from '@/app/labels/catalog';
 import { ModuleContainer } from '@/app/tableaux-de-bord/modules/module/module.container';
 import { FichesActionCountByModule } from '@/app/tableaux-de-bord/plans-action/fiches-action-count-by/fiches-action-count-by.module';
 import { useCurrentCollectivite } from '@tet/api/collectivites';
@@ -76,7 +77,7 @@ const Page = () => {
                     })}
                     size="sm"
                   >
-                    Créer un plan
+                    {appLabels.creerPlan}
                   </Button>
                 )}
               </div>

--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/users/users-header.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/users/users-header.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { InviteMembreButton } from '@/app/collectivites/membres/invite-membre/invite-membre.button';
+import { appLabels } from '@/app/labels/catalog';
 import { PageHeader } from '@tet/ui';
 import { ReactElement } from 'react';
 
@@ -10,7 +11,7 @@ export const UsersHeader = ({
   canInvite: boolean;
 }): ReactElement => (
   <PageHeader>
-    <PageHeader.Title>Gestion des utilisateurs</PageHeader.Title>
+    <PageHeader.Title>{appLabels.gestionDesUtilisateurs}</PageHeader.Title>
     {canInvite && (
       <PageHeader.Actions>
         <InviteMembreButton />

--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/accueil/_components/accueil.page.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/accueil/_components/accueil.page.tsx
@@ -37,7 +37,7 @@ const AccueilPage = () => {
   return (
     <div data-test="accueil-collectivite">
       <PageHeader>
-        <PageHeader.Title>Présentation des services</PageHeader.Title>
+        <PageHeader.Title>{appLabels.presentationDesServices}</PageHeader.Title>
         <PageHeader.Subtitle>
           <p className="text-lg text-grey-8 mb-0">
             {appLabels.bienvenueCollectivite({

--- a/apps/app/app/(authed)/recherches/template.tsx
+++ b/apps/app/app/(authed)/recherches/template.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { appLabels } from '@/app/labels/catalog';
 import { getRejoindreCollectivitePath } from '@tet/api';
 import { Alert, Button } from '@tet/ui';
 import { useEffect, useEffectEvent, useState } from 'react';
@@ -27,7 +28,7 @@ export default function Template({ children }: { children: React.ReactNode }) {
             size="xs"
             href={rejoindreUrl}
           >
-            Rejoindre une collectivité
+            {appLabels.rejoindreUneCollectivite}
           </Button>
         }
       />

--- a/apps/app/eslint.config.mjs
+++ b/apps/app/eslint.config.mjs
@@ -23,6 +23,22 @@ const eslintConfig = defineConfig([
 
       // Would be better to keep it as an error instead of warning, but too much places to fix for now.
       'react-hooks/set-state-in-effect': 'warn',
+
+      'react/jsx-no-literals': [
+        'error',
+        { allowedStrings: ['-', '+', '%', '€'] },
+      ],
+    },
+  },
+  {
+    files: [
+      '**/*.stories.tsx',
+      '**/fixtures.tsx',
+      '**/*.fixtures.tsx',
+      '**/fixtures/**/*.tsx',
+    ],
+    rules: {
+      'react/jsx-no-literals': 'off',
     },
   },
 ]);

--- a/apps/app/src/app/pages/CollectivitesEngagees/contacts/contacts-button.tsx
+++ b/apps/app/src/app/pages/CollectivitesEngagees/contacts/contacts-button.tsx
@@ -1,5 +1,6 @@
 import { Button, Tooltip } from '@tet/ui';
 import classNames from 'classnames';
+import { appLabels } from '@/app/labels/catalog';
 
 type Props = {
   disabled: boolean;
@@ -22,7 +23,7 @@ const ContactButton = ({ disabled, className, onClick }: Props) => {
         disabled={disabled}
         onClick={onClick}
       >
-        Voir les contacts
+        {appLabels.voirContacts}
       </Button>
     </Tooltip>
   );

--- a/apps/app/src/app/pages/CollectivitesEngagees/header/collectivites-header.tsx
+++ b/apps/app/src/app/pages/CollectivitesEngagees/header/collectivites-header.tsx
@@ -63,7 +63,7 @@ export const CollectivitesHeader = ({
   return (
     <>
       <PageHeader>
-        <PageHeader.Title>{appLabels.collectivitesTitre}</PageHeader.Title>
+        <PageHeader.Title>{appLabels.collectivites}</PageHeader.Title>
         <PageHeader.Metadata>
           <div className="flex max-md:flex-col gap-3 items-start md:items-center justify-between">
             <div className="flex flex-wrap max-md:flex-col items-center gap-3 max-md:w-full">
@@ -108,7 +108,7 @@ export const CollectivitesHeader = ({
                 buttons={[
                   {
                     id: 'collectivites',
-                    children: appLabels.collectivitesTitre,
+                    children: appLabels.collectivites,
                     icon:
                       view === 'collectivites'
                         ? 'layout-grid-fill'
@@ -125,7 +125,7 @@ export const CollectivitesHeader = ({
                   {
                     id: 'plans',
                     'data-test': 'ToggleVuePlan',
-                    children: appLabels.plansTitre,
+                    children: appLabels.plans,
                     icon: view === 'plans' ? 'list-check' : 'list-unordered',
                     onClick: () => handleChangeView('plans'),
                   },

--- a/apps/app/src/app/pages/collectivite/BibliothequeDocs/PreuvesTable.tsx
+++ b/apps/app/src/app/pages/collectivite/BibliothequeDocs/PreuvesTable.tsx
@@ -91,7 +91,7 @@ export const PreuvesTable = (props: TPreuvesTableProps) => {
     >
       <div className="body" {...getTableBodyProps()}>
         {isLoading ? (
-          <div className="message">Chargement en cours...</div>
+          <div className="message">{appLabels.chargementEnCours}</div>
         ) : rows.length ? (
           rows.map((row, index: number, rows) => {
             prepareRow(row);

--- a/apps/app/src/app/pages/collectivite/Historique/actionPrecision/HistoriqueItemActionPrecision.tsx
+++ b/apps/app/src/app/pages/collectivite/Historique/actionPrecision/HistoriqueItemActionPrecision.tsx
@@ -7,6 +7,7 @@ import {
 } from '../DetailModificationWrapper';
 import { getItemActionProps } from '../actionStatut/getItemActionProps';
 import { HistoriqueItemPropsOf } from '../types';
+import { appLabels } from '@/app/labels/catalog';
 
 type Props = HistoriqueItemPropsOf<'action_precision'>;
 
@@ -58,7 +59,7 @@ const renderPrecision = (value: string, isPrevious?: boolean) => (
         className="!bg-transparent border-none !px-2 py-0"
       />
     ) : (
-      <i>Non renseigné</i>
+      <i>{appLabels.nonRenseigne}</i>
     )}
   </span>
 );

--- a/apps/app/src/app/pages/collectivite/Historique/reponse/formatReponseValue.tsx
+++ b/apps/app/src/app/pages/collectivite/Historique/reponse/formatReponseValue.tsx
@@ -1,11 +1,12 @@
 import { toPercentString } from '@/app/utils/to-percent-string';
+import { appLabels } from '@/app/labels/catalog';
 
 export const formatReponseValue = (
   value: unknown,
   type: string | null
 ) => {
   if (value === null || value === undefined) {
-    return <i>Non renseigné</i>;
+    return <i>{appLabels.nonRenseigne}</i>;
   }
 
   if (type === 'binaire') {

--- a/apps/app/src/app/pages/collectivite/Indicateurs/Indicateur/detail/IndicateurDetailChart.tsx
+++ b/apps/app/src/app/pages/collectivite/Indicateurs/Indicateur/detail/IndicateurDetailChart.tsx
@@ -51,7 +51,7 @@ const IndicateurDetailChart = ({
               className={classNames('ml-auto', buttonClassName)}
               onClick={() => setIsChartOpen(true)}
             >
-              {appLabels.telechargerGraphique}
+              {appLabels.telechargerLeGraphique}
             </Button>
           </div>
         )}

--- a/apps/app/src/app/pages/collectivite/Indicateurs/detail/Header/IndicateurHeader.tsx
+++ b/apps/app/src/app/pages/collectivite/Indicateurs/detail/Header/IndicateurHeader.tsx
@@ -29,7 +29,7 @@ const IndicateurHeader = ({
   const { titre, unite } = definition;
   const isTitleReadonly = isReadonly || !isPerso;
   const uniteSuffix = composeSansAgregation ? null : (
-    <sup className="ml-1 text-grey-6 font-medium">({unite})</sup>
+    <sup className="ml-1 text-grey-6 font-medium">{`(${unite})`}</sup>
   );
   const showInfos = hasIndicateurInfos({
     definition,

--- a/apps/app/src/app/pages/collectivite/Indicateurs/table/cell-annee-list.tsx
+++ b/apps/app/src/app/pages/collectivite/Indicateurs/table/cell-annee-list.tsx
@@ -8,6 +8,7 @@ import {
 import classNames from 'classnames';
 import { PreparedData, PreparedValue } from '../data/prepare-data';
 import { SourceType } from '../types';
+import { appLabels } from '@/app/labels/catalog';
 
 type CellAnneeListProps = {
   confidentiel?: boolean;
@@ -44,7 +45,7 @@ export const CellAnneeList = ({
         <div className="flex items-center justify-between">
           {modePrive && (
             <Tooltip
-              label={<p className="min-w-max">Le résultat est en mode privé</p>}
+              label={<p className="min-w-max">{appLabels.resultatModePrive}</p>}
             >
               <div>
                 <Notification icon="lock-fill" classname="w-8 h-8" size="sm" />

--- a/apps/app/src/app/pages/collectivite/PlansActions/ActionsGroupees/ActionsGroupeesMenu.tsx
+++ b/apps/app/src/app/pages/collectivite/PlansActions/ActionsGroupees/ActionsGroupeesMenu.tsx
@@ -13,6 +13,7 @@ import EditionReferent from './EditionReferent';
 import EditionService from './EditionService';
 import EditionStatut from './EditionStatut';
 import EditionTagsLibres from './EditionTagsLibres';
+import { appLabels } from '@/app/labels/catalog';
 
 type ActionsGroupeesMenuProps = {
   isVisible: boolean;
@@ -64,7 +65,7 @@ const ActionsGroupeesMenu = ({
     >
       <div className="mx-auto max-w-8xl p-6">
         <div className="mb-3 font-bold text-info-1">
-          Appliquer une action groupée
+          {appLabels.appliquerActionGroupee}
         </div>
         <div className="flex gap-3 flex-wrap">
           <EditionPilote onUpdate={mutate('pilotes')} />

--- a/apps/app/src/app/pages/collectivite/PlansActions/ActionsGroupees/EditionPlanning.tsx
+++ b/apps/app/src/app/pages/collectivite/PlansActions/ActionsGroupees/EditionPlanning.tsx
@@ -11,6 +11,7 @@ import {
 import { OpenState } from '@tet/ui/utils/types';
 import { useRef, useState } from 'react';
 import ActionsGroupeesModale from './ActionsGroupeesModale';
+import { appLabels } from '@/app/labels/catalog';
 
 type ModaleEditionPlanningProps = {
   openState: OpenState;
@@ -96,7 +97,7 @@ const EditionPlanning = ({ onUpdate }: EditionPlanningProps) => {
         variant="outlined"
         onClick={() => setIsModalOpen(true)}
       >
-        Associer un planning
+        {appLabels.associerPlanning}
       </Button>
       {isModalOpen && (
         <ModaleEditionPlanning

--- a/apps/app/src/app/pages/collectivite/PlansActions/ActionsGroupees/EditionPriorite.tsx
+++ b/apps/app/src/app/pages/collectivite/PlansActions/ActionsGroupees/EditionPriorite.tsx
@@ -5,6 +5,7 @@ import { Button, Event, Field, useEventTracker } from '@tet/ui';
 import { OpenState } from '@tet/ui/utils/types';
 import { useState } from 'react';
 import ActionsGroupeesModale from './ActionsGroupeesModale';
+import { appLabels } from '@/app/labels/catalog';
 
 type ModaleEditionPrioriteProps = {
   openState: OpenState;
@@ -55,7 +56,7 @@ const EditionPriorite = ({ onUpdate }: EditionPrioriteProps) => {
         variant="outlined"
         onClick={() => setIsModalOpen(true)}
       >
-        Associer un niveau de priorité
+        {appLabels.associerPriorite}
       </Button>
       {isModalOpen && (
         <ModaleEditionPriorite

--- a/apps/app/src/app/pages/collectivite/PlansActions/ActionsGroupees/EditionStatut.tsx
+++ b/apps/app/src/app/pages/collectivite/PlansActions/ActionsGroupees/EditionStatut.tsx
@@ -5,6 +5,7 @@ import { Button, Event, Field, useEventTracker } from '@tet/ui';
 import { OpenState } from '@tet/ui/utils/types';
 import { useState } from 'react';
 import ActionsGroupeesModale from './ActionsGroupeesModale';
+import { appLabels } from '@/app/labels/catalog';
 
 type StatusEnumType = RouterInput['plans']['fiches']['bulkEdit']['statut'];
 
@@ -56,7 +57,7 @@ const EditionStatut = ({ onUpdate }: EditionStatutProps) => {
         size="xs"
         onClick={() => setIsModalOpen(true)}
       >
-        Associer un statut
+        {appLabels.associerStatut}
       </Button>
       {isModalOpen && (
         <ModaleEditionStatut

--- a/apps/app/src/app/pages/collectivite/PlansActions/ActionsGroupees/EditionTagsLibres.tsx
+++ b/apps/app/src/app/pages/collectivite/PlansActions/ActionsGroupees/EditionTagsLibres.tsx
@@ -5,6 +5,7 @@ import { Button, Event, Field, useEventTracker } from '@tet/ui';
 import { OpenState } from '@tet/ui/utils/types';
 import { useState } from 'react';
 import ActionsGroupeesModale from './ActionsGroupeesModale';
+import { appLabels } from '@/app/labels/catalog';
 
 type ModaleEditionTagsLibresProps = {
   openState: OpenState;
@@ -57,7 +58,7 @@ const EditionTagsLibres = ({ onUpdate }: EditionTagsLibresProps) => {
         variant="outlined"
         onClick={() => setIsModalOpen(true)}
       >
-        Associer des tags personnalisés
+        {appLabels.associerTagsPersonnalises}
       </Button>
       {isModalOpen && (
         <ModaleEditionTagsLibres

--- a/apps/app/src/app/pages/collectivite/PlansActions/ActionsGroupees/fiche-access-bulk-editor.modal.tsx
+++ b/apps/app/src/app/pages/collectivite/PlansActions/ActionsGroupees/fiche-access-bulk-editor.modal.tsx
@@ -5,6 +5,7 @@ import { IdNameSchema } from '@tet/domain/shared';
 import { Button, Event, useEventTracker } from '@tet/ui';
 import { OpenState } from '@tet/ui/utils/types';
 import { useState } from 'react';
+import { appLabels } from '@/app/labels/catalog';
 
 type FicheAccessBulkEditorModalProps = {
   openState: OpenState;
@@ -65,7 +66,7 @@ export const FicheAccessBulkEditorModalButton = ({
         size="xs"
         onClick={() => setIsModalOpen(true)}
       >
-        Gestion des droits d&apos;accès
+        {appLabels.gestionDroitsAcces}
       </Button>
       {isModalOpen && (
         <FicheAccessBulkEditorModal

--- a/apps/app/src/app/pages/collectivite/Trajectoire/DonneesCollectivite/TableauDonnees.tsx
+++ b/apps/app/src/app/pages/collectivite/Trajectoire/DonneesCollectivite/TableauDonnees.tsx
@@ -10,6 +10,7 @@ import {
 } from '@tet/ui';
 import classNames from 'classnames';
 import { getNomSource } from '../../../../../indicateurs/trajectoires/trajectoire-constants';
+import { appLabels } from '@/app/labels/catalog';
 
 type Source = {
   id: string;
@@ -74,7 +75,7 @@ export const TableauDonnees = (props: TableauDonneesProps) => {
       <DEPRECATED_THead>
         <DEPRECATED_TRow>
           <DEPRECATED_THeadCell className="text-left uppercase">
-            Secteur
+            {appLabels.secteur}
           </DEPRECATED_THeadCell>
           {sources.map((source) => (
             <DEPRECATED_THeadCell

--- a/apps/app/src/app/pages/collectivite/Trajectoire/TrajectoireCalculee.tsx
+++ b/apps/app/src/app/pages/collectivite/Trajectoire/TrajectoireCalculee.tsx
@@ -162,7 +162,7 @@ export const TrajectoireCalculee = () => {
             {recomputeButtonIsVisible && (
               <PageHeader.Actions>
                 <Button size="sm" onClick={() => setIsModalDataOpen(true)}>
-                  {appLabels.trajectoireRecalculer}
+                  {appLabels.recalculerLaTrajectoire}
                 </Button>
               </PageHeader.Actions>
             )}
@@ -404,7 +404,7 @@ const LinksToIndicateurs = ({
         })}
         aria-label={`Consulter la fiche de l'indicateur ${indicateurData.name}`}
       >
-        {appLabels.trajectoireVoirFicheIndicateur}
+        {appLabels.voirFicheIndicateur}
       </Button>
     );
   }

--- a/apps/app/src/app/pages/collectivite/presentation/info-administratives.tsx
+++ b/apps/app/src/app/pages/collectivite/presentation/info-administratives.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { appLabels } from '@/app/labels/catalog';
+import { Colon } from '@/app/ui/colon';
 import { useGetCollectivite } from '@/app/collectivites/collectivites/use-get-collectivite';
 import { capitalize } from '@/app/utils/formatUtils';
 import SpinnerLoader from '@/app/ui/shared/SpinnerLoader';
@@ -60,7 +61,10 @@ export function InfosAdministratives() {
 function Item({ title, value }: { title: string; value: string | null }) {
   return (
     <div>
-      <span className="font-medium text-primary-10">{title}&nbsp;:&nbsp;</span>
+      <span className="font-medium text-primary-10">
+        {title}
+        <Colon />
+      </span>
       <span className="font-normal text-grey-8">{value}</span>
     </div>
   );

--- a/apps/app/src/collectivites/membres/invite-membre/invite-membre.button.tsx
+++ b/apps/app/src/collectivites/membres/invite-membre/invite-membre.button.tsx
@@ -4,6 +4,7 @@ import { useCurrentCollectivite } from '@tet/api/collectivites';
 import { Button } from '@tet/ui';
 import { useState } from 'react';
 import { InviteMemberModal } from './invite-membre.modal';
+import { appLabels } from '@/app/labels/catalog';
 
 export function InviteMembreButton() {
   const collectivite = useCurrentCollectivite();
@@ -26,7 +27,7 @@ export function InviteMembreButton() {
         className="h-fit"
         onClick={() => setIsInviteOpen(true)}
       >
-        Inviter un membre
+        {appLabels.inviterMembre}
       </Button>
 
       <InviteMemberModal

--- a/apps/app/src/collectivites/personnalisations/filters/personnalisation-filters.menu.tsx
+++ b/apps/app/src/collectivites/personnalisations/filters/personnalisation-filters.menu.tsx
@@ -5,6 +5,7 @@ import { ButtonMenu, Field } from '@tet/ui';
 import { usePersonnalisationFilters } from './personnalisation-filters-context';
 import { PersonnalisationThematiquesDropdown } from './personnalisation-thematiques.dropdown';
 import { ReferentielsDropdown } from './referentiels.dropdown';
+import { appLabels } from '@/app/labels/catalog';
 
 export function PersonnalisationFiltersMenu() {
   const currentCollectivite = useCurrentCollectivite();
@@ -51,7 +52,7 @@ export function PersonnalisationFiltersMenu() {
         ),
       }}
     >
-      Filtrer
+      {appLabels.filtrer}
     </ButtonMenu>
   );
 }

--- a/apps/app/src/indicateurs/trajectoire-leviers/sgpe-mondrian.tsx
+++ b/apps/app/src/indicateurs/trajectoire-leviers/sgpe-mondrian.tsx
@@ -7,6 +7,7 @@ import { getErrorMessage } from '@tet/domain/utils';
 import { Card, Event, preset, useEventTracker } from '@tet/ui';
 import { MondrianTreemap } from 'mondrian-treemap';
 import React from 'react';
+import { appLabels } from '@/app/labels/catalog';
 
 const { colors } = preset.theme.extend;
 
@@ -35,7 +36,7 @@ export const SgpeMondrian: React.FC<SgpeMondrianProps> = (
       <Card>
         <div className="h-96 flex flex-col">
           <h3 className="text-base mb-0">
-            Objectifs du territoire répartis par levier
+            {appLabels.objectifsTerritoireParLevier}
           </h3>
           <div className="flex grow flex-col items-center justify-center">
             {error ? (

--- a/apps/app/src/labels/catalog.ts
+++ b/apps/app/src/labels/catalog.ts
@@ -367,8 +367,6 @@ export const appLabels = {
   }): string => `${etoileLabel} étoile`,
   demarrerAuditCotAvecLabellisationMessage:
     'Pour passer en CNL, penser à joindre les documents de labellisation.',
-  demarrerAuditEnvoyer: 'Envoyer ma demande',
-  demarrerAuditDemandeSucces: "Votre demande d'audit a bien été envoyée.",
   demarrerAuditSelectionIncomplete:
     "Sélectionnez un type d'audit et une étoile.",
   demarrerAuditTypeCotAvecLabellisation: 'Audit COT avec labellisation',
@@ -522,38 +520,34 @@ export const appLabels = {
   visiteEffectuee: ({ dateVisite }: { dateVisite: string }): string =>
     `Visite effectuée le ${dateVisite}`,
 
-  navTableauxDeBord: 'Tableaux de bord',
-  navTableauDeBordSynthetique: 'Tableau de bord synthétique',
-  navTableauDeBord: 'Tableau de bord',
-  navMonSuiviPersonnel: 'Mon suivi personnel',
-  navPlansEtActions: 'Plans & Actions',
+  tableauxDeBord: 'Tableaux de bord',
+  tableauDeBordSynthetique: 'Tableau de bord synthétique',
+  tableauDeBord: 'Tableau de bord',
+  monSuiviPersonnel: 'Mon suivi personnel',
+  plansEtActions: 'Plans & Actions',
   plans: 'Plans',
   actions: 'Actions',
-  navActionsAImpact: 'Actions à Impact',
+  actionsAImpact: 'Actions à Impact',
   indicateurs: 'Indicateurs',
-  navListesIndicateurs: "Listes d'indicateurs",
+  listesIndicateurs: "Listes d'indicateurs",
   trajectoireSnbcEtObjectifs: 'Trajectoire SNBC et objectifs',
-  navEtatDesLieux: 'État des lieux',
-  navTableauDeBordEtatDesLieux: 'Tableau de bord État des Lieux',
-  navReferentielClimatAirEnergie: 'Référentiel Climat-Air-Énergie',
-  navLabellisationClimatAirEnergie: 'Labellisation Climat-Air-Énergie',
-  navReferentielEconomieCirculaire: 'Référentiel Économie Circulaire',
-  navLabellisationEconomieCirculaire: 'Labellisation Économie Circulaire',
-  navReferentielTransitionEcologique: 'Référentiel Transition Écologique',
-  navParametres: 'Paramètres',
-  navMaCollectivite: 'Ma collectivité',
-  navGestionDesUtilisateurs: 'Gestion des utilisateurs',
-  navBibliothequeDeDocuments: 'Bibliothèque de documents',
-  navCollectivites: 'Collectivités',
-  navSuperAdmin: 'Super Admin',
-  navImporterUnPlan: 'Importer un plan',
+  etatDesLieux: 'État des lieux',
+  tableauDeBordEtatDesLieux: 'Tableau de bord État des Lieux',
+  referentielClimatAirEnergie: 'Référentiel Climat-Air-Énergie',
+  labellisationClimatAirEnergie: 'Labellisation Climat-Air-Énergie',
+  referentielEconomieCirculaire: 'Référentiel Économie Circulaire',
+  labellisationEconomieCirculaire: 'Labellisation Économie Circulaire',
+  referentielTransitionEcologique: 'Référentiel Transition Écologique',
+  parametres: 'Paramètres',
+  maCollectivite: 'Ma collectivité',
+  gestionDesUtilisateurs: 'Gestion des utilisateurs',
+  collectivites: 'Collectivités',
+  superAdmin: 'Super Admin',
   ajouterCollectivite: 'Ajouter une collectivité',
   modifierCollectivite: 'Modifier la collectivité',
-  navAffichageReferentiels: 'Affichage des référentiels',
-  navFinaliserInscription: 'Finaliser mon inscription',
-  navAide: 'Aide',
-  navProfil: 'Profil',
-  navDeconnexion: 'Déconnexion',
+  finaliserInscription: 'Finaliser mon inscription',
+  profil: 'Profil',
+  deconnexion: 'Déconnexion',
 
   formChercherCollectivite: 'Chercher la collectivité',
   formChercherInsee: "Cherche la collectivité dans les données de l'INSEE 2020",
@@ -735,7 +729,6 @@ export const appLabels = {
     "Ajoutez des notes pour documenter le suivi et l'avancement de votre fiche action.",
   actionsLiees: 'Actions liées',
 
-  noteHeaderAnnee: 'Année',
   noteHeaderAuteurDate: 'Auteur/Date',
   documentsAssocies: 'Documents associés',
   documentsAssociesDescription:
@@ -819,9 +812,7 @@ export const appLabels = {
   filtrerAvecCount: ({ count }: { count: number }): string =>
     `Filtrer (${count})`,
   afficherLesResultats: 'Afficher les résultats',
-  collectivitesTitre: 'Collectivités',
   referentielsTitre: 'Référentiels',
-  plansTitre: 'Plans',
   correspondAVotreRecherche: ({
     count,
     label,
@@ -882,13 +873,11 @@ export const appLabels = {
   aucuneActionDansCePlan: 'Aucune action dans ce plan',
   completezStatutsActionsPourRepartition:
     'Complétez les statuts de vos actions pour voir la répartition',
-  creerUnPlan: 'Créer un plan',
   vousSouhaitez: 'Vous souhaitez',
   resultatPluralWord: ({ count }: { count: number }): string =>
     count > 1 ? 'résultats' : 'résultat',
   aucuneActionCorrespondRecherche:
     'Aucune action ne correspond à votre recherche',
-  creerUneAction: 'Créer une action',
   actionsMasqueesDansAffichageGlobal:
     "Les actions sont masquées dans l'affichage global",
   cliquerPourOuvrirFermerLAxe:
@@ -929,7 +918,6 @@ export const appLabels = {
   }): string =>
     `Bravo, vous avez plus de ${scorePercent} % d'actions réalisées ! Les critères ont été mis à jour pour préparer votre candidature à la ${numLabel} étoile.`,
   actionsGroupees: 'Actions groupées',
-  rechercherParNomOuDescription: 'Rechercher par nom ou description',
   vueGrille: 'Grille',
   vueTableau: 'Tableau',
   vueCalendrier: 'Calendrier',
@@ -941,13 +929,10 @@ export const appLabels = {
   actionCountTotal: ({ count }: { count: number }): string =>
     `/ ${count} action${count > 1 ? 's' : ''}`,
   criteresDeLabellisation: 'Critères de labellisation',
-  envoyerMaDemandeLabel: 'Envoyer ma demande',
   revenirPreparationAudit: "Revenir à la préparation de l'audit",
-  demanderUnAudit: 'Demander un audit',
   demanderLaPremiereEtoile: 'Demander la première étoile',
   demanderAuditPourEtoile: ({ numLabel }: { numLabel: string }): string =>
     `Demander un audit pour la ${numLabel} étoile`,
-  envoiEnCoursLabel: 'Envoi en cours...',
   bravoConditionsPremiereEtoile:
     "Bravo ! Vous remplissez apparemment les conditions minimales requises pour la première étoile. Ces conditions vont être vérifiées par l'ADEME qui reviendra vers vous par mail dans les prochaines 48h (ouvrées) pour vous confirmer l'attribution de la première étoile ou vous demander des informations complémentaires !",
   bravoConditionsAuditAvecParenthese: ({
@@ -1312,11 +1297,10 @@ export const appLabels = {
   trajectoireSimulateurTerritorial: 'Simulateur territorial',
   trajectoireVoirSimulateurSgpe: 'Voir le simulateur du SGPE',
   trajectoireEnSavoirPlus: 'En savoir plus',
-  trajectoireRecalculer: 'Recalculer la trajectoire',
   trajectoireTousLesSecteurs: 'Tous les secteurs',
   trajectoireDonneesPartiellesDescriptionLecture:
     "Il manque des données pour certains secteurs : un utilisateur en Edition ou Admin sur le profil de cette collectivité peut compléter les données manquantes pour l'année 2015 afin de finaliser le calcul",
-  trajectoireVoirFicheIndicateur: "Voir la fiche de l'indicateur",
+  voirFicheIndicateur: "Voir la fiche de l'indicateur",
   trajectoireVoirFichesIndicateurs: 'Voir les fiches des indicateurs :',
   trajectoireDonneesPartiellesTitle:
     'Voici un premier calcul de votre trajectoire SNBC territorialisée, avec les données disponibles !',
@@ -1333,7 +1317,6 @@ export const appLabels = {
   retirerFavoris: 'Retirer des favoris',
   ajouterFavoris: 'Ajouter aux favoris',
   telechargerGraphiquePng: 'Télécharger le graphique (.png)',
-  telechargerGraphique: 'Télécharger le graphique',
   aucuneValeurCollectivite:
     "Aucune valeur n'est associée aux résultats ou aux objectifs de la collectivité !",
   aucuneValeurTrouvee: 'Aucune valeur trouvée',
@@ -1582,6 +1565,50 @@ export const appLabels = {
       : "la valeur de l'indicateur de",
   valeurSelectionneePourPourcentageIndicatif: (avancement: string): string =>
     `Valeur sélectionnée pour le calcul du pourcentage indicatif ${avancement} :`,
+
+  voirContacts: 'Voir les contacts',
+  chargementEnCours: 'Chargement en cours...',
+  resultatModePrive: 'Le résultat est en mode privé',
+  appliquerActionGroupee: 'Appliquer une action groupée',
+  associerPlanning: 'Associer un planning',
+  associerPriorite: 'Associer un niveau de priorité',
+  associerStatut: 'Associer un statut',
+  associerTagsPersonnalises: 'Associer des tags personnalisés',
+  gestionDroitsAcces: "Gestion des droits d'accès",
+  secteur: 'Secteur',
+  objectifsTerritoireParLevier: 'Objectifs du territoire répartis par levier',
+  modifie: 'Modifié',
+  tousLesAns: 'Tous les ans',
+  confirmationSuppressionFiche:
+    'Souhaitez-vous vraiment supprimer cette action ?',
+  resultat: plural({ one: 'résultat', other: 'résultats' }),
+  exportPdf: 'Export PDF',
+  sections: 'Sections',
+  axeVide: 'Cet axe ne contient aucune action ni axe',
+  affichage: 'Affichage',
+  tousLesStatuts: 'Tous les statuts',
+  trierPar: 'Trier par',
+  exemples: 'Exemples',
+  exporter: 'Exporter',
+  tous: 'Tous',
+  selectionnerSauvegardesAfficher: 'Sélectionner les sauvegardes à afficher',
+  termine: 'Terminé',
+  colonnes: 'Colonnes',
+  commentairesTitre: 'Commentaires',
+  erreurChangementDonnees: 'Erreur lors du changement des données !',
+  hautDePage: 'Haut de page',
+  cliquezPourVoirDetail: 'Cliquez pour voir le détail',
+  nonPriorise: 'Non priorisé',
+  superAdminPermissionsWarning:
+    'Vous avez des permissions administrateur sur toutes les collectivités. Prudence ⛑️',
+  notificationsParEmail: 'Notifications par email',
+  renvoyerLienConfirmation: 'Renvoyer un lien de confirmation',
+
+  actionNonTrouvee: 'Action non trouvée',
+  collectiviteInaccessibleEnVisite:
+    "Cette collectivité n'est pas accessible en mode visite.",
+  collectiviteIdInvalide: 'Identifiant de collectivité invalide',
+  uneErreurEstSurvenue: 'Une erreur est survenue',
 
   acteEngagementDocUrl: '/Acte_engagement.docx',
   reglementLabelUrl: ({

--- a/apps/app/src/plans/fiches/components/card/fiche.card.tsx
+++ b/apps/app/src/plans/fiches/components/card/fiche.card.tsx
@@ -29,6 +29,7 @@ import { useState } from 'react';
 import { EditFicheModal } from './edit-fiche.modal';
 import { FicheCompletionStatus } from './fiche.completion';
 import { FicheFooter } from './fiche.footer';
+import { appLabels } from '@/app/labels/catalog';
 
 export type FicheCardProps = {
   /** Contenu de la carte fiche action */
@@ -289,7 +290,7 @@ export const FicheCard = ({
                       className="text-xs font-medium italic text-grey-6"
                       title="Dernière modification"
                     >
-                      Modifié {getModifiedSince(ficheAction.modifiedAt)}
+                      {appLabels.modifie} {getModifiedSince(ficheAction.modifiedAt)}
                     </span>
                   )}
                   {/* Complétion */}

--- a/apps/app/src/plans/fiches/components/card/fiche.footer.tsx
+++ b/apps/app/src/plans/fiches/components/card/fiche.footer.tsx
@@ -4,6 +4,7 @@ import { PersonneTagOrUser, Tag } from '@tet/domain/collectivites';
 import { Icon } from '@tet/ui';
 import classNames from 'classnames';
 import { isBefore, startOfToday } from 'date-fns';
+import { appLabels } from '@/app/labels/catalog';
 
 type FicheFooterProps = {
   pilotes: PersonneTagOrUser[] | null | undefined;
@@ -44,7 +45,7 @@ export const FicheFooter = ({
       {!hasDateDeFin && ameliorationContinue && (
         <span title="Échéance">
           <Icon icon="loop-left-line" size="sm" className="mr-1" />
-          Tous les ans
+          {appLabels.tousLesAns}
         </span>
       )}
 

--- a/apps/app/src/plans/fiches/list-all-fiches/components/fiches-list.table/cells/fiches-list.cell-plans.tsx
+++ b/apps/app/src/plans/fiches/list-all-fiches/components/fiches-list.table/cells/fiches-list.cell-plans.tsx
@@ -2,6 +2,7 @@ import ListWithTooltip from '@/app/ui/lists/ListWithTooltip';
 import { generateTitle } from '@/app/utils/generate-title';
 import { FicheWithRelationsAndCollectivite } from '@tet/domain/plans';
 import { TableCell } from '@tet/ui';
+import { appLabels } from '@/app/labels/catalog';
 
 type Props = {
   plans: FicheWithRelationsAndCollectivite['plans'] | null;
@@ -10,7 +11,7 @@ type Props = {
 export const FichesListCellPlans = ({ plans }: Props) => (
   <TableCell>
     {!plans || plans.length === 0 ? (
-      <span className="text-grey-8">Sans plan</span>
+      <span className="text-grey-8">{appLabels.filtreNoPlan}</span>
     ) : (
       <ListWithTooltip
         title={plans[0].nom}

--- a/apps/app/src/plans/fiches/list-all-fiches/components/header-fiche-list.tsx
+++ b/apps/app/src/plans/fiches/list-all-fiches/components/header-fiche-list.tsx
@@ -107,7 +107,7 @@ export const HeaderFicheList = ({
               }}
               value={search ?? ''}
               containerClassname="w-full xl:w-80"
-              placeholder={appLabels.rechercherParNomOuDescription}
+              placeholder={appLabels.rechercherNomDescription}
               displaySize="sm"
             />
 

--- a/apps/app/src/plans/fiches/list-all-fiches/toutes-les-fiches.view.tsx
+++ b/apps/app/src/plans/fiches/list-all-fiches/toutes-les-fiches.view.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { makeCollectiviteToutesLesFichesUrl } from '@/app/app/paths';
+import { appLabels } from '@/app/labels/catalog';
 import { useCreateFicheAction } from '@/app/plans/fiches/data/use-create-fiche-action';
 import { useCurrentCollectivite } from '@tet/api/collectivites';
 import { Button, PageHeader, Spacer } from '@tet/ui';
@@ -100,7 +101,7 @@ const ToutesLesFichesActionContent = () => {
   return (
     <>
       <PageHeader>
-        <PageHeader.Title>Toutes les actions</PageHeader.Title>
+        <PageHeader.Title>{appLabels.toutesLesActions}</PageHeader.Title>
         {hasCollectivitePermission('plans.fiches.create') && (
           <PageHeader.Actions>
             <Button size="sm" onClick={() => createFicheAction()}>

--- a/apps/app/src/plans/fiches/shared/delete-fiche.modal.tsx
+++ b/apps/app/src/plans/fiches/shared/delete-fiche.modal.tsx
@@ -77,7 +77,7 @@ export const DeleteFicheModal = ({
               'mb-4': isInMultipleAxes || hasSousActions,
             })}
           >
-            Souhaitez-vous vraiment supprimer cette action ?
+            {appLabels.confirmationSuppressionFiche}
           </span>
           {isInMultipleAxes && (
             <Alert

--- a/apps/app/src/plans/fiches/show-fiche/content/actions-liees/card/fiche-action.card.tsx
+++ b/apps/app/src/plans/fiches/show-fiche/content/actions-liees/card/fiche-action.card.tsx
@@ -18,6 +18,7 @@ import {
 } from '../../../share-fiche/fiche-share-info';
 import { isFicheEditableByCollectiviteUser } from '../../../share-fiche/share-fiche.utils';
 import FicheActionFooterInfo from './fiche-action.footer';
+import { appLabels } from '@/app/labels/catalog';
 
 export type FicheActionCardProps = {
   /** Contenu de la carte fiche action */
@@ -187,7 +188,7 @@ export const FicheActionCard = ({
                       className="text-xs font-medium italic text-grey-6"
                       title="Dernière modification"
                     >
-                      Modifié {getModifiedSince(ficheAction.modifiedAt)}
+                      {appLabels.modifie} {getModifiedSince(ficheAction.modifiedAt)}
                     </span>
                   )}
                   {/* Complétion */}

--- a/apps/app/src/plans/fiches/show-fiche/content/actions-liees/card/fiche-action.footer.tsx
+++ b/apps/app/src/plans/fiches/show-fiche/content/actions-liees/card/fiche-action.footer.tsx
@@ -4,6 +4,7 @@ import { PersonneTagOrUser, Tag } from '@tet/domain/collectivites';
 import { Icon } from '@tet/ui';
 import classNames from 'classnames';
 import { isBefore, startOfToday } from 'date-fns';
+import { appLabels } from '@/app/labels/catalog';
 
 type FicheActionFooterInfoProps = {
   pilotes: PersonneTagOrUser[] | null | undefined;
@@ -44,7 +45,7 @@ const FicheActionFooterInfo = ({
       {!hasDateDeFin && ameliorationContinue && (
         <span title="Échéance">
           <Icon icon="loop-left-line" size="sm" className="mr-1" />
-          Tous les ans
+          {appLabels.tousLesAns}
         </span>
       )}
 

--- a/apps/app/src/plans/fiches/show-fiche/content/actions-liees/side-menu/fiches-selector.grid.tsx
+++ b/apps/app/src/plans/fiches/show-fiche/content/actions-liees/side-menu/fiches-selector.grid.tsx
@@ -3,6 +3,7 @@ import { FicheListItem } from '@/app/plans/fiches/list-all-fiches/data/use-list-
 import { useCurrentCollectivite } from '@tet/api/collectivites';
 import { useUser } from '@tet/api/users';
 import { FicheActionCard } from '../card/fiche-action.card';
+import { appLabels } from '@/app/labels/catalog';
 
 type Props = {
   fiches?: FicheListItem[];
@@ -18,7 +19,7 @@ export const FichesSelectorGrid = (props: Props) => {
   if (fiches.length === 0) {
     return (
       <div className="my-24 text-center text-sm text-grey-6">
-        Aucune action ne correspond à votre recherche
+        {appLabels.aucuneActionCorrespondRecherche}
       </div>
     );
   }

--- a/apps/app/src/plans/fiches/show-fiche/content/indicateurs/side-menu/indicateurs-selector.grid.tsx
+++ b/apps/app/src/plans/fiches/show-fiche/content/indicateurs/side-menu/indicateurs-selector.grid.tsx
@@ -25,8 +25,8 @@ export const IndicateursSelectorGrid = (props: Props) => {
         <>
           {/** Nb results */}
           <div className="mb-4 text-sm text-grey-7">
-            {definitions.length} résultat
-            {definitions.length > 1 && 's'}
+            {definitions.length}{' '}
+            {appLabels.resultat({ count: definitions.length })}
           </div>
           {/** Grid */}
           <div className="flex flex-col gap-6">

--- a/apps/app/src/plans/fiches/show-fiche/content/moyens/budget/summary-table/index.tsx
+++ b/apps/app/src/plans/fiches/show-fiche/content/moyens/budget/summary-table/index.tsx
@@ -12,6 +12,7 @@ import { useFicheContext } from '../../../../context/fiche-context';
 import { Budget } from '../../../../context/types';
 import { emptyViewsProps } from '../../empty-view';
 import { useBudgetSummaryForm } from '../use-budget-form';
+import { appLabels } from '@/app/labels/catalog';
 
 type BudgetSummaryTableProps = {
   type: 'investissement' | 'fonctionnement';
@@ -32,7 +33,7 @@ const CellValue = ({
 }) => {
   if (!value)
     return (
-      <span className="font-normal italic text-grey-6">Ajouter une valeur</span>
+      <span className="font-normal italic text-grey-6">{appLabels.ajouterValeur}</span>
     );
   if (item.unit === 'ETP') return <ETPValue value={value} />;
   return (

--- a/apps/app/src/plans/fiches/show-fiche/content/notes/notes.table.tsx
+++ b/apps/app/src/plans/fiches/show-fiche/content/notes/notes.table.tsx
@@ -58,7 +58,7 @@ export const NotesTable = ({
     () => [
       columnHelper.accessor('dateNote', {
         header: () => (
-          <TableHeaderCell title={appLabels.noteHeaderAnnee} className="w-32" />
+          <TableHeaderCell title={appLabels.annee} className="w-32" />
         ),
         cell: () => <NoteYearCell />,
       }),

--- a/apps/app/src/plans/fiches/show-fiche/header/menu/actions/pdf-export/ExportModal/export-fa-modal.tsx
+++ b/apps/app/src/plans/fiches/show-fiche/header/menu/actions/pdf-export/ExportModal/export-fa-modal.tsx
@@ -165,7 +165,7 @@ function ExportPdfButton({
       variant="outlined"
       icon="download-fill"
     >
-      Export PDF
+      {appLabels.exportPdf}
     </Button>
   );
 }

--- a/apps/app/src/plans/fiches/show-fiche/header/menu/actions/pdf-export/ExportModal/export-fa-table.tsx
+++ b/apps/app/src/plans/fiches/show-fiche/header/menu/actions/pdf-export/ExportModal/export-fa-table.tsx
@@ -34,7 +34,7 @@ const ExportFicheActionTable = ({ options, setOptions }: Props) => {
         {/* En-tête du tableau */}
         <DEPRECATED_THead>
           <DEPRECATED_TRow className="bg-primary-2 text-primary-9 font-bold text-sm">
-            <DEPRECATED_TCell className="min-w-80">Sections</DEPRECATED_TCell>
+            <DEPRECATED_TCell className="min-w-80">{appLabels.sections}</DEPRECATED_TCell>
             <DEPRECATED_TCell className="w-96">
               {appLabels.personnaliserSection}
             </DEPRECATED_TCell>

--- a/apps/app/src/plans/fiches/show-fiche/header/subheader/pilotes.tsx
+++ b/apps/app/src/plans/fiches/show-fiche/header/subheader/pilotes.tsx
@@ -1,6 +1,7 @@
 import PersonneTagDropdown from '@/app/collectivites/tags/personne-tag.dropdown';
 import { getPersonneStringId } from '@/app/collectivites/tags/personnes.utils';
 import { appLabels } from '@/app/labels/catalog';
+import { Colon } from '@/app/ui/colon';
 import { getFicheAllEditorCollectiviteIds } from '@/app/plans/fiches/share-fiche/share-fiche.utils';
 import { useFicheContext } from '@/app/plans/fiches/show-fiche/context/fiche-context';
 import ListWithTooltip from '@/app/ui/lists/ListWithTooltip';
@@ -18,7 +19,8 @@ export const Pilotes = ({ personnes }: PilotesTriggerProps) => {
 
   return (
     <div className="flex gap-2 hover:bg-grey-3 rounded px-2 py-1 -my-1 -mx-2">
-      Pilotes:
+      {appLabels.pilotes}
+      <Colon />
       <InlineEditWrapper
         disabled={isReadonly}
         renderOnEdit={({ openState }) => (

--- a/apps/app/src/plans/plans/create-plan/create-plan-options.view.tsx
+++ b/apps/app/src/plans/plans/create-plan/create-plan-options.view.tsx
@@ -10,7 +10,7 @@ export const CreatePlanOptionsView = () => {
 
   return (
     <div className="text-center">
-      <h3 className="mb-4">{appLabels.creerUnPlan}</h3>
+      <h3 className="mb-4">{appLabels.creerPlan}</h3>
       <p className="text-lg text-grey-6">{appLabels.vousSouhaitez}</p>
       <CreatePlanOptionLinksList
         collectiviteId={collectiviteId}

--- a/apps/app/src/plans/plans/create-plan/create-plan.view.tsx
+++ b/apps/app/src/plans/plans/create-plan/create-plan.view.tsx
@@ -73,7 +73,7 @@ export const CreatePlanView = () => {
       <div className="w-full mx-auto">
         <h3 className="mb-8">
           <Icon icon="edit-box-fill" size="lg" className="mr-2" />
-          {appLabels.creerUnPlan}
+          {appLabels.creerPlan}
         </h3>
         <div className="flex flex-col mt-2 mb-10 py-14 px-24 bg-white rounded-lg">
           <UpsertPlanForm

--- a/apps/app/src/plans/plans/list-all-plans/all-plans.view.tsx
+++ b/apps/app/src/plans/plans/list-all-plans/all-plans.view.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { appLabels } from '@/app/labels/catalog';
 import { CreatePlanButton } from '@/app/plans/plans/create-plan/components/create-plan.button';
 import { useListPlans } from '@/app/plans/plans/list-all-plans/data/use-list-plans';
 import { ListPlansEmptyCard } from '@/app/plans/plans/list-all-plans/list-plans.empty-card';
@@ -33,7 +34,7 @@ export const AllPlansView = ({ panierId }: Props) => {
   return (
     <>
       <PageHeader>
-        <PageHeader.Title>Tous les plans</PageHeader.Title>
+        <PageHeader.Title>{appLabels.tousLesPlans}</PageHeader.Title>
         {plansAvailable && hasCollectivitePermission('plans.mutate') && (
           <PageHeader.Actions>
             <CreatePlanButton

--- a/apps/app/src/plans/plans/show-plan/actions/move-fiche.modal.tsx
+++ b/apps/app/src/plans/plans/show-plan/actions/move-fiche.modal.tsx
@@ -3,6 +3,7 @@ import { Button, Modal } from '@tet/ui';
 import { OpenState } from '@tet/ui/utils/types';
 import { ColonneTableauEmplacement } from '../../../fiches/show-fiche/header/actions/emplacement/EmplacementFiche/NouvelEmplacement/ColonneTableauEmplacement';
 import { useMoveFiche } from './use-move-fiche';
+import { appLabels } from '@/app/labels/catalog';
 
 type FicheEmplacement = Pick<FicheWithRelations, 'id' | 'axes'>;
 
@@ -73,10 +74,10 @@ const MoveFicheModal = ({
           <Button
             onClick={handleSave}
             disabled={!selectedAxes.length || isReadonly}
-            aria-label="Valider"
+            aria-label={appLabels.valider}
             className="ml-auto"
           >
-            Valider
+            {appLabels.valider}
           </Button>
         </div>
       )}

--- a/apps/app/src/plans/plans/show-plan/plan-arborescence.view/axe/axe-header.tsx
+++ b/apps/app/src/plans/plans/show-plan/plan-arborescence.view/axe/axe-header.tsx
@@ -94,12 +94,12 @@ export const AxeHeader = () => {
                     createFicheResume.mutateAsync();
                   }}
                 >
-                  {appLabels.creerUneAction}
+                  {appLabels.creerAction}
                 </Button>
               ) : (
                 <Tooltip label={appLabels.actionsMasqueesDansAffichageGlobal}>
                   <Button disabled variant="grey" size="xs">
-                    {appLabels.creerUneAction}
+                    {appLabels.creerAction}
                   </Button>
                 </Tooltip>
               )}

--- a/apps/app/src/plans/plans/show-plan/plan-arborescence.view/axe/axe.tsx
+++ b/apps/app/src/plans/plans/show-plan/plan-arborescence.view/axe/axe.tsx
@@ -9,6 +9,7 @@ import { AxeIndicateurs } from './axe-indicateurs';
 import { AxeSkeleton } from './axe-skeleton';
 import { AxeSousAxes } from './axe-sous-axes';
 import { AxeProvider, useAxeContext } from './axe.context';
+import { appLabels } from '@/app/labels/catalog';
 
 type Props = {
   axe: PlanNode;
@@ -70,7 +71,7 @@ const AxeContent = () => {
           <AxeSousAxes />
           {!hasFiches && !hasSousAxes && (
             <span className="px-6 pt-3 pb-0 text-sm italic text-grey-6">
-              Cet axe ne contient aucune action ni axe
+              {appLabels.axeVide}
             </span>
           )}
         </div>

--- a/apps/app/src/plans/plans/show-plan/plan-arborescence.view/plan-options.button.tsx
+++ b/apps/app/src/plans/plans/show-plan/plan-arborescence.view/plan-options.button.tsx
@@ -50,7 +50,7 @@ export const PlanOptionsButton = () => {
         ),
       }}
     >
-      Affichage
+      {appLabels.affichage}
     </ButtonMenu>
   );
 };

--- a/apps/app/src/plans/plans/show-plan/plan.view.tsx
+++ b/apps/app/src/plans/plans/show-plan/plan.view.tsx
@@ -22,6 +22,7 @@ import {
 import { PlanOptionsButton } from './plan-arborescence.view/plan-options.button';
 import { PlanTree } from './plan-arborescence.view/plan-tree';
 import { PlanHeader } from './plan.header';
+import { appLabels } from '@/app/labels/catalog';
 
 type Props = {
   plan: Plan;
@@ -34,7 +35,7 @@ export const PlanView = ({ plan: initialPlanData }: Props) => {
   const rootAxe = plan?.axes.find((axe) => axe.parent === null);
 
   if (!plan || !rootAxe) {
-    return <div>Plan non trouvé</div>;
+    return <div>{appLabels.planNonTrouve}</div>;
   }
 
   return (

--- a/apps/app/src/plans/plans/upsert-plan/upsert-plan.form.tsx
+++ b/apps/app/src/plans/plans/upsert-plan/upsert-plan.form.tsx
@@ -1,4 +1,6 @@
 import PersonneTagDropdown from '@/app/collectivites/tags/personne-tag.dropdown';
+import { appLabels } from '@/app/labels/catalog';
+import { Colon } from '@/app/ui/colon';
 import SpinnerLoader from '@/app/ui/shared/SpinnerLoader';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { PersonneId, personneIdSchema } from '@tet/domain/collectivites';
@@ -222,7 +224,9 @@ export function UpsertPlanForm({
 
                 {field.value && (
                   <p className="mt-2 text-sm text-grey-7 break-all">
-                    Fichier sélectionné : <strong>{field.value.name}</strong>
+                    {appLabels.fichierSelectionne}
+                    <Colon />
+                    <strong>{field.value.name}</strong>
                   </p>
                 )}
               </>

--- a/apps/app/src/plans/reports/generate-plan-report-pptx/generate-report.form.tsx
+++ b/apps/app/src/plans/reports/generate-plan-report-pptx/generate-report.form.tsx
@@ -1,4 +1,5 @@
 import { appLabels } from '@/app/labels/catalog';
+import { Colon } from '@/app/ui/colon';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Plan, generateReportInputSchema } from '@tet/domain/plans';
 import { Checkbox, Field, Input, Select } from '@tet/ui';
@@ -108,7 +109,9 @@ export function GenerateReportForm({
                     className="max-w-48 object-contain rounded-lg border border-grey-4 p-2 bg-grey-1"
                   />
                   <span>
-                    {appLabels.fichierSelectionne} : <strong>{field.value.name}</strong>
+                    {appLabels.fichierSelectionne}
+                    <Colon />
+                    <strong>{field.value.name}</strong>
                   </span>
                 </div>
               )}

--- a/apps/app/src/referentiels/DEPRECATED_ReferentielTable/index.tsx
+++ b/apps/app/src/referentiels/DEPRECATED_ReferentielTable/index.tsx
@@ -71,7 +71,7 @@ export const ReferentielTable: Table = (props) => {
       </div>
       <div className="body" {...getTableBodyProps()}>
         {isLoading ? (
-          <div className="message">Chargement en cours...</div>
+          <div className="message">{appLabels.chargementEnCours}</div>
         ) : rows.length ? (
           rows.map(renderRow)
         ) : (

--- a/apps/app/src/referentiels/DetailTaches/FiltreStatut.tsx
+++ b/apps/app/src/referentiels/DetailTaches/FiltreStatut.tsx
@@ -8,6 +8,7 @@ import { StatutAvancementCreate } from '@tet/domain/referentiels';
 import { ITEM_ALL } from '@tet/ui';
 import { ACTION_STATUT_SELECT_DEFAULT_OPTIONS } from '../actions/action-statut/action-statut.dropdown';
 import { TFiltreProps } from './filters';
+import { appLabels } from '@/app/labels/catalog';
 
 // les options sont celles du sélecteur de statut + une entrée "tous les statuts"
 const items = [
@@ -32,7 +33,7 @@ export const FiltreStatut = (props: TFiltreProps) => {
       )}
       renderOption={(option) =>
         option.value === ITEM_ALL ? (
-          <span className="leading-6">Tous les statuts</span>
+          <span className="leading-6">{appLabels.tousLesStatuts}</span>
         ) : (
           <ActionStatutBadge statut={option.value as StatutAvancementCreate} />
         )

--- a/apps/app/src/referentiels/actions/action.linked-card.tsx
+++ b/apps/app/src/referentiels/actions/action.linked-card.tsx
@@ -6,6 +6,7 @@ import { Action } from '@tet/domain/referentiels';
 import { Button, Card } from '@tet/ui';
 import { ScoreProgressBar } from '../scores/score.progress-bar';
 import { ScoreRatioBadge } from '../scores/score.ratio-badge';
+import { appLabels } from '@/app/labels/catalog';
 
 type ActionCardProps = {
   isReadonly?: boolean;
@@ -55,7 +56,7 @@ const ActionLinkedCard = ({
       >
         {/* Référentiel de l'action */}
         <span className="text-grey-8 text-sm font-medium">
-          Référentiel {referentielToName[referentiel]}
+          {appLabels.referentiel} {referentielToName[referentiel]}
         </span>
 
         {/* Identifiant et titre de l'action */}

--- a/apps/app/src/referentiels/actions/comments/action-comments-filters.tsx
+++ b/apps/app/src/referentiels/actions/comments/action-comments-filters.tsx
@@ -16,6 +16,7 @@ import {
   orderByOptions,
   statusOptions,
 } from './action-comments-filters.constants';
+import { appLabels } from '@/app/labels/catalog';
 
 export type Option = {
   label: string;
@@ -39,7 +40,7 @@ export const OrderBySelect = ({
       onChange={(value) => onOrderByChange(value as DiscussionOrderBy)}
       custom={{
         renderOptionItem: (v) => (
-          <span className="text-grey-8 text-xs">Trier par {v.label}</span>
+          <span className="text-grey-8 text-xs">{appLabels.trierPar} {v.label}</span>
         ),
       }}
       small

--- a/apps/app/src/referentiels/actions/sub-action/sub-action.description.tsx
+++ b/apps/app/src/referentiels/actions/sub-action/sub-action.description.tsx
@@ -2,6 +2,7 @@ import Markdown from '@/app/ui/Markdown';
 import classNames from 'classnames';
 import { ComponentPropsWithoutRef } from 'react';
 import { ActionListItem } from '../use-list-actions';
+import { appLabels } from '@/app/labels/catalog';
 
 interface SubActionDescriptionProps extends ComponentPropsWithoutRef<'div'> {
   subAction: ActionListItem;
@@ -26,7 +27,7 @@ const SubActionDescription = ({
       {subAction.description && <Markdown content={subAction.description} />}
       {exemples && (
         <>
-          <p className="font-bold mb-2">Exemples</p>
+          <p className="font-bold mb-2">{appLabels.exemples}</p>
           <Markdown className="htmlContent" content={exemples} />
         </>
       )}

--- a/apps/app/src/referentiels/audits/AuditComparaison/index.tsx
+++ b/apps/app/src/referentiels/audits/AuditComparaison/index.tsx
@@ -12,6 +12,7 @@ import { TScoreAuditRowData } from './types';
 import { useExportComparisonScores } from './useExportComparisonScore';
 import { useTableData } from './useTableData';
 import { getFormattedScore } from './utils';
+import { appLabels } from '@/app/labels/catalog';
 
 export const AuditComparaison = () => {
   const tableData = useTableData();
@@ -41,7 +42,7 @@ export const AuditComparaison = () => {
           exportAuditScores();
         }}
       >
-        Exporter
+        {appLabels.exporter}
       </Button>
 
       <BarChartCardWithSubrows

--- a/apps/app/src/referentiels/audits/AuditSuivi/FiltreAuditStatut.tsx
+++ b/apps/app/src/referentiels/audits/AuditSuivi/FiltreAuditStatut.tsx
@@ -6,6 +6,7 @@ import {
 import { MesureAuditStatutEnum } from '@tet/domain/referentiels';
 import { ITEM_ALL } from '@tet/ui';
 import { TFiltreProps } from './filters';
+import { appLabels } from '@/app/labels/catalog';
 
 export const FILTER = 'statut';
 
@@ -32,7 +33,7 @@ export const FiltreAuditStatut = (props: TFiltreProps) => {
       onSelect={(newValues) => setFilters({ ...filters, [FILTER]: newValues })}
       renderOption={(option) =>
         option.value === ITEM_ALL ? (
-          <span className="pr-4 py-1">Tous</span>
+          <span className="pr-4 py-1">{appLabels.tous}</span>
         ) : (
           <BadgeAuditStatut statut={option.value as MesureAuditStatutEnum} />
         )

--- a/apps/app/src/referentiels/comparisons/index.tsx
+++ b/apps/app/src/referentiels/comparisons/index.tsx
@@ -9,6 +9,8 @@ import PictoDashboard from '../../ui/pictogrammes/PictoDashboard';
 import { useReferentielId } from '../referentiel-context';
 import { SnapshotListItem, useListSnapshots } from '../use-snapshot';
 import { ScoreTotalEvolutionsChart } from './evolutions-score-total.chart';
+import { appLabels } from '@/app/labels/catalog';
+import { Colon } from '@/app/ui/colon';
 
 export const ScoreEvolutions = () => {
   const referentielId = useReferentielId();
@@ -40,7 +42,8 @@ export const ScoreEvolutions = () => {
       <div className="px-4">
         <div>
           <label className="mb-2">
-            Sélectionner les sauvegardes à afficher :
+            {appLabels.selectionnerSauvegardesAfficher}
+            <Colon />
           </label>
           <div className="flex items-center justify-between">
             <div className="w-full max-w-6xl">

--- a/apps/app/src/referentiels/labellisations/CritereRempli.tsx
+++ b/apps/app/src/referentiels/labellisations/CritereRempli.tsx
@@ -1,5 +1,6 @@
 import { Icon } from '@tet/ui';
 import classNames from 'classnames';
+import { appLabels } from '@/app/labels/catalog';
 
 /** Affiche le picto et le libellé pour un critère rempli */
 export const CritereRempli = ({ className }: { className?: string }) => (
@@ -8,6 +9,6 @@ export const CritereRempli = ({ className }: { className?: string }) => (
       icon="checkbox-circle-fill"
       className={classNames('ml-4 text-success', className)}
     />
-    Terminé
+    {appLabels.termine}
   </span>
 );

--- a/apps/app/src/referentiels/labellisations/DemandeLabellisationModal.tsx
+++ b/apps/app/src/referentiels/labellisations/DemandeLabellisationModal.tsx
@@ -90,7 +90,7 @@ export const DemandeLabellisationModal = (
 
 const getTitle = (etoile: Etoile | undefined): string => {
   if (!etoile) {
-    return appLabels.demanderUnAudit;
+    return appLabels.demanderAudit;
   }
   if (etoile === 1) {
     return appLabels.demanderLaPremiereEtoile;
@@ -113,7 +113,7 @@ export const DemandeLabellisationModalContent = (
       <h3 className="mb-6">{getTitle(etoiles)}</h3>
       <div className="w-full">
         {status === 'non_demandee' && isLoading
-          ? appLabels.envoiEnCoursLabel
+          ? appLabels.envoiEnCours
           : null}
         {status === 'demande_envoyee' ? (
           <Alert
@@ -144,7 +144,7 @@ export const DemandeLabellisationModalContent = (
                   }
                 }}
               >
-                {appLabels.envoyerMaDemandeLabel}
+                {appLabels.envoyerMaDemande}
               </Button>
               {etoiles !== 1 && (
                 <Button variant="outlined" size="sm" onClick={onClose}>

--- a/apps/app/src/referentiels/labellisations/start-audit/start-audit.form.tsx
+++ b/apps/app/src/referentiels/labellisations/start-audit/start-audit.form.tsx
@@ -101,7 +101,7 @@ export const StartAuditForm = ({
         btnOKProps={{
           type: 'submit',
           disabled: !isValid || isPending,
-          children: appLabels.demarrerAuditEnvoyer,
+          children: appLabels.envoyerMaDemande,
         }}
         btnCancelProps={{ onClick: onCancel }}
       />

--- a/apps/app/src/referentiels/labellisations/start-audit/start-audit.modal.tsx
+++ b/apps/app/src/referentiels/labellisations/start-audit/start-audit.modal.tsx
@@ -36,7 +36,7 @@ export const StartAuditModal = ({
       ),
       {
         onSuccess: () => {
-          setToast('success', appLabels.demarrerAuditDemandeSucces);
+          setToast('success', appLabels.demandeAuditEnvoyee);
           close();
         },
         onError: (error) => {

--- a/apps/app/src/referentiels/referentiel.table/referentiel-table.comments.cell.tsx
+++ b/apps/app/src/referentiels/referentiel.table/referentiel-table.comments.cell.tsx
@@ -15,6 +15,7 @@ import {
 import { Button, cn, TableCell } from '@tet/ui';
 import { useCallback, useMemo } from 'react';
 import { getTableMeta } from './utils';
+import { appLabels } from '@/app/labels/catalog';
 
 type Props = {
   info: CellContext<ActionListItem, unknown>;
@@ -68,7 +69,7 @@ function CommentsCellContent({
       title: panelKey,
       Title: () => (
         <h5 className="text-primary-9 font-bold leading-7 text-xl">
-          Commentaires
+          {appLabels.commentairesTitre}
         </h5>
       ),
       content: (

--- a/apps/app/src/referentiels/referentiel.table/referentiel-table.filters.form.tsx
+++ b/apps/app/src/referentiels/referentiel.table/referentiel-table.filters.form.tsx
@@ -3,6 +3,7 @@ import {
   ReferentielTableColumnOption,
   useReferentielTableColumnVisibility,
 } from './use-referentiel-table-column-visibility';
+import { appLabels } from '@/app/labels/catalog';
 
 export function ReferentielTableFiltersForm({
   columnVisibility: { visibleColumnIds, setVisibleColumnIds, columnOptions },
@@ -41,7 +42,7 @@ export function ReferentielTableFiltersForm({
           ),
         }}
       >
-        Colonnes
+        {appLabels.colonnes}
       </ButtonMenu>
     </div>
   );

--- a/apps/app/src/referentiels/referentiel.table/referentiel-table.header-filters.tsx
+++ b/apps/app/src/referentiels/referentiel.table/referentiel-table.header-filters.tsx
@@ -15,6 +15,7 @@ import { Z_INDEX_ABOVE_STICKY_HEADER } from '../../ui/layout/HeaderSticky';
 import { categorieToLabel } from '../utils';
 import { scoreRangeItems } from './referentiel-table.score-ranges';
 import { useGetReferentielTableFiltersState } from './use-get-referentiel-table-filters-state';
+import { appLabels } from '@/app/labels/catalog';
 
 const statutOptions = (
   [
@@ -193,6 +194,6 @@ const FilterButton = ({ filterCount, ...props }: { filterCount: number }) => (
     }
     {...props}
   >
-    Filtrer
+    {appLabels.filtrer}
   </Button>
 );

--- a/apps/app/src/referentiels/tableau-de-bord/graphs/EtatDesLieuxGraphs.tsx
+++ b/apps/app/src/referentiels/tableau-de-bord/graphs/EtatDesLieuxGraphs.tsx
@@ -11,6 +11,7 @@ import { ActionListItem } from '../../actions/use-list-actions';
 import { AccueilCard } from '../AccueilCard';
 import ProgressionReferentiel from './ProgressionReferentiel';
 import { TdbScoreTotalChart } from './tdb-score-total.chart';
+import { appLabels } from '@/app/labels/catalog';
 
 type EtatDesLieuxGraphsProps = {
   referentiel: ReferentielId;
@@ -159,7 +160,7 @@ export const GraphCard = ({
             className="ml-auto h-fit"
             href={href}
           >
-            Afficher le détail
+            {appLabels.afficherDetail}
           </Button>
         ) : (
           <Button

--- a/apps/app/src/tableaux-de-bord/modules/module/module.error.tsx
+++ b/apps/app/src/tableaux-de-bord/modules/module/module.error.tsx
@@ -4,6 +4,7 @@ import { Button, ButtonProps, PictoWarning } from '@tet/ui';
 import React from 'react';
 import { ModuleProps } from './module';
 import { ModuleContainer } from './module.container';
+import { appLabels } from '@/app/labels/catalog';
 
 type Props = Pick<ModuleProps, 'className' | 'title' | 'errorButtons'>;
 
@@ -20,7 +21,7 @@ export const ModuleError = ({ className, title, errorButtons }: Props) => {
         <PictoWarning />
       </div>
       <h6 className="mb-2 text-primary-8">
-        Erreur lors du changement des données !
+        {appLabels.erreurChangementDonnees}
       </h6>
       <p className={classNames('mb-0', 'text-primary-9')}>{title}</p>
       {errorButtons && (

--- a/apps/app/src/tableaux-de-bord/referentiels/mesures.module-page.tsx
+++ b/apps/app/src/tableaux-de-bord/referentiels/mesures.module-page.tsx
@@ -15,6 +15,7 @@ import { ActionTypeEnum, ReferentielId } from '@tet/domain/referentiels';
 import { Button, EmptyCard } from '@tet/ui';
 import { OpenState } from '@tet/ui/utils/types';
 import { useState } from 'react';
+import { appLabels } from '@/app/labels/catalog';
 
 type Props = {
   module: ModuleMesuresSelect;
@@ -67,7 +68,7 @@ export const MesuresModulePage = ({
               icon="equalizer-line"
               onClick={() => setIsOpen(true)}
             >
-              Filtrer
+              {appLabels.filtrer}
             </Button>
             {filtersModal({ isOpen, setIsOpen })}
           </div>

--- a/apps/app/src/ui/buttons/ScrollTopButton.tsx
+++ b/apps/app/src/ui/buttons/ScrollTopButton.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@tet/ui';
 import { APP_HEADER_ID } from '../layout/header/header';
+import { appLabels } from '@/app/labels/catalog';
 
 const ScrollTopButton = ({ className = '' }: { className?: string }) => {
   return (
@@ -13,7 +14,7 @@ const ScrollTopButton = ({ className = '' }: { className?: string }) => {
           ?.scrollIntoView({ behavior: 'smooth' })
       }
     >
-      Haut de page
+      {appLabels.hautDePage}
     </Button>
   );
 };

--- a/apps/app/src/ui/charts/ChartModal.tsx
+++ b/apps/app/src/ui/charts/ChartModal.tsx
@@ -3,6 +3,7 @@ import { Modal } from '@tet/ui';
 import DownloadCanvasButton from '@/app/ui/buttons/DownloadCanvasButton';
 import { ChartProps } from './Chart';
 import DonutChart from './Donut/DonutChart';
+import { appLabels } from '@/app/labels/catalog';
 
 /** Modale qui présente le graphique complet et permet de le télécharger */
 const ChartModal = (props: ChartProps) => {
@@ -44,7 +45,7 @@ const ChartModal = (props: ChartProps) => {
               className="m-auto"
               onClick={() => onDownload?.()}
             >
-              Télécharger
+              {appLabels.telecharger}
             </DownloadCanvasButton>
           )}
           {donut && (

--- a/apps/app/src/ui/charts/old/BarChart.tsx
+++ b/apps/app/src/ui/charts/old/BarChart.tsx
@@ -5,6 +5,8 @@ import {
   ResponsiveBar,
 } from '@nivo/bar';
 import { defaultColors } from '../chartsTheme';
+import { appLabels } from '@/app/labels/catalog';
+import { Colon } from '@/app/ui/colon';
 
 const getCustomColor = ({
   id,
@@ -64,14 +66,15 @@ const getTooltip = (
           }}
         ></div>
         <span>
-          {id} :{' '}
+          {id}
+          <Colon />
           <strong>
             {Math.round(value * 10) / 10} {unit}
           </strong>
         </span>
       </div>
       {clickable && (
-        <div className="text-[#929292] pt-4">Cliquez pour voir le détail</div>
+        <div className="text-[#929292] pt-4">{appLabels.cliquezPourVoirDetail}</div>
       )}
     </div>
   );

--- a/apps/app/src/ui/colon.tsx
+++ b/apps/app/src/ui/colon.tsx
@@ -1,0 +1,7 @@
+import { ReactElement } from 'react';
+
+const NON_BREAKING_SPACE = '\u00a0';
+
+const Colon = (): ReactElement => <>{`${NON_BREAKING_SPACE}: `}</>;
+
+export { Colon };

--- a/apps/app/src/ui/dropdownLists/ficheAction/priorites/PrioritesFilterDropdown.tsx
+++ b/apps/app/src/ui/dropdownLists/ficheAction/priorites/PrioritesFilterDropdown.tsx
@@ -3,6 +3,7 @@ import FichePrioriteBadge from '@/app/plans/fiches/show-fiche/components/fiche-p
 import { ficheActionNiveauPrioriteOptions } from '@/app/ui/dropdownLists/listesStatiques';
 import { Priorite, SANS_PRIORITE_LABEL } from '@tet/domain/plans';
 import { Option, SelectFilter, SelectMultipleProps } from '@tet/ui';
+import { appLabels } from '@/app/labels/catalog';
 
 const options: Option[] = [
   { value: SANS_PRIORITE_LABEL, label: SANS_PRIORITE_LABEL },
@@ -24,7 +25,7 @@ const PrioritesFilterDropdown = (props: Props) => {
       custom={{
         renderOptionItem: (item) =>
           item.value === SANS_PRIORITE_LABEL ? (
-            <span>Non priorisé</span>
+            <span>{appLabels.nonPriorise}</span>
           ) : (
             <FichePrioriteBadge priorite={item.value as Priorite} />
           ),

--- a/apps/app/src/ui/dropdownLists/ficheAction/statuts/StatutsFilterDropdown.tsx
+++ b/apps/app/src/ui/dropdownLists/ficheAction/statuts/StatutsFilterDropdown.tsx
@@ -4,6 +4,7 @@ import { ficheActionStatutOptions } from '@/app/ui/dropdownLists/listesStatiques
 
 import { SANS_STATUT_LABEL, Statut } from '@tet/domain/plans';
 import { Option, SelectFilter, SelectMultipleProps } from '@tet/ui';
+import { appLabels } from '@/app/labels/catalog';
 
 const options: Option[] = [
   { value: SANS_STATUT_LABEL, label: SANS_STATUT_LABEL },
@@ -25,7 +26,7 @@ const StatutsFilterDropdown = (props: Props) => {
       custom={{
         renderOptionItem: (item) =>
           item.value === SANS_STATUT_LABEL ? (
-            <span>Sans statut</span>
+            <span>{appLabels.filtreNoStatut}</span>
           ) : (
             <FicheStatutBadge statut={item.value as Statut} />
           ),

--- a/apps/app/src/ui/layout/header/main-nav/collectivite/generate-edl-dropdown.ts
+++ b/apps/app/src/ui/layout/header/main-nav/collectivite/generate-edl-dropdown.ts
@@ -31,16 +31,16 @@ export const generateEdlDropdown = ({
   referentielsDisplay: ReferentielDisplayMap;
 }): CollectiviteNavItem => ({
   isVisible: !(collectiviteAccesRestreint && isVisitor),
-  children: appLabels.navEtatDesLieux,
+  children: appLabels.etatDesLieux,
   dataTest: 'nav-edl',
   links: [
     {
-      children: appLabels.navTableauDeBordEtatDesLieux,
+      children: appLabels.tableauDeBordEtatDesLieux,
       href: makeReferentielRootUrl({ collectiviteId }),
       dataTest: 'edl-synthese',
     },
     {
-      children: appLabels.navReferentielClimatAirEnergie,
+      children: appLabels.referentielClimatAirEnergie,
       dataTest: 'edl-cae',
       isVisible: isReferentielDisplayed(referentielsDisplay, 'cae'),
       href: makeReferentielUrl({
@@ -63,7 +63,7 @@ export const generateEdlDropdown = ({
       ],
     },
     {
-      children: appLabels.navLabellisationClimatAirEnergie,
+      children: appLabels.labellisationClimatAirEnergie,
       dataTest: 'labellisation-cae',
       isVisible: isReferentielDisplayed(referentielsDisplay, 'cae'),
       href: makeReferentielLabellisationUrl({
@@ -73,7 +73,7 @@ export const generateEdlDropdown = ({
       urlPrefix: ['cae/labellisation'],
     },
     {
-      children: appLabels.navReferentielEconomieCirculaire,
+      children: appLabels.referentielEconomieCirculaire,
       dataTest: 'edl-eci',
       isVisible: isReferentielDisplayed(referentielsDisplay, 'eci'),
       href: makeReferentielUrl({
@@ -96,7 +96,7 @@ export const generateEdlDropdown = ({
       ],
     },
     {
-      children: appLabels.navLabellisationEconomieCirculaire,
+      children: appLabels.labellisationEconomieCirculaire,
       dataTest: 'labellisation-eci',
       isVisible: isReferentielDisplayed(referentielsDisplay, 'eci'),
       href: makeReferentielLabellisationUrl({
@@ -106,7 +106,7 @@ export const generateEdlDropdown = ({
       urlPrefix: ['eci/labellisation'],
     },
     {
-      children: appLabels.navReferentielTransitionEcologique,
+      children: appLabels.referentielTransitionEcologique,
       isVisible: isReferentielDisplayed(referentielsDisplay, 'te'),
       dataTest: 'edl-te',
       href: makeReferentielUrl({

--- a/apps/app/src/ui/layout/header/main-nav/collectivite/generate-indicateurs-dropdown.ts
+++ b/apps/app/src/ui/layout/header/main-nav/collectivite/generate-indicateurs-dropdown.ts
@@ -19,7 +19,7 @@ export const generateIndicateursDropdown = ({
   dataTest: 'nav-ind',
   links: [
     {
-      children: appLabels.navListesIndicateurs,
+      children: appLabels.listesIndicateurs,
       dataTest: 'ind-tous',
       href: makeCollectiviteIndicateursListUrl({
         collectiviteId,

--- a/apps/app/src/ui/layout/header/main-nav/collectivite/generate-parametres-dropdown.ts
+++ b/apps/app/src/ui/layout/header/main-nav/collectivite/generate-parametres-dropdown.ts
@@ -19,11 +19,11 @@ export const generateParametresDropdown = ({
   isAdeme: boolean;
 }): CollectiviteNavItem => ({
   isVisible: !(collectiviteAccesRestreint && isVisitor),
-  children: appLabels.navParametres,
+  children: appLabels.parametres,
   dataTest: 'nav-params',
   links: [
     {
-      children: appLabels.navMaCollectivite,
+      children: appLabels.maCollectivite,
       dataTest: 'params-collectivite',
       href: makeMaCollectiviteUrl({
         collectiviteId,
@@ -31,14 +31,14 @@ export const generateParametresDropdown = ({
       urlPrefix: ['/ma-collectivite'],
     },
     {
-      children: appLabels.navGestionDesUtilisateurs,
+      children: appLabels.gestionDesUtilisateurs,
       dataTest: 'params-membres',
       href: makeCollectiviteUsersUrl({
         collectiviteId,
       }),
     },
     {
-      children: appLabels.navBibliothequeDeDocuments,
+      children: appLabels.bibliothequeDeDocuments,
       dataTest: 'params-docs',
       href: makeCollectiviteBibliothequeUrl({
         collectiviteId,

--- a/apps/app/src/ui/layout/header/main-nav/collectivite/generate-plans-actions-dropdown.ts
+++ b/apps/app/src/ui/layout/header/main-nav/collectivite/generate-plans-actions-dropdown.ts
@@ -19,11 +19,11 @@ export const generatePlansActionsDropdown = ({
   panierId?: string;
 }): CollectiviteNavItem => ({
   isVisible: !(collectiviteAccesRestreint && isVisitor),
-  children: appLabels.navPlansEtActions,
+  children: appLabels.plansEtActions,
   dataTest: 'nav-pa',
   links: [
     {
-      children: appLabels.navTableauDeBord,
+      children: appLabels.tableauDeBord,
       dataTest: 'pa-tdb',
       href: makeTdbPlansEtActionsUrl({
         collectiviteId,
@@ -45,7 +45,7 @@ export const generatePlansActionsDropdown = ({
     },
     {
       isVisible: !isVisitor,
-      children: appLabels.navActionsAImpact,
+      children: appLabels.actionsAImpact,
       dataTest: 'pa-ai',
       href: makeCollectivitePanierUrl({
         collectiviteId,

--- a/apps/app/src/ui/layout/header/main-nav/collectivite/generate-tdb-dropdown.ts
+++ b/apps/app/src/ui/layout/header/main-nav/collectivite/generate-tdb-dropdown.ts
@@ -14,11 +14,11 @@ export const generateTdbDropdown = ({
 }): CollectiviteNavItem | null => {
   if (!isVisitor) {
     return {
-      children: appLabels.navTableauxDeBord,
+      children: appLabels.tableauxDeBord,
       dataTest: 'nav-tdb',
       links: [
         {
-          children: appLabels.navTableauDeBordSynthetique,
+          children: appLabels.tableauDeBordSynthetique,
           dataTest: 'tdb-collectivite',
           href: makeTdbCollectiviteUrl({
             collectiviteId,
@@ -37,7 +37,7 @@ export const generateTdbDropdown = ({
   }
 
   return {
-    children: appLabels.navTableauDeBord,
+    children: appLabels.tableauDeBord,
     dataTest: 'nav-tdb',
     href: makeTdbCollectiviteUrl({
       collectiviteId,

--- a/apps/app/src/ui/layout/header/main-nav/collectivite/generate-tdb-personal-link.ts
+++ b/apps/app/src/ui/layout/header/main-nav/collectivite/generate-tdb-personal-link.ts
@@ -10,7 +10,7 @@ export const generateTdbPersonalLink = ({
   isVisitor: boolean;
 }): CollectiviteNavLink => ({
   isVisible: !isVisitor,
-  children: appLabels.navMonSuiviPersonnel,
+  children: appLabels.monSuiviPersonnel,
   dataTest: 'tdb-perso',
   href: makeTdbCollectiviteUrl({
     collectiviteId,

--- a/apps/app/src/ui/layout/header/main-nav/collectivite/make-collectivite-nav.ts
+++ b/apps/app/src/ui/layout/header/main-nav/collectivite/make-collectivite-nav.ts
@@ -105,7 +105,7 @@ export const makeCollectiviteNav = ({
       isVisitor,
     }),
     {
-      children: appLabels.navCollectivites,
+      children: appLabels.collectivites,
       dataTest: 'nav-collectivites',
       href: getRechercheViewUrl({
         collectiviteId,
@@ -114,10 +114,10 @@ export const makeCollectiviteNav = ({
     },
     {
       isVisible: hasRole(user, PlatformRole.SUPER_ADMIN),
-      children: appLabels.navSuperAdmin,
+      children: appLabels.superAdmin,
       links: [
         {
-          children: appLabels.navImporterUnPlan,
+          children: appLabels.importerUnPlan,
           href: importerPlanUrl,
         },
         {
@@ -131,7 +131,7 @@ export const makeCollectiviteNav = ({
           }),
         },
         {
-          children: appLabels.navAffichageReferentiels,
+          children: appLabels.affichageDesReferentiels,
           href: makeCollectiviteAffichageReferentielsUrl({
             collectiviteId,
           }),

--- a/apps/app/src/ui/layout/header/main-nav/make-main-nav.ts
+++ b/apps/app/src/ui/layout/header/main-nav/make-main-nav.ts
@@ -31,7 +31,7 @@ export const makeMainNav = ({
     return {
       startItems: [
         {
-          children: appLabels.navFinaliserInscription,
+          children: appLabels.finaliserInscription,
           href: finaliserMonInscriptionUrl,
         },
       ],

--- a/apps/app/src/ui/layout/header/make-secondary-nav.ts
+++ b/apps/app/src/ui/layout/header/make-secondary-nav.ts
@@ -10,7 +10,7 @@ import {
 export const makeSecondaryNav = (user: UserWithRolesAndPermissions) => {
   return [
     {
-      children: appLabels.navAide,
+      children: appLabels.aide,
       href: 'https://aide.territoiresentransitions.fr/fr/',
       icon: 'question-line',
       external: true,
@@ -28,11 +28,11 @@ export const makeSecondaryNav = (user: UserWithRolesAndPermissions) => {
         {
           dataTest: 'user-profile',
           href: profilPath,
-          children: appLabels.navProfil,
+          children: appLabels.profil,
         },
         {
           dataTest: 'user-logout',
-          children: appLabels.navDeconnexion,
+          children: appLabels.deconnexion,
           href: '/',
           onClick: async () => await signOutUser(),
         },

--- a/apps/app/src/ui/lists/filters.generic-button-menu.tsx
+++ b/apps/app/src/ui/lists/filters.generic-button-menu.tsx
@@ -1,5 +1,6 @@
 import { ButtonMenu } from '@tet/ui';
 import { ReactNode } from 'react';
+import { appLabels } from '@/app/labels/catalog';
 
 export const FiltersGenericButtonMenu = ({
   children,
@@ -22,6 +23,6 @@ export const FiltersGenericButtonMenu = ({
       startContent: <div className="p-4">{children}</div>,
     }}
   >
-    Filtrer
+    {appLabels.filtrer}
   </ButtonMenu>
 );

--- a/apps/app/src/ui/metadata-line/metadata-item.tsx
+++ b/apps/app/src/ui/metadata-line/metadata-item.tsx
@@ -1,6 +1,8 @@
 import { cn, Icon, IconValue } from '@tet/ui';
 import { isNil } from 'es-toolkit';
 import { HTMLAttributes, ReactNode } from 'react';
+import { appLabels } from '@/app/labels/catalog';
+import { Colon } from '@/app/ui/colon';
 
 export type MetadataItemProps = {
   dataTest?: string;
@@ -32,9 +34,12 @@ export const MetadataItem = ({
         })}
       >
         <Icon icon={icon} />
-        <span className="font-normal">{label} :{' '}</span>
+        <span className="font-normal">
+          {label}
+          <Colon />
+        </span>
         {isNil(value) || value === '' ? (
-          <span className="text-warning-1">À compléter</span>
+          <span className="text-warning-1">{appLabels.aCompleterMaj}</span>
         ) : (
           <span className="font-medium">{value}</span>
         )}

--- a/apps/app/src/users/authorizations/super-admin-mode/super-admin-mode-enabled.alert.tsx
+++ b/apps/app/src/users/authorizations/super-admin-mode/super-admin-mode-enabled.alert.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import { Alert } from '@tet/ui';
 import { ToggleSuperAdminModeCheckbox } from './toggle-super-admin-mode.checkbox';
 
@@ -9,10 +10,7 @@ export function SuperAdminModeEnabledAlert() {
       title={
         <div className="flex gap-5">
           <ToggleSuperAdminModeCheckbox />
-          <span>
-            Vous avez des permissions administrateur sur toutes les
-            collectivités. Prudence ⛑️
-          </span>
+          <span>{appLabels.superAdminPermissionsWarning}</span>
         </div>
       }
     />

--- a/apps/app/src/users/profil/profil-notifications.tsx
+++ b/apps/app/src/users/profil/profil-notifications.tsx
@@ -3,6 +3,7 @@ import {
   useUserPreferences,
 } from '@/app/users/use-user-preferences';
 import { Checkbox } from '@tet/ui';
+import { appLabels } from '@/app/labels/catalog';
 
 export const ProfilNotifications = () => {
   const { data: preferences } = useUserPreferences();
@@ -17,7 +18,7 @@ export const ProfilNotifications = () => {
   return (
     <div className="flex flex-col gap-6 max-w-xl p-8 font-medium rounded-xl border border-grey-3 bg-white">
       <div className="flex flex-wrap justify-between items-center gap-6">
-        <span className="text-lg font-bold">Notifications par email</span>
+        <span className="text-lg font-bold">{appLabels.notificationsParEmail}</span>
       </div>
       <div className="h-px w-full bg-grey-3" />
       <div className="flex flex-col gap-4">

--- a/apps/app/src/users/profil/resend-confirmation-link.button.tsx
+++ b/apps/app/src/users/profil/resend-confirmation-link.button.tsx
@@ -2,6 +2,7 @@
 
 import { useUpdateEmail } from '@/app/users/use-update-email';
 import { Button, ButtonProps } from '@tet/ui';
+import { appLabels } from '@/app/labels/catalog';
 
 type Props = ButtonProps & {
   newEmail: string;
@@ -16,7 +17,7 @@ export function ResendConfirmationLinkButton({ newEmail, ...props }: Props) {
       onClick={() => handleUpdateEmail({ email: newEmail })}
       loading={isPending}
     >
-      Renvoyer un lien de confirmation
+      {appLabels.renvoyerLienConfirmation}
     </Button>
   );
 }

--- a/e2e/tests/plans/plans/edit-plan/edit-plan.pom.ts
+++ b/e2e/tests/plans/plans/edit-plan/edit-plan.pom.ts
@@ -31,15 +31,15 @@ export class EditPlanPom {
       title: page.locator('h1'),
       editableTitle: page.getByPlaceholder('Saisir un titre'),
       type: page.getByText('Type :').locator('..'),
-      pilote: page.getByText(/^Pilotes? :/).locator('..'),
-      referent: page.getByText(/^Élu·es? référent·es? :/).locator('..'),
+      pilote: page.getByText(/^Pilotes?\s:/).locator('..'),
+      referent: page.getByText(/^Élu·es? référent·es?\s:/).locator('..'),
       investissement: page
         .getByText("Budget d'investissement :")
         .locator('..'),
       fonctionnement: page.getByText('Budget de fonctionnement :').locator('..'),
-      axes: page.getByText(/^Axes? :/).locator('..'),
-      sousAxes: page.getByText(/^Sous-axes? :/).locator('..'),
-      actions: page.getByText(/^Actions? :/).locator('..'),
+      axes: page.getByText(/^Axes?\s:/).locator('..'),
+      sousAxes: page.getByText(/^Sous-axes?\s:/).locator('..'),
+      actions: page.getByText(/^Actions?\s:/).locator('..'),
     };
   }
 


### PR DESCRIPTION
## Objectif

Empêcher l'ajout de libellés JSX hardcodés et centraliser les libellés dans `appLabels`.

## Changements

- **Règle eslint** : active `react/jsx-no-literals` en `error` dans `apps/app/eslint.config.mjs`. `allowedStrings` limité aux glyphes (`-`, `+`, `%`, `€`). Règle désactivée sur les `*.stories.tsx` et les fixtures.
- **Catalogue** : 35 clés ajoutées à `appLabels` et migration des libellés JSX hardcodés correspondants (réutilisation des clés existantes le cas échéant).
- **Séparateur deux-points** : nouveau composant `<Colon />` (`apps/app/src/ui/colon.tsx`) qui porte l'espace insécable + deux-points en un seul endroit. `":"` retiré de `allowedStrings` pour que tout deux-points hardcodé en JSX devienne une erreur et passe obligatoirement par `<Colon />`. Appliqué aux 7 sites libellé/valeur.

## Vérifications

- `react/jsx-no-literals` : 0 violation sur `apps/app/src/**/*.tsx`
- `tsc --noEmit` (apps/app) : 0 erreur

## Hors périmètre

- Les deux-points internes à des valeurs de catalogue préexistantes (ex. `detailleStatutPourcentage`) ne sont pas traités : la règle ne gouverne que le JSX.
- Les libellés passés en props `string` (ex. titres de `info-administratives`) ne sont pas détectables par la règle (texte JSX uniquement).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Restructuration du catalogue de libellés pour centraliser et harmoniser les textes de l’interface.
  * Activation d’une règle de lint pour renforcer la qualité du code (impact visible via messages de développement).

* **New Features**
  * Application généralisée des libellés centralisés dans l’UI (titres, boutons, placeholders, messages, tooltips, modales) pour cohérence.
  * Nouveau composant "Colon" pour un affichage uniforme de la ponctuation dans les libellés.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->