### PR TITLE
feat(ai-plan-import): backend import IA — endpoint statut, robustesse Gemini, création du plan

### DIFF
--- a/apps/backend/src/plans/plans/ai-plan-import/adapters/extracted-action-to-import-action.spec.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/adapters/extracted-action-to-import-action.spec.ts
@@ -6,9 +6,16 @@ import {
   ExtractedAction,
   ExtractedSousAction,
 } from '../models/extracted-action';
-import { extractedActionToImportActions } from './extracted-action-to-import-action';
+import {
+  capExtractedActionTitles,
+  countOverlongTitles,
+  dedupeExtractedActions,
+  extractedActionToImportActions,
+  MAX_FICHE_TITLE_LENGTH,
+  normalizeExtractedActions,
+} from './extracted-action-to-import-action';
 
-const aSousAction = (
+const toSousAction = (
   overrides: Partial<ExtractedSousAction> = {}
 ): ExtractedSousAction => ({
   titre: 'Déployer des lignes de covoiturage',
@@ -20,7 +27,7 @@ const aSousAction = (
   ...overrides,
 });
 
-const anAction = (
+const toAction = (
   overrides: Partial<ExtractedAction> = {}
 ): ExtractedAction => ({
   axe: 'Mobilité',
@@ -41,7 +48,7 @@ const anAction = (
 describe('extractedActionToImportActions', () => {
   it('mappe une action (axisPath, statut, budget, pilote)', () => {
     const [action] = extractedActionToImportActions(
-      anAction({
+      toAction({
         statut: 'A discuter',
         budget: 24000,
         personnePilote: 'Jean Dupont',
@@ -64,9 +71,9 @@ describe('extractedActionToImportActions', () => {
 
   it('mappe une sous-action imbriquée qui hérite des axes de son action parente', () => {
     const [, sousAction] = extractedActionToImportActions(
-      anAction({
+      toAction({
         sousActions: [
-          aSousAction({ dateDebut: '2025-01-01', statut: 'En cours' }),
+          toSousAction({ dateDebut: '2025-01-01', statut: 'En cours' }),
         ],
       })
     );
@@ -85,10 +92,10 @@ describe('extractedActionToImportActions', () => {
 
   it('déplie une action en 1 action + N sous-actions partageant axisPath et parent', () => {
     const result = extractedActionToImportActions(
-      anAction({
+      toAction({
         sousActions: [
-          aSousAction({ titre: 'Sous-action A' }),
-          aSousAction({ titre: 'Sous-action B' }),
+          toSousAction({ titre: 'Sous-action A' }),
+          toSousAction({ titre: 'Sous-action B' }),
         ],
       })
     );
@@ -107,19 +114,138 @@ describe('extractedActionToImportActions', () => {
   });
 
   it('mappe statut null vers status undefined', () => {
-    const [action] = extractedActionToImportActions(anAction());
+    const [action] = extractedActionToImportActions(toAction());
     expect(action.status).toBeUndefined();
   });
 
   it('round-trip : un draft mappé passe validateImportPlanInput', () => {
     const planInput: ImportPlanInput = {
       nom: 'Plan importé',
-      actions: [anAction({ sousActions: [aSousAction()] })].flatMap(
+      actions: [toAction({ sousActions: [toSousAction()] })].flatMap(
         extractedActionToImportActions
       ),
     };
 
     const result = validateImportPlanInput(planInput);
     expect(result.success).toBe(true);
+  });
+});
+
+describe('dedupeExtractedActions', () => {
+  it('supprime les actions de même axe, sous-axe et titre en gardant la première', () => {
+    const result = dedupeExtractedActions([
+      toAction({ description: 'première' }),
+      toAction({ description: 'doublon' }),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].description).toBe('première');
+  });
+
+  it('conserve un même titre sous des sous-axes différents', () => {
+    const result = dedupeExtractedActions([
+      toAction({ sousAxe: 'Covoiturage' }),
+      toAction({ sousAxe: 'Vélo' }),
+    ]);
+
+    expect(result).toHaveLength(2);
+  });
+
+  it('traite les espaces de bordure comme un même axe (parité avec la validation)', () => {
+    const result = dedupeExtractedActions([
+      toAction({ axe: 'Mobilité' }),
+      toAction({ axe: '  Mobilité  ' }),
+    ]);
+
+    expect(result).toHaveLength(1);
+  });
+
+  it('laisse des actions distinctes intactes', () => {
+    const result = dedupeExtractedActions([
+      toAction({ titre: 'Action A' }),
+      toAction({ titre: 'Action B' }),
+    ]);
+
+    expect(result).toHaveLength(2);
+  });
+});
+
+describe('capExtractedActionTitles', () => {
+  const longTitre = 'A'.repeat(MAX_FICHE_TITLE_LENGTH + 50);
+
+  it('tronque un titre d action trop long à la limite de la colonne', () => {
+    const [capped] = capExtractedActionTitles([toAction({ titre: longTitre })]);
+
+    expect(capped.titre).toHaveLength(MAX_FICHE_TITLE_LENGTH);
+    expect(capped.titre.endsWith('...')).toBe(true);
+  });
+
+  it('tronque aussi les titres de sous-actions', () => {
+    const [capped] = capExtractedActionTitles([
+      toAction({ sousActions: [toSousAction({ titre: longTitre })] }),
+    ]);
+
+    expect(capped.sousActions[0].titre).toHaveLength(MAX_FICHE_TITLE_LENGTH);
+  });
+
+  it('laisse intact un titre dans la limite', () => {
+    const [capped] = capExtractedActionTitles([
+      toAction({ titre: 'Titre court' }),
+    ]);
+
+    expect(capped.titre).toBe('Titre court');
+  });
+});
+
+describe('countOverlongTitles', () => {
+  const longTitre = 'A'.repeat(MAX_FICHE_TITLE_LENGTH + 1);
+
+  it('compte les titres d actions et de sous-actions au-delà de la limite', () => {
+    const count = countOverlongTitles([
+      toAction({ titre: longTitre }),
+      toAction({
+        titre: 'Court',
+        sousActions: [
+          toSousAction({ titre: longTitre }),
+          toSousAction({ titre: 'Court' }),
+        ],
+      }),
+    ]);
+
+    expect(count).toBe(2);
+  });
+
+  it('renvoie 0 quand tous les titres sont dans la limite', () => {
+    expect(countOverlongTitles([toAction()])).toBe(0);
+  });
+});
+
+describe('normalizeExtractedActions', () => {
+  it('plafonne, déduplique et renvoie les compteurs en un seul passage', () => {
+    const longTitre = 'A'.repeat(MAX_FICHE_TITLE_LENGTH + 10);
+    const result = normalizeExtractedActions([
+      toAction({ titre: 'Action 1' }),
+      toAction({ titre: 'Action 1' }),
+      toAction({ titre: longTitre, sousAxe: 'Autre' }),
+    ]);
+
+    expect(result.duplicateCount).toBe(1);
+    expect(result.truncatedCount).toBe(1);
+    expect(result.actions).toHaveLength(2);
+    expect(
+      result.actions.every(
+        (action) => action.titre.length <= MAX_FICHE_TITLE_LENGTH
+      )
+    ).toBe(true);
+  });
+
+  it('ne signale ni doublon ni troncature sur des actions propres', () => {
+    const result = normalizeExtractedActions([
+      toAction({ titre: 'Action A' }),
+      toAction({ titre: 'Action B' }),
+    ]);
+
+    expect(result).toMatchObject({ truncatedCount: 0, duplicateCount: 0 });
+    expect(result.actions).toHaveLength(2);
   });
 });

--- a/apps/backend/src/plans/plans/ai-plan-import/adapters/extracted-action-to-import-action.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/adapters/extracted-action-to-import-action.ts
@@ -1,12 +1,67 @@
+import { getActionKey } from '@tet/backend/plans/plans/create-plan-aggregate/create-plan-aggregate.rules';
 import {
   ImportActionInput,
   ImportActionOrSousAction,
   ImportSousActionInput,
 } from '@tet/backend/plans/plans/import-plan-aggregate/schemas/import-action.input';
+import { uniqBy } from 'es-toolkit';
 import {
   ExtractedAction,
   ExtractedSousAction,
 } from '../models/extracted-action';
+
+export const MAX_FICHE_TITLE_LENGTH = 300;
+
+const capTitle = (titre: string): string =>
+  titre.length > MAX_FICHE_TITLE_LENGTH
+    ? `${titre.slice(0, MAX_FICHE_TITLE_LENGTH - 3)}...`
+    : titre;
+
+export const capExtractedActionTitles = (
+  actions: ExtractedAction[]
+): ExtractedAction[] =>
+  actions.map((action) => ({
+    ...action,
+    titre: capTitle(action.titre),
+    sousActions: action.sousActions.map((sousAction) => ({
+      ...sousAction,
+      titre: capTitle(sousAction.titre),
+    })),
+  }));
+
+export const countOverlongTitles = (actions: ExtractedAction[]): number =>
+  actions
+    .flatMap((action) => [
+      action.titre,
+      ...action.sousActions.map((sousAction) => sousAction.titre),
+    ])
+    .filter((titre) => titre.length > MAX_FICHE_TITLE_LENGTH).length;
+
+export const dedupeExtractedActions = (
+  actions: ExtractedAction[]
+): ExtractedAction[] =>
+  uniqBy(actions, (action) =>
+    getActionKey(action.titre, toAxisPath(action.axe, action.sousAxe))
+  );
+
+export type NormalizedExtractedActions = {
+  actions: ExtractedAction[];
+  truncatedCount: number;
+  duplicateCount: number;
+};
+
+export const normalizeExtractedActions = (
+  actions: ExtractedAction[]
+): NormalizedExtractedActions => {
+  const truncatedCount = countOverlongTitles(actions);
+  const capped = capExtractedActionTitles(actions);
+  const deduped = dedupeExtractedActions(capped);
+  return {
+    actions: deduped,
+    truncatedCount,
+    duplicateCount: capped.length - deduped.length,
+  };
+};
 
 export const extractedActionToImportActions = (
   action: ExtractedAction

--- a/apps/backend/src/plans/plans/ai-plan-import/ai-plan-import-job.repository.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/ai-plan-import-job.repository.ts
@@ -3,7 +3,7 @@ import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { Transaction } from '@tet/backend/utils/database/transaction.utils';
 import { failure, success, type Result } from '@tet/backend/utils/result.type';
 import { getErrorMessage } from '@tet/domain/utils';
-import { and, count, eq, inArray, sql } from 'drizzle-orm';
+import { and, count, desc, eq, inArray, sql } from 'drizzle-orm';
 import { PlanDraft } from './models/plan-draft';
 import {
   AiPlanImportJob,
@@ -28,6 +28,18 @@ export type CreateJobInput = {
   createdBy: string;
   sourcePath: string;
   options: AiPlanImportJobOptions;
+};
+
+const statusViewProjection = {
+  id: aiPlanImportJobTable.id,
+  collectiviteId: aiPlanImportJobTable.collectiviteId,
+  status: aiPlanImportJobTable.status,
+  stepStates: aiPlanImportJobTable.stepStates,
+  error: aiPlanImportJobTable.error,
+  createdPlanId: aiPlanImportJobTable.createdPlanId,
+  qualitativeReview: sql<
+    string | null
+  >`${aiPlanImportJobTable.draft} ->> 'qualitativeReview'`,
 };
 
 @Injectable()
@@ -93,17 +105,7 @@ export class AiPlanImportJobRepository {
   ): Promise<Result<AiPlanImportJobStatusView, AiPlanImportError>> {
     try {
       const [row] = await this.db
-        .select({
-          id: aiPlanImportJobTable.id,
-          collectiviteId: aiPlanImportJobTable.collectiviteId,
-          status: aiPlanImportJobTable.status,
-          stepStates: aiPlanImportJobTable.stepStates,
-          error: aiPlanImportJobTable.error,
-          createdPlanId: aiPlanImportJobTable.createdPlanId,
-          qualitativeReview: sql<
-            string | null
-          >`${aiPlanImportJobTable.draft} ->> 'qualitativeReview'`,
-        })
+        .select(statusViewProjection)
         .from(aiPlanImportJobTable)
         .where(eq(aiPlanImportJobTable.id, id))
         .limit(1);
@@ -116,6 +118,36 @@ export class AiPlanImportJobRepository {
     } catch (error) {
       this.logger.error(
         `Lecture du statut du job ${id}: ${getErrorMessage(error)}`
+      );
+      return failure(AiPlanImportErrorEnum.GET_JOB_ERROR, toError(error));
+    }
+  }
+
+  async findInFlightByCollectivite(
+    collectiviteId: number
+  ): Promise<Result<AiPlanImportJobStatusView | null, AiPlanImportError>> {
+    try {
+      const [row] = await this.db
+        .select(statusViewProjection)
+        .from(aiPlanImportJobTable)
+        .where(
+          and(
+            eq(aiPlanImportJobTable.collectiviteId, collectiviteId),
+            inArray(
+              aiPlanImportJobTable.status,
+              aiPlanImportJobInFlightStatuses
+            )
+          )
+        )
+        .orderBy(desc(aiPlanImportJobTable.createdAt))
+        .limit(1);
+
+      return success(row ?? null);
+    } catch (error) {
+      this.logger.error(
+        `Reading in-flight job for collectivité ${collectiviteId}: ${getErrorMessage(
+          error
+        )}`
       );
       return failure(AiPlanImportErrorEnum.GET_JOB_ERROR, toError(error));
     }
@@ -188,6 +220,7 @@ export class AiPlanImportJobRepository {
     id: string;
     error: string;
     stepStates: StepStates;
+    draft?: PlanDraft;
   }): Promise<Result<AiPlanImportJob, AiPlanImportError>> {
     return this.updateAndReturn({
       id: input.id,
@@ -195,6 +228,7 @@ export class AiPlanImportJobRepository {
         status: AiPlanImportJobStatusEnum.FAILED,
         error: input.error,
         stepStates: input.stepStates,
+        draft: input.draft,
         modifiedAt: new Date().toISOString(),
       },
       allowedFromStatuses: [

--- a/apps/backend/src/plans/plans/ai-plan-import/ai-plan-import.full-flow.e2e-spec.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/ai-plan-import.full-flow.e2e-spec.ts
@@ -1,0 +1,388 @@
+import { getQueueToken } from '@nestjs/bullmq';
+import { INestApplication } from '@nestjs/common';
+import { axeTable } from '@tet/backend/plans/fiches/shared/models/axe.table';
+import { ficheActionAxeTable } from '@tet/backend/plans/fiches/shared/models/fiche-action-axe.table';
+import { ficheActionPiloteTable } from '@tet/backend/plans/fiches/shared/models/fiche-action-pilote.table';
+import { ficheActionTable } from '@tet/backend/plans/fiches/shared/models/fiche-action.table';
+import {
+  getAuthToken,
+  getAuthUserFromUserCredentials,
+  getDisposableTestApp,
+  getTestDatabase,
+  getTestRouter,
+} from '@tet/backend/test';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import {
+  addAndEnableUserSuperAdminMode,
+  addTestUser,
+} from '@tet/backend/users/users/users.test-fixture';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { LlmService } from '@tet/backend/utils/llm/llm.service';
+import { TokenUsage } from '@tet/backend/utils/llm/llm.repository';
+import { DocumentStorageService } from '@tet/backend/utils/supabase/document-storage.service';
+import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
+import { CollectiviteRole } from '@tet/domain/users';
+import { and, eq, inArray } from 'drizzle-orm';
+import request from 'supertest';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { AI_PLAN_IMPORT_QUEUE_NAME } from './ai-plan-import.queue';
+import { aiPlanImportJobTable } from './models/ai-plan-import-job.table';
+import { consolidationResponseSchema } from './generate-import-draft/consolidate-actions/consolidate-actions.schema';
+import { enrichmentResponseSchema } from './generate-import-draft/enrich-sous-actions/enrich-sous-actions.schema';
+import { extractionResponseSchema } from './generate-import-draft/extract-actions/extract-actions.schema';
+import { GenerateImportDraftService } from './generate-import-draft/generate-import-draft.service';
+import { GenerateImportDraftWorker } from './generate-import-draft/generate-import-draft.worker';
+import { qualitativeReviewResponseSchema } from './generate-import-draft/qualitative-review/qualitative-review.schema';
+import { scoringResponseSchema } from './generate-import-draft/score-actions/score-actions.schema';
+
+const QUALITATIVE_REVIEW_TEXT = 'Plan cohérent et bien structuré.';
+
+const noTokens: TokenUsage = {
+  promptTokens: 0,
+  candidatesTokens: 0,
+  thoughtsTokens: 0,
+  totalTokens: 0,
+};
+
+const extractionAction = {
+  axe: 'Axe 1',
+  'sous-axe': 'Sous-axe 1.1',
+  titre: 'Action 1.1.1',
+  description: 'Description initiale',
+  'sous-actions': ['Sous-action A'],
+  objectifs: 'Objectif principal',
+  'structure pilote': 'Direction Transition',
+  'direction ou service pilote': 'Service Environnement',
+  'personne pilote': 'Jean Dupont',
+  budget: '10000',
+  statut: '',
+};
+
+const buildFakeLlm = (): LlmService => {
+  const respondTo = (schema: unknown): unknown => {
+    if (schema === extractionResponseSchema) {
+      return [extractionAction];
+    }
+    if (schema === scoringResponseSchema) {
+      return [{ index: 0, score: 50, explication: 'À consolider' }];
+    }
+    if (schema === consolidationResponseSchema) {
+      return [
+        {
+          index: 0,
+          titre: 'Action consolidée 1.1.1',
+          description: 'Description consolidée',
+          'sous-actions': ['Sous-action A'],
+        },
+      ];
+    }
+    if (schema === enrichmentResponseSchema) {
+      return [
+        {
+          index: 0,
+          description: 'Sous-action enrichie',
+          personne_pilote: 'Jean Dupont',
+          statut: '',
+          date_debut: '',
+          date_fin: '',
+        },
+      ];
+    }
+    if (schema === qualitativeReviewResponseSchema) {
+      return { avis: QUALITATIVE_REVIEW_TEXT };
+    }
+    throw new Error('Schéma LLM inattendu dans le mock');
+  };
+
+  return {
+    generateStructured: async ({ schema }: { schema: unknown }) => ({
+      success: true,
+      data: { data: respondTo(schema), tokens: noTokens },
+    }),
+  } as unknown as LlmService;
+};
+
+const buildInMemoryDocumentStorage = (): DocumentStorageService => {
+  const store = new Map<string, { buffer: Buffer; mimeType: string }>();
+  const locationKey = (input: { bucketId: string; key: string }): string =>
+    `${input.bucketId}/${input.key}`;
+
+  return {
+    storeDocument: async (input: {
+      bucketId: string;
+      key: string;
+      content: Buffer;
+      contentType: string;
+    }) => {
+      store.set(locationKey(input), {
+        buffer: input.content,
+        mimeType: input.contentType,
+      });
+      return { success: true, data: { key: input.key } };
+    },
+    downloadDocument: async (input: { bucketId: string; key: string }) => {
+      const stored = store.get(locationKey(input));
+      if (stored === undefined) {
+        return { success: false, error: 'READ_DOCUMENT_ERROR' };
+      }
+      return { success: true, data: stored };
+    },
+    removeDocument: async (input: { bucketId: string; key: string }) => {
+      store.delete(locationKey(input));
+      return { success: true, data: undefined };
+    },
+  } as unknown as DocumentStorageService;
+};
+
+const csvSource = (): Buffer =>
+  Buffer.from('axe,sous-axe,titre\nAxe 1,Sous-axe 1.1,Action 1.1.1', 'utf-8');
+
+const TEST_COLLECTIVITE_ID = 1;
+
+describe("Import IA d'un plan - parcours complet", { timeout: 60_000 }, () => {
+  let app: INestApplication;
+  let db: DatabaseService;
+  let router: TrpcRouter;
+  let user: AuthenticatedUser;
+  let userToken: string;
+  let cleanupSuperAdmin: () => Promise<void>;
+  const createdPlanIds: number[] = [];
+  const createdJobIds: string[] = [];
+
+  const enqueueUrl = (): string =>
+    `/collectivites/${TEST_COLLECTIVITE_ID}/plans/import-ia`;
+
+  const getStatus = (jobId: string) =>
+    router
+      .createCaller({ user })
+      .plans.aiImport.getAiImportStatus({ jobId });
+
+  const getCurrentImport = () =>
+    router
+      .createCaller({ user })
+      .plans.aiImport.getCurrentAiImport({
+        collectiviteId: TEST_COLLECTIVITE_ID,
+      });
+
+  const fichesByTitreInPlan = async (planId: number, titre: string) => {
+    const axeIds = await db.db
+      .select({ id: axeTable.id })
+      .from(axeTable)
+      .where(eq(axeTable.plan, planId));
+    const allAxeIds = [planId, ...axeIds.map((axe) => axe.id)];
+
+    return db.db
+      .select({
+        id: ficheActionTable.id,
+        titre: ficheActionTable.titre,
+        description: ficheActionTable.description,
+        parentId: ficheActionTable.parentId,
+      })
+      .from(ficheActionTable)
+      .innerJoin(
+        ficheActionAxeTable,
+        eq(ficheActionTable.id, ficheActionAxeTable.ficheId)
+      )
+      .where(
+        and(
+          eq(ficheActionTable.titre, titre),
+          inArray(ficheActionAxeTable.axeId, allAxeIds)
+        )
+      );
+  };
+
+  const deletePlan = async (planId: number): Promise<void> => {
+    const axeIds = await db.db
+      .select({ id: axeTable.id })
+      .from(axeTable)
+      .where(eq(axeTable.plan, planId));
+    const allAxeIds = [planId, ...axeIds.map((axe) => axe.id)];
+
+    const fiches = await db.db
+      .select({ ficheId: ficheActionAxeTable.ficheId })
+      .from(ficheActionAxeTable)
+      .where(inArray(ficheActionAxeTable.axeId, allAxeIds));
+    const ficheIds = fiches
+      .map((fiche) => fiche.ficheId)
+      .filter((id): id is number => id !== null);
+
+    if (ficheIds.length > 0) {
+      await db.db
+        .delete(ficheActionPiloteTable)
+        .where(inArray(ficheActionPiloteTable.ficheId, ficheIds));
+    }
+
+    await router.createCaller({ user }).plans.plans.delete({ planId });
+  };
+
+  beforeAll(async () => {
+    app = await getDisposableTestApp({
+      overrides: (moduleBuilder) => {
+        moduleBuilder
+          .overrideProvider(GenerateImportDraftWorker)
+          .useValue({ onModuleInit: () => undefined });
+        moduleBuilder
+          .overrideProvider(getQueueToken(AI_PLAN_IMPORT_QUEUE_NAME))
+          .useValue({ add: async () => ({ id: 'fake-job' }) });
+        moduleBuilder.overrideProvider(LlmService).useValue(buildFakeLlm());
+        moduleBuilder
+          .overrideProvider(DocumentStorageService)
+          .useValue(buildInMemoryDocumentStorage());
+      },
+    });
+    db = await getTestDatabase(app);
+    router = await getTestRouter(app);
+
+    const testUser = await addTestUser(db, {
+      collectiviteId: TEST_COLLECTIVITE_ID,
+      role: CollectiviteRole.ADMIN,
+    });
+    user = getAuthUserFromUserCredentials(testUser.user);
+    userToken = await getAuthToken({
+      email: testUser.user.email ?? '',
+      password: testUser.user.password,
+    });
+
+    ({ cleanup: cleanupSuperAdmin } = await addAndEnableUserSuperAdminMode({
+      app,
+      caller: router.createCaller({ user }),
+      userId: user.id,
+    }));
+  });
+
+  afterAll(async () => {
+    for (const planId of createdPlanIds) {
+      await deletePlan(planId);
+    }
+    if (createdJobIds.length > 0) {
+      await db.db
+        .delete(aiPlanImportJobTable)
+        .where(inArray(aiPlanImportJobTable.id, createdJobIds));
+    }
+    await cleanupSuperAdmin();
+    await app.close();
+  });
+
+  const enqueue = async (
+    fields: Record<string, string>
+  ): Promise<{ jobId: string }> => {
+    let pending = request(app.getHttpServer())
+      .post(enqueueUrl())
+      .set('Authorization', `Bearer ${userToken}`);
+    for (const [name, value] of Object.entries(fields)) {
+      pending = pending.field(name, value);
+    }
+    const response = await pending.attach('file', csvSource(), {
+      filename: 'plan.csv',
+      contentType: 'text/csv',
+    });
+    expect(response.status).toBe(201);
+    createdJobIds.push(response.body.jobId);
+    return response.body;
+  };
+
+  test('exécute toutes les étapes puis crée le plan en base', async () => {
+    const { jobId } = await enqueue({
+      planName: 'Plan import IA complet',
+      withVerifications: 'true',
+      withSousActions: 'true',
+    });
+
+    const ongoing = await getCurrentImport();
+    expect(ongoing).toMatchObject({ jobId, status: 'pending' });
+
+    const generated = await app
+      .get(GenerateImportDraftService)
+      .generate(jobId);
+    expect(generated).toEqual({ success: true });
+
+    expect(await getCurrentImport()).toBeNull();
+
+    const status = await getStatus(jobId);
+    expect(status).toMatchObject({
+      status: 'done',
+      error: null,
+      qualitativeReview: QUALITATIVE_REVIEW_TEXT,
+      stepStates: {
+        extraction: 'ok',
+        scoring: 'ok',
+        consolidation: 'ok',
+        enrichment: 'ok',
+        qualitativeReview: 'ok',
+      },
+    });
+    expect(status.createdPlanId).toBeGreaterThan(0);
+
+    const planId = status.createdPlanId;
+    if (planId === null) {
+      throw new Error('createdPlanId manquant après un import terminé');
+    }
+    createdPlanIds.push(planId);
+
+    const [plan] = await db.db
+      .select({
+        nom: axeTable.nom,
+        collectiviteId: axeTable.collectiviteId,
+        parent: axeTable.parent,
+      })
+      .from(axeTable)
+      .where(eq(axeTable.id, planId));
+    expect(plan).toMatchObject({
+      nom: 'Plan import IA complet',
+      collectiviteId: TEST_COLLECTIVITE_ID,
+      parent: null,
+    });
+
+    const actions = await fichesByTitreInPlan(planId, 'Action consolidée 1.1.1');
+    expect(actions).toHaveLength(1);
+    expect(actions[0]).toMatchObject({
+      description: 'Description consolidée',
+      parentId: null,
+    });
+
+    const sousActions = await fichesByTitreInPlan(planId, 'Sous-action A');
+    expect(sousActions).toHaveLength(1);
+    expect(sousActions[0]).toMatchObject({
+      description: 'Sous-action enrichie',
+      parentId: actions[0].id,
+    });
+  });
+
+  test('saute les vérifications et sous-actions quand elles sont désactivées', async () => {
+    const { jobId } = await enqueue({
+      planName: 'Plan import IA minimal',
+      withVerifications: 'false',
+      withSousActions: 'false',
+    });
+
+    const generated = await app
+      .get(GenerateImportDraftService)
+      .generate(jobId);
+    expect(generated).toEqual({ success: true });
+
+    const status = await getStatus(jobId);
+    expect(status).toMatchObject({
+      status: 'done',
+      stepStates: {
+        extraction: 'ok',
+        scoring: 'skipped',
+        consolidation: 'skipped',
+        enrichment: 'skipped',
+        qualitativeReview: 'ok',
+      },
+    });
+    expect(status.createdPlanId).toBeGreaterThan(0);
+
+    const planId = status.createdPlanId;
+    if (planId === null) {
+      throw new Error('createdPlanId manquant après un import terminé');
+    }
+    createdPlanIds.push(planId);
+
+    const actions = await fichesByTitreInPlan(planId, 'Action 1.1.1');
+    expect(actions).toHaveLength(1);
+
+    const sousActions = await fichesByTitreInPlan(planId, 'Sous-action A');
+    expect(sousActions).toHaveLength(0);
+  });
+});

--- a/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/generate-import-draft.service.spec.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/generate-import-draft.service.spec.ts
@@ -174,11 +174,18 @@ describe('GenerateImportDraftService', () => {
 
     expect(result).toMatchObject({ success: true });
     expect(mocks.jobRepository.markDone).not.toHaveBeenCalled();
-    expect(mocks.jobRepository.markFailed).toHaveBeenCalledWith({
-      id: 'job-1',
-      error: 'Création du plan impossible : Plan invalide',
-      stepStates: initialStepStates(),
-    });
+    expect(mocks.jobRepository.markFailed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'job-1',
+        error: 'Création du plan impossible : Plan invalide',
+        stepStates: initialStepStates(),
+        draft: expect.objectContaining({
+          actions: expect.arrayContaining([
+            expect.objectContaining({ titre: '1.1.1 Action' }),
+          ]),
+        }),
+      })
+    );
   });
 
   it('marque le job failed quand la création du plan lève une exception (seam en transaction partagée)', async () => {
@@ -192,11 +199,18 @@ describe('GenerateImportDraftService', () => {
 
     expect(result).toMatchObject({ success: true });
     expect(mocks.jobRepository.markDone).not.toHaveBeenCalled();
-    expect(mocks.jobRepository.markFailed).toHaveBeenCalledWith({
-      id: 'job-1',
-      error: 'Création du plan impossible : insert en conflit',
-      stepStates: initialStepStates(),
-    });
+    expect(mocks.jobRepository.markFailed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'job-1',
+        error: 'Création du plan impossible : insert en conflit',
+        stepStates: initialStepStates(),
+        draft: expect.objectContaining({
+          actions: expect.arrayContaining([
+            expect.objectContaining({ titre: '1.1.1 Action' }),
+          ]),
+        }),
+      })
+    );
   });
 
   it('marque le job failed et supprime la source quand la pipeline lève une exception', async () => {

--- a/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/generate-import-draft.service.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/generate-import-draft.service.ts
@@ -1,4 +1,8 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  MAX_FICHE_TITLE_LENGTH,
+  normalizeExtractedActions,
+} from '../adapters/extracted-action-to-import-action';
 import { ImportPlanInput } from '@tet/backend/plans/plans/import-plan-aggregate/import-plan.input';
 import { ImportPlanService } from '@tet/backend/plans/plans/import-plan-aggregate/import-plan.service';
 import { AuthRole, type AuthenticatedUser } from '@tet/backend/users/models/auth.models';
@@ -30,6 +34,8 @@ export type GenerateImportDraftError =
 
 @Injectable()
 export class GenerateImportDraftService {
+  private readonly logger = new Logger(GenerateImportDraftService.name);
+
   constructor(
     private readonly jobRepository: AiPlanImportJobRepository,
     private readonly documentStorage: DocumentStorageService,
@@ -74,12 +80,14 @@ export class GenerateImportDraftService {
 
   private async markFailed(
     jobId: string,
-    message: string
+    message: string,
+    draft?: PlanDraft
   ): Promise<Result<AiPlanImportJob, AiPlanImportError>> {
     return this.jobRepository.markFailed({
       id: jobId,
       error: message,
       stepStates: initialStepStates(),
+      draft,
     });
   }
 
@@ -134,8 +142,25 @@ export class GenerateImportDraftService {
     draft: PlanDraft,
     stepStates: StepStates
   ): Promise<Result<undefined, GenerateImportDraftError>> {
+    const { actions, truncatedCount, duplicateCount } =
+      normalizeExtractedActions(draft.actions);
+    if (truncatedCount > 0) {
+      this.logger.warn(
+        `Import ${job.id}: ${truncatedCount} title(s) truncated to ${MAX_FICHE_TITLE_LENGTH} chars before plan creation`
+      );
+    }
+    if (duplicateCount > 0) {
+      this.logger.warn(
+        `Import ${job.id}: ${duplicateCount} duplicate action(s) skipped before plan creation`
+      );
+    }
+
+    const normalizedDraft: PlanDraft = {
+      actions,
+      qualitativeReview: draft.qualitativeReview,
+    };
     const planInput = draftToImportPlanInput({
-      actions: draft.actions,
+      actions,
       planName: job.options.planName,
       planType: job.options.planType,
     });
@@ -148,7 +173,7 @@ export class GenerateImportDraftService {
         }
         const done = await this.jobRepository.markDone({
           id: job.id,
-          draft,
+          draft: normalizedDraft,
           stepStates,
           createdPlanId: planId.data,
           tx,
@@ -160,7 +185,7 @@ export class GenerateImportDraftService {
     );
 
     if (!created.success) {
-      return this.recordFailure(job.id, created.error);
+      return this.recordFailure(job.id, created.error, normalizedDraft);
     }
     return success(undefined);
   }
@@ -187,9 +212,10 @@ export class GenerateImportDraftService {
 
   private async recordFailure(
     jobId: string,
-    message: string
+    message: string,
+    draft?: PlanDraft
   ): Promise<Result<undefined, GenerateImportDraftError>> {
-    const marked = await this.markFailed(jobId, message);
+    const marked = await this.markFailed(jobId, message, draft);
     return marked.success
       ? success(undefined)
       : failure({ kind: 'failure_record_failed', jobId, cause: marked.error });

--- a/apps/backend/src/plans/plans/ai-plan-import/get-import-status/get-import-status.input.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/get-import-status/get-import-status.input.ts
@@ -3,3 +3,7 @@ import { z } from 'zod';
 export const getImportStatusInputSchema = z.object({
   jobId: z.string().uuid(),
 });
+
+export const getCurrentImportInputSchema = z.object({
+  collectiviteId: z.number().int().positive(),
+});

--- a/apps/backend/src/plans/plans/ai-plan-import/get-import-status/get-import-status.router.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/get-import-status/get-import-status.router.ts
@@ -2,7 +2,10 @@ import { Injectable } from '@nestjs/common';
 import { createTrpcErrorHandler } from '@tet/backend/utils/trpc/trpc-error-handler';
 import { TrpcService } from '@tet/backend/utils/trpc/trpc.service';
 import { aiPlanImportErrorConfig } from '../ai-plan-import.trpc-errors';
-import { getImportStatusInputSchema } from './get-import-status.input';
+import {
+  getCurrentImportInputSchema,
+  getImportStatusInputSchema,
+} from './get-import-status.input';
 import { getImportStatusOutputSchema } from './get-import-status.output';
 import { GetImportStatusService } from './get-import-status.service';
 
@@ -24,6 +27,17 @@ export class GetImportStatusRouter {
       .query(async ({ input, ctx: { user } }) => {
         const result = await this.getImportStatusService.getStatus({
           jobId: input.jobId,
+          user,
+        });
+        return this.getResultDataOrThrowError(result);
+      }),
+
+    getCurrentAiImport: this.trpc.authedProcedure
+      .input(getCurrentImportInputSchema)
+      .output(getImportStatusOutputSchema.nullable())
+      .query(async ({ input, ctx: { user } }) => {
+        const result = await this.getImportStatusService.getCurrentImport({
+          collectiviteId: input.collectiviteId,
           user,
         });
         return this.getResultDataOrThrowError(result);

--- a/apps/backend/src/plans/plans/ai-plan-import/get-import-status/get-import-status.service.spec.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/get-import-status/get-import-status.service.spec.ts
@@ -27,7 +27,8 @@ const toView = (
 });
 
 const buildService = (args: {
-  view: AiPlanImportJobStatusView | null;
+  view?: AiPlanImportJobStatusView | null;
+  inFlight?: AiPlanImportJobStatusView | null;
   isAllowed: boolean;
 }): GetImportStatusService => {
   const jobRepository = {
@@ -35,6 +36,9 @@ const buildService = (args: {
       args.view
         ? success(args.view)
         : failure(AiPlanImportErrorEnum.JOB_NOT_FOUND)
+    ),
+    findInFlightByCollectivite: vi.fn(async () =>
+      success(args.inFlight ?? null)
     ),
   } as unknown as AiPlanImportJobRepository;
   const permissions = {
@@ -92,6 +96,48 @@ describe('GetImportStatusService', () => {
     expect(result).toMatchObject({
       success: false,
       error: AiPlanImportErrorEnum.JOB_NOT_FOUND,
+    });
+  });
+
+  it('expose le job en cours de la collectivité', async () => {
+    const service = buildService({
+      inFlight: toView({ id: 'job-9', status: AiPlanImportJobStatusEnum.RUNNING }),
+      isAllowed: true,
+    });
+
+    const result = await service.getCurrentImport({
+      collectiviteId: 10,
+      user,
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      data: { jobId: 'job-9', status: 'running' },
+    });
+  });
+
+  it('renvoie null quand aucun job n est en cours', async () => {
+    const service = buildService({ inFlight: null, isAllowed: true });
+
+    const result = await service.getCurrentImport({
+      collectiviteId: 10,
+      user,
+    });
+
+    expect(result).toEqual({ success: true, data: null });
+  });
+
+  it('renvoie UNAUTHORIZED pour le job en cours sans droit', async () => {
+    const service = buildService({ inFlight: toView({}), isAllowed: false });
+
+    const result = await service.getCurrentImport({
+      collectiviteId: 10,
+      user,
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      error: AiPlanImportErrorEnum.UNAUTHORIZED,
     });
   });
 });

--- a/apps/backend/src/plans/plans/ai-plan-import/get-import-status/get-import-status.service.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/get-import-status/get-import-status.service.ts
@@ -16,6 +16,11 @@ export type GetImportStatusServiceInput = {
   user: AuthenticatedUser;
 };
 
+export type GetCurrentImportServiceInput = {
+  collectiviteId: number;
+  user: AuthenticatedUser;
+};
+
 @Injectable()
 export class GetImportStatusService {
   constructor(
@@ -43,6 +48,30 @@ export class GetImportStatusService {
     }
 
     return success(toOutput(view.data));
+  }
+
+  async getCurrentImport(
+    input: GetCurrentImportServiceInput
+  ): Promise<Result<GetImportStatusOutput | null, AiPlanImportError>> {
+    const isAllowed = await this.permissions.isAllowed(
+      input.user,
+      'plans.fiches.import',
+      ResourceType.COLLECTIVITE,
+      input.collectiviteId,
+      true
+    );
+    if (!isAllowed) {
+      return failure(AiPlanImportErrorEnum.UNAUTHORIZED);
+    }
+
+    const inFlight = await this.jobRepository.findInFlightByCollectivite(
+      input.collectiviteId
+    );
+    if (!inFlight.success) {
+      return inFlight;
+    }
+
+    return success(inFlight.data === null ? null : toOutput(inFlight.data));
   }
 }
 

--- a/apps/backend/src/plans/plans/ai-plan-import/prompts/consolidation.prompt.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/prompts/consolidation.prompt.ts
@@ -55,7 +55,7 @@ Types et formats attendus
 • "index" est l’entier identifiant l’action, repris tel quel depuis la liste en entrée
 • "titre" est une chaîne de la forme "n.X.Y Titre de l'action" qui doit correspondre à l’une des actions listées. Le titre ne doit pas dépasser 300 caractères. Si le titre issu du texte source dépasse 300 caractères, conserver uniquement les 300 premiers caractères significatifs dans "titre" et reporter le reste dans "description"
 • "description" est une chaîne
-• "sous-actions" est une liste de chaînes. Si aucune sous action ne s’impose, mettre []
+• "sous-actions" est une liste de chaînes. Chaque sous-action est un libellé d’étape court (300 caractères maximum) : résumer en un libellé concis si le passage source est long, et ne jamais produire une sous-action de plus de 300 caractères. Si aucune sous action ne s’impose, mettre []
 
 Règles d’extraction spécifiques
 1) Si l’information n’est pas explicitement présente dans le texte source, laisser ces champs à [] pour "sous-actions"

--- a/apps/backend/src/plans/plans/ai-plan-import/prompts/extraction.prompt.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/prompts/extraction.prompt.ts
@@ -33,7 +33,7 @@ Types et formats attendus
 • "sous-axe" est une chaîne
 • "titre" est une chaîne courte (300 caractères maximum). Si le titre issu du texte source dépasse 300 caractères, conserver uniquement les 300 premiers caractères significatifs dans "titre" et reporter le reste dans "description"
 • "description" est une chaîne
-• "sous-actions" est une liste de chaînes. Si aucune sous action ne s’impose, mettre une liste vide []
+• "sous-actions" est une liste de chaînes. Chaque sous-action est un libellé d’étape court (300 caractères maximum) : si un passage du texte source est long, le résumer en un libellé concis plutôt que de le recopier intégralement, et ne jamais produire une sous-action de plus de 300 caractères. Si aucune sous action ne s’impose, mettre une liste vide []
 • "objectifs" est une chaîne. Reprendre fidèlement le contenu du champ "Objectifs" du document source si présent (par exemple "Préserver la qualité et la diversité des productions agricoles"). Si l'information n'est pas explicitement présente, laisser ""
 • "structure pilote" est une chaîne. Une ou plusieurs structures (organisme englobant : la collectivité elle-même, ou par exemple "Chambre d'agriculture", "DDT", etc.) séparées par ", ". Distinct de "direction ou service pilote" qui est interne à la structure. Si l'information n'est pas explicitement présente, laisser ""
 • "direction ou service pilote" est une chaîne

--- a/apps/backend/src/utils/llm/gemini.repository.ts
+++ b/apps/backend/src/utils/llm/gemini.repository.ts
@@ -14,7 +14,7 @@ import {
   TokenUsage,
 } from './llm.repository';
 
-const CALL_TIMEOUT_MS = 120_000;
+const CALL_TIMEOUT_MS = 9 * 60 * 1000;
 const RATE_LIMITED_STATUSES = new Set([429, 503]);
 
 @Injectable()
@@ -41,8 +41,12 @@ export class GeminiRepository extends LlmRepository {
       return failure({ kind: 'api_error', httpStatus: null });
     }
 
+    this.logger.log(
+      `Gemini call (model ${this.model}, prompt ${request.prompt.length} chars, instruction ${request.systemInstruction?.length ?? 0} chars)`
+    );
+
     try {
-      const response = await client.models.generateContent({
+      const stream = await client.models.generateContentStream({
         model: this.model,
         contents: request.prompt,
         config: {
@@ -59,14 +63,47 @@ export class GeminiRepository extends LlmRepository {
           abortSignal: request.signal,
         },
       });
+
+      let text = '';
+      let finishReason: FinishReason | undefined;
+      let usageMetadata: GenerateContentResponseUsageMetadata | undefined;
+
+      for await (const chunk of stream) {
+        if (chunk.text !== undefined) {
+          text += chunk.text;
+        }
+        const chunkFinishReason = chunk.candidates?.[0]?.finishReason;
+        if (chunkFinishReason !== undefined) {
+          finishReason = chunkFinishReason;
+        }
+        if (chunk.usageMetadata !== undefined) {
+          usageMetadata = chunk.usageMetadata;
+        }
+      }
+
+      const usage = toTokenUsage(usageMetadata);
+      if (finishReason !== FinishReason.STOP) {
+        this.logger.warn(
+          `Incomplete Gemini response (model ${this.model}, finishReason ${
+            finishReason ?? 'unknown'
+          }, ${usage.candidatesTokens} tokens generated of ${
+            request.maxOutputTokens
+          } allowed)`
+        );
+      }
+
       return success({
-        completed: response.candidates?.[0]?.finishReason === FinishReason.STOP,
-        text: response.text,
-        usage: toTokenUsage(response.usageMetadata),
+        completed: finishReason === FinishReason.STOP,
+        text: text.length > 0 ? text : undefined,
+        usage,
       });
     } catch (error) {
       const httpStatus = extractHttpStatus(error);
-      this.logger.error(`Erreur API Gemini (status ${httpStatus})`);
+      this.logger.error(
+        `Gemini API error (model ${this.model}, status ${httpStatus}): ${describeError(
+          error
+        )}`
+      );
       if (httpStatus !== null && RATE_LIMITED_STATUSES.has(httpStatus)) {
         return failure({ kind: 'rate_limited' });
       }
@@ -107,3 +144,19 @@ const extractHttpStatus = (error: unknown): number | null => {
   }
   return null;
 };
+
+const describeError = (error: unknown): string => {
+  if (!(error instanceof Error)) {
+    return String(error);
+  }
+  const { cause } = error;
+  if (cause instanceof Error) {
+    const code = errorCode(cause);
+    const prefix = code === null ? '' : `${code} `;
+    return `${error.message} — cause: ${prefix}${cause.message}`;
+  }
+  return error.message;
+};
+
+const errorCode = (error: Error): string | null =>
+  'code' in error && typeof error.code === 'string' ? error.code : null;

--- a/apps/backend/src/utils/llm/is-transient-error.spec.ts
+++ b/apps/backend/src/utils/llm/is-transient-error.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { isTransientError } from './llm.service';
+
+describe('isTransientError', () => {
+  it('réessaie une limitation de débit', () => {
+    expect(isTransientError({ kind: 'rate_limited' })).toBe(true);
+  });
+
+  it('réessaie une erreur réseau (sans statut HTTP)', () => {
+    expect(isTransientError({ kind: 'api_error', httpStatus: null })).toBe(true);
+  });
+
+  it('réessaie une erreur serveur 5xx', () => {
+    expect(isTransientError({ kind: 'api_error', httpStatus: 504 })).toBe(true);
+  });
+
+  it('ne réessaie pas une erreur client 4xx', () => {
+    expect(isTransientError({ kind: 'api_error', httpStatus: 400 })).toBe(
+      false
+    );
+  });
+
+  it('ne réessaie pas une réponse tronquée', () => {
+    expect(isTransientError({ kind: 'truncated' })).toBe(false);
+  });
+
+  it('ne réessaie pas un JSON invalide', () => {
+    expect(
+      isTransientError({ kind: 'invalid_json', rawTextLength: 10 })
+    ).toBe(false);
+  });
+});

--- a/apps/backend/src/utils/llm/llm.service.ts
+++ b/apps/backend/src/utils/llm/llm.service.ts
@@ -74,16 +74,28 @@ export class LlmService {
   private async callWithRetry(
     call: () => Promise<Result<LlmRawCompletion, LlmError>>
   ): Promise<Result<LlmRawCompletion, LlmError>> {
+    let lastRetryableResult: Result<LlmRawCompletion, LlmError> | null = null;
     try {
       return await retry(async () => {
         const result = await call();
-        if (!result.success && result.error.kind === 'rate_limited') {
-          throw new Error('rate_limited');
+        if (!result.success && isTransientError(result.error)) {
+          lastRetryableResult = result;
+          throw new Error(result.error.kind);
         }
         return result;
       }, RETRY_OPTIONS);
     } catch {
-      return failure({ kind: 'rate_limited' });
+      return lastRetryableResult ?? failure({ kind: 'api_error', httpStatus: null });
     }
   }
 }
+
+export const isTransientError = (error: LlmError): boolean => {
+  if (error.kind === 'rate_limited') {
+    return true;
+  }
+  if (error.kind === 'api_error') {
+    return error.httpStatus === null || error.httpStatus >= 500;
+  }
+  return false;
+};


### PR DESCRIPTION
Partie **back** de l'import IA d'un plan d'action, séparée du front (#4608) pour limiter la taille des PR et faciliter la revue.

> Cette PR doit être mergée **avant** #4608 (le front en dépend : il consomme les procédures tRPC `aiImport` ajoutées ici).

## Contenu

### Fiabilité des appels Gemini
- Appels en **streaming** (`generateContentStream`) : supprime le deadline serveur (504 `DEADLINE_EXCEEDED`) sur les longues générations, tout en gardant `gemini-2.5-pro` ; timeout client porté à 9 min.
- **Retry** des erreurs transitoires (réseau sans statut HTTP type `UND_ERR_CONNECT_TIMEOUT`, et 5xx) en plus des 429/503, avec remontée de la vraie erreur après épuisement des essais.
- Logs enrichis : modèle, taille du prompt, réponses incomplètes, et **cause réelle** des erreurs.

### Endpoint de statut et reprise d'un import en cours
- `getAiImportStatus` (suivi par jobId) et `getCurrentAiImport` (`findInFlightByCollectivite`) qui renvoie le job `pending`/`running` d'une collectivité, ou `null`.
- **Draft persisté en cas d'échec** : permet d'inspecter la donnée extraite quand la création du plan échoue.

### Fiabilisation de la création du plan depuis le draft
- **Déduplication** des actions extraites (même `axe::sous-axe::titre`) avant l'import.
- **Plafond des titres à 300 caractères** (contrainte `varchar(300)` de `fiche_action.titre`) — filet de sécurité.
- **Consignes de longueur** des sous-actions ajoutées aux prompts d'extraction et de consolidation (le LLM résume au lieu de tronquer à la source).

## Tests
- E2E du parcours complet (`ai-plan-import.full-flow.e2e-spec.ts`) avec LLM, stockage et queue BullMQ mockés (zéro appel Gemini, pas de Redis).
- Specs unitaires : `isTransientError`, déduplication, plafond/comptage des titres, service de statut (dont `getCurrentImport`), persistance du draft en échec.

## Notes
- ⚠️ `CONFLICTING` : la branche part d'une base antérieure à la divergence de `main` (renommages `.rules → .rule`, etc.). Rebase sur `main` à prévoir avant merge — indépendant du contenu de la PR.
