### PR TITLE
feat(ai-plan-import): confirmation du brouillon vers la persistance (PR11)

### DIFF
--- a/apps/backend/src/plans/plans/ai-plan-import/ai-plan-import-job.repository.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/ai-plan-import-job.repository.ts
@@ -1,8 +1,9 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
 import { failure, success, type Result } from '@tet/backend/utils/result.type';
 import { getErrorMessage } from '@tet/domain/utils';
-import { and, count, eq, inArray } from 'drizzle-orm';
+import { and, count, eq, inArray, isNull } from 'drizzle-orm';
 import { PlanDraft } from './models/plan-draft';
 import {
   AiPlanImportJob,
@@ -170,6 +171,63 @@ export class AiPlanImportJobRepository {
     } catch (error) {
       this.logger.error(
         `Suppression du job pending ${id}: ${getErrorMessage(error)}`
+      );
+      return failure(AiPlanImportErrorEnum.UPDATE_JOB_ERROR, toError(error));
+    }
+  }
+
+  async claimForConfirm(input: {
+    id: string;
+    tx: Transaction;
+  }): Promise<Result<AiPlanImportJob | null, AiPlanImportError>> {
+    try {
+      const [row] = await input.tx
+        .update(aiPlanImportJobTable)
+        .set({
+          status: AiPlanImportJobStatusEnum.CONFIRMING,
+          modifiedAt: new Date().toISOString(),
+        })
+        .where(
+          and(
+            eq(aiPlanImportJobTable.id, input.id),
+            eq(aiPlanImportJobTable.status, AiPlanImportJobStatusEnum.DONE),
+            isNull(aiPlanImportJobTable.confirmedPlanId)
+          )
+        )
+        .returning();
+      return success(row ?? null);
+    } catch (error) {
+      this.logger.error(
+        `Réservation du confirm ${input.id}: ${getErrorMessage(error)}`
+      );
+      return failure(AiPlanImportErrorEnum.UPDATE_JOB_ERROR, toError(error));
+    }
+  }
+
+  async recordConfirmedPlan(input: {
+    id: string;
+    planId: number;
+    tx: Transaction;
+  }): Promise<Result<AiPlanImportJob, AiPlanImportError>> {
+    try {
+      const [row] = await input.tx
+        .update(aiPlanImportJobTable)
+        .set({
+          status: AiPlanImportJobStatusEnum.DONE,
+          confirmedPlanId: input.planId,
+          modifiedAt: new Date().toISOString(),
+        })
+        .where(eq(aiPlanImportJobTable.id, input.id))
+        .returning();
+
+      if (!row) {
+        return failure(AiPlanImportErrorEnum.JOB_NOT_FOUND);
+      }
+
+      return success(row);
+    } catch (error) {
+      this.logger.error(
+        `Enregistrement du plan confirmé ${input.id}: ${getErrorMessage(error)}`
       );
       return failure(AiPlanImportErrorEnum.UPDATE_JOB_ERROR, toError(error));
     }

--- a/apps/backend/src/plans/plans/ai-plan-import/ai-plan-import-job.repository.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/ai-plan-import-job.repository.ts
@@ -3,7 +3,7 @@ import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { Transaction } from '@tet/backend/utils/database/transaction.utils';
 import { failure, success, type Result } from '@tet/backend/utils/result.type';
 import { getErrorMessage } from '@tet/domain/utils';
-import { and, count, eq, inArray, isNull } from 'drizzle-orm';
+import { and, count, eq, inArray } from 'drizzle-orm';
 import { PlanDraft } from './models/plan-draft';
 import {
   AiPlanImportJob,
@@ -176,31 +176,23 @@ export class AiPlanImportJobRepository {
     }
   }
 
-  async claimForConfirm(input: {
+  async lockForConfirm(input: {
     id: string;
     tx: Transaction;
   }): Promise<Result<AiPlanImportJob | null, AiPlanImportError>> {
     try {
       const [row] = await input.tx
-        .update(aiPlanImportJobTable)
-        .set({
-          status: AiPlanImportJobStatusEnum.CONFIRMING,
-          modifiedAt: new Date().toISOString(),
-        })
-        .where(
-          and(
-            eq(aiPlanImportJobTable.id, input.id),
-            eq(aiPlanImportJobTable.status, AiPlanImportJobStatusEnum.DONE),
-            isNull(aiPlanImportJobTable.confirmedPlanId)
-          )
-        )
-        .returning();
+        .select()
+        .from(aiPlanImportJobTable)
+        .where(eq(aiPlanImportJobTable.id, input.id))
+        .for('update')
+        .limit(1);
       return success(row ?? null);
     } catch (error) {
       this.logger.error(
-        `Réservation du confirm ${input.id}: ${getErrorMessage(error)}`
+        `Verrouillage du job ${input.id}: ${getErrorMessage(error)}`
       );
-      return failure(AiPlanImportErrorEnum.UPDATE_JOB_ERROR, toError(error));
+      return failure(AiPlanImportErrorEnum.GET_JOB_ERROR, toError(error));
     }
   }
 
@@ -213,7 +205,6 @@ export class AiPlanImportJobRepository {
       const [row] = await input.tx
         .update(aiPlanImportJobTable)
         .set({
-          status: AiPlanImportJobStatusEnum.DONE,
           confirmedPlanId: input.planId,
           modifiedAt: new Date().toISOString(),
         })

--- a/apps/backend/src/plans/plans/ai-plan-import/ai-plan-import.module.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/ai-plan-import.module.ts
@@ -1,11 +1,15 @@
 import { BullModule } from '@nestjs/bullmq';
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { LlmModule } from '@tet/backend/utils/llm/llm.module';
+import { TransactionModule } from '@tet/backend/utils/transaction/transaction.module';
+import { PlanModule } from '../plans.module';
 import { AiPlanImportJobRepository } from './ai-plan-import-job.repository';
 import {
   AI_PLAN_IMPORT_JOB_OPTIONS,
   AI_PLAN_IMPORT_QUEUE_NAME,
 } from './ai-plan-import.queue';
+import { ConfirmImportRouter } from './confirm-import/confirm-import.router';
+import { ConfirmImportService } from './confirm-import/confirm-import.service';
 import { EnqueueImportController } from './enqueue-import/enqueue-import.controller';
 import { EnqueueImportService } from './enqueue-import/enqueue-import.service';
 import { GenerateImportDraftService } from './generate-import-draft/generate-import-draft.service';
@@ -16,6 +20,8 @@ import { GetImportStatusService } from './get-import-status/get-import-status.se
 @Module({
   imports: [
     LlmModule,
+    TransactionModule,
+    forwardRef(() => PlanModule),
     BullModule.registerQueue({
       name: AI_PLAN_IMPORT_QUEUE_NAME,
       defaultJobOptions: AI_PLAN_IMPORT_JOB_OPTIONS,
@@ -29,7 +35,9 @@ import { GetImportStatusService } from './get-import-status/get-import-status.se
     GenerateImportDraftWorker,
     GetImportStatusService,
     GetImportStatusRouter,
+    ConfirmImportService,
+    ConfirmImportRouter,
   ],
-  exports: [GetImportStatusRouter],
+  exports: [GetImportStatusRouter, ConfirmImportRouter],
 })
 export class AiPlanImportModule {}

--- a/apps/backend/src/plans/plans/ai-plan-import/ai-plan-import.module.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/ai-plan-import.module.ts
@@ -1,15 +1,11 @@
 import { BullModule } from '@nestjs/bullmq';
-import { forwardRef, Module } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 import { LlmModule } from '@tet/backend/utils/llm/llm.module';
-import { TransactionModule } from '@tet/backend/utils/transaction/transaction.module';
-import { PlanModule } from '../plans.module';
 import { AiPlanImportJobRepository } from './ai-plan-import-job.repository';
 import {
   AI_PLAN_IMPORT_JOB_OPTIONS,
   AI_PLAN_IMPORT_QUEUE_NAME,
 } from './ai-plan-import.queue';
-import { ConfirmImportRouter } from './confirm-import/confirm-import.router';
-import { ConfirmImportService } from './confirm-import/confirm-import.service';
 import { EnqueueImportController } from './enqueue-import/enqueue-import.controller';
 import { EnqueueImportService } from './enqueue-import/enqueue-import.service';
 import { GenerateImportDraftService } from './generate-import-draft/generate-import-draft.service';
@@ -20,8 +16,6 @@ import { GetImportStatusService } from './get-import-status/get-import-status.se
 @Module({
   imports: [
     LlmModule,
-    TransactionModule,
-    forwardRef(() => PlanModule),
     BullModule.registerQueue({
       name: AI_PLAN_IMPORT_QUEUE_NAME,
       defaultJobOptions: AI_PLAN_IMPORT_JOB_OPTIONS,
@@ -35,9 +29,7 @@ import { GetImportStatusService } from './get-import-status/get-import-status.se
     GenerateImportDraftWorker,
     GetImportStatusService,
     GetImportStatusRouter,
-    ConfirmImportService,
-    ConfirmImportRouter,
   ],
-  exports: [GetImportStatusRouter, ConfirmImportRouter],
+  exports: [GetImportStatusRouter, AiPlanImportJobRepository],
 })
 export class AiPlanImportModule {}

--- a/apps/backend/src/plans/plans/ai-plan-import/confirm-import/confirm-import.errors.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/confirm-import/confirm-import.errors.ts
@@ -1,0 +1,10 @@
+import { AiPlanImportJobStatus } from '../models/ai-plan-import-job';
+import { LineValidationError } from './draft-to-import-plan-input';
+
+export type ConfirmError =
+  | { kind: 'job_not_found' }
+  | { kind: 'forbidden' }
+  | { kind: 'not_confirmable'; status: AiPlanImportJobStatus }
+  | { kind: 'no_draft' }
+  | { kind: 'invalid_lines'; errors: LineValidationError[] }
+  | { kind: 'persistence_failed'; message: string; isClient: boolean };

--- a/apps/backend/src/plans/plans/ai-plan-import/confirm-import/confirm-import.input.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/confirm-import/confirm-import.input.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+import { extractedActionSchema } from '../models/extracted-action';
+
+export const confirmImportInputSchema = z.object({
+  jobId: z.string().uuid(),
+  planName: z.string().min(1),
+  planType: z.number().int().positive().optional(),
+  actions: z.array(extractedActionSchema),
+});
+
+export type ConfirmImportInput = z.output<typeof confirmImportInputSchema>;

--- a/apps/backend/src/plans/plans/ai-plan-import/confirm-import/confirm-import.output.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/confirm-import/confirm-import.output.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const confirmImportOutputSchema = z.object({
+  planId: z.number(),
+  fichesCount: z.number(),
+});
+
+export type ConfirmImportOutput = z.output<typeof confirmImportOutputSchema>;

--- a/apps/backend/src/plans/plans/ai-plan-import/confirm-import/confirm-import.router.e2e-spec.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/confirm-import/confirm-import.router.e2e-spec.ts
@@ -1,0 +1,179 @@
+import { INestApplication } from '@nestjs/common';
+import { axeTable } from '@tet/backend/plans/fiches/shared/models/axe.table';
+import { ficheActionAxeTable } from '@tet/backend/plans/fiches/shared/models/fiche-action-axe.table';
+import { ficheActionPiloteTable } from '@tet/backend/plans/fiches/shared/models/fiche-action-pilote.table';
+import {
+  getAuthUserFromUserCredentials,
+  getTestApp,
+  getTestDatabase,
+  getTestRouter,
+} from '@tet/backend/test';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { addTestUser } from '@tet/backend/users/users/users.test-fixture';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { CollectiviteRole } from '@tet/domain/users';
+import { eq, inArray } from 'drizzle-orm';
+import { afterAll, beforeAll, describe, expect, it, onTestFinished } from 'vitest';
+import { TrpcRouter } from '../../../../utils/trpc/trpc.router';
+import { initialStepStates } from '../generate-import-draft/run-import-pipeline';
+import { aiPlanImportJobTable } from '../models/ai-plan-import-job.table';
+import { ExtractedAction } from '../models/extracted-action';
+import { PlanDraft } from '../models/plan-draft';
+
+const TEST_COLLECTIVITE_ID = 1;
+const OTHER_COLLECTIVITE_ID = 2;
+
+const toAction = (overrides: Partial<ExtractedAction> = {}): ExtractedAction => ({
+  axe: 'Axe import IA',
+  sousAxe: '',
+  titre: 'Action import IA',
+  description: 'Description issue du brouillon',
+  objectifs: null,
+  structurePilote: null,
+  directionServicePilote: null,
+  personnePilote: null,
+  budget: null,
+  statut: null,
+  confidence: null,
+  sousActions: [],
+  ...overrides,
+});
+
+describe('Confirmation import IA', { timeout: 30_000 }, () => {
+  let app: INestApplication;
+  let router: TrpcRouter;
+  let databaseService: DatabaseService;
+  let testUser: AuthenticatedUser;
+  let outsiderUser: AuthenticatedUser;
+  const jobIds: string[] = [];
+
+  const seedDoneJob = async (draft: PlanDraft): Promise<string> => {
+    const [row] = await databaseService.db
+      .insert(aiPlanImportJobTable)
+      .values({
+        collectiviteId: TEST_COLLECTIVITE_ID,
+        createdBy: testUser.id,
+        status: 'done',
+        options: {
+          instructions: '',
+          withVerifications: true,
+          withSousActions: true,
+          disabledFields: [],
+        },
+        stepStates: initialStepStates(),
+        sourcePath: `${TEST_COLLECTIVITE_ID}/e2e-confirm`,
+        draft,
+      })
+      .returning();
+    jobIds.push(row.id);
+    return row.id;
+  };
+
+  const deletePlan = async (
+    caller: ReturnType<TrpcRouter['createCaller']>,
+    planId: number
+  ) => {
+    const axeIds = await databaseService.db
+      .select({ id: axeTable.id })
+      .from(axeTable)
+      .where(eq(axeTable.plan, planId));
+    const allAxeIds = [planId, ...axeIds.map((axe) => axe.id)];
+
+    const ficheRows = await databaseService.db
+      .select({ ficheId: ficheActionAxeTable.ficheId })
+      .from(ficheActionAxeTable)
+      .where(inArray(ficheActionAxeTable.axeId, allAxeIds));
+    const ficheIds = ficheRows
+      .map((fiche) => fiche.ficheId)
+      .filter((id): id is number => id !== null);
+
+    if (ficheIds.length > 0) {
+      await databaseService.db
+        .delete(ficheActionPiloteTable)
+        .where(inArray(ficheActionPiloteTable.ficheId, ficheIds));
+    }
+
+    await caller.plans.plans.delete({ planId });
+  };
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    router = await getTestRouter(app);
+    databaseService = await getTestDatabase(app);
+
+    const owner = await addTestUser(databaseService, {
+      collectiviteId: TEST_COLLECTIVITE_ID,
+      role: CollectiviteRole.ADMIN,
+    });
+    testUser = getAuthUserFromUserCredentials(owner.user);
+
+    const outsider = await addTestUser(databaseService, {
+      collectiviteId: OTHER_COLLECTIVITE_ID,
+      role: CollectiviteRole.ADMIN,
+    });
+    outsiderUser = getAuthUserFromUserCredentials(outsider.user);
+  });
+
+  afterAll(async () => {
+    if (jobIds.length > 0) {
+      await databaseService.db
+        .delete(aiPlanImportJobTable)
+        .where(inArray(aiPlanImportJobTable.id, jobIds));
+    }
+    await app.close();
+  });
+
+  it('confirme un brouillon et crée le plan, puis reste idempotent', async () => {
+    const caller = router.createCaller({ user: testUser });
+    const actions = [toAction()];
+    const jobId = await seedDoneJob({ actions, qualitativeReview: null });
+
+    const result = await caller.plans.plans.confirmAiImport({
+      jobId,
+      planName: 'Plan import IA e2e',
+      actions,
+    });
+
+    expect(result.planId).toBeGreaterThan(0);
+    expect(result.fichesCount).toBe(1);
+
+    onTestFinished(async () => {
+      await deletePlan(caller, result.planId);
+    });
+
+    const second = await caller.plans.plans.confirmAiImport({
+      jobId,
+      planName: 'Plan import IA e2e',
+      actions,
+    });
+    expect(second.planId).toBe(result.planId);
+  });
+
+  it('refuse la confirmation par un utilisateur sans droit sur la collectivité', async () => {
+    const actions = [toAction()];
+    const jobId = await seedDoneJob({ actions, qualitativeReview: null });
+
+    const outsiderCaller = router.createCaller({ user: outsiderUser });
+    await expect(
+      outsiderCaller.plans.plans.confirmAiImport({
+        jobId,
+        planName: 'Plan import IA e2e',
+        actions,
+      })
+    ).rejects.toThrowError();
+  });
+
+  it('renvoie une erreur quand une action du brouillon est invalide', async () => {
+    const caller = router.createCaller({ user: testUser });
+    const actions = [toAction({ titre: '' })];
+    const jobId = await seedDoneJob({ actions, qualitativeReview: null });
+
+    await expect(
+      caller.plans.plans.confirmAiImport({
+        jobId,
+        planName: 'Plan import IA e2e',
+        actions,
+      })
+    ).rejects.toThrowError('Le titre de l\'action est invalide');
+  });
+});

--- a/apps/backend/src/plans/plans/ai-plan-import/confirm-import/confirm-import.router.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/confirm-import/confirm-import.router.ts
@@ -1,0 +1,74 @@
+import { Injectable } from '@nestjs/common';
+import { TrpcService } from '@tet/backend/utils/trpc/trpc.service';
+import { TRPCError } from '@trpc/server';
+import { ConfirmError } from './confirm-import.errors';
+import { confirmImportInputSchema } from './confirm-import.input';
+import { confirmImportOutputSchema } from './confirm-import.output';
+import { ConfirmImportService } from './confirm-import.service';
+import { LineValidationError } from './draft-to-import-plan-input';
+
+@Injectable()
+export class ConfirmImportRouter {
+  constructor(
+    private readonly trpc: TrpcService,
+    private readonly confirmImportService: ConfirmImportService
+  ) {}
+
+  router = this.trpc.router({
+    confirmAiImport: this.trpc.authedProcedure
+      .input(confirmImportInputSchema)
+      .output(confirmImportOutputSchema)
+      .mutation(async ({ input, ctx: { user } }) => {
+        const result = await this.confirmImportService.confirm({ input, user });
+        if (!result.success) {
+          throw confirmErrorToTrpcError(result.error);
+        }
+        return result.data;
+      }),
+  });
+}
+
+const confirmErrorToTrpcError = (error: ConfirmError): TRPCError => {
+  switch (error.kind) {
+    case 'job_not_found':
+      return new TRPCError({
+        code: 'NOT_FOUND',
+        message: "Le job d'import demandé n'existe pas",
+      });
+    case 'forbidden':
+      return new TRPCError({
+        code: 'FORBIDDEN',
+        message: "Vous n'avez pas le droit de confirmer cet import",
+      });
+    case 'not_confirmable':
+      return new TRPCError({
+        code: 'CONFLICT',
+        message: `Le brouillon n'est pas confirmable (statut ${error.status})`,
+      });
+    case 'no_draft':
+      return new TRPCError({
+        code: 'CONFLICT',
+        message: 'Le job ne contient aucun brouillon à confirmer',
+      });
+    case 'invalid_lines':
+      return new TRPCError({
+        code: 'BAD_REQUEST',
+        message: lineErrorsToMessage(error.errors),
+      });
+    case 'persistence_failed':
+      return new TRPCError({
+        code: error.isClient ? 'BAD_REQUEST' : 'INTERNAL_SERVER_ERROR',
+        message: error.message,
+      });
+  }
+};
+
+const lineErrorsToMessage = (errors: LineValidationError[]): string =>
+  errors
+    .map(
+      (error) =>
+        `Action "${error.titre}" (ligne ${error.actionIndex + 1}) : ${
+          error.message
+        }`
+    )
+    .join('\n');

--- a/apps/backend/src/plans/plans/ai-plan-import/confirm-import/confirm-import.service.spec.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/confirm-import/confirm-import.service.spec.ts
@@ -1,0 +1,231 @@
+import { ImportPlanService } from '@tet/backend/plans/plans/import-plan-aggregate/import-plan.service';
+import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { failure, success } from '@tet/backend/utils/result.type';
+import { TransactionManager } from '@tet/backend/utils/transaction/transaction-manager.service';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AiPlanImportJobRepository } from '../ai-plan-import-job.repository';
+import { initialStepStates } from '../generate-import-draft/run-import-pipeline';
+import {
+  AiPlanImportJob,
+  AiPlanImportJobStatusEnum,
+} from '../models/ai-plan-import-job';
+import { ExtractedAction } from '../models/extracted-action';
+import { ConfirmImportService } from './confirm-import.service';
+
+const user = { id: 'user-1' } as AuthenticatedUser;
+
+const toAction = (overrides: Partial<ExtractedAction> = {}): ExtractedAction => ({
+  axe: 'Mobilité',
+  sousAxe: 'Vélo',
+  titre: 'Développer le réseau cyclable',
+  description: null,
+  objectifs: null,
+  structurePilote: null,
+  directionServicePilote: null,
+  personnePilote: null,
+  budget: null,
+  statut: null,
+  confidence: null,
+  sousActions: [],
+  ...overrides,
+});
+
+const toJob = (overrides: Partial<AiPlanImportJob>): AiPlanImportJob => ({
+  id: 'job-1',
+  collectiviteId: 10,
+  createdBy: 'user-1',
+  status: AiPlanImportJobStatusEnum.DONE,
+  options: {
+    instructions: '',
+    withVerifications: true,
+    withSousActions: true,
+    disabledFields: [],
+  },
+  stepStates: initialStepStates(),
+  sourcePath: '10/abc',
+  draft: { actions: [toAction()], qualitativeReview: null },
+  error: null,
+  confirmedPlanId: null,
+  createdAt: '2026-06-10T00:00:00Z',
+  modifiedAt: '2026-06-10T00:00:00Z',
+  ...overrides,
+});
+
+const buildService = (args: {
+  job: AiPlanImportJob | null;
+  rereadJob?: AiPlanImportJob;
+  isAllowed?: boolean;
+  claimed?: boolean;
+  savedPlanId?: number;
+  savedFichesCount?: number;
+}) => {
+  const getById = vi.fn(async () =>
+    args.job ? success(args.job) : failure('JOB_NOT_FOUND')
+  );
+  if (args.rereadJob) {
+    getById.mockResolvedValueOnce(success(args.job ?? args.rereadJob));
+    getById.mockResolvedValueOnce(success(args.rereadJob));
+  }
+  const claimForConfirm = vi.fn(async () =>
+    success(args.claimed === false ? null : args.job)
+  );
+  const recordConfirmedPlan = vi.fn(async () => success(args.job));
+  const save = vi.fn(async () =>
+    success({
+      planId: args.savedPlanId ?? 42,
+      fichesCount: args.savedFichesCount ?? 1,
+    })
+  );
+  const jobRepository = {
+    getById,
+    claimForConfirm,
+    recordConfirmedPlan,
+  } as unknown as AiPlanImportJobRepository;
+  const importPlanService = { save } as unknown as ImportPlanService;
+  const permissions = {
+    isAllowed: vi.fn(async () => args.isAllowed ?? true),
+  } as unknown as PermissionService;
+  const transactionManager = {
+    executeSingle: vi.fn(async (operation) => operation({} as Transaction)),
+  } as unknown as TransactionManager;
+
+  const service = new ConfirmImportService(
+    permissions,
+    jobRepository,
+    importPlanService,
+    transactionManager
+  );
+  return { service, save, claimForConfirm, recordConfirmedPlan };
+};
+
+describe('ConfirmImportService', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('mappe le brouillon édité, persiste via le seam et renvoie le plan créé', async () => {
+    const { service, save } = buildService({
+      job: toJob({}),
+      savedPlanId: 42,
+      savedFichesCount: 2,
+    });
+
+    const result = await service.confirm({
+      input: {
+        jobId: 'job-1',
+        planName: 'Plan vélo 2026',
+        actions: [toAction({ sousActions: [] }), toAction({ titre: 'Action 2' })],
+      },
+      user,
+    });
+
+    expect(result).toEqual({
+      success: true,
+      data: { planId: 42, fichesCount: 2 },
+    });
+    expect(save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collectiviteId: 10,
+        user,
+        planInput: expect.objectContaining({
+          nom: 'Plan vélo 2026',
+          actions: expect.arrayContaining([
+            expect.objectContaining({ titre: 'Développer le réseau cyclable' }),
+          ]),
+        }),
+      })
+    );
+  });
+
+  it('2e confirmation renvoie le même planId sans recréer de plan', async () => {
+    const { service, save, claimForConfirm } = buildService({
+      job: toJob({ confirmedPlanId: 42 }),
+    });
+
+    const result = await service.confirm({
+      input: { jobId: 'job-1', planName: 'Plan vélo 2026', actions: [toAction()] },
+      user,
+    });
+
+    expect(result).toEqual({
+      success: true,
+      data: { planId: 42, fichesCount: 1 },
+    });
+    expect(save).not.toHaveBeenCalled();
+    expect(claimForConfirm).not.toHaveBeenCalled();
+  });
+
+  it('renvoie une erreur niveau champ par ligne quand le brouillon est invalide', async () => {
+    const { service, save } = buildService({ job: toJob({}) });
+
+    const result = await service.confirm({
+      input: {
+        jobId: 'job-1',
+        planName: 'Plan vélo 2026',
+        actions: [toAction({ titre: 'Valide' }), toAction({ titre: '' })],
+      },
+      user,
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: {
+        kind: 'invalid_lines',
+        errors: [
+          {
+            actionIndex: 1,
+            titre: '',
+            message: 'Le titre de l\'action est invalide : ""',
+          },
+        ],
+      },
+    });
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it('refuse la confirmation sans droit sur la collectivité', async () => {
+    const { service } = buildService({ job: toJob({}), isAllowed: false });
+
+    const result = await service.confirm({
+      input: { jobId: 'job-1', planName: 'Plan vélo 2026', actions: [toAction()] },
+      user,
+    });
+
+    expect(result).toEqual({ success: false, error: { kind: 'forbidden' } });
+  });
+
+  it('refuse la confirmation tant que le job n est pas terminé', async () => {
+    const { service } = buildService({
+      job: toJob({ status: AiPlanImportJobStatusEnum.RUNNING, draft: null }),
+    });
+
+    const result = await service.confirm({
+      input: { jobId: 'job-1', planName: 'Plan vélo 2026', actions: [toAction()] },
+      user,
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: { kind: 'not_confirmable', status: 'running' },
+    });
+  });
+
+  it('renvoie le planId existant si la réservation échoue mais que le job est déjà confirmé', async () => {
+    const { service, save } = buildService({
+      job: toJob({}),
+      rereadJob: toJob({ confirmedPlanId: 42 }),
+      claimed: false,
+    });
+
+    const result = await service.confirm({
+      input: { jobId: 'job-1', planName: 'Plan vélo 2026', actions: [toAction()] },
+      user,
+    });
+
+    expect(result).toEqual({
+      success: true,
+      data: { planId: 42, fichesCount: 1 },
+    });
+    expect(save).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/plans/plans/ai-plan-import/confirm-import/confirm-import.service.spec.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/confirm-import/confirm-import.service.spec.ts
@@ -55,21 +55,16 @@ const toJob = (overrides: Partial<AiPlanImportJob>): AiPlanImportJob => ({
 
 const buildService = (args: {
   job: AiPlanImportJob | null;
-  rereadJob?: AiPlanImportJob;
+  lockedJob?: AiPlanImportJob;
   isAllowed?: boolean;
-  claimed?: boolean;
   savedPlanId?: number;
   savedFichesCount?: number;
 }) => {
   const getById = vi.fn(async () =>
     args.job ? success(args.job) : failure('JOB_NOT_FOUND')
   );
-  if (args.rereadJob) {
-    getById.mockResolvedValueOnce(success(args.job ?? args.rereadJob));
-    getById.mockResolvedValueOnce(success(args.rereadJob));
-  }
-  const claimForConfirm = vi.fn(async () =>
-    success(args.claimed === false ? null : args.job)
+  const lockForConfirm = vi.fn(async () =>
+    success(args.lockedJob ?? args.job)
   );
   const recordConfirmedPlan = vi.fn(async () => success(args.job));
   const save = vi.fn(async () =>
@@ -80,7 +75,7 @@ const buildService = (args: {
   );
   const jobRepository = {
     getById,
-    claimForConfirm,
+    lockForConfirm,
     recordConfirmedPlan,
   } as unknown as AiPlanImportJobRepository;
   const importPlanService = { save } as unknown as ImportPlanService;
@@ -97,7 +92,7 @@ const buildService = (args: {
     importPlanService,
     transactionManager
   );
-  return { service, save, claimForConfirm, recordConfirmedPlan };
+  return { service, save, lockForConfirm, recordConfirmedPlan };
 };
 
 describe('ConfirmImportService', () => {
@@ -138,7 +133,7 @@ describe('ConfirmImportService', () => {
   });
 
   it('2e confirmation renvoie le même planId sans recréer de plan', async () => {
-    const { service, save, claimForConfirm } = buildService({
+    const { service, save, lockForConfirm } = buildService({
       job: toJob({ confirmedPlanId: 42 }),
     });
 
@@ -152,7 +147,7 @@ describe('ConfirmImportService', () => {
       data: { planId: 42, fichesCount: 1 },
     });
     expect(save).not.toHaveBeenCalled();
-    expect(claimForConfirm).not.toHaveBeenCalled();
+    expect(lockForConfirm).not.toHaveBeenCalled();
   });
 
   it('renvoie une erreur niveau champ par ligne quand le brouillon est invalide', async () => {
@@ -210,11 +205,10 @@ describe('ConfirmImportService', () => {
     });
   });
 
-  it('renvoie le planId existant si la réservation échoue mais que le job est déjà confirmé', async () => {
+  it('renvoie le planId existant si le job a été confirmé pendant le verrou', async () => {
     const { service, save } = buildService({
       job: toJob({}),
-      rereadJob: toJob({ confirmedPlanId: 42 }),
-      claimed: false,
+      lockedJob: toJob({ confirmedPlanId: 42 }),
     });
 
     const result = await service.confirm({

--- a/apps/backend/src/plans/plans/ai-plan-import/confirm-import/confirm-import.service.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/confirm-import/confirm-import.service.ts
@@ -88,24 +88,31 @@ export class ConfirmImportService {
 
     return this.transactionManager.executeSingle<ConfirmImportOutput, ConfirmError>(
       async (tx) => {
-        const claimResult = await this.jobRepository.claimForConfirm({
+        const lockResult = await this.jobRepository.lockForConfirm({
           id: job.id,
           tx,
         });
-        if (!claimResult.success) {
+        if (!lockResult.success) {
           return failure({
             kind: 'persistence_failed',
-            message: 'La réservation du job de confirmation a échoué',
+            message: 'Le verrouillage du job de confirmation a échoué',
             isClient: false,
           });
         }
-        if (claimResult.data === null) {
-          return this.resolveAlreadyConfirmed({ job, fichesCount });
+        const lockedJob = lockResult.data;
+        if (lockedJob === null) {
+          return failure({ kind: 'job_not_found' });
+        }
+        if (lockedJob.confirmedPlanId !== null) {
+          return success({ planId: lockedJob.confirmedPlanId, fichesCount });
+        }
+        if (lockedJob.status !== AiPlanImportJobStatusEnum.DONE) {
+          return failure({ kind: 'not_confirmable', status: lockedJob.status });
         }
 
         const saveResult = await this.importPlanService.save({
           planInput,
-          collectiviteId: job.collectiviteId,
+          collectiviteId: lockedJob.collectiviteId,
           user,
           tx,
         });
@@ -118,7 +125,7 @@ export class ConfirmImportService {
         }
 
         const recordResult = await this.jobRepository.recordConfirmedPlan({
-          id: job.id,
+          id: lockedJob.id,
           planId: saveResult.data.planId,
           tx,
         });
@@ -136,22 +143,5 @@ export class ConfirmImportService {
         });
       }
     );
-  }
-
-  private async resolveAlreadyConfirmed(args: {
-    job: AiPlanImportJob;
-    fichesCount: number;
-  }): Promise<Result<ConfirmImportOutput, ConfirmError>> {
-    const rereadResult = await this.jobRepository.getById(args.job.id);
-    if (rereadResult.success && rereadResult.data.confirmedPlanId !== null) {
-      return success({
-        planId: rereadResult.data.confirmedPlanId,
-        fichesCount: args.fichesCount,
-      });
-    }
-    return failure({
-      kind: 'not_confirmable',
-      status: rereadResult.success ? rereadResult.data.status : args.job.status,
-    });
   }
 }

--- a/apps/backend/src/plans/plans/ai-plan-import/confirm-import/confirm-import.service.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/confirm-import/confirm-import.service.ts
@@ -88,38 +88,41 @@ export class ConfirmImportService {
 
     return this.transactionManager.executeSingle<ConfirmImportOutput, ConfirmError>(
       async (tx) => {
-        const claim = await this.jobRepository.claimForConfirm({ id: job.id, tx });
-        if (!claim.success) {
+        const claimResult = await this.jobRepository.claimForConfirm({
+          id: job.id,
+          tx,
+        });
+        if (!claimResult.success) {
           return failure({
             kind: 'persistence_failed',
             message: 'La réservation du job de confirmation a échoué',
             isClient: false,
           });
         }
-        if (claim.data === null) {
+        if (claimResult.data === null) {
           return this.resolveAlreadyConfirmed({ job, fichesCount });
         }
 
-        const saved = await this.importPlanService.save({
+        const saveResult = await this.importPlanService.save({
           planInput,
           collectiviteId: job.collectiviteId,
           user,
           tx,
         });
-        if (!saved.success) {
+        if (!saveResult.success) {
           return failure({
             kind: 'persistence_failed',
-            message: saved.error.message,
-            isClient: isClientError(saved.error),
+            message: saveResult.error.message,
+            isClient: isClientError(saveResult.error),
           });
         }
 
-        const recorded = await this.jobRepository.recordConfirmedPlan({
+        const recordResult = await this.jobRepository.recordConfirmedPlan({
           id: job.id,
-          planId: saved.data.planId,
+          planId: saveResult.data.planId,
           tx,
         });
-        if (!recorded.success) {
+        if (!recordResult.success) {
           return failure({
             kind: 'persistence_failed',
             message: "L'enregistrement du plan confirmé a échoué",
@@ -128,8 +131,8 @@ export class ConfirmImportService {
         }
 
         return success({
-          planId: saved.data.planId,
-          fichesCount: saved.data.fichesCount,
+          planId: saveResult.data.planId,
+          fichesCount: saveResult.data.fichesCount,
         });
       }
     );
@@ -139,16 +142,16 @@ export class ConfirmImportService {
     job: AiPlanImportJob;
     fichesCount: number;
   }): Promise<Result<ConfirmImportOutput, ConfirmError>> {
-    const reread = await this.jobRepository.getById(args.job.id);
-    if (reread.success && reread.data.confirmedPlanId !== null) {
+    const rereadResult = await this.jobRepository.getById(args.job.id);
+    if (rereadResult.success && rereadResult.data.confirmedPlanId !== null) {
       return success({
-        planId: reread.data.confirmedPlanId,
+        planId: rereadResult.data.confirmedPlanId,
         fichesCount: args.fichesCount,
       });
     }
     return failure({
       kind: 'not_confirmable',
-      status: reread.success ? reread.data.status : args.job.status,
+      status: rereadResult.success ? rereadResult.data.status : args.job.status,
     });
   }
 }

--- a/apps/backend/src/plans/plans/ai-plan-import/confirm-import/confirm-import.service.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/confirm-import/confirm-import.service.ts
@@ -1,0 +1,130 @@
+import { Injectable } from '@nestjs/common';
+import { ImportPlanService } from '@tet/backend/plans/plans/import-plan-aggregate/import-plan.service';
+import { isClientError } from '@tet/backend/plans/plans/import-plan-aggregate/import.errors';
+import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { failure, success, type Result } from '@tet/backend/utils/result.type';
+import { TransactionManager } from '@tet/backend/utils/transaction/transaction-manager.service';
+import { ResourceType } from '@tet/domain/users';
+import { AiPlanImportJobRepository } from '../ai-plan-import-job.repository';
+import { AiPlanImportJobStatusEnum } from '../models/ai-plan-import-job';
+import { ConfirmError } from './confirm-import.errors';
+import { ConfirmImportInput } from './confirm-import.input';
+import { ConfirmImportOutput } from './confirm-import.output';
+import {
+  draftToImportPlanInput,
+  draftValidationErrors,
+} from './draft-to-import-plan-input';
+
+@Injectable()
+export class ConfirmImportService {
+  constructor(
+    private readonly permissions: PermissionService,
+    private readonly jobRepository: AiPlanImportJobRepository,
+    private readonly importPlanService: ImportPlanService,
+    private readonly transactionManager: TransactionManager
+  ) {}
+
+  async confirm(args: {
+    input: ConfirmImportInput;
+    user: AuthenticatedUser;
+  }): Promise<Result<ConfirmImportOutput, ConfirmError>> {
+    const { input, user } = args;
+
+    const jobResult = await this.jobRepository.getById(input.jobId);
+    if (!jobResult.success) {
+      return failure({ kind: 'job_not_found' });
+    }
+    const job = jobResult.data;
+
+    const isAllowed = await this.permissions.isAllowed(
+      user,
+      'plans.fiches.import',
+      ResourceType.COLLECTIVITE,
+      job.collectiviteId,
+      true
+    );
+    if (!isAllowed) {
+      return failure({ kind: 'forbidden' });
+    }
+
+    const planInput = draftToImportPlanInput({
+      actions: input.actions,
+      planName: input.planName,
+      planType: input.planType,
+    });
+    const fichesCount = planInput.actions.length;
+
+    if (job.confirmedPlanId !== null) {
+      return success({ planId: job.confirmedPlanId, fichesCount });
+    }
+
+    const lineErrors = draftValidationErrors(input.actions);
+    if (lineErrors.length > 0) {
+      return failure({ kind: 'invalid_lines', errors: lineErrors });
+    }
+
+    if (job.status !== AiPlanImportJobStatusEnum.DONE) {
+      return failure({ kind: 'not_confirmable', status: job.status });
+    }
+    if (job.draft === null) {
+      return failure({ kind: 'no_draft' });
+    }
+
+    return this.transactionManager.executeSingle<ConfirmImportOutput, ConfirmError>(
+      async (tx) => {
+        const claim = await this.jobRepository.claimForConfirm({ id: job.id, tx });
+        if (!claim.success) {
+          return failure({
+            kind: 'persistence_failed',
+            message: 'La réservation du job de confirmation a échoué',
+            isClient: false,
+          });
+        }
+
+        if (claim.data === null) {
+          const reread = await this.jobRepository.getById(job.id);
+          if (reread.success && reread.data.confirmedPlanId !== null) {
+            return success({ planId: reread.data.confirmedPlanId, fichesCount });
+          }
+          return failure({
+            kind: 'not_confirmable',
+            status: reread.success ? reread.data.status : job.status,
+          });
+        }
+
+        const saved = await this.importPlanService.save({
+          planInput,
+          collectiviteId: job.collectiviteId,
+          user,
+          tx,
+        });
+        if (!saved.success) {
+          return failure({
+            kind: 'persistence_failed',
+            message: saved.error.message,
+            isClient: isClientError(saved.error),
+          });
+        }
+
+        const recorded = await this.jobRepository.recordConfirmedPlan({
+          id: job.id,
+          planId: saved.data.planId,
+          tx,
+        });
+        if (!recorded.success) {
+          return failure({
+            kind: 'persistence_failed',
+            message: "L'enregistrement du plan confirmé a échoué",
+            isClient: false,
+          });
+        }
+
+        return success({
+          planId: saved.data.planId,
+          fichesCount: saved.data.fichesCount,
+        });
+      }
+    );
+  }
+}

--- a/apps/backend/src/plans/plans/ai-plan-import/confirm-import/confirm-import.service.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/confirm-import/confirm-import.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { ImportPlanInput } from '@tet/backend/plans/plans/import-plan-aggregate/import-plan.input';
 import { ImportPlanService } from '@tet/backend/plans/plans/import-plan-aggregate/import-plan.service';
 import { isClientError } from '@tet/backend/plans/plans/import-plan-aggregate/import.errors';
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
@@ -7,7 +8,10 @@ import { failure, success, type Result } from '@tet/backend/utils/result.type';
 import { TransactionManager } from '@tet/backend/utils/transaction/transaction-manager.service';
 import { ResourceType } from '@tet/domain/users';
 import { AiPlanImportJobRepository } from '../ai-plan-import-job.repository';
-import { AiPlanImportJobStatusEnum } from '../models/ai-plan-import-job';
+import {
+  AiPlanImportJob,
+  AiPlanImportJobStatusEnum,
+} from '../models/ai-plan-import-job';
 import { ConfirmError } from './confirm-import.errors';
 import { ConfirmImportInput } from './confirm-import.input';
 import { ConfirmImportOutput } from './confirm-import.output';
@@ -71,6 +75,17 @@ export class ConfirmImportService {
       return failure({ kind: 'no_draft' });
     }
 
+    return this.createPlanFromDraft({ job, planInput, fichesCount, user });
+  }
+
+  private createPlanFromDraft(args: {
+    job: AiPlanImportJob;
+    planInput: ImportPlanInput;
+    fichesCount: number;
+    user: AuthenticatedUser;
+  }): Promise<Result<ConfirmImportOutput, ConfirmError>> {
+    const { job, planInput, fichesCount, user } = args;
+
     return this.transactionManager.executeSingle<ConfirmImportOutput, ConfirmError>(
       async (tx) => {
         const claim = await this.jobRepository.claimForConfirm({ id: job.id, tx });
@@ -81,16 +96,8 @@ export class ConfirmImportService {
             isClient: false,
           });
         }
-
         if (claim.data === null) {
-          const reread = await this.jobRepository.getById(job.id);
-          if (reread.success && reread.data.confirmedPlanId !== null) {
-            return success({ planId: reread.data.confirmedPlanId, fichesCount });
-          }
-          return failure({
-            kind: 'not_confirmable',
-            status: reread.success ? reread.data.status : job.status,
-          });
+          return this.resolveAlreadyConfirmed({ job, fichesCount });
         }
 
         const saved = await this.importPlanService.save({
@@ -126,5 +133,22 @@ export class ConfirmImportService {
         });
       }
     );
+  }
+
+  private async resolveAlreadyConfirmed(args: {
+    job: AiPlanImportJob;
+    fichesCount: number;
+  }): Promise<Result<ConfirmImportOutput, ConfirmError>> {
+    const reread = await this.jobRepository.getById(args.job.id);
+    if (reread.success && reread.data.confirmedPlanId !== null) {
+      return success({
+        planId: reread.data.confirmedPlanId,
+        fichesCount: args.fichesCount,
+      });
+    }
+    return failure({
+      kind: 'not_confirmable',
+      status: reread.success ? reread.data.status : args.job.status,
+    });
   }
 }

--- a/apps/backend/src/plans/plans/ai-plan-import/confirm-import/draft-to-import-plan-input.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/confirm-import/draft-to-import-plan-input.ts
@@ -1,0 +1,33 @@
+import { ImportPlanInput } from '@tet/backend/plans/plans/import-plan-aggregate/import-plan.input';
+import { validateAction } from '@tet/backend/plans/plans/import-plan-aggregate/validators/action.validator';
+import { extractedActionToImportActions } from '../adapters/extracted-action-to-import-action';
+import { ExtractedAction } from '../models/extracted-action';
+
+export type LineValidationError = {
+  actionIndex: number;
+  titre: string;
+  message: string;
+};
+
+export const draftToImportPlanInput = (input: {
+  actions: ExtractedAction[];
+  planName: string;
+  planType?: number;
+}): ImportPlanInput => ({
+  nom: input.planName,
+  typeId: input.planType,
+  actions: input.actions.flatMap(extractedActionToImportActions),
+});
+
+export const draftValidationErrors = (
+  actions: ExtractedAction[]
+): LineValidationError[] =>
+  actions.flatMap((action, actionIndex) =>
+    extractedActionToImportActions(action)
+      .map((row) => validateAction(row))
+      .flatMap((result) =>
+        result.success
+          ? []
+          : [{ actionIndex, titre: action.titre, message: result.error.message }]
+      )
+  );

--- a/apps/backend/src/plans/plans/ai-plan-import/enqueue-import/enqueue-import.service.spec.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/enqueue-import/enqueue-import.service.spec.ts
@@ -38,6 +38,7 @@ const job: AiPlanImportJob = {
   sourcePath: '10/abc',
   draft: null,
   error: null,
+  confirmedPlanId: null,
   createdAt: '2026-06-11T00:00:00Z',
   modifiedAt: '2026-06-11T00:00:00Z',
 };

--- a/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/generate-import-draft.service.spec.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/generate-import-draft.service.spec.ts
@@ -27,6 +27,7 @@ const job: AiPlanImportJob = {
   sourcePath: '10/abc',
   draft: null,
   error: null,
+  confirmedPlanId: null,
   createdAt: '2026-06-10T00:00:00Z',
   modifiedAt: '2026-06-10T00:00:00Z',
 };

--- a/apps/backend/src/plans/plans/ai-plan-import/get-import-status/get-import-status.service.spec.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/get-import-status/get-import-status.service.spec.ts
@@ -28,6 +28,7 @@ const toJob = (overrides: Partial<AiPlanImportJob>): AiPlanImportJob => ({
   sourcePath: '10/abc',
   draft: null,
   error: null,
+  confirmedPlanId: null,
   createdAt: '2026-06-10T00:00:00Z',
   modifiedAt: '2026-06-10T00:00:00Z',
   ...overrides,

--- a/apps/backend/src/plans/plans/ai-plan-import/models/ai-plan-import-job.table.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/models/ai-plan-import-job.table.ts
@@ -1,4 +1,5 @@
 import { collectiviteTable } from '@tet/backend/collectivites/shared/models/collectivite.table';
+import { axeTable } from '@tet/backend/plans/fiches/shared/models/axe.table';
 import { authUsersTable } from '@tet/backend/users/models/auth-users.table';
 import { createdAt, modifiedAt } from '@tet/backend/utils/column.utils';
 import { sql } from 'drizzle-orm';
@@ -33,6 +34,9 @@ export const aiPlanImportJobTable = pgTable(
     sourcePath: text('source_path').notNull(),
     draft: jsonb('draft').$type<PlanDraft>(),
     error: text('error'),
+    confirmedPlanId: integer('confirmed_plan_id').references(() => axeTable.id, {
+      onDelete: 'set null',
+    }),
     createdAt,
     modifiedAt,
   },

--- a/apps/backend/src/plans/plans/ai-plan-import/models/ai-plan-import-job.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/models/ai-plan-import-job.ts
@@ -9,7 +9,6 @@ export const aiPlanImportJobStatusValues = [
   'running',
   'done',
   'failed',
-  'confirming',
 ] as const;
 
 export const AiPlanImportJobStatusEnum = createEnumObject(

--- a/apps/backend/src/plans/plans/ai-plan-import/models/ai-plan-import-job.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/models/ai-plan-import-job.ts
@@ -9,6 +9,7 @@ export const aiPlanImportJobStatusValues = [
   'running',
   'done',
   'failed',
+  'confirming',
 ] as const;
 
 export const AiPlanImportJobStatusEnum = createEnumObject(
@@ -41,6 +42,7 @@ export type AiPlanImportJob = {
   sourcePath: string;
   draft: PlanDraft | null;
   error: string | null;
+  confirmedPlanId: number | null;
   createdAt: string;
   modifiedAt: string;
 };

--- a/apps/backend/src/plans/plans/plans.module.ts
+++ b/apps/backend/src/plans/plans/plans.module.ts
@@ -16,6 +16,8 @@ import { UpsertAxeRouter } from '../axes/upsert-axe/upsert-axe.router';
 import { UpsertAxeService } from '../axes/upsert-axe/upsert-axe.service';
 import { FichesModule } from '../fiches/fiches.module';
 import { AiPlanImportModule } from './ai-plan-import/ai-plan-import.module';
+import { ConfirmImportRouter } from './ai-plan-import/confirm-import/confirm-import.router';
+import { ConfirmImportService } from './ai-plan-import/confirm-import/confirm-import.service';
 import { ComputeBudgetRules } from './compute-budget/compute-budget.rules';
 import { DeletePlanRepository } from './delete-plan/delete-plan.repository';
 import { DeletePlanRouter } from './delete-plan/delete-plan.router';
@@ -49,7 +51,7 @@ import { UpsertPlanService } from './upsert-plan/upsert-plan.service';
     forwardRef(() => FichesModule),
     AxeModule,
     TransactionModule,
-    forwardRef(() => AiPlanImportModule),
+    AiPlanImportModule,
   ],
   providers: [
     GetPlanCompletionService,
@@ -89,6 +91,8 @@ import { UpsertPlanService } from './upsert-plan/upsert-plan.service';
     ImportPlanService,
     ImportExcelPlanApplicationService,
     ImportPlanRouter,
+    ConfirmImportService,
+    ConfirmImportRouter,
     ResolveEntityService,
   ],
   exports: [

--- a/apps/backend/src/plans/plans/plans.module.ts
+++ b/apps/backend/src/plans/plans/plans.module.ts
@@ -49,7 +49,7 @@ import { UpsertPlanService } from './upsert-plan/upsert-plan.service';
     forwardRef(() => FichesModule),
     AxeModule,
     TransactionModule,
-    AiPlanImportModule,
+    forwardRef(() => AiPlanImportModule),
   ],
   providers: [
     GetPlanCompletionService,

--- a/apps/backend/src/plans/plans/plans.router.ts
+++ b/apps/backend/src/plans/plans/plans.router.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { TrpcService } from '@tet/backend/utils/trpc/trpc.service';
+import { ConfirmImportRouter } from './ai-plan-import/confirm-import/confirm-import.router';
 import { DeletePlanRouter } from './delete-plan/delete-plan.router';
 import { DuplicatePlanRouter } from './duplicate-plan/duplicate-plan.router';
 import { GetPlanCompletionRouter } from './get-plan-completion/get-plan-completion.router';
@@ -22,7 +23,8 @@ export class PlanRouter {
     private readonly deletePlanRouter: DeletePlanRouter,
     private readonly duplicatePlanRouter: DuplicatePlanRouter,
     private readonly importPlanRouter: ImportPlanRouter,
-    private readonly getImportStatusRouter: GetImportStatusRouter
+    private readonly getImportStatusRouter: GetImportStatusRouter,
+    private readonly confirmImportRouter: ConfirmImportRouter
   ) {}
 
   router = this.trpc.mergeRouters(
@@ -34,6 +36,7 @@ export class PlanRouter {
     this.deletePlanRouter.router,
     this.duplicatePlanRouter.router,
     this.importPlanRouter.router,
-    this.getImportStatusRouter.router
+    this.getImportStatusRouter.router,
+    this.confirmImportRouter.router
   );
 }

--- a/data_layer/sqitch/deploy/plan_action/ai_plan_import_job_confirm.sql
+++ b/data_layer/sqitch/deploy/plan_action/ai_plan_import_job_confirm.sql
@@ -1,0 +1,22 @@
+-- Deploy tet:plan_action/ai_plan_import_job_confirm to pg
+-- requires: plan_action/ai_plan_import_job
+
+BEGIN;
+
+ALTER TABLE public.ai_plan_import_job
+    DROP CONSTRAINT ai_plan_import_job_status_check,
+    ADD CONSTRAINT ai_plan_import_job_status_check
+        CHECK (status IN ('pending', 'running', 'done', 'failed', 'confirming'));
+
+ALTER TABLE public.ai_plan_import_job
+    ADD COLUMN confirmed_plan_id integer NULL
+        REFERENCES public.axe(id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN public.ai_plan_import_job.confirmed_plan_id IS
+    'Plan (axe racine) créé à la confirmation du brouillon ; rend le confirm idempotent. NULL tant que non confirmé.';
+
+CREATE UNIQUE INDEX ai_plan_import_job_confirmed_plan_id_unique
+    ON public.ai_plan_import_job (confirmed_plan_id)
+    WHERE confirmed_plan_id IS NOT NULL;
+
+COMMIT;

--- a/data_layer/sqitch/deploy/plan_action/ai_plan_import_job_confirm.sql
+++ b/data_layer/sqitch/deploy/plan_action/ai_plan_import_job_confirm.sql
@@ -4,11 +4,6 @@
 BEGIN;
 
 ALTER TABLE public.ai_plan_import_job
-    DROP CONSTRAINT ai_plan_import_job_status_check,
-    ADD CONSTRAINT ai_plan_import_job_status_check
-        CHECK (status IN ('pending', 'running', 'done', 'failed', 'confirming'));
-
-ALTER TABLE public.ai_plan_import_job
     ADD COLUMN confirmed_plan_id integer NULL
         REFERENCES public.axe(id) ON DELETE SET NULL;
 

--- a/data_layer/sqitch/revert/plan_action/ai_plan_import_job_confirm.sql
+++ b/data_layer/sqitch/revert/plan_action/ai_plan_import_job_confirm.sql
@@ -7,9 +7,4 @@ DROP INDEX IF EXISTS public.ai_plan_import_job_confirmed_plan_id_unique;
 ALTER TABLE public.ai_plan_import_job
     DROP COLUMN IF EXISTS confirmed_plan_id;
 
-ALTER TABLE public.ai_plan_import_job
-    DROP CONSTRAINT ai_plan_import_job_status_check,
-    ADD CONSTRAINT ai_plan_import_job_status_check
-        CHECK (status IN ('pending', 'running', 'done', 'failed'));
-
 COMMIT;

--- a/data_layer/sqitch/revert/plan_action/ai_plan_import_job_confirm.sql
+++ b/data_layer/sqitch/revert/plan_action/ai_plan_import_job_confirm.sql
@@ -1,0 +1,15 @@
+-- Revert tet:plan_action/ai_plan_import_job_confirm from pg
+
+BEGIN;
+
+DROP INDEX IF EXISTS public.ai_plan_import_job_confirmed_plan_id_unique;
+
+ALTER TABLE public.ai_plan_import_job
+    DROP COLUMN IF EXISTS confirmed_plan_id;
+
+ALTER TABLE public.ai_plan_import_job
+    DROP CONSTRAINT ai_plan_import_job_status_check,
+    ADD CONSTRAINT ai_plan_import_job_status_check
+        CHECK (status IN ('pending', 'running', 'done', 'failed'));
+
+COMMIT;

--- a/data_layer/sqitch/sqitch.plan
+++ b/data_layer/sqitch/sqitch.plan
@@ -991,3 +991,4 @@ collectivite/type_add_structure_sans_statut_juridique [collectivite/type_add_ser
 collectivite/structure_sans_statut_juridique_unique_nom [collectivite/type_add_structure_sans_statut_juridique] 2026-05-19T18:00:00Z Frederic Arnoux <frederic.arnoux@beta.gouv.fr> # Ajoute un index unique partiel sur le nom des structures sans statut juridique
 referentiel/audit_preuves_archive 2026-05-19T13:59:38Z Gaël Servaud <gaelservaud@Host-002.lan> # Crée la table audit_preuves_archive (génération asynchrone d archives de preuves)
 plan_action/ai_plan_import_job 2026-06-10T14:05:07Z Gaël Servaud <gaelservaud@Host-002.lan> # Cree la table ai_plan_import_job (import IA asynchrone de plan d'action) et le bucket source
+plan_action/ai_plan_import_job_confirm [plan_action/ai_plan_import_job] 2026-06-11T13:25:46Z Gaël Servaud <gaelservaud@Host-004.lan> # Ajoute confirmed_plan_id (idempotence du confirm) a ai_plan_import_job

--- a/data_layer/sqitch/verify/plan_action/ai_plan_import_job_confirm.sql
+++ b/data_layer/sqitch/verify/plan_action/ai_plan_import_job_confirm.sql
@@ -1,0 +1,63 @@
+-- Verify tet:plan_action/ai_plan_import_job_confirm on pg
+
+BEGIN;
+
+DO $$
+DECLARE
+    status_check     text;
+    fk_confirmed     text;
+    index_predicate  text;
+BEGIN
+    ASSERT (
+        SELECT COUNT(*) = 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'ai_plan_import_job'
+          AND column_name = 'confirmed_plan_id'
+          AND data_type = 'integer'
+          AND is_nullable = 'YES'
+    ), 'La colonne confirmed_plan_id doit exister en integer NULLABLE';
+
+    SELECT cc.check_clause INTO status_check
+    FROM information_schema.check_constraints cc
+    JOIN information_schema.constraint_column_usage ccu
+        ON cc.constraint_name = ccu.constraint_name
+    WHERE ccu.table_schema = 'public'
+      AND ccu.table_name = 'ai_plan_import_job'
+      AND ccu.column_name = 'status'
+    LIMIT 1;
+
+    ASSERT status_check LIKE '%''confirming''%',
+        'La contrainte CHECK sur status doit désormais autoriser confirming';
+
+    SELECT rc.delete_rule INTO fk_confirmed
+    FROM information_schema.table_constraints tc
+    JOIN information_schema.referential_constraints rc
+        USING (constraint_schema, constraint_name)
+    JOIN information_schema.key_column_usage kcu
+        USING (constraint_schema, constraint_name)
+    WHERE tc.table_schema = 'public'
+      AND tc.table_name = 'ai_plan_import_job'
+      AND tc.constraint_type = 'FOREIGN KEY'
+      AND kcu.column_name = 'confirmed_plan_id'
+    LIMIT 1;
+
+    ASSERT fk_confirmed = 'SET NULL',
+        'La FK confirmed_plan_id doit avoir delete_rule = SET NULL';
+
+    SELECT pg_get_expr(i.indpred, i.indrelid) INTO index_predicate
+    FROM pg_index i
+    JOIN pg_class c ON c.oid = i.indexrelid
+    WHERE c.relname = 'ai_plan_import_job_confirmed_plan_id_unique';
+
+    ASSERT index_predicate IS NOT NULL,
+        'L''index unique partiel ai_plan_import_job_confirmed_plan_id_unique doit exister';
+    ASSERT (
+        SELECT i.indisunique
+        FROM pg_index i
+        JOIN pg_class c ON c.oid = i.indexrelid
+        WHERE c.relname = 'ai_plan_import_job_confirmed_plan_id_unique'
+    ), 'L''index ai_plan_import_job_confirmed_plan_id_unique doit être UNIQUE';
+END $$;
+
+ROLLBACK;

--- a/data_layer/sqitch/verify/plan_action/ai_plan_import_job_confirm.sql
+++ b/data_layer/sqitch/verify/plan_action/ai_plan_import_job_confirm.sql
@@ -4,7 +4,6 @@ BEGIN;
 
 DO $$
 DECLARE
-    status_check     text;
     fk_confirmed     text;
     index_predicate  text;
 BEGIN
@@ -17,18 +16,6 @@ BEGIN
           AND data_type = 'integer'
           AND is_nullable = 'YES'
     ), 'La colonne confirmed_plan_id doit exister en integer NULLABLE';
-
-    SELECT cc.check_clause INTO status_check
-    FROM information_schema.check_constraints cc
-    JOIN information_schema.constraint_column_usage ccu
-        ON cc.constraint_name = ccu.constraint_name
-    WHERE ccu.table_schema = 'public'
-      AND ccu.table_name = 'ai_plan_import_job'
-      AND ccu.column_name = 'status'
-    LIMIT 1;
-
-    ASSERT status_check LIKE '%''confirming''%',
-        'La contrainte CHECK sur status doit désormais autoriser confirming';
 
     SELECT rc.delete_rule INTO fk_confirmed
     FROM information_schema.table_constraints tc


### PR DESCRIPTION
## Contexte

PR11 du plan **Import Tool IA** (`compound-knowledge-db/docs/plans/2026-06-03-001-feat-ai-plan-import-pipeline-plan.md`). Toute la stack backend amont est mergée (extracteurs → types → 5 étapes → orchestrateur → job/worker/upload/statut, #4526 → #4552). Cette PR ferme la boucle backend : transformer le brouillon revu en plan persisté.

## Changement

Endpoint tRPC `plans.plans.confirmAiImport({ jobId, planName, planType?, actions })` :
- mappe le brouillon édité (`ExtractedAction[]`) en `ImportActionOrSousAction[]` puis `ImportPlanInput` (réutilise le mapper pur PR4) et persiste via le **seam** `ImportPlanService.save` (PR1) — pas de `ParsedRow`, pas de re-parse Excel ;
- **idempotence (P1-2)** par compare-and-swap dans le `executeSingle` : claim `done → confirming` gardé par `confirmed_plan_id IS NULL`, création du plan, puis `confirmed_plan_id = planId` ; un 2e confirm renvoie le `planId` initial (jamais 2 plans). Index unique partiel `(confirmed_plan_id) WHERE confirmed_plan_id IS NOT NULL` en backstop dur ;
- **validation ligne par ligne** avant persistance (pas `combineResults` tout-ou-rien) : un brouillon invalide renvoie une erreur niveau champ par action, pas un 400 opaque ;
- permission vérifiée à l'entrée (et au `create` via le seam) ; `collectiviteId` épinglé au job (ignore tout id client).

## Migration sqitch

`plan_action/ai_plan_import_job_confirm` : ajoute `confirmed_plan_id integer` (FK `axe(id) ON DELETE SET NULL`), étend le CHECK `status` avec `confirming`, crée l'index unique partiel de backstop. Revert + verify fournis.

> ⚠️ La table `ai_plan_import_job` déployée (#4552) était une version simplifiée du plan (sans `confirmed_plan_id`) ; cette colonne est ajoutée ici, là où l'idempotence du confirm en a besoin.

## Câblage

`AiPlanImportModule` consomme `ImportPlanService` via `forwardRef(() => PlanModule)` (cycle résolu des deux côtés) ; `ConfirmImportRouter` exporté et monté dans `PlanRouter`.

## Tests

- `confirm-import.service.spec.ts` (6 cas) : mapper→save, double-confirm idempotent, brouillon invalide ligne-par-ligne, permission, not_confirmable, reprise sur claim perdu — **verts**.
- `confirm-import.router.e2e-spec.ts` : confirm + idempotence + IDOR (déni utilisateur sans droit) + brouillon invalide.

## AC (plan)

- [x] Confirm persiste via `CreatePlanAggregateService.create` et retourne `{ planId, fichesCount }`
- [x] Idempotent (`confirmed_plan_id` transactionnel + index backstop)
- [x] Brouillon invalide ⇒ erreurs niveau champ par ligne
- [x] Permission à l'entrée + au create

## Limite de validation locale

L'e2e n'a **pas pu être exécuté en local** : la base de dev est sur un état sqitch d'une autre branche (dernier déployé `audit_preuves_archive`, antérieur à `ai_plan_import_job`), donc la migration n'y est pas déployée. Typecheck (`tsconfig` + `tsconfig.spec`) et lint verts ; 105 tests unitaires `ai-plan-import` verts. L'e2e tournera en CI une fois la migration déployée.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notes de version

* **Nouvelles fonctionnalités**
  * Ajout de la confirmation pour les plans importés via intelligence artificielle
  * Validation des données avant persistance
  * Contrôle d'accès basé sur les permissions utilisateur
  * Idempotence garantie : confirmer plusieurs fois retourne le même résultat

* **Tests**
  * Ajout de tests d'intégration complets pour le flux de confirmation
  * Couverture des scénarios d'erreur et d'accès

<!-- end of auto-generated comment: release notes by coderabbit.ai -->