### PR TITLE
refactor(plans): extrait FicheDuplicationService de DuplicatePlanService

### DIFF
--- a/apps/backend/src/plans/fiches/fiche-duplication/fiche-duplication.service.ts
+++ b/apps/backend/src/plans/fiches/fiche-duplication/fiche-duplication.service.ts
@@ -1,0 +1,114 @@
+import { Injectable } from '@nestjs/common';
+import { AddAnnexeService } from '@tet/backend/plans/fiches/add-annexe/add-annexe.service';
+import { CreateFicheService } from '@tet/backend/plans/fiches/create-fiche/create-fiche.service';
+import { FicheCreateAuthorization } from '@tet/backend/plans/fiches/create-fiche/fiche-create-authorization';
+import { FicheActionBudgetService } from '@tet/backend/plans/fiches/fiche-action-budget/fiche-action-budget.service';
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { failure, Result, success } from '@tet/backend/utils/result.type';
+import {
+  AxeIdRemapping,
+  mapSourceFicheToDuplicate,
+} from '@tet/backend/plans/plans/duplicate-plan/duplicated-fiche.mapper';
+import { mapSourceFicheAnnexes } from '@tet/backend/plans/plans/duplicate-plan/duplicated-fiche-annexes.mapper';
+import { mapSourceFicheBudgets } from '@tet/backend/plans/plans/duplicate-plan/duplicated-fiche-budgets.mapper';
+import { FicheWithRelations } from '@tet/domain/plans';
+
+export type FicheDuplicationError = 'SERVER_ERROR';
+
+@Injectable()
+export class FicheDuplicationService {
+  constructor(
+    private readonly createFicheService: CreateFicheService,
+    private readonly ficheBudgetService: FicheActionBudgetService,
+    private readonly addAnnexeService: AddAnnexeService
+  ) {}
+
+  async duplicateFiche({
+    source,
+    collectiviteId,
+    parentId,
+    authorization,
+    axeIdRemapping,
+    tx,
+  }: {
+    source: FicheWithRelations;
+    collectiviteId: number;
+    parentId: number | null;
+    authorization: FicheCreateAuthorization;
+    axeIdRemapping: AxeIdRemapping;
+    tx: Transaction;
+  }): Promise<Result<number, FicheDuplicationError>> {
+    const { fiche, ficheFields } = mapSourceFicheToDuplicate({
+      source,
+      collectiviteId,
+      parentId,
+      axeIdRemapping,
+    });
+
+    const created = await this.createFicheService.createFicheWithAuthorization({
+      authorization,
+      fiche,
+      ficheFields,
+      tx,
+    });
+    if (!created.success) {
+      return failure('SERVER_ERROR');
+    }
+    const newFicheId = created.data.id;
+
+    const budgetsResult = await this.copyBudgets(source, newFicheId, tx);
+    if (!budgetsResult.success) return budgetsResult;
+
+    const annexesResult = await this.copyAnnexes({
+      source,
+      newFicheId,
+      modifiedBy: authorization.user.id,
+      tx,
+    });
+    if (!annexesResult.success) return annexesResult;
+
+    return success(newFicheId);
+  }
+
+  private async copyBudgets(
+    source: FicheWithRelations,
+    newFicheId: number,
+    tx: Transaction
+  ): Promise<Result<undefined, FicheDuplicationError>> {
+    const budgets = mapSourceFicheBudgets(source, newFicheId);
+    const result = await this.ficheBudgetService.insertBudgets(budgets, tx);
+    if (!result.success) {
+      return failure('SERVER_ERROR');
+    }
+    return success(undefined);
+  }
+
+  private async copyAnnexes({
+    source,
+    newFicheId,
+    modifiedBy,
+    tx,
+  }: {
+    source: FicheWithRelations;
+    newFicheId: number;
+    modifiedBy: string;
+    tx: Transaction;
+  }): Promise<Result<undefined, FicheDuplicationError>> {
+    const sourceAnnexes =
+      await this.addAnnexeService.loadRawAnnexesForDuplication(
+        source.id,
+        source.collectiviteId,
+        tx
+      );
+    const annexes = mapSourceFicheAnnexes(sourceAnnexes, {
+      newFicheId,
+      collectiviteId: source.collectiviteId,
+      modifiedBy,
+    });
+    const result = await this.addAnnexeService.insertAnnexes(annexes, tx);
+    if (!result.success) {
+      return failure('SERVER_ERROR');
+    }
+    return success(undefined);
+  }
+}

--- a/apps/backend/src/plans/fiches/fiches.module.ts
+++ b/apps/backend/src/plans/fiches/fiches.module.ts
@@ -39,6 +39,7 @@ import FicheActionPermissionsService from './fiche-action-permissions.service';
 import { FicheAnnexesRepository } from './fiche-annexes/fiche-annexes.repository';
 import { FicheAnnexesRouter } from './fiche-annexes/fiche-annexes.router';
 import { FicheAnnexesService } from './fiche-annexes/fiche-annexes.service';
+import { FicheDuplicationService } from './fiche-duplication/fiche-duplication.service';
 import { ListFichesBelongingToPlansRepository } from './list-fiches/list-fiches-belonging-to-plans.repository';
 import { ListFichesBudgetRepository } from './list-fiches/list-fiches-budget.repository';
 import { NotifyPiloteService } from './notify-pilote/notify-pilote.service';
@@ -92,6 +93,7 @@ import UpdateFicheService from './update-fiche/update-fiche.service';
     FicheAnnexesRepository,
     FicheAnnexesService,
     FicheAnnexesRouter,
+    FicheDuplicationService,
     FichesRouter,
     NotifyPiloteService,
     FicheExportPayloadService,
@@ -122,6 +124,7 @@ import UpdateFicheService from './update-fiche/update-fiche.service';
     AddAnnexeRouter,
     FicheAnnexesService,
     FicheAnnexesRouter,
+    FicheDuplicationService,
 
     UpdateFicheService,
     UpdateFicheRouter,

--- a/apps/backend/src/plans/plans/duplicate-plan/duplicate-plan.service.ts
+++ b/apps/backend/src/plans/plans/duplicate-plan/duplicate-plan.service.ts
@@ -1,8 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { AddAnnexeService } from '@tet/backend/plans/fiches/add-annexe/add-annexe.service';
-import { CreateFicheService } from '@tet/backend/plans/fiches/create-fiche/create-fiche.service';
 import { FicheCreateAuthorization } from '@tet/backend/plans/fiches/create-fiche/fiche-create-authorization';
-import { FicheActionBudgetService } from '@tet/backend/plans/fiches/fiche-action-budget/fiche-action-budget.service';
+import { FicheDuplicationService } from '@tet/backend/plans/fiches/fiche-duplication/fiche-duplication.service';
 import ListFichesService from '@tet/backend/plans/fiches/list-fiches/list-fiches.service';
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
@@ -18,12 +16,7 @@ import { UpsertPlanErrorEnum } from '../upsert-plan/upsert-plan.errors';
 import { UpsertPlanService } from '../upsert-plan/upsert-plan.service';
 import { DuplicatePlanError, DuplicatePlanErrorEnum } from './duplicate-plan.errors';
 import { DuplicatePlanInput } from './duplicate-plan.input';
-import {
-  AxeIdRemapping,
-  mapSourceFicheToDuplicate,
-} from './duplicated-fiche.mapper';
-import { mapSourceFicheAnnexes } from './duplicated-fiche-annexes.mapper';
-import { mapSourceFicheBudgets } from './duplicated-fiche-budgets.mapper';
+import { AxeIdRemapping } from './duplicated-fiche.mapper';
 
 const toPersonneId = (personne: Personne): PersonneId => ({
   tagId: personne.tagId,
@@ -64,9 +57,7 @@ export class DuplicatePlanService {
     private readonly listFichesService: ListFichesService,
     private readonly upsertPlanService: UpsertPlanService,
     private readonly upsertAxeService: UpsertAxeService,
-    private readonly createFicheService: CreateFicheService,
-    private readonly ficheBudgetService: FicheActionBudgetService,
-    private readonly addAnnexeService: AddAnnexeService
+    private readonly ficheDuplicationService: FicheDuplicationService
   ) {}
 
   async duplicate(
@@ -260,7 +251,7 @@ export class DuplicatePlanService {
     const ficheIdRemapping = new Map<number, number>();
 
     for (const source of actions) {
-      const created = await this.duplicateFiche({
+      const created = await this.ficheDuplicationService.duplicateFiche({
         source,
         collectiviteId,
         parentId: null,
@@ -268,7 +259,9 @@ export class DuplicatePlanService {
         axeIdRemapping,
         tx,
       });
-      if (!created.success) return created;
+      if (!created.success) {
+        return failure(DuplicatePlanErrorEnum.DUPLICATE_PLAN_ERROR);
+      }
       ficheIdRemapping.set(source.id, created.data);
     }
 
@@ -281,7 +274,7 @@ export class DuplicatePlanService {
         return failure(DuplicatePlanErrorEnum.DUPLICATE_PLAN_ERROR);
       }
 
-      const created = await this.duplicateFiche({
+      const created = await this.ficheDuplicationService.duplicateFiche({
         source,
         collectiviteId,
         parentId,
@@ -289,99 +282,12 @@ export class DuplicatePlanService {
         axeIdRemapping,
         tx,
       });
-      if (!created.success) return created;
+      if (!created.success) {
+        return failure(DuplicatePlanErrorEnum.DUPLICATE_PLAN_ERROR);
+      }
       ficheIdRemapping.set(source.id, created.data);
     }
 
-    return success(undefined);
-  }
-
-  private async duplicateFiche({
-    source,
-    collectiviteId,
-    parentId,
-    authorization,
-    axeIdRemapping,
-    tx,
-  }: {
-    source: FicheWithRelations;
-    collectiviteId: number;
-    parentId: number | null;
-    authorization: FicheCreateAuthorization;
-    axeIdRemapping: AxeIdRemapping;
-    tx: Transaction;
-  }): Promise<Result<number, DuplicatePlanError>> {
-    const { fiche, ficheFields } = mapSourceFicheToDuplicate({
-      source,
-      collectiviteId,
-      parentId,
-      axeIdRemapping,
-    });
-
-    const created = await this.createFicheService.createFicheWithAuthorization({
-      authorization,
-      fiche,
-      ficheFields,
-      tx,
-    });
-    if (!created.success) {
-      return failure(DuplicatePlanErrorEnum.DUPLICATE_PLAN_ERROR);
-    }
-    const newFicheId = created.data.id;
-
-    const budgetsResult = await this.copyBudgets(source, newFicheId, tx);
-    if (!budgetsResult.success) return budgetsResult;
-
-    const annexesResult = await this.copyAnnexes({
-      source,
-      newFicheId,
-      modifiedBy: authorization.user.id,
-      tx,
-    });
-    if (!annexesResult.success) return annexesResult;
-
-    return success(newFicheId);
-  }
-
-  private async copyAnnexes({
-    source,
-    newFicheId,
-    modifiedBy,
-    tx,
-  }: {
-    source: FicheWithRelations;
-    newFicheId: number;
-    modifiedBy: string;
-    tx: Transaction;
-  }): Promise<Result<undefined, DuplicatePlanError>> {
-    const sourceAnnexes =
-      await this.addAnnexeService.loadRawAnnexesForDuplication(
-        source.id,
-        source.collectiviteId,
-        tx
-      );
-    const annexes = mapSourceFicheAnnexes(sourceAnnexes, {
-      newFicheId,
-      collectiviteId: source.collectiviteId,
-      modifiedBy,
-    });
-    const result = await this.addAnnexeService.insertAnnexes(annexes, tx);
-    if (!result.success) {
-      return failure(DuplicatePlanErrorEnum.DUPLICATE_PLAN_ERROR);
-    }
-    return success(undefined);
-  }
-
-  private async copyBudgets(
-    source: FicheWithRelations,
-    newFicheId: number,
-    tx: Transaction
-  ): Promise<Result<undefined, DuplicatePlanError>> {
-    const budgets = mapSourceFicheBudgets(source, newFicheId);
-    const result = await this.ficheBudgetService.insertBudgets(budgets, tx);
-    if (!result.success) {
-      return failure(DuplicatePlanErrorEnum.DUPLICATE_PLAN_ERROR);
-    }
     return success(undefined);
   }
 }


### PR DESCRIPTION
## Résumé
PR A de la stack « dupliquer une fiche action ». **Refactor pur**, aucun changement de comportement : extrait la logique de copie d'une fiche de `DuplicatePlanService` vers un `FicheDuplicationService` réutilisable (pré-requis du futur endpoint de duplication d'une fiche seule).

- Nouveau `FicheDuplicationService.duplicateFiche(...)` (+ `copyBudgets`, `copyAnnexes` privés) — déplacés tels quels, erreur générique `'SERVER_ERROR'`.
- `DuplicatePlanService.recreateFiches` délègue désormais à ce service et mappe l'erreur vers `DUPLICATE_PLAN_ERROR`. `DuplicatePlanService` n'injecte plus directement createFiche/budget/annexe pour la copie de fiche.
- Wiring : `FicheDuplicationService` exporté par `FichesModule`.

## Non-régression
**Les e2e `duplicate-plan` existants restent verts sans aucune modification** (arborescence, sous-actions, budgets, annexes, notes, restreint, IDOR) — preuve que le comportement est identique. 26 tests verts (10 e2e + mappers).

## Anti-scope
- L'endpoint de duplication d'une fiche + l'override de titre `(copie)` → **PR B** (feature).
- Les mappers restent dans `duplicate-plan/` (importés par le service extrait) ; déplacement éventuel hors scope.

## Tests
- Suite duplicate-plan : 26 verts. Lint + `backend:typecheck` propres.
- Aucun nouveau test (refactor pur ; la suite existante est le filet de non-régression).

## Post-Deploy Monitoring & Validation
`No additional operational monitoring required` : refactor sans changement de comportement ni de contrat (la duplication de plan est inchangée fonctionnellement).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimisation interne de la duplication des plans en extrayant la logique de duplication des fiches dans un service dédié pour améliorer la maintenabilité et la réutilisabilité du code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->