### PR TITLE
feat(plans): copie les preuves/documents lors de la duplication d'un plan

### DIFF
--- a/apps/backend/src/plans/fiches/add-annexe/add-annexe.repository.ts
+++ b/apps/backend/src/plans/fiches/add-annexe/add-annexe.repository.ts
@@ -3,16 +3,19 @@ import { annexeTable } from '@tet/backend/collectivites/documents/models/annexe.
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { failure, Result, success } from '@tet/backend/utils/result.type';
 import { CommonErrorEnum } from '@tet/backend/utils/trpc/common-errors';
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
 import { Annexe } from '@tet/domain/collectivites';
 import { getErrorMessage } from '@tet/domain/utils';
-import type { InferSelectModel } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
+import type { InferInsertModel, InferSelectModel } from 'drizzle-orm';
 import { AddAnnexeError } from './add-annexe.errors';
 import type {
   AddAnnexeWithFileInput,
   AddAnnexeWithLinkInput,
 } from './add-annexe.input';
 
-type AnnexeRow = InferSelectModel<typeof annexeTable>;
+export type AnnexeRow = InferSelectModel<typeof annexeTable>;
+export type AnnexeInsert = InferInsertModel<typeof annexeTable>;
 
 type AddAnnexeCommonParams = {
   collectiviteId: number;
@@ -95,6 +98,43 @@ export class AddAnnexeRepository {
         `Erreur lors de la création d'une annexe (lien) pour la fiche ${ficheId}: ${getErrorMessage(
           error
         )}`
+      );
+      return failure(
+        CommonErrorEnum.DATABASE_ERROR,
+        error instanceof Error ? error : new Error(getErrorMessage(error))
+      );
+    }
+  }
+
+  async loadRawAnnexesForDuplication(
+    ficheId: number,
+    collectiviteId: number,
+    tx: Transaction
+  ): Promise<AnnexeRow[]> {
+    return tx
+      .select()
+      .from(annexeTable)
+      .where(
+        and(
+          eq(annexeTable.ficheId, ficheId),
+          eq(annexeTable.collectiviteId, collectiviteId)
+        )
+      );
+  }
+
+  async insertAnnexes(
+    annexes: AnnexeInsert[],
+    tx: Transaction
+  ): Promise<Result<undefined, AddAnnexeError>> {
+    if (annexes.length === 0) {
+      return success(undefined);
+    }
+    try {
+      await tx.insert(annexeTable).values(annexes);
+      return success(undefined);
+    } catch (error) {
+      this.logger.error(
+        `Erreur lors de la copie des annexes: ${getErrorMessage(error)}`
       );
       return failure(
         CommonErrorEnum.DATABASE_ERROR,

--- a/apps/backend/src/plans/fiches/add-annexe/add-annexe.service.ts
+++ b/apps/backend/src/plans/fiches/add-annexe/add-annexe.service.ts
@@ -1,12 +1,17 @@
 import { Injectable } from '@nestjs/common';
 import FicheActionPermissionsService from '@tet/backend/plans/fiches/fiche-action-permissions.service';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
 import { failure, Result } from '@tet/backend/utils/result.type';
 import { CommonErrorEnum } from '@tet/backend/utils/trpc/common-errors';
 import { Annexe } from '@tet/domain/collectivites';
 import { AddAnnexeError } from './add-annexe.errors';
 import { AddAnnexeInput } from './add-annexe.input';
-import { AddAnnexeRepository } from './add-annexe.repository';
+import {
+  AddAnnexeRepository,
+  AnnexeInsert,
+  AnnexeRow,
+} from './add-annexe.repository';
 
 @Injectable()
 export class AddAnnexeService {
@@ -55,5 +60,24 @@ export class AddAnnexeService {
           commentaire,
           modifiedBy: user.id,
         });
+  }
+
+  loadRawAnnexesForDuplication(
+    ficheId: number,
+    collectiviteId: number,
+    tx: Transaction
+  ): Promise<AnnexeRow[]> {
+    return this.addAnnexeRepository.loadRawAnnexesForDuplication(
+      ficheId,
+      collectiviteId,
+      tx
+    );
+  }
+
+  insertAnnexes(
+    annexes: AnnexeInsert[],
+    tx: Transaction
+  ): Promise<Result<undefined, AddAnnexeError>> {
+    return this.addAnnexeRepository.insertAnnexes(annexes, tx);
   }
 }

--- a/apps/backend/src/plans/plans/duplicate-plan/duplicate-plan.router.e2e-spec.ts
+++ b/apps/backend/src/plans/plans/duplicate-plan/duplicate-plan.router.e2e-spec.ts
@@ -1,10 +1,12 @@
 import { INestApplication } from '@nestjs/common';
 import { addTestCollectiviteAndUser } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { uploadCreateTestDocument } from '@tet/backend/collectivites/documents/documents.test-fixture';
 import { createIndicateurPerso } from '@tet/backend/indicateurs/definitions/definitions.test-fixture';
 import {
   getAuthUserFromUserCredentials,
   getTestApp,
   getTestDatabase,
+  signInWith,
 } from '@tet/backend/test';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { addTestUser } from '@tet/backend/users/users/users.test-fixture';
@@ -12,6 +14,7 @@ import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
 import { Collectivite, TagEnum, TagType } from '@tet/domain/collectivites';
 import { CollectiviteRole } from '@tet/domain/users';
+import request from 'supertest';
 import { onTestFinished } from 'vitest';
 
 describe('Dupliquer un plan', () => {
@@ -22,6 +25,7 @@ describe('Dupliquer un plan', () => {
   let collectivite: Collectivite;
   let editorUser: AuthenticatedUser;
   let noAccessUser: AuthenticatedUser;
+  let fichierId: number;
 
   beforeAll(async () => {
     app = await getTestApp();
@@ -40,6 +44,22 @@ describe('Dupliquer un plan', () => {
 
     const noAccessUserResult = await addTestUser(db);
     noAccessUser = getAuthUserFromUserCredentials(noAccessUserResult.user);
+
+    const signIn = await signInWith({
+      email: testCollectiviteAndUserResult.user.email,
+      password: testCollectiviteAndUserResult.user.password,
+    });
+    const editorAuthToken = signIn.data.session?.access_token ?? '';
+    if (!editorAuthToken) {
+      throw new Error('token éditeur manquant');
+    }
+    const doc = await uploadCreateTestDocument({
+      collectiviteId: collectivite.id,
+      testAgent: request(app.getHttpServer()),
+      token: editorAuthToken,
+      fileName: 'preuve-dupliquee.pdf',
+    });
+    fichierId = doc.id;
   });
 
   afterAll(async () => {
@@ -60,6 +80,58 @@ describe('Dupliquer un plan', () => {
       }
     });
   };
+
+  test('duplique les preuves (annexe fichier et annexe lien) de chaque fiche', async () => {
+    const caller = buildEditorCaller();
+
+    const sourcePlan = await caller.plans.plans.create({
+      nom: 'Plan avec preuves',
+      collectiviteId: collectivite.id,
+    });
+    const sourceFiche = await caller.plans.fiches.create({
+      fiche: { collectiviteId: collectivite.id, titre: 'Action avec preuves' },
+      ficheFields: { axes: [{ id: sourcePlan.id }] },
+    });
+
+    await caller.plans.fiches.addAnnexe({
+      ficheId: sourceFiche.id,
+      commentaire: 'Preuve fichier',
+      fichierId,
+    });
+    await caller.plans.fiches.addAnnexe({
+      ficheId: sourceFiche.id,
+      commentaire: 'Preuve lien',
+      lien: { url: 'https://example.org/preuve', titre: 'Lien preuve' },
+    });
+
+    const duplicated = await caller.plans.plans.duplicate({
+      planId: sourcePlan.id,
+    });
+    cleanupPlans([sourcePlan.id, duplicated.planId]);
+
+    const { data: newFiches } = await caller.plans.fiches.listFiches({
+      collectiviteId: collectivite.id,
+      filters: { planActionIds: [duplicated.planId] },
+      queryOptions: { limit: 'all' },
+    });
+    expect(newFiches.length).toBe(1);
+    const newFicheId = newFiches[0].id;
+    expect(newFicheId).not.toBe(sourceFiche.id);
+
+    const annexes = await caller.plans.fiches.ficheAnnexes({
+      collectiviteId: collectivite.id,
+      ficheIds: [newFicheId],
+    });
+    expect(annexes.length).toBe(2);
+    expect(annexes.every((annexe) => annexe.ficheId === newFicheId)).toBe(true);
+
+    const fichierAnnexe = annexes.find((annexe) => annexe.fichier !== null);
+    const lienAnnexe = annexes.find((annexe) => annexe.lien !== null);
+    expect(fichierAnnexe?.fichier?.filename).toBe('preuve-dupliquee.pdf');
+    expect(fichierAnnexe?.commentaire).toBe('Preuve fichier');
+    expect(lienAnnexe?.lien?.url).toBe('https://example.org/preuve');
+    expect(lienAnnexe?.commentaire).toBe('Preuve lien');
+  });
 
   test('duplique un plan avec son arborescence, ses fiches et sous-actions', async () => {
     const caller = buildEditorCaller();

--- a/apps/backend/src/plans/plans/duplicate-plan/duplicate-plan.service.ts
+++ b/apps/backend/src/plans/plans/duplicate-plan/duplicate-plan.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { AddAnnexeService } from '@tet/backend/plans/fiches/add-annexe/add-annexe.service';
 import { CreateFicheService } from '@tet/backend/plans/fiches/create-fiche/create-fiche.service';
 import { FicheCreateAuthorization } from '@tet/backend/plans/fiches/create-fiche/fiche-create-authorization';
 import { FicheActionBudgetService } from '@tet/backend/plans/fiches/fiche-action-budget/fiche-action-budget.service';
@@ -21,6 +22,7 @@ import {
   AxeIdRemapping,
   mapSourceFicheToDuplicate,
 } from './duplicated-fiche.mapper';
+import { mapSourceFicheAnnexes } from './duplicated-fiche-annexes.mapper';
 import { mapSourceFicheBudgets } from './duplicated-fiche-budgets.mapper';
 import { buildDuplicatedPlanName } from './duplicated-plan-name';
 
@@ -64,7 +66,8 @@ export class DuplicatePlanService {
     private readonly upsertPlanService: UpsertPlanService,
     private readonly upsertAxeService: UpsertAxeService,
     private readonly createFicheService: CreateFicheService,
-    private readonly ficheBudgetService: FicheActionBudgetService
+    private readonly ficheBudgetService: FicheActionBudgetService,
+    private readonly addAnnexeService: AddAnnexeService
   ) {}
 
   async duplicate(
@@ -330,7 +333,44 @@ export class DuplicatePlanService {
     const budgetsResult = await this.copyBudgets(source, newFicheId, tx);
     if (!budgetsResult.success) return budgetsResult;
 
+    const annexesResult = await this.copyAnnexes({
+      source,
+      newFicheId,
+      modifiedBy: authorization.user.id,
+      tx,
+    });
+    if (!annexesResult.success) return annexesResult;
+
     return success(newFicheId);
+  }
+
+  private async copyAnnexes({
+    source,
+    newFicheId,
+    modifiedBy,
+    tx,
+  }: {
+    source: FicheWithRelations;
+    newFicheId: number;
+    modifiedBy: string;
+    tx: Transaction;
+  }): Promise<Result<undefined, DuplicatePlanError>> {
+    const sourceAnnexes =
+      await this.addAnnexeService.loadRawAnnexesForDuplication(
+        source.id,
+        source.collectiviteId,
+        tx
+      );
+    const annexes = mapSourceFicheAnnexes(sourceAnnexes, {
+      newFicheId,
+      collectiviteId: source.collectiviteId,
+      modifiedBy,
+    });
+    const result = await this.addAnnexeService.insertAnnexes(annexes, tx);
+    if (!result.success) {
+      return failure(DuplicatePlanErrorEnum.DUPLICATE_PLAN_ERROR);
+    }
+    return success(undefined);
   }
 
   private async copyBudgets(

--- a/apps/backend/src/plans/plans/duplicate-plan/duplicated-fiche-annexes.mapper.spec.ts
+++ b/apps/backend/src/plans/plans/duplicate-plan/duplicated-fiche-annexes.mapper.spec.ts
@@ -1,0 +1,85 @@
+import type { AnnexeRow } from '@tet/backend/plans/fiches/add-annexe/add-annexe.repository';
+import { describe, expect, test } from 'vitest';
+import { mapSourceFicheAnnexes } from './duplicated-fiche-annexes.mapper';
+
+const sourceAnnexe = (overrides: Partial<AnnexeRow>): AnnexeRow => ({
+  id: 1,
+  collectiviteId: 10,
+  ficheId: 100,
+  fichierId: null,
+  url: null,
+  titre: null,
+  commentaire: null,
+  lien: null,
+  modifiedAt: '2026-01-01T00:00:00.000Z',
+  modifiedBy: 'source-user',
+  ...overrides,
+});
+
+describe('mapSourceFicheAnnexes', () => {
+  test('recopie une annexe-fichier et une annexe-lien vers la nouvelle fiche', () => {
+    const annexes = [
+      sourceAnnexe({ id: 1, fichierId: 42, commentaire: 'preuve A' }),
+      sourceAnnexe({
+        id: 2,
+        url: 'https://example.org',
+        titre: 'Doc externe',
+        commentaire: 'lien B',
+      }),
+    ];
+
+    const result = mapSourceFicheAnnexes(annexes, {
+      newFicheId: 200,
+      collectiviteId: 10,
+      modifiedBy: 'duplicating-user',
+    });
+
+    expect(result).toEqual([
+      {
+        collectiviteId: 10,
+        ficheId: 200,
+        fichierId: 42,
+        url: null,
+        titre: null,
+        commentaire: 'preuve A',
+        modifiedBy: 'duplicating-user',
+      },
+      {
+        collectiviteId: 10,
+        ficheId: 200,
+        fichierId: null,
+        url: 'https://example.org',
+        titre: 'Doc externe',
+        commentaire: 'lien B',
+        modifiedBy: 'duplicating-user',
+      },
+    ]);
+  });
+
+  test("n'inclut ni l'id, ni le modifiedAt, ni le lien généré de la source", () => {
+    const result = mapSourceFicheAnnexes(
+      [
+        sourceAnnexe({
+          id: 7,
+          modifiedAt: '2020-01-01T00:00:00.000Z',
+          lien: { titre: 'genere', url: 'https://example.org' },
+        }),
+      ],
+      { newFicheId: 200, collectiviteId: 10, modifiedBy: 'duplicating-user' }
+    );
+
+    expect(result[0]).not.toHaveProperty('id');
+    expect(result[0]).not.toHaveProperty('modifiedAt');
+    expect(result[0]).not.toHaveProperty('lien');
+  });
+
+  test('retourne un tableau vide pour une fiche sans annexe', () => {
+    expect(
+      mapSourceFicheAnnexes([], {
+        newFicheId: 200,
+        collectiviteId: 10,
+        modifiedBy: 'duplicating-user',
+      })
+    ).toEqual([]);
+  });
+});

--- a/apps/backend/src/plans/plans/duplicate-plan/duplicated-fiche-annexes.mapper.ts
+++ b/apps/backend/src/plans/plans/duplicate-plan/duplicated-fiche-annexes.mapper.ts
@@ -1,0 +1,23 @@
+import type {
+  AnnexeInsert,
+  AnnexeRow,
+} from '@tet/backend/plans/fiches/add-annexe/add-annexe.repository';
+
+export function mapSourceFicheAnnexes(
+  annexes: AnnexeRow[],
+  {
+    newFicheId,
+    collectiviteId,
+    modifiedBy,
+  }: { newFicheId: number; collectiviteId: number; modifiedBy: string }
+): AnnexeInsert[] {
+  return annexes.map((annexe) => ({
+    collectiviteId,
+    ficheId: newFicheId,
+    fichierId: annexe.fichierId,
+    url: annexe.url,
+    titre: annexe.titre,
+    commentaire: annexe.commentaire,
+    modifiedBy,
+  }));
+}


### PR DESCRIPTION
## Résumé
PR2 de la stack `duplicate-plan` (PR1 cœur + budgets déjà mergés). Recopie les **annexes** (preuves/documents) de chaque fiche lors de la duplication d'un plan, **par référence partagée** : nouvelles lignes `annexe` pointant le même `fichierId` (ou même url/titre), commentaire recopié, sans copie binaire dans le bucket.

## Décisions
- **Référence partagée + clone fidèle** : pas de duplication de fichier ni de `bibliotheque_fichier`. La FK `annexe.fiche_id` cascade, donc supprimer la fiche source ne touche pas le clone.
- **Colonne `lien` générée** (à partir de `url`/`titre`) : on recopie `url`+`titre`, la DB régénère `lien`.
- **Confidentiel préservé** : le flag vit sur `bibliotheque_fichier` partagé ; le contrôle d'accès réel est au download. Copier le pointeur ne crée aucun nouveau chemin d'accès.
- Chargement brut **re-scopé par collectivité**, insertion bulk **pré-autorisée** dans la transaction de duplication (mapper pur + `insertAnnexes` tx-aware, sur le modèle des budgets).

## Tests
- Unitaire : `duplicated-fiche-annexes.mapper.spec.ts` (recopie url/titre/fichierId/commentaire, omission de `id`/`modifiedAt`/`lien`, liste vide).
- E2E : duplication d'une fiche avec **annexe-fichier ET annexe-lien** → les 2 annexes recréées sur la nouvelle fiche, même fichier/url, commentaires recopiés. 27 tests verts sur la suite duplicate-plan.

## Post-Deploy Monitoring & Validation
- **À surveiller** : logs backend `AddAnnexeRepository` (`Erreur lors de la copie des annexes`) ; erreurs `DUPLICATE_PLAN_ERROR` sur `plans.plans.duplicate`.
- **Signal sain** : duplication d'un plan → les fiches dupliquées exposent les mêmes preuves (liste annexes), aucun nouveau fichier créé dans le bucket.
- **Signal d'échec / rollback** : montée d'erreurs de duplication ; la transaction unique garantit le rollback complet (aucune fiche/annexe partielle). Mitigation : revert de la PR.
- **Fenêtre / owner** : 48h post-merge, équipe plans.