### PR TITLE
feat(llm): client Gemini structuré (LlmService + GeminiRepository)

### DIFF
--- a/apps/backend/src/utils/config/configuration.model.ts
+++ b/apps/backend/src/utils/config/configuration.model.ts
@@ -38,6 +38,22 @@ export const backendConfigurationSchema = z.object({
     .describe(
       "Clé du compte de service Google Cloud pour l'accès aux api drive et sheets"
     ),
+  // TODO(import-ia) : passer GOOGLE_API_KEY et GEMINI_MODEL en .min(1) (requis au boot)
+  // quand l'import IA est câblé en prod (worker + endpoints). Optionnelles pour l'instant
+  // car le LlmModule n'est encore consommé nulle part — les rendre requises casserait
+  // le démarrage du backend pour tous les environnements sans clé Gemini.
+  GOOGLE_API_KEY: z
+    .string()
+    .optional()
+    .describe(
+      "Clé API Google Generative Language (Gemini) pour l'import IA de plan d'action"
+    ),
+  GEMINI_MODEL: z
+    .string()
+    .optional()
+    .describe(
+      "Identifiant du modèle Gemini pour l'import IA (ex : gemini-2.5-pro) ; requis à l'usage"
+    ),
   TRAJECTOIRE_SNBC_SHEET_ID: z
     .string()
     .min(1)

--- a/apps/backend/src/utils/llm/gemini.repository.ts
+++ b/apps/backend/src/utils/llm/gemini.repository.ts
@@ -1,0 +1,109 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  FinishReason,
+  GenerateContentResponseUsageMetadata,
+  GoogleGenAI,
+} from '@google/genai';
+import ConfigurationService from '@tet/backend/utils/config/configuration.service';
+import { failure, Result, success } from '@tet/backend/utils/result.type';
+import { LlmError } from './llm.errors';
+import {
+  LlmCompletionRequest,
+  LlmRawCompletion,
+  LlmRepository,
+  TokenUsage,
+} from './llm.repository';
+
+const CALL_TIMEOUT_MS = 120_000;
+const RATE_LIMITED_STATUSES = new Set([429, 503]);
+
+@Injectable()
+export class GeminiRepository extends LlmRepository {
+  private readonly logger = new Logger(GeminiRepository.name);
+  private readonly model: string | undefined;
+  private client: GoogleGenAI | null = null;
+
+  constructor(private readonly configService: ConfigurationService) {
+    super();
+    this.model = configService.get('GEMINI_MODEL');
+  }
+
+  async complete(
+    request: LlmCompletionRequest
+  ): Promise<Result<LlmRawCompletion, LlmError>> {
+    const client = this.getClient();
+    if (!client) {
+      this.logger.error('GOOGLE_API_KEY manquant : appel Gemini impossible');
+      return failure({ kind: 'api_error', httpStatus: null });
+    }
+    if (!this.model) {
+      this.logger.error('GEMINI_MODEL manquant : appel Gemini impossible');
+      return failure({ kind: 'api_error', httpStatus: null });
+    }
+
+    try {
+      const response = await client.models.generateContent({
+        model: this.model,
+        contents: request.prompt,
+        config: {
+          responseMimeType: 'application/json',
+          responseJsonSchema: request.jsonSchema,
+          systemInstruction: request.systemInstruction,
+          temperature: request.temperature,
+          maxOutputTokens: request.maxOutputTokens,
+          thinkingConfig:
+            request.thinkingBudget === undefined
+              ? undefined
+              : { thinkingBudget: request.thinkingBudget },
+          httpOptions: { timeout: CALL_TIMEOUT_MS },
+          abortSignal: request.signal,
+        },
+      });
+      return success({
+        completed: response.candidates?.[0]?.finishReason === FinishReason.STOP,
+        text: response.text,
+        usage: toTokenUsage(response.usageMetadata),
+      });
+    } catch (error) {
+      const httpStatus = extractHttpStatus(error);
+      this.logger.error(`Erreur API Gemini (status ${httpStatus})`);
+      if (httpStatus !== null && RATE_LIMITED_STATUSES.has(httpStatus)) {
+        return failure({ kind: 'rate_limited' });
+      }
+      return failure({ kind: 'api_error', httpStatus });
+    }
+  }
+
+  private getClient(): GoogleGenAI | null {
+    if (this.client) {
+      return this.client;
+    }
+    const apiKey = this.configService.get('GOOGLE_API_KEY');
+    if (!apiKey) {
+      return null;
+    }
+    this.client = new GoogleGenAI({ apiKey });
+    return this.client;
+  }
+}
+
+const toTokenUsage = (
+  usage: GenerateContentResponseUsageMetadata | undefined
+): TokenUsage => ({
+  promptTokens: usage?.promptTokenCount ?? 0,
+  candidatesTokens: usage?.candidatesTokenCount ?? 0,
+  thoughtsTokens: usage?.thoughtsTokenCount ?? 0,
+  totalTokens: usage?.totalTokenCount ?? 0,
+});
+
+const extractHttpStatus = (error: unknown): number | null => {
+  if (
+    error !== null &&
+    typeof error === 'object' &&
+    'status' in error &&
+    typeof error.status === 'number'
+  ) {
+    return error.status;
+  }
+  return null;
+};

--- a/apps/backend/src/utils/llm/llm.errors.ts
+++ b/apps/backend/src/utils/llm/llm.errors.ts
@@ -1,0 +1,5 @@
+export type LlmError =
+  | { kind: 'rate_limited' }
+  | { kind: 'truncated' }
+  | { kind: 'invalid_json'; rawTextLength: number }
+  | { kind: 'api_error'; httpStatus: number | null };

--- a/apps/backend/src/utils/llm/llm.module.ts
+++ b/apps/backend/src/utils/llm/llm.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { GeminiRepository } from './gemini.repository';
+import { LlmRepository } from './llm.repository';
+import { LlmService } from './llm.service';
+
+@Module({
+  providers: [
+    LlmService,
+    { provide: LlmRepository, useClass: GeminiRepository },
+  ],
+  exports: [LlmService],
+})
+export class LlmModule {}

--- a/apps/backend/src/utils/llm/llm.repository.ts
+++ b/apps/backend/src/utils/llm/llm.repository.ts
@@ -1,0 +1,31 @@
+import { Result } from '@tet/backend/utils/result.type';
+import { LlmError } from './llm.errors';
+
+export type TokenUsage = {
+  promptTokens: number;
+  candidatesTokens: number;
+  thoughtsTokens: number;
+  totalTokens: number;
+};
+
+export type LlmCompletionRequest = {
+  prompt: string;
+  jsonSchema: Record<string, unknown>;
+  systemInstruction?: string;
+  temperature?: number;
+  maxOutputTokens?: number;
+  thinkingBudget?: number;
+  signal?: AbortSignal;
+};
+
+export type LlmRawCompletion = {
+  completed: boolean;
+  text: string | undefined;
+  usage: TokenUsage;
+};
+
+export abstract class LlmRepository {
+  abstract complete(
+    request: LlmCompletionRequest
+  ): Promise<Result<LlmRawCompletion, LlmError>>;
+}

--- a/apps/backend/src/utils/llm/llm.service.ts
+++ b/apps/backend/src/utils/llm/llm.service.ts
@@ -1,0 +1,89 @@
+import { Injectable } from '@nestjs/common';
+import { failure, Result, success } from '@tet/backend/utils/result.type';
+import { Options, default as retry } from 'async-retry';
+import { z, ZodType } from 'zod';
+import { LlmError } from './llm.errors';
+import {
+  LlmRawCompletion,
+  LlmRepository,
+  TokenUsage,
+} from './llm.repository';
+import { parseStructuredResponse } from './parse-json-response';
+
+const DEFAULT_TEMPERATURE = 0.2;
+const DEFAULT_MAX_OUTPUT_TOKENS = 64000;
+const DEFAULT_THINKING_BUDGET = 8192;
+const RETRY_OPTIONS: Options = {
+  retries: 5,
+  factor: 2,
+  minTimeout: 500,
+  maxTimeout: 8000,
+  randomize: true,
+};
+
+export type GenerateStructuredArgs<Schema extends ZodType> = {
+  prompt: string;
+  schema: Schema;
+  systemInstruction?: string;
+  temperature?: number;
+  maxOutputTokens?: number;
+  thinkingBudget?: number;
+  signal?: AbortSignal;
+};
+
+export type StructuredCompletion<Schema extends ZodType> = {
+  data: z.output<Schema>;
+  tokens: TokenUsage;
+};
+
+@Injectable()
+export class LlmService {
+  constructor(private readonly llmRepository: LlmRepository) {}
+
+  async generateStructured<Schema extends ZodType>(
+    args: GenerateStructuredArgs<Schema>
+  ): Promise<Result<StructuredCompletion<Schema>, LlmError>> {
+    const completionResult = await this.callWithRetry(() =>
+      this.llmRepository.complete({
+        prompt: args.prompt,
+        jsonSchema: z.toJSONSchema(args.schema),
+        systemInstruction: args.systemInstruction,
+        temperature: args.temperature ?? DEFAULT_TEMPERATURE,
+        maxOutputTokens: args.maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS,
+        thinkingBudget: args.thinkingBudget ?? DEFAULT_THINKING_BUDGET,
+        signal: args.signal,
+      })
+    );
+    if (!completionResult.success) {
+      return completionResult;
+    }
+
+    const completion = completionResult.data;
+    const parsed = parseStructuredResponse({
+      completed: completion.completed,
+      text: completion.text,
+      schema: args.schema,
+    });
+    if (!parsed.success) {
+      return parsed;
+    }
+
+    return success({ data: parsed.data, tokens: completion.usage });
+  }
+
+  private async callWithRetry(
+    call: () => Promise<Result<LlmRawCompletion, LlmError>>
+  ): Promise<Result<LlmRawCompletion, LlmError>> {
+    try {
+      return await retry(async () => {
+        const result = await call();
+        if (!result.success && result.error.kind === 'rate_limited') {
+          throw new Error('rate_limited');
+        }
+        return result;
+      }, RETRY_OPTIONS);
+    } catch {
+      return failure({ kind: 'rate_limited' });
+    }
+  }
+}

--- a/apps/backend/src/utils/llm/parse-json-response.spec.ts
+++ b/apps/backend/src/utils/llm/parse-json-response.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { parseStructuredResponse } from './parse-json-response';
+
+const schema = z.object({ titre: z.string(), score: z.number() });
+const validPayload = { titre: 'Action', score: 42 };
+const validText = JSON.stringify(validPayload);
+
+describe('parseStructuredResponse', () => {
+  it('retourne success quand la complétion est terminée et le JSON conforme', () => {
+    const result = parseStructuredResponse({
+      completed: true,
+      text: validText,
+      schema,
+    });
+    expect(result).toEqual({ success: true, data: validPayload });
+  });
+
+  it('ne parse jamais et renvoie truncated quand la complétion est incomplète', () => {
+    const result = parseStructuredResponse({
+      completed: false,
+      text: validText,
+      schema,
+    });
+    expect(result).toEqual({ success: false, error: { kind: 'truncated' } });
+  });
+
+  it('renvoie invalid_json quand le texte est vide malgré une complétion terminée', () => {
+    const result = parseStructuredResponse({
+      completed: true,
+      text: '',
+      schema,
+    });
+    expect(result).toEqual({
+      success: false,
+      error: { kind: 'invalid_json', rawTextLength: 0 },
+    });
+  });
+
+  it('renvoie invalid_json quand le texte n est pas du JSON', () => {
+    const text = 'pas du json {';
+    const result = parseStructuredResponse({
+      completed: true,
+      text,
+      schema,
+    });
+    expect(result).toEqual({
+      success: false,
+      error: { kind: 'invalid_json', rawTextLength: text.length },
+    });
+  });
+
+  it('renvoie invalid_json quand le JSON ne respecte pas le schema', () => {
+    const text = JSON.stringify({ titre: 'Action', score: 'pas un nombre' });
+    const result = parseStructuredResponse({
+      completed: true,
+      text,
+      schema,
+    });
+    expect(result).toEqual({
+      success: false,
+      error: { kind: 'invalid_json', rawTextLength: text.length },
+    });
+  });
+});

--- a/apps/backend/src/utils/llm/parse-json-response.ts
+++ b/apps/backend/src/utils/llm/parse-json-response.ts
@@ -1,0 +1,39 @@
+import { failure, Result, success } from '@tet/backend/utils/result.type';
+import { z, ZodType } from 'zod';
+import { LlmError } from './llm.errors';
+
+export const parseStructuredResponse = <Schema extends ZodType>(args: {
+  completed: boolean;
+  text: string | undefined;
+  schema: Schema;
+}): Result<z.output<Schema>, LlmError> => {
+  const { completed, text, schema } = args;
+
+  if (!completed) {
+    return failure({ kind: 'truncated' });
+  }
+
+  if (!text) {
+    return failure({ kind: 'invalid_json', rawTextLength: 0 });
+  }
+
+  const parsed = tryParseJson(text);
+  if (!parsed.success) {
+    return failure({ kind: 'invalid_json', rawTextLength: text.length });
+  }
+
+  const validated = schema.safeParse(parsed.data);
+  if (!validated.success) {
+    return failure({ kind: 'invalid_json', rawTextLength: text.length });
+  }
+
+  return success(validated.data);
+};
+
+const tryParseJson = (text: string): Result<unknown, 'invalid'> => {
+  try {
+    return success(JSON.parse(text));
+  } catch {
+    return failure('invalid');
+  }
+};

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@emotion/react": "11.14.0",
     "@emotion/styled": "11.14.1",
     "@floating-ui/react": "0.26.28",
+    "@google/genai": "2.8.0",
     "@gouvfr/dsfr": "1.10.2",
     "@hookform/resolvers": "5.2.2",
     "@nestjs/bullmq": "11.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       '@floating-ui/react':
         specifier: 0.26.28
         version: 0.26.28(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@google/genai':
+        specifier: 2.8.0
+        version: 2.8.0
       '@gouvfr/dsfr':
         specifier: 1.10.2
         version: 1.10.2
@@ -2366,6 +2369,15 @@ packages:
   '@floating-ui/utils@0.2.9':
     resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
 
+  '@google/genai@2.8.0':
+    resolution: {integrity: sha512-pc2ayxqO5+O7AvnHBqpNHIk7PAZkHZgL31tbyx0gJZBSS9qPYiQoqwK7oYOw/ePmG6QY4EMSu+304vD5QlhXAw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.25.2
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
+
   '@gouvfr/dsfr@1.10.2':
     resolution: {integrity: sha512-twPj+VFMTOKUfI9vbBnK8fH1iDpXuDVWeMJzgmmQ5LKjRtZdUsvSbHNlp7HWcDvhWxDGNHxSboErC7UB3oskYQ==}
     engines: {node: '>=18.16.1'}
@@ -4567,6 +4579,36 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.8
 
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.2':
+    resolution: {integrity: sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
+
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
 
@@ -6601,6 +6643,9 @@ packages:
 
   '@types/responselike@1.0.3':
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
+
+  '@types/retry@0.12.0':
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
 
   '@types/retry@0.12.2':
     resolution: {integrity: sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==}
@@ -9527,9 +9572,17 @@ packages:
     resolution: {integrity: sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==}
     engines: {node: '>=14'}
 
+  gaxios@7.1.4:
+    resolution: {integrity: sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==}
+    engines: {node: '>=18'}
+
   gcp-metadata@6.1.1:
     resolution: {integrity: sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==}
     engines: {node: '>=14'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
 
   generic-names@4.0.0:
     resolution: {integrity: sha512-ySFolZQfw9FoDb3ed9d80Cm9f0+r7qj+HJkWjeD9RBfpxEVTlVhol+gvaQB/78WbwYfbnNh8nWHHBSlg072y6A==}
@@ -9664,12 +9717,20 @@ packages:
   globrex@0.1.2:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
 
+  google-auth-library@10.6.2:
+    resolution: {integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==}
+    engines: {node: '>=18'}
+
   google-auth-library@9.15.1:
     resolution: {integrity: sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==}
     engines: {node: '>=14'}
 
   google-logging-utils@0.0.2:
     resolution: {integrity: sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==}
+    engines: {node: '>=14'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
     engines: {node: '>=14'}
 
   googleapis-common@7.2.0:
@@ -10908,6 +10969,9 @@ packages:
   long-timeout@0.1.1:
     resolution: {integrity: sha512-BFRuQUqc7x2NWxfJBCyUrN8iYUYznzL9JROmRz1gZ6KlOIgmoD+njPVbb+VNn2nGMKggMsK79iUNErillsrx7w==}
 
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
@@ -11887,6 +11951,10 @@ packages:
     resolution: {integrity: sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
+
   p-retry@6.2.1:
     resolution: {integrity: sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ==}
     engines: {node: '>=16.17'}
@@ -12654,6 +12722,10 @@ packages:
 
   prosemirror-view@1.41.1:
     resolution: {integrity: sha512-cViIhlt1/T5bQMINrmXh43JZcdIgdW1YkOABmIuH5gSt3/HiCZHsLN9d5GvsgzrXn2+zZ8il0kkghisusm7tSA==}
+
+  protobufjs@7.6.2:
+    resolution: {integrity: sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ==}
+    engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
@@ -16808,6 +16880,17 @@ snapshots:
 
   '@floating-ui/utils@0.2.9': {}
 
+  '@google/genai@2.8.0':
+    dependencies:
+      google-auth-library: 10.6.2
+      p-retry: 4.6.2
+      protobufjs: 7.6.2
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   '@gouvfr/dsfr@1.10.2': {}
 
   '@hey-api/client-fetch@0.10.2(@hey-api/openapi-ts@0.86.3(magicast@0.3.5)(typescript@5.9.3))':
@@ -19612,6 +19695,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.1': {}
+
   '@radix-ui/number@1.1.1': {}
 
   '@radix-ui/primitive@1.1.2': {}
@@ -21792,6 +21897,8 @@ snapshots:
   '@types/responselike@1.0.3':
     dependencies:
       '@types/node': 24.1.0
+
+  '@types/retry@0.12.0': {}
 
   '@types/retry@0.12.2': {}
 
@@ -25262,6 +25369,14 @@ snapshots:
       - encoding
       - supports-color
 
+  gaxios@7.1.4:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
   gcp-metadata@6.1.1(encoding@0.1.13):
     dependencies:
       gaxios: 6.7.1(encoding@0.1.13)
@@ -25269,6 +25384,14 @@ snapshots:
       json-bigint: 1.0.0
     transitivePeerDependencies:
       - encoding
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.1.4
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
       - supports-color
 
   generic-names@4.0.0:
@@ -25420,6 +25543,17 @@ snapshots:
 
   globrex@0.1.2: {}
 
+  google-auth-library@10.6.2:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.4
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   google-auth-library@9.15.1(encoding@0.1.13):
     dependencies:
       base64-js: 1.5.1
@@ -25433,6 +25567,8 @@ snapshots:
       - supports-color
 
   google-logging-utils@0.0.2: {}
+
+  google-logging-utils@1.1.3: {}
 
   googleapis-common@7.2.0(encoding@0.1.13):
     dependencies:
@@ -27046,6 +27182,8 @@ snapshots:
 
   long-timeout@0.1.1: {}
 
+  long@5.3.2: {}
+
   longest-streak@3.1.0: {}
 
   loose-envify@1.4.0:
@@ -28589,6 +28727,11 @@ snapshots:
     dependencies:
       p-limit: 4.0.0
 
+  p-retry@4.6.2:
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
+
   p-retry@6.2.1:
     dependencies:
       '@types/retry': 0.12.2
@@ -29369,6 +29512,21 @@ snapshots:
       prosemirror-model: 1.25.3
       prosemirror-state: 1.4.3
       prosemirror-transform: 1.10.4
+
+  protobufjs@7.6.2:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/node': 24.1.0
+      long: 5.3.2
 
   proxy-addr@2.0.7:
     dependencies:


### PR DESCRIPTION
## Objectif

Infra LLM partagée du backend (première intégration LLM), suivant la convention **service/repository** du codebase, avec un **contrat neutre** (provider-agnostique). Fondation consommée par l'import IA de plan d'action (PR suivantes).

## Architecture (`apps/backend/src/utils/llm/`)

- **`LlmService`** — orchestration : `generateStructured(prompt, zodSchema)` → `Result` ; defaults, retry sur `rate_limited` (backoff + jitter borné), parse + validation zod.
- **`LlmRepository`** (abstrait) — contrat neutre `complete(request)` → `Result<{ completed, text, usage }, LlmError>` ; token DI.
- **`GeminiRepository extends LlmRepository`** — accès `@google/genai` confiné (client, modèle, `GOOGLE_API_KEY`) ; mappe le spécifique-Gemini en neutre : `finishReason === STOP` → `completed`, `429/503` → `rate_limited`, autres → `api_error{httpStatus}`.
- **`parse-json-response.ts`** (pur, testé) — `!completed` → `truncated` (jamais de parse partiel) ; JSON validé par le schéma zod (`responseJsonSchema` via `z.toJSONSchema`).
- **`LlmError`** = `rate_limited | truncated | invalid_json | api_error`.
- `llm.module` : `LlmService` + `{ provide: LlmRepository, useClass: GeminiRepository }`.

Swap de fournisseur = nouveau repository sur le même token ; `LlmService` + `parse-json-response` inchangés. Aucune fuite de `'STOP'`/httpStatus hors du `GeminiRepository`.

## Décisions

- **Developer API uniquement** (Vertex non codé) ; **pas de default model** (`GEMINI_MODEL` requis à l'usage) ; **pas de `safetySettings`**.
- `GOOGLE_API_KEY`/`GEMINI_MODEL` **optionnelles** en config (module pas encore câblé → ne pas casser le boot ; à promouvoir requises quand consommé).
- `LlmModule` **pas encore importé** (dormant) — consommé par l'étape d'extraction (PR suivante).

## Revue

Revue multi-agents (TS / sécurité / archi / simplicité) intégrée : dead code supprimé, champs spéculatifs retirés, boucle retry simplifiée, contrat rendu réellement neutre. Sécurité : clé/prompts/réponses jamais loggés (aucun P1).

## Vérifications

- ✅ `nx run backend:typecheck` (+ deps) vert.
- ✅ tests unitaires `parse-json-response` verts (matrice completed/JSON/zod).
- Retry & appel réseau non couverts en unit (backoff → fake timers ; le cœur P1-4 pur est testé).