### PR TITLE
feat(plans): copie les notes de chaque fiche lors de la duplication d'un plan

### DIFF
--- a/apps/backend/src/plans/plans/duplicate-plan/duplicate-plan.router.e2e-spec.ts
+++ b/apps/backend/src/plans/plans/duplicate-plan/duplicate-plan.router.e2e-spec.ts
@@ -81,6 +81,52 @@ describe('Dupliquer un plan', () => {
     });
   };
 
+  test('duplique les notes de chaque fiche', async () => {
+    const caller = buildEditorCaller();
+
+    const sourcePlan = await caller.plans.plans.create({
+      nom: 'Plan avec notes',
+      collectiviteId: collectivite.id,
+    });
+    const sourceFiche = await caller.plans.fiches.create({
+      fiche: { collectiviteId: collectivite.id, titre: 'Action avec notes' },
+      ficheFields: { axes: [{ id: sourcePlan.id }] },
+    });
+
+    await caller.plans.fiches.update({
+      ficheId: sourceFiche.id,
+      ficheFields: {
+        notes: [
+          { dateNote: '2024-01-15', note: 'Première note' },
+          { dateNote: '2024-06-20', note: 'Seconde note' },
+        ],
+      },
+    });
+
+    const duplicated = await caller.plans.plans.duplicate({
+      planId: sourcePlan.id,
+      nom: 'Plan dupliqué',
+    });
+    cleanupPlans([sourcePlan.id, duplicated.planId]);
+
+    const { data: newFiches } = await caller.plans.fiches.listFiches({
+      collectiviteId: collectivite.id,
+      filters: { planActionIds: [duplicated.planId] },
+      queryOptions: { limit: 'all' },
+    });
+    expect(newFiches.length).toBe(1);
+    const newFiche = newFiches[0];
+    expect(newFiche.id).not.toBe(sourceFiche.id);
+
+    expect(newFiche.notes).toHaveLength(2);
+    expect(newFiche.notes).toContainEqual(
+      expect.objectContaining({ dateNote: '2024-01-15', note: 'Première note' })
+    );
+    expect(newFiche.notes).toContainEqual(
+      expect.objectContaining({ dateNote: '2024-06-20', note: 'Seconde note' })
+    );
+  });
+
   test('duplique les preuves (annexe fichier et annexe lien) de chaque fiche', async () => {
     const caller = buildEditorCaller();
 

--- a/apps/backend/src/plans/plans/duplicate-plan/duplicated-fiche.mapper.spec.ts
+++ b/apps/backend/src/plans/plans/duplicate-plan/duplicated-fiche.mapper.spec.ts
@@ -244,7 +244,7 @@ describe('mapSourceFicheToDuplicate', () => {
     expect(ficheFields.actionsImpact).toEqual([{ id: 77 }]);
   });
 
-  it("n'expose ni fiches liées, ni notes, ni partage", () => {
+  it("n'expose ni fiches liées ni partage", () => {
     const source = createSourceFiche();
 
     const { ficheFields } = mapSourceFicheToDuplicate({
@@ -255,7 +255,43 @@ describe('mapSourceFicheToDuplicate', () => {
     });
 
     expect('fichesLiees' in ficheFields).toBe(false);
-    expect('notes' in ficheFields).toBe(false);
     expect('sharedWithCollectivites' in ficheFields).toBe(false);
+  });
+
+  it('recopie les notes (date et contenu) sans leur id', () => {
+    const source = createSourceFiche({
+      notes: [
+        {
+          id: 1,
+          dateNote: '2024-01-15',
+          note: 'Note A',
+          createdAt: '2024-01-15T00:00:00.000Z',
+          modifiedAt: '2024-01-15T00:00:00.000Z',
+          createdBy: null,
+          modifiedBy: null,
+        },
+        {
+          id: 2,
+          dateNote: '2024-06-20',
+          note: 'Note B',
+          createdAt: '2024-06-20T00:00:00.000Z',
+          modifiedAt: '2024-06-20T00:00:00.000Z',
+          createdBy: null,
+          modifiedBy: null,
+        },
+      ],
+    });
+
+    const { ficheFields } = mapSourceFicheToDuplicate({
+      source,
+      collectiviteId: 99,
+      parentId: null,
+      axeIdRemapping: emptyRemapping,
+    });
+
+    expect(ficheFields.notes).toEqual([
+      { dateNote: '2024-01-15', note: 'Note A' },
+      { dateNote: '2024-06-20', note: 'Note B' },
+    ]);
   });
 });

--- a/apps/backend/src/plans/plans/duplicate-plan/duplicated-fiche.mapper.ts
+++ b/apps/backend/src/plans/plans/duplicate-plan/duplicated-fiche.mapper.ts
@@ -21,6 +21,7 @@ type DuplicableFicheFields = Pick<
   | 'financeurs'
   | 'tempsDeMiseEnOeuvre'
   | 'actionsImpact'
+  | 'notes'
 >;
 
 const remapAxes = (
@@ -106,6 +107,10 @@ export function mapSourceFicheToDuplicate({
       source.actionImpactId !== null && source.actionImpactId !== undefined
         ? [{ id: source.actionImpactId }]
         : undefined,
+    notes: source.notes?.map((note) => ({
+      dateNote: note.dateNote,
+      note: note.note,
+    })),
   };
 
   return { fiche, ficheFields };


### PR DESCRIPTION
## Résumé
Étend la duplication d'un plan pour recopier les **notes de suivi** de chaque fiche (date + contenu), par référence, dans la transaction de duplication.

- Nouveau `FicheActionNoteRepository.insertNotes` (bulk, tx-aware, `Result`+cause) + `FicheActionNoteService` mince, exposés via `FichesModule`.
- Mapper pur `mapSourceFicheNotes` (réinitialise l'id, conserve `dateNote`+`note`).
- `copyNotes` ajouté à `duplicateFiche`, après budgets et annexes.

## Détail
- `createdBy`/`modifiedBy` des notes copiées sont attribués au **duplicateur** (`authorization.user.id`) : la transaction de duplication n'a pas de contexte `auth.uid()` et la colonne `modified_by` est `NOT NULL` — il faut donc les fournir explicitement (comme pour les annexes).
- Pré-autorisé : pas de re-check par note (la duplication a vérifié les droits en amont, la fiche cible vient d'être créée dans la même transaction). Rollback atomique si échec.

## Tests
28 tests verts sur la suite duplicate-plan : mapper unitaire (3) + e2e **« duplique les notes de chaque fiche »** (fiche avec 2 notes via `update-fiche` → duplication → notes recréées sur la nouvelle fiche). Fixtures via service (`caller.plans.fiches.update`), pas de `db.insert`.

## Post-Deploy Monitoring & Validation
- **À surveiller** : logs `FicheActionNoteRepository` (« Erreur lors de la copie des notes »), erreurs `DUPLICATE_PLAN_ERROR`.
- **Signal sain** : duplication d'un plan → les fiches dupliquées portent les mêmes notes (date + contenu), attribuées au duplicateur.
- Indépendant du frontend ; aucun impact tant que `duplicate` est appelé normalement.