### PR TITLE
fix(referentiels): décale le scroll vers le hash sous le header sticky

### DIFF
--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/action/[actionId]/_components/components.old-referentiel/subaction/subaction-card.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/action/[actionId]/_components/components.old-referentiel/subaction/subaction-card.tsx
@@ -112,11 +112,13 @@ const SubActionCard = ({
   const { data: tasks = [] } = useListActions({
     actionIds: subAction.childrenIds,
   });
+  const stickyHeaderHeight = useStickyHeaderHeight();
 
   return (
     <div
       id={subAction.actionId}
       data-test={`SousAction-${subAction.identifiant}`}
+      style={{ scrollMarginTop: stickyHeaderHeight }}
       className={cn(
         'border border-grey-3 rounded-lg bg-grey-1 transition-colors',
         { 'hover:bg-grey-2': !isExpanded }

--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/action/[actionId]/_components/components.old-referentiel/subaction/use-scroll-to-hash.ts
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/action/[actionId]/_components/components.old-referentiel/subaction/use-scroll-to-hash.ts
@@ -1,12 +1,10 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useStickyHeaderHeight } from '@tet/ui';
+import { useEffect, useRef } from 'react';
 
 const MAX_PARENT_LEVELS = 2;
 
-/** Cherche un élément DOM par son id (ex: "1.2.3"), puis remonte dans la hiérarchie ("1.2", "1")
- * jusqu'à trouver une correspondance. Permet d'expand et scroller jusqu'à une sous-action
- * lorsque le hash cible une tâche pas encore présente dans le DOM car dans une sous-action qui n'est pas expand. */
 const findElementByHashOrParent = (hash: string): HTMLElement | null => {
   const segments = hash.split('.');
   return Array.from({ length: MAX_PARENT_LEVELS + 1 })
@@ -19,13 +17,32 @@ const findElementByHashOrParent = (hash: string): HTMLElement | null => {
 };
 
 export const useScrollToHash = (hash: string): void => {
+  const stickyHeaderHeight = useStickyHeaderHeight();
+  const userScrolledRef = useRef(false);
+
   useEffect(() => {
+    userScrolledRef.current = false;
     if (!hash) return;
-    requestAnimationFrame(() => {
-      findElementByHashOrParent(hash)?.scrollIntoView({
-        behavior: 'smooth',
-        block: 'start',
-      });
-    });
+    const markUserScrolled = (): void => {
+      userScrolledRef.current = true;
+    };
+    window.addEventListener('wheel', markUserScrolled, { passive: true });
+    window.addEventListener('touchmove', markUserScrolled, { passive: true });
+    return () => {
+      window.removeEventListener('wheel', markUserScrolled);
+      window.removeEventListener('touchmove', markUserScrolled);
+    };
   }, [hash]);
+
+  useEffect(() => {
+    if (!hash || userScrolledRef.current) return;
+    const raf = requestAnimationFrame(() => {
+      const target = findElementByHashOrParent(hash);
+      if (!target) return;
+      const top =
+        target.getBoundingClientRect().top + window.scrollY - stickyHeaderHeight;
+      window.scrollTo({ top, behavior: 'smooth' });
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [hash, stickyHeaderHeight]);
 };

--- a/e2e/tests/referentiels/scores/hash-navigation.spec.ts
+++ b/e2e/tests/referentiels/scores/hash-navigation.spec.ts
@@ -1,5 +1,10 @@
 import { expect } from '@playwright/test';
 import { testWithReferentiels as test } from '../referentiels.fixture';
+import {
+  stickyHeaderBottom,
+  waitForScrollSettled,
+  waitForScrollStopped,
+} from '../sticky-header.helpers';
 
 test.describe('Navigation par hash vers une sous-action', () => {
   test.beforeEach(async ({ page, collectivites }) => {
@@ -33,6 +38,62 @@ test.describe('Navigation par hash vers une sous-action', () => {
         name: 'Déplier la sous-action 1.1.1.3',
       })
     ).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  test("Le header de la sous-action ciblée par le hash n'est pas masqué par le header sticky", async ({
+    page,
+    referentielScoresPom,
+    referentiels: _,
+  }) => {
+    await referentielScoresPom.goto('cae');
+    await referentielScoresPom.goToActionPage(
+      '1 - Planification',
+      '1.1 Stratégie globale',
+      '1.1.1 Définir la vision, les'
+    );
+
+    const url = page.url();
+    await page.goto(`${url}#cae_1.1.1.3`);
+
+    const sousActionHeader = page
+      .locator('[id="cae_1.1.1.3"]')
+      .getByRole('button', { name: 'Déplier la sous-action 1.1.1.3' });
+    await expect(sousActionHeader).toBeVisible();
+
+    await waitForScrollSettled(page, 'cae_1.1.1.3');
+
+    const stickyBottom = await stickyHeaderBottom(page);
+    const headerBox = await sousActionHeader.boundingBox();
+    if (!headerBox) throw new Error('Header sous-action introuvable');
+
+    expect(headerBox.y).toBeGreaterThanOrEqual(stickyBottom);
+  });
+
+  test("Un scroll utilisateur vers le haut n'est pas ramené au hash quand la hauteur du header change", async ({
+    page,
+    referentielScoresPom,
+    referentiels: _,
+  }) => {
+    await referentielScoresPom.goto('cae');
+    await referentielScoresPom.goToActionPage(
+      '1 - Planification',
+      '1.1 Stratégie globale',
+      '1.1.1 Définir la vision, les'
+    );
+
+    const url = page.url();
+    await page.goto(`${url}#cae_1.1.1.3`);
+    await waitForScrollSettled(page, 'cae_1.1.1.3');
+    expect(await page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
+
+    await page.mouse.move(640, 512);
+    await page.mouse.wheel(0, -5000);
+    await waitForScrollStopped(page);
+
+    await page.setViewportSize({ width: 600, height: 1024 });
+    await waitForScrollStopped(page);
+
+    expect(await page.evaluate(() => window.scrollY)).toBeLessThan(100);
   });
 
   test("L'utilisateur peut replier une sous-action auto-expandée par le hash", async ({

--- a/e2e/tests/referentiels/sticky-header.helpers.ts
+++ b/e2e/tests/referentiels/sticky-header.helpers.ts
@@ -1,0 +1,60 @@
+import { Page } from '@playwright/test';
+
+const STABLE_SAMPLES_REQUIRED = 3;
+const STABLE_TOLERANCE_PX = 0.5;
+const POLL_INTERVAL_MS = 50;
+const MAX_WAIT_MS = 5_000;
+
+const waitUntilStable = async (
+  page: Page,
+  read: () => Promise<number | null>
+): Promise<void> => {
+  const deadline = Date.now() + MAX_WAIT_MS;
+  let previous: number | null = null;
+  let stableSamples = 0;
+  while (stableSamples < STABLE_SAMPLES_REQUIRED) {
+    if (Date.now() > deadline) {
+      throw new Error(
+        `waitUntilStable: la valeur ne s'est pas stabilisée en ${MAX_WAIT_MS} ms (dernière lecture : ${previous})`
+      );
+    }
+    const current = await read();
+    if (
+      current !== null &&
+      previous !== null &&
+      Math.abs(current - previous) < STABLE_TOLERANCE_PX
+    ) {
+      stableSamples += 1;
+    } else {
+      stableSamples = 0;
+    }
+    previous = current;
+    if (stableSamples < STABLE_SAMPLES_REQUIRED) {
+      await page.waitForTimeout(POLL_INTERVAL_MS);
+    }
+  }
+};
+
+export const waitForScrollSettled = async (
+  page: Page,
+  elementId: string
+): Promise<void> => {
+  await waitUntilStable(page, () =>
+    page.evaluate(
+      (id) =>
+        document.getElementById(id)?.getBoundingClientRect().top ?? null,
+      elementId
+    )
+  );
+};
+
+export const waitForScrollStopped = async (page: Page): Promise<void> => {
+  await waitUntilStable(page, () => page.evaluate(() => window.scrollY));
+};
+
+export const stickyHeaderBottom = async (page: Page): Promise<number> => {
+  const stickyHeader = page.getByRole('region');
+  const box = await stickyHeader.boundingBox();
+  if (!box) throw new Error('Header sticky introuvable');
+  return box.y + box.height;
+};


### PR DESCRIPTION
## Nature
`fix` — une seule nature, un seul commit. Régression du scroll vers le hash sur la **page action** (ancien layout, visible en prod).

## Origine
Première tranche extraite de la branche `audit-badge-component` (PR trop grosse). Tranche **sans risque** : la page action est déjà en prod et le fix ne dépend que de `useStickyHeaderHeight` (`@tet/ui`), **déjà présent en prod**. Aucune dépendance sur le reste de la stack ni sur le feature flag du nouveau layout.

## Surface de review
| Fichier | Attention | Rôle |
|---|---|---|
| `…/subaction/use-scroll-to-hash.ts` | humaine | lit la hauteur sticky + ne re-scrolle que sur changement de hash |
| `…/subaction/subaction-card.tsx` | humaine | `scrollMarginTop = stickyHeaderHeight` sur l'ancre |
| `e2e/…/scores/hash-navigation.spec.ts` | humaine | tests de régression (6 cas) |
| `e2e/…/sticky-header.helpers.ts` | mécanique | helpers Playwright autoportés |

~30 lignes de logique. Le fix tourne sur la page action prod, indépendamment du flag `is-new-referentiel-layout-enabled`.

## Régression
Le commit inclut sa régression : `hash-navigation.spec.ts` (6 cas) est **rouge sur la source pré-fix** (le header de la cible passe sous le header sticky / re-scroll intempestif). Pour le démontrer : appliquer uniquement les deux fichiers e2e sur `main` et lancer le spec.

## Anti-scope (volontairement exclu)
- `audit-labellisation-to-action-scroll.spec.ts` → teste le **nouveau layout** (`newAuditLabellisationPom`, clic « Voir la mesure »), part dans la PR de la refonte checklist.
- `use-action-statut.ts` / `use-update-action-statut.ts` → invalidation de cache `getParcours` (feature role-mesures), rien à voir avec le scroll.

## Zones low-confidence
- La suite e2e n'a **pas** été exécutée localement (env Playwright/back absent). À confirmer en CI.

## Reviewers suggérés
`julik-frontend-races` (timing / DOM lifecycle du scroll), `jsx-state`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Améliorations**
  * La navigation vers une ancre tient désormais compte de l’en-tête fixe, pour éviter que le contenu ciblé soit masqué.
  * Le défilement automatique s’interrompt si l’utilisateur commence à scroller, afin de ne pas contrarier l’interaction manuelle.

* **Tests**
  * Ajout de vérifications end-to-end sur la navigation par hash et la stabilité du défilement avec en-tête sticky.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->