### PR TITLE
refactor(plans): sépare ImportPlanService (persistance) du front Excel

### DIFF
--- a/apps/backend/src/plans/plans/import-plan-aggregate/import-excel-plan.application-service.ts
+++ b/apps/backend/src/plans/plans/import-plan-aggregate/import-excel-plan.application-service.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@nestjs/common';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { failure, Result } from '@tet/backend/utils/result.type';
+import { PersonneId } from '@tet/domain/collectivites';
+import { createImportPlanInput } from './factories/create-plan-import-input.factory';
+import { ImportPlanService } from './import-plan.service';
+import {
+  ExcelParsingError,
+  ImportErrors,
+  TransformationError,
+} from './import.errors';
+import { parsePlanExcel } from './parsers/excel-parser';
+
+@Injectable()
+export class ImportExcelPlanApplicationService {
+  constructor(private readonly importPlanService: ImportPlanService) {}
+
+  async import(
+    user: AuthenticatedUser,
+    file: string,
+    collectiviteId: number,
+    planName: string,
+    planType?: number,
+    pilotes?: PersonneId[],
+    referents?: PersonneId[]
+  ): Promise<Result<{ planId: number; fichesCount: number }, ImportErrors>> {
+    // 1. Parse Excel file
+    const parsedRows = await parsePlanExcel(file);
+    if (!parsedRows.success) {
+      return failure(new ExcelParsingError(parsedRows.error.message));
+    }
+
+    // 2. Transform to domain objects
+    const planResult = await createImportPlanInput(
+      parsedRows.data,
+      planName,
+      planType,
+      pilotes,
+      referents
+    );
+    if (!planResult.success) {
+      return failure(new TransformationError(planResult.error));
+    }
+
+    // 3. Persist (validation + transaction)
+    return this.importPlanService.save({
+      planInput: planResult.data,
+      collectiviteId,
+      user,
+    });
+  }
+}

--- a/apps/backend/src/plans/plans/import-plan-aggregate/import-plan.module.ts
+++ b/apps/backend/src/plans/plans/import-plan-aggregate/import-plan.module.ts
@@ -5,8 +5,9 @@ import { ResolveEntityService } from '@tet/backend/plans/plans/import-plan-aggre
 import { PlanModule } from '@tet/backend/plans/plans/plans.module';
 import { SharedModule } from '@tet/backend/shared/shared.module';
 import { TransactionModule } from '@tet/backend/utils/transaction/transaction.module';
-import { ImportPlanApplicationService } from './import-plan.application-service';
+import { ImportExcelPlanApplicationService } from './import-excel-plan.application-service';
 import { ImportPlanRouter } from './import-plan.router';
+import { ImportPlanService } from './import-plan.service';
 
 @Module({
   imports: [
@@ -18,10 +19,11 @@ import { ImportPlanRouter } from './import-plan.router';
   ],
 
   providers: [
-    ImportPlanApplicationService,
+    ImportPlanService,
+    ImportExcelPlanApplicationService,
     ImportPlanRouter,
     ResolveEntityService,
   ],
-  exports: [ImportPlanRouter],
+  exports: [ImportPlanRouter, ImportPlanService],
 })
 export class ImportPlanModule {}

--- a/apps/backend/src/plans/plans/import-plan-aggregate/import-plan.router.ts
+++ b/apps/backend/src/plans/plans/import-plan-aggregate/import-plan.router.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { TRPCError } from '@trpc/server';
 import { TrpcService } from '../../../utils/trpc/trpc.service';
-import { ImportPlanApplicationService } from './import-plan.application-service';
+import { ImportExcelPlanApplicationService } from './import-excel-plan.application-service';
 import { importPlanInputSchema } from './import-plan.input';
 import { isClientError } from './import.errors';
 
@@ -9,7 +9,7 @@ import { isClientError } from './import.errors';
 export class ImportPlanRouter {
   constructor(
     private readonly trpc: TrpcService,
-    private readonly service: ImportPlanApplicationService
+    private readonly service: ImportExcelPlanApplicationService
   ) {}
 
   router = this.trpc.router({

--- a/apps/backend/src/plans/plans/import-plan-aggregate/import-plan.service.ts
+++ b/apps/backend/src/plans/plans/import-plan-aggregate/import-plan.service.ts
@@ -1,26 +1,23 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { CreatePlanAggregateService } from '@tet/backend/plans/plans/create-plan-aggregate/create-plan-aggregate.service';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
 import { failure, Result, success } from '@tet/backend/utils/result.type';
 import { TransactionManager } from '@tet/backend/utils/transaction/transaction-manager.service';
-import { PersonneId } from '@tet/domain/collectivites';
 import { importPlanInputToCreatePlanAggregateInput } from './adapters/import-plan-input-to-create-plan-aggregate-input';
-import { createImportPlanInput } from './factories/create-plan-import-input.factory';
+import { ImportPlanInput } from './import-plan.input';
 import {
   EntityResolutionError,
-  ExcelParsingError,
   ImportErrors,
   PlanCreationError,
   TransactionError,
-  TransformationError,
 } from './import.errors';
-import { parsePlanExcel } from './parsers/excel-parser';
 import { ResolveEntityService } from './resolvers/resolve-entity.service';
 import { validateImportPlanInput } from './validators/plan.rule';
 
 @Injectable()
-export class ImportPlanApplicationService {
-  private readonly logger = new Logger(ImportPlanApplicationService.name);
+export class ImportPlanService {
+  private readonly logger = new Logger(ImportPlanService.name);
 
   constructor(
     private readonly resolveEntityService: ResolveEntityService,
@@ -28,53 +25,34 @@ export class ImportPlanApplicationService {
     private readonly planAggregate: CreatePlanAggregateService
   ) {}
 
-  async import(
-    user: AuthenticatedUser,
-    file: string,
-    collectiviteId: number,
-    planName: string,
-    planType?: number,
-    pilotes?: PersonneId[],
-    referents?: PersonneId[]
-  ): Promise<Result<{ planId: number; fichesCount: number }, ImportErrors>> {
-    // 1. Parse Excel file
-    const parsedRows = await parsePlanExcel(file);
-    if (!parsedRows.success) {
-      return failure(new ExcelParsingError(parsedRows.error.message));
-    }
+  async save(args: {
+    planInput: ImportPlanInput;
+    collectiviteId: number;
+    user: AuthenticatedUser;
+    tx?: Transaction;
+  }): Promise<Result<{ planId: number; fichesCount: number }, ImportErrors>> {
+    const { planInput, collectiviteId, user, tx } = args;
 
-    // 2. Transform to domain objects
-    const planResult = await createImportPlanInput(
-      parsedRows.data,
-      planName,
-      planType,
-      pilotes,
-      referents
-    );
-    if (!planResult.success) {
-      return failure(new TransformationError(planResult.error));
-    }
-
-    // 3. Validate business rules
-    const validationResult = validateImportPlanInput(planResult.data);
+    // 1. Validate business rules
+    const validationResult = validateImportPlanInput(planInput);
     if (!validationResult.success) {
       return validationResult;
     }
 
-    const fichesCount = planResult.data.actions.length;
+    const fichesCount = planInput.actions.length;
 
-    // 4. Execute import in transaction
+    // 2. Execute import in transaction
     const saveResult = await this.transactionManager.executeSingle<
       { planId: number; fichesCount: number },
       ImportErrors
-    >(async (tx) => {
+    >(async (transaction) => {
       try {
-        // 4a. Resolve entities (find or create tags/users)
+        // 2a. Resolve entities (find or create tags/users)
         const resolvedEntitiesResult =
           await this.resolveEntityService.resolveFicheEntities(
             collectiviteId,
-            planResult.data.actions,
-            tx,
+            planInput.actions,
+            transaction,
             user
           );
 
@@ -88,9 +66,9 @@ export class ImportPlanApplicationService {
           );
         }
 
-        // 4b. Adapt import data to plan creation request
+        // 2b. Adapt import data to plan creation request
         const planCreationRequest = importPlanInputToCreatePlanAggregateInput(
-          planResult.data,
+          planInput,
           resolvedEntitiesResult.data,
           collectiviteId
         );
@@ -99,11 +77,11 @@ export class ImportPlanApplicationService {
           return failure(new PlanCreationError(planCreationRequest.error));
         }
 
-        // 4c. Create plan aggregate
+        // 2c. Create plan aggregate
         const planCreationResult = await this.planAggregate.create(
           planCreationRequest.data,
           user,
-          tx
+          transaction
         );
 
         if (!planCreationResult.success) {
@@ -119,7 +97,7 @@ export class ImportPlanApplicationService {
         this.logger.error('Error during import transaction:', error);
         return failure(new TransactionError(error));
       }
-    });
+    }, tx);
 
     if (!saveResult.success) {
       this.logger.error('Error saving import data:', saveResult.error);

--- a/apps/backend/src/plans/plans/plans.module.ts
+++ b/apps/backend/src/plans/plans/plans.module.ts
@@ -25,8 +25,9 @@ import { GetPlanRepository } from './get-plan/get-plan.repository';
 import { GetPlanRouter } from './get-plan/get-plan.router';
 import { GetPlanService } from './get-plan/get-plan.service';
 import { CreatePlanAggregateService } from './create-plan-aggregate/create-plan-aggregate.service';
-import { ImportPlanApplicationService } from './import-plan-aggregate/import-plan.application-service';
+import { ImportExcelPlanApplicationService } from './import-plan-aggregate/import-excel-plan.application-service';
 import { ImportPlanRouter } from './import-plan-aggregate/import-plan.router';
+import { ImportPlanService } from './import-plan-aggregate/import-plan.service';
 import { ResolveEntityService } from './import-plan-aggregate/resolvers/resolve-entity.service';
 import { ListPlanTypesRouter } from './list-plan-types/list-plan-types.router';
 import { ListPlanTypesService } from './list-plan-types/list-plan-types.service';
@@ -79,7 +80,8 @@ import { UpsertPlanService } from './upsert-plan/upsert-plan.service';
     ComputeBudgetRules,
     PlanRouter,
     CreatePlanAggregateService,
-    ImportPlanApplicationService,
+    ImportPlanService,
+    ImportExcelPlanApplicationService,
     ImportPlanRouter,
     ResolveEntityService,
   ],
@@ -91,6 +93,7 @@ import { UpsertPlanService } from './upsert-plan/upsert-plan.service';
     GetPlanService,
     PlanProgressRules,
     ComputeBudgetRules,
+    ImportPlanService,
   ],
 })
 export class PlanModule {}


### PR DESCRIPTION
## Objectif

Séparer la **persistance d'un plan importé** (agnostique de la provenance) du **front Excel**, pour que l'import IA (à venir) réutilise la même logique de persistance sans la dupliquer ni passer par un service à saveur Excel.

**PR1** de la stack « Import Tool IA ».

## Changements

- **`ImportPlanService.save({ planInput, collectiviteId, user, tx? })`** : nouveau service cœur, persistance agnostique (validation des règles métier + transaction : `resolveFicheEntities` → adapter → `CreatePlanAggregateService.create`). `tx?` optionnel transmis à `executeSingle` (composition transactionnelle).
- **`ImportPlanApplicationService` → `ImportExcelPlanApplicationService`** : front Excel mince qui parse (`parsePlanExcel` → `createImportPlanInput`) puis délègue à `ImportPlanService.save`.
- `ImportPlanService` exporté depuis `PlanModule` (consommé par le front IA en PR11).

## Layering

- Service cœur (`ImportPlanService`) = persistance, une seule forme d'entrée normalisée (`ImportPlanInput`).
- Services applicatifs par provenance (Excel ici, IA en PR11) = orchestration du use-case, composent le service cœur. **Composition, pas héritage.**

## Comportement

Import Excel **strictement inchangé** : même ordre (parse → transform → persist), mêmes erreurs typées, même `{ planId, fichesCount }`.

## Notes

- `ImportPlanModule` est du **dead code pré-existant** (importé nulle part ; ne résout pas `CreatePlanAggregateService`). Conservé tel quel, juste maintenu compilable. Le vrai câblage est `PlanModule`.

## Vérifications

- ✅ `nx run backend:typecheck` (+ deps) vert.
- ✅ 86/86 tests unitaires `import-plan-aggregate` verts.
- ⚠️ `import-plan.router.e2e-spec.ts` non bootstrap-able en local (service Google Sheets eager au bootstrap, creds absentes du repo) — à confirmer en CI ; indépendant de cette PR.