### PR TITLE
feat(referentiel): add restrictions on action_pilote and action_service to enforce action level compliance

### DIFF
--- a/data_layer/sqitch/deploy/referentiel/restrict_action_pilote_service_to_action_level.sql
+++ b/data_layer/sqitch/deploy/referentiel/restrict_action_pilote_service_to_action_level.sql
@@ -1,0 +1,65 @@
+-- Deploy tet:referentiel/restrict_action_pilote_service_to_action_level to pg
+-- requires: referentiel/action_pilote
+-- requires: referentiel/action_service
+-- requires: referentiel/referentiel@v4.50.0
+-- requires: referentiel/vue_tabulaire@v2.11.0
+
+BEGIN;
+
+-- Type d'action dérivé de la profondeur dans private.action_hierarchy
+-- et de la hiérarchie du référentiel (referentiel_definition.hierarchie).
+CREATE OR REPLACE FUNCTION private.action_id_is_action_level(p_action_id action_id)
+    RETURNS boolean
+    LANGUAGE sql
+    STABLE
+AS
+$$
+SELECT EXISTS (SELECT 1
+               FROM private.action_hierarchy ah
+                        JOIN referentiel_definition rd ON rd.id = ah.referentiel::text
+               WHERE ah.action_id = p_action_id
+                 AND rd.hierarchie[ah.depth + 1] = 'action'::action_type);
+$$;
+
+COMMENT ON FUNCTION private.action_id_is_action_level(action_id) IS
+    'Vrai si l''action_id correspond au niveau "action" (mesure) du référentiel, selon action_hierarchy et referentiel_definition.hierarchie.';
+
+DELETE
+FROM action_pilote ap
+WHERE NOT private.action_id_is_action_level(ap.action_id);
+
+DELETE
+FROM action_service aserv
+WHERE NOT private.action_id_is_action_level(aserv.action_id);
+
+CREATE OR REPLACE FUNCTION private.check_action_pilote_service_action_level()
+    RETURNS trigger
+    LANGUAGE plpgsql
+AS
+$$
+BEGIN
+    IF NOT private.action_id_is_action_level(NEW.action_id) THEN
+        RAISE EXCEPTION
+            'action_id % doit référencer une action de type "action" (mesure), pas un autre niveau de la hiérarchie',
+            NEW.action_id
+            USING ERRCODE = 'check_violation';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS check_action_level ON action_pilote;
+CREATE TRIGGER check_action_level
+    BEFORE INSERT OR UPDATE OF action_id
+    ON action_pilote
+    FOR EACH ROW
+EXECUTE FUNCTION private.check_action_pilote_service_action_level();
+
+DROP TRIGGER IF EXISTS check_action_level ON action_service;
+CREATE TRIGGER check_action_level
+    BEFORE INSERT OR UPDATE OF action_id
+    ON action_service
+    FOR EACH ROW
+EXECUTE FUNCTION private.check_action_pilote_service_action_level();
+
+COMMIT;

--- a/data_layer/sqitch/revert/referentiel/restrict_action_pilote_service_to_action_level.sql
+++ b/data_layer/sqitch/revert/referentiel/restrict_action_pilote_service_to_action_level.sql
@@ -1,0 +1,11 @@
+-- Revert tet:referentiel/restrict_action_pilote_service_to_action_level from pg
+
+BEGIN;
+
+DROP TRIGGER IF EXISTS check_action_level ON action_service;
+DROP TRIGGER IF EXISTS check_action_level ON action_pilote;
+
+DROP FUNCTION IF EXISTS private.check_action_pilote_service_action_level();
+DROP FUNCTION IF EXISTS private.action_id_is_action_level(action_id);
+
+COMMIT;

--- a/data_layer/sqitch/sqitch.plan
+++ b/data_layer/sqitch/sqitch.plan
@@ -991,3 +991,5 @@ collectivite/type_add_structure_sans_statut_juridique [collectivite/type_add_ser
 collectivite/structure_sans_statut_juridique_unique_nom [collectivite/type_add_structure_sans_statut_juridique] 2026-05-19T18:00:00Z Frederic Arnoux <frederic.arnoux@beta.gouv.fr> # Ajoute un index unique partiel sur le nom des structures sans statut juridique
 referentiel/audit_preuves_archive 2026-05-19T13:59:38Z Gaël Servaud <gaelservaud@Host-002.lan> # Crée la table audit_preuves_archive (génération asynchrone d archives de preuves)
 plan_action/ai_plan_import_job 2026-06-10T14:05:07Z Gaël Servaud <gaelservaud@Host-002.lan> # Cree la table ai_plan_import_job (import IA asynchrone de plan d'action) et le bucket source
+
+referentiel/restrict_action_pilote_service_to_action_level [referentiel/action_pilote referentiel/action_service referentiel/referentiel@v4.50.0 referentiel/vue_tabulaire@v2.11.0] 2026-06-04T10:00:00Z Frederic Arnoux <frederic.arnoux@beta.gouv.fr> # Restreint action_pilote et action_service aux actions de type mesure (niveau action)

--- a/data_layer/sqitch/verify/referentiel/restrict_action_pilote_service_to_action_level.sql
+++ b/data_layer/sqitch/verify/referentiel/restrict_action_pilote_service_to_action_level.sql
@@ -1,0 +1,41 @@
+-- Verify tet:referentiel/restrict_action_pilote_service_to_action_level on pg
+
+BEGIN;
+
+DO
+$$
+    DECLARE
+        invalid_pilotes integer;
+        invalid_services integer;
+    BEGIN
+        SELECT count(*)
+        INTO invalid_pilotes
+        FROM action_pilote ap
+        WHERE NOT private.action_id_is_action_level(ap.action_id);
+
+        IF invalid_pilotes > 0 THEN
+            RAISE EXCEPTION '% ligne(s) action_pilote hors niveau "action"', invalid_pilotes;
+        END IF;
+
+        SELECT count(*)
+        INTO invalid_services
+        FROM action_service aserv
+        WHERE NOT private.action_id_is_action_level(aserv.action_id);
+
+        IF invalid_services > 0 THEN
+            RAISE EXCEPTION '% ligne(s) action_service hors niveau "action"', invalid_services;
+        END IF;
+    END;
+$$;
+
+SELECT 1
+FROM pg_trigger
+WHERE tgname = 'check_action_level'
+  AND tgrelid = 'action_pilote'::regclass;
+
+SELECT 1
+FROM pg_trigger
+WHERE tgname = 'check_action_level'
+  AND tgrelid = 'action_service'::regclass;
+
+ROLLBACK;


### PR DESCRIPTION
- Implemented functions and triggers to ensure that action_id references only actions of type "action" (mesure).