### PR TITLE
fix(referentiels): limite les preuves de l'archive au référentiel de l'audit

### DIFF
--- a/apps/backend/src/referentiels/preuves-archive/generate-preuves-archive/generate-preuves-archive.service.ts
+++ b/apps/backend/src/referentiels/preuves-archive/generate-preuves-archive/generate-preuves-archive.service.ts
@@ -212,6 +212,7 @@ export class GeneratePreuvesArchiveService {
   ): Promise<Result<ArchiveFolderArborescence, GenerateArchiveFailure>> {
     const preuvesResult = await this.listAuditPreuvesService.list({
       collectiviteId: archive.collectiviteId,
+      referentielId: context.referentielId,
       auditId: archive.auditId,
       demandeId: context.demandeId,
       user: context.user,

--- a/apps/backend/src/referentiels/preuves-archive/list-audit-preuves/collect-preuves.repository.e2e-spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/list-audit-preuves/collect-preuves.repository.e2e-spec.ts
@@ -114,6 +114,7 @@ describe('CollectPreuvesRepository - filtre confidentiel (SQL réel)', () => {
   test('canReadConfidentiel=true : expose le fichier public ET le confidentiel', async () => {
     const result = await repository.getComplementairePreuves({
       collectiviteId: collectivite.id,
+      referentielId: 'cae',
       canReadConfidentiel: true,
     });
 
@@ -127,6 +128,7 @@ describe('CollectPreuvesRepository - filtre confidentiel (SQL réel)', () => {
   test('canReadConfidentiel=false : masque le confidentiel, garde le public', async () => {
     const result = await repository.getComplementairePreuves({
       collectiviteId: collectivite.id,
+      referentielId: 'cae',
       canReadConfidentiel: false,
     });
 
@@ -138,6 +140,7 @@ describe('CollectPreuvesRepository - filtre confidentiel (SQL réel)', () => {
   test('un lien (sans fichier) reste visible même sans droit confidentiel', async () => {
     const result = await repository.getComplementairePreuves({
       collectiviteId: collectivite.id,
+      referentielId: 'cae',
       canReadConfidentiel: false,
     });
 
@@ -146,5 +149,122 @@ describe('CollectPreuvesRepository - filtre confidentiel (SQL réel)', () => {
     expect(result.data.links.map((link) => link.url)).toEqual([
       'https://exemple.fr/lien-public',
     ]);
+  });
+});
+
+describe('CollectPreuvesRepository - scope par référentiel (SQL réel)', () => {
+  let app: INestApplication;
+  let db: DatabaseService;
+  let repository: CollectPreuvesRepository;
+  let collectivite: Collectivite;
+  let adminUserId: string;
+  let cleanupCollectivite: () => Promise<void>;
+
+  let caeHash: string;
+  let eciHash: string;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    db = await getTestDatabase(app);
+    repository = app.get(CollectPreuvesRepository);
+
+    const fixture = await addTestCollectiviteAndUser(db, {
+      user: { role: CollectiviteRole.ADMIN },
+    });
+    collectivite = fixture.collectivite;
+    adminUserId = getAuthUserFromUserCredentials(fixture.user).id;
+    cleanupCollectivite = fixture.cleanup;
+
+    caeHash = `hash-cae-${collectivite.id}`;
+    eciHash = `hash-eci-${collectivite.id}`;
+
+    await db.db
+      .insert(collectiviteBucketTable)
+      .values({ bucketId: PREUVES_ARCHIVES_BUCKET, collectiviteId: collectivite.id });
+
+    const fichiers = await db.db
+      .insert(bibliothequeFichierTable)
+      .values([
+        {
+          collectiviteId: collectivite.id,
+          hash: caeHash,
+          filename: 'preuve-cae.pdf',
+          confidentiel: false,
+        },
+        {
+          collectiviteId: collectivite.id,
+          hash: eciHash,
+          filename: 'preuve-eci.pdf',
+          confidentiel: false,
+        },
+      ])
+      .returning();
+    const [fichierCae, fichierEci] = fichiers;
+
+    await db.db.insert(storageObjectTable).values(
+      fichiers.map((fichier) => ({
+        bucketId: PREUVES_ARCHIVES_BUCKET,
+        name: fichier.hash,
+        metadata: { size: 1024 },
+      }))
+    );
+
+    await db.db.insert(preuveComplementaireTable).values([
+      {
+        collectiviteId: collectivite.id,
+        actionId: 'cae_1.1.3',
+        fichierId: fichierCae.id,
+        modifiedBy: adminUserId,
+      },
+      {
+        collectiviteId: collectivite.id,
+        actionId: 'eci_1.1.1',
+        fichierId: fichierEci.id,
+        modifiedBy: adminUserId,
+      },
+    ]);
+  });
+
+  afterAll(async () => {
+    await db.db
+      .delete(preuveComplementaireTable)
+      .where(eq(preuveComplementaireTable.collectiviteId, collectivite.id));
+    await db.db
+      .delete(storageObjectTable)
+      .where(
+        and(
+          eq(storageObjectTable.bucketId, PREUVES_ARCHIVES_BUCKET),
+          like(storageObjectTable.name, `%${collectivite.id}`)
+        )
+      );
+    await db.db
+      .delete(bibliothequeFichierTable)
+      .where(eq(bibliothequeFichierTable.collectiviteId, collectivite.id));
+    await cleanupCollectivite();
+    await app.close();
+  });
+
+  test('referentielId=cae : ne renvoie que la preuve rattachée à une action CAE', async () => {
+    const result = await repository.getComplementairePreuves({
+      collectiviteId: collectivite.id,
+      referentielId: 'cae',
+      canReadConfidentiel: true,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.files.map((file) => file.hash)).toEqual([caeHash]);
+  });
+
+  test('referentielId=eci : ne renvoie que la preuve rattachée à une action ECI', async () => {
+    const result = await repository.getComplementairePreuves({
+      collectiviteId: collectivite.id,
+      referentielId: 'eci',
+      canReadConfidentiel: true,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.files.map((file) => file.hash)).toEqual([eciHash]);
   });
 });

--- a/apps/backend/src/referentiels/preuves-archive/list-audit-preuves/collect-preuves.repository.ts
+++ b/apps/backend/src/referentiels/preuves-archive/list-audit-preuves/collect-preuves.repository.ts
@@ -7,8 +7,10 @@ import { preuveLabellisationTable } from '@tet/backend/collectivites/documents/m
 import { preuveReglementaireTable } from '@tet/backend/collectivites/documents/models/preuve-reglementaire.table';
 import { storageObjectTable } from '@tet/backend/collectivites/documents/models/storage-object.table';
 import { collectiviteBucketTable } from '@tet/backend/collectivites/shared/models/collectivite-bucket.table';
+import { actionDefinitionTable } from '@tet/backend/referentiels/models/action-definition.table';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { failure, success, type Result } from '@tet/backend/utils/result.type';
+import { ReferentielId } from '@tet/domain/referentiels';
 import { getErrorMessage } from '@tet/domain/utils';
 import { and, eq, inArray, isNull, or, sql, type Column, type SQL } from 'drizzle-orm';
 import { z } from 'zod';
@@ -50,9 +52,10 @@ export class CollectPreuvesRepository {
 
   async getComplementairePreuves(input: {
     collectiviteId: number;
+    referentielId: ReferentielId;
     canReadConfidentiel: boolean;
   }): Promise<Result<CollectedPreuves, PreuvesArchiveError>> {
-    const { collectiviteId, canReadConfidentiel } = input;
+    const { collectiviteId, referentielId, canReadConfidentiel } = input;
     try {
       const rows = await this.db
         .select({
@@ -67,6 +70,13 @@ export class CollectPreuvesRepository {
           metadata: storageObjectTable.metadata,
         })
         .from(preuveComplementaireTable)
+        .innerJoin(
+          actionDefinitionTable,
+          and(
+            eq(actionDefinitionTable.actionId, preuveComplementaireTable.actionId),
+            eq(actionDefinitionTable.referentielId, referentielId)
+          )
+        )
         .leftJoin(
           bibliothequeFichierTable,
           and(
@@ -105,9 +115,10 @@ export class CollectPreuvesRepository {
 
   async getReglementairePreuves(input: {
     collectiviteId: number;
+    referentielId: ReferentielId;
     canReadConfidentiel: boolean;
   }): Promise<Result<CollectedPreuves, PreuvesArchiveError>> {
-    const { collectiviteId, canReadConfidentiel } = input;
+    const { collectiviteId, referentielId, canReadConfidentiel } = input;
     try {
       const rows = await this.db
         .select({
@@ -125,6 +136,13 @@ export class CollectPreuvesRepository {
         .innerJoin(
           preuveActionTable,
           eq(preuveReglementaireTable.preuveId, preuveActionTable.preuveId)
+        )
+        .innerJoin(
+          actionDefinitionTable,
+          and(
+            eq(actionDefinitionTable.actionId, preuveActionTable.actionId),
+            eq(actionDefinitionTable.referentielId, referentielId)
+          )
         )
         .leftJoin(
           bibliothequeFichierTable,

--- a/apps/backend/src/referentiels/preuves-archive/list-audit-preuves/list-audit-preuves.service.spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/list-audit-preuves/list-audit-preuves.service.spec.ts
@@ -1,4 +1,5 @@
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { ReferentielId } from '@tet/domain/referentiels';
 import { ResourceType } from '@tet/domain/users';
 import { describe, expect, it, vi } from 'vitest';
 import type {
@@ -9,8 +10,11 @@ import { ListAuditPreuvesService } from './list-audit-preuves.service';
 
 const user = { id: 'user-id' } as AuthenticatedUser;
 
+const referentielId: ReferentielId = 'cae';
+
 const baseInput = {
   collectiviteId: 1,
+  referentielId,
   auditId: 10,
   demandeId: 20,
   user,
@@ -38,6 +42,8 @@ function buildService({
 } = {}): {
   service: ListAuditPreuvesService;
   permissionsIsAllowed: ReturnType<typeof vi.fn>;
+  getComplementairePreuves: ReturnType<typeof vi.fn>;
+  getReglementairePreuves: ReturnType<typeof vi.fn>;
 } {
   const repository = {
     getComplementairePreuves: vi
@@ -62,7 +68,12 @@ function buildService({
     permissions as never
   );
 
-  return { service, permissionsIsAllowed };
+  return {
+    service,
+    permissionsIsAllowed,
+    getComplementairePreuves: repository.getComplementairePreuves,
+    getReglementairePreuves: repository.getReglementairePreuves,
+  };
 }
 
 function makeFile(
@@ -90,6 +101,20 @@ describe('ListAuditPreuvesService', () => {
       ResourceType.COLLECTIVITE,
       1,
       true
+    );
+  });
+
+  it('transmet le referentielId aux collectes mesure (complémentaire et réglementaire)', async () => {
+    const { service, getComplementairePreuves, getReglementairePreuves } =
+      buildService();
+
+    await service.list(baseInput);
+
+    expect(getComplementairePreuves).toHaveBeenCalledWith(
+      expect.objectContaining({ referentielId })
+    );
+    expect(getReglementairePreuves).toHaveBeenCalledWith(
+      expect.objectContaining({ referentielId })
     );
   });
 

--- a/apps/backend/src/referentiels/preuves-archive/list-audit-preuves/list-audit-preuves.service.ts
+++ b/apps/backend/src/referentiels/preuves-archive/list-audit-preuves/list-audit-preuves.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { failure, success, type Result } from '@tet/backend/utils/result.type';
+import { ReferentielId } from '@tet/domain/referentiels';
 import { ResourceType } from '@tet/domain/users';
 import { getErrorMessage } from '@tet/domain/utils';
 import {
@@ -27,6 +28,7 @@ export interface PreuvesByOrigin {
 
 export interface ListPreuvesForAuditInput {
   collectiviteId: number;
+  referentielId: ReferentielId;
   demandeId: number;
   auditId: number;
   user: AuthenticatedUser;
@@ -44,7 +46,7 @@ export class ListAuditPreuvesService {
   async list(
     input: ListPreuvesForAuditInput
   ): Promise<Result<PreuvesByOrigin, PreuvesArchiveError>> {
-    const { collectiviteId, demandeId, auditId, user } = input;
+    const { collectiviteId, referentielId, demandeId, auditId, user } = input;
 
     try {
       const canReadConfidentiel = await this.permissions.isAllowed(
@@ -59,10 +61,12 @@ export class ListAuditPreuvesService {
         await Promise.all([
           this.repository.getComplementairePreuves({
             collectiviteId,
+            referentielId,
             canReadConfidentiel,
           }),
           this.repository.getReglementairePreuves({
             collectiviteId,
+            referentielId,
             canReadConfidentiel,
           }),
           this.repository.getLabellisationPreuves({


### PR DESCRIPTION
## Problème

L'archive ZIP des preuves d'un audit affichait des **fichiers en vrac** à la racine du dossier `mesures/`.

Cause : la collecte des preuves « mesure » (complémentaires + réglementaires) dans `CollectPreuvesRepository` filtrait uniquement sur `collectivite_id`, **jamais sur le référentiel**. Une archive CAE embarquait donc les preuves rattachées aux actions ECI (et inversement) de la même collectivité ; leurs `action_id` (`eci_*`) ne correspondant à aucune mesure de l'arbre CAE, elles étaient rangées par défaut à la racine de `mesures/`.

Constaté en base sur une collectivité réelle : 5 preuves réglementaires `eci_*` polluaient l'archive CAE.

## Correctif

- `getComplementairePreuves` et `getReglementairePreuves` reçoivent le `referentielId` et joignent `action_definition` filtré sur ce référentiel (`innerJoin`).
- L'`innerJoin` exclut nativement les preuves d'un autre référentiel **et** les `action_id` absents de l'arbre (NULL / orphelins).
- `referentielId` est propagé depuis `GeneratePreuvesArchiveService` → `ListAuditPreuvesService.list` → repository.

## Tests

- `list-audit-preuves.service.spec` : nouveau test vérifiant la propagation de `referentielId` aux deux collectes mesure.
- `collect-preuves.repository.e2e-spec` : nouveau bloc « scope par référentiel » prouvant en SQL réel qu'une preuve rattachée à une action d'un autre référentiel est exclue (scoping cae/eci bidirectionnel).

> Note : l'e2e n'a pas pu être exécuté localement (worktree neuf non provisionné, `@tet/domain` dist périmé empêchant le bootstrap du Nest app — indépendant de ce changement). À valider en CI.