### PR TITLE
feat(plans): duplique un plan d'action depuis son id

### DIFF
--- a/apps/backend/src/plans/plans/duplicate-plan/duplicate-plan.errors.ts
+++ b/apps/backend/src/plans/plans/duplicate-plan/duplicate-plan.errors.ts
@@ -1,0 +1,23 @@
+import {
+  createErrorsEnum,
+  TrpcErrorHandlerConfig,
+} from '@tet/backend/utils/trpc/trpc-error-handler';
+
+const specificErrors = ['PLAN_NOT_FOUND', 'DUPLICATE_PLAN_ERROR'] as const;
+type SpecificError = (typeof specificErrors)[number];
+
+export const duplicatePlanErrorConfig: TrpcErrorHandlerConfig<SpecificError> = {
+  specificErrors: {
+    PLAN_NOT_FOUND: {
+      code: 'NOT_FOUND',
+      message: "Le plan à dupliquer n'a pas été trouvé",
+    },
+    DUPLICATE_PLAN_ERROR: {
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'Une erreur est survenue lors de la duplication du plan',
+    },
+  },
+};
+
+export const DuplicatePlanErrorEnum = createErrorsEnum(specificErrors);
+export type DuplicatePlanError = keyof typeof DuplicatePlanErrorEnum;

--- a/apps/backend/src/plans/plans/duplicate-plan/duplicate-plan.input.ts
+++ b/apps/backend/src/plans/plans/duplicate-plan/duplicate-plan.input.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const duplicatePlanInputSchema = z.object({
+  planId: z.number().positive("L'ID du plan doit être positif"),
+});
+
+export type DuplicatePlanInput = z.infer<typeof duplicatePlanInputSchema>;

--- a/apps/backend/src/plans/plans/duplicate-plan/duplicate-plan.router.e2e-spec.ts
+++ b/apps/backend/src/plans/plans/duplicate-plan/duplicate-plan.router.e2e-spec.ts
@@ -1,0 +1,511 @@
+import { INestApplication } from '@nestjs/common';
+import { addTestCollectiviteAndUser } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { createIndicateurPerso } from '@tet/backend/indicateurs/definitions/definitions.test-fixture';
+import {
+  getAuthUserFromUserCredentials,
+  getTestApp,
+  getTestDatabase,
+} from '@tet/backend/test';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { addTestUser } from '@tet/backend/users/users/users.test-fixture';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
+import { Collectivite, TagEnum, TagType } from '@tet/domain/collectivites';
+import { CollectiviteRole } from '@tet/domain/users';
+import { onTestFinished } from 'vitest';
+
+describe('Dupliquer un plan', () => {
+  let app: INestApplication;
+  let router: TrpcRouter;
+  let db: DatabaseService;
+
+  let collectivite: Collectivite;
+  let editorUser: AuthenticatedUser;
+  let noAccessUser: AuthenticatedUser;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    router = await app.get(TrpcRouter);
+    db = await getTestDatabase(app);
+
+    const testCollectiviteAndUserResult = await addTestCollectiviteAndUser(db, {
+      user: { role: CollectiviteRole.ADMIN },
+      collectivite: { accesRestreint: true },
+    });
+
+    collectivite = testCollectiviteAndUserResult.collectivite;
+    editorUser = getAuthUserFromUserCredentials(
+      testCollectiviteAndUserResult.user
+    );
+
+    const noAccessUserResult = await addTestUser(db);
+    noAccessUser = getAuthUserFromUserCredentials(noAccessUserResult.user);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  const buildEditorCaller = () => router.createCaller({ user: editorUser });
+
+  const cleanupPlans = (planIds: number[]) => {
+    onTestFinished(async () => {
+      const cleanupCaller = buildEditorCaller();
+      for (const planId of planIds) {
+        try {
+          await cleanupCaller.plans.plans.delete({ planId });
+        } catch {
+          // déjà supprimé
+        }
+      }
+    });
+  };
+
+  test('duplique un plan avec son arborescence, ses fiches et sous-actions', async () => {
+    const caller = buildEditorCaller();
+
+    const sourcePlan = await caller.plans.plans.create({
+      nom: 'Plan source',
+      collectiviteId: collectivite.id,
+    });
+    const axe1 = await caller.plans.axes.create({
+      nom: 'Axe 1',
+      collectiviteId: collectivite.id,
+      planId: sourcePlan.id,
+      parent: sourcePlan.id,
+    });
+    const axe11 = await caller.plans.axes.create({
+      nom: 'Axe 1.1',
+      collectiviteId: collectivite.id,
+      planId: sourcePlan.id,
+      parent: axe1.id,
+    });
+    const axe111 = await caller.plans.axes.create({
+      nom: 'Axe 1.1.1',
+      collectiviteId: collectivite.id,
+      planId: sourcePlan.id,
+      parent: axe11.id,
+    });
+
+    const sourceFiche = await caller.plans.fiches.create({
+      fiche: {
+        collectiviteId: collectivite.id,
+        titre: 'Action A',
+        objectifs: 'Objectifs A',
+        statut: 'En cours',
+        priorite: 'Élevé',
+        restreint: true,
+      },
+      ficheFields: { axes: [{ id: axe111.id }] },
+    });
+    await caller.plans.fiches.create({
+      fiche: {
+        collectiviteId: collectivite.id,
+        titre: 'Sous-action A1',
+        description: 'Description sous-action',
+        parentId: sourceFiche.id,
+      },
+    });
+
+    const duplicated = await caller.plans.plans.duplicate({
+      planId: sourcePlan.id,
+    });
+    cleanupPlans([sourcePlan.id, duplicated.planId]);
+
+    expect(duplicated.planId).not.toBe(sourcePlan.id);
+
+    const newPlan = await caller.plans.plans.get({ planId: duplicated.planId });
+    expect(newPlan.nom).toContain('Plan source');
+    expect(newPlan.nom).toContain('(copie du');
+    expect(newPlan.nom).not.toBe('Plan source');
+    const newAxeNoms = newPlan.axes.map((axe) => axe.nom);
+    expect(newAxeNoms).toContain('Axe 1');
+    expect(newAxeNoms).toContain('Axe 1.1');
+    expect(newAxeNoms).toContain('Axe 1.1.1');
+
+    const newAxe111Id = newPlan.axes.find((axe) => axe.nom === 'Axe 1.1.1')?.id;
+    expect(newAxe111Id).toBeDefined();
+
+    const { data: newParents } = await caller.plans.fiches.listFiches({
+      collectiviteId: collectivite.id,
+      filters: { planActionIds: [duplicated.planId] },
+      queryOptions: { limit: 'all' },
+    });
+    expect(newParents.length).toBe(1);
+
+    const newParent = newParents[0];
+    expect(newParent.titre).toBe('Action A');
+    expect(newParent.objectifs).toBe('Objectifs A');
+    expect(newParent.statut).toBe('En cours');
+    expect(newParent.priorite).toBe('Élevé');
+    expect(newParent.restreint).toBe(true);
+    expect(newParent.id).not.toBe(sourceFiche.id);
+    expect(newParent.axes?.map((axe) => axe.id)).toEqual([newAxe111Id]);
+
+    const { data: newSousActions } = await caller.plans.fiches.listFiches({
+      collectiviteId: collectivite.id,
+      filters: { parentsId: [newParent.id] },
+      queryOptions: { limit: 'all' },
+    });
+    expect(newSousActions.length).toBe(1);
+    expect(newSousActions[0].titre).toBe('Sous-action A1');
+    expect(newSousActions[0].description).toBe('Description sous-action');
+    expect(newSousActions[0].parentId).toBe(newParent.id);
+  });
+
+  test('recrée toutes les appartenances aux axes pour une fiche multi-axes', async () => {
+    const caller = buildEditorCaller();
+
+    const sourcePlan = await caller.plans.plans.create({
+      nom: 'Plan multi-axes',
+      collectiviteId: collectivite.id,
+    });
+    const axeA = await caller.plans.axes.create({
+      nom: 'Axe A',
+      collectiviteId: collectivite.id,
+      planId: sourcePlan.id,
+      parent: sourcePlan.id,
+    });
+    const axeB = await caller.plans.axes.create({
+      nom: 'Axe B',
+      collectiviteId: collectivite.id,
+      planId: sourcePlan.id,
+      parent: sourcePlan.id,
+    });
+
+    await caller.plans.fiches.create({
+      fiche: { collectiviteId: collectivite.id, titre: 'Action partagée' },
+      ficheFields: { axes: [{ id: axeA.id }, { id: axeB.id }] },
+    });
+
+    const duplicated = await caller.plans.plans.duplicate({
+      planId: sourcePlan.id,
+    });
+    cleanupPlans([sourcePlan.id, duplicated.planId]);
+
+    const newPlan = await caller.plans.plans.get({ planId: duplicated.planId });
+    const newAxeIds = newPlan.axes
+      .filter((axe) => axe.id !== duplicated.planId)
+      .map((axe) => axe.id);
+
+    const { data: newFiches } = await caller.plans.fiches.listFiches({
+      collectiviteId: collectivite.id,
+      filters: { planActionIds: [duplicated.planId], withChildren: true },
+      queryOptions: { limit: 'all' },
+    });
+    const newFiche = newFiches[0];
+    const ficheAxeIds = (newFiche.axes ?? []).map((axe) => axe.id).sort();
+
+    expect(ficheAxeIds).toEqual([...newAxeIds].sort());
+    expect(ficheAxeIds).not.toContain(axeA.id);
+    expect(ficheAxeIds).not.toContain(axeB.id);
+  });
+
+  test('duplique un plan vide', async () => {
+    const caller = buildEditorCaller();
+
+    const sourcePlan = await caller.plans.plans.create({
+      nom: 'Plan vide',
+      collectiviteId: collectivite.id,
+    });
+
+    const duplicated = await caller.plans.plans.duplicate({
+      planId: sourcePlan.id,
+    });
+    cleanupPlans([sourcePlan.id, duplicated.planId]);
+
+    const newPlan = await caller.plans.plans.get({ planId: duplicated.planId });
+    expect(newPlan.nom).toContain('Plan vide');
+    expect(newPlan.nom).toContain('(copie du');
+
+    const { data: newFiches } = await caller.plans.fiches.listFiches({
+      collectiviteId: collectivite.id,
+      filters: { planActionIds: [duplicated.planId], withChildren: true },
+      queryOptions: { limit: 'all' },
+    });
+    expect(newFiches.length).toBe(0);
+  });
+
+  test('préserve la confidentialité (restreint) des fiches dupliquées', async () => {
+    const caller = buildEditorCaller();
+
+    const sourcePlan = await caller.plans.plans.create({
+      nom: 'Plan confidentiel',
+      collectiviteId: collectivite.id,
+    });
+    const axe = await caller.plans.axes.create({
+      nom: 'Axe confidentiel',
+      collectiviteId: collectivite.id,
+      planId: sourcePlan.id,
+      parent: sourcePlan.id,
+    });
+
+    const ficheRestreinte = await caller.plans.fiches.create({
+      fiche: {
+        collectiviteId: collectivite.id,
+        titre: 'Fiche restreinte',
+        restreint: true,
+      },
+      ficheFields: { axes: [{ id: axe.id }] },
+    });
+    await caller.plans.fiches.create({
+      fiche: {
+        collectiviteId: collectivite.id,
+        titre: 'Sous-action restreinte',
+        restreint: true,
+        parentId: ficheRestreinte.id,
+      },
+    });
+    await caller.plans.fiches.create({
+      fiche: {
+        collectiviteId: collectivite.id,
+        titre: 'Fiche publique',
+        restreint: false,
+      },
+      ficheFields: { axes: [{ id: axe.id }] },
+    });
+
+    const duplicated = await caller.plans.plans.duplicate({
+      planId: sourcePlan.id,
+    });
+    cleanupPlans([sourcePlan.id, duplicated.planId]);
+
+    const { data: newParents } = await caller.plans.fiches.listFiches({
+      collectiviteId: collectivite.id,
+      filters: { planActionIds: [duplicated.planId] },
+      queryOptions: { limit: 'all' },
+    });
+    const newRestreinte = newParents.find(
+      (fiche) => fiche.titre === 'Fiche restreinte'
+    );
+    const newPublique = newParents.find(
+      (fiche) => fiche.titre === 'Fiche publique'
+    );
+    expect(newRestreinte?.restreint).toBe(true);
+    expect(newPublique?.restreint).toBe(false);
+
+    expect(newRestreinte).toBeDefined();
+    const { data: newSousActions } = await caller.plans.fiches.listFiches({
+      collectiviteId: collectivite.id,
+      filters: { parentsId: [newRestreinte?.id ?? 0] },
+      queryOptions: { limit: 'all' },
+    });
+    expect(newSousActions.length).toBe(1);
+    expect(newSousActions[0].titre).toBe('Sous-action restreinte');
+    expect(newSousActions[0].restreint).toBe(true);
+  });
+
+  test('duplique exhaustivement une fiche avec tous ses champs renseignés', async () => {
+    const caller = buildEditorCaller();
+
+    const createTag = (tagType: TagType, nom: string) =>
+      caller.collectivites.tags.create({
+        tagType,
+        nom,
+        collectiviteId: collectivite.id,
+      });
+
+    const piloteTag = await createTag(TagEnum.Personne, 'Pilote exhaustif');
+    const referentTag = await createTag(TagEnum.Personne, 'Référent exhaustif');
+    const serviceTag = await createTag(TagEnum.Service, 'Service exhaustif');
+    const structureTag = await createTag(TagEnum.Structure, 'Structure exhaustive');
+    const partenaireTag = await createTag(
+      TagEnum.Partenaire,
+      'Partenaire exhaustif'
+    );
+    const libreTag = await createTag(TagEnum.Libre, 'Tag libre exhaustif');
+    const instanceTag = await createTag(
+      TagEnum.InstanceGouvernance,
+      'Instance exhaustive'
+    );
+    const financeurTag = await createTag(TagEnum.Financeur, 'Financeur exhaustif');
+
+    const [thematique] = await caller.shared.thematiques.list();
+    const [sousThematique] =
+      await caller.shared.thematiques.listSousThematiques();
+    const [effetAttendu] = await caller.shared.effetsAttendus.list();
+    const [temps] = await caller.shared.tempsDeMiseEnOeuvre.list();
+
+    const indicateurId = await createIndicateurPerso({
+      caller,
+      indicateurData: {
+        collectiviteId: collectivite.id,
+        titre: 'Indicateur exhaustif',
+        unite: 'kg',
+      },
+    });
+
+    const sourcePlan = await caller.plans.plans.create({
+      nom: 'Plan exhaustif',
+      collectiviteId: collectivite.id,
+    });
+    const axe = await caller.plans.axes.create({
+      nom: 'Axe exhaustif',
+      collectiviteId: collectivite.id,
+      planId: sourcePlan.id,
+      parent: sourcePlan.id,
+    });
+
+    const sourceFiche = await caller.plans.fiches.create({
+      fiche: {
+        collectiviteId: collectivite.id,
+        titre: 'Fiche exhaustive',
+        description: 'Description complète',
+        objectifs: 'Objectifs complets',
+        ressources: 'Moyens complets',
+        financements: 'Financements complets',
+        cibles: ['Grand public', 'Associations'],
+        piliersEci: ['Recyclage', 'Écoconception'],
+        budgetPrevisionnel: '50000',
+        statut: 'En cours',
+        priorite: 'Élevé',
+        dateDebut: '2026-01-15T00:00:00.000Z',
+        dateFin: '2026-12-15T00:00:00.000Z',
+        ameliorationContinue: true,
+        participationCitoyenne: 'Concertation menée',
+        participationCitoyenneType: 'concertation',
+        majTermine: true,
+        restreint: true,
+      },
+      ficheFields: {
+        axes: [{ id: axe.id }],
+        thematiques: [{ id: thematique.id }],
+        sousThematiques: [{ id: sousThematique.id }],
+        effetsAttendus: [{ id: effetAttendu.id }],
+        partenaires: [{ id: partenaireTag.id }],
+        structures: [{ id: structureTag.id }],
+        services: [{ id: serviceTag.id }],
+        pilotes: [{ tagId: piloteTag.id }],
+        referents: [{ tagId: referentTag.id }],
+        financeurs: [{ financeurTag: { id: financeurTag.id }, montantTtc: 12345 }],
+        indicateurs: [{ id: indicateurId }],
+        libreTags: [{ id: libreTag.id }],
+        instanceGouvernance: [{ id: instanceTag.id }],
+        tempsDeMiseEnOeuvre: { id: temps.id },
+      },
+    });
+
+    const duplicated = await caller.plans.plans.duplicate({
+      planId: sourcePlan.id,
+    });
+    cleanupPlans([sourcePlan.id, duplicated.planId]);
+
+    const { data: newParents } = await caller.plans.fiches.listFiches({
+      collectiviteId: collectivite.id,
+      filters: { planActionIds: [duplicated.planId] },
+      queryOptions: { limit: 'all' },
+    });
+    expect(newParents.length).toBe(1);
+    const dup = newParents[0];
+
+    expect(dup.id).not.toBe(sourceFiche.id);
+    expect(dup).toMatchObject({
+      titre: 'Fiche exhaustive',
+      description: 'Description complète',
+      objectifs: 'Objectifs complets',
+      ressources: 'Moyens complets',
+      financements: 'Financements complets',
+      budgetPrevisionnel: '50000',
+      statut: 'En cours',
+      priorite: 'Élevé',
+      ameliorationContinue: true,
+      participationCitoyenne: 'Concertation menée',
+      participationCitoyenneType: 'concertation',
+      majTermine: true,
+      restreint: true,
+    });
+    expect(dup.cibles).toEqual(['Grand public', 'Associations']);
+    expect(dup.piliersEci).toEqual(['Recyclage', 'Écoconception']);
+    expect(dup.dateDebut).toContain('2026-01-15');
+    expect(dup.dateFin).toContain('2026-12-15');
+
+    expect(dup.thematiques?.map((item) => item.id)).toEqual([thematique.id]);
+    expect(dup.sousThematiques?.map((item) => item.id)).toEqual([
+      sousThematique.id,
+    ]);
+    expect(dup.effetsAttendus?.map((item) => item.id)).toEqual([
+      effetAttendu.id,
+    ]);
+    expect(dup.partenaires?.map((item) => item.id)).toEqual([partenaireTag.id]);
+    expect(dup.structures?.map((item) => item.id)).toEqual([structureTag.id]);
+    expect(dup.services?.map((item) => item.id)).toEqual([serviceTag.id]);
+    expect(dup.pilotes?.map((item) => item.tagId)).toEqual([piloteTag.id]);
+    expect(dup.referents?.map((item) => item.tagId)).toEqual([referentTag.id]);
+    expect(dup.libreTags?.map((item) => item.id)).toEqual([libreTag.id]);
+    expect(dup.instanceGouvernance?.map((item) => item.id)).toEqual([
+      instanceTag.id,
+    ]);
+    expect(dup.indicateurs?.map((item) => item.id)).toEqual([indicateurId]);
+    expect(dup.tempsDeMiseEnOeuvre?.id).toBe(temps.id);
+    expect(
+      dup.financeurs?.map((item) => ({
+        id: item.financeurTagId,
+        montant: item.montantTtc,
+      }))
+    ).toEqual([{ id: financeurTag.id, montant: 12345 }]);
+
+    const newPlan = await caller.plans.plans.get({ planId: duplicated.planId });
+    const newAxeId = newPlan.axes.find(
+      (item) => item.nom === 'Axe exhaustif'
+    )?.id;
+    expect(dup.axes?.map((item) => item.id)).toEqual([newAxeId]);
+    expect(dup.axes?.map((item) => item.id)).not.toContain(axe.id);
+
+    expect(dup.fichesLiees ?? []).toEqual([]);
+    expect(dup.docs ?? []).toEqual([]);
+    expect(dup.budgets ?? []).toEqual([]);
+    expect(dup.etapes ?? []).toEqual([]);
+    expect(dup.sharedWithCollectivites ?? []).toEqual([]);
+  });
+
+  test('refuse la duplication à un utilisateur sans droit sur la collectivité', async () => {
+    const caller = buildEditorCaller();
+    const sourcePlan = await caller.plans.plans.create({
+      nom: 'Plan protégé',
+      collectiviteId: collectivite.id,
+    });
+    cleanupPlans([sourcePlan.id]);
+
+    const unauthorizedCaller = router.createCaller({ user: noAccessUser });
+
+    await expect(
+      unauthorizedCaller.plans.plans.duplicate({ planId: sourcePlan.id })
+    ).rejects.toThrow("Vous n'avez pas les permissions nécessaires");
+  });
+
+  test('refuse la duplication inter-collectivités (IDOR) et ne crée rien', async () => {
+    const caller = buildEditorCaller();
+    const sourcePlan = await caller.plans.plans.create({
+      nom: 'Plan collectivité A',
+      collectiviteId: collectivite.id,
+    });
+    cleanupPlans([sourcePlan.id]);
+
+    const otherResult = await addTestCollectiviteAndUser(db, {
+      user: { role: CollectiviteRole.ADMIN },
+    });
+    const otherUser = getAuthUserFromUserCredentials(otherResult.user);
+    const otherCaller = router.createCaller({ user: otherUser });
+
+    const plansBefore = await otherCaller.plans.plans.list({
+      collectiviteId: otherResult.collectivite.id,
+    });
+
+    await expect(
+      otherCaller.plans.plans.duplicate({ planId: sourcePlan.id })
+    ).rejects.toThrow("Vous n'avez pas les permissions nécessaires");
+
+    const plansAfter = await otherCaller.plans.plans.list({
+      collectiviteId: otherResult.collectivite.id,
+    });
+    expect(plansAfter.plans.length).toBe(plansBefore.plans.length);
+  });
+
+  test('renvoie une erreur quand le plan source est introuvable', async () => {
+    const caller = buildEditorCaller();
+
+    await expect(
+      caller.plans.plans.duplicate({ planId: 999999 })
+    ).rejects.toThrow("Le plan à dupliquer n'a pas été trouvé");
+  });
+});

--- a/apps/backend/src/plans/plans/duplicate-plan/duplicate-plan.router.ts
+++ b/apps/backend/src/plans/plans/duplicate-plan/duplicate-plan.router.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+import { createTrpcErrorHandler } from '@tet/backend/utils/trpc/trpc-error-handler';
+import { TrpcService } from '@tet/backend/utils/trpc/trpc.service';
+import { duplicatePlanErrorConfig } from './duplicate-plan.errors';
+import { duplicatePlanInputSchema } from './duplicate-plan.input';
+import { DuplicatePlanService } from './duplicate-plan.service';
+
+@Injectable()
+export class DuplicatePlanRouter {
+  constructor(
+    private readonly trpc: TrpcService,
+    private readonly duplicatePlanService: DuplicatePlanService
+  ) {}
+
+  private readonly getResultDataOrThrowError = createTrpcErrorHandler(
+    duplicatePlanErrorConfig
+  );
+
+  router = this.trpc.router({
+    duplicate: this.trpc.authedProcedure
+      .input(duplicatePlanInputSchema)
+      .mutation(async ({ input, ctx }) => {
+        const result = await this.duplicatePlanService.duplicate(
+          input,
+          ctx.user
+        );
+        return this.getResultDataOrThrowError(result);
+      }),
+  });
+}

--- a/apps/backend/src/plans/plans/duplicate-plan/duplicate-plan.service.ts
+++ b/apps/backend/src/plans/plans/duplicate-plan/duplicate-plan.service.ts
@@ -1,0 +1,327 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { CreateFicheService } from '@tet/backend/plans/fiches/create-fiche/create-fiche.service';
+import { FicheCreateAuthorization } from '@tet/backend/plans/fiches/create-fiche/fiche-create-authorization';
+import ListFichesService from '@tet/backend/plans/fiches/list-fiches/list-fiches.service';
+import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { failure, Result, success } from '@tet/backend/utils/result.type';
+import { TransactionManager } from '@tet/backend/utils/transaction/transaction-manager.service';
+import { Personne, PersonneId } from '@tet/domain/collectivites';
+import { FicheWithRelations, Plan } from '@tet/domain/plans';
+import { UpsertAxeService } from '../../axes/upsert-axe/upsert-axe.service';
+import { GetPlanError, GetPlanErrorEnum } from '../get-plan/get-plan.errors';
+import { GetPlanService } from '../get-plan/get-plan.service';
+import { UpsertPlanErrorEnum } from '../upsert-plan/upsert-plan.errors';
+import { UpsertPlanService } from '../upsert-plan/upsert-plan.service';
+import { DuplicatePlanError, DuplicatePlanErrorEnum } from './duplicate-plan.errors';
+import { DuplicatePlanInput } from './duplicate-plan.input';
+import {
+  AxeIdRemapping,
+  mapSourceFicheToDuplicate,
+} from './duplicated-fiche.mapper';
+import { buildDuplicatedPlanName } from './duplicated-plan-name';
+
+const toPersonneId = (personne: Personne): PersonneId => ({
+  tagId: personne.tagId,
+  userId: personne.userId,
+});
+
+const getPlanErrorToDuplicateError = (
+  error: GetPlanError
+): DuplicatePlanError => {
+  if (error === GetPlanErrorEnum.UNAUTHORIZED) {
+    return DuplicatePlanErrorEnum.UNAUTHORIZED;
+  }
+  if (error === GetPlanErrorEnum.PLAN_NOT_FOUND) {
+    return DuplicatePlanErrorEnum.PLAN_NOT_FOUND;
+  }
+  return DuplicatePlanErrorEnum.DUPLICATE_PLAN_ERROR;
+};
+
+const ownedByCollectivite = (
+  fiches: FicheWithRelations[],
+  collectiviteId: number
+): FicheWithRelations[] =>
+  fiches.filter((fiche) => fiche.collectiviteId === collectiviteId);
+
+type PlanFichesToDuplicate = {
+  actions: FicheWithRelations[];
+  sousActions: FicheWithRelations[];
+};
+
+@Injectable()
+export class DuplicatePlanService {
+  private readonly logger = new Logger(DuplicatePlanService.name);
+
+  constructor(
+    private readonly transactionManager: TransactionManager,
+    private readonly permissionService: PermissionService,
+    private readonly getPlanService: GetPlanService,
+    private readonly listFichesService: ListFichesService,
+    private readonly upsertPlanService: UpsertPlanService,
+    private readonly upsertAxeService: UpsertAxeService,
+    private readonly createFicheService: CreateFicheService
+  ) {}
+
+  async duplicate(
+    { planId }: DuplicatePlanInput,
+    user: AuthenticatedUser,
+    tx?: Transaction
+  ): Promise<Result<{ planId: number }, DuplicatePlanError>> {
+    return this.transactionManager.executeSingle<
+      { planId: number },
+      DuplicatePlanError
+    >(async (transaction) => {
+      const sourceResult = await this.getPlanService.getPlan(
+        { planId },
+        user,
+        transaction
+      );
+      if (!sourceResult.success) {
+        return failure(getPlanErrorToDuplicateError(sourceResult.error));
+      }
+      const source = sourceResult.data;
+      const { collectiviteId } = source;
+
+      const authorizationResult = await this.buildWriteAuthorization(
+        user,
+        collectiviteId,
+        transaction
+      );
+      if (!authorizationResult.success) return authorizationResult;
+      const authorization = authorizationResult.data;
+
+      const planFiches = await this.loadPlanFiches(
+        planId,
+        collectiviteId,
+        transaction
+      );
+
+      const newPlanResult = await this.upsertPlanService.upsertPlan(
+        {
+          collectiviteId,
+          nom: buildDuplicatedPlanName(source.nom, new Date()),
+          typeId: source.type?.id ?? undefined,
+          pilotes: source.pilotes.map(toPersonneId),
+          referents: source.referents.map(toPersonneId),
+        },
+        user,
+        transaction
+      );
+      if (!newPlanResult.success) {
+        return failure(
+          newPlanResult.error === UpsertPlanErrorEnum.UNAUTHORIZED
+            ? DuplicatePlanErrorEnum.UNAUTHORIZED
+            : DuplicatePlanErrorEnum.DUPLICATE_PLAN_ERROR
+        );
+      }
+      const newPlanId = newPlanResult.data.id;
+
+      const axeIdRemappingResult = await this.recreateAxes({
+        source,
+        newPlanId,
+        collectiviteId,
+        user,
+        tx: transaction,
+      });
+      if (!axeIdRemappingResult.success) return axeIdRemappingResult;
+
+      const fichesResult = await this.recreateFiches({
+        actions: planFiches.actions,
+        sousActions: planFiches.sousActions,
+        authorization,
+        collectiviteId,
+        axeIdRemapping: axeIdRemappingResult.data,
+        tx: transaction,
+      });
+      if (!fichesResult.success) return fichesResult;
+
+      const ficheCount =
+        planFiches.actions.length + planFiches.sousActions.length;
+      this.logger.log(
+        `Plan ${planId} dupliqué vers ${newPlanId} (${ficheCount} fiches) pour la collectivité ${collectiviteId}`
+      );
+      return success({ planId: newPlanId });
+    }, tx);
+  }
+
+  private async loadPlanFiches(
+    planId: number,
+    collectiviteId: number,
+    tx: Transaction
+  ): Promise<PlanFichesToDuplicate> {
+    const { data: matchedActions } =
+      await this.listFichesService.listFichesQuery(
+        collectiviteId,
+        { planActionIds: [planId] },
+        undefined,
+        tx
+      );
+    const actions = ownedByCollectivite(matchedActions, collectiviteId);
+
+    const actionIds = actions.map((fiche) => fiche.id);
+    if (actionIds.length === 0) return { actions, sousActions: [] };
+
+    const { data: matchedChildren } =
+      await this.listFichesService.listFichesQuery(
+        collectiviteId,
+        { parentsId: actionIds },
+        undefined,
+        tx
+      );
+
+    return { actions, sousActions: ownedByCollectivite(matchedChildren, collectiviteId) };
+  }
+
+  private async buildWriteAuthorization(
+    user: AuthenticatedUser,
+    collectiviteId: number,
+    tx: Transaction
+  ): Promise<Result<FicheCreateAuthorization, DuplicatePlanError>> {
+    try {
+      const authorization = await FicheCreateAuthorization.forCollectivite(
+        this.permissionService,
+        user,
+        collectiviteId,
+        tx
+      );
+      return success(authorization);
+    } catch (error) {
+      this.logger.warn(
+        `Duplication refusée sur la collectivité ${collectiviteId}: ${
+          error instanceof Error ? error.message : error
+        }`
+      );
+      return failure(DuplicatePlanErrorEnum.UNAUTHORIZED);
+    }
+  }
+
+  private async recreateAxes({
+    source,
+    newPlanId,
+    collectiviteId,
+    user,
+    tx,
+  }: {
+    source: Plan;
+    newPlanId: number;
+    collectiviteId: number;
+    user: AuthenticatedUser;
+    tx: Transaction;
+  }): Promise<Result<AxeIdRemapping, DuplicatePlanError>> {
+    const remapping = new Map<number, number>([[source.id, newPlanId]]);
+
+    const childAxesByDepth = source.axes
+      .filter((axe) => axe.id !== source.id)
+      .sort((first, second) => first.depth - second.depth);
+
+    for (const axe of childAxesByDepth) {
+      const parentNewId =
+        axe.parent === null ? newPlanId : remapping.get(axe.parent);
+      if (parentNewId === undefined) {
+        return failure(DuplicatePlanErrorEnum.DUPLICATE_PLAN_ERROR);
+      }
+
+      const createdAxe = await this.upsertAxeService.upsertAxe(
+        { planId: newPlanId, parent: parentNewId, collectiviteId, nom: axe.nom },
+        user,
+        tx
+      );
+      if (!createdAxe.success) {
+        return failure(DuplicatePlanErrorEnum.DUPLICATE_PLAN_ERROR);
+      }
+      remapping.set(axe.id, createdAxe.data.id);
+    }
+
+    return success(remapping);
+  }
+
+  private async recreateFiches({
+    actions,
+    sousActions,
+    authorization,
+    collectiviteId,
+    axeIdRemapping,
+    tx,
+  }: {
+    actions: FicheWithRelations[];
+    sousActions: FicheWithRelations[];
+    authorization: FicheCreateAuthorization;
+    collectiviteId: number;
+    axeIdRemapping: AxeIdRemapping;
+    tx: Transaction;
+  }): Promise<Result<undefined, DuplicatePlanError>> {
+    const ficheIdRemapping = new Map<number, number>();
+
+    for (const source of actions) {
+      const created = await this.duplicateFiche({
+        source,
+        collectiviteId,
+        parentId: null,
+        authorization,
+        axeIdRemapping,
+        tx,
+      });
+      if (!created.success) return created;
+      ficheIdRemapping.set(source.id, created.data);
+    }
+
+    for (const source of sousActions) {
+      const parentId =
+        source.parentId === null
+          ? undefined
+          : ficheIdRemapping.get(source.parentId);
+      if (parentId === undefined) {
+        return failure(DuplicatePlanErrorEnum.DUPLICATE_PLAN_ERROR);
+      }
+
+      const created = await this.duplicateFiche({
+        source,
+        collectiviteId,
+        parentId,
+        authorization,
+        axeIdRemapping,
+        tx,
+      });
+      if (!created.success) return created;
+      ficheIdRemapping.set(source.id, created.data);
+    }
+
+    return success(undefined);
+  }
+
+  private async duplicateFiche({
+    source,
+    collectiviteId,
+    parentId,
+    authorization,
+    axeIdRemapping,
+    tx,
+  }: {
+    source: FicheWithRelations;
+    collectiviteId: number;
+    parentId: number | null;
+    authorization: FicheCreateAuthorization;
+    axeIdRemapping: AxeIdRemapping;
+    tx: Transaction;
+  }): Promise<Result<number, DuplicatePlanError>> {
+    const { fiche, ficheFields } = mapSourceFicheToDuplicate({
+      source,
+      collectiviteId,
+      parentId,
+      axeIdRemapping,
+    });
+
+    const created = await this.createFicheService.createFicheWithAuthorization({
+      authorization,
+      fiche,
+      ficheFields,
+      tx,
+    });
+    if (!created.success) {
+      return failure(DuplicatePlanErrorEnum.DUPLICATE_PLAN_ERROR);
+    }
+    return success(created.data.id);
+  }
+}

--- a/apps/backend/src/plans/plans/duplicate-plan/duplicated-fiche.mapper.spec.ts
+++ b/apps/backend/src/plans/plans/duplicate-plan/duplicated-fiche.mapper.spec.ts
@@ -1,0 +1,261 @@
+import { FicheWithRelations } from '@tet/domain/plans';
+import { describe, expect, it } from 'vitest';
+import {
+  AxeIdRemapping,
+  mapSourceFicheToDuplicate,
+} from './duplicated-fiche.mapper';
+
+const createSourceFiche = (
+  overrides: Partial<FicheWithRelations> = {}
+): FicheWithRelations =>
+  ({
+    id: 1,
+    collectiviteId: 10,
+    parentId: null,
+    titre: 'Action source',
+    description: 'Description source',
+    piliersEci: null,
+    objectifs: 'Objectifs source',
+    cibles: null,
+    ressources: 'Moyens source',
+    financements: 'Financements source',
+    budgetPrevisionnel: '12000',
+    statut: 'En cours',
+    priorite: 'Élevé',
+    dateDebut: '2026-01-01T00:00:00.000Z',
+    dateFin: '2026-12-31T00:00:00.000Z',
+    ameliorationContinue: true,
+    participationCitoyenne: 'Concertation',
+    participationCitoyenneType: 'information',
+    tempsDeMiseEnOeuvre: null,
+    majTermine: true,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    createdBy: null,
+    modifiedAt: '2026-01-01T00:00:00.000Z',
+    modifiedBy: null,
+    restreint: false,
+    collectiviteNom: null,
+    partenaires: null,
+    pilotes: null,
+    referents: null,
+    libreTags: null,
+    instanceGouvernance: null,
+    financeurs: null,
+    sousThematiques: null,
+    thematiques: null,
+    structures: null,
+    sharedWithCollectivites: null,
+    indicateurs: null,
+    services: null,
+    effetsAttendus: null,
+    axes: null,
+    plans: null,
+    etapes: null,
+    notes: null,
+    mesures: null,
+    fichesLiees: null,
+    docs: null,
+    budgets: null,
+    actionImpactId: null,
+    completion: { ficheId: 1, fields: [], isCompleted: false },
+    ...overrides,
+  } as FicheWithRelations);
+
+const emptyRemapping: AxeIdRemapping = new Map();
+
+describe('mapSourceFicheToDuplicate', () => {
+  it('recopie les colonnes de contenu et de suivi', () => {
+    const source = createSourceFiche();
+
+    const { fiche } = mapSourceFicheToDuplicate({
+      source,
+      collectiviteId: 99,
+      parentId: null,
+      axeIdRemapping: emptyRemapping,
+    });
+
+    expect(fiche).toMatchObject({
+      collectiviteId: 99,
+      parentId: null,
+      titre: 'Action source',
+      description: 'Description source',
+      objectifs: 'Objectifs source',
+      ressources: 'Moyens source',
+      financements: 'Financements source',
+      budgetPrevisionnel: '12000',
+      statut: 'En cours',
+      priorite: 'Élevé',
+      dateDebut: '2026-01-01T00:00:00.000Z',
+      dateFin: '2026-12-31T00:00:00.000Z',
+      ameliorationContinue: true,
+      participationCitoyenne: 'Concertation',
+      majTermine: true,
+      restreint: false,
+    });
+  });
+
+  it('préserve le flag restreint à true', () => {
+    const source = createSourceFiche({ restreint: true });
+
+    const { fiche } = mapSourceFicheToDuplicate({
+      source,
+      collectiviteId: 99,
+      parentId: null,
+      axeIdRemapping: emptyRemapping,
+    });
+
+    expect(fiche.restreint).toBe(true);
+  });
+
+  it('place le parentId fourni sur la fiche', () => {
+    const source = createSourceFiche();
+
+    const { fiche } = mapSourceFicheToDuplicate({
+      source,
+      collectiviteId: 99,
+      parentId: 555,
+      axeIdRemapping: emptyRemapping,
+    });
+
+    expect(fiche.parentId).toBe(555);
+  });
+
+  it('remappe les appartenances aux axes vers les nouveaux ids', () => {
+    const source = createSourceFiche({
+      axes: [
+        { id: 1, nom: 'A', collectiviteId: 10, parentId: null, planId: 1 },
+        { id: 2, nom: 'B', collectiviteId: 10, parentId: 1, planId: 1 },
+      ],
+    });
+    const axeIdRemapping: AxeIdRemapping = new Map([
+      [1, 101],
+      [2, 102],
+    ]);
+
+    const { ficheFields } = mapSourceFicheToDuplicate({
+      source,
+      collectiviteId: 99,
+      parentId: null,
+      axeIdRemapping,
+    });
+
+    expect(ficheFields.axes).toEqual([{ id: 101 }, { id: 102 }]);
+  });
+
+  it('ignore les axes absents du remapping (appartenance à un autre plan)', () => {
+    const source = createSourceFiche({
+      axes: [
+        { id: 1, nom: 'A', collectiviteId: 10, parentId: null, planId: 1 },
+        { id: 9, nom: 'Autre', collectiviteId: 10, parentId: null, planId: 7 },
+      ],
+    });
+    const axeIdRemapping: AxeIdRemapping = new Map([[1, 101]]);
+
+    const { ficheFields } = mapSourceFicheToDuplicate({
+      source,
+      collectiviteId: 99,
+      parentId: null,
+      axeIdRemapping,
+    });
+
+    expect(ficheFields.axes).toEqual([{ id: 101 }]);
+  });
+
+  it('extrait les ids des relations de catégorisation', () => {
+    const source = createSourceFiche({
+      thematiques: [{ id: 1, nom: 'T1' }],
+      sousThematiques: [{ id: 2, nom: 'ST2', thematiqueId: 1 }],
+      effetsAttendus: [{ id: 3, nom: 'E3', notice: null }],
+      mesures: [{ id: 'eci_1.1', identifiant: '1.1', nom: 'M', referentiel: 'eci' }],
+      indicateurs: [{ id: 4, nom: 'I4', unite: 'kg' }],
+      libreTags: [{ id: 5, nom: 'Tag' }],
+    });
+
+    const { ficheFields } = mapSourceFicheToDuplicate({
+      source,
+      collectiviteId: 99,
+      parentId: null,
+      axeIdRemapping: emptyRemapping,
+    });
+
+    expect(ficheFields.thematiques).toEqual([{ id: 1 }]);
+    expect(ficheFields.sousThematiques).toEqual([{ id: 2 }]);
+    expect(ficheFields.effetsAttendus).toEqual([{ id: 3 }]);
+    expect(ficheFields.mesures).toEqual([{ id: 'eci_1.1' }]);
+    expect(ficheFields.indicateurs).toEqual([{ id: 4 }]);
+    expect(ficheFields.libreTags).toEqual([{ id: 5 }]);
+  });
+
+  it('convertit pilotes et référents au format tag/user', () => {
+    const source = createSourceFiche({
+      pilotes: [{ nom: 'P', tagId: 11, userId: null }],
+      referents: [{ nom: 'R', tagId: null, userId: 'user-1' }],
+    });
+
+    const { ficheFields } = mapSourceFicheToDuplicate({
+      source,
+      collectiviteId: 99,
+      parentId: null,
+      axeIdRemapping: emptyRemapping,
+    });
+
+    expect(ficheFields.pilotes).toEqual([{ tagId: 11, userId: null }]);
+    expect(ficheFields.referents).toEqual([{ tagId: null, userId: 'user-1' }]);
+  });
+
+  it('convertit les financeurs au format attendu avec montant', () => {
+    const source = createSourceFiche({
+      financeurs: [
+        {
+          ficheId: 1,
+          montantTtc: 5000,
+          financeurTagId: 42,
+          financeurTag: { id: 42, nom: 'Financeur', collectiviteId: 10 },
+        },
+      ],
+    });
+
+    const { ficheFields } = mapSourceFicheToDuplicate({
+      source,
+      collectiviteId: 99,
+      parentId: null,
+      axeIdRemapping: emptyRemapping,
+    });
+
+    expect(ficheFields.financeurs).toEqual([
+      { financeurTag: { id: 42 }, montantTtc: 5000 },
+    ]);
+  });
+
+  it('mappe tempsDeMiseEnOeuvre et actionImpactId', () => {
+    const source = createSourceFiche({
+      tempsDeMiseEnOeuvre: { id: 3, nom: 'Court' },
+      actionImpactId: 77,
+    });
+
+    const { ficheFields } = mapSourceFicheToDuplicate({
+      source,
+      collectiviteId: 99,
+      parentId: null,
+      axeIdRemapping: emptyRemapping,
+    });
+
+    expect(ficheFields.tempsDeMiseEnOeuvre).toEqual({ id: 3 });
+    expect(ficheFields.actionsImpact).toEqual([{ id: 77 }]);
+  });
+
+  it("n'expose ni fiches liées, ni notes, ni partage", () => {
+    const source = createSourceFiche();
+
+    const { ficheFields } = mapSourceFicheToDuplicate({
+      source,
+      collectiviteId: 99,
+      parentId: null,
+      axeIdRemapping: emptyRemapping,
+    });
+
+    expect('fichesLiees' in ficheFields).toBe(false);
+    expect('notes' in ficheFields).toBe(false);
+    expect('sharedWithCollectivites' in ficheFields).toBe(false);
+  });
+});

--- a/apps/backend/src/plans/plans/duplicate-plan/duplicated-fiche.mapper.ts
+++ b/apps/backend/src/plans/plans/duplicate-plan/duplicated-fiche.mapper.ts
@@ -1,0 +1,112 @@
+import { FicheCreate, FicheWithRelations } from '@tet/domain/plans';
+import { UpdateFicheInput } from '../../fiches/update-fiche/update-fiche.input';
+
+export type AxeIdRemapping = ReadonlyMap<number, number>;
+
+export type DuplicableFicheFields = Pick<
+  UpdateFicheInput,
+  | 'axes'
+  | 'thematiques'
+  | 'sousThematiques'
+  | 'effetsAttendus'
+  | 'partenaires'
+  | 'structures'
+  | 'services'
+  | 'libreTags'
+  | 'instanceGouvernance'
+  | 'mesures'
+  | 'indicateurs'
+  | 'pilotes'
+  | 'referents'
+  | 'financeurs'
+  | 'tempsDeMiseEnOeuvre'
+  | 'actionsImpact'
+>;
+
+const remapAxes = (
+  axes: FicheWithRelations['axes'],
+  axeIdRemapping: AxeIdRemapping
+): { id: number }[] =>
+  (axes ?? [])
+    .map((axe) => axeIdRemapping.get(axe.id))
+    .filter((id): id is number => id !== undefined)
+    .map((id) => ({ id }));
+
+export function mapSourceFicheToDuplicate({
+  source,
+  collectiviteId,
+  parentId,
+  axeIdRemapping,
+}: {
+  source: FicheWithRelations;
+  collectiviteId: number;
+  parentId: number | null;
+  axeIdRemapping: AxeIdRemapping;
+}): { fiche: FicheCreate; ficheFields: DuplicableFicheFields } {
+  const fiche: FicheCreate = {
+    collectiviteId,
+    parentId,
+    titre: source.titre,
+    description: source.description,
+    piliersEci: source.piliersEci,
+    objectifs: source.objectifs,
+    cibles: source.cibles,
+    ressources: source.ressources,
+    financements: source.financements,
+    budgetPrevisionnel: source.budgetPrevisionnel,
+    statut: source.statut,
+    priorite: source.priorite,
+    dateDebut: source.dateDebut,
+    dateFin: source.dateFin,
+    ameliorationContinue: source.ameliorationContinue,
+    participationCitoyenne: source.participationCitoyenne,
+    participationCitoyenneType: source.participationCitoyenneType,
+    majTermine: source.majTermine,
+    restreint: source.restreint,
+  };
+
+  const ficheFields: DuplicableFicheFields = {
+    axes: remapAxes(source.axes, axeIdRemapping),
+    thematiques: source.thematiques?.map((thematique) => ({
+      id: thematique.id,
+    })),
+    sousThematiques: source.sousThematiques?.map((sousThematique) => ({
+      id: sousThematique.id,
+    })),
+    effetsAttendus: source.effetsAttendus?.map((effet) => ({ id: effet.id })),
+    partenaires: source.partenaires?.map((partenaire) => ({
+      id: partenaire.id,
+    })),
+    structures: source.structures?.map((structure) => ({ id: structure.id })),
+    services: source.services?.map((service) => ({ id: service.id })),
+    libreTags: source.libreTags?.map((tag) => ({ id: tag.id })),
+    instanceGouvernance: source.instanceGouvernance?.map((tag) => ({
+      id: tag.id,
+    })),
+    mesures: source.mesures?.map((mesure) => ({ id: mesure.id })),
+    indicateurs: source.indicateurs?.map((indicateur) => ({
+      id: indicateur.id,
+    })),
+    pilotes: source.pilotes?.map((pilote) => ({
+      tagId: pilote.tagId,
+      userId: pilote.userId,
+    })),
+    referents: source.referents?.map((referent) => ({
+      tagId: referent.tagId,
+      userId: referent.userId,
+    })),
+    financeurs: source.financeurs?.map((financeur) => ({
+      financeurTag: { id: financeur.financeurTagId },
+      montantTtc: financeur.montantTtc,
+    })),
+    tempsDeMiseEnOeuvre: source.tempsDeMiseEnOeuvre
+      ? { id: source.tempsDeMiseEnOeuvre.id }
+      : null,
+    actionsImpact:
+      source.actionImpactId !== null && source.actionImpactId !== undefined
+        ? [{ id: source.actionImpactId }]
+        : undefined,
+  };
+
+  return { fiche, ficheFields };
+}

--- a/apps/backend/src/plans/plans/duplicate-plan/duplicated-plan-name.spec.ts
+++ b/apps/backend/src/plans/plans/duplicate-plan/duplicated-plan-name.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { buildDuplicatedPlanName } from './duplicated-plan-name';
+
+describe('buildDuplicatedPlanName', () => {
+  it('suffixe le nom source avec la date et l\'heure de duplication', () => {
+    const instant = new Date('2026-06-04T17:08:05');
+
+    expect(buildDuplicatedPlanName('Plan vélo', instant)).toBe(
+      'Plan vélo (copie du 04/06/2026 à 17:08:05)'
+    );
+  });
+
+  it('distingue deux duplications du même plan le même jour', () => {
+    const matin = new Date('2026-06-04T09:30:00');
+    const apresMidi = new Date('2026-06-04T14:45:12');
+
+    expect(buildDuplicatedPlanName('Plan vélo', matin)).not.toBe(
+      buildDuplicatedPlanName('Plan vélo', apresMidi)
+    );
+  });
+
+  it('reste robuste quand le plan source n\'a pas de nom', () => {
+    const instant = new Date('2026-06-04T17:08:05');
+
+    expect(buildDuplicatedPlanName(null, instant)).toBe(
+      'Plan (copie du 04/06/2026 à 17:08:05)'
+    );
+  });
+});

--- a/apps/backend/src/plans/plans/duplicate-plan/duplicated-plan-name.ts
+++ b/apps/backend/src/plans/plans/duplicate-plan/duplicated-plan-name.ts
@@ -1,0 +1,15 @@
+const pad = (value: number): string => `${value}`.padStart(2, '0');
+
+export function buildDuplicatedPlanName(
+  sourceNom: string | null,
+  duplicatedAt: Date
+): string {
+  const date = `${pad(duplicatedAt.getDate())}/${pad(
+    duplicatedAt.getMonth() + 1
+  )}/${duplicatedAt.getFullYear()}`;
+  const heure = `${pad(duplicatedAt.getHours())}:${pad(
+    duplicatedAt.getMinutes()
+  )}:${pad(duplicatedAt.getSeconds())}`;
+  const base = sourceNom ?? 'Plan';
+  return `${base} (copie du ${date} à ${heure})`;
+}

--- a/apps/backend/src/plans/plans/plans.module.ts
+++ b/apps/backend/src/plans/plans/plans.module.ts
@@ -19,6 +19,8 @@ import { ComputeBudgetRules } from './compute-budget/compute-budget.rules';
 import { DeletePlanRepository } from './delete-plan/delete-plan.repository';
 import { DeletePlanRouter } from './delete-plan/delete-plan.router';
 import { DeletePlanService } from './delete-plan/delete-plan.service';
+import { DuplicatePlanRouter } from './duplicate-plan/duplicate-plan.router';
+import { DuplicatePlanService } from './duplicate-plan/duplicate-plan.service';
 import { GetPlanCompletionRouter } from './get-plan-completion/get-plan-completion.router';
 import { GetPlanCompletionService } from './get-plan-completion/get-plan-completion.service';
 import { GetPlanRepository } from './get-plan/get-plan.repository';
@@ -65,6 +67,8 @@ import { UpsertPlanService } from './upsert-plan/upsert-plan.service';
     DeletePlanRepository,
     DeletePlanService,
     DeletePlanRouter,
+    DuplicatePlanService,
+    DuplicatePlanRouter,
     GetPlanRepository,
     GetPlanService,
     GetPlanRouter,

--- a/apps/backend/src/plans/plans/plans.router.ts
+++ b/apps/backend/src/plans/plans/plans.router.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { TrpcService } from '@tet/backend/utils/trpc/trpc.service';
 import { DeletePlanRouter } from './delete-plan/delete-plan.router';
+import { DuplicatePlanRouter } from './duplicate-plan/duplicate-plan.router';
 import { GetPlanCompletionRouter } from './get-plan-completion/get-plan-completion.router';
 import { GetPlanRouter } from './get-plan/get-plan.router';
 import { ImportPlanRouter } from './import-plan-aggregate/import-plan.router';
@@ -18,6 +19,7 @@ export class PlanRouter {
     private readonly listPlansRouter: ListPlansRouter,
     private readonly listPlanTypesRouter: ListPlanTypesRouter,
     private readonly deletePlanRouter: DeletePlanRouter,
+    private readonly duplicatePlanRouter: DuplicatePlanRouter,
     private readonly importPlanRouter: ImportPlanRouter
   ) {}
 
@@ -28,6 +30,7 @@ export class PlanRouter {
     this.listPlansRouter.router,
     this.listPlanTypesRouter.router,
     this.deletePlanRouter.router,
+    this.duplicatePlanRouter.router,
     this.importPlanRouter.router
   );
 }


### PR DESCRIPTION
## Résumé

Ajoute la procédure tRPC `plans.plans.duplicate({ planId })` qui clone un plan d'action **au sein de la même collectivité** à partir de son seul identifiant.

La duplication s'exécute de façon **synchrone** dans une **transaction unique** (rollback complet en cas d'échec). Elle compose les services de domaine existants (`getPlan`, `upsertPlan`, `upsertAxe`, `createFicheWithAuthorization`) ; toute la translation lecture→écriture est isolée dans un **mapper pur** testé unitairement.

### Ce qui est copié
- Colonnes de la fiche : titre, description, objectifs, ressources, financements, cibles, piliers ECI, participation citoyenne, temps de mise en œuvre, statut, priorité, dates, `restreint`…
- Relations : thématiques, sous-thématiques, effets attendus, mesures du référentiel, partenaires, structures, services, pilotes, référents, financeurs (+ montants), liens indicateurs, tags libres, instances de gouvernance.
- Plan : `typeId`, pilotes et référents de niveau plan.
- Structure : arbre d'axes complet ; appartenances M:N et parents de sous-actions **remappés** vers les nouveaux identifiants.

### Nom du plan dupliqué
Le plan dupliqué reçoit un **nom dérivé horodaté à la seconde** — `"{nom} (copie du JJ/MM/AAAA à HH:MM:SS)"` — pour le distinguer de l'original et éviter les collisions entre plusieurs duplications le même jour.

### Hors périmètre (volontaire)
- **Partage** (`sharedWithCollectivites`) : la copie démarre non partagée.
- **Fiches liées** et **étapes/jalons** : différés.
- **Preuves/documents** → PR suivante. **Budgets détaillés** → PR suivante.
- Seules les fiches **natives** de la collectivité source sont dupliquées (les fiches d'une autre collectivité simplement partagées dans le plan sont exclues — pas d'élévation de donnée).

## Tests
- Unitaires du mapper (10) : extraction des relations au format attendu, remapping des axes, exclusion des champs hors périmètre, préservation de `restreint`.
- Unitaires du nom (3) : format horodaté, distinction de deux duplications le même jour, robustesse sans nom source.
- E2e (7) : duplication d'un plan à ≥3 niveaux d'axes avec fiche + sous-action, fiche multi-axes, plan vide, **préservation du `restreint` (fiche + sous-action restreintes, fiche publique)**, refus sans droit, refus inter-collectivités (IDOR) sans création, plan introuvable.
- Typecheck et ESLint OK.

## Post-Deploy Monitoring & Validation
- **Logs** : `[DuplicatePlanService] Plan X dupliqué vers Y (N fiches)` confirme les duplications réussies ; `[TransactionManager] Transaction failed` signale un rollback.
- **Validation** : déclencher une duplication sur un plan de test, vérifier que le nouveau plan reprend l'arborescence et les fiches, et qu'aucune fiche partielle ne subsiste en cas d'erreur.
- **Signal d'échec / rollback** : montée d'erreurs `DUPLICATE_PLAN_ERROR` ; aucun plan partiel attendu grâce à la transaction unique.
- **Fenêtre** : surveiller après le premier usage en production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notes de Version

* **Nouvelles Fonctionnalités**
  * Ajout de la fonctionnalité de duplication de plan. Cette fonctionnalité duplique un plan avec l'ensemble de son contenu, y compris les axes, fiches et leurs relations. Le plan dupliqué est renommé automatiquement avec la date et l'heure de duplication. Les paramètres de confidentialité sont préservés lors de la duplication.

* **Tests**
  * Ajout de tests e2e pour valider les scénarios de duplication et les cas d'erreur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->