### PR TITLE
fix(site): ouvre la recherche de collectivités à toutes les CTs

### DIFF
--- a/apps/site/app/useFilteredCollectivites.ts
+++ b/apps/site/app/useFilteredCollectivites.ts
@@ -1,5 +1,4 @@
 import { supabase } from '@/site/app/initSupabase';
-import Fuse from 'fuse.js';
 import useSWR from 'swr';
 
 export const useFilteredCollectivites = (search: string) => {
@@ -15,6 +14,23 @@ export const useFilteredCollectivites = (search: string) => {
     // commencé sa recherche, pour éviter de charger trop de données.
     if (search.length === 0) {
       query.limit(10);
+    } else {
+      // Recherche full-text côté serveur pour éviter la limite de lignes de Supabase.
+      // L'index GIN sur nom (to_tsvector('french', nom)) rend cette recherche performante.
+      const tsquery = search
+        .trim()
+        .split(/\s+/)
+        .filter(Boolean)
+        .map((w) => w.replace(/[^\p{L}\p{N}]/gu, ''))
+        .filter(Boolean)
+        .map((w) => `${w}:*`)
+        .join(' & ');
+
+      if (tsquery) {
+        query.textSearch('nom', tsquery, { config: 'french' });
+      } else {
+        query.limit(10);
+      }
     }
 
     const { error, data } = await query;
@@ -27,20 +43,6 @@ export const useFilteredCollectivites = (search: string) => {
       return null;
     }
 
-    if (search.length) {
-      const fuse = new Fuse(data, {
-        keys: ['nom'],
-        threshold: 0.3,
-        shouldSort: true,
-        ignoreLocation: true,
-      });
-      return {
-        filteredCollectivites: fuse.search(search).map((r) => r.item) || [],
-      };
-    }
-
-    return {
-      filteredCollectivites: data || [],
-    };
+    return { filteredCollectivites: data };
   });
 };


### PR DESCRIPTION
La recherche de collectivités sur le site public ne trouvait pas les CTs dont le nom est alphabétiquement au-delà du seuil `max_rows` de Supabase (6 000 lignes) — les syndicats dont le nom commence par "SM" ou "SY" étaient par exemple introuvables. La cause : la vue `site_labellisation` s'appuyait sur `stats.collectivite`, une vue matérialisée que Fuse.js devait charger entièrement côté client, avec pour effet que seules les 6 000 premières CTs alphabétiquement étaient accessibles à la recherche.

Ce PR remplace la source de `site_labellisation` par la table `collectivite` directement, avec les jointures équivalentes (`collectivite_banatic_type`, `imports.region`, `imports.departement`). Toutes les CTs non-test sont désormais incluses à chaque rafraîchissement de la vue, indépendamment de leur statut actif ou engagé.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Sonnet_4.6_(200K)](https://img.shields.io/badge/Sonnet_4.6_(200K)-D97757?logo=claude&logoColor=white)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notes de mise à jour

* **Améliorations**
  * Optimisation du système de recherche de collectivités avec recherche full-text côté serveur.
  * Meilleure précision et performance des résultats de recherche avec support natif de la langue française.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->