### PR TITLE
feat(ai-plan-import): étape 2 scoring de confiance des actions

### DIFF
--- a/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/score-actions/apply-scores.spec.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/score-actions/apply-scores.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { ExtractedAction } from '../../models/extracted-action';
+import { applyScores } from './apply-scores';
+
+const anAction = (titre: string): ExtractedAction => ({
+  axe: 'Axe 1',
+  sousAxe: '1.1',
+  titre,
+  description: null,
+  objectifs: null,
+  structurePilote: null,
+  directionServicePilote: null,
+  personnePilote: null,
+  budget: null,
+  statut: null,
+  confidence: null,
+  sousActions: [],
+});
+
+describe('applyScores', () => {
+  it('attache la confiance par index avec amelioree à false', () => {
+    const actions = [anAction('A'), anAction('B')];
+
+    const result = applyScores(actions, [
+      { index: 0, score: 95, explication: '' },
+      { index: 1, score: 70, explication: 'omissions partielles' },
+    ]);
+
+    expect(result[0].confidence).toEqual({
+      score: 95,
+      explication: '',
+      amelioree: false,
+    });
+    expect(result[1].confidence).toEqual({
+      score: 70,
+      explication: 'omissions partielles',
+      amelioree: false,
+    });
+  });
+
+  it('laisse confidence à null pour une action non scorée', () => {
+    const actions = [anAction('A'), anAction('B')];
+
+    const result = applyScores(actions, [
+      { index: 0, score: 88, explication: 'reformulation' },
+    ]);
+
+    expect(result[1].confidence).toBeNull();
+  });
+
+  it('ignore un index hors bornes sans muter les autres actions', () => {
+    const actions = [anAction('A')];
+
+    const result = applyScores(actions, [
+      { index: 5, score: 50, explication: 'hors sujet' },
+    ]);
+
+    expect(result[0].confidence).toBeNull();
+  });
+});

--- a/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/score-actions/apply-scores.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/score-actions/apply-scores.ts
@@ -1,0 +1,23 @@
+import { ExtractedAction } from '../../models/extracted-action';
+import { ScoringEntry } from './score-actions.schema';
+
+export const applyScores = (
+  actions: ExtractedAction[],
+  scores: ScoringEntry[]
+): ExtractedAction[] => {
+  const scoreByIndex = new Map(scores.map((score) => [score.index, score]));
+  return actions.map((action, index) => {
+    const score = scoreByIndex.get(index);
+    if (!score) {
+      return action;
+    }
+    return {
+      ...action,
+      confidence: {
+        score: score.score,
+        explication: score.explication,
+        amelioree: false,
+      },
+    };
+  });
+};

--- a/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/score-actions/render-actions-text.spec.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/score-actions/render-actions-text.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ExtractedAction,
+  ExtractedSousAction,
+} from '../../models/extracted-action';
+import { renderActionsText } from './render-actions-text';
+
+const aSousAction = (titre: string): ExtractedSousAction => ({
+  titre,
+  description: null,
+  personnePilote: null,
+  statut: null,
+  dateDebut: null,
+  dateFin: null,
+});
+
+const anAction = (overrides: Partial<ExtractedAction>): ExtractedAction => ({
+  axe: 'Axe 1',
+  sousAxe: '1.1',
+  titre: 'Titre',
+  description: null,
+  objectifs: null,
+  structurePilote: null,
+  directionServicePilote: null,
+  personnePilote: null,
+  budget: null,
+  statut: null,
+  confidence: null,
+  sousActions: [],
+  ...overrides,
+});
+
+describe('renderActionsText', () => {
+  it('rend les en-têtes axe / sous-axe et les champs renseignés', () => {
+    const text = renderActionsText([
+      anAction({
+        axe: 'Axe 4 Mobilité',
+        sousAxe: '4.2 Covoiturage',
+        titre: '4.2.1 Réduire l autosolisme',
+        description: 'Développer le covoiturage',
+        personnePilote: 'Jean Dupont',
+        budget: 24000,
+        statut: 'En cours',
+        sousActions: [aSousAction('Déployer des lignes'), aSousAction('Autopartage')],
+      }),
+    ]);
+
+    expect(text).toContain('Axe 4 Mobilité :');
+    expect(text).toContain('Sous axe 4.2 Covoiturage :');
+    expect(text).toContain('| 0 | 4.2.1 Réduire l autosolisme');
+    expect(text).toContain('Développer le covoiturage');
+    expect(text).toContain('Déployer des lignes; Autopartage');
+    expect(text).toContain('Personne pilote Jean Dupont');
+    expect(text).toContain('Budget 24000');
+    expect(text).toContain('Statut En cours');
+  });
+
+  it('préserve l index d origine du tableau, pas la position triée', () => {
+    const text = renderActionsText([
+      anAction({ axe: 'Axe Z', titre: 'Action Z' }),
+      anAction({ axe: 'Axe A', titre: 'Action A' }),
+    ]);
+
+    expect(text.indexOf('Axe A :')).toBeLessThan(text.indexOf('Axe Z :'));
+    expect(text).toContain('| 1 | Action A');
+    expect(text).toContain('| 0 | Action Z');
+  });
+});

--- a/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/score-actions/render-actions-text.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/score-actions/render-actions-text.ts
@@ -1,0 +1,48 @@
+import { groupBy } from 'es-toolkit';
+import { ExtractedAction } from '../../models/extracted-action';
+
+type IndexedAction = { index: number; action: ExtractedAction };
+
+export const renderActionsText = (actions: ExtractedAction[]): string => {
+  const sorted = actions
+    .map((action, index) => ({ index, action }))
+    .sort(compareByHierarchy);
+
+  return Object.entries(groupBy(sorted, (entry) => entry.action.axe))
+    .map(([axe, axeEntries]) => renderAxe(axe, axeEntries))
+    .join('\n');
+};
+
+const renderAxe = (axe: string, entries: IndexedAction[]): string => {
+  const body = Object.entries(groupBy(entries, (entry) => entry.action.sousAxe))
+    .map(([sousAxe, sousAxeEntries]) =>
+      [`Sous axe ${sousAxe} :`, ...sousAxeEntries.map(renderActionLine)].join(
+        '\n'
+      )
+    )
+    .join('\n');
+  return `${axe} :\n${body}`;
+};
+
+const renderActionLine = ({ index, action }: IndexedAction): string => {
+  const champs = [
+    `| ${index} | ${action.titre}`,
+    action.description,
+    action.sousActions.map((sousAction) => sousAction.titre).join('; ') || null,
+    labelled('Objectifs', action.objectifs),
+    labelled('Structure pilote', action.structurePilote),
+    labelled('Direction ou service pilote', action.directionServicePilote),
+    labelled('Personne pilote', action.personnePilote),
+    labelled('Budget', action.budget === null ? null : String(action.budget)),
+    labelled('Statut', action.statut),
+  ].filter((champ): champ is string => champ !== null && champ.length > 0);
+  return `${champs.join('; ')}.`;
+};
+
+const labelled = (label: string, value: string | null): string | null =>
+  value && value.trim().length > 0 ? `${label} ${value.trim()}` : null;
+
+const compareByHierarchy = (a: IndexedAction, b: IndexedAction): number =>
+  a.action.axe.localeCompare(b.action.axe) ||
+  a.action.sousAxe.localeCompare(b.action.sousAxe) ||
+  a.index - b.index;

--- a/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/score-actions/score-actions.prompt.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/score-actions/score-actions.prompt.ts
@@ -1,0 +1,15 @@
+import { SCORING_PROMPT } from '../../prompts/scoring.prompt';
+
+export type ScoringPromptInput = {
+  renderedActions: string;
+  text: string;
+};
+
+export const buildScoringPrompt = ({
+  renderedActions,
+  text,
+}: ScoringPromptInput): string =>
+  SCORING_PROMPT.replaceAll('{reponse_ia}', renderedActions).replaceAll(
+    '{texte_pdf_a_analyser}',
+    text
+  );

--- a/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/score-actions/score-actions.schema.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/score-actions/score-actions.schema.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+const scoringEntrySchema = z.object({
+  index: z.number().int(),
+  score: z.number().int().min(0).max(100),
+  explication: z.string(),
+});
+
+export const scoringResponseSchema = z.array(scoringEntrySchema);
+
+export type ScoringEntry = z.output<typeof scoringEntrySchema>;

--- a/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/score-actions/score-actions.spec.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/score-actions/score-actions.spec.ts
@@ -1,0 +1,78 @@
+import { TokenUsage } from '@tet/backend/utils/llm/llm.repository';
+import { LlmService } from '@tet/backend/utils/llm/llm.service';
+import { failure, Result, success } from '@tet/backend/utils/result.type';
+import { describe, expect, it } from 'vitest';
+import { ExtractedAction } from '../../models/extracted-action';
+import { scoreActions } from './score-actions';
+import { ScoringEntry } from './score-actions.schema';
+
+const tokens: TokenUsage = {
+  promptTokens: 80,
+  candidatesTokens: 20,
+  thoughtsTokens: 5,
+  totalTokens: 105,
+};
+
+const anAction = (titre: string): ExtractedAction => ({
+  axe: 'Axe 1',
+  sousAxe: '1.1',
+  titre,
+  description: null,
+  objectifs: null,
+  structurePilote: null,
+  directionServicePilote: null,
+  personnePilote: null,
+  budget: null,
+  statut: null,
+  confidence: null,
+  sousActions: [],
+});
+
+const llmReturning = (
+  result: Result<{ data: ScoringEntry[]; tokens: TokenUsage }, never>
+): Pick<LlmService, 'generateStructured'> =>
+  ({
+    generateStructured: async () => result,
+  } as unknown as Pick<LlmService, 'generateStructured'>);
+
+describe('scoreActions', () => {
+  it('attache les scores aux actions et propage les tokens', async () => {
+    const llm = llmReturning(
+      success({
+        data: [{ index: 0, score: 92, explication: '' }],
+        tokens,
+      })
+    );
+
+    const result = await scoreActions(llm, {
+      actions: [anAction('A')],
+      text: 'texte source',
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.actions[0].confidence).toEqual({
+        score: 92,
+        explication: '',
+        amelioree: false,
+      });
+      expect(result.data.tokens).toEqual(tokens);
+    }
+  });
+
+  it('propage l erreur du LLM', async () => {
+    const llm = {
+      generateStructured: async () => failure({ kind: 'rate_limited' }),
+    } as unknown as Pick<LlmService, 'generateStructured'>;
+
+    const result = await scoreActions(llm, {
+      actions: [anAction('A')],
+      text: 'texte source',
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      error: { kind: 'rate_limited' },
+    });
+  });
+});

--- a/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/score-actions/score-actions.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/score-actions/score-actions.ts
@@ -1,0 +1,40 @@
+import { LlmError } from '@tet/backend/utils/llm/llm.errors';
+import { TokenUsage } from '@tet/backend/utils/llm/llm.repository';
+import { LlmService } from '@tet/backend/utils/llm/llm.service';
+import { Result, success } from '@tet/backend/utils/result.type';
+import { ExtractedAction } from '../../models/extracted-action';
+import { applyScores } from './apply-scores';
+import { buildScoringPrompt } from './score-actions.prompt';
+import { scoringResponseSchema } from './score-actions.schema';
+import { renderActionsText } from './render-actions-text';
+
+export type ScoreActionsInput = {
+  actions: ExtractedAction[];
+  text: string;
+  signal?: AbortSignal;
+};
+
+export type ScoreActionsResult = {
+  actions: ExtractedAction[];
+  tokens: TokenUsage;
+};
+
+export const scoreActions = async (
+  llm: Pick<LlmService, 'generateStructured'>,
+  { actions, text, signal }: ScoreActionsInput
+): Promise<Result<ScoreActionsResult, LlmError>> => {
+  const completion = await llm.generateStructured({
+    prompt: buildScoringPrompt({
+      renderedActions: renderActionsText(actions),
+      text,
+    }),
+    schema: scoringResponseSchema,
+    signal,
+  });
+  if (!completion.success) {
+    return completion;
+  }
+
+  const { data: scores, tokens } = completion.data;
+  return success({ actions: applyScores(actions, scores), tokens });
+};

--- a/apps/backend/src/plans/plans/ai-plan-import/prompts/scoring.prompt.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/prompts/scoring.prompt.ts
@@ -1,0 +1,75 @@
+export const SCORING_PROMPT = `
+Tu es un agent de validation d’extractions documentaires extrêmement strict.
+
+Contexte
+Le document source accessible plus bas est un plan d’action.
+Une première IA a déjà extrait une série d’actions.
+
+Structure attendue des actions
+Les actions sont repérables car elles commencent par un identifiant numérique du type :
+1.1.1 Titre de l’action; Description; Sous actions; Direction ou service pilote; Statut; Budget; Personne pilote; etc.
+Tout ce qui suit une action appartient à cette action jusqu’au prochain identifiant du même type ou la fin du texte.
+
+Objectif
+1 Tu dois identifier chaque action dans le texte fourni
+2 Pour chaque action, parcourir le document source.
+3 Retrouver le passage correspondant à cette action dans le plan d’action.
+4 Vérifier la fidélité de l’extraction pour cette action.
+5 Attribuer un score de confiance entre 0 et 100 pour chaque identifiant d’action.
+
+Critères de jugement
+Tu dois juger uniquement sur
+• omissions de texte significatives
+• reformulations textuelles (changement de vocabulaire ou de structure de phrase)
+Les ajouts de vocabulaire non présents dans le texte source sont considérés comme des reformulations.
+
+Règles de notation
+Tu dois attribuer pour chaque action un score entier entre 0 et 100, noté score, qui reflète la fidélité au texte source.
+
+Guides de notation
+• 100  texte quasi identique au texte source, aucune information manquante ni reformulation significative
+• 90 à 99  quelques reformulations légères, aucun changement de sens, pas d’omission d’information importante
+• 70 à 89  plusieurs reformulations ou petites omissions, mais le sens global reste correct
+• 30 à 69  omissions importantes et ou nombreuses reformulations qui altèrent le texte
+• 1 à 29  action très éloignée du contenu du document source
+• 0  action hors sujet ou ne correspondant pas au document source
+
+Changement de sens
+• Si tu détectes un changement de sens, même partiel, le score doit chuter fortement en dessous de 70.
+• Si le sens est largement incorrect ou trompeur, le score doit être inférieur ou égal à 30.
+
+Contraintes pour le score
+• Le score doit être un entier compris entre 0 et 100.
+• Si le calcul te conduirait en dehors de ces bornes, ramène systématiquement le score dans l’intervalle.
+• La notation doit suivre l’esprit du barème ci dessus et être stricte.
+
+Format de sortie
+Tu dois répondre uniquement avec un tableau JSON. Chaque élément est un objet contenant :
+• "index" : l’entier identifiant l’action, celui qui se trouve entre les | au début de la ligne (exemple : 12)
+• "score" : un entier entre 0 et 100 représentant le score de confiance
+• "explication" : une explication très courte (quelques mots maximum) uniquement si le score est strictement inférieur à 90 ; si le score est supérieur ou égal à 90, une chaîne vide ""
+
+Exemples d’explications acceptables :
+"omissions partielles"
+"reformulation légère"
+"altération mineure du sens"
+"omissions + reformulation"
+
+Exemple de format attendu :
+[
+  { "index": 1, "score": 95, "explication": "" },
+  { "index": 2, "score": 82, "explication": "omissions partielles" }
+]
+
+Contraintes supplémentaires
+• Ne pas recopier de longs extraits du document source.
+• Ne pas citer le texte du plan.
+• Ne pas ajouter de commentaires, d’explications ou de texte en dehors du JSON.
+• Chaque action du texte extrait doit apparaître exactement une fois dans le tableau, identifiée par son index.
+
+Voici le texte extrait par l'IA :
+{reponse_ia}
+
+Voici le texte original :
+{texte_pdf_a_analyser}
+`;


### PR DESCRIPTION
## Objectif

Étape 2 de la pipeline d'import IA : attribuer à chaque action extraite (PR5) un **score de confiance 0-100** mesurant la fidélité de l'extraction au texte source. Alimente l'enrichissement `confidence` du modèle `ExtractedAction` et conditionne la consolidation (étape 3, PR suivante : seules les actions `score < 90` seront retravaillées).

## Contenu

**`prompts/scoring.prompt.ts`** — `prompt_verif_1` du proto porté (barème 0-100, critères omissions/reformulations, règles de chute de score). **Sortie adaptée en tableau** (`[{ index, score, explication }]`) au lieu du dictionnaire indexé du proto, pour rester compatible avec le structured output (clés dynamiques mal supportées par `responseJsonSchema`).

**`generate-import-draft/score-actions/`**
- **`render-actions-text.ts`** — rendu **pur** `ExtractedAction[]` → texte compact indexé (port de `df_to_compact_text`), groupé axe / sous-axe, chaque action préfixée `| <index> | <titre>` (l'index = position d'origine dans le tableau, préservée malgré le tri d'affichage). Sera réutilisé par la revue qualitative (étape 5) → à promouvoir en partagé à ce moment.
- **`score-actions.schema.ts`** — responseSchema : `array<{ index: int, score: int 0-100, explication: string }>`.
- **`score-actions.prompt.ts`** — assembleur (interpole `{reponse_ia}` = actions rendues + `{texte_pdf_a_analyser}`).
- **`apply-scores.ts`** — mapper **pur** : applique les scores aux actions **par index**, `confidence = { score, explication, amelioree: false }` ; action non scorée → `confidence` reste `null`.
- **`score-actions.ts`** — `scoreActions(llm, { actions, text, signal? })` → `Result<{ actions; tokens }, LlmError>`. Fonction (pas de service), `Pick<LlmService, 'generateStructured'>`, propage les `tokens`.

## Décisions

- **Identification des actions par index dans `ExtractedAction[]`** (équivalent typé du `|n|` DataFrame du proto), échangé explicitement avec le LLM (champ `index`) plutôt que par alignement positionnel (robuste aux réponses partielles/réordonnées).
- **Dict → array** sur la sortie (cf. structured output acté en PR5 pour toute la pipeline).
- L'`amelioree` reste `false` ici ; il passera à `true` à la consolidation (étape 3).

## Vérifications

- ✅ typecheck + lint backend.
- ✅ 7 tests : `apply-scores` (par index, non-scoré → null, index hors bornes ignoré), `render-actions-text` (en-têtes axe/sous-axe + champs, préservation de l'index d'origine), `score-actions` (happy path + tokens, propagation d'erreur LLM).

## Portée

Étape 2 uniquement. La consolidation (étape 3, `consolidate-actions`, batches + concurrence bornée) suit dans une PR dédiée et consommera ces actions scorées. Pas encore câblé dans un worker (PR8/PR10).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notes de version

* **Nouvelles fonctionnalités**
  * Ajout de la capacité de notation IA pour l'importation de plans, permettant d'évaluer la fidélité des actions extraites et d'attribuer des scores de confiance.

* **Tests**
  * Suite de tests complète pour la validation des mécanismes de notation et de traitement des scores.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->