### PR TITLE
feat(ai-plan-import): étape 4 enrichissement des sous-actions

### DIFF
--- a/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/enrich-sous-actions/apply-enrichments.spec.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/enrich-sous-actions/apply-enrichments.spec.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createUnenrichedSousAction,
+  ExtractedAction,
+} from '../../models/extracted-action';
+import { applyEnrichments } from './apply-enrichments';
+import { EnrichmentEntry } from './enrich-sous-actions.schema';
+import { indexSousActions } from './index-sous-actions';
+
+const anAction = (
+  titre: string,
+  sousActionTitres: string[]
+): ExtractedAction => ({
+  axe: 'Axe 1',
+  sousAxe: '1.1',
+  titre,
+  description: null,
+  objectifs: null,
+  structurePilote: null,
+  directionServicePilote: null,
+  personnePilote: null,
+  budget: null,
+  statut: null,
+  confidence: null,
+  sousActions: sousActionTitres.map(createUnenrichedSousAction),
+});
+
+const emptyEntry = (index: number): EnrichmentEntry => ({
+  index,
+  description: '',
+  personne_pilote: '',
+  statut: '',
+  date_debut: '',
+  date_fin: '',
+});
+
+describe('applyEnrichments', () => {
+  it('enrichit en place la sous-action correspondant à son index global', () => {
+    const actions = [
+      anAction('Action A', ['a0', 'a1']),
+      anAction('Action B', ['b0']),
+    ];
+    const indexed = indexSousActions(actions);
+    const entries: EnrichmentEntry[] = [
+      {
+        index: 2,
+        description: 'Pilotée par le service mobilité',
+        personne_pilote: 'Jean Dupont',
+        statut: 'En cours',
+        date_debut: '01/02/2025',
+        date_fin: '15/03/2025',
+      },
+    ];
+
+    const [actionA, actionB] = applyEnrichments(actions, indexed, entries);
+
+    expect(actionA.sousActions).toEqual([
+      createUnenrichedSousAction('a0'),
+      createUnenrichedSousAction('a1'),
+    ]);
+    expect(actionB.sousActions[0]).toEqual({
+      titre: 'b0',
+      description: 'Pilotée par le service mobilité',
+      personnePilote: 'Jean Dupont',
+      statut: 'En cours',
+      dateDebut: '2025-02-01',
+      dateFin: '2025-03-15',
+    });
+  });
+
+  it('laisse à null les champs vides et les dates non parsables', () => {
+    const actions = [anAction('Action A', ['a0'])];
+    const indexed = indexSousActions(actions);
+    const entries: EnrichmentEntry[] = [
+      { ...emptyEntry(0), date_debut: '31/02/2025', date_fin: 'pas une date' },
+    ];
+
+    const [action] = applyEnrichments(actions, indexed, entries);
+
+    expect(action.sousActions[0]).toEqual(createUnenrichedSousAction('a0'));
+  });
+
+  it('ne touche pas aux sous-actions sans entrée correspondante', () => {
+    const actions = [anAction('Action A', ['a0', 'a1'])];
+    const indexed = indexSousActions(actions);
+
+    const [action] = applyEnrichments(actions, indexed, [
+      { ...emptyEntry(1), description: 'Seule a1 enrichie' },
+    ]);
+
+    expect(action.sousActions[0]).toEqual(createUnenrichedSousAction('a0'));
+    expect(action.sousActions[1].description).toBe('Seule a1 enrichie');
+  });
+});

--- a/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/enrich-sous-actions/apply-enrichments.spec.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/enrich-sous-actions/apply-enrichments.spec.ts
@@ -7,7 +7,7 @@ import { applyEnrichments } from './apply-enrichments';
 import { EnrichmentEntry } from './enrich-sous-actions.schema';
 import { indexSousActions } from './index-sous-actions';
 
-const anAction = (
+const toAction = (
   titre: string,
   sousActionTitres: string[]
 ): ExtractedAction => ({
@@ -37,8 +37,8 @@ const emptyEntry = (index: number): EnrichmentEntry => ({
 describe('applyEnrichments', () => {
   it('enrichit en place la sous-action correspondant à son index global', () => {
     const actions = [
-      anAction('Action A', ['a0', 'a1']),
-      anAction('Action B', ['b0']),
+      toAction('Action A', ['a0', 'a1']),
+      toAction('Action B', ['b0']),
     ];
     const indexed = indexSousActions(actions);
     const entries: EnrichmentEntry[] = [
@@ -69,7 +69,7 @@ describe('applyEnrichments', () => {
   });
 
   it('laisse à null les champs vides et les dates non parsables', () => {
-    const actions = [anAction('Action A', ['a0'])];
+    const actions = [toAction('Action A', ['a0'])];
     const indexed = indexSousActions(actions);
     const entries: EnrichmentEntry[] = [
       { ...emptyEntry(0), date_debut: '31/02/2025', date_fin: 'pas une date' },
@@ -81,7 +81,7 @@ describe('applyEnrichments', () => {
   });
 
   it('ne touche pas aux sous-actions sans entrée correspondante', () => {
-    const actions = [anAction('Action A', ['a0', 'a1'])];
+    const actions = [toAction('Action A', ['a0', 'a1'])];
     const indexed = indexSousActions(actions);
 
     const [action] = applyEnrichments(actions, indexed, [

--- a/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/enrich-sous-actions/apply-enrichments.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/enrich-sous-actions/apply-enrichments.ts
@@ -1,0 +1,81 @@
+import { Statut } from '@tet/domain/plans';
+import {
+  ExtractedAction,
+  ExtractedSousAction,
+} from '../../models/extracted-action';
+import { EnrichmentEntry } from './enrich-sous-actions.schema';
+import { IndexedSousAction } from './index-sous-actions';
+
+export const applyEnrichments = (
+  actions: ExtractedAction[],
+  indexed: IndexedSousAction[],
+  entries: EnrichmentEntry[]
+): ExtractedAction[] => {
+  const entryByIndex = new Map(entries.map((entry) => [entry.index, entry]));
+  const enrichmentByPosition = new Map(
+    indexed
+      .map((item) => ({ item, entry: entryByIndex.get(item.index) }))
+      .filter(isEnriched)
+      .map(({ item, entry }) => [
+        positionKey(item.actionIndex, item.sousActionIndex),
+        entry,
+      ])
+  );
+
+  return actions.map((action, actionIndex) => ({
+    ...action,
+    sousActions: action.sousActions.map((sousAction, sousActionIndex) => {
+      const entry = enrichmentByPosition.get(
+        positionKey(actionIndex, sousActionIndex)
+      );
+      return entry ? enrichSousAction(sousAction, entry) : sousAction;
+    }),
+  }));
+};
+
+type EnrichedPosition = { item: IndexedSousAction; entry: EnrichmentEntry };
+
+const isEnriched = (pair: {
+  item: IndexedSousAction;
+  entry: EnrichmentEntry | undefined;
+}): pair is EnrichedPosition => pair.entry !== undefined;
+
+const positionKey = (actionIndex: number, sousActionIndex: number): string =>
+  `${actionIndex}:${sousActionIndex}`;
+
+const enrichSousAction = (
+  sousAction: ExtractedSousAction,
+  entry: EnrichmentEntry
+): ExtractedSousAction => ({
+  ...sousAction,
+  description: toNullable(entry.description),
+  personnePilote: toNullable(entry.personne_pilote),
+  statut: toStatut(entry.statut),
+  dateDebut: frenchDateToIso(entry.date_debut),
+  dateFin: frenchDateToIso(entry.date_fin),
+});
+
+const toNullable = (value: string): string | null => {
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const toStatut = (value: '' | Statut): Statut | null =>
+  value === '' ? null : value;
+
+const FRENCH_DATE = /^(\d{2})\/(\d{2})\/(\d{4})$/;
+
+const frenchDateToIso = (value: string): string | null => {
+  const match = value.trim().match(FRENCH_DATE);
+  if (!match) {
+    return null;
+  }
+  const [, day, month, year] = match;
+  const iso = `${year}-${month}-${day}`;
+  return isValidIsoDate(iso) ? iso : null;
+};
+
+const isValidIsoDate = (iso: string): boolean => {
+  const date = new Date(iso);
+  return !Number.isNaN(date.getTime()) && date.toISOString().startsWith(iso);
+};

--- a/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/enrich-sous-actions/enrich-sous-actions.prompt.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/enrich-sous-actions/enrich-sous-actions.prompt.ts
@@ -1,0 +1,19 @@
+import { ENRICHMENT_PROMPT } from '../../prompts/enrichment.prompt';
+import { buildIgnoreDirective } from '../../prompts/ignore-directive';
+
+export type EnrichmentPromptInput = {
+  renderedSousActions: string;
+  text: string;
+  disabledFields: string[];
+};
+
+export const buildEnrichmentPrompt = ({
+  renderedSousActions,
+  text,
+  disabledFields,
+}: EnrichmentPromptInput): string =>
+  buildIgnoreDirective(disabledFields) +
+  ENRICHMENT_PROMPT.replaceAll(
+    '{sous_actions_list}',
+    renderedSousActions
+  ).replaceAll('{texte_pdf_a_analyser}', text);

--- a/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/enrich-sous-actions/enrich-sous-actions.schema.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/enrich-sous-actions/enrich-sous-actions.schema.ts
@@ -1,0 +1,17 @@
+import { statutEnumValues } from '@tet/domain/plans';
+import { z } from 'zod';
+
+const enrichmentStatutValues = ['', ...statutEnumValues] as const;
+
+const enrichmentEntrySchema = z.object({
+  index: z.number().int().min(0),
+  description: z.string(),
+  personne_pilote: z.string(),
+  statut: z.enum(enrichmentStatutValues),
+  date_debut: z.string(),
+  date_fin: z.string(),
+});
+
+export const enrichmentResponseSchema = z.array(enrichmentEntrySchema);
+
+export type EnrichmentEntry = z.output<typeof enrichmentEntrySchema>;

--- a/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/enrich-sous-actions/enrich-sous-actions.spec.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/enrich-sous-actions/enrich-sous-actions.spec.ts
@@ -1,0 +1,157 @@
+import { TokenUsage } from '@tet/backend/utils/llm/llm.repository';
+import { LlmService } from '@tet/backend/utils/llm/llm.service';
+import { failure, success } from '@tet/backend/utils/result.type';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createUnenrichedSousAction,
+  ExtractedAction,
+} from '../../models/extracted-action';
+import {
+  ENRICHMENT_BATCH_SIZE,
+  enrichSousActions,
+} from './enrich-sous-actions';
+
+const tokens: TokenUsage = {
+  promptTokens: 10,
+  candidatesTokens: 4,
+  thoughtsTokens: 1,
+  totalTokens: 15,
+};
+
+const anAction = (
+  titre: string,
+  sousActionTitres: string[]
+): ExtractedAction => ({
+  axe: 'Axe 1',
+  sousAxe: '1.1',
+  titre,
+  description: null,
+  objectifs: null,
+  structurePilote: null,
+  directionServicePilote: null,
+  personnePilote: null,
+  budget: null,
+  statut: null,
+  confidence: null,
+  sousActions: sousActionTitres.map(createUnenrichedSousAction),
+});
+
+const echoingLlm = (): Pick<LlmService, 'generateStructured'> =>
+  ({
+    generateStructured: vi.fn(async ({ prompt }: { prompt: string }) => {
+      const indices = [
+        ...prompt.matchAll(/(\d+) \| \[Action parente/g),
+      ].map((match) => Number(match[1]));
+      return success({
+        data: indices.map((index) => ({
+          index,
+          description: `enrichie ${index}`,
+          personne_pilote: '',
+          statut: '',
+          date_debut: '',
+          date_fin: '',
+        })),
+        tokens,
+      });
+    }),
+  } as unknown as Pick<LlmService, 'generateStructured'>);
+
+describe('enrichSousActions', () => {
+  it('ne fait aucun appel LLM quand aucune action n\'a de sous-action', async () => {
+    const llm = echoingLlm();
+
+    const result = await enrichSousActions(llm, {
+      actions: [anAction('Action A', []), anAction('Action B', [])],
+      text: 'texte',
+      disabledFields: [],
+    });
+
+    expect(llm.generateStructured).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ success: true });
+    if (result.success) {
+      expect(result.data.tokens.totalTokens).toBe(0);
+    }
+  });
+
+  it('enrichit les sous-actions sur plusieurs lots et somme les tokens', async () => {
+    const count = ENRICHMENT_BATCH_SIZE + 2;
+    const sousActionTitres = Array.from(
+      { length: count },
+      (_, index) => `sa ${index}`
+    );
+    const llm = echoingLlm();
+
+    const result = await enrichSousActions(llm, {
+      actions: [anAction('Action A', sousActionTitres)],
+      text: 'texte',
+      disabledFields: [],
+    });
+
+    expect(llm.generateStructured).toHaveBeenCalledTimes(2);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      result.data.actions[0].sousActions.forEach((sousAction, index) => {
+        expect(sousAction.description).toBe(`enrichie ${index}`);
+      });
+      expect(result.data.tokens.totalTokens).toBe(tokens.totalTokens * 2);
+    }
+  });
+
+  it("ignore une entrée dont l'index n'appartient pas au lot demandé", async () => {
+    const llm = {
+      generateStructured: async () =>
+        success({
+          data: [
+            {
+              index: 0,
+              description: 'enrichie 0',
+              personne_pilote: '',
+              statut: '',
+              date_debut: '',
+              date_fin: '',
+            },
+            {
+              index: 99,
+              description: 'CORROMPU',
+              personne_pilote: '',
+              statut: '',
+              date_debut: '',
+              date_fin: '',
+            },
+          ],
+          tokens,
+        }),
+    } as unknown as Pick<LlmService, 'generateStructured'>;
+
+    const result = await enrichSousActions(llm, {
+      actions: [anAction('Action A', ['a0', 'a1'])],
+      text: 'texte',
+      disabledFields: [],
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.actions[0].sousActions[0].description).toBe(
+        'enrichie 0'
+      );
+      expect(result.data.actions[0].sousActions[1].description).toBeNull();
+    }
+  });
+
+  it('échoue si un lot échoue', async () => {
+    const llm = {
+      generateStructured: async () => failure({ kind: 'rate_limited' }),
+    } as unknown as Pick<LlmService, 'generateStructured'>;
+
+    const result = await enrichSousActions(llm, {
+      actions: [anAction('Action A', ['a0'])],
+      text: 'texte',
+      disabledFields: [],
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      error: { kind: 'rate_limited' },
+    });
+  });
+});

--- a/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/enrich-sous-actions/enrich-sous-actions.spec.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/enrich-sous-actions/enrich-sous-actions.spec.ts
@@ -18,7 +18,7 @@ const tokens: TokenUsage = {
   totalTokens: 15,
 };
 
-const anAction = (
+const toAction = (
   titre: string,
   sousActionTitres: string[]
 ): ExtractedAction => ({
@@ -61,7 +61,7 @@ describe('enrichSousActions', () => {
     const llm = echoingLlm();
 
     const result = await enrichSousActions(llm, {
-      actions: [anAction('Action A', []), anAction('Action B', [])],
+      actions: [toAction('Action A', []), toAction('Action B', [])],
       text: 'texte',
       disabledFields: [],
     });
@@ -82,7 +82,7 @@ describe('enrichSousActions', () => {
     const llm = echoingLlm();
 
     const result = await enrichSousActions(llm, {
-      actions: [anAction('Action A', sousActionTitres)],
+      actions: [toAction('Action A', sousActionTitres)],
       text: 'texte',
       disabledFields: [],
     });
@@ -124,7 +124,7 @@ describe('enrichSousActions', () => {
     } as unknown as Pick<LlmService, 'generateStructured'>;
 
     const result = await enrichSousActions(llm, {
-      actions: [anAction('Action A', ['a0', 'a1'])],
+      actions: [toAction('Action A', ['a0', 'a1'])],
       text: 'texte',
       disabledFields: [],
     });
@@ -144,7 +144,7 @@ describe('enrichSousActions', () => {
     } as unknown as Pick<LlmService, 'generateStructured'>;
 
     const result = await enrichSousActions(llm, {
-      actions: [anAction('Action A', ['a0'])],
+      actions: [toAction('Action A', ['a0'])],
       text: 'texte',
       disabledFields: [],
     });

--- a/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/enrich-sous-actions/enrich-sous-actions.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/enrich-sous-actions/enrich-sous-actions.ts
@@ -1,56 +1,57 @@
 import { LlmError } from '@tet/backend/utils/llm/llm.errors';
 import { TokenUsage } from '@tet/backend/utils/llm/llm.repository';
 import { LlmService } from '@tet/backend/utils/llm/llm.service';
-import { mapWithConcurrency } from '@tet/backend/utils/map-with-concurrency';
 import {
   emptyTokenUsage,
   sumTokenUsage,
 } from '@tet/backend/utils/llm/token-usage';
+import { mapWithConcurrency } from '@tet/backend/utils/map-with-concurrency';
 import { combineResults, Result, success } from '@tet/backend/utils/result.type';
 import { chunk } from 'es-toolkit';
 import { ExtractedAction } from '../../models/extracted-action';
-import { buildConsolidationPrompt } from './consolidate-actions.prompt';
+import { applyEnrichments } from './apply-enrichments';
+import { buildEnrichmentPrompt } from './enrich-sous-actions.prompt';
 import {
-  ConsolidationEntry,
-  consolidationResponseSchema,
-} from './consolidate-actions.schema';
+  EnrichmentEntry,
+  enrichmentResponseSchema,
+} from './enrich-sous-actions.schema';
 import {
-  IndexedAction,
-  selectLowScoreActions,
-} from './select-low-score-actions';
-import { updateActionsWithConsolidatedEntries } from './update-actions-with-consolidated-entries';
+  IndexedSousAction,
+  indexSousActions,
+  renderSousActionsToEnrich,
+} from './index-sous-actions';
 
-export const CONSOLIDATION_BATCH_SIZE = 5;
-export const CONSOLIDATION_CONCURRENCY = 5;
+export const ENRICHMENT_BATCH_SIZE = 30;
+export const ENRICHMENT_CONCURRENCY = 5;
 
-export type ConsolidateActionsInput = {
+export type EnrichSousActionsInput = {
   actions: ExtractedAction[];
   text: string;
   disabledFields: string[];
   signal?: AbortSignal;
 };
 
-export type ConsolidateActionsResult = {
+export type EnrichSousActionsResult = {
   actions: ExtractedAction[];
   tokens: TokenUsage;
 };
 
-type BatchOutcome = { entries: ConsolidationEntry[]; tokens: TokenUsage };
+type BatchOutcome = { entries: EnrichmentEntry[]; tokens: TokenUsage };
 
-export const consolidateActions = async (
+export const enrichSousActions = async (
   llm: Pick<LlmService, 'generateStructured'>,
-  { actions, text, disabledFields, signal }: ConsolidateActionsInput
-): Promise<Result<ConsolidateActionsResult, LlmError>> => {
-  const lowScoreActions = selectLowScoreActions(actions);
-  if (lowScoreActions.length === 0) {
+  { actions, text, disabledFields, signal }: EnrichSousActionsInput
+): Promise<Result<EnrichSousActionsResult, LlmError>> => {
+  const indexed = indexSousActions(actions);
+  if (indexed.length === 0) {
     return success({ actions, tokens: emptyTokenUsage() });
   }
 
-  const batches = chunk(lowScoreActions, CONSOLIDATION_BATCH_SIZE);
+  const batches = chunk(indexed, ENRICHMENT_BATCH_SIZE);
   const outcomes = await mapWithConcurrency(
     batches,
-    CONSOLIDATION_CONCURRENCY,
-    (batch) => consolidateBatch(llm, { batch, text, disabledFields, signal })
+    ENRICHMENT_CONCURRENCY,
+    (batch) => enrichBatch(llm, { batch, text, disabledFields, signal })
   );
 
   const combined = combineResults(outcomes);
@@ -60,15 +61,16 @@ export const consolidateActions = async (
 
   const succeeded = combined.data;
   return success({
-    actions: updateActionsWithConsolidatedEntries(
+    actions: applyEnrichments(
       actions,
+      indexed,
       succeeded.flatMap((outcome) => outcome.entries)
     ),
     tokens: sumTokenUsage(succeeded.map((outcome) => outcome.tokens)),
   });
 };
 
-const consolidateBatch = async (
+const enrichBatch = async (
   llm: Pick<LlmService, 'generateStructured'>,
   {
     batch,
@@ -76,19 +78,19 @@ const consolidateBatch = async (
     disabledFields,
     signal,
   }: {
-    batch: IndexedAction[];
+    batch: IndexedSousAction[];
     text: string;
     disabledFields: string[];
     signal?: AbortSignal;
   }
 ): Promise<Result<BatchOutcome, LlmError>> => {
   const completion = await llm.generateStructured({
-    prompt: buildConsolidationPrompt({
-      renderedActionsToImprove: renderActionsToImprove(batch),
+    prompt: buildEnrichmentPrompt({
+      renderedSousActions: renderSousActionsToEnrich(batch),
       text,
       disabledFields,
     }),
-    schema: consolidationResponseSchema,
+    schema: enrichmentResponseSchema,
     signal,
   });
   if (!completion.success) {
@@ -102,6 +104,3 @@ const consolidateBatch = async (
     tokens: completion.data.tokens,
   });
 };
-
-const renderActionsToImprove = (batch: IndexedAction[]): string =>
-  batch.map(({ index, action }) => `|${index}| ${action.titre}`).join('\n');

--- a/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/enrich-sous-actions/index-sous-actions.spec.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/enrich-sous-actions/index-sous-actions.spec.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createUnenrichedSousAction,
+  ExtractedAction,
+} from '../../models/extracted-action';
+import {
+  indexSousActions,
+  renderSousActionsToEnrich,
+} from './index-sous-actions';
+
+const anAction = (
+  titre: string,
+  sousActionTitres: string[]
+): ExtractedAction => ({
+  axe: 'Axe 1',
+  sousAxe: '1.1',
+  titre,
+  description: null,
+  objectifs: null,
+  structurePilote: null,
+  directionServicePilote: null,
+  personnePilote: null,
+  budget: null,
+  statut: null,
+  confidence: null,
+  sousActions: sousActionTitres.map(createUnenrichedSousAction),
+});
+
+describe('indexSousActions', () => {
+  it('aplatit les sous-actions avec un index global continu et le titre parent', () => {
+    const indexed = indexSousActions([
+      anAction('Action A', ['a0', 'a1']),
+      anAction('Action B', []),
+      anAction('Action C', ['c0']),
+    ]);
+
+    expect(indexed).toEqual([
+      {
+        index: 0,
+        actionIndex: 0,
+        sousActionIndex: 0,
+        parentTitre: 'Action A',
+        sousAction: createUnenrichedSousAction('a0'),
+      },
+      {
+        index: 1,
+        actionIndex: 0,
+        sousActionIndex: 1,
+        parentTitre: 'Action A',
+        sousAction: createUnenrichedSousAction('a1'),
+      },
+      {
+        index: 2,
+        actionIndex: 2,
+        sousActionIndex: 0,
+        parentTitre: 'Action C',
+        sousAction: createUnenrichedSousAction('c0'),
+      },
+    ]);
+  });
+});
+
+describe('renderSousActionsToEnrich', () => {
+  it('rend une ligne par sous-action avec son index et son action parente', () => {
+    const indexed = indexSousActions([anAction('Action A', ['a0', 'a1'])]);
+
+    expect(renderSousActionsToEnrich(indexed)).toBe(
+      '0 | [Action parente : Action A] a0\n' +
+        '1 | [Action parente : Action A] a1'
+    );
+  });
+});

--- a/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/enrich-sous-actions/index-sous-actions.spec.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/enrich-sous-actions/index-sous-actions.spec.ts
@@ -8,7 +8,7 @@ import {
   renderSousActionsToEnrich,
 } from './index-sous-actions';
 
-const anAction = (
+const toAction = (
   titre: string,
   sousActionTitres: string[]
 ): ExtractedAction => ({
@@ -29,9 +29,9 @@ const anAction = (
 describe('indexSousActions', () => {
   it('aplatit les sous-actions avec un index global continu et le titre parent', () => {
     const indexed = indexSousActions([
-      anAction('Action A', ['a0', 'a1']),
-      anAction('Action B', []),
-      anAction('Action C', ['c0']),
+      toAction('Action A', ['a0', 'a1']),
+      toAction('Action B', []),
+      toAction('Action C', ['c0']),
     ]);
 
     expect(indexed).toEqual([
@@ -62,7 +62,7 @@ describe('indexSousActions', () => {
 
 describe('renderSousActionsToEnrich', () => {
   it('rend une ligne par sous-action avec son index et son action parente', () => {
-    const indexed = indexSousActions([anAction('Action A', ['a0', 'a1'])]);
+    const indexed = indexSousActions([toAction('Action A', ['a0', 'a1'])]);
 
     expect(renderSousActionsToEnrich(indexed)).toBe(
       '0 | [Action parente : Action A] a0\n' +

--- a/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/enrich-sous-actions/index-sous-actions.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/enrich-sous-actions/index-sous-actions.ts
@@ -1,0 +1,34 @@
+import {
+  ExtractedAction,
+  ExtractedSousAction,
+} from '../../models/extracted-action';
+
+export type IndexedSousAction = {
+  index: number;
+  actionIndex: number;
+  sousActionIndex: number;
+  parentTitre: string;
+  sousAction: ExtractedSousAction;
+};
+
+export const indexSousActions = (
+  actions: ExtractedAction[]
+): IndexedSousAction[] =>
+  actions
+    .flatMap((action, actionIndex) =>
+      action.sousActions.map((sousAction, sousActionIndex) => ({
+        actionIndex,
+        sousActionIndex,
+        parentTitre: action.titre,
+        sousAction,
+      }))
+    )
+    .map((entry, index) => ({ index, ...entry }));
+
+export const renderSousActionsToEnrich = (batch: IndexedSousAction[]): string =>
+  batch
+    .map(
+      ({ index, parentTitre, sousAction }) =>
+        `${index} | [Action parente : ${parentTitre}] ${sousAction.titre}`
+    )
+    .join('\n');

--- a/apps/backend/src/plans/plans/ai-plan-import/prompts/enrichment.prompt.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/prompts/enrichment.prompt.ts
@@ -1,0 +1,81 @@
+export const ENRICHMENT_PROMPT = `
+Vous êtes un agent d'enrichissement documentaire spécialisé dans les plans d'actions de transition écologique des collectivités, y compris les PCAET.
+
+Contexte
+On vous fournit :
+1) Une liste numérotée de sous-actions, chacune rattachée à son action parente (indiquée entre crochets pour le contexte).
+2) Le texte source complet du plan d'actions (issu d'un PDF parfois bruité).
+
+Objectif
+Pour chaque sous-action de la liste ci-dessous, parcourir le texte source et extraire les informations suivantes si elles sont explicitement présentes dans le document :
+- "description" : une description synthétique et fidèle au texte source de la sous-action
+- "personne_pilote" : le nom de la personne pilote ou référente de la sous-action.
+- "statut" : le statut de la sous-action
+- "date_debut" : la date de début
+- "date_fin" : la date de fin ou échéance
+
+Valeurs autorisées pour "statut"
+["À venir", "À discuter", "En cours", "Réalisé", "En retard", "En pause", "Bloqué"]
+Si le statut trouvé ne correspond à aucune de ces valeurs exactes, laisser "".
+
+Règles strictes
+1 Aucun champ n'est obligatoire. Si l'information n'est pas explicitement présente dans le texte source, laisser une chaîne vide "".
+2 Ne jamais inventer d'informations, de dates ou de statuts.
+3 Les dates doivent être au format JJ/MM/AAAA. Si seule l'année est disponible, utiliser 01/01/AAAA. Si seuls le mois et l'année sont disponibles, utiliser 01/MM/AAAA.
+4 La description doit être fidèle au texte source. Ne pas réécrire le sens, uniquement nettoyer les artefacts de conversion.
+5 Le titre de l'action parente entre crochets sert uniquement de contexte pour localiser la sous-action dans le document. Ne pas le reproduire dans la description.
+6 Si une sous-action est trop générique ou introuvable dans le texte source, laisser tous les champs à "".
+7 Une personne pilote doit forcément être une personne physique et NE PEUT PAS être une direction ou service
+8 La description de la sous-action ne doit pas répéter le titre de la sous-action. Elle doit apporter des informations complémentaires. Si le titre est suffisant, laisser "description" à "".
+
+Liste des sous-actions à enrichir
+Chaque ligne est préfixée de l'index de la sous-action.
+
+-------- DEBUT LISTE --------
+{sous_actions_list}
+--------- FIN LISTE ---------
+
+Texte source du plan d'actions
+
+--------- TEXTE SOURCE ---------
+{texte_pdf_a_analyser}
+--------- FIN TEXTE SOURCE ---------
+
+Format de sortie
+La sortie doit être un tableau JSON. Chaque élément est un objet contenant exactement ces champs :
+
+"index"
+"description"
+"personne_pilote"
+"statut"
+"date_debut"
+"date_fin"
+
+"index" est l'entier identifiant la sous-action, repris tel quel depuis la liste en entrée.
+
+Sortie attendue
+1 Répondre uniquement avec un tableau JSON valide
+2 Ne rien ajouter avant ni après le JSON
+3 Ne pas utiliser de balises Markdown
+4 Le tableau ne doit contenir QUE les sous-actions demandées qui ont pu être retrouvées dans le texte source
+
+Exemple de format attendu
+[
+  {
+    "index": 0,
+    "description": "Description trouvée dans le texte",
+    "personne_pilote": "Jean Dupont",
+    "statut": "En cours",
+    "date_debut": "01/01/2025",
+    "date_fin": "31/12/2025"
+  },
+  {
+    "index": 1,
+    "description": "",
+    "personne_pilote": "",
+    "statut": "",
+    "date_debut": "",
+    "date_fin": ""
+  }
+]
+`;

--- a/apps/backend/src/utils/llm/token-usage.ts
+++ b/apps/backend/src/utils/llm/token-usage.ts
@@ -1,0 +1,19 @@
+import { TokenUsage } from './llm.repository';
+
+export const emptyTokenUsage = (): TokenUsage => ({
+  promptTokens: 0,
+  candidatesTokens: 0,
+  thoughtsTokens: 0,
+  totalTokens: 0,
+});
+
+export const sumTokenUsage = (usages: TokenUsage[]): TokenUsage =>
+  usages.reduce(
+    (total, usage) => ({
+      promptTokens: total.promptTokens + usage.promptTokens,
+      candidatesTokens: total.candidatesTokens + usage.candidatesTokens,
+      thoughtsTokens: total.thoughtsTokens + usage.thoughtsTokens,
+      totalTokens: total.totalTokens + usage.totalTokens,
+    }),
+    emptyTokenUsage()
+  );


### PR DESCRIPTION
## Contexte

PR7 de la stack [Import Tool IA](https://github.com/incubateur-ademe/territoires-en-transitions) (`PR5 → PR6 → PR7 → PR8`). Porte l'**étape 4** du prototype (`prompt_enrich_sous_actions`) dans le pipeline backend, sur le modèle structurel des étapes 2/3.

## Contenu

Nouvelle brique `generate-import-draft/enrich-sous-actions/` :
- `enrich-sous-actions.ts` — `enrichSousActions(llm, { actions, text, disabledFields, signal })` : aplatit les sous-actions en index global, enrichit par **lots de 30** bornés via `mapWithConcurrency` (concurrence 5). Un lot qui échoue ⇒ `failure` ; no-op (aucun appel LLM) si aucune sous-action.
- `index-sous-actions.ts` — `indexSousActions` (flatMap pur, index global continu + réf action parente) + `renderSousActionsToEnrich`.
- `apply-enrichments.ts` — mapper pur, enrichit **en place** par position `(actionIndex, sousActionIndex)` : `"" → null`, statut `'' → null`, conversion `JJ/MM/AAAA → ISO` avec validation (rejette les dates impossibles).
- `enrich-sous-actions.schema.ts` — boundary Gemini en **tableau** (structured output), statut contraint à l'enum domaine + `''`.
- `enrich-sous-actions.prompt.ts` + `prompts/enrichment.prompt.ts` — prompt porté (sortie dict → tableau), ignore-directive préfixée.

Le saut d'étape selon le toggle `withSousActions` reste à la charge de l'orchestrateur (PR8) : si les actions n'ont pas de sous-actions, l'étape est un no-op.

## Promotion (2ᵉ consommateur)

`emptyTokenUsage`/`sumTokenUsage`, jusque-là locaux à `consolidate-actions.ts`, sont promus vers `utils/llm/token-usage.ts` et réutilisés par la consolidation et l'enrichissement — même pattern que la promotion de `mapWithConcurrency` en PR6b.

## Tests

3 specs (indexation/rendu, mapper d'enrichissement, fonction d'étape). Suite `ai-plan-import` complète : 48/48. Typecheck + lint OK.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ajout d'une fonctionnalité d'enrichissement automatique des sous-actions via traitement IA, avec traitement par lots et gestion concurrente.

* **Refactor**
  * Extraction d'utilitaires partagés pour la gestion des jetons au sein du système.

* **Tests**
  * Couverture de tests complète pour l'enrichissement et les fonctions associées.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->