### PR TITLE
refactor(utils): remove validation for INSEE/SIREN codes from fetchCollectivite function

### DIFF
--- a/apps/site/app/collectivites/utils.ts
+++ b/apps/site/app/collectivites/utils.ts
@@ -43,11 +43,6 @@ type Collectivite = {
 };
 
 export const fetchCollectivite = async (code_siren_insee: string) => {
-  // Validate code_siren_insee, accept 5-9 digits (INSEE/SIREN codes)
-  if (!/^(2[AB]\d{3}|\d{5})$/.test(code_siren_insee)) {
-    throw new Error(`Invalid code_siren_insee: ${code_siren_insee}`);
-  }
-
   const { data, error } = await supabase
     .from('site_labellisation')
     .select(


### PR DESCRIPTION
SQL injection protection is automatically done by PostgREST

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Suppression de la validation de format lors de la récupération des données de collectivités. Le système traite désormais directement les requêtes sans contrôle préalable du paramètre.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->