### PR TITLE
fix(security): bloque l'IDOR sur plans.fiches.budgets.upsert (TET-7356)

### DIFF
--- a/apps/backend/src/plans/fiches/fiche-action-budget/fiche-action-budget.router.e2e-spec.ts
+++ b/apps/backend/src/plans/fiches/fiche-action-budget/fiche-action-budget.router.e2e-spec.ts
@@ -38,6 +38,79 @@ describe('Route CRUD des budgets des fiches actions', () => {
     await app.close();
   });
 
+  test(`Sécurité IDOR — upsert ne peut pas hijacker un budget d'une autre fiche`, async () => {
+    const caller = router.createCaller({ user: authenticatedUser });
+
+    // Fiche A appartient à la collectivité de l'utilisateur authentifié (collectiviteId=1)
+    const [ficheA] = await databaseService.db
+      .insert(ficheActionTable)
+      .values({ titre: 'fiche A', collectiviteId: 1 })
+      .returning();
+
+    // Fiche B appartient à une autre collectivité (la « victime »)
+    const victimCollectiviteId = 21;
+    const [ficheB] = await databaseService.db
+      .insert(ficheActionTable)
+      .values({ titre: 'fiche B', collectiviteId: victimCollectiviteId })
+      .returning();
+
+    // Budget existant sur la fiche B
+    const victimBudget: FicheBudgetCreate = {
+      ficheId: ficheB.id,
+      type: 'investissement',
+      unite: 'HT',
+      annee: 2030,
+      budgetPrevisionnel: 1000,
+      budgetReel: 1000,
+    };
+    const [insertedVictimBudget] = await databaseService.db
+      .insert(ficheActionBudgetTable)
+      .values(victimBudget)
+      .returning();
+
+    // L'attaquant envoie l'id du budget de la fiche B mais avec le ficheId de sa fiche A.
+    // canWriteFiche(ficheA) passe car l'utilisateur est admin sur la collectivité 1.
+    await expect(() =>
+      caller.plans.fiches.budgets.upsert([
+        {
+          id: insertedVictimBudget.id,
+          ficheId: ficheA.id,
+          type: 'investissement',
+          unite: 'HT',
+          annee: 2030,
+          budgetPrevisionnel: 999999,
+          budgetReel: 999999,
+        },
+      ])
+    ).rejects.toThrowError();
+
+    // Le budget de la victime doit être intact (ficheId et montants inchangés).
+    const [budgetAfter] = await databaseService.db
+      .select()
+      .from(ficheActionBudgetTable)
+      .where(eq(ficheActionBudgetTable.id, insertedVictimBudget.id));
+
+    expect(budgetAfter.ficheId).toBe(ficheB.id);
+    expect(Number(budgetAfter.budgetPrevisionnel)).toBe(1000);
+    expect(Number(budgetAfter.budgetReel)).toBe(1000);
+
+    onTestFinished(async () => {
+      try {
+        await databaseService.db
+          .delete(ficheActionBudgetTable)
+          .where(eq(ficheActionBudgetTable.id, insertedVictimBudget.id));
+        await databaseService.db
+          .delete(ficheActionTable)
+          .where(eq(ficheActionTable.id, ficheA.id));
+        await databaseService.db
+          .delete(ficheActionTable)
+          .where(eq(ficheActionTable.id, ficheB.id));
+      } catch (error) {
+        console.error('Erreur lors de la suppression:', error);
+      }
+    });
+  });
+
   test(`Test droit`, async () => {
     const caller = router.createCaller({ user: authenticatedUser });
     const collectiviteId = 20;

--- a/apps/backend/src/plans/fiches/fiche-action-budget/fiche-action-budget.service.ts
+++ b/apps/backend/src/plans/fiches/fiche-action-budget/fiche-action-budget.service.ts
@@ -26,24 +26,39 @@ export class FicheActionBudgetService {
 
   private async findExistingBudgetById(
     id: number,
+    ficheId: number,
     trx: Transaction
   ): Promise<FicheBudget | undefined> {
     const [budget] = await trx
       .select()
       .from(ficheActionBudgetTable)
-      .where(eq(ficheActionBudgetTable.id, id))
+      .where(
+        and(
+          eq(ficheActionBudgetTable.id, id),
+          eq(ficheActionBudgetTable.ficheId, ficheId)
+        )
+      )
       .limit(1);
     return budget;
   }
 
   private async updateBudget(
-    budget: Omit<FicheBudgetCreate, 'id'> & { id: number },
+    budget: Omit<FicheBudgetCreate, 'id' | 'ficheId'> & {
+      id: number;
+      ficheId: number;
+    },
     trx: Transaction
   ): Promise<FicheBudget> {
+    const { ficheId, ...updatable } = budget;
     const [updated] = await trx
       .update(ficheActionBudgetTable)
-      .set(budget)
-      .where(eq(ficheActionBudgetTable.id, budget.id))
+      .set(updatable)
+      .where(
+        and(
+          eq(ficheActionBudgetTable.id, budget.id),
+          eq(ficheActionBudgetTable.ficheId, ficheId)
+        )
+      )
       .returning();
     return updated;
   }
@@ -73,11 +88,20 @@ export class FicheActionBudgetService {
     if (id === undefined) {
       return this.insertBudget(budget, trx);
     }
-    const existingBudget = await this.findExistingBudgetById(id, trx);
+    const existingBudget = await this.findExistingBudgetById(
+      id,
+      budget.ficheId,
+      trx
+    );
     if (!existingBudget) {
-      return this.insertBudget(budget, trx);
+      throw new Error(
+        `Budget ${id} not found on fiche ${budget.ficheId}.`
+      );
     }
-    return this.updateBudget({ ...existingBudget, ...budget }, trx);
+    return this.updateBudget(
+      { ...existingBudget, ...budget, id, ficheId: existingBudget.ficheId },
+      trx
+    );
   }
 
   private async updateFicheModifiedAt(


### PR DESCRIPTION
## Summary
- Corrige une faille IDOR critique (same class as ORHUS-302) sur `plans.fiches.budgets.upsert` : un pilote/admin de la collectivité A pouvait envoyer `{ id: <budget_B>, ficheId: <fiche_A>, ... }` pour écraser/voler un budget de la collectivité B.
- `findExistingBudgetById` filtre désormais sur `(id, ficheId)`, `upsertSingleBudget` rejette une mise à jour orpheline, et `updateBudget` ajoute `ficheId` au `WHERE` tout en empêchant la réécriture du `ficheId`.
- Ajoute un test e2e qui rejoue le scénario d'attaque inter-collectivités et vérifie que le budget victime reste intact.

Ticket Notion : [🔓 [Sécurité — IDOR] plans.fiches.fiche-action-budget.upsert](https://app.notion.com/p/3726523d57d781eaa7a7f32fefac93a2) — finding 🔴 Critique n°3 de l'audit IDOR du 2026-06-01.

## Test plan
- [x] `nx test backend -- fiche-action-budget.router.e2e-spec` : le nouveau test `Sécurité IDOR — upsert ne peut pas hijacker un budget d'une autre fiche` passe, `Test droit` toujours vert (`Tests CRUD` était déjà rouge sur `main`, indépendant de ce PR).
- [x] `tsc --noEmit -p apps/backend/tsconfig.json` propre.
- [ ] QA manuelle : tenter l'upsert cross-fiche depuis l'UI doit échouer avec 500 / message d'erreur.