### PR TITLE
feat(plans): copie les budgets détaillés lors de la duplication d'un plan

### DIFF
--- a/apps/backend/src/plans/fiches/fiche-action-budget/fiche-action-budget.service.ts
+++ b/apps/backend/src/plans/fiches/fiche-action-budget/fiche-action-budget.service.ts
@@ -9,6 +9,7 @@ import {
 } from '@tet/backend/users/models/auth.models';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { failure, Result, success } from '@tet/backend/utils/result.type';
 import {
   assertNoDuplicateBudgets,
   FicheBudget,
@@ -121,18 +122,21 @@ export class FicheActionBudgetService {
     });
   }
 
-  async createBudgets(
+  async insertBudgets(
     budgets: FicheBudgetCreate[],
     tx: Transaction
-  ): Promise<void> {
-    if (budgets.length === 0) {
-      return;
-    }
-    await tx
-      .insert(ficheActionBudgetTable)
-      .values(
-        budgets.map((budget) => ({ ...budget, annee: budget.annee ?? null }))
+  ): Promise<Result<undefined, 'SERVER_ERROR'>> {
+    try {
+      for (const budget of budgets) {
+        await this.insertBudget(budget, tx);
+      }
+      return success(undefined);
+    } catch (error) {
+      return failure(
+        'SERVER_ERROR',
+        error instanceof Error ? error : undefined
       );
+    }
   }
 
   async delete(ficheId: number, budgetsIds: number[], user: AuthenticatedUser) {

--- a/apps/backend/src/plans/fiches/fiche-action-budget/fiche-action-budget.service.ts
+++ b/apps/backend/src/plans/fiches/fiche-action-budget/fiche-action-budget.service.ts
@@ -121,6 +121,20 @@ export class FicheActionBudgetService {
     });
   }
 
+  async createBudgets(
+    budgets: FicheBudgetCreate[],
+    tx: Transaction
+  ): Promise<void> {
+    if (budgets.length === 0) {
+      return;
+    }
+    await tx
+      .insert(ficheActionBudgetTable)
+      .values(
+        budgets.map((budget) => ({ ...budget, annee: budget.annee ?? null }))
+      );
+  }
+
   async delete(ficheId: number, budgetsIds: number[], user: AuthenticatedUser) {
     if (budgetsIds.length === 0) {
       return;

--- a/apps/backend/src/plans/fiches/list-fiches/list-fiches-budget.repository.ts
+++ b/apps/backend/src/plans/fiches/list-fiches/list-fiches-budget.repository.ts
@@ -73,6 +73,7 @@ export class ListFichesBudgetRepository {
         >`array_agg
         (json_build_object(
           'id', ${ficheActionBudgetTable.id},
+          'ficheId', ${ficheActionBudgetTable.ficheId},
           'type', ${ficheActionBudgetTable.type},
           'unite', ${ficheActionBudgetTable.unite},
           'annee', ${ficheActionBudgetTable.annee},

--- a/apps/backend/src/plans/plans/duplicate-plan/duplicate-plan.router.e2e-spec.ts
+++ b/apps/backend/src/plans/plans/duplicate-plan/duplicate-plan.router.e2e-spec.ts
@@ -384,6 +384,26 @@ describe('Dupliquer un plan', () => {
         tempsDeMiseEnOeuvre: { id: temps.id },
       },
     });
+    await caller.plans.fiches.budgets.upsert([
+      {
+        ficheId: sourceFiche.id,
+        type: 'investissement',
+        unite: 'HT',
+        annee: 2026,
+        budgetPrevisionnel: 50000,
+        budgetReel: 12000,
+        estEtale: false,
+      },
+      {
+        ficheId: sourceFiche.id,
+        type: 'fonctionnement',
+        unite: 'ETP',
+        annee: 2026,
+        budgetPrevisionnel: 2,
+        budgetReel: null,
+        estEtale: false,
+      },
+    ]);
 
     const duplicated = await caller.plans.plans.duplicate({
       planId: sourcePlan.id,
@@ -451,9 +471,38 @@ describe('Dupliquer un plan', () => {
     expect(dup.axes?.map((item) => item.id)).toEqual([newAxeId]);
     expect(dup.axes?.map((item) => item.id)).not.toContain(axe.id);
 
+    const dupBudgets = (dup.budgets ?? []).map((budget) => ({
+      type: budget.type,
+      unite: budget.unite,
+      annee: budget.annee ?? null,
+      budgetPrevisionnel: budget.budgetPrevisionnel ?? null,
+      budgetReel: budget.budgetReel ?? null,
+      estEtale: budget.estEtale,
+    }));
+    expect(dupBudgets).toHaveLength(2);
+    expect(dupBudgets).toEqual(
+      expect.arrayContaining([
+        {
+          type: 'investissement',
+          unite: 'HT',
+          annee: 2026,
+          budgetPrevisionnel: 50000,
+          budgetReel: 12000,
+          estEtale: false,
+        },
+        {
+          type: 'fonctionnement',
+          unite: 'ETP',
+          annee: 2026,
+          budgetPrevisionnel: 2,
+          budgetReel: null,
+          estEtale: false,
+        },
+      ])
+    );
+
     expect(dup.fichesLiees ?? []).toEqual([]);
     expect(dup.docs ?? []).toEqual([]);
-    expect(dup.budgets ?? []).toEqual([]);
     expect(dup.etapes ?? []).toEqual([]);
     expect(dup.sharedWithCollectivites ?? []).toEqual([]);
   });

--- a/apps/backend/src/plans/plans/duplicate-plan/duplicate-plan.router.e2e-spec.ts
+++ b/apps/backend/src/plans/plans/duplicate-plan/duplicate-plan.router.e2e-spec.ts
@@ -500,6 +500,7 @@ describe('Dupliquer un plan', () => {
         },
       ])
     );
+    expect(dup.budgets?.every((budget) => budget.ficheId === dup.id)).toBe(true);
 
     expect(dup.fichesLiees ?? []).toEqual([]);
     expect(dup.docs ?? []).toEqual([]);

--- a/apps/backend/src/plans/plans/duplicate-plan/duplicate-plan.service.ts
+++ b/apps/backend/src/plans/plans/duplicate-plan/duplicate-plan.service.ts
@@ -339,13 +339,10 @@ export class DuplicatePlanService {
     tx: Transaction
   ): Promise<Result<undefined, DuplicatePlanError>> {
     const budgets = mapSourceFicheBudgets(source, newFicheId);
-    if (budgets.length === 0) return success(undefined);
-
-    try {
-      await this.ficheBudgetService.createBudgets(budgets, tx);
-      return success(undefined);
-    } catch {
+    const result = await this.ficheBudgetService.insertBudgets(budgets, tx);
+    if (!result.success) {
       return failure(DuplicatePlanErrorEnum.DUPLICATE_PLAN_ERROR);
     }
+    return success(undefined);
   }
 }

--- a/apps/backend/src/plans/plans/duplicate-plan/duplicate-plan.service.ts
+++ b/apps/backend/src/plans/plans/duplicate-plan/duplicate-plan.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { CreateFicheService } from '@tet/backend/plans/fiches/create-fiche/create-fiche.service';
 import { FicheCreateAuthorization } from '@tet/backend/plans/fiches/create-fiche/fiche-create-authorization';
+import { FicheActionBudgetService } from '@tet/backend/plans/fiches/fiche-action-budget/fiche-action-budget.service';
 import ListFichesService from '@tet/backend/plans/fiches/list-fiches/list-fiches.service';
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
@@ -20,6 +21,7 @@ import {
   AxeIdRemapping,
   mapSourceFicheToDuplicate,
 } from './duplicated-fiche.mapper';
+import { mapSourceFicheBudgets } from './duplicated-fiche-budgets.mapper';
 import { buildDuplicatedPlanName } from './duplicated-plan-name';
 
 const toPersonneId = (personne: Personne): PersonneId => ({
@@ -61,7 +63,8 @@ export class DuplicatePlanService {
     private readonly listFichesService: ListFichesService,
     private readonly upsertPlanService: UpsertPlanService,
     private readonly upsertAxeService: UpsertAxeService,
-    private readonly createFicheService: CreateFicheService
+    private readonly createFicheService: CreateFicheService,
+    private readonly ficheBudgetService: FicheActionBudgetService
   ) {}
 
   async duplicate(
@@ -322,6 +325,27 @@ export class DuplicatePlanService {
     if (!created.success) {
       return failure(DuplicatePlanErrorEnum.DUPLICATE_PLAN_ERROR);
     }
-    return success(created.data.id);
+    const newFicheId = created.data.id;
+
+    const budgetsResult = await this.copyBudgets(source, newFicheId, tx);
+    if (!budgetsResult.success) return budgetsResult;
+
+    return success(newFicheId);
+  }
+
+  private async copyBudgets(
+    source: FicheWithRelations,
+    newFicheId: number,
+    tx: Transaction
+  ): Promise<Result<undefined, DuplicatePlanError>> {
+    const budgets = mapSourceFicheBudgets(source, newFicheId);
+    if (budgets.length === 0) return success(undefined);
+
+    try {
+      await this.ficheBudgetService.createBudgets(budgets, tx);
+      return success(undefined);
+    } catch {
+      return failure(DuplicatePlanErrorEnum.DUPLICATE_PLAN_ERROR);
+    }
   }
 }

--- a/apps/backend/src/plans/plans/duplicate-plan/duplicated-fiche-budgets.mapper.spec.ts
+++ b/apps/backend/src/plans/plans/duplicate-plan/duplicated-fiche-budgets.mapper.spec.ts
@@ -1,0 +1,59 @@
+import { FicheWithRelations } from '@tet/domain/plans';
+import { describe, expect, it } from 'vitest';
+import { mapSourceFicheBudgets } from './duplicated-fiche-budgets.mapper';
+
+const sourceWithBudgets = (
+  budgets: FicheWithRelations['budgets']
+): FicheWithRelations => ({ budgets } as FicheWithRelations);
+
+describe('mapSourceFicheBudgets', () => {
+  it('recopie chaque budget vers la nouvelle fiche en réinitialisant ses ids', () => {
+    const source = sourceWithBudgets([
+      {
+        id: 1,
+        ficheId: 10,
+        type: 'investissement',
+        unite: 'HT',
+        annee: 2026,
+        budgetPrevisionnel: 50000,
+        budgetReel: 12000,
+        estEtale: false,
+      },
+      {
+        id: 2,
+        ficheId: 10,
+        type: 'fonctionnement',
+        unite: 'ETP',
+        annee: null,
+        budgetPrevisionnel: 2,
+        budgetReel: null,
+        estEtale: true,
+      },
+    ]);
+
+    expect(mapSourceFicheBudgets(source, 99)).toEqual([
+      {
+        ficheId: 99,
+        type: 'investissement',
+        unite: 'HT',
+        annee: 2026,
+        budgetPrevisionnel: 50000,
+        budgetReel: 12000,
+        estEtale: false,
+      },
+      {
+        ficheId: 99,
+        type: 'fonctionnement',
+        unite: 'ETP',
+        annee: null,
+        budgetPrevisionnel: 2,
+        budgetReel: null,
+        estEtale: true,
+      },
+    ]);
+  });
+
+  it('retourne un tableau vide quand la fiche source n\'a pas de budget', () => {
+    expect(mapSourceFicheBudgets(sourceWithBudgets(null), 99)).toEqual([]);
+  });
+});

--- a/apps/backend/src/plans/plans/duplicate-plan/duplicated-fiche-budgets.mapper.ts
+++ b/apps/backend/src/plans/plans/duplicate-plan/duplicated-fiche-budgets.mapper.ts
@@ -1,0 +1,16 @@
+import { FicheBudgetCreate, FicheWithRelations } from '@tet/domain/plans';
+
+export function mapSourceFicheBudgets(
+  source: FicheWithRelations,
+  newFicheId: number
+): FicheBudgetCreate[] {
+  return (source.budgets ?? []).map((budget) => ({
+    ficheId: newFicheId,
+    type: budget.type,
+    unite: budget.unite,
+    annee: budget.annee,
+    budgetPrevisionnel: budget.budgetPrevisionnel,
+    budgetReel: budget.budgetReel,
+    estEtale: budget.estEtale,
+  }));
+}


### PR DESCRIPTION
## Résumé

PR3 de la stack duplication de plan (dépend de #4527). Ajoute la recopie des **budgets détaillés** (`fiche_action_budget`) lors de la duplication d'un plan.

Empilée sur `feat/duplicate-plan` — à rebaser sur `main` une fois #4527 mergée (la base GitHub se réajustera automatiquement).

## Détails

- **`FicheActionBudgetService.createBudgets(budgets, tx)`** : nouvelle méthode tx-aware et **pré-autorisée** (pas de re-vérification de permission par fiche), sur le modèle de `createFicheWithAuthorization`. La duplication ayant déjà vérifié les droits en amont et créant les fiches dans la même transaction, les budgets sont insérés dans cette transaction → atomicité préservée (rollback complet en cas d'échec).
- **Mapper pur `mapSourceFicheBudgets(source, newFicheId)`** : dérive les `FicheBudgetCreate` depuis la fiche source en réinitialisant les ids et en pointant la nouvelle fiche. Testé unitairement.
- L'orchestrateur copie les budgets juste après la création de chaque fiche, dans la transaction.

Les budgets source sont déjà chargés par `listFichesQuery` (`FicheWithRelations.budgets`) — aucune lecture supplémentaire.

## Hors périmètre
Inchangé par rapport à la stack : preuves/documents (PR2), étapes/jalons, fiches liées, partage restent non copiés.

## Tests
- Mapper budget (2) : recopie vers la nouvelle fiche + réinitialisation des ids, fiche sans budget → `[]`.
- E2e exhaustif étendu : la fiche source reçoit 2 budgets (investissement HT / fonctionnement ETP) → vérifie qu'ils sont fidèlement recopiés sur la fiche dupliquée.
- 23 tests verts au total sur la feature ; ESLint OK.

## Post-Deploy Monitoring & Validation
- Vérifier après duplication d'un plan contenant des fiches budgétées que les budgets apparaissent sur les fiches copiées.
- Échec → rollback de toute la duplication (transaction unique), erreur `DUPLICATE_PLAN_ERROR`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * La duplication d'un plan copie désormais automatiquement les budgets des fiches.
  * Ajout d’un mappage pour transformer les budgets d’une fiche source vers la fiche dupliquée.
  * Nouveau chemin d’insertion des budgets lors des opérations transactionnelles.

* **Corrections**
  * Les budgets sont maintenant correctement inclus et référencés dans l’agrégation des fiches.

* **Tests**
  * Tests e2e et unitaires mis à jour pour vérifier la duplication et l’insertion des budgets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->