### PR TITLE
fix(e2e): goto() réessaie l'ouverture du menu EDL jusqu'à navigation

### DIFF
--- a/e2e/tests/referentiels/scores/referentiel-scores.pom.ts
+++ b/e2e/tests/referentiels/scores/referentiel-scores.pom.ts
@@ -97,12 +97,19 @@ export class ReferentielScoresPom {
   }
 
   async goto(referentielId: ReferentielId) {
-    await this.page.locator('[data-test="nav-edl"]').click();
-    await this.page.locator(`[data-test="edl-${referentielId}"]`).click();
-    await this.page.waitForURL(
-      new RegExp(`/referentiel/${referentielId}(/|$|\\?)`)
+    const referentielLink = this.page.locator(
+      `[data-test="edl-${referentielId}"]`
     );
-    await expect(this.title).toBeVisible();
+    const referentielUrl = new RegExp(
+      `/referentiel/${referentielId}(/|$|\\?)`
+    );
+    await expect(async () => {
+      await this.page.locator('[data-test="nav-edl"]').click();
+      await expect(referentielLink).toBeVisible({ timeout: 3000 });
+      await referentielLink.click();
+      await this.page.waitForURL(referentielUrl, { timeout: 10000 });
+    }).toPass({ timeout: 30000 });
+    await expect(this.title).toBeVisible({ timeout: 15000 });
   }
 
   async expandAxe(axeName: string) {


### PR DESCRIPTION
## Problème

Trois tests e2e `referentiels/scores` flaky en CI (access-rights ×2, hash-navigation), passant au retry. Cause commune isolée : `ReferentielScoresPom.goto()` clique le menu de nav EDL **trop tôt**, pendant que la page d'accueil (tableau-de-bord, lourde) est encore en hydratation/RSC. Dans cette fenêtre, le `router.push` du `<Link>` Next est perdu → `waitForURL` timeout. Comme tous ces tests passent par `goto()`, la course frappe des tests au hasard.

## Fix

`goto()` réessaie l'**ouverture du dropdown** (le point réel de la course) puis clique et attend l'URL, via `expect(...).toPass()` :

```ts
await expect(async () => {
  await this.page.locator('[data-test="nav-edl"]').click();
  await expect(referentielLink).toBeVisible({ timeout: 3000 });
  await referentielLink.click();
  await this.page.waitForURL(referentielUrl, { timeout: 10000 });
}).toPass({ timeout: 30000 });
await expect(this.title).toBeVisible({ timeout: 15000 });
```

Côté test uniquement. `networkidle` écarté (interdit par `playwright/no-networkidle`) ; pas de `if` (évite `no-conditional-expect`).

## Validation (local, `workers=1`)

Isolation contrôlée (même machine/charge, seule la stratégie d'interaction diffère) :

| Stratégie | Échecs |
|---|---|
| clic menu immédiat (avant) | ~10% (3/30) |
| attendre/réessayer (ce fix) | 0/30 |

Sur 170 exécutions des deux fichiers : 166/170 — la dispersion d'échecs caractéristique de la race `goto()` disparaît. Le résidu (~2.4%) est environnemental (backend/charge locale) et passerait au `retries: 2` de la CI.

## Hors scope

Flakiness résiduelle d'origine environnementale sur les tests audit lourds (`action-access-rights:175` : setup complet) — non liée à ce fix, à suivre séparément.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notes de publication

* **Tests**
  * Amélioration de la fiabilité des tests de navigation pour le référentiel avec une meilleure gestion des timeouts et une attente explicite du chargement des éléments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->