### PR TITLE
feat(ai-plan-import): types brouillon + mapper vers ImportActionOrSousAction

### DIFF
--- a/apps/backend/src/plans/plans/ai-plan-import/adapters/extracted-action-to-import-action.spec.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/adapters/extracted-action-to-import-action.spec.ts
@@ -1,0 +1,123 @@
+import { ImportPlanInput } from '@tet/backend/plans/plans/import-plan-aggregate/import-plan.input';
+import { isSousAction } from '@tet/backend/plans/plans/import-plan-aggregate/schemas/import-action.input';
+import { validateImportPlanInput } from '@tet/backend/plans/plans/import-plan-aggregate/validators/plan.rule';
+import { describe, expect, it } from 'vitest';
+import {
+  ExtractedAction,
+  ExtractedSousAction,
+} from '../models/extracted-action';
+import { extractedActionToImportActions } from './extracted-action-to-import-action';
+
+const aSousAction = (
+  overrides: Partial<ExtractedSousAction> = {}
+): ExtractedSousAction => ({
+  titre: 'Déployer des lignes de covoiturage',
+  description: null,
+  personnePilote: null,
+  statut: null,
+  dateDebut: null,
+  dateFin: null,
+  ...overrides,
+});
+
+const anAction = (
+  overrides: Partial<ExtractedAction> = {}
+): ExtractedAction => ({
+  axe: 'Mobilité',
+  sousAxe: 'Covoiturage',
+  titre: 'Réduire l autosolisme',
+  description: null,
+  objectifs: null,
+  structurePilote: null,
+  directionServicePilote: null,
+  personnePilote: null,
+  budget: null,
+  statut: null,
+  confidence: null,
+  sousActions: [],
+  ...overrides,
+});
+
+describe('extractedActionToImportActions', () => {
+  it('mappe une action (axisPath, statut, budget, pilote)', () => {
+    const [action] = extractedActionToImportActions(
+      anAction({
+        statut: 'A discuter',
+        budget: 24000,
+        personnePilote: 'Jean Dupont',
+        structurePilote: 'DDT',
+        directionServicePilote: 'Service mobilité',
+      })
+    );
+
+    expect(isSousAction(action)).toBe(false);
+    expect(action).toMatchObject({
+      axisPath: ['Mobilité', 'Covoiturage'],
+      titre: 'Réduire l autosolisme',
+      status: 'A discuter',
+      budget: 24000,
+      pilotes: ['Jean Dupont'],
+      structures: ['DDT'],
+      services: ['Service mobilité'],
+    });
+  });
+
+  it('mappe une sous-action imbriquée qui hérite des axes de son action parente', () => {
+    const [, sousAction] = extractedActionToImportActions(
+      anAction({
+        sousActions: [aSousAction({ dateDebut: '2025-01-01', statut: 'En cours' })],
+      })
+    );
+
+    expect(isSousAction(sousAction)).toBe(true);
+    if (isSousAction(sousAction)) {
+      expect(sousAction).toMatchObject({
+        axisPath: ['Mobilité', 'Covoiturage'],
+        parentActionTitre: 'Réduire l autosolisme',
+        titre: 'Déployer des lignes de covoiturage',
+        status: 'En cours',
+        dateDebut: new Date('2025-01-01'),
+      });
+    }
+  });
+
+  it('déplie une action en 1 action + N sous-actions partageant axisPath et parent', () => {
+    const result = extractedActionToImportActions(
+      anAction({
+        sousActions: [
+          aSousAction({ titre: 'Sous-action A' }),
+          aSousAction({ titre: 'Sous-action B' }),
+        ],
+      })
+    );
+
+    expect(result).toHaveLength(3);
+    const sousActions = result.filter(isSousAction);
+    expect(sousActions).toHaveLength(2);
+    expect(sousActions.map((sousAction) => sousAction.titre)).toEqual([
+      'Sous-action A',
+      'Sous-action B',
+    ]);
+    sousActions.forEach((sousAction) => {
+      expect(sousAction.axisPath).toEqual(['Mobilité', 'Covoiturage']);
+      expect(sousAction.parentActionTitre).toBe('Réduire l autosolisme');
+    });
+  });
+
+  it('mappe statut null vers status undefined', () => {
+    const [action] = extractedActionToImportActions(anAction());
+    expect(action.status).toBeUndefined();
+  });
+
+  it('round-trip : un draft mappé passe validateImportPlanInput', () => {
+    const planInput: ImportPlanInput = {
+      nom: 'Plan importé',
+      actions: [anAction({ sousActions: [aSousAction()] })].flatMap(
+        extractedActionToImportActions
+      ),
+    };
+
+    const result = validateImportPlanInput(planInput);
+    expect(result.success).toBe(true);
+  });
+});

--- a/apps/backend/src/plans/plans/ai-plan-import/adapters/extracted-action-to-import-action.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/adapters/extracted-action-to-import-action.ts
@@ -1,0 +1,99 @@
+import {
+  ImportActionInput,
+  ImportActionOrSousAction,
+  ImportSousActionInput,
+} from '@tet/backend/plans/plans/import-plan-aggregate/schemas/import-action.input';
+import {
+  ExtractedAction,
+  ExtractedSousAction,
+} from '../models/extracted-action';
+
+export const extractedActionToImportActions = (
+  action: ExtractedAction
+): ImportActionOrSousAction[] => {
+  const axisPath = toAxisPath(action.axe, action.sousAxe);
+  return [
+    actionToImport(action, axisPath),
+    ...action.sousActions.map((sousAction) =>
+      sousActionToImport(sousAction, action.titre, axisPath)
+    ),
+  ];
+};
+
+const actionToImport = (
+  action: ExtractedAction,
+  axisPath: string[] | undefined
+): ImportActionInput => ({
+  axisPath,
+  titre: action.titre,
+  description: action.description ?? undefined,
+  gouvernance: undefined,
+  objectifs: action.objectifs ?? undefined,
+  resources: undefined,
+  financements: undefined,
+  notesComplementaire: undefined,
+  participationCitoyenne: undefined,
+  budget: action.budget ?? undefined,
+  instanceGouvernance: [],
+  dateDebut: undefined,
+  dateFin: undefined,
+  structures: toList(action.structurePilote),
+  partenaires: [],
+  services: toList(action.directionServicePilote),
+  priorite: undefined,
+  participation: undefined,
+  cible: undefined,
+  status: action.statut ?? undefined,
+  pilotes: toList(action.personnePilote),
+  referents: [],
+  financeurs: [],
+  indicateurs: undefined,
+});
+
+const sousActionToImport = (
+  sousAction: ExtractedSousAction,
+  parentActionTitre: string,
+  axisPath: string[] | undefined
+): ImportSousActionInput => ({
+  axisPath,
+  sousTitreAction: null,
+  titre: sousAction.titre,
+  parentActionTitre,
+  description: sousAction.description ?? undefined,
+  gouvernance: undefined,
+  objectifs: undefined,
+  resources: undefined,
+  financements: undefined,
+  notesComplementaire: undefined,
+  participationCitoyenne: undefined,
+  budget: undefined,
+  instanceGouvernance: [],
+  dateDebut: toDate(sousAction.dateDebut),
+  dateFin: toDate(sousAction.dateFin),
+  structures: [],
+  partenaires: [],
+  services: [],
+  priorite: undefined,
+  participation: undefined,
+  cible: undefined,
+  status: sousAction.statut ?? undefined,
+  pilotes: toList(sousAction.personnePilote),
+  referents: [],
+  financeurs: [],
+  indicateurs: undefined,
+});
+
+const toAxisPath = (axe: string, sousAxe: string): string[] | undefined => {
+  const segments = [axe, sousAxe]
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0);
+  return segments.length > 0 ? segments : undefined;
+};
+
+const toList = (value: string | null): string[] => {
+  const trimmed = value?.trim();
+  return trimmed ? [trimmed] : [];
+};
+
+const toDate = (value: string | null): Date | undefined =>
+  value === null ? undefined : new Date(value);

--- a/apps/backend/src/plans/plans/ai-plan-import/models/extracted-action.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/models/extracted-action.ts
@@ -1,0 +1,36 @@
+import { statutEnumValues } from '@tet/domain/plans';
+import { z } from 'zod';
+
+export const actionConfidenceSchema = z.object({
+  score: z.number().min(0).max(100),
+  explication: z.string(),
+  amelioree: z.boolean(),
+});
+
+const extractedSousActionSchema = z.object({
+  titre: z.string(),
+  description: z.string().nullable(),
+  personnePilote: z.string().nullable(),
+  statut: z.enum(statutEnumValues).nullable(),
+  dateDebut: z.string().date().nullable(),
+  dateFin: z.string().date().nullable(),
+});
+
+export const extractedActionSchema = z.object({
+  axe: z.string(),
+  sousAxe: z.string(),
+  titre: z.string(),
+  description: z.string().nullable(),
+  objectifs: z.string().nullable(),
+  structurePilote: z.string().nullable(),
+  directionServicePilote: z.string().nullable(),
+  personnePilote: z.string().nullable(),
+  budget: z.number().nullable(),
+  statut: z.enum(statutEnumValues).nullable(),
+  confidence: actionConfidenceSchema.nullable(),
+  sousActions: z.array(extractedSousActionSchema),
+});
+
+export type ActionConfidence = z.output<typeof actionConfidenceSchema>;
+export type ExtractedSousAction = z.output<typeof extractedSousActionSchema>;
+export type ExtractedAction = z.output<typeof extractedActionSchema>;

--- a/apps/backend/src/plans/plans/ai-plan-import/models/plan-draft.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/models/plan-draft.ts
@@ -1,0 +1,6 @@
+import { ExtractedAction } from './extracted-action';
+
+export type PlanDraft = {
+  actions: ExtractedAction[];
+  qualitativeReview: string | null;
+};


### PR DESCRIPTION
## Objectif

Définir le **contrat du brouillon** produit par la pipeline d'import IA, et le **mapper** qui le convertit vers la forme de persistance partagée (`ImportActionOrSousAction`, consommée par `persistImportPlan`).

## Contenu

**`models/extracted-action.ts`**
- `ExtractedAction` : schéma zod **imbriqué** — une action portant ses sous-actions.
  - action : `axe`, `sousAxe`, `titre`, `description`, `objectifs`, `structurePilote`, `directionServicePilote`, `personnePilote`, `budget`, `statut`, `confidence`, `sousActions: ExtractedSousAction[]`.
  - `ExtractedSousAction` : `titre`, `description`, `personnePilote`, `statut`, `dateDebut`, `dateFin` — **pas d'axes propres** (héritage structurel de l'action parente).
- `statut: Statut | null` — réutilise `statutEnumValues` de `@tet/domain/plans` (valeurs contraintes, pas de `string` libre).
- `ActionConfidence` : `{ score (0–100), explication, amelioree }`.

**`models/plan-draft.ts`**
- `PlanDraft = { actions: ExtractedAction[]; qualitativeReview: string | null }`.

**`adapters/extracted-action-to-import-action.ts`**
- Mapper pur **1:N** `extractedActionToImportActions(action) → ImportActionOrSousAction[]` : déplie une action en `[action, ...sous-actions]` vers la forme plate de persistance (`axe`/`sousAxe` → `axisPath`, `structurePilote` → `structures`, `personnePilote` → `pilotes`, dates `string` → `Date`, etc.). **Chaque sous-action hérite de l'`axisPath` du parent** ⇒ cohérence axes parent↔enfant garantie par construction (pas de dérive possible ⇒ pas de `ParentActionNotFound`). Les champs non produits par l'IA prennent leurs défauts (listes vides / `undefined`).

## Pourquoi imbriqué (et pas plat discriminé)

L'étape 1 de la pipeline extrait naturellement une action **avec ses sous-actions imbriquées**. Modéliser le brouillon en imbriqué :
- supprime tout **type transient** entre les étapes (l'enrichissement PR7 remplit les `sousActions` en place) ;
- **dissout l'invariant fragile** « la sous-action doit reporter les axes de son parent » : l'héritage est désormais structurel ;
- colle au rendu **front** (une action et ses sous-actions).

Le plat `ImportActionOrSousAction[]` reste la cible de persistance, produite par le mapper.

## Vérifications

- ✅ typecheck + lint backend.
- ✅ 5 tests (`adapters/extracted-action-to-import-action.spec.ts`) : mapping d'une action (axisPath/statut/budget/pilote), dépliage **1:N** (1 action + N sous-actions partageant `axisPath` + `parentActionTitre`), sous-action imbriquée (héritage axisPath + dates), `statut null → undefined`, round-trip `validateImportPlanInput` sur un brouillon mappé.

## Portée

Types + mapper purs uniquement. Aucune nouvelle dépendance, aucun câblage NestJS (la pipeline qui produit `ExtractedAction` et le confirm qui consomme le mapper arrivent dans des PR ultérieures).