### PR TITLE
feat(referentiels): dérive le plafond d'étoile demandable du score réalisé

### DIFF
--- a/apps/backend/src/referentiels/labellisations/request-labellisation/request-labellisation.router.e2e-spec.ts
+++ b/apps/backend/src/referentiels/labellisations/request-labellisation/request-labellisation.router.e2e-spec.ts
@@ -484,8 +484,30 @@ describe('Request Labellisation Router', () => {
       ).rejects.toThrow(
         /Un audit ou une labellisation a déjà été demandé pour cette collectivité./i
       );
+    });
 
-      // Ask another audit
+    test('Cannot request a labellisation 1ère étoile while a cot audit demande is pending (the cot demande stays intact)', async () => {
+      const caller = router.createCaller({ user: adminUser });
+      const trpcClient = createTRPCClientFromCaller(caller);
+
+      await updateAllNeedReferentielStatutsToCompleteReferentiel(
+        trpcClient,
+        collectivite.id,
+        ReferentielIdEnum.CAE
+      );
+      await updateAllNeedReferentielStatutsToMatchReferentielScoreCriteria(
+        trpcClient,
+        collectivite.id,
+        ReferentielIdEnum.CAE
+      );
+
+      await caller.referentiels.labellisations.requestLabellisation({
+        collectiviteId: collectivite.id,
+        referentiel: ReferentielIdEnum.CAE,
+        sujet: 'cot',
+        etoiles: null,
+      });
+
       await expect(
         caller.referentiels.labellisations.requestLabellisation({
           collectiviteId: collectivite.id,
@@ -496,6 +518,18 @@ describe('Request Labellisation Router', () => {
       ).rejects.toThrow(
         /Un audit ou une labellisation a déjà été demandé pour cette collectivité./i
       );
-    });
+
+      const parcours =
+        await caller.referentiels.labellisations.getParcours({
+          collectiviteId: collectivite.id,
+          referentielId: ReferentielIdEnum.CAE,
+        });
+
+      expect(parcours.status).toBe('demande_envoyee');
+      expect(parcours.demande).toMatchObject({
+        sujet: 'cot',
+        etoiles: null,
+      });
+    }, 20_000);
   });
 });

--- a/apps/backend/src/referentiels/labellisations/request-labellisation/request-labellisation.rules.spec.ts
+++ b/apps/backend/src/referentiels/labellisations/request-labellisation/request-labellisation.rules.spec.ts
@@ -14,8 +14,8 @@ const createParcours = (
   critere_score: {
     atteint: true,
     etoiles: 1,
-    score_fait: 50,
-    score_a_realiser: 50,
+    score_fait: 0.5,
+    score_a_realiser: 0.5,
   },
   criteres_action: [
     {
@@ -122,14 +122,14 @@ describe('canRequestAuditOrLabellisation', () => {
     expect(result.reason).toBeNull();
   });
 
-  it('returns SCORE_GLOBAL_CRITERIA_NOT_SATISFIED when requested etoiles is greater than parcours etoiles', () => {
+  it('returns SCORE_GLOBAL_CRITERIA_NOT_SATISFIED when requested etoiles is greater than the score-eligible star', () => {
     const result = canRequestAuditOrLabellisation(
       createParcours({
         critere_score: {
           atteint: false,
           etoiles: 1,
-          score_fait: 30,
-          score_a_realiser: 50,
+          score_fait: 0.3,
+          score_a_realiser: 0.35,
         },
       }),
       'labellisation',
@@ -141,18 +141,52 @@ describe('canRequestAuditOrLabellisation', () => {
     );
   });
 
-  it('returns SCORE_GLOBAL_CRITERIA_NOT_SATISFIED when labellisation and critere_score not atteint', () => {
+  it('autorise une 1ère étoile quel que soit le score réalisé (seuil 0%)', () => {
     const result = canRequestAuditOrLabellisation(
       createParcours({
         critere_score: {
           atteint: false,
           etoiles: 1,
-          score_fait: 30,
-          score_a_realiser: 50,
+          score_fait: 0.3,
+          score_a_realiser: 0.35,
         },
       }),
       'labellisation',
       1 as Etoile
+    );
+    expect(result).toEqual({ canRequest: true, reason: null });
+  });
+
+  it('autorise une demande 4★ quand le score réalisé atteint le seuil 4★ (65%) même si objectif vise la 5★', () => {
+    const result = canRequestAuditOrLabellisation(
+      createParcours({
+        etoiles: 5,
+        critere_score: {
+          atteint: false,
+          etoiles: 5,
+          score_fait: 0.68,
+          score_a_realiser: 0.75,
+        },
+      }),
+      'labellisation',
+      4 as Etoile
+    );
+    expect(result).toEqual({ canRequest: true, reason: null });
+  });
+
+  it('refuse une demande 5★ quand le score réalisé ne permet que la 4ème étoile (68%)', () => {
+    const result = canRequestAuditOrLabellisation(
+      createParcours({
+        etoiles: 5,
+        critere_score: {
+          atteint: false,
+          etoiles: 5,
+          score_fait: 0.68,
+          score_a_realiser: 0.75,
+        },
+      }),
+      'labellisation',
+      5 as Etoile
     );
     expect(result.canRequest).toBe(false);
     expect(result.reason).toBe(

--- a/packages/domain/src/referentiels/index.ts
+++ b/packages/domain/src/referentiels/index.ts
@@ -30,6 +30,7 @@ export * from './labellisations/parcours-labellisation-status.enum';
 export * from './labellisations/parcours-labellisation.schema';
 export * from './labellisations/request-labellisation/request-labellisation.rules';
 export * from './labellisations/request-labellisation/request-labellisation.rules-errors';
+export * from './labellisations/requestable-star';
 export * from './labellisations/start-audit/start-audit.rules';
 export * from './labellisations/start-audit/start-audit.rules-errors';
 export * from './labellisations/start-new-audit-cycle/start-new-audit-cycle.rules';

--- a/packages/domain/src/referentiels/labellisations/request-labellisation/request-labellisation.rules.spec.ts
+++ b/packages/domain/src/referentiels/labellisations/request-labellisation/request-labellisation.rules.spec.ts
@@ -1,0 +1,56 @@
+import { Etoile } from '../labellisation-etoile.enum.schema';
+import {
+  ParcoursLabellisationForRequest,
+  canRequestAuditOrLabellisation,
+} from './request-labellisation.rules';
+
+const baseParcours: ParcoursLabellisationForRequest = {
+  status: 'non_demandee',
+  completude_ok: true,
+  critere_score: {
+    atteint: true,
+    score_a_realiser: 0.5,
+    score_fait: 0.6,
+  } as ParcoursLabellisationForRequest['critere_score'],
+  isCot: false,
+  etoiles: 1 as Etoile,
+  conditionFichiers: { atteint: true },
+  criteres_action: [{ atteint: true }],
+};
+
+describe('canRequestAuditOrLabellisation — plafond d\'étoile dérivé du score réalisé', () => {
+  it('autorise une étoile au-delà des étoiles obtenues quand le score réalisé le permet', () => {
+    expect(
+      canRequestAuditOrLabellisation(baseParcours, 'labellisation', 2)
+    ).toEqual({ canRequest: true, reason: null });
+  });
+
+  it('se base sur le score réalisé et non sur le flag critere_score.atteint', () => {
+    expect(
+      canRequestAuditOrLabellisation(
+        {
+          ...baseParcours,
+          critere_score: { ...baseParcours.critere_score, atteint: false },
+        },
+        'labellisation',
+        1
+      )
+    ).toEqual({ canRequest: true, reason: null });
+  });
+
+  it('refuse une étoile au-delà du plafond autorisé par le score réalisé', () => {
+    expect(
+      canRequestAuditOrLabellisation(
+        {
+          ...baseParcours,
+          critere_score: { ...baseParcours.critere_score, score_fait: 0.35 },
+        },
+        'labellisation',
+        3
+      )
+    ).toEqual({
+      canRequest: false,
+      reason: 'SCORE_GLOBAL_CRITERIA_NOT_SATISFIED',
+    });
+  });
+});

--- a/packages/domain/src/referentiels/labellisations/request-labellisation/request-labellisation.rules.ts
+++ b/packages/domain/src/referentiels/labellisations/request-labellisation/request-labellisation.rules.ts
@@ -10,6 +10,7 @@ import {
   ConditionFichiers,
   ParcoursLabellisation,
 } from '../parcours-labellisation.schema';
+import { getMaxRequestableStar } from '../requestable-star';
 import {
   RequestLabellisationRulesErrors,
   RequestLabellisationRulesErrorsEnum,
@@ -97,9 +98,43 @@ export function canRequestAuditOrLabellisation(
     };
   }
 
-  if (!parcours.completude_ok) {
+  const prerequisites = areAuditPrerequisitesMet(parcours, sujet, etoiles);
+  if (!prerequisites.met) {
     return {
       canRequest: false,
+      reason: prerequisites.reason,
+    };
+  }
+
+  return {
+    canRequest: true,
+    reason: null,
+  };
+}
+
+export type AuditPrerequisitesError = Extract<
+  RequestLabellisationRulesErrors,
+  | 'REFERENTIEL_NOT_COMPLETED'
+  | 'SCORE_GLOBAL_CRITERIA_NOT_SATISFIED'
+  | 'SCORE_ACTIONS_CRITERIA_NOT_SATISFIED'
+  | 'MISSING_FILE'
+>;
+
+export type ParcoursForAuditPrerequisites = Omit<
+  ParcoursLabellisationForRequest,
+  'status'
+>;
+
+export function areAuditPrerequisitesMet(
+  parcours: ParcoursForAuditPrerequisites,
+  sujet: SujetDemande,
+  etoiles: Etoile | null
+):
+  | { met: true; reason: null }
+  | { met: false; reason: AuditPrerequisitesError } {
+  if (!parcours.completude_ok) {
+    return {
+      met: false,
       reason: RequestLabellisationRulesErrorsEnum.REFERENTIEL_NOT_COMPLETED,
     };
   }
@@ -107,16 +142,13 @@ export function canRequestAuditOrLabellisation(
   if (sujet === 'cot') {
     // Pour un audit seul sans labellisation, il suffit d'avoir le référentiel complet pour pouvoir demander un audit
     // il n'y a pas de critères de score
-    return {
-      canRequest: true,
-      reason: null,
-    };
+    return { met: true, reason: null };
   }
 
   // Pour les autres, il faut vérifier les critères de score
-  if ((etoiles || 0) > parcours.etoiles || !parcours.critere_score.atteint) {
+  if ((etoiles ?? 0) > getMaxRequestableStar(parcours.critere_score.score_fait)) {
     return {
-      canRequest: false,
+      met: false,
       reason:
         RequestLabellisationRulesErrorsEnum.SCORE_GLOBAL_CRITERIA_NOT_SATISFIED,
     };
@@ -124,7 +156,7 @@ export function canRequestAuditOrLabellisation(
 
   if (!parcours.criteres_action.every((c) => c.atteint)) {
     return {
-      canRequest: false,
+      met: false,
       reason:
         RequestLabellisationRulesErrorsEnum.SCORE_ACTIONS_CRITERIA_NOT_SATISFIED,
     };
@@ -136,22 +168,16 @@ export function canRequestAuditOrLabellisation(
     parcours.isCot &&
     etoiles === 1
   ) {
-    return {
-      canRequest: true,
-      reason: null,
-    };
+    return { met: true, reason: null };
   }
 
   // Pour les autres cas, il faut vérifier le fichier déposé
   if (!parcours.conditionFichiers.atteint) {
     return {
-      canRequest: false,
+      met: false,
       reason: RequestLabellisationRulesErrorsEnum.MISSING_FILE,
     };
   }
 
-  return {
-    canRequest: true,
-    reason: null,
-  };
+  return { met: true, reason: null };
 }

--- a/packages/domain/src/referentiels/labellisations/requestable-star.spec.ts
+++ b/packages/domain/src/referentiels/labellisations/requestable-star.spec.ts
@@ -1,0 +1,31 @@
+import { Etoile } from './labellisation-etoile.enum.schema';
+import { getMaxRequestableStar } from './requestable-star';
+
+describe('getMaxRequestableStar', () => {
+  it.each<[number, Etoile]>([
+    [-0.1, 1],
+    [0, 1],
+    [0.34, 1],
+    [0.35, 2],
+    [0.49, 2],
+    [0.5, 3],
+    [0.64, 3],
+    [0.65, 4],
+    [0.6812, 4],
+    [0.74, 4],
+    [0.75, 5],
+    [1, 5],
+  ])('score réalisé %d → étoile %d max', (scoreFait, expected) => {
+    expect(getMaxRequestableStar(scoreFait)).toBe(expected);
+  });
+
+  it('est monotone croissant avec le score', () => {
+    const scores = Array.from({ length: 101 }, (_, i) => i / 100);
+    scores.forEach((score, index) => {
+      if (index === 0) return;
+      expect(getMaxRequestableStar(score)).toBeGreaterThanOrEqual(
+        getMaxRequestableStar(scores[index - 1])
+      );
+    });
+  });
+});

--- a/packages/domain/src/referentiels/labellisations/requestable-star.ts
+++ b/packages/domain/src/referentiels/labellisations/requestable-star.ts
@@ -1,0 +1,21 @@
+import { Etoile, EtoileEnum } from './labellisation-etoile.enum.schema';
+
+export const ETOILE_MIN_REALISE_SCORE: Record<Etoile, number> = {
+  [EtoileEnum.PREMIERE_ETOILE]: 0,
+  [EtoileEnum.DEUXIEME_ETOILE]: 0.35,
+  [EtoileEnum.TROISIEME_ETOILE]: 0.5,
+  [EtoileEnum.QUATRIEME_ETOILE]: 0.65,
+  [EtoileEnum.CINQUIEME_ETOILE]: 0.75,
+};
+
+const ETOILES_DESC = [
+  EtoileEnum.CINQUIEME_ETOILE,
+  EtoileEnum.QUATRIEME_ETOILE,
+  EtoileEnum.TROISIEME_ETOILE,
+  EtoileEnum.DEUXIEME_ETOILE,
+  EtoileEnum.PREMIERE_ETOILE,
+] as const;
+
+export const getMaxRequestableStar = (scoreFait: number): Etoile =>
+  ETOILES_DESC.find((etoile) => scoreFait >= ETOILE_MIN_REALISE_SCORE[etoile]) ??
+  EtoileEnum.PREMIERE_ETOILE;


### PR DESCRIPTION
## Nature & impact
`feat` — **changement de comportement prod, hors feature flag.** `request-labellisation.rules` est consommée par `request-labellisation.service` (tRPC), servie à **tous** les clients dont l'ancien layout `/labellisation` toujours live.

## Le changement
`canRequestAuditOrLabellisation` dérive désormais le **plafond d'étoile demandable du score réalisé** :

| | Plafond | Condition |
|---|---|---|
| **avant (main)** | `parcours.etoiles` (étoiles **obtenues**) | + `critere_score.atteint` |
| **après** | `getMaxRequestableStar(score_fait)` (≥0.35→2★, ≥0.5→3★, ≥0.65→4★, ≥0.75→5★) | — |

→ Une collectivité peut demander une étoile **au-delà de celles obtenues** si son score le permet (et inversement le plafond peut se resserrer si le score est bas). **À valider produit.**

## Ce qui N'est PAS le changement
Le verrou « un seul cycle à la fois » (`status != non_demandee` → `AUDIT_ALREADY_REQUESTED`) **existe déjà sur main** et est **préservé**, pas introduit ici.

## Refacto accompagnant (même fichier)
- Extraction de `areAuditPrerequisitesMet` (prérequis complétude/score/fichier).
- Nouveau helper pur `getMaxRequestableStar` (`packages/domain`, plafond ← score).

## Surface de review
| Fichier | Attention |
|---|---|
| `domain/.../request-labellisation.rules.ts` | **humaine ++** (gating prod) |
| `domain/.../requestable-star.ts` | humaine (seuils score → étoile) |
| `domain/.../request-labellisation.rules.spec.ts` | humaine (tests rouges sur main) |
| `backend/.../request-labellisation.{router.e2e,rules}.spec.ts` | humaine |
| `domain/.../index.ts` | mécanique (export) |

## Tests
- `request-labellisation.rules.spec` : **rouges sur main** — « autorise une étoile au-delà des étoiles obtenues quand le score le permet » + « se base sur le score et non sur critere_score.atteint ».
- Verrou « un seul cycle » couvert en caractérisation (vert des deux côtés).

## Vérifications
- `tsc` domain + backend → 0 erreur ; `eslint` → 0.
- ⚠️ vitest/e2e non exécutés localement (env absent) → CI.

## Dépendance aval
Le CORE (refonte checklist, flag off) dépend de cette règle via `useCycleLabellisation` → cette PR avant le CORE.

> Note : le nom de branche `feat/labellisation-cycle-unique` est resté (legacy) ; le vrai sujet est le gating par score.