### PR TITLE
feat(plans): endpoint de duplication d'une fiche action

### DIFF
--- a/apps/backend/src/plans/fiches/duplicate-fiche/duplicate-fiche.errors.ts
+++ b/apps/backend/src/plans/fiches/duplicate-fiche/duplicate-fiche.errors.ts
@@ -1,0 +1,23 @@
+import {
+  createErrorsEnum,
+  TrpcErrorHandlerConfig,
+} from '@tet/backend/utils/trpc/trpc-error-handler';
+
+const specificErrors = ['FICHE_NOT_FOUND', 'DUPLICATE_FICHE_ERROR'] as const;
+type SpecificError = (typeof specificErrors)[number];
+
+export const duplicateFicheErrorConfig: TrpcErrorHandlerConfig<SpecificError> = {
+  specificErrors: {
+    FICHE_NOT_FOUND: {
+      code: 'NOT_FOUND',
+      message: "La fiche à dupliquer n'a pas été trouvée",
+    },
+    DUPLICATE_FICHE_ERROR: {
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'Une erreur est survenue lors de la duplication de la fiche',
+    },
+  },
+};
+
+export const DuplicateFicheErrorEnum = createErrorsEnum(specificErrors);
+export type DuplicateFicheError = keyof typeof DuplicateFicheErrorEnum;

--- a/apps/backend/src/plans/fiches/duplicate-fiche/duplicate-fiche.input.ts
+++ b/apps/backend/src/plans/fiches/duplicate-fiche/duplicate-fiche.input.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const duplicateFicheInputSchema = z.object({
+  ficheId: z.number().positive("L'ID de la fiche doit être positif"),
+});
+
+export type DuplicateFicheInput = z.infer<typeof duplicateFicheInputSchema>;

--- a/apps/backend/src/plans/fiches/duplicate-fiche/duplicate-fiche.router.e2e-spec.ts
+++ b/apps/backend/src/plans/fiches/duplicate-fiche/duplicate-fiche.router.e2e-spec.ts
@@ -1,0 +1,358 @@
+import { INestApplication } from '@nestjs/common';
+import { addTestCollectiviteAndUser } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { uploadCreateTestDocument } from '@tet/backend/collectivites/documents/documents.test-fixture';
+import { createIndicateurPerso } from '@tet/backend/indicateurs/definitions/definitions.test-fixture';
+import {
+  getAuthUserFromUserCredentials,
+  getTestApp,
+  getTestDatabase,
+  signInWith,
+} from '@tet/backend/test';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
+import { Collectivite, TagEnum, TagType } from '@tet/domain/collectivites';
+import { CollectiviteRole } from '@tet/domain/users';
+import request from 'supertest';
+import { onTestFinished } from 'vitest';
+
+describe('Dupliquer une fiche action', () => {
+  let app: INestApplication;
+  let router: TrpcRouter;
+  let db: DatabaseService;
+
+  let collectivite: Collectivite;
+  let editorUser: AuthenticatedUser;
+  let fichierId: number;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    router = await app.get(TrpcRouter);
+    db = await getTestDatabase(app);
+
+    const result = await addTestCollectiviteAndUser(db, {
+      user: { role: CollectiviteRole.ADMIN },
+    });
+    collectivite = result.collectivite;
+    editorUser = getAuthUserFromUserCredentials(result.user);
+
+    const signIn = await signInWith({
+      email: result.user.email,
+      password: result.user.password,
+    });
+    const token = signIn.data.session?.access_token ?? '';
+    if (!token) {
+      throw new Error('token éditeur manquant');
+    }
+    const doc = await uploadCreateTestDocument({
+      collectiviteId: collectivite.id,
+      testAgent: request(app.getHttpServer()),
+      token,
+      fileName: 'preuve-fiche.pdf',
+    });
+    fichierId = doc.id;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  const buildEditorCaller = () => router.createCaller({ user: editorUser });
+
+  const cleanupPlans = (planIds: number[]) => {
+    onTestFinished(async () => {
+      const cleanupCaller = buildEditorCaller();
+      for (const planId of planIds) {
+        try {
+          await cleanupCaller.plans.plans.delete({ planId });
+        } catch {
+          // déjà supprimé
+        }
+      }
+    });
+  };
+
+  test('duplique exhaustivement une fiche (champs, relations, budgets, annexes, notes) et ses sous-actions', async () => {
+    const caller = buildEditorCaller();
+
+    const createTag = (tagType: TagType, nom: string) =>
+      caller.collectivites.tags.create({
+        tagType,
+        nom,
+        collectiviteId: collectivite.id,
+      });
+
+    const piloteTag = await createTag(TagEnum.Personne, 'Pilote fiche');
+    const referentTag = await createTag(TagEnum.Personne, 'Référent fiche');
+    const serviceTag = await createTag(TagEnum.Service, 'Service fiche');
+    const structureTag = await createTag(TagEnum.Structure, 'Structure fiche');
+    const partenaireTag = await createTag(TagEnum.Partenaire, 'Partenaire fiche');
+    const libreTag = await createTag(TagEnum.Libre, 'Tag libre fiche');
+    const instanceTag = await createTag(
+      TagEnum.InstanceGouvernance,
+      'Instance fiche'
+    );
+    const financeurTag = await createTag(TagEnum.Financeur, 'Financeur fiche');
+
+    const [thematique] = await caller.shared.thematiques.list();
+    const [sousThematique] =
+      await caller.shared.thematiques.listSousThematiques();
+    const [effetAttendu] = await caller.shared.effetsAttendus.list();
+    const [temps] = await caller.shared.tempsDeMiseEnOeuvre.list();
+
+    const indicateurId = await createIndicateurPerso({
+      caller,
+      indicateurData: {
+        collectiviteId: collectivite.id,
+        titre: 'Indicateur fiche',
+        unite: 'kg',
+      },
+    });
+
+    const plan = await caller.plans.plans.create({
+      nom: 'Plan',
+      collectiviteId: collectivite.id,
+    });
+    const axe = await caller.plans.axes.create({
+      nom: 'Axe',
+      collectiviteId: collectivite.id,
+      planId: plan.id,
+      parent: plan.id,
+    });
+
+    const sourceFiche = await caller.plans.fiches.create({
+      fiche: {
+        collectiviteId: collectivite.id,
+        titre: 'Fiche exhaustive',
+        description: 'Description complète',
+        objectifs: 'Objectifs complets',
+        ressources: 'Moyens complets',
+        financements: 'Financements complets',
+        cibles: ['Grand public', 'Associations'],
+        piliersEci: ['Recyclage', 'Écoconception'],
+        budgetPrevisionnel: '50000',
+        statut: 'En cours',
+        priorite: 'Élevé',
+        dateDebut: '2026-01-15T00:00:00.000Z',
+        dateFin: '2026-12-15T00:00:00.000Z',
+        ameliorationContinue: true,
+        participationCitoyenne: 'Concertation menée',
+        participationCitoyenneType: 'concertation',
+        majTermine: true,
+        restreint: true,
+      },
+      ficheFields: {
+        axes: [{ id: axe.id }],
+        thematiques: [{ id: thematique.id }],
+        sousThematiques: [{ id: sousThematique.id }],
+        effetsAttendus: [{ id: effetAttendu.id }],
+        partenaires: [{ id: partenaireTag.id }],
+        structures: [{ id: structureTag.id }],
+        services: [{ id: serviceTag.id }],
+        pilotes: [{ tagId: piloteTag.id }],
+        referents: [{ tagId: referentTag.id }],
+        financeurs: [{ financeurTag: { id: financeurTag.id }, montantTtc: 12345 }],
+        indicateurs: [{ id: indicateurId }],
+        libreTags: [{ id: libreTag.id }],
+        instanceGouvernance: [{ id: instanceTag.id }],
+      },
+    });
+    await caller.plans.fiches.budgets.upsert([
+      {
+        ficheId: sourceFiche.id,
+        type: 'investissement',
+        unite: 'HT',
+        annee: 2026,
+        budgetPrevisionnel: 50000,
+        budgetReel: 12000,
+        estEtale: false,
+      },
+      {
+        ficheId: sourceFiche.id,
+        type: 'fonctionnement',
+        unite: 'ETP',
+        annee: 2026,
+        budgetPrevisionnel: 2,
+        budgetReel: null,
+        estEtale: false,
+      },
+    ]);
+    await caller.plans.fiches.addAnnexe({
+      ficheId: sourceFiche.id,
+      commentaire: 'Preuve fichier',
+      fichierId,
+    });
+    await caller.plans.fiches.addAnnexe({
+      ficheId: sourceFiche.id,
+      commentaire: 'Preuve lien',
+      lien: { url: 'https://example.org/preuve', titre: 'Lien preuve' },
+    });
+    await caller.plans.fiches.update({
+      ficheId: sourceFiche.id,
+      ficheFields: {
+        notes: [{ dateNote: '2024-01-15', note: 'Une note' }],
+        tempsDeMiseEnOeuvre: { id: temps.id },
+      },
+    });
+    await caller.plans.fiches.create({
+      fiche: {
+        collectiviteId: collectivite.id,
+        titre: 'Sous-action',
+        description: 'Description sous-action',
+        parentId: sourceFiche.id,
+      },
+    });
+
+    const { ficheId: newFicheId } = await caller.plans.fiches.duplicate({
+      ficheId: sourceFiche.id,
+    });
+    cleanupPlans([plan.id]);
+    expect(newFicheId).not.toBe(sourceFiche.id);
+
+    const { data: planFiches } = await caller.plans.fiches.listFiches({
+      collectiviteId: collectivite.id,
+      filters: { planActionIds: [plan.id] },
+      queryOptions: { limit: 'all' },
+    });
+    const duplicatedFiche = planFiches.find((fiche) => fiche.id === newFicheId);
+    if (!duplicatedFiche) {
+      throw new Error('fiche dupliquée introuvable');
+    }
+    expect(duplicatedFiche).toMatchObject({
+      titre: 'Fiche exhaustive (copie)',
+      description: 'Description complète',
+      objectifs: 'Objectifs complets',
+      ressources: 'Moyens complets',
+      financements: 'Financements complets',
+      budgetPrevisionnel: '50000',
+      statut: 'En cours',
+      priorite: 'Élevé',
+      ameliorationContinue: true,
+      participationCitoyenne: 'Concertation menée',
+      participationCitoyenneType: 'concertation',
+      majTermine: true,
+      restreint: true,
+    });
+    expect(duplicatedFiche.cibles).toEqual(['Grand public', 'Associations']);
+    expect(duplicatedFiche.piliersEci).toEqual(['Recyclage', 'Écoconception']);
+    expect(duplicatedFiche.dateDebut).toContain('2026-01-15');
+    expect(duplicatedFiche.dateFin).toContain('2026-12-15');
+
+    expect(duplicatedFiche.axes?.map((item) => item.id)).toEqual([axe.id]);
+    expect(duplicatedFiche.thematiques?.map((item) => item.id)).toEqual([thematique.id]);
+    expect(duplicatedFiche.sousThematiques?.map((item) => item.id)).toEqual([
+      sousThematique.id,
+    ]);
+    expect(duplicatedFiche.effetsAttendus?.map((item) => item.id)).toEqual([
+      effetAttendu.id,
+    ]);
+    expect(duplicatedFiche.partenaires?.map((item) => item.id)).toEqual([partenaireTag.id]);
+    expect(duplicatedFiche.structures?.map((item) => item.id)).toEqual([structureTag.id]);
+    expect(duplicatedFiche.services?.map((item) => item.id)).toEqual([serviceTag.id]);
+    expect(duplicatedFiche.pilotes?.map((item) => item.tagId)).toEqual([piloteTag.id]);
+    expect(duplicatedFiche.referents?.map((item) => item.tagId)).toEqual([referentTag.id]);
+    expect(duplicatedFiche.libreTags?.map((item) => item.id)).toEqual([libreTag.id]);
+    expect(duplicatedFiche.instanceGouvernance?.map((item) => item.id)).toEqual([
+      instanceTag.id,
+    ]);
+    expect(duplicatedFiche.indicateurs?.map((item) => item.id)).toEqual([indicateurId]);
+    expect(duplicatedFiche.tempsDeMiseEnOeuvre?.id).toBe(temps.id);
+    expect(
+      duplicatedFiche.financeurs?.map((item) => ({
+        id: item.financeurTagId,
+        montant: item.montantTtc,
+      }))
+    ).toEqual([{ id: financeurTag.id, montant: 12345 }]);
+
+    const duplicatedBudgets = (duplicatedFiche.budgets ?? []).map((budget) => ({
+      type: budget.type,
+      unite: budget.unite,
+      annee: budget.annee ?? null,
+      budgetPrevisionnel: budget.budgetPrevisionnel ?? null,
+      budgetReel: budget.budgetReel ?? null,
+      estEtale: budget.estEtale,
+    }));
+    expect(duplicatedBudgets).toHaveLength(2);
+    expect(duplicatedBudgets).toEqual(
+      expect.arrayContaining([
+        {
+          type: 'investissement',
+          unite: 'HT',
+          annee: 2026,
+          budgetPrevisionnel: 50000,
+          budgetReel: 12000,
+          estEtale: false,
+        },
+        {
+          type: 'fonctionnement',
+          unite: 'ETP',
+          annee: 2026,
+          budgetPrevisionnel: 2,
+          budgetReel: null,
+          estEtale: false,
+        },
+      ])
+    );
+
+    expect(duplicatedFiche.notes).toHaveLength(1);
+    expect(duplicatedFiche.notes).toContainEqual(
+      expect.objectContaining({ dateNote: '2024-01-15', note: 'Une note' })
+    );
+
+    const annexes = await caller.plans.fiches.ficheAnnexes({
+      collectiviteId: collectivite.id,
+      ficheIds: [newFicheId],
+    });
+    expect(annexes.length).toBe(2);
+    const fichierAnnexe = annexes.find((annexe) => annexe.fichier !== null);
+    const lienAnnexe = annexes.find((annexe) => annexe.lien !== null);
+    expect(fichierAnnexe?.fichier?.filename).toBe('preuve-fiche.pdf');
+    expect(fichierAnnexe?.commentaire).toBe('Preuve fichier');
+    expect(lienAnnexe?.lien?.url).toBe('https://example.org/preuve');
+    expect(lienAnnexe?.commentaire).toBe('Preuve lien');
+
+    expect(duplicatedFiche.fichesLiees ?? []).toEqual([]);
+    expect(duplicatedFiche.etapes ?? []).toEqual([]);
+    expect(duplicatedFiche.sharedWithCollectivites ?? []).toEqual([]);
+
+    const { data: newSousActions } = await caller.plans.fiches.listFiches({
+      collectiviteId: collectivite.id,
+      filters: { parentsId: [newFicheId] },
+      queryOptions: { limit: 'all' },
+    });
+    expect(newSousActions.length).toBe(1);
+    expect(newSousActions[0].titre).toBe('Sous-action');
+    expect(newSousActions[0].description).toBe('Description sous-action');
+    expect(newSousActions[0].parentId).toBe(newFicheId);
+  });
+
+  test('refuse la duplication inter-collectivités (IDOR)', async () => {
+    const caller = buildEditorCaller();
+    const plan = await caller.plans.plans.create({
+      nom: 'Plan A',
+      collectiviteId: collectivite.id,
+    });
+    const source = await caller.plans.fiches.create({
+      fiche: { collectiviteId: collectivite.id, titre: 'Action A' },
+      ficheFields: { axes: [{ id: plan.id }] },
+    });
+    cleanupPlans([plan.id]);
+
+    const otherResult = await addTestCollectiviteAndUser(db, {
+      user: { role: CollectiviteRole.ADMIN },
+    });
+    const otherCaller = router.createCaller({
+      user: getAuthUserFromUserCredentials(otherResult.user),
+    });
+
+    await expect(
+      otherCaller.plans.fiches.duplicate({ ficheId: source.id })
+    ).rejects.toThrow("Vous n'avez pas les permissions nécessaires");
+  });
+
+  test('renvoie une erreur quand la fiche est introuvable', async () => {
+    await expect(
+      buildEditorCaller().plans.fiches.duplicate({ ficheId: 999999 })
+    ).rejects.toThrow("La fiche à dupliquer n'a pas été trouvée");
+  });
+});

--- a/apps/backend/src/plans/fiches/duplicate-fiche/duplicate-fiche.router.ts
+++ b/apps/backend/src/plans/fiches/duplicate-fiche/duplicate-fiche.router.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+import { createTrpcErrorHandler } from '@tet/backend/utils/trpc/trpc-error-handler';
+import { TrpcService } from '@tet/backend/utils/trpc/trpc.service';
+import { duplicateFicheErrorConfig } from './duplicate-fiche.errors';
+import { duplicateFicheInputSchema } from './duplicate-fiche.input';
+import { DuplicateFicheService } from './duplicate-fiche.service';
+
+@Injectable()
+export class DuplicateFicheRouter {
+  constructor(
+    private readonly trpc: TrpcService,
+    private readonly service: DuplicateFicheService
+  ) {}
+
+  private readonly getResultDataOrThrowError = createTrpcErrorHandler(
+    duplicateFicheErrorConfig
+  );
+
+  router = this.trpc.router({
+    duplicate: this.trpc.authedProcedure
+      .input(duplicateFicheInputSchema)
+      .mutation(async ({ input, ctx }) => {
+        const result = await this.service.duplicate(input, ctx.user);
+        return this.getResultDataOrThrowError(result);
+      }),
+  });
+}

--- a/apps/backend/src/plans/fiches/duplicate-fiche/duplicate-fiche.service.ts
+++ b/apps/backend/src/plans/fiches/duplicate-fiche/duplicate-fiche.service.ts
@@ -1,0 +1,146 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { FicheCreateAuthorization } from '@tet/backend/plans/fiches/create-fiche/fiche-create-authorization';
+import FicheActionPermissionsService from '@tet/backend/plans/fiches/fiche-action-permissions.service';
+import { FicheDuplicationService } from '@tet/backend/plans/fiches/fiche-duplication/fiche-duplication.service';
+import ListFichesService from '@tet/backend/plans/fiches/list-fiches/list-fiches.service';
+import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { failure, Result, success } from '@tet/backend/utils/result.type';
+import { TransactionManager } from '@tet/backend/utils/transaction/transaction-manager.service';
+import { AxeIdRemapping } from '@tet/backend/plans/plans/duplicate-plan/duplicated-fiche.mapper';
+import { FicheWithRelations } from '@tet/domain/plans';
+import {
+  DuplicateFicheError,
+  DuplicateFicheErrorEnum,
+} from './duplicate-fiche.errors';
+import { DuplicateFicheInput } from './duplicate-fiche.input';
+
+const ownedByCollectivite = (
+  fiches: FicheWithRelations[],
+  collectiviteId: number
+): FicheWithRelations[] =>
+  fiches.filter((fiche) => fiche.collectiviteId === collectiviteId);
+
+const identityAxeRemapping = (fiche: FicheWithRelations): AxeIdRemapping =>
+  new Map((fiche.axes ?? []).map((axe) => [axe.id, axe.id]));
+
+@Injectable()
+export class DuplicateFicheService {
+  private readonly logger = new Logger(DuplicateFicheService.name);
+
+  constructor(
+    private readonly transactionManager: TransactionManager,
+    private readonly permissionService: PermissionService,
+    private readonly ficheActionPermissionsService: FicheActionPermissionsService,
+    private readonly listFichesService: ListFichesService,
+    private readonly ficheDuplicationService: FicheDuplicationService
+  ) {}
+
+  async duplicate(
+    { ficheId }: DuplicateFicheInput,
+    user: AuthenticatedUser,
+    tx?: Transaction
+  ): Promise<Result<{ ficheId: number }, DuplicateFicheError>> {
+    return this.transactionManager.executeSingle<
+      { ficheId: number },
+      DuplicateFicheError
+    >(async (transaction) => {
+      const existingFiche =
+        await this.ficheActionPermissionsService.getFicheFromId(
+          ficheId,
+          transaction
+        );
+      if (!existingFiche) {
+        return failure(DuplicateFicheErrorEnum.FICHE_NOT_FOUND);
+      }
+      const { collectiviteId } = existingFiche;
+
+      const authorizationResult = await this.buildWriteAuthorization(
+        user,
+        collectiviteId,
+        transaction
+      );
+      if (!authorizationResult.success) return authorizationResult;
+      const authorization = authorizationResult.data;
+
+      const { data: matchedFiches } =
+        await this.listFichesService.listFichesQuery(
+          collectiviteId,
+          { ficheIds: [ficheId] },
+          undefined,
+          transaction
+        );
+      const [source] = ownedByCollectivite(matchedFiches, collectiviteId);
+      if (!source) {
+        return failure(DuplicateFicheErrorEnum.FICHE_NOT_FOUND);
+      }
+
+      const { data: matchedChildren } =
+        await this.listFichesService.listFichesQuery(
+          collectiviteId,
+          { parentsId: [ficheId] },
+          undefined,
+          transaction
+        );
+      const sousActions = ownedByCollectivite(matchedChildren, collectiviteId);
+
+      const created = await this.ficheDuplicationService.duplicateFiche({
+        source,
+        collectiviteId,
+        parentId: source.parentId,
+        authorization,
+        axeIdRemapping: identityAxeRemapping(source),
+        tx: transaction,
+        titre: source.titre ? `${source.titre} (copie)` : source.titre,
+      });
+      if (!created.success) {
+        return failure(DuplicateFicheErrorEnum.DUPLICATE_FICHE_ERROR);
+      }
+      const newFicheId = created.data;
+
+      for (const sousAction of sousActions) {
+        const createdChild =
+          await this.ficheDuplicationService.duplicateFiche({
+            source: sousAction,
+            collectiviteId,
+            parentId: newFicheId,
+            authorization,
+            axeIdRemapping: identityAxeRemapping(sousAction),
+            tx: transaction,
+          });
+        if (!createdChild.success) {
+          return failure(DuplicateFicheErrorEnum.DUPLICATE_FICHE_ERROR);
+        }
+      }
+
+      this.logger.log(
+        `Fiche ${ficheId} dupliquée vers ${newFicheId} (${sousActions.length} sous-actions) pour la collectivité ${collectiviteId}`
+      );
+      return success({ ficheId: newFicheId });
+    }, tx);
+  }
+
+  private async buildWriteAuthorization(
+    user: AuthenticatedUser,
+    collectiviteId: number,
+    tx: Transaction
+  ): Promise<Result<FicheCreateAuthorization, DuplicateFicheError>> {
+    try {
+      const authorization = await FicheCreateAuthorization.forCollectivite(
+        this.permissionService,
+        user,
+        collectiviteId,
+        tx
+      );
+      return success(authorization);
+    } catch (error) {
+      this.logger.warn(
+        `Duplication de fiche refusée sur la collectivité ${collectiviteId}: ${
+          error instanceof Error ? error.message : error
+        }`
+      );
+      return failure(DuplicateFicheErrorEnum.UNAUTHORIZED);
+    }
+  }
+}

--- a/apps/backend/src/plans/fiches/fiche-duplication/fiche-duplication.service.ts
+++ b/apps/backend/src/plans/fiches/fiche-duplication/fiche-duplication.service.ts
@@ -30,6 +30,7 @@ export class FicheDuplicationService {
     authorization,
     axeIdRemapping,
     tx,
+    titre,
   }: {
     source: FicheWithRelations;
     collectiviteId: number;
@@ -37,12 +38,14 @@ export class FicheDuplicationService {
     authorization: FicheCreateAuthorization;
     axeIdRemapping: AxeIdRemapping;
     tx: Transaction;
+    titre?: string | null;
   }): Promise<Result<number, FicheDuplicationError>> {
     const { fiche, ficheFields } = mapSourceFicheToDuplicate({
       source,
       collectiviteId,
       parentId,
       axeIdRemapping,
+      titre,
     });
 
     const created = await this.createFicheService.createFicheWithAuthorization({

--- a/apps/backend/src/plans/fiches/fiches.module.ts
+++ b/apps/backend/src/plans/fiches/fiches.module.ts
@@ -28,6 +28,8 @@ import { CountByService } from './count-by/count-by.service';
 import { CreateFicheRouter } from './create-fiche/create-fiche.router';
 import { DeleteFicheRouter } from './delete-fiche/delete-fiche.router';
 import { DeleteFicheService } from './delete-fiche/delete-fiche.service';
+import { DuplicateFicheRouter } from './duplicate-fiche/duplicate-fiche.router';
+import { DuplicateFicheService } from './duplicate-fiche/duplicate-fiche.service';
 import { ExportService } from './export/export.service';
 import { FicheActionEtapeRouter } from './fiche-action-etape/fiche-action-etape.router';
 import { FicheActionEtapeService } from './fiche-action-etape/fiche-action-etape.service';
@@ -76,6 +78,8 @@ import UpdateFicheService from './update-fiche/update-fiche.service';
     BulkEditRouter,
     DeleteFicheService,
     DeleteFicheRouter,
+    DuplicateFicheService,
+    DuplicateFicheRouter,
     UpdateFicheService,
     UpdateFicheRouter,
     FicheActionLinkRepository,
@@ -134,6 +138,8 @@ import UpdateFicheService from './update-fiche/update-fiche.service';
 
     DeleteFicheService,
     DeleteFicheRouter,
+    DuplicateFicheService,
+    DuplicateFicheRouter,
   ],
 })
 export class FichesModule {}

--- a/apps/backend/src/plans/fiches/fiches.router.ts
+++ b/apps/backend/src/plans/fiches/fiches.router.ts
@@ -5,6 +5,7 @@ import { BulkEditRouter } from './bulk-edit/bulk-edit.router';
 import { CountByRouter } from './count-by/count-by.router';
 import { CreateFicheRouter } from './create-fiche/create-fiche.router';
 import { DeleteFicheRouter } from './delete-fiche/delete-fiche.router';
+import { DuplicateFicheRouter } from './duplicate-fiche/duplicate-fiche.router';
 import { FicheActionBudgetRouter } from './fiche-action-budget/fiche-action-budget.router';
 import { FicheActionEtapeRouter } from './fiche-action-etape/fiche-action-etape.router';
 import { FicheActionPdfExportRouter } from './fiche-action-pdf-export/fiche-action-pdf-export.router';
@@ -22,6 +23,7 @@ export class FichesRouter {
     private readonly createFicheRouter: CreateFicheRouter,
     private readonly addAnnexeRouter: AddAnnexeRouter,
     private readonly deleteFicheRouter: DeleteFicheRouter,
+    private readonly duplicateFicheRouter: DuplicateFicheRouter,
     private readonly countByRouter: CountByRouter,
     private readonly bulkEditRouter: BulkEditRouter,
     private readonly ficheActionEtapeRouter: FicheActionEtapeRouter,
@@ -36,6 +38,7 @@ export class FichesRouter {
     this.addAnnexeRouter.router,
     this.updateFicheRouter.router,
     this.deleteFicheRouter.router,
+    this.duplicateFicheRouter.router,
 
     this.countByRouter.router,
     this.bulkEditRouter.router,

--- a/apps/backend/src/plans/plans/duplicate-plan/duplicate-plan.router.e2e-spec.ts
+++ b/apps/backend/src/plans/plans/duplicate-plan/duplicate-plan.router.e2e-spec.ts
@@ -1,20 +1,16 @@
 import { INestApplication } from '@nestjs/common';
 import { addTestCollectiviteAndUser } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
-import { uploadCreateTestDocument } from '@tet/backend/collectivites/documents/documents.test-fixture';
-import { createIndicateurPerso } from '@tet/backend/indicateurs/definitions/definitions.test-fixture';
 import {
   getAuthUserFromUserCredentials,
   getTestApp,
   getTestDatabase,
-  signInWith,
 } from '@tet/backend/test';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { addTestUser } from '@tet/backend/users/users/users.test-fixture';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
-import { Collectivite, TagEnum, TagType } from '@tet/domain/collectivites';
+import { Collectivite } from '@tet/domain/collectivites';
 import { CollectiviteRole } from '@tet/domain/users';
-import request from 'supertest';
 import { onTestFinished } from 'vitest';
 
 describe('Dupliquer un plan', () => {
@@ -25,7 +21,6 @@ describe('Dupliquer un plan', () => {
   let collectivite: Collectivite;
   let editorUser: AuthenticatedUser;
   let noAccessUser: AuthenticatedUser;
-  let fichierId: number;
 
   beforeAll(async () => {
     app = await getTestApp();
@@ -44,22 +39,6 @@ describe('Dupliquer un plan', () => {
 
     const noAccessUserResult = await addTestUser(db);
     noAccessUser = getAuthUserFromUserCredentials(noAccessUserResult.user);
-
-    const signIn = await signInWith({
-      email: testCollectiviteAndUserResult.user.email,
-      password: testCollectiviteAndUserResult.user.password,
-    });
-    const editorAuthToken = signIn.data.session?.access_token ?? '';
-    if (!editorAuthToken) {
-      throw new Error('token éditeur manquant');
-    }
-    const doc = await uploadCreateTestDocument({
-      collectiviteId: collectivite.id,
-      testAgent: request(app.getHttpServer()),
-      token: editorAuthToken,
-      fileName: 'preuve-dupliquee.pdf',
-    });
-    fichierId = doc.id;
   });
 
   afterAll(async () => {
@@ -81,106 +60,7 @@ describe('Dupliquer un plan', () => {
     });
   };
 
-  test('duplique les notes de chaque fiche', async () => {
-    const caller = buildEditorCaller();
-
-    const sourcePlan = await caller.plans.plans.create({
-      nom: 'Plan avec notes',
-      collectiviteId: collectivite.id,
-    });
-    const sourceFiche = await caller.plans.fiches.create({
-      fiche: { collectiviteId: collectivite.id, titre: 'Action avec notes' },
-      ficheFields: { axes: [{ id: sourcePlan.id }] },
-    });
-
-    await caller.plans.fiches.update({
-      ficheId: sourceFiche.id,
-      ficheFields: {
-        notes: [
-          { dateNote: '2024-01-15', note: 'Première note' },
-          { dateNote: '2024-06-20', note: 'Seconde note' },
-        ],
-      },
-    });
-
-    const duplicated = await caller.plans.plans.duplicate({
-      planId: sourcePlan.id,
-      nom: 'Plan dupliqué',
-    });
-    cleanupPlans([sourcePlan.id, duplicated.planId]);
-
-    const { data: newFiches } = await caller.plans.fiches.listFiches({
-      collectiviteId: collectivite.id,
-      filters: { planActionIds: [duplicated.planId] },
-      queryOptions: { limit: 'all' },
-    });
-    expect(newFiches.length).toBe(1);
-    const newFiche = newFiches[0];
-    expect(newFiche.id).not.toBe(sourceFiche.id);
-
-    expect(newFiche.notes).toHaveLength(2);
-    expect(newFiche.notes).toContainEqual(
-      expect.objectContaining({ dateNote: '2024-01-15', note: 'Première note' })
-    );
-    expect(newFiche.notes).toContainEqual(
-      expect.objectContaining({ dateNote: '2024-06-20', note: 'Seconde note' })
-    );
-  });
-
-  test('duplique les preuves (annexe fichier et annexe lien) de chaque fiche', async () => {
-    const caller = buildEditorCaller();
-
-    const sourcePlan = await caller.plans.plans.create({
-      nom: 'Plan avec preuves',
-      collectiviteId: collectivite.id,
-    });
-    const sourceFiche = await caller.plans.fiches.create({
-      fiche: { collectiviteId: collectivite.id, titre: 'Action avec preuves' },
-      ficheFields: { axes: [{ id: sourcePlan.id }] },
-    });
-
-    await caller.plans.fiches.addAnnexe({
-      ficheId: sourceFiche.id,
-      commentaire: 'Preuve fichier',
-      fichierId,
-    });
-    await caller.plans.fiches.addAnnexe({
-      ficheId: sourceFiche.id,
-      commentaire: 'Preuve lien',
-      lien: { url: 'https://example.org/preuve', titre: 'Lien preuve' },
-    });
-
-    const duplicated = await caller.plans.plans.duplicate({
-      planId: sourcePlan.id,
-      nom: 'Plan dupliqué',
-    });
-    cleanupPlans([sourcePlan.id, duplicated.planId]);
-
-    const { data: newFiches } = await caller.plans.fiches.listFiches({
-      collectiviteId: collectivite.id,
-      filters: { planActionIds: [duplicated.planId] },
-      queryOptions: { limit: 'all' },
-    });
-    expect(newFiches.length).toBe(1);
-    const newFicheId = newFiches[0].id;
-    expect(newFicheId).not.toBe(sourceFiche.id);
-
-    const annexes = await caller.plans.fiches.ficheAnnexes({
-      collectiviteId: collectivite.id,
-      ficheIds: [newFicheId],
-    });
-    expect(annexes.length).toBe(2);
-    expect(annexes.every((annexe) => annexe.ficheId === newFicheId)).toBe(true);
-
-    const fichierAnnexe = annexes.find((annexe) => annexe.fichier !== null);
-    const lienAnnexe = annexes.find((annexe) => annexe.lien !== null);
-    expect(fichierAnnexe?.fichier?.filename).toBe('preuve-dupliquee.pdf');
-    expect(fichierAnnexe?.commentaire).toBe('Preuve fichier');
-    expect(lienAnnexe?.lien?.url).toBe('https://example.org/preuve');
-    expect(lienAnnexe?.commentaire).toBe('Preuve lien');
-  });
-
-  test('duplique un plan avec son arborescence, ses fiches et sous-actions', async () => {
+  test("recrée le plan, son arborescence d'axes et le bon nombre de fiches", async () => {
     const caller = buildEditorCaller();
 
     const sourcePlan = await caller.plans.plans.create({
@@ -207,21 +87,13 @@ describe('Dupliquer un plan', () => {
     });
 
     const sourceFiche = await caller.plans.fiches.create({
-      fiche: {
-        collectiviteId: collectivite.id,
-        titre: 'Action A',
-        objectifs: 'Objectifs A',
-        statut: 'En cours',
-        priorite: 'Élevé',
-        restreint: true,
-      },
+      fiche: { collectiviteId: collectivite.id, titre: 'Action A' },
       ficheFields: { axes: [{ id: axe111.id }] },
     });
     await caller.plans.fiches.create({
       fiche: {
         collectiviteId: collectivite.id,
         titre: 'Sous-action A1',
-        description: 'Description sous-action',
         parentId: sourceFiche.id,
       },
     });
@@ -250,13 +122,7 @@ describe('Dupliquer un plan', () => {
       queryOptions: { limit: 'all' },
     });
     expect(newParents.length).toBe(1);
-
     const newParent = newParents[0];
-    expect(newParent.titre).toBe('Action A');
-    expect(newParent.objectifs).toBe('Objectifs A');
-    expect(newParent.statut).toBe('En cours');
-    expect(newParent.priorite).toBe('Élevé');
-    expect(newParent.restreint).toBe(true);
     expect(newParent.id).not.toBe(sourceFiche.id);
     expect(newParent.axes?.map((axe) => axe.id)).toEqual([newAxe111Id]);
 
@@ -266,8 +132,6 @@ describe('Dupliquer un plan', () => {
       queryOptions: { limit: 'all' },
     });
     expect(newSousActions.length).toBe(1);
-    expect(newSousActions[0].titre).toBe('Sous-action A1');
-    expect(newSousActions[0].description).toBe('Description sous-action');
     expect(newSousActions[0].parentId).toBe(newParent.id);
   });
 
@@ -343,290 +207,6 @@ describe('Dupliquer un plan', () => {
       queryOptions: { limit: 'all' },
     });
     expect(newFiches.length).toBe(0);
-  });
-
-  test('préserve la confidentialité (restreint) des fiches dupliquées', async () => {
-    const caller = buildEditorCaller();
-
-    const sourcePlan = await caller.plans.plans.create({
-      nom: 'Plan confidentiel',
-      collectiviteId: collectivite.id,
-    });
-    const axe = await caller.plans.axes.create({
-      nom: 'Axe confidentiel',
-      collectiviteId: collectivite.id,
-      planId: sourcePlan.id,
-      parent: sourcePlan.id,
-    });
-
-    const ficheRestreinte = await caller.plans.fiches.create({
-      fiche: {
-        collectiviteId: collectivite.id,
-        titre: 'Fiche restreinte',
-        restreint: true,
-      },
-      ficheFields: { axes: [{ id: axe.id }] },
-    });
-    await caller.plans.fiches.create({
-      fiche: {
-        collectiviteId: collectivite.id,
-        titre: 'Sous-action restreinte',
-        restreint: true,
-        parentId: ficheRestreinte.id,
-      },
-    });
-    await caller.plans.fiches.create({
-      fiche: {
-        collectiviteId: collectivite.id,
-        titre: 'Fiche publique',
-        restreint: false,
-      },
-      ficheFields: { axes: [{ id: axe.id }] },
-    });
-
-    const duplicated = await caller.plans.plans.duplicate({
-      planId: sourcePlan.id,
-      nom: 'Plan dupliqué',
-    });
-    cleanupPlans([sourcePlan.id, duplicated.planId]);
-
-    const { data: newParents } = await caller.plans.fiches.listFiches({
-      collectiviteId: collectivite.id,
-      filters: { planActionIds: [duplicated.planId] },
-      queryOptions: { limit: 'all' },
-    });
-    const newRestreinte = newParents.find(
-      (fiche) => fiche.titre === 'Fiche restreinte'
-    );
-    const newPublique = newParents.find(
-      (fiche) => fiche.titre === 'Fiche publique'
-    );
-    expect(newRestreinte?.restreint).toBe(true);
-    expect(newPublique?.restreint).toBe(false);
-
-    expect(newRestreinte).toBeDefined();
-    const { data: newSousActions } = await caller.plans.fiches.listFiches({
-      collectiviteId: collectivite.id,
-      filters: { parentsId: [newRestreinte?.id ?? 0] },
-      queryOptions: { limit: 'all' },
-    });
-    expect(newSousActions.length).toBe(1);
-    expect(newSousActions[0].titre).toBe('Sous-action restreinte');
-    expect(newSousActions[0].restreint).toBe(true);
-  });
-
-  test('duplique exhaustivement une fiche avec tous ses champs renseignés', async () => {
-    const caller = buildEditorCaller();
-
-    const createTag = (tagType: TagType, nom: string) =>
-      caller.collectivites.tags.create({
-        tagType,
-        nom,
-        collectiviteId: collectivite.id,
-      });
-
-    const piloteTag = await createTag(TagEnum.Personne, 'Pilote exhaustif');
-    const referentTag = await createTag(TagEnum.Personne, 'Référent exhaustif');
-    const serviceTag = await createTag(TagEnum.Service, 'Service exhaustif');
-    const structureTag = await createTag(TagEnum.Structure, 'Structure exhaustive');
-    const partenaireTag = await createTag(
-      TagEnum.Partenaire,
-      'Partenaire exhaustif'
-    );
-    const libreTag = await createTag(TagEnum.Libre, 'Tag libre exhaustif');
-    const instanceTag = await createTag(
-      TagEnum.InstanceGouvernance,
-      'Instance exhaustive'
-    );
-    const financeurTag = await createTag(TagEnum.Financeur, 'Financeur exhaustif');
-
-    const [thematique] = await caller.shared.thematiques.list();
-    const [sousThematique] =
-      await caller.shared.thematiques.listSousThematiques();
-    const [effetAttendu] = await caller.shared.effetsAttendus.list();
-    const [temps] = await caller.shared.tempsDeMiseEnOeuvre.list();
-
-    const indicateurId = await createIndicateurPerso({
-      caller,
-      indicateurData: {
-        collectiviteId: collectivite.id,
-        titre: 'Indicateur exhaustif',
-        unite: 'kg',
-      },
-    });
-
-    const sourcePlan = await caller.plans.plans.create({
-      nom: 'Plan exhaustif',
-      collectiviteId: collectivite.id,
-    });
-    const axe = await caller.plans.axes.create({
-      nom: 'Axe exhaustif',
-      collectiviteId: collectivite.id,
-      planId: sourcePlan.id,
-      parent: sourcePlan.id,
-    });
-
-    const sourceFiche = await caller.plans.fiches.create({
-      fiche: {
-        collectiviteId: collectivite.id,
-        titre: 'Fiche exhaustive',
-        description: 'Description complète',
-        objectifs: 'Objectifs complets',
-        ressources: 'Moyens complets',
-        financements: 'Financements complets',
-        cibles: ['Grand public', 'Associations'],
-        piliersEci: ['Recyclage', 'Écoconception'],
-        budgetPrevisionnel: '50000',
-        statut: 'En cours',
-        priorite: 'Élevé',
-        dateDebut: '2026-01-15T00:00:00.000Z',
-        dateFin: '2026-12-15T00:00:00.000Z',
-        ameliorationContinue: true,
-        participationCitoyenne: 'Concertation menée',
-        participationCitoyenneType: 'concertation',
-        majTermine: true,
-        restreint: true,
-      },
-      ficheFields: {
-        axes: [{ id: axe.id }],
-        thematiques: [{ id: thematique.id }],
-        sousThematiques: [{ id: sousThematique.id }],
-        effetsAttendus: [{ id: effetAttendu.id }],
-        partenaires: [{ id: partenaireTag.id }],
-        structures: [{ id: structureTag.id }],
-        services: [{ id: serviceTag.id }],
-        pilotes: [{ tagId: piloteTag.id }],
-        referents: [{ tagId: referentTag.id }],
-        financeurs: [{ financeurTag: { id: financeurTag.id }, montantTtc: 12345 }],
-        indicateurs: [{ id: indicateurId }],
-        libreTags: [{ id: libreTag.id }],
-        instanceGouvernance: [{ id: instanceTag.id }],
-        tempsDeMiseEnOeuvre: { id: temps.id },
-      },
-    });
-    await caller.plans.fiches.budgets.upsert([
-      {
-        ficheId: sourceFiche.id,
-        type: 'investissement',
-        unite: 'HT',
-        annee: 2026,
-        budgetPrevisionnel: 50000,
-        budgetReel: 12000,
-        estEtale: false,
-      },
-      {
-        ficheId: sourceFiche.id,
-        type: 'fonctionnement',
-        unite: 'ETP',
-        annee: 2026,
-        budgetPrevisionnel: 2,
-        budgetReel: null,
-        estEtale: false,
-      },
-    ]);
-
-    const duplicated = await caller.plans.plans.duplicate({
-      planId: sourcePlan.id,
-      nom: 'Plan dupliqué',
-    });
-    cleanupPlans([sourcePlan.id, duplicated.planId]);
-
-    const { data: newParents } = await caller.plans.fiches.listFiches({
-      collectiviteId: collectivite.id,
-      filters: { planActionIds: [duplicated.planId] },
-      queryOptions: { limit: 'all' },
-    });
-    expect(newParents.length).toBe(1);
-    const dup = newParents[0];
-
-    expect(dup.id).not.toBe(sourceFiche.id);
-    expect(dup).toMatchObject({
-      titre: 'Fiche exhaustive',
-      description: 'Description complète',
-      objectifs: 'Objectifs complets',
-      ressources: 'Moyens complets',
-      financements: 'Financements complets',
-      budgetPrevisionnel: '50000',
-      statut: 'En cours',
-      priorite: 'Élevé',
-      ameliorationContinue: true,
-      participationCitoyenne: 'Concertation menée',
-      participationCitoyenneType: 'concertation',
-      majTermine: true,
-      restreint: true,
-    });
-    expect(dup.cibles).toEqual(['Grand public', 'Associations']);
-    expect(dup.piliersEci).toEqual(['Recyclage', 'Écoconception']);
-    expect(dup.dateDebut).toContain('2026-01-15');
-    expect(dup.dateFin).toContain('2026-12-15');
-
-    expect(dup.thematiques?.map((item) => item.id)).toEqual([thematique.id]);
-    expect(dup.sousThematiques?.map((item) => item.id)).toEqual([
-      sousThematique.id,
-    ]);
-    expect(dup.effetsAttendus?.map((item) => item.id)).toEqual([
-      effetAttendu.id,
-    ]);
-    expect(dup.partenaires?.map((item) => item.id)).toEqual([partenaireTag.id]);
-    expect(dup.structures?.map((item) => item.id)).toEqual([structureTag.id]);
-    expect(dup.services?.map((item) => item.id)).toEqual([serviceTag.id]);
-    expect(dup.pilotes?.map((item) => item.tagId)).toEqual([piloteTag.id]);
-    expect(dup.referents?.map((item) => item.tagId)).toEqual([referentTag.id]);
-    expect(dup.libreTags?.map((item) => item.id)).toEqual([libreTag.id]);
-    expect(dup.instanceGouvernance?.map((item) => item.id)).toEqual([
-      instanceTag.id,
-    ]);
-    expect(dup.indicateurs?.map((item) => item.id)).toEqual([indicateurId]);
-    expect(dup.tempsDeMiseEnOeuvre?.id).toBe(temps.id);
-    expect(
-      dup.financeurs?.map((item) => ({
-        id: item.financeurTagId,
-        montant: item.montantTtc,
-      }))
-    ).toEqual([{ id: financeurTag.id, montant: 12345 }]);
-
-    const newPlan = await caller.plans.plans.get({ planId: duplicated.planId });
-    const newAxeId = newPlan.axes.find(
-      (item) => item.nom === 'Axe exhaustif'
-    )?.id;
-    expect(dup.axes?.map((item) => item.id)).toEqual([newAxeId]);
-    expect(dup.axes?.map((item) => item.id)).not.toContain(axe.id);
-
-    const dupBudgets = (dup.budgets ?? []).map((budget) => ({
-      type: budget.type,
-      unite: budget.unite,
-      annee: budget.annee ?? null,
-      budgetPrevisionnel: budget.budgetPrevisionnel ?? null,
-      budgetReel: budget.budgetReel ?? null,
-      estEtale: budget.estEtale,
-    }));
-    expect(dupBudgets).toHaveLength(2);
-    expect(dupBudgets).toEqual(
-      expect.arrayContaining([
-        {
-          type: 'investissement',
-          unite: 'HT',
-          annee: 2026,
-          budgetPrevisionnel: 50000,
-          budgetReel: 12000,
-          estEtale: false,
-        },
-        {
-          type: 'fonctionnement',
-          unite: 'ETP',
-          annee: 2026,
-          budgetPrevisionnel: 2,
-          budgetReel: null,
-          estEtale: false,
-        },
-      ])
-    );
-    expect(dup.budgets?.every((budget) => budget.ficheId === dup.id)).toBe(true);
-
-    expect(dup.fichesLiees ?? []).toEqual([]);
-    expect(dup.docs ?? []).toEqual([]);
-    expect(dup.etapes ?? []).toEqual([]);
-    expect(dup.sharedWithCollectivites ?? []).toEqual([]);
   });
 
   test('refuse la duplication à un utilisateur sans droit sur la collectivité', async () => {

--- a/apps/backend/src/plans/plans/duplicate-plan/duplicated-fiche.mapper.ts
+++ b/apps/backend/src/plans/plans/duplicate-plan/duplicated-fiche.mapper.ts
@@ -38,16 +38,18 @@ export function mapSourceFicheToDuplicate({
   collectiviteId,
   parentId,
   axeIdRemapping,
+  titre,
 }: {
   source: FicheWithRelations;
   collectiviteId: number;
   parentId: number | null;
   axeIdRemapping: AxeIdRemapping;
+  titre?: string | null;
 }): { fiche: FicheCreate; ficheFields: DuplicableFicheFields } {
   const fiche: FicheCreate = {
     collectiviteId,
     parentId,
-    titre: source.titre,
+    titre: titre !== undefined ? titre : source.titre,
     description: source.description,
     piliersEci: source.piliersEci,
     objectifs: source.objectifs,


### PR DESCRIPTION
## Résumé
PR B de la stack « dupliquer une fiche action ». **Stackée sur #4550** (refactor `FicheDuplicationService`). Nouvel endpoint `plans.fiches.duplicate({ ficheId })`.

- Clone une fiche **et ses sous-actions** au sein de la même collectivité, rattachée aux **mêmes axes** (remapping identité), titre **« {titre} (copie) »** (sous-actions verbatim).
- Réutilise `FicheDuplicationService.duplicateFiche` (PR A) ; `mapSourceFicheToDuplicate` accepte un override de titre optionnel.
- Auth `FicheCreateAuthorization.forCollectivite` (cloisonnement / IDOR), transaction unique (rollback atomique), parentId préservé.

## Tests (e2e, fixtures via services)
3 tests : duplication (sous-action + mêmes axes + note + titre copie), refus IDOR inter-collectivités, fiche introuvable. **Non-régression** : 26 tests duplicate-plan toujours verts.

## Dépendance
Base = `refactor/fiche-duplication-service` (#4550). À merger après #4550 (sera re-ciblée sur main).

## Post-Deploy Monitoring & Validation
- **À surveiller** : logs `DuplicateFicheService`, erreurs `DUPLICATE_FICHE_ERROR` sur `plans.fiches.duplicate`.
- **Signal sain** : duplication d'une fiche → copie « (copie) » avec sous-actions, mêmes axes, relations (budgets/annexes/notes).
- Endpoint non encore exposé en UI (frontend = PR suivante).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles Fonctionnalités**
  * Possibilité de dupliquer individuellement une fiche action avec tous les éléments et relations associés (budgets prévus et réalisés, annexes, notes, sous-actions) préservés dans la copie.

* **Refactorisation**
  * Restructuration du service de duplication des plans pour améliorer la maintenabilité et la réutilisabilité du code de duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->