### PR TITLE
feat(ai-plan-import): étape 1 extraction structurée des actions

### DIFF
--- a/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/extract-actions/extract-actions.prompt.spec.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/extract-actions/extract-actions.prompt.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { buildExtractionPrompt } from './extract-actions.prompt';
+
+describe('buildExtractionPrompt', () => {
+  it('interpole le texte, les précisions et la date du jour', () => {
+    const prompt = buildExtractionPrompt({
+      text: 'TEXTE_SOURCE_MARQUEUR',
+      precisions: 'PRECISIONS_MARQUEUR',
+      disabledFields: [],
+      currentDate: '08/06/2026',
+    });
+
+    expect(prompt).toContain('TEXTE_SOURCE_MARQUEUR');
+    expect(prompt).toContain('PRECISIONS_MARQUEUR');
+    expect(prompt).toContain('08/06/2026');
+    expect(prompt).not.toContain('{texte_pdf_a_analyser}');
+    expect(prompt).not.toContain('{precisions}');
+    expect(prompt).not.toContain('{date_du_jour}');
+  });
+
+  it('n ajoute pas de directive d ignorance sans champ désactivé', () => {
+    const prompt = buildExtractionPrompt({
+      text: 'texte',
+      precisions: '',
+      disabledFields: [],
+      currentDate: '08/06/2026',
+    });
+
+    expect(prompt).not.toContain('INSTRUCTION PRIORITAIRE');
+  });
+
+  it('préfixe la directive d ignorance pour les champs désactivés', () => {
+    const prompt = buildExtractionPrompt({
+      text: 'texte',
+      precisions: '',
+      disabledFields: ['budget', 'statut'],
+      currentDate: '08/06/2026',
+    });
+
+    expect(prompt).toContain('INSTRUCTION PRIORITAIRE');
+    expect(prompt).toContain('- "budget"');
+    expect(prompt).toContain('- "statut"');
+    expect(prompt.indexOf('INSTRUCTION PRIORITAIRE')).toBeLessThan(
+      prompt.indexOf('agent d’extraction documentaire')
+    );
+  });
+});

--- a/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/extract-actions/extract-actions.prompt.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/extract-actions/extract-actions.prompt.ts
@@ -1,0 +1,38 @@
+import { EXTRACTION_PROMPT } from '../../prompts/extraction.prompt';
+
+export type ExtractionPromptInput = {
+  text: string;
+  precisions: string;
+  disabledFields: string[];
+  currentDate: string;
+};
+
+export const buildExtractionPrompt = ({
+  text,
+  precisions,
+  disabledFields,
+  currentDate,
+}: ExtractionPromptInput): string =>
+  buildIgnoreDirective(disabledFields) +
+  EXTRACTION_PROMPT.replaceAll('{precisions}', precisions)
+    .replaceAll('{texte_pdf_a_analyser}', text)
+    .replaceAll('{date_du_jour}', currentDate);
+
+const buildIgnoreDirective = (disabledFields: string[]): string => {
+  if (disabledFields.length === 0) {
+    return '';
+  }
+  const lines = disabledFields.map((field) => `- "${field}"`).join('\n');
+  return (
+    '================================================================\n' +
+    'INSTRUCTION PRIORITAIRE — COLONNES / CHAMPS À IGNORER\n' +
+    'Les colonnes/champs suivants NE doivent PAS être remplis :\n' +
+    `${lines}\n` +
+    'Pour chacun de ces champs, retournez systématiquement la valeur ' +
+    'vide ("" pour les chaînes, [] pour les listes, "" pour les nombres).\n' +
+    'Si les règles, exemples ou précisions ci-dessous décrivent comment ' +
+    'remplir ces champs, IGNOREZ ces instructions : ne remplissez que ' +
+    'les autres champs. Cette consigne est PRIORITAIRE sur tout le reste.\n' +
+    '================================================================\n\n'
+  );
+};

--- a/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/extract-actions/extract-actions.schema.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/extract-actions/extract-actions.schema.ts
@@ -1,0 +1,23 @@
+import { statutEnumValues } from '@tet/domain/plans';
+import { z } from 'zod';
+
+const extractionStatutValues = ['', ...statutEnumValues] as const;
+
+const extractionActionSchema = z.object({
+  axe: z.string(),
+  'sous-axe': z.string(),
+  titre: z.string(),
+  description: z.string(),
+  'sous-actions': z.array(z.string()),
+  objectifs: z.string(),
+  'structure pilote': z.string(),
+  'direction ou service pilote': z.string(),
+  'personne pilote': z.string(),
+  budget: z.string(),
+  statut: z.enum(extractionStatutValues),
+});
+
+export const extractionResponseSchema = z.array(extractionActionSchema);
+
+export type ExtractionAction = z.output<typeof extractionActionSchema>;
+export type ExtractionResponse = z.output<typeof extractionResponseSchema>;

--- a/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/extract-actions/extract-actions.spec.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/extract-actions/extract-actions.spec.ts
@@ -1,0 +1,85 @@
+import { TokenUsage } from '@tet/backend/utils/llm/llm.repository';
+import { LlmService } from '@tet/backend/utils/llm/llm.service';
+import { failure, Result, success } from '@tet/backend/utils/result.type';
+import { describe, expect, it } from 'vitest';
+import { extractActions } from './extract-actions';
+import { ExtractionAction, ExtractionResponse } from './extract-actions.schema';
+
+const tokens: TokenUsage = {
+  promptTokens: 100,
+  candidatesTokens: 50,
+  thoughtsTokens: 10,
+  totalTokens: 160,
+};
+
+const anExtractionAction = (
+  overrides: Partial<ExtractionAction> = {}
+): ExtractionAction => ({
+  axe: 'Axe 1 Gouvernance',
+  'sous-axe': '1.1 Pilotage',
+  titre: '1.1.1 Définir un portage politique',
+  description: '',
+  'sous-actions': [],
+  objectifs: '',
+  'structure pilote': '',
+  'direction ou service pilote': '',
+  'personne pilote': '',
+  budget: '',
+  statut: '',
+  ...overrides,
+});
+
+const llmReturning = (
+  result: Result<{ data: ExtractionResponse; tokens: TokenUsage }, never>
+): Pick<LlmService, 'generateStructured'> =>
+  ({
+    generateStructured: async () => result,
+  } as unknown as Pick<LlmService, 'generateStructured'>);
+
+const promptInput = {
+  text: 'texte source',
+  precisions: '',
+  disabledFields: [],
+  currentDate: '08/06/2026',
+};
+
+describe('extractActions', () => {
+  it('mappe la réponse du LLM en actions et propage les tokens', async () => {
+    const llm = llmReturning(
+      success({ data: [anExtractionAction({ budget: '5000' })], tokens })
+    );
+
+    const result = await extractActions(llm, promptInput);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.actions).toHaveLength(1);
+      expect(result.data.actions[0].budget).toBe(5000);
+      expect(result.data.tokens).toEqual(tokens);
+    }
+  });
+
+  it('échoue explicitement quand aucune action n est extraite', async () => {
+    const llm = llmReturning(success({ data: [], tokens }));
+
+    const result = await extractActions(llm, promptInput);
+
+    expect(result).toMatchObject({
+      success: false,
+      error: { kind: 'no_actions_extracted' },
+    });
+  });
+
+  it('propage l erreur du LLM', async () => {
+    const llm = {
+      generateStructured: async () => failure({ kind: 'rate_limited' }),
+    } as unknown as Pick<LlmService, 'generateStructured'>;
+
+    const result = await extractActions(llm, promptInput);
+
+    expect(result).toMatchObject({
+      success: false,
+      error: { kind: 'rate_limited' },
+    });
+  });
+});

--- a/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/extract-actions/extract-actions.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/extract-actions/extract-actions.ts
@@ -1,0 +1,46 @@
+import { LlmError } from '@tet/backend/utils/llm/llm.errors';
+import { TokenUsage } from '@tet/backend/utils/llm/llm.repository';
+import { LlmService } from '@tet/backend/utils/llm/llm.service';
+import { failure, Result, success } from '@tet/backend/utils/result.type';
+import { ExtractedAction } from '../../models/extracted-action';
+import {
+  buildExtractionPrompt,
+  ExtractionPromptInput,
+} from './extract-actions.prompt';
+import { extractionResponseSchema } from './extract-actions.schema';
+import { extractionResponseToExtractedActions } from './extraction-response-to-extracted-actions';
+
+export type ExtractActionsInput = ExtractionPromptInput & {
+  signal?: AbortSignal;
+};
+
+export type ExtractActionsResult = {
+  actions: ExtractedAction[];
+  tokens: TokenUsage;
+};
+
+export type ExtractActionsError = LlmError | { kind: 'no_actions_extracted' };
+
+export const extractActions = async (
+  llm: Pick<LlmService, 'generateStructured'>,
+  { signal, ...promptInput }: ExtractActionsInput
+): Promise<Result<ExtractActionsResult, ExtractActionsError>> => {
+  const completion = await llm.generateStructured({
+    prompt: buildExtractionPrompt(promptInput),
+    schema: extractionResponseSchema,
+    signal,
+  });
+  if (!completion.success) {
+    return completion;
+  }
+
+  const { data: response, tokens } = completion.data;
+  if (response.length === 0) {
+    return failure({ kind: 'no_actions_extracted' });
+  }
+
+  return success({
+    actions: extractionResponseToExtractedActions(response),
+    tokens,
+  });
+};

--- a/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/extract-actions/extraction-response-to-extracted-actions.spec.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/extract-actions/extraction-response-to-extracted-actions.spec.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import { ExtractionAction } from './extract-actions.schema';
+import { extractionResponseToExtractedActions } from './extraction-response-to-extracted-actions';
+
+const anExtractionAction = (
+  overrides: Partial<ExtractionAction> = {}
+): ExtractionAction => ({
+  axe: 'Axe 4 Mobilité',
+  'sous-axe': '4.2 Covoiturage',
+  titre: '4.2.1 Réduire l autosolisme',
+  description: '',
+  'sous-actions': [],
+  objectifs: '',
+  'structure pilote': '',
+  'direction ou service pilote': '',
+  'personne pilote': '',
+  budget: '',
+  statut: '',
+  ...overrides,
+});
+
+describe('extractionResponseToExtractedActions', () => {
+  it('mappe les clés françaises vers le modèle camelCase', () => {
+    const [action] = extractionResponseToExtractedActions([
+      anExtractionAction({
+        description: 'Développer le covoiturage',
+        objectifs: 'Rendre le covoiturage courant',
+        'structure pilote': 'DDT',
+        'direction ou service pilote': 'Service mobilité',
+        'personne pilote': 'Jean Dupont',
+        budget: '24000',
+        statut: 'En cours',
+      }),
+    ]);
+
+    expect(action).toEqual({
+      axe: 'Axe 4 Mobilité',
+      sousAxe: '4.2 Covoiturage',
+      titre: '4.2.1 Réduire l autosolisme',
+      description: 'Développer le covoiturage',
+      objectifs: 'Rendre le covoiturage courant',
+      structurePilote: 'DDT',
+      directionServicePilote: 'Service mobilité',
+      personnePilote: 'Jean Dupont',
+      budget: 24000,
+      statut: 'En cours',
+      confidence: null,
+      sousActions: [],
+    });
+  });
+
+  it('convertit les chaînes vides en null et le budget en nombre', () => {
+    const [action] = extractionResponseToExtractedActions([
+      anExtractionAction({ budget: '  ', statut: '', description: '   ' }),
+    ]);
+
+    expect(action).toMatchObject({
+      description: null,
+      objectifs: null,
+      structurePilote: null,
+      personnePilote: null,
+      budget: null,
+      statut: null,
+    });
+  });
+
+  it('met budget à null quand la valeur n est pas un entier', () => {
+    const [action] = extractionResponseToExtractedActions([
+      anExtractionAction({ budget: 'à définir' }),
+    ]);
+
+    expect(action.budget).toBeNull();
+  });
+
+  it('transforme les titres de sous-actions en sous-actions non enrichies', () => {
+    const [action] = extractionResponseToExtractedActions([
+      anExtractionAction({
+        'sous-actions': ['Déployer des lignes', '  ', '  Autopartage  '],
+      }),
+    ]);
+
+    expect(action.sousActions).toEqual([
+      {
+        titre: 'Déployer des lignes',
+        description: null,
+        personnePilote: null,
+        statut: null,
+        dateDebut: null,
+        dateFin: null,
+      },
+      {
+        titre: 'Autopartage',
+        description: null,
+        personnePilote: null,
+        statut: null,
+        dateDebut: null,
+        dateFin: null,
+      },
+    ]);
+  });
+});

--- a/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/extract-actions/extraction-response-to-extracted-actions.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/extract-actions/extraction-response-to-extracted-actions.ts
@@ -1,0 +1,53 @@
+import { Statut } from '@tet/domain/plans';
+import {
+  ExtractedAction,
+  ExtractedSousAction,
+} from '../../models/extracted-action';
+import { ExtractionAction, ExtractionResponse } from './extract-actions.schema';
+
+export const extractionResponseToExtractedActions = (
+  response: ExtractionResponse
+): ExtractedAction[] => response.map(toExtractedAction);
+
+const toExtractedAction = (action: ExtractionAction): ExtractedAction => ({
+  axe: action.axe,
+  sousAxe: action['sous-axe'],
+  titre: action.titre,
+  description: toNullable(action.description),
+  objectifs: toNullable(action.objectifs),
+  structurePilote: toNullable(action['structure pilote']),
+  directionServicePilote: toNullable(action['direction ou service pilote']),
+  personnePilote: toNullable(action['personne pilote']),
+  budget: toBudget(action.budget),
+  statut: toStatut(action.statut),
+  confidence: null,
+  sousActions: action['sous-actions']
+    .map(toSousAction)
+    .filter((sousAction) => sousAction.titre.length > 0),
+});
+
+const toSousAction = (titre: string): ExtractedSousAction => ({
+  titre: titre.trim(),
+  description: null,
+  personnePilote: null,
+  statut: null,
+  dateDebut: null,
+  dateFin: null,
+});
+
+const toNullable = (value: string): string | null => {
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const toBudget = (value: string): number | null => {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  return Number.isNaN(parsed) ? null : parsed;
+};
+
+const toStatut = (value: '' | Statut): Statut | null =>
+  value === '' ? null : value;

--- a/apps/backend/src/plans/plans/ai-plan-import/prompts/extraction.prompt.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/prompts/extraction.prompt.ts
@@ -1,0 +1,170 @@
+export const EXTRACTION_PROMPT = `
+Vous êtes un agent d’extraction documentaire spécialisé dans les plans d’actions de transition écologique des collectivités, y compris les PCAET.
+
+Contexte du fichier en entrée
+Le texte fourni est un document de plan d’actions d’une collectivité. Un plan est structuré en axes, sous axes, actions et parfois sous actions. Le contenu peut être issu d’un PDF converti avec des artefacts de mise en page. Certaines rubriques comme budget, service pilote ou statut ne sont pas toujours explicites.
+
+Objectif
+Analyser le texte ci dessous et extraire toutes les actions, en reconstruisant la hiérarchie axe puis sous axe puis action, et en ajoutant des sous actions si nécessaire. Axes, sous axes et actions sont obligatoires. Les sous actions sont optionnels.
+
+Sortie attendue
+1 Répondre uniquement avec un tableau JSON valide
+2 Ne rien ajouter avant ni après le JSON
+3 Ne pas utiliser de balises Markdown
+
+Schéma des objets du tableau
+Chaque entrée du tableau est un objet avec exactement ces champs
+[
+ "axe",
+ "sous-axe",
+ "titre",
+ "description",
+ "sous-actions",
+ "objectifs",
+ "structure pilote",
+ "direction ou service pilote",
+ "personne pilote",
+ "budget",
+ "statut"
+]
+
+Types et formats attendus
+• "axe" est une chaîne
+• "sous-axe" est une chaîne
+• "titre" est une chaîne courte (300 caractères maximum). Si le titre issu du texte source dépasse 300 caractères, conserver uniquement les 300 premiers caractères significatifs dans "titre" et reporter le reste dans "description"
+• "description" est une chaîne
+• "sous-actions" est une liste de chaînes. Si aucune sous action ne s’impose, mettre une liste vide []
+• "objectifs" est une chaîne. Reprendre fidèlement le contenu du champ "Objectifs" du document source si présent (par exemple "Préserver la qualité et la diversité des productions agricoles"). Si l'information n'est pas explicitement présente, laisser ""
+• "structure pilote" est une chaîne. Une ou plusieurs structures (organisme englobant : la collectivité elle-même, ou par exemple "Chambre d'agriculture", "DDT", etc.) séparées par ", ". Distinct de "direction ou service pilote" qui est interne à la structure. Si l'information n'est pas explicitement présente, laisser ""
+• "direction ou service pilote" est une chaîne
+• "personne pilote" est une chaîne
+• "budget" est soit la valeur vide "", soit un entier sans séparateur d’espace
+• "statut" est une chaîne
+
+Définitions opérationnelles
+• Plan. Ensemble structuré d’orientations et de mesures d’une collectivité
+• Axe. Grande orientation stratégique du plan. Exemple "Vers une mobilité vertueuse et réfléchie"
+• Sous axe. Déclinaison thématique d’un axe. Exemple "Mettre en œuvre les conditions favorables à des déplacements plus sobres"
+• Action. Mesure opérationnelle unique qui peut être mise en œuvre et suivie. Elle a un titre court et, uniquement si nécessaire, une description synthétique apportant des informations complémentaires au titre
+• Sous action. Etape ou brique concrète qui détaille la mise en œuvre d’une action. Les sous actions sont listées dans "sous-actions"
+
+Hiérarchie et numérotation
+1 Conserver strictement les libellés exacts du texte source lorsque la numérotation et les titres existent
+2 Lorsque le texte ne fournit pas de numérotation explicite, construire une numérotation stable et cohérente selon la règle suivante
+   On note les axes "n".
+   On note les sous axes "n.X".
+   On note les actions "n.X.Y"
+3 "axe" doit être formaté exactement "Axe n : Titre de l’axe"
+4 "sous-axe" doit être formaté exactement "n.X  Titre du sous-axe"
+6 "titre" doit être formaté "n.X.Y Titre de l’action"
+7 Un sous axe doit avoir un nom complet. Il ne peut pas être uniquement un nombre
+8 Pour un même identifiant hiérarchique le libellé doit être identique partout
+
+Tâches obligatoires et ordre d’exécution
+1 Normalisation du texte source
+   • Retirer uniquement les artefacts manifestes de conversion comme "Unnamed" ou des mots isolés insérés au milieu d’une phrase
+   • Conserver l’orthographe et les majuscules des noms propres et sigles
+2 Relevé de structure
+   • Repérer les axes puis les sous axes
+3 Extraction des actions
+   • Lister chaque action avec un titre court et une description synthétique fidèle au texte
+   • Lorsque le texte présente des puces, des sous parties ou des verbes d’exécution multiples rattachés à une même action, créer des sous actions dans "sous-actions" comme une liste de chaînes
+4 Rattachement hiérarchique
+   • Associer chaque action à son sous axe et à son axe
+5 Complétude des champs
+   • Remplir "objectifs", "structure pilote", "direction ou service pilote", "personne pilote", "budget" et "statut" uniquement si l’information est explicite et non ambiguë. "objectifs" et "structure pilote" sont des champs facultatifs : ne pas inventer, laisser "" en l'absence d'information explicite
+   • Lorsque le texte présente pour une action des dates ou un calendrier (sans libellé de statut explicite pour cette action), vous pouvez déduire « statut » uniquement parmi « À venir » et « En cours » en vous appuyant sur ces dates et la date du jour ({date_du_jour}). Si seule une année est mentionnée sans mois précis (par exemple "2026"), considérer le statut comme « En cours » si cette année correspond à l'année actuelle, et « À venir » si elle est dans le futur
+6 Validation du format
+   • Produire un JSON valide
+   • Vérifier que chaque objet contient exactement les champs définis
+   • Si une information manque, la laisser à "" sauf "sous-actions" qui doit être une liste vide et "budget" qui doit être "" ou un entier
+7 Dé duplication
+   • Si deux entrées décrivent la même action, conserver une seule entrée avec la description la plus complète
+8 Couverture
+   • Parcourir tout le texte fourni et extraire l’ensemble des actions identifiables
+
+Règles générales
+1 Ne jamais inventer des informations ou des chiffres
+2 Ne pas réécrire le sens de la "description". La nettoyer uniquement pour supprimer des artefacts évidents
+3 "statut" ne peut prendre que l’une des valeurs suivantes sinon ""
+   ["À venir", "À discuter", "En cours", "Réalisé", "En retard", "En pause", "Bloqué"]
+4 "direction ou service pilote" contient uniquement des organismes ou services. "personne pilote" contient uniquement des noms de personnes
+4 bis Distinction entre "structure pilote" et "direction ou service pilote" :
+   • "structure pilote" est l'organisme global englobant (ex. la collectivité, "Chambre d'agriculture", "DDT", "Communauté de communes X").
+   • "direction ou service pilote" est l'entité interne à cette structure (ex. "Service urbanisme", "Service économique", "Direction de la transition écologique").
+   • Exemple : si le document indique "Service urbanisme de la Collectivité X", alors "structure pilote" = "Collectivité X" et "direction ou service pilote" = "Service urbanisme".
+   • Si une seule des deux informations est présente, ne remplir que ce champ et laisser l'autre à "".
+5 Majuscules. Mettre une majuscule au premier mot de chaque champ texte. Conserver les majuscules des noms propres et des sigles. Supprimer les espaces superflus au début et à la fin
+6 Respect strict des libellés existants pour axes et sous axes lorsque fournis. En l’absence de libellé explicite, créer un libellé concis et fidèle au contenu
+7 Ordre de tri. Le tableau doit être trié selon la hiérarchie axe puis sous axe puis ordre des actions
+8 "titre" et "description" ne doivent jamais contenir les mêmes informations. La description apporte un complément au titre. Si le titre suffit à décrire l’action et qu’il n’y a rien de pertinent à ajouter, laisser "description" à ""
+9 Ne recopie pas les objectifs dans les descriptions. S'il n'y a pas de description et seulement des objectifs, les mettre dans le champ "objectifs"
+
+Exemples de bonne structure de plan
+Exemple de titres hiérarchiques attendus quand le texte les fournit
+Axe 1 : Une transition construite de manière transversale
+1.1 S’appuyer sur un pilotage et des coopérations stables
+1.1.1 Définir un portage politique fort
+1.2 Impliquer tous les publics dans les transitions
+Axe 2 : Vers un territoire rural affirmé aux multiples atouts en faveur du climat
+2.1 Soutenir une agriculture paysanne
+Axe 3 : Vers des équipements de qualité thermique et écologique
+3.1 Concevoir des bâtiments publics de qualité une normalité
+Axe 4 : Vers une mobilité vertueuse et réfléchie
+4.2 Mettre en œuvre les conditions favorables à des déplacements plus sobres
+
+Exemple de bonne extraction avec sous actions
+Texte source
+"Réduire l’autosolisme. Développer la pratique du covoiturage en s’appuyant tout d’abord sur des services existants mais aussi en mettant en place des infrastructures permettant de diversifier les offres
+• S’appuyer sur l’offre existante proposée par Blablacar Daily pour le covoiturage domicile travail
+• Déployer des lignes de covoiturage à haut niveau de service et les aménagements associés
+• Réfléchir à des solutions d’autopartage en boucle.
+Budget de 24000€ pour cette action en cours menée par Jean Dupoint du Service mobilité, piloté par la DDT, qui a pour but de rendre la pratique du covoiturage plus courante."
+
+Extraction attendue pour une action située dans le sous axe "4.2 Mettre en œuvre les conditions favorables à des déplacements plus sobres"
+{
+ "axe": "Axe 4  Vers une mobilité vertueuse et réfléchie",
+ "sous-axe": "4.2  Mettre en œuvre les conditions favorables à des déplacements plus sobres",
+ "titre": "4.2.1 Réduire l’autosolisme",
+ "description": "Développer la pratique du covoiturage en s’appuyant sur des services existants et en mettant en place des infrastructures qui diversifient l’offre",
+ "sous-actions": [
+   "S’appuyer sur l’offre existante proposée par Blablacar Daily pour le covoiturage domicile travail",
+   "Déployer des lignes de covoiturage à haut niveau de service et les aménagements associés",
+   "Réfléchir à des solutions d’autopartage en boucle"
+ ],
+ "objectifs": "Rendre la pratique du covoiturage plus courante",
+ "structure pilote": "DDT",
+ "direction ou service pilote": "Service mobilité",
+ "personne pilote": "Jean Dupoint",
+ "budget": "24000",
+ "statut": "En cours"
+}
+
+Précisions sur le nettoyage minimal
+• Retirer les mentions "Unnamed"
+• Corriger les espaces multiples
+• Conserver la ponctuation et les capitales des noms propres et sigles
+• Ne pas corriger l’orthographe sauf artefacts de conversion manifestes
+
+Consignes de saisie de champs
+1 "direction ou service pilote" et "personne pilote" doivent contenir uniquement le nom de l’entité ou de la personne sans préposition. Exemple "SNCF" et non "Avec la SNCF"
+2 **En cas de pluralité d’entités pour "direction ou service pilote" et/ou "personne pilote", les lister séparées par une virgule et un espace**
+3 "budget" ne doit contenir que des chiffres sans séparateur ou la valeur vide
+4 Si "statut" n’est pas exactement dans la liste autorisée, laisser ""
+
+Rappel de robustesse
+• Si le document fournit des numérotations et des titres, les réutiliser strictement
+• Si des titres existent sans numéro, générer des numéros cohérents et stables
+• Si la position d’une action parmi plusieurs sous axes demeure ambiguë, laisser vides les champs d’appartenance incertains plutôt que de forcer un rattachement
+
+Jusqu’à présent, le prompt décrivait les règles générales d’extraction. Si le champ suivant n’est pas vide, vous devez impérativement tenir compte des précisions spécifiques ci-dessous.
+Elles peuvent modifier ou affiner l’interprétation de la structure du plan. Elles prévalent sur les règles générales lorsqu’il existe une contradiction ou une ambiguïté.
+
+--- Consignes spécifiques IMPORTANTES (à appliquer strictement si présentes) qui prennent le dessus sur les règles générales ---
+{precisions}
+--- Fin des consignes spécifiques IMPORTANTES ---
+
+
+Voici le texte à analyser :
+{texte_pdf_a_analyser}
+`;


### PR DESCRIPTION
## Objectif

Première étape de la pipeline d'import IA : transformer le **texte** d'un plan d'actions en `ExtractedAction[]` structurées via Gemini. Premier vrai consommateur de `LlmService` (PR2) et producteur du modèle `ExtractedAction` (PR4).

## Contenu

**`prompts/extraction.prompt.ts`** — le prompt `custom_prompt` du proto porté **en littéral**, isolé comme **donnée** (territoire data engineer : éditable sans toucher au TS). Placeholders `{precisions}`, `{texte_pdf_a_analyser}`, `{date_du_jour}`. Dossier `prompts/` destiné à accueillir les 5 prompts de la pipeline.

**`generate-import-draft/extract-actions/`** — l'étape 1 (un step multi-fichiers = un dossier) :
- **`extract-actions.ts`** — `extractActions(llm, { text, precisions, disabledFields, currentDate, signal? })` → `Result<{ actions; tokens }, ExtractActionsError>`. Fonction (pas de service), prend `Pick<LlmService, 'generateStructured'>` ⇒ composable par `run-import-pipeline` (PR8), testable sans DI. Propage les `tokens`.
- **`extract-actions.prompt.ts`** — assembleur : interpolation + `buildIgnoreDirective` (bloc « INSTRUCTION PRIORITAIRE » préfixé pour les colonnes désactivées). Importe le texte depuis `prompts/extraction.prompt`. `{date_du_jour}` passé en argument (pas de `new Date()` interne).
- **`extract-actions.schema.ts`** — `responseSchema` au **boundary Gemini** : root tableau, clés **françaises** (`sous-axe`, `structure pilote`…), `sous-actions: string[]` (titres seuls), `budget` chaîne, `statut` enum incluant `""` (réutilise `statutEnumValues`).
- **`extraction-response-to-extracted-actions.ts`** — mapper **pur** raw→`ExtractedAction[]` : français→camelCase, titres→`ExtractedSousAction` (champs `null`, enrichis en PR7), `budget` chaîne→`number|null`, `""`→`null`, `confidence: null` (le scoring naît en PR6).

## Décisions

- **Structured output** (`generateStructured`/`responseJsonSchema`) plutôt que le JSON libre du proto : parsing garanti, pas de strip de fences. Le prompt benchmarké est porté verbatim (ses règles de contenu restent la valeur ; le schéma garantit le format).
- **Prompt = donnée** isolée dans `prompts/` (`.ts` exportant une string, pas `.txt` : évite le chargement d'assets fragile dans le backend bundlé).
- **Modèle imbriqué confirmé par le proto** : à l'étape 1 les sous-actions ne sont que des titres ; l'enrichissement (PR7) les remplit en place.
- **AC** : 0 action → `failure({ kind: 'no_actions_extracted' })` (jamais de table vide silencieuse). Pas de borne `maxActions` (absente du proto, retirée pour le moment).

## Vérifications

- ✅ typecheck + lint backend.
- ✅ 10 tests : mapper pur (clés/conversions budget/statut/sous-actions), construction du prompt (interpolation + directive d'ignorance), orchestration (happy path + tokens, 0 action, propagation d'erreur LLM via faux `LlmService`).

## Portée

Étape 1 uniquement. Pas encore câblé dans un worker (`run-import-pipeline`/`@Processor` arrivent en PR8/PR10). `GEMINI_MODEL` reste optionnel dans la config jusqu'à la mise en service (cible : `gemini-2.5-pro`).