### PR TITLE
fix(indicateurs): supprime un return de debug qui masquait le bloc d'infos d'un indicateur

### DIFF
--- a/apps/app/src/app/pages/collectivite/Indicateurs/detail/Header/IndicateurInfos.tsx
+++ b/apps/app/src/app/pages/collectivite/Indicateurs/detail/Header/IndicateurInfos.tsx
@@ -53,8 +53,6 @@ export const IndicateurInfos = ({
   const hasPilotes = pilotes && pilotes.length > 0;
   const hasServices = services && services.length > 0;
 
-  return <div>Lol</div>;
-
   return (
     <>
       <div


### PR DESCRIPTION
## Nature

Hotfix (régression prod). Une seule nature.

Pas de doc de plan — fix ponctuel d'une ligne de debug.

## Symptôme

`IndicateurInfos` retournait `return <div>Lol</div>;` avant son rendu réel : le bloc d'informations d'un indicateur (date/auteur de modification, pilotes, services, participation au score, badges perso/open-data) n'affichait que « Lol ». Tout le JSX en dessous était du dead code inatteignable.

Introduit par `137d1e0b6f feat(app): migre les page headers vers PageHeader` (déjà sur `main`).

## Surface de review

- `apps/app/src/app/pages/collectivite/Indicateurs/detail/Header/IndicateurInfos.tsx` — suppression de la ligne de debug (2 lignes supprimées)

La visibilité du bloc reste gérée par le parent (`IndicateurHeader` via `<PageHeader.Metadata visibleWhen={hasIndicateurInfos(...)}>`) et les séparateurs par les `<Divider>` de `PageHeader` : le `displayInfo` interne et le `border-y` retirés par `137d1e0b6f` étaient des changements légitimes du refactor, seul le `return` de debug devait sauter.

## Hypothèses

- Le `return <div>Lol</div>;` est bien un oubli de debug, pas un placeholder intentionnel (le JSX complet existe juste en dessous).
