### PR TITLE
feat(ai-plan-import): création directe du plan par le worker (sans étape de confirmation)

### DIFF
--- a/apps/backend/src/plans/plans-main.module.ts
+++ b/apps/backend/src/plans/plans-main.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { AxeModule } from './axes/axe.module';
 import { FichesModule } from './fiches/fiches.module';
 import { PaniersModule } from './paniers/paniers.module';
+import { AiPlanImportModule } from './plans/ai-plan-import/ai-plan-import.module';
 import { PlanMainRouter } from './plans-main.router';
 import { PlanModule } from './plans/plans.module';
 import { ReportsModule } from './reports/reports.module';
@@ -13,6 +14,7 @@ import { PlansUtilsModule } from './utils/plans-utils.module';
     AxeModule,
     FichesModule,
     PlanModule,
+    AiPlanImportModule,
     PaniersModule,
     ReportsModule,
   ],

--- a/apps/backend/src/plans/plans-main.router.ts
+++ b/apps/backend/src/plans/plans-main.router.ts
@@ -3,6 +3,7 @@ import { TrpcService } from '@tet/backend/utils/trpc/trpc.service';
 import { AxesRouter } from './axes/axes.router';
 import { FichesRouter } from './fiches/fiches.router';
 import { PaniersRouter } from './paniers/paniers.router';
+import { GetImportStatusRouter } from './plans/ai-plan-import/get-import-status/get-import-status.router';
 import { PlanRouter } from './plans/plans.router';
 import { GenerateReportsRouter } from './reports/generate-plan-report-pptx/generate-reports.router';
 
@@ -14,7 +15,8 @@ export class PlanMainRouter {
     private readonly planRouter: PlanRouter,
     private readonly axesRouter: AxesRouter,
     private readonly paniersRouter: PaniersRouter,
-    private readonly generateReportsRouter: GenerateReportsRouter
+    private readonly generateReportsRouter: GenerateReportsRouter,
+    private readonly getImportStatusRouter: GetImportStatusRouter
   ) {}
 
   router = this.trpc.router({
@@ -23,6 +25,7 @@ export class PlanMainRouter {
     axes: this.axesRouter.router,
     paniers: this.paniersRouter.router,
     reports: this.generateReportsRouter.router,
+    aiImport: this.getImportStatusRouter.router,
   });
 
   createCaller = this.trpc.createCallerFactory(this.router);

--- a/apps/backend/src/plans/plans/ai-plan-import/ai-plan-import-job.repository.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/ai-plan-import-job.repository.ts
@@ -1,8 +1,9 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
 import { failure, success, type Result } from '@tet/backend/utils/result.type';
 import { getErrorMessage } from '@tet/domain/utils';
-import { and, count, eq, inArray } from 'drizzle-orm';
+import { and, count, eq, inArray, sql } from 'drizzle-orm';
 import { PlanDraft } from './models/plan-draft';
 import {
   AiPlanImportJob,
@@ -10,6 +11,7 @@ import {
   AiPlanImportJobOptions,
   AiPlanImportJobStatus,
   AiPlanImportJobStatusEnum,
+  AiPlanImportJobStatusView,
 } from './models/ai-plan-import-job';
 import { aiPlanImportJobTable } from './models/ai-plan-import-job.table';
 import {
@@ -86,6 +88,39 @@ export class AiPlanImportJobRepository {
     }
   }
 
+  async getStatusView(
+    id: string
+  ): Promise<Result<AiPlanImportJobStatusView, AiPlanImportError>> {
+    try {
+      const [row] = await this.db
+        .select({
+          id: aiPlanImportJobTable.id,
+          collectiviteId: aiPlanImportJobTable.collectiviteId,
+          status: aiPlanImportJobTable.status,
+          stepStates: aiPlanImportJobTable.stepStates,
+          error: aiPlanImportJobTable.error,
+          createdPlanId: aiPlanImportJobTable.createdPlanId,
+          qualitativeReview: sql<
+            string | null
+          >`${aiPlanImportJobTable.draft} ->> 'qualitativeReview'`,
+        })
+        .from(aiPlanImportJobTable)
+        .where(eq(aiPlanImportJobTable.id, id))
+        .limit(1);
+
+      if (!row) {
+        return failure(AiPlanImportErrorEnum.JOB_NOT_FOUND);
+      }
+
+      return success(row);
+    } catch (error) {
+      this.logger.error(
+        `Lecture du statut du job ${id}: ${getErrorMessage(error)}`
+      );
+      return failure(AiPlanImportErrorEnum.GET_JOB_ERROR, toError(error));
+    }
+  }
+
   async countInFlight(): Promise<Result<number, AiPlanImportError>> {
     try {
       const [row] = await this.db
@@ -121,6 +156,8 @@ export class AiPlanImportJobRepository {
     id: string;
     draft: PlanDraft;
     stepStates: StepStates;
+    createdPlanId: number;
+    tx?: Transaction;
   }): Promise<Result<AiPlanImportJob, AiPlanImportError>> {
     return this.updateAndReturn({
       id: input.id,
@@ -128,9 +165,11 @@ export class AiPlanImportJobRepository {
         status: AiPlanImportJobStatusEnum.DONE,
         draft: input.draft,
         stepStates: input.stepStates,
+        createdPlanId: input.createdPlanId,
         modifiedAt: new Date().toISOString(),
       },
       allowedFromStatuses: [AiPlanImportJobStatusEnum.RUNNING],
+      tx: input.tx,
     });
   }
 
@@ -179,13 +218,15 @@ export class AiPlanImportJobRepository {
     id,
     patch,
     allowedFromStatuses,
+    tx,
   }: {
     id: string;
     patch: Partial<typeof aiPlanImportJobTable.$inferInsert>;
     allowedFromStatuses: AiPlanImportJobStatus[];
+    tx?: Transaction;
   }): Promise<Result<AiPlanImportJob, AiPlanImportError>> {
     try {
-      const [row] = await this.db
+      const [row] = await (tx ?? this.db)
         .update(aiPlanImportJobTable)
         .set(patch)
         .where(

--- a/apps/backend/src/plans/plans/ai-plan-import/ai-plan-import.errors.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/ai-plan-import.errors.ts
@@ -9,6 +9,7 @@ export const AiPlanImportSpecificErrors = [
   'TOO_MANY_IN_FLIGHT_JOBS',
   'UNSUPPORTED_FILE_TYPE',
   'FILE_TOO_LARGE',
+  'UNKNOWN_PLAN_TYPE',
   'STORAGE_ERROR',
   'UNAUTHORIZED',
 ] as const;

--- a/apps/backend/src/plans/plans/ai-plan-import/ai-plan-import.module.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/ai-plan-import.module.ts
@@ -1,6 +1,8 @@
 import { BullModule } from '@nestjs/bullmq';
 import { Module } from '@nestjs/common';
 import { LlmModule } from '@tet/backend/utils/llm/llm.module';
+import { TransactionModule } from '@tet/backend/utils/transaction/transaction.module';
+import { PlanModule } from '../plans.module';
 import { AiPlanImportJobRepository } from './ai-plan-import-job.repository';
 import {
   AI_PLAN_IMPORT_JOB_OPTIONS,
@@ -16,6 +18,8 @@ import { GetImportStatusService } from './get-import-status/get-import-status.se
 @Module({
   imports: [
     LlmModule,
+    TransactionModule,
+    PlanModule,
     BullModule.registerQueue({
       name: AI_PLAN_IMPORT_QUEUE_NAME,
       defaultJobOptions: AI_PLAN_IMPORT_JOB_OPTIONS,

--- a/apps/backend/src/plans/plans/ai-plan-import/ai-plan-import.trpc-errors.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/ai-plan-import.trpc-errors.ts
@@ -36,6 +36,10 @@ export const aiPlanImportErrorConfig: TrpcErrorHandlerConfig<AiPlanImportSpecifi
         code: 'PAYLOAD_TOO_LARGE',
         message: 'Le fichier dépasse la taille maximale autorisée',
       },
+      UNKNOWN_PLAN_TYPE: {
+        code: 'BAD_REQUEST',
+        message: 'Type de plan inconnu',
+      },
       STORAGE_ERROR: {
         code: 'INTERNAL_SERVER_ERROR',
         message: "L'enregistrement du fichier source a échoué",

--- a/apps/backend/src/plans/plans/ai-plan-import/enqueue-import/enqueue-import.controller.e2e-spec.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/enqueue-import/enqueue-import.controller.e2e-spec.ts
@@ -1,0 +1,119 @@
+import { INestApplication } from '@nestjs/common';
+import {
+  getAuthToken,
+  getAuthUserFromUserCredentials,
+  getTestApp,
+  getTestDatabase,
+  getTestRouter,
+} from '@tet/backend/test';
+import {
+  addAndEnableUserSuperAdminMode,
+  addTestUser,
+} from '@tet/backend/users/users/users.test-fixture';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
+import { CollectiviteRole } from '@tet/domain/users';
+import { eq } from 'drizzle-orm';
+import request from 'supertest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { aiPlanImportJobTable } from '../models/ai-plan-import-job.table';
+
+const TEST_COLLECTIVITE_ID = 1;
+const ENQUEUE_URL = `/collectivites/${TEST_COLLECTIVITE_ID}/plans/import-ia`;
+const csvFile = () => Buffer.from('axe,titre\n1,Action', 'utf-8');
+
+describe('Enqueue import IA (controller)', { timeout: 30_000 }, () => {
+  let app: INestApplication;
+  let db: DatabaseService;
+  let router: TrpcRouter;
+  let supportToken: string;
+  let outsiderToken: string;
+  let disableSupport: () => Promise<void>;
+
+  const deleteJobs = () =>
+    db.db
+      .delete(aiPlanImportJobTable)
+      .where(eq(aiPlanImportJobTable.collectiviteId, TEST_COLLECTIVITE_ID));
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    db = await getTestDatabase(app);
+    router = await getTestRouter(app);
+
+    const support = await addTestUser(db, {
+      collectiviteId: TEST_COLLECTIVITE_ID,
+      role: CollectiviteRole.ADMIN,
+    });
+    const supportUser = getAuthUserFromUserCredentials(support.user);
+    supportToken = await getAuthToken({
+      email: support.user.email ?? '',
+      password: support.user.password,
+    });
+    const caller = router.createCaller({ user: supportUser });
+    const { cleanup } = await addAndEnableUserSuperAdminMode({
+      app,
+      caller,
+      userId: supportUser.id,
+    });
+    disableSupport = cleanup;
+
+    const outsider = await addTestUser(db);
+    outsiderToken = await getAuthToken({
+      email: outsider.user.email ?? '',
+      password: outsider.user.password,
+    });
+
+    await deleteJobs();
+  });
+
+  afterAll(async () => {
+    await deleteJobs();
+    await disableSupport();
+    await app.close();
+  });
+
+  it('rejette un type de plan inconnu avant de créer un job (400)', async () => {
+    const response = await request(app.getHttpServer())
+      .post(ENQUEUE_URL)
+      .set('Authorization', `Bearer ${supportToken}`)
+      .field('planName', 'Plan import IA e2e')
+      .field('planType', '999999')
+      .attach('file', csvFile(), {
+        filename: 'plan.csv',
+        contentType: 'text/csv',
+      });
+
+    expect(response.status).toBe(400);
+
+    const jobs = await db.db
+      .select()
+      .from(aiPlanImportJobTable)
+      .where(eq(aiPlanImportJobTable.collectiviteId, TEST_COLLECTIVITE_ID));
+    expect(jobs).toHaveLength(0);
+  });
+
+  it('rejette un utilisateur sans droit sur la collectivité (403)', async () => {
+    const response = await request(app.getHttpServer())
+      .post(ENQUEUE_URL)
+      .set('Authorization', `Bearer ${outsiderToken}`)
+      .field('planName', 'Plan import IA e2e')
+      .attach('file', csvFile(), {
+        filename: 'plan.csv',
+        contentType: 'text/csv',
+      });
+
+    expect(response.status).toBe(403);
+  });
+
+  it('rejette un formulaire sans nom de plan (400)', async () => {
+    const response = await request(app.getHttpServer())
+      .post(ENQUEUE_URL)
+      .set('Authorization', `Bearer ${supportToken}`)
+      .attach('file', csvFile(), {
+        filename: 'plan.csv',
+        contentType: 'text/csv',
+      });
+
+    expect(response.status).toBe(400);
+  });
+});

--- a/apps/backend/src/plans/plans/ai-plan-import/enqueue-import/enqueue-import.input.spec.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/enqueue-import/enqueue-import.input.spec.ts
@@ -2,25 +2,39 @@ import { describe, expect, it } from 'vitest';
 import { enqueueImportFormSchema } from './enqueue-import.input';
 
 describe('enqueueImportFormSchema', () => {
-  it('applique les valeurs par défaut quand le formulaire est vide', () => {
-    expect(enqueueImportFormSchema.parse({})).toEqual({
+  it('applique les valeurs par défaut quand seul le nom du plan est fourni', () => {
+    expect(enqueueImportFormSchema.parse({ planName: 'Mon plan' })).toEqual({
       instructions: '',
+      planName: 'Mon plan',
       withVerifications: true,
       withSousActions: true,
       disabledFields: [],
     });
   });
 
+  it('rejette un formulaire sans nom de plan', () => {
+    expect(enqueueImportFormSchema.safeParse({}).success).toBe(false);
+  });
+
+  it('convertit planType en nombre depuis le formulaire multipart', () => {
+    expect(
+      enqueueImportFormSchema.parse({ planName: 'Mon plan', planType: '4' })
+        .planType
+    ).toBe(4);
+  });
+
   it('convertit les booléens en chaîne et accepte les colonnes désactivées en tableau', () => {
     expect(
       enqueueImportFormSchema.parse({
         instructions: 'Ignore les annexes',
+        planName: 'Mon plan',
         withVerifications: 'false',
         withSousActions: 'true',
         disabledFields: ['budget', 'statut'],
       })
     ).toEqual({
       instructions: 'Ignore les annexes',
+      planName: 'Mon plan',
       withVerifications: false,
       withSousActions: true,
       disabledFields: ['budget', 'statut'],
@@ -29,27 +43,35 @@ describe('enqueueImportFormSchema', () => {
 
   it('enveloppe en tableau une colonne désactivée unique envoyée seule', () => {
     expect(
-      enqueueImportFormSchema.parse({ disabledFields: 'budget' }).disabledFields
+      enqueueImportFormSchema.parse({
+        planName: 'Mon plan',
+        disabledFields: 'budget',
+      }).disabledFields
     ).toEqual(['budget']);
   });
 
   it('rejette une colonne désactivée hors de la liste des champs désactivables', () => {
     expect(
-      enqueueImportFormSchema.safeParse({ disabledFields: ['inexistant'] })
-        .success
+      enqueueImportFormSchema.safeParse({
+        planName: 'Mon plan',
+        disabledFields: ['inexistant'],
+      }).success
     ).toBe(false);
   });
 
   it('rejette des instructions de plus de 2000 caractères', () => {
     expect(
-      enqueueImportFormSchema.safeParse({ instructions: 'a'.repeat(2001) })
-        .success
+      enqueueImportFormSchema.safeParse({
+        planName: 'Mon plan',
+        instructions: 'a'.repeat(2001),
+      }).success
     ).toBe(false);
   });
 
   it('rejette plus de 9 colonnes désactivées', () => {
     expect(
       enqueueImportFormSchema.safeParse({
+        planName: 'Mon plan',
         disabledFields: Array.from({ length: 10 }, () => 'budget'),
       }).success
     ).toBe(false);

--- a/apps/backend/src/plans/plans/ai-plan-import/enqueue-import/enqueue-import.input.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/enqueue-import/enqueue-import.input.ts
@@ -15,6 +15,8 @@ const disabledFieldsFromForm = z
 
 export const enqueueImportFormSchema = z.object({
   instructions: z.string().max(2000).default(''),
+  planName: z.string().min(1).max(300),
+  planType: z.coerce.number().int().positive().optional(),
   withVerifications: booleanFromString,
   withSousActions: booleanFromString,
   disabledFields: disabledFieldsFromForm,

--- a/apps/backend/src/plans/plans/ai-plan-import/enqueue-import/enqueue-import.service.spec.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/enqueue-import/enqueue-import.service.spec.ts
@@ -1,5 +1,6 @@
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { ListPlanTypesService } from '@tet/backend/plans/plans/list-plan-types/list-plan-types.service';
 import { failure, success } from '@tet/backend/utils/result.type';
 import { DocumentStorageErrorEnum } from '@tet/backend/utils/supabase/document-storage.errors';
 import { DocumentStorageService } from '@tet/backend/utils/supabase/document-storage.service';
@@ -23,6 +24,7 @@ const user = { id: 'user-1' } as AuthenticatedUser;
 
 const options: AiPlanImportJobOptions = {
   instructions: '',
+  planName: 'Plan importé',
   withVerifications: true,
   withSousActions: true,
   disabledFields: [],
@@ -38,6 +40,7 @@ const job: AiPlanImportJob = {
   sourcePath: '10/abc',
   draft: null,
   error: null,
+  createdPlanId: null,
   createdAt: '2026-06-11T00:00:00Z',
   modifiedAt: '2026-06-11T00:00:00Z',
 };
@@ -90,6 +93,7 @@ const toXlsxBomb = () => {
 type MockOverrides = {
   isAllowed?: boolean;
   countInFlight?: number;
+  planTypes?: { id: number }[];
   createUnlessInFlight?: () => Promise<unknown>;
   storeDocument?: () => Promise<unknown>;
   queueAdd?: () => Promise<unknown>;
@@ -123,10 +127,16 @@ const buildService = (overrides: MockOverrides = {}) => {
   const add = vi.fn(overrides.queueAdd ?? (async () => undefined));
   const queue = { add } as unknown as Queue<AiPlanImportJobData>;
 
+  const listPlanTypes = vi.fn(async () => overrides.planTypes ?? []);
+  const listPlanTypesService = {
+    listPlanTypes,
+  } as unknown as ListPlanTypesService;
+
   const service = new EnqueueImportService(
     permissions,
     jobRepository,
     documentStorage,
+    listPlanTypesService,
     queue
   );
 
@@ -136,6 +146,7 @@ const buildService = (overrides: MockOverrides = {}) => {
     deleteIfPending,
     storeDocument,
     removeDocument,
+    listPlanTypes,
     add,
   };
 };
@@ -157,6 +168,41 @@ describe('EnqueueImportService', () => {
       { jobId: 'job-1' },
       { jobId: 'job-1' }
     );
+  });
+
+  it('refuse un type de plan inconnu avant tout stockage ou enfilement', async () => {
+    const { service, createUnlessInFlight, storeDocument, add } = buildService({
+      planTypes: [{ id: 1 }],
+    });
+
+    const result = await service.enqueue({
+      collectiviteId: 10,
+      user,
+      file: toCsvFile(),
+      options: { ...options, planType: 999 },
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: AiPlanImportErrorEnum.UNKNOWN_PLAN_TYPE,
+    });
+    expect(createUnlessInFlight).not.toHaveBeenCalled();
+    expect(storeDocument).not.toHaveBeenCalled();
+    expect(add).not.toHaveBeenCalled();
+  });
+
+  it('accepte un type de plan existant', async () => {
+    const { service, add } = buildService({ planTypes: [{ id: 4 }] });
+
+    const result = await service.enqueue({
+      collectiviteId: 10,
+      user,
+      file: toCsvFile(),
+      options: { ...options, planType: 4 },
+    });
+
+    expect(result).toMatchObject({ success: true });
+    expect(add).toHaveBeenCalled();
   });
 
   it('écrit le même sourcePath dans la ligne du job et dans le storage', async () => {

--- a/apps/backend/src/plans/plans/ai-plan-import/enqueue-import/enqueue-import.service.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/enqueue-import/enqueue-import.service.ts
@@ -1,5 +1,6 @@
 import { InjectQueue } from '@nestjs/bullmq';
 import { Injectable, Logger } from '@nestjs/common';
+import { ListPlanTypesService } from '@tet/backend/plans/plans/list-plan-types/list-plan-types.service';
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { failure, success, type Result } from '@tet/backend/utils/result.type';
@@ -44,6 +45,7 @@ export class EnqueueImportService {
     private readonly permissions: PermissionService,
     private readonly jobRepository: AiPlanImportJobRepository,
     private readonly documentStorage: DocumentStorageService,
+    private readonly listPlanTypesService: ListPlanTypesService,
     @InjectQueue(AI_PLAN_IMPORT_QUEUE_NAME)
     private readonly queue: Queue<AiPlanImportJobData>
   ) {}
@@ -62,6 +64,16 @@ export class EnqueueImportService {
     );
     if (!isAllowed) {
       return failure(AiPlanImportErrorEnum.UNAUTHORIZED);
+    }
+
+    if (options.planType !== undefined) {
+      const planTypes = await this.listPlanTypesService.listPlanTypes();
+      const planTypeExists = planTypes.some(
+        (planType) => planType.id === options.planType
+      );
+      if (!planTypeExists) {
+        return failure(AiPlanImportErrorEnum.UNKNOWN_PLAN_TYPE);
+      }
     }
 
     if (file.size > AI_PLAN_IMPORT_MAX_SOURCE_BYTES) {

--- a/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/draft-to-import-plan-input.spec.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/draft-to-import-plan-input.spec.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createUnenrichedSousAction,
+  ExtractedAction,
+} from '../models/extracted-action';
+import { draftToImportPlanInput } from './draft-to-import-plan-input';
+
+const toAction = (overrides: Partial<ExtractedAction> = {}): ExtractedAction => ({
+  axe: 'Mobilité',
+  sousAxe: 'Vélo',
+  titre: 'Développer le réseau cyclable',
+  description: null,
+  objectifs: null,
+  structurePilote: null,
+  directionServicePilote: null,
+  personnePilote: null,
+  budget: null,
+  statut: null,
+  confidence: null,
+  sousActions: [],
+  ...overrides,
+});
+
+describe('draftToImportPlanInput', () => {
+  it('reporte le nom et le type de plan saisis', () => {
+    const result = draftToImportPlanInput({
+      actions: [],
+      planName: 'Plan vélo 2026',
+      planType: 4,
+    });
+
+    expect(result).toEqual({ nom: 'Plan vélo 2026', typeId: 4, actions: [] });
+  });
+
+  it('laisse typeId indéfini quand aucun type n est fourni', () => {
+    const result = draftToImportPlanInput({ actions: [], planName: 'Plan' });
+
+    expect(result.typeId).toBeUndefined();
+  });
+
+  it('aplatit chaque action puis ses sous-actions en lignes d import', () => {
+    const result = draftToImportPlanInput({
+      planName: 'Plan',
+      actions: [
+        toAction({
+          titre: 'Action 1',
+          sousActions: [
+            createUnenrichedSousAction('Sous-action 1.1'),
+            createUnenrichedSousAction('Sous-action 1.2'),
+          ],
+        }),
+        toAction({ titre: 'Action 2' }),
+      ],
+    });
+
+    expect(result.actions).toHaveLength(4);
+    expect(result.actions.map((action) => action.titre)).toEqual([
+      'Action 1',
+      'Sous-action 1.1',
+      'Sous-action 1.2',
+      'Action 2',
+    ]);
+  });
+});

--- a/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/draft-to-import-plan-input.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/draft-to-import-plan-input.ts
@@ -1,0 +1,13 @@
+import { ImportPlanInput } from '@tet/backend/plans/plans/import-plan-aggregate/import-plan.input';
+import { extractedActionToImportActions } from '../adapters/extracted-action-to-import-action';
+import { ExtractedAction } from '../models/extracted-action';
+
+export const draftToImportPlanInput = (input: {
+  actions: ExtractedAction[];
+  planName: string;
+  planType?: number;
+}): ImportPlanInput => ({
+  nom: input.planName,
+  typeId: input.planType,
+  actions: input.actions.flatMap(extractedActionToImportActions),
+});

--- a/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/generate-import-draft.service.spec.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/generate-import-draft.service.spec.ts
@@ -1,3 +1,6 @@
+import { ImportPlanService } from '@tet/backend/plans/plans/import-plan-aggregate/import-plan.service';
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { TransactionManager } from '@tet/backend/utils/transaction/transaction-manager.service';
 import { TokenUsage } from '@tet/backend/utils/llm/llm.repository';
 import { LlmService } from '@tet/backend/utils/llm/llm.service';
 import { failure, Result, success } from '@tet/backend/utils/result.type';
@@ -19,6 +22,7 @@ const job: AiPlanImportJob = {
   status: AiPlanImportJobStatusEnum.PENDING,
   options: {
     instructions: '',
+    planName: 'Plan importé',
     withVerifications: false,
     withSousActions: false,
     disabledFields: [],
@@ -27,6 +31,7 @@ const job: AiPlanImportJob = {
   sourcePath: '10/abc',
   draft: null,
   error: null,
+  createdPlanId: null,
   createdAt: '2026-06-10T00:00:00Z',
   modifiedAt: '2026-06-10T00:00:00Z',
 };
@@ -55,16 +60,19 @@ const extractionAction = {
 type MockOverrides = {
   sourceContent?: string;
   generateStructured?: () => Promise<unknown>;
+  save?: () => Promise<Result<{ planId: number; fichesCount: number }, never>>;
   markDone?: () => Promise<Result<AiPlanImportJob, string>>;
   markFailed?: () => Promise<Result<AiPlanImportJob, string>>;
   getById?: () => Promise<Result<AiPlanImportJob, string>>;
 };
 
 const buildMocks = (overrides: MockOverrides = {}) => {
+  const markDone = vi.fn(overrides.markDone ?? (async () => success(job)));
+  const markFailed = vi.fn(overrides.markFailed ?? (async () => success(job)));
   const jobRepository = {
     transitionToRunning: vi.fn(async () => success(job)),
-    markFailed: vi.fn(overrides.markFailed ?? (async () => success(job))),
-    markDone: vi.fn(overrides.markDone ?? (async () => success(job))),
+    markFailed,
+    markDone,
     getById: vi.fn(overrides.getById ?? (async () => success(job))),
   } as unknown as AiPlanImportJobRepository;
 
@@ -92,28 +100,100 @@ const buildMocks = (overrides: MockOverrides = {}) => {
       : defaultLlm,
   } as unknown as LlmService;
 
-  return { jobRepository, documentStorage, llm, removeDocument };
+  const save = vi.fn(
+    overrides.save ?? (async () => success({ planId: 7, fichesCount: 1 }))
+  );
+  const importPlanService = { save } as unknown as ImportPlanService;
+
+  const transactionManager = {
+    executeSingle: vi.fn(async (operation) => operation({} as Transaction)),
+  } as unknown as TransactionManager;
+
+  return {
+    jobRepository,
+    documentStorage,
+    llm,
+    importPlanService,
+    transactionManager,
+    save,
+    removeDocument,
+  };
 };
 
+const buildService = (mocks: ReturnType<typeof buildMocks>) =>
+  new GenerateImportDraftService(
+    mocks.jobRepository,
+    mocks.documentStorage,
+    mocks.llm,
+    mocks.importPlanService,
+    mocks.transactionManager
+  );
+
 describe('GenerateImportDraftService', () => {
-  it('marque le job done au terme du run et supprime la source', async () => {
-    const { jobRepository, documentStorage, llm, removeDocument } = buildMocks();
-    const service = new GenerateImportDraftService(jobRepository, documentStorage, llm);
+  it('crée le plan, marque le job done avec le plan créé et supprime la source', async () => {
+    const mocks = buildMocks();
+    const service = buildService(mocks);
 
     const result = await service.generate('job-1');
 
     expect(result).toMatchObject({ success: true });
-    expect(jobRepository.markDone).toHaveBeenCalled();
-    expect(removeDocument).toHaveBeenCalledWith({ bucketId: 'ai-plan-import-sources', key: '10/abc' });
+    expect(mocks.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collectiviteId: 10,
+        planInput: expect.objectContaining({ nom: 'Plan importé' }),
+      })
+    );
+    expect(mocks.jobRepository.markDone).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'job-1', createdPlanId: 7 })
+    );
+    expect(mocks.removeDocument).toHaveBeenCalledWith({
+      bucketId: 'ai-plan-import-sources',
+      key: '10/abc',
+    });
+  });
+
+  it('marque le job failed quand la création du plan échoue', async () => {
+    const mocks = buildMocks({
+      save: async () => failure({ message: 'Plan invalide' } as never),
+    });
+    const service = buildService(mocks);
+
+    const result = await service.generate('job-1');
+
+    expect(result).toMatchObject({ success: true });
+    expect(mocks.jobRepository.markDone).not.toHaveBeenCalled();
+    expect(mocks.jobRepository.markFailed).toHaveBeenCalledWith({
+      id: 'job-1',
+      error: 'Création du plan impossible : Plan invalide',
+      stepStates: initialStepStates(),
+    });
+  });
+
+  it('marque le job failed quand la création du plan lève une exception (seam en transaction partagée)', async () => {
+    const mocks = buildMocks();
+    mocks.save.mockImplementation(() => {
+      throw new Error('insert en conflit');
+    });
+    const service = buildService(mocks);
+
+    const result = await service.generate('job-1');
+
+    expect(result).toMatchObject({ success: true });
+    expect(mocks.jobRepository.markDone).not.toHaveBeenCalled();
+    expect(mocks.jobRepository.markFailed).toHaveBeenCalledWith({
+      id: 'job-1',
+      error: 'Création du plan impossible : insert en conflit',
+      stepStates: initialStepStates(),
+    });
   });
 
   it('marque le job failed et supprime la source quand la pipeline lève une exception', async () => {
-    const { jobRepository, documentStorage, llm, removeDocument } = buildMocks({
+    const mocks = buildMocks({
       generateStructured: async () => {
         throw new Error('boom réseau');
       },
     });
-    const service = new GenerateImportDraftService(jobRepository, documentStorage, llm);
+    const service = buildService(mocks);
 
     const result = await service.generate('job-1');
 
@@ -125,72 +205,56 @@ describe('GenerateImportDraftService', () => {
         message: 'Import interrompu: boom réseau',
       },
     });
-    expect(jobRepository.markFailed).toHaveBeenCalledWith({
+    expect(mocks.jobRepository.markFailed).toHaveBeenCalledWith({
       id: 'job-1',
       error: 'Import interrompu: boom réseau',
       stepStates: initialStepStates(),
     });
-    expect(removeDocument).toHaveBeenCalledWith({ bucketId: 'ai-plan-import-sources', key: '10/abc' });
-  });
-
-  it("remonte un échec quand l'enregistrement du brouillon échoue après un run payé", async () => {
-    const { jobRepository, documentStorage, llm } = buildMocks({
-      markDone: async () => failure(AiPlanImportErrorEnum.UPDATE_JOB_ERROR),
-    });
-    const service = new GenerateImportDraftService(jobRepository, documentStorage, llm);
-
-    const result = await service.generate('job-1');
-
-    expect(jobRepository.markDone).toHaveBeenCalled();
-    expect(result).toEqual({
-      success: false,
-      error: {
-        kind: 'draft_record_failed',
-        jobId: 'job-1',
-        cause: AiPlanImportErrorEnum.UPDATE_JOB_ERROR,
-      },
+    expect(mocks.removeDocument).toHaveBeenCalledWith({
+      bucketId: 'ai-plan-import-sources',
+      key: '10/abc',
     });
   });
 
   it('marque failed et supprime la source sur échec terminal hors-process', async () => {
-    const { jobRepository, documentStorage, llm, removeDocument } = buildMocks();
-    const service = new GenerateImportDraftService(jobRepository, documentStorage, llm);
+    const mocks = buildMocks();
+    const service = buildService(mocks);
 
     await service.recordTerminalFailure('job-1', 'Import interrompu: stall');
 
-    expect(jobRepository.markFailed).toHaveBeenCalledWith({
+    expect(mocks.jobRepository.markFailed).toHaveBeenCalledWith({
       id: 'job-1',
       error: 'Import interrompu: stall',
       stepStates: initialStepStates(),
     });
-    expect(removeDocument).toHaveBeenCalledWith({
+    expect(mocks.removeDocument).toHaveBeenCalledWith({
       bucketId: 'ai-plan-import-sources',
       key: '10/abc',
     });
   });
 
   it('ne supprime pas de source quand la ligne du job a disparu', async () => {
-    const { jobRepository, documentStorage, llm, removeDocument } = buildMocks({
+    const mocks = buildMocks({
       getById: async () => failure(AiPlanImportErrorEnum.JOB_NOT_FOUND),
     });
-    const service = new GenerateImportDraftService(jobRepository, documentStorage, llm);
+    const service = buildService(mocks);
 
     await service.recordTerminalFailure('job-1', 'Import interrompu: stall');
 
-    expect(jobRepository.markFailed).toHaveBeenCalled();
-    expect(removeDocument).not.toHaveBeenCalled();
+    expect(mocks.jobRepository.markFailed).toHaveBeenCalled();
+    expect(mocks.removeDocument).not.toHaveBeenCalled();
   });
 
   it("remonte un échec quand l'enregistrement de l'échec d'extraction échoue", async () => {
-    const { jobRepository, documentStorage, llm } = buildMocks({
+    const mocks = buildMocks({
       sourceContent: '',
       markFailed: async () => failure(AiPlanImportErrorEnum.UPDATE_JOB_ERROR),
     });
-    const service = new GenerateImportDraftService(jobRepository, documentStorage, llm);
+    const service = buildService(mocks);
 
     const result = await service.generate('job-1');
 
-    expect(llm.generateStructured).not.toHaveBeenCalled();
+    expect(mocks.llm.generateStructured).not.toHaveBeenCalled();
     expect(result).toEqual({
       success: false,
       error: {

--- a/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/generate-import-draft.service.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/generate-import-draft.service.ts
@@ -1,24 +1,31 @@
 import { Injectable } from '@nestjs/common';
+import { ImportPlanInput } from '@tet/backend/plans/plans/import-plan-aggregate/import-plan.input';
+import { ImportPlanService } from '@tet/backend/plans/plans/import-plan-aggregate/import-plan.service';
+import { AuthRole, type AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
 import { LlmService } from '@tet/backend/utils/llm/llm.service';
 import { failure, success, type Result } from '@tet/backend/utils/result.type';
 import { DocumentStorageService } from '@tet/backend/utils/supabase/document-storage.service';
+import { TransactionManager } from '@tet/backend/utils/transaction/transaction-manager.service';
 import { getErrorMessage } from '@tet/domain/utils';
 import { AI_PLAN_IMPORT_SOURCE_BUCKET } from '../ai-plan-import.constants';
 import { type AiPlanImportError } from '../ai-plan-import.errors';
 import { AiPlanImportJobRepository } from '../ai-plan-import-job.repository';
 import { AiPlanImportJob } from '../models/ai-plan-import-job';
+import { PlanDraft } from '../models/plan-draft';
+import { draftToImportPlanInput } from './draft-to-import-plan-input';
 import { ExtractionError, extractText } from './extract-text';
 import {
   initialStepStates,
   PipelineError,
   runImportPipeline,
   StepName,
+  StepStates,
 } from './run-import-pipeline';
 
 export type GenerateImportDraftError =
   | { kind: 'transition_failed'; jobId: string; cause: AiPlanImportError }
   | { kind: 'failure_record_failed'; jobId: string; cause: AiPlanImportError }
-  | { kind: 'draft_record_failed'; jobId: string; cause: AiPlanImportError }
   | { kind: 'interrupted'; jobId: string; message: string };
 
 @Injectable()
@@ -26,7 +33,9 @@ export class GenerateImportDraftService {
   constructor(
     private readonly jobRepository: AiPlanImportJobRepository,
     private readonly documentStorage: DocumentStorageService,
-    private readonly llm: LlmService
+    private readonly llm: LlmService,
+    private readonly importPlanService: ImportPlanService,
+    private readonly transactionManager: TransactionManager
   ) {}
 
   async generate(
@@ -114,18 +123,63 @@ export class GenerateImportDraftService {
           });
     }
 
-    const done = await this.jobRepository.markDone({
-      id: job.id,
-      draft: outcome.draft,
-      stepStates: outcome.stepStates,
+    return this.persistDraftAsPlan(job, outcome.draft, outcome.stepStates);
+  }
+
+  private async persistDraftAsPlan(
+    job: AiPlanImportJob,
+    draft: PlanDraft,
+    stepStates: StepStates
+  ): Promise<Result<undefined, GenerateImportDraftError>> {
+    const planInput = draftToImportPlanInput({
+      actions: draft.actions,
+      planName: job.options.planName,
+      planType: job.options.planType,
     });
-    return done.success
-      ? success(undefined)
-      : failure({
-          kind: 'draft_record_failed',
-          jobId: job.id,
-          cause: done.error,
+
+    const created = await this.transactionManager.executeSingle<number, string>(
+      async (tx) => {
+        const planId = await this.createPlan(planInput, job, tx);
+        if (!planId.success) {
+          return planId;
+        }
+        const done = await this.jobRepository.markDone({
+          id: job.id,
+          draft,
+          stepStates,
+          createdPlanId: planId.data,
+          tx,
         });
+        return done.success
+          ? success(planId.data)
+          : failure('Enregistrement du job terminé impossible');
+      }
+    );
+
+    if (!created.success) {
+      return this.recordFailure(job.id, created.error);
+    }
+    return success(undefined);
+  }
+
+  private async createPlan(
+    planInput: ImportPlanInput,
+    job: AiPlanImportJob,
+    tx: Transaction
+  ): Promise<Result<number, string>> {
+    try {
+      const saved = await this.importPlanService.save({
+        planInput,
+        collectiviteId: job.collectiviteId,
+        user: buildRequesterUser(job.createdBy),
+        tx,
+      });
+      return saved.success
+        ? success(saved.data.planId)
+        : failure(`Création du plan impossible : ${saved.error.message}`);
+    } catch (error) {
+      return failure(`Création du plan impossible : ${getErrorMessage(error)}`);
+    }
   }
 
   private async recordFailure(
@@ -148,6 +202,13 @@ export class GenerateImportDraftService {
     return downloaded.success ? downloaded.data : null;
   }
 }
+
+const buildRequesterUser = (userId: string): AuthenticatedUser => ({
+  id: userId,
+  role: AuthRole.AUTHENTICATED,
+  isAnonymous: false,
+  jwtPayload: { role: AuthRole.AUTHENTICATED },
+});
 
 const extractionErrorMessage = (error: ExtractionError): string => {
   switch (error.kind) {

--- a/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/generate-import-draft.worker.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/generate-import-draft.worker.ts
@@ -63,8 +63,6 @@ const toErrorMessage = (error: GenerateImportDraftError): string => {
       return `Transition du job ${error.jobId} impossible (${error.cause})`;
     case 'failure_record_failed':
       return `Enregistrement de l'échec du job ${error.jobId} impossible (${error.cause})`;
-    case 'draft_record_failed':
-      return `Enregistrement du brouillon du job ${error.jobId} impossible (${error.cause})`;
     case 'interrupted':
       return error.message;
   }

--- a/apps/backend/src/plans/plans/ai-plan-import/get-import-status/get-import-status.output.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/get-import-status/get-import-status.output.ts
@@ -1,19 +1,14 @@
 import { z } from 'zod';
 import { stepStatesSchema } from '../generate-import-draft/run-import-pipeline';
 import { aiPlanImportJobStatusSchema } from '../models/ai-plan-import-job';
-import { extractedActionSchema } from '../models/extracted-action';
-
-const planDraftSchema = z.object({
-  actions: z.array(extractedActionSchema),
-  qualitativeReview: z.string().nullable(),
-});
 
 export const getImportStatusOutputSchema = z.object({
   jobId: z.string(),
   status: aiPlanImportJobStatusSchema,
   stepStates: stepStatesSchema,
-  draft: planDraftSchema.nullable(),
+  qualitativeReview: z.string().nullable(),
   error: z.string().nullable(),
+  createdPlanId: z.number().nullable(),
 });
 
 export type GetImportStatusOutput = z.output<typeof getImportStatusOutputSchema>;

--- a/apps/backend/src/plans/plans/ai-plan-import/get-import-status/get-import-status.service.spec.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/get-import-status/get-import-status.service.spec.ts
@@ -5,42 +5,35 @@ import { describe, expect, it, vi } from 'vitest';
 import { AiPlanImportErrorEnum } from '../ai-plan-import.errors';
 import { AiPlanImportJobRepository } from '../ai-plan-import-job.repository';
 import {
-  AiPlanImportJob,
   AiPlanImportJobStatusEnum,
+  AiPlanImportJobStatusView,
 } from '../models/ai-plan-import-job';
 import { initialStepStates } from '../generate-import-draft/run-import-pipeline';
 import { GetImportStatusService } from './get-import-status.service';
 
 const user = { id: 'user-1' } as AuthenticatedUser;
 
-const toJob = (overrides: Partial<AiPlanImportJob>): AiPlanImportJob => ({
+const toView = (
+  overrides: Partial<AiPlanImportJobStatusView>
+): AiPlanImportJobStatusView => ({
   id: 'job-1',
   collectiviteId: 10,
-  createdBy: 'user-1',
   status: AiPlanImportJobStatusEnum.RUNNING,
-  options: {
-    instructions: '',
-    withVerifications: true,
-    withSousActions: true,
-    disabledFields: [],
-  },
   stepStates: initialStepStates(),
-  sourcePath: '10/abc',
-  draft: null,
   error: null,
-  createdAt: '2026-06-10T00:00:00Z',
-  modifiedAt: '2026-06-10T00:00:00Z',
+  createdPlanId: null,
+  qualitativeReview: null,
   ...overrides,
 });
 
 const buildService = (args: {
-  job: ReturnType<typeof toJob> | null;
+  view: AiPlanImportJobStatusView | null;
   isAllowed: boolean;
 }): GetImportStatusService => {
   const jobRepository = {
-    getById: vi.fn(async () =>
-      args.job
-        ? success(args.job)
+    getStatusView: vi.fn(async () =>
+      args.view
+        ? success(args.view)
         : failure(AiPlanImportErrorEnum.JOB_NOT_FOUND)
     ),
   } as unknown as AiPlanImportJobRepository;
@@ -51,31 +44,37 @@ const buildService = (args: {
 };
 
 describe('GetImportStatusService', () => {
-  it('expose le statut sans brouillon tant que le job tourne', async () => {
-    const service = buildService({ job: toJob({}), isAllowed: true });
+  it('expose le statut sans avis tant que le job tourne', async () => {
+    const service = buildService({ view: toView({}), isAllowed: true });
 
     const result = await service.getStatus({ jobId: 'job-1', user });
 
     expect(result).toMatchObject({
       success: true,
-      data: { jobId: 'job-1', status: 'running', draft: null },
+      data: { jobId: 'job-1', status: 'running', qualitativeReview: null },
     });
   });
 
-  it('expose le brouillon quand le job est terminé', async () => {
-    const draft = { actions: [], qualitativeReview: 'Avis' };
+  it('expose l avis qualitatif quand le job est terminé', async () => {
     const service = buildService({
-      job: toJob({ status: AiPlanImportJobStatusEnum.DONE, draft }),
+      view: toView({
+        status: AiPlanImportJobStatusEnum.DONE,
+        qualitativeReview: 'Avis IA',
+        createdPlanId: 42,
+      }),
       isAllowed: true,
     });
 
     const result = await service.getStatus({ jobId: 'job-1', user });
 
-    expect(result).toMatchObject({ success: true, data: { draft } });
+    expect(result).toMatchObject({
+      success: true,
+      data: { qualitativeReview: 'Avis IA', createdPlanId: 42 },
+    });
   });
 
   it('renvoie JOB_NOT_FOUND quand le job est introuvable', async () => {
-    const service = buildService({ job: null, isAllowed: true });
+    const service = buildService({ view: null, isAllowed: true });
 
     const result = await service.getStatus({ jobId: 'job-1', user });
 
@@ -86,7 +85,7 @@ describe('GetImportStatusService', () => {
   });
 
   it('renvoie JOB_NOT_FOUND sans droit (anti-énumération)', async () => {
-    const service = buildService({ job: toJob({}), isAllowed: false });
+    const service = buildService({ view: toView({}), isAllowed: false });
 
     const result = await service.getStatus({ jobId: 'job-1', user });
 

--- a/apps/backend/src/plans/plans/ai-plan-import/get-import-status/get-import-status.service.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/get-import-status/get-import-status.service.ts
@@ -8,7 +8,7 @@ import {
   type AiPlanImportError,
 } from '../ai-plan-import.errors';
 import { AiPlanImportJobRepository } from '../ai-plan-import-job.repository';
-import { AiPlanImportJob } from '../models/ai-plan-import-job';
+import { AiPlanImportJobStatusView } from '../models/ai-plan-import-job';
 import type { GetImportStatusOutput } from './get-import-status.output';
 
 export type GetImportStatusServiceInput = {
@@ -26,30 +26,31 @@ export class GetImportStatusService {
   async getStatus(
     input: GetImportStatusServiceInput
   ): Promise<Result<GetImportStatusOutput, AiPlanImportError>> {
-    const job = await this.jobRepository.getById(input.jobId);
-    if (!job.success) {
-      return job;
+    const view = await this.jobRepository.getStatusView(input.jobId);
+    if (!view.success) {
+      return view;
     }
 
     const isAllowed = await this.permissions.isAllowed(
       input.user,
       'plans.fiches.import',
       ResourceType.COLLECTIVITE,
-      job.data.collectiviteId,
+      view.data.collectiviteId,
       true
     );
     if (!isAllowed) {
       return failure(AiPlanImportErrorEnum.JOB_NOT_FOUND);
     }
 
-    return success(toOutput(job.data));
+    return success(toOutput(view.data));
   }
 }
 
-const toOutput = (job: AiPlanImportJob): GetImportStatusOutput => ({
-  jobId: job.id,
-  status: job.status,
-  stepStates: job.stepStates,
-  draft: job.draft,
-  error: job.error,
+const toOutput = (view: AiPlanImportJobStatusView): GetImportStatusOutput => ({
+  jobId: view.id,
+  status: view.status,
+  stepStates: view.stepStates,
+  qualitativeReview: view.qualitativeReview,
+  error: view.error,
+  createdPlanId: view.createdPlanId,
 });

--- a/apps/backend/src/plans/plans/ai-plan-import/models/ai-plan-import-job.table.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/models/ai-plan-import-job.table.ts
@@ -1,4 +1,5 @@
 import { collectiviteTable } from '@tet/backend/collectivites/shared/models/collectivite.table';
+import { axeTable } from '@tet/backend/plans/fiches/shared/models/axe.table';
 import { authUsersTable } from '@tet/backend/users/models/auth-users.table';
 import { createdAt, modifiedAt } from '@tet/backend/utils/column.utils';
 import { sql } from 'drizzle-orm';
@@ -33,6 +34,9 @@ export const aiPlanImportJobTable = pgTable(
     sourcePath: text('source_path').notNull(),
     draft: jsonb('draft').$type<PlanDraft>(),
     error: text('error'),
+    createdPlanId: integer('created_plan_id').references(() => axeTable.id, {
+      onDelete: 'set null',
+    }),
     createdAt,
     modifiedAt,
   },

--- a/apps/backend/src/plans/plans/ai-plan-import/models/ai-plan-import-job.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/models/ai-plan-import-job.ts
@@ -26,6 +26,8 @@ export const aiPlanImportJobInFlightStatuses: AiPlanImportJobStatus[] = [
 
 export type AiPlanImportJobOptions = {
   instructions: string;
+  planName: string;
+  planType?: number;
   withVerifications: boolean;
   withSousActions: boolean;
   disabledFields: DisableableField[];
@@ -41,6 +43,17 @@ export type AiPlanImportJob = {
   sourcePath: string;
   draft: PlanDraft | null;
   error: string | null;
+  createdPlanId: number | null;
   createdAt: string;
   modifiedAt: string;
+};
+
+export type AiPlanImportJobStatusView = {
+  id: string;
+  collectiviteId: number;
+  status: AiPlanImportJobStatus;
+  stepStates: StepStates;
+  error: string | null;
+  createdPlanId: number | null;
+  qualitativeReview: string | null;
 };

--- a/apps/backend/src/plans/plans/plans.module.ts
+++ b/apps/backend/src/plans/plans/plans.module.ts
@@ -15,7 +15,6 @@ import { UpsertAxeRepository } from '../axes/upsert-axe/upsert-axe.repository';
 import { UpsertAxeRouter } from '../axes/upsert-axe/upsert-axe.router';
 import { UpsertAxeService } from '../axes/upsert-axe/upsert-axe.service';
 import { FichesModule } from '../fiches/fiches.module';
-import { AiPlanImportModule } from './ai-plan-import/ai-plan-import.module';
 import { ComputeBudgetRules } from './compute-budget/compute-budget.rules';
 import { DeletePlanRepository } from './delete-plan/delete-plan.repository';
 import { DeletePlanRouter } from './delete-plan/delete-plan.router';
@@ -49,7 +48,6 @@ import { UpsertPlanService } from './upsert-plan/upsert-plan.service';
     forwardRef(() => FichesModule),
     AxeModule,
     TransactionModule,
-    AiPlanImportModule,
   ],
   providers: [
     GetPlanCompletionService,
@@ -100,6 +98,7 @@ import { UpsertPlanService } from './upsert-plan/upsert-plan.service';
     PlanProgressRules,
     ComputeBudgetRules,
     ImportPlanService,
+    ListPlanTypesService,
   ],
 })
 export class PlanModule {}

--- a/apps/backend/src/plans/plans/plans.router.ts
+++ b/apps/backend/src/plans/plans/plans.router.ts
@@ -3,7 +3,6 @@ import { TrpcService } from '@tet/backend/utils/trpc/trpc.service';
 import { DeletePlanRouter } from './delete-plan/delete-plan.router';
 import { DuplicatePlanRouter } from './duplicate-plan/duplicate-plan.router';
 import { GetPlanCompletionRouter } from './get-plan-completion/get-plan-completion.router';
-import { GetImportStatusRouter } from './ai-plan-import/get-import-status/get-import-status.router';
 import { GetPlanRouter } from './get-plan/get-plan.router';
 import { ImportPlanRouter } from './import-plan-aggregate/import-plan.router';
 import { ListPlanTypesRouter } from './list-plan-types/list-plan-types.router';
@@ -21,8 +20,7 @@ export class PlanRouter {
     private readonly listPlanTypesRouter: ListPlanTypesRouter,
     private readonly deletePlanRouter: DeletePlanRouter,
     private readonly duplicatePlanRouter: DuplicatePlanRouter,
-    private readonly importPlanRouter: ImportPlanRouter,
-    private readonly getImportStatusRouter: GetImportStatusRouter
+    private readonly importPlanRouter: ImportPlanRouter
   ) {}
 
   router = this.trpc.mergeRouters(
@@ -33,7 +31,6 @@ export class PlanRouter {
     this.listPlanTypesRouter.router,
     this.deletePlanRouter.router,
     this.duplicatePlanRouter.router,
-    this.importPlanRouter.router,
-    this.getImportStatusRouter.router
+    this.importPlanRouter.router
   );
 }

--- a/data_layer/sqitch/deploy/plan_action/ai_plan_import_job_created_plan.sql
+++ b/data_layer/sqitch/deploy/plan_action/ai_plan_import_job_created_plan.sql
@@ -1,0 +1,13 @@
+-- Deploy tet:plan_action/ai_plan_import_job_created_plan to pg
+-- requires: plan_action/ai_plan_import_job
+
+BEGIN;
+
+ALTER TABLE public.ai_plan_import_job
+    ADD COLUMN created_plan_id integer NULL
+        REFERENCES public.axe(id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN public.ai_plan_import_job.created_plan_id IS
+    'Plan (axe racine) créé par le worker à partir du brouillon ; NULL tant que non créé. Lien de traçabilité exposé par get-import-status (redirection vers le plan).';
+
+COMMIT;

--- a/data_layer/sqitch/revert/plan_action/ai_plan_import_job_created_plan.sql
+++ b/data_layer/sqitch/revert/plan_action/ai_plan_import_job_created_plan.sql
@@ -1,0 +1,8 @@
+-- Revert tet:plan_action/ai_plan_import_job_created_plan from pg
+
+BEGIN;
+
+ALTER TABLE public.ai_plan_import_job
+    DROP COLUMN IF EXISTS created_plan_id;
+
+COMMIT;

--- a/data_layer/sqitch/sqitch.plan
+++ b/data_layer/sqitch/sqitch.plan
@@ -995,3 +995,4 @@ plan_action/ai_plan_import_job 2026-06-10T14:05:07Z Gaël Servaud <gaelservaud@H
 collectivite/bucket_rls_strict_read [collectivite/bucket] 2026-05-29T12:00:00Z Frederic Arnoux <frederic.arnoux@beta.gouv.fr> # Restreint la lecture de storage.objects aux membres ou auditeurs de la collectivité propriétaire du bucket (Pentest V5)
 
 referentiel/add_adaptation_niveau 2026-06-02T17:55:00Z Marc Rutkowski <marc@attractive-media.fr> # Ajoute la colonne pour stocker le niveau d'exposition au changement climatique associé à une mesure
+plan_action/ai_plan_import_job_created_plan [plan_action/ai_plan_import_job] 2026-06-15T08:59:54Z Gaël Servaud <gaelservaud@Host-002.lan> # Ajoute created_plan_id (plan cree par le worker d'import IA) a ai_plan_import_job

--- a/data_layer/sqitch/verify/plan_action/ai_plan_import_job_created_plan.sql
+++ b/data_layer/sqitch/verify/plan_action/ai_plan_import_job_created_plan.sql
@@ -1,0 +1,35 @@
+-- Verify tet:plan_action/ai_plan_import_job_created_plan on pg
+
+BEGIN;
+
+DO $$
+DECLARE
+    fk_created text;
+BEGIN
+    ASSERT (
+        SELECT COUNT(*) = 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'ai_plan_import_job'
+          AND column_name = 'created_plan_id'
+          AND data_type = 'integer'
+          AND is_nullable = 'YES'
+    ), 'La colonne created_plan_id doit exister en integer NULLABLE';
+
+    SELECT rc.delete_rule INTO fk_created
+    FROM information_schema.table_constraints tc
+    JOIN information_schema.referential_constraints rc
+        USING (constraint_schema, constraint_name)
+    JOIN information_schema.key_column_usage kcu
+        USING (constraint_schema, constraint_name)
+    WHERE tc.table_schema = 'public'
+      AND tc.table_name = 'ai_plan_import_job'
+      AND tc.constraint_type = 'FOREIGN KEY'
+      AND kcu.column_name = 'created_plan_id'
+    LIMIT 1;
+
+    ASSERT fk_created = 'SET NULL',
+        'La FK created_plan_id doit avoir delete_rule = SET NULL';
+END $$;
+
+ROLLBACK;


### PR DESCRIPTION
## Contexte

Remplace l'approche « brouillon → étape de confirmation » (la pipeline produisait un `PlanDraft` que l'utilisateur reconfirmait, faisant transiter un gros payload édité front→back) par une **création directe du plan en base par le worker**. L'utilisateur édite ensuite le plan dans l'éditeur normal, hors du flow d'import.

Décision produit assumée : on fait confiance à la qualité d'extraction ; pas d'état `brouillon` sur les plans pour l'instant (ajoutable plus tard). Réverse les décisions D2/A2 du plan initial → PR11 (confirm) et PR13 (UI de revue) abandonnées.

## Flow

`POST collectivites/:id/plans/import-ia` (multipart) → `{ jobId }` immédiat (201) → la pipeline tourne dans le worker BullMQ → le worker **crée le plan** en fin de pipeline → le front poll `plans.aiImport.getAiImportStatus` et, à `done`, affiche l'avis qualitatif puis redirige vers `createdPlanId`.

## Changements

**Worker (création directe)**
- En fin de pipeline : reconstruit l'utilisateur depuis `job.createdBy` (`buildRequesterUser`, comme `generate-preuves-archive`), mappe le brouillon en `ImportPlanInput` (mapper pur `draft-to-import-plan-input`) et persiste via le seam `ImportPlanService.save`.
- `save` + enregistrement de `created_plan_id` + `markDone` dans **une seule transaction** (atomique : pas de plan orphelin). `createPlan` isole l'appel au seam dans un `try/catch` — nécessaire car `save` re-`throw` quand on lui passe une transaction partagée (le `TransactionManager` re-throw sur `tx` fourni).

**Enqueue**
- `planName` (requis) + `planType` (optionnel) saisis à l'upload, ajoutés aux `options` du job.
- **Validation amont du `planType`** : s'il est fourni, vérifie son existence (`ListPlanTypesService`) **avant tout stockage/enfilement** → `UNKNOWN_PLAN_TYPE` (400) sinon. Évite de déclencher la pipeline LLM complète pour échouer in fine sur une violation de FK.

**Statut**
- Sortie réduite à `qualitativeReview` + `createdPlanId` (+ status/stepStates/error) — plus le brouillon complet (actions + pilotes = PII).
- Projection dédiée `getStatusView` (lit `draft ->> 'qualitativeReview'` au lieu de charger tout le jsonb `draft` à chaque polling).

**Migration**
- `created_plan_id integer REFERENCES axe(id) ON DELETE SET NULL` (traçabilité du plan créé, exposé par le statut pour la redirection).

**Câblage modules — sans `forwardRef`**
Le worker (dans `AiPlanImportModule`) a besoin du seam `ImportPlanService` (dans `PlanModule`), qui importait `AiPlanImportModule` → cycle. Résolu en suivant la direction existante : le routeur statut passe sous l'agrégateur `plans` (`PlanMainRouter` → `plans.aiImport`), `PlanModule` ne dépend plus de `AiPlanImportModule`, et `AiPlanImportModule` importe `PlanModule` en sens unique.

## Tests

- `generate-import-draft.service.spec` : création du plan + `markDone(createdPlanId)`, `failed` si la création échoue (retour **et** exception du seam), chemins d'échec inchangés.
- `draft-to-import-plan-input.spec` : mapping nom/type + aplatissement action/sous-actions.
- `enqueue-import.service.spec` : `planName` requis, `planType` inconnu rejeté **avant tout effet de bord**, `planType` connu accepté.
- `get-import-status.service.spec` : projection (avis qualitatif + createdPlanId), IDOR.
- `enqueue-import.controller.e2e-spec` : type inconnu → 400 sans job créé, **déni utilisateur ad-hoc → 403**, formulaire sans `planName` → 400 (user autorisé via mode support).
- App + spec typecheck verts, suite unitaire `ai-plan-import` verte, lint clean.

## Limites / suivi
- Migration et e2e **non exécutés en local** (drift sqitch de la base de dev) → tourneront en CI.
- Suivi : cap de sécurité sur la taille de `actions[]` (transaction bornée), renommage `PlanMainRouter`/`PlanMainModule` (PR dédiée), front (PR12 : upload + suivi + affichage avis + redirection).