### PR TITLE
feat(ai-plan-import): propage les etapes d'import au fil de l'eau

### DIFF
--- a/apps/backend/src/plans/plans/ai-plan-import/ai-plan-import-job.repository.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/ai-plan-import-job.repository.ts
@@ -152,6 +152,17 @@ export class AiPlanImportJobRepository {
     });
   }
 
+  async updateStepStates(
+    id: string,
+    stepStates: StepStates
+  ): Promise<Result<AiPlanImportJob, AiPlanImportError>> {
+    return this.updateAndReturn({
+      id,
+      patch: { stepStates, modifiedAt: new Date().toISOString() },
+      allowedFromStatuses: [AiPlanImportJobStatusEnum.RUNNING],
+    });
+  }
+
   async markDone(input: {
     id: string;
     draft: PlanDraft;

--- a/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/generate-import-draft.service.spec.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/generate-import-draft.service.spec.ts
@@ -69,10 +69,12 @@ type MockOverrides = {
 const buildMocks = (overrides: MockOverrides = {}) => {
   const markDone = vi.fn(overrides.markDone ?? (async () => success(job)));
   const markFailed = vi.fn(overrides.markFailed ?? (async () => success(job)));
+  const updateStepStates = vi.fn(async () => success(job));
   const jobRepository = {
     transitionToRunning: vi.fn(async () => success(job)),
     markFailed,
     markDone,
+    updateStepStates,
     getById: vi.fn(overrides.getById ?? (async () => success(job))),
   } as unknown as AiPlanImportJobRepository;
 
@@ -145,6 +147,16 @@ describe('GenerateImportDraftService', () => {
     );
     expect(mocks.jobRepository.markDone).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'job-1', createdPlanId: 7 })
+    );
+    expect(mocks.jobRepository.updateStepStates).toHaveBeenLastCalledWith(
+      'job-1',
+      {
+        extraction: 'ok',
+        scoring: 'skipped',
+        consolidation: 'skipped',
+        enrichment: 'skipped',
+        qualitativeReview: 'ok',
+      }
     );
     expect(mocks.removeDocument).toHaveBeenCalledWith({
       bucketId: 'ai-plan-import-sources',

--- a/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/generate-import-draft.service.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/generate-import-draft.service.ts
@@ -106,6 +106,9 @@ export class GenerateImportDraftService {
       currentDate: new Date().toISOString(),
       withVerifications: job.options.withVerifications,
       withSousActions: job.options.withSousActions,
+      onStepStatesChange: async (stepStates) => {
+        await this.jobRepository.updateStepStates(job.id, stepStates);
+      },
     });
 
     if (outcome.status === 'failed') {

--- a/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/run-import-pipeline.spec.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/run-import-pipeline.spec.ts
@@ -6,6 +6,7 @@ import {
   RunImportPipelineInput,
   runImportPipeline,
   StepName,
+  StepStates,
 } from './run-import-pipeline';
 
 const tokens: TokenUsage = {
@@ -147,6 +148,55 @@ describe('runImportPipeline', () => {
       expect(outcome.draft.actions[0].sousActions).toEqual([]);
       expect(outcome.stepStates.enrichment).toBe('skipped');
     }
+  });
+
+  it('émet la progression cumulée après chaque étape', async () => {
+    const llm = routedLlm();
+    const onStepStatesChange =
+      vi.fn<(stepStates: StepStates) => Promise<void>>(async () => {});
+
+    await runImportPipeline(llm, input({ onStepStatesChange }));
+
+    const reportedStates = onStepStatesChange.mock.calls.map(
+      ([states]) => states
+    );
+    expect(reportedStates).toEqual([
+      {
+        extraction: 'ok',
+        scoring: 'pending',
+        consolidation: 'pending',
+        enrichment: 'pending',
+        qualitativeReview: 'pending',
+      },
+      {
+        extraction: 'ok',
+        scoring: 'ok',
+        consolidation: 'pending',
+        enrichment: 'pending',
+        qualitativeReview: 'pending',
+      },
+      {
+        extraction: 'ok',
+        scoring: 'ok',
+        consolidation: 'ok',
+        enrichment: 'pending',
+        qualitativeReview: 'pending',
+      },
+      {
+        extraction: 'ok',
+        scoring: 'ok',
+        consolidation: 'ok',
+        enrichment: 'ok',
+        qualitativeReview: 'pending',
+      },
+      {
+        extraction: 'ok',
+        scoring: 'ok',
+        consolidation: 'ok',
+        enrichment: 'ok',
+        qualitativeReview: 'ok',
+      },
+    ]);
   });
 
   it('échoue à la première étape qui échoue, sans brouillon', async () => {

--- a/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/run-import-pipeline.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/run-import-pipeline.ts
@@ -44,6 +44,7 @@ export type RunImportPipelineInput = {
   withVerifications: boolean;
   withSousActions: boolean;
   signal?: AbortSignal;
+  onStepStatesChange?: (stepStates: Readonly<StepStates>) => Promise<void>;
 };
 
 export type PipelineOutcome =
@@ -82,6 +83,9 @@ export const runImportPipeline = async (
   llm: Pick<LlmService, 'generateStructured'>,
   input: RunImportPipelineInput
 ): Promise<PipelineOutcome> => {
+  const reportProgress = (stepStates: StepStates): Promise<void> =>
+    input.onStepStatesChange?.(stepStates) ?? Promise.resolve();
+
   const extracted = await runStep({
     progress: initialProgress(),
     name: 'extraction',
@@ -95,6 +99,7 @@ export const runImportPipeline = async (
       }),
   });
   if (!extracted.success) return extracted.outcome;
+  await reportProgress(extracted.progress.stepStates);
 
   const scored = await runStep({
     progress: extracted.progress,
@@ -104,6 +109,7 @@ export const runImportPipeline = async (
       scoreActions(llm, { actions, text: input.text, signal: input.signal }),
   });
   if (!scored.success) return scored.outcome;
+  await reportProgress(scored.progress.stepStates);
 
   const consolidated = await runStep({
     progress: scored.progress,
@@ -118,6 +124,7 @@ export const runImportPipeline = async (
       }),
   });
   if (!consolidated.success) return consolidated.outcome;
+  await reportProgress(consolidated.progress.stepStates);
 
   const enriched = await runStep({
     progress: consolidated.progress,
@@ -133,6 +140,7 @@ export const runImportPipeline = async (
       }),
   });
   if (!enriched.success) return enriched.outcome;
+  await reportProgress(enriched.progress.stepStates);
 
   const reviewed = await runStep({
     progress: enriched.progress,
@@ -140,6 +148,7 @@ export const runImportPipeline = async (
     run: (actions) => reviewQuality(llm, { actions, signal: input.signal }),
   });
   if (!reviewed.success) return reviewed.outcome;
+  await reportProgress(reviewed.progress.stepStates);
 
   return done(reviewed.progress);
 };


### PR DESCRIPTION
## Contexte

Le statut d'un job d'import IA expose deja `stepStates` (extraction, scoring, consolidation, enrichment, qualitativeReview), mais ces etats n'etaient ecrits en base qu'aux **etats terminaux** (`markDone` / `markFailed`). Pendant que le job tourne, le polling renvoyait donc toutes les etapes a `pending`, puis tout basculait d'un coup a la fin.

Cette PR fait remonter l'avancement **au fil de l'eau**, sans changer le contrat de l'endpoint de statut. Elle prepare la barre de progression cote front (PR a venir).

## Changements

- `run-import-pipeline.ts` : `RunImportPipelineInput` accepte un callback optionnel `onStepStatesChange`, invoque apres **chaque etape franchie** avec les `stepStates` cumules.
- `ai-plan-import-job.repository.ts` : nouvelle methode `updateStepStates(id, stepStates)`, autorisee uniquement depuis le statut `running`.
- `generate-import-draft.service.ts` : branche le callback sur `updateStepStates` (best-effort, le resultat est ignore : un echec d'ecriture de progression n'interrompt pas l'import).

## Hors scope

Aucune migration (colonne `step_states` deja presente). Aucune modification du schema de sortie ni du front.

## Tests

- `run-import-pipeline.spec.ts` : nouveau test verifiant l'emission cumulee apres chaque etape.
- `generate-import-draft.service.spec.ts` : mock `updateStepStates` + assertion de l'etat terminal persiste.
- Suite `ai-plan-import` complete verte (111 tests), typecheck (`tsc -b`) et lint OK sur les fichiers touches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Nouvelles fonctionnalités

* **Suivi de la progression en temps réel** : Le pipeline d'import communique désormais les états d'avancement au fur et à mesure de l'exécution, permettant une meilleure visibilité sur le statut de chaque étape du processus d'import.

## Tests

* **Couverture améliorée** : Tests ajoutés pour valider le reporting de progression et la mise à jour des états d'étapes pendant l'exécution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->