### PR TITLE
feat(preuves): verrouille les preuves de labellisation une fois l'audit validé

### DIFF
--- a/apps/backend/src/collectivites/documents/edit-preuve-document/edit-preuve-document.errors.ts
+++ b/apps/backend/src/collectivites/documents/edit-preuve-document/edit-preuve-document.errors.ts
@@ -3,7 +3,7 @@ import {
   TrpcErrorHandlerConfig,
 } from '@tet/backend/utils/trpc/trpc-error-handler';
 
-const specificErrors = ['PREUVE_FICHIER'] as const;
+const specificErrors = ['PREUVE_FICHIER', 'LABELLISATION_IN_PROGRESS'] as const;
 type SpecificError = (typeof specificErrors)[number];
 
 export const editPreuveDocumentErrorConfig: TrpcErrorHandlerConfig<SpecificError> =
@@ -13,6 +13,11 @@ export const editPreuveDocumentErrorConfig: TrpcErrorHandlerConfig<SpecificError
         code: 'BAD_REQUEST',
         message:
           "Cette preuve est un fichier : le lien ne peut pas être modifié via cette opération.",
+      },
+      LABELLISATION_IN_PROGRESS: {
+        code: 'BAD_REQUEST',
+        message:
+          "Les documents de candidature ne peuvent plus être modifiés une fois l'audit clôturé et la labellisation en cours.",
       },
     },
   };

--- a/apps/backend/src/collectivites/documents/edit-preuve-document/edit-preuve-document.repository.ts
+++ b/apps/backend/src/collectivites/documents/edit-preuve-document/edit-preuve-document.repository.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { auditTable } from '@tet/backend/referentiels/labellisations/audit.table';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { failure, Result, success } from '@tet/backend/utils/result.type';
 import {
@@ -6,9 +7,11 @@ import {
   CommonErrorEnum,
 } from '@tet/backend/utils/trpc/common-errors';
 import { PreuveBase, PreuveType } from '@tet/domain/collectivites';
+import { LabellisationAudit } from '@tet/domain/referentiels';
 import { getErrorMessage } from '@tet/domain/utils';
-import { eq } from 'drizzle-orm';
+import { desc, eq } from 'drizzle-orm';
 import { DocumentBase } from '../models/document.basetable';
+import { preuveLabellisationTable } from '../models/preuve-labellisation.table';
 import { preuveTableByType } from '../models/preuve-tables.map';
 
 export type PreuveDocumentPatch = {
@@ -33,6 +36,22 @@ export class EditPreuveDocumentRepository {
       .where(eq(table.id, preuveId))
       .limit(1);
     return row;
+  }
+
+  async findAuditByLabellisationPreuve(
+    preuveId: number
+  ): Promise<Pick<LabellisationAudit, 'valide'> | null> {
+    const [row] = await this.databaseService.db
+      .select({ valide: auditTable.valide })
+      .from(preuveLabellisationTable)
+      .innerJoin(
+        auditTable,
+        eq(auditTable.demandeId, preuveLabellisationTable.demandeId)
+      )
+      .where(eq(preuveLabellisationTable.id, preuveId))
+      .orderBy(desc(auditTable.dateDebut))
+      .limit(1);
+    return row ?? null;
   }
 
   async updateById(

--- a/apps/backend/src/collectivites/documents/edit-preuve-document/edit-preuve-document.router.e2e-spec.ts
+++ b/apps/backend/src/collectivites/documents/edit-preuve-document/edit-preuve-document.router.e2e-spec.ts
@@ -2,6 +2,8 @@ import { INestApplication } from '@nestjs/common';
 import { addTestCollectiviteAndUsers } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
 import { uploadCreateTestDocument } from '@tet/backend/collectivites/documents/documents.test-fixture';
 import { createFiche } from '@tet/backend/plans/fiches/fiches.test-fixture';
+import { validateAudit } from '@tet/backend/referentiels/labellisations/labellisations.test-fixture';
+import { createAuditWithOnTestFinished } from '@tet/backend/referentiels/referentiels.test-fixture';
 import {
   getAuthUserFromUserCredentials,
   getTestApp,
@@ -14,6 +16,7 @@ import { addTestUser } from '@tet/backend/users/users/users.test-fixture';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
 import { Collectivite } from '@tet/domain/collectivites';
+import { ReferentielIdEnum } from '@tet/domain/referentiels';
 import { CollectiviteRole } from '@tet/domain/users';
 import request from 'supertest';
 
@@ -217,6 +220,69 @@ describe('EditPreuveDocumentRouter', () => {
           preuveType: 'annexe',
         })
       ).rejects.toThrowError(/Droits insuffisants|permissions nécessaires/i);
+    });
+  });
+
+  describe('documents de candidature (preuve labellisation)', () => {
+    const createCandidaturePreuve = async () => {
+      const caller = router.createCaller({ user: editorUser });
+      const { audit, demande } = await createAuditWithOnTestFinished({
+        databaseService: db,
+        collectiviteId: collectivite.id,
+        referentielId: ReferentielIdEnum.CAE,
+        withDemande: true,
+      });
+      if (!demande) {
+        throw new Error('demande manquante');
+      }
+
+      const preuve =
+        await caller.referentiels.labellisations.createLabellisationPreuve({
+          demandeId: demande.id,
+          fichierId,
+          commentaire: '',
+        });
+
+      return { caller, preuve, auditId: audit.id };
+    };
+
+    const validerAuditEnCours = (auditId: number) =>
+      validateAudit({ databaseService: db, auditId });
+
+    test("un éditeur peut supprimer un document de candidature tant que l'audit n'est pas validé", async () => {
+      const { caller, preuve } = await createCandidaturePreuve();
+
+      const result = await caller.collectivites.documents.removePreuve({
+        preuveId: preuve.id,
+        preuveType: 'labellisation',
+      });
+
+      expect(result.id).toBe(preuve.id);
+    });
+
+    test("la suppression d'un document de candidature est refusée une fois l'audit validé (labellisation en cours)", async () => {
+      const { caller, preuve, auditId } = await createCandidaturePreuve();
+      await validerAuditEnCours(auditId);
+
+      await expect(
+        caller.collectivites.documents.removePreuve({
+          preuveId: preuve.id,
+          preuveType: 'labellisation',
+        })
+      ).rejects.toThrowError(/labellisation en cours/i);
+    });
+
+    test("la modification d'un document de candidature est refusée une fois l'audit validé (labellisation en cours)", async () => {
+      const { caller, preuve, auditId } = await createCandidaturePreuve();
+      await validerAuditEnCours(auditId);
+
+      await expect(
+        caller.collectivites.documents.updatePreuve({
+          preuveId: preuve.id,
+          preuveType: 'labellisation',
+          commentaire: 'tentative de modification',
+        })
+      ).rejects.toThrowError(/labellisation en cours/i);
     });
   });
 });

--- a/apps/backend/src/collectivites/documents/edit-preuve-document/edit-preuve-document.service.ts
+++ b/apps/backend/src/collectivites/documents/edit-preuve-document/edit-preuve-document.service.ts
@@ -2,11 +2,9 @@ import { Injectable } from '@nestjs/common';
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { failure, Result } from '@tet/backend/utils/result.type';
-import {
-  CommonError,
-  CommonErrorEnum,
-} from '@tet/backend/utils/trpc/common-errors';
-import { PreuveBase } from '@tet/domain/collectivites';
+import { CommonErrorEnum } from '@tet/backend/utils/trpc/common-errors';
+import { PreuveBase, PreuveType } from '@tet/domain/collectivites';
+import { canModifyLabellisationPreuves } from '@tet/domain/referentiels';
 import { ResourceType } from '@tet/domain/users';
 import { EditPreuveDocumentError } from './edit-preuve-document.errors';
 import {
@@ -47,6 +45,10 @@ export class EditPreuveDocumentService {
       return failure(CommonErrorEnum.UNAUTHORIZED);
     }
 
+    if (!(await this.canModifyPreuve(preuveType, preuveId))) {
+      return failure('LABELLISATION_IN_PROGRESS');
+    }
+
     if (preuve.fichierId != null && lien !== undefined) {
       return failure('PREUVE_FICHIER');
     }
@@ -62,7 +64,7 @@ export class EditPreuveDocumentService {
   async removePreuve(
     input: RemovePreuveInput,
     user: AuthenticatedUser
-  ): Promise<Result<{ id: number }, CommonError>> {
+  ): Promise<Result<{ id: number }, EditPreuveDocumentError>> {
     const { preuveId, preuveType } = input;
 
     const preuve = await this.editPreuveDocumentRepository.findById(
@@ -84,6 +86,24 @@ export class EditPreuveDocumentService {
       return failure(CommonErrorEnum.UNAUTHORIZED);
     }
 
+    if (!(await this.canModifyPreuve(preuveType, preuveId))) {
+      return failure('LABELLISATION_IN_PROGRESS');
+    }
+
     return this.editPreuveDocumentRepository.deleteById(preuveType, preuveId);
+  }
+
+  private async canModifyPreuve(
+    preuveType: PreuveType,
+    preuveId: number
+  ): Promise<boolean> {
+    if (preuveType !== 'labellisation') {
+      return true;
+    }
+    const audit =
+      await this.editPreuveDocumentRepository.findAuditByLabellisationPreuve(
+        preuveId
+      );
+    return canModifyLabellisationPreuves({ audit });
   }
 }

--- a/apps/backend/src/referentiels/labellisations/create-preuve/create-labellisation-preuve.errors.ts
+++ b/apps/backend/src/referentiels/labellisations/create-preuve/create-labellisation-preuve.errors.ts
@@ -6,6 +6,7 @@ import {
 const specificErrors = [
   'UNAUTHORIZED',
   'DEMANDE_NOT_FOUND',
+  'LABELLISATION_IN_PROGRESS',
   'DATABASE_ERROR',
 ] as const;
 type SpecificError = (typeof specificErrors)[number];
@@ -22,6 +23,11 @@ export const createLabellisationPreuveErrorConfig: TrpcErrorHandlerConfig<Specif
         code: 'BAD_REQUEST',
         message:
           'Aucune demande de labellisation trouvée pour cette collectivité et ce référentiel.',
+      },
+      LABELLISATION_IN_PROGRESS: {
+        code: 'BAD_REQUEST',
+        message:
+          "Les documents de candidature ne peuvent plus être modifiés une fois l'audit clôturé et la labellisation en cours.",
       },
       DATABASE_ERROR: {
         code: 'INTERNAL_SERVER_ERROR',

--- a/apps/backend/src/referentiels/labellisations/create-preuve/create-preuve.router.e2e-spec.ts
+++ b/apps/backend/src/referentiels/labellisations/create-preuve/create-preuve.router.e2e-spec.ts
@@ -7,6 +7,7 @@ import { Collectivite } from '@tet/domain/collectivites';
 import { ReferentielIdEnum } from '@tet/domain/referentiels';
 import { CollectiviteRole } from '@tet/domain/users';
 import { inferProcedureInput } from '@trpc/server';
+import { eq } from 'drizzle-orm';
 import request from 'supertest';
 import {
   getTestApp,
@@ -16,6 +17,7 @@ import {
 import { AuthenticatedUser } from '../../../users/models/auth.models';
 import { AppRouter, TrpcRouter } from '../../../utils/trpc/trpc.router';
 import { createAuditWithOnTestFinished } from '../../referentiels.test-fixture';
+import { auditTable } from '../audit.table';
 import { addAuditeurPermission } from '../labellisations.test-fixture';
 
 type Input = inferProcedureInput<
@@ -172,5 +174,22 @@ describe('CreatePreuveRouter', () => {
       commentaire: '',
       modifiedBy: readerUser.id,
     });
+  });
+
+  const validerAudit = async (auditId: number): Promise<void> => {
+    await databaseService.db
+      .update(auditTable)
+      .set({ valide: true })
+      .where(eq(auditTable.id, auditId));
+  };
+
+  test("refuse l'ajout d'une preuve une fois l'audit validé (labellisation en cours)", async () => {
+    const caller = router.createCaller({ user: editorUser });
+    const { input, auditId } = await createValidInput();
+    await validerAudit(auditId);
+
+    await expect(
+      caller.referentiels.labellisations.createLabellisationPreuve(input)
+    ).rejects.toThrowError(/labellisation en cours/i);
   });
 });

--- a/apps/backend/src/referentiels/labellisations/create-preuve/create-preuve.service.ts
+++ b/apps/backend/src/referentiels/labellisations/create-preuve/create-preuve.service.ts
@@ -5,6 +5,7 @@ import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { Result } from '@tet/backend/utils/result.type';
 import { PreuveLabellisation } from '@tet/domain/collectivites';
+import { canModifyLabellisationPreuves } from '@tet/domain/referentiels';
 import { ResourceType } from '@tet/domain/users';
 import { getErrorMessage } from '@tet/domain/utils';
 import { GetLabellisationService } from '../get-labellisation.service';
@@ -60,6 +61,25 @@ export class CreatePreuveService {
       return {
         success: false,
         error: 'UNAUTHORIZED',
+      };
+    }
+
+    const auditResult = await this.getLabellisationService.getAuditByDemande(
+      demandeId
+    );
+    if (!auditResult.success && auditResult.error === 'DATABASE_ERROR') {
+      return {
+        success: false,
+        error: CreateLabellisationPreuveErrorEnum.DATABASE_ERROR,
+      };
+    }
+    if (
+      auditResult.success &&
+      canModifyLabellisationPreuves({ audit: auditResult.data }) === false
+    ) {
+      return {
+        success: false,
+        error: CreateLabellisationPreuveErrorEnum.LABELLISATION_IN_PROGRESS,
       };
     }
 

--- a/apps/backend/src/referentiels/labellisations/get-labellisation.service.ts
+++ b/apps/backend/src/referentiels/labellisations/get-labellisation.service.ts
@@ -184,6 +184,37 @@ export class GetLabellisationService {
     }
   }
 
+  async getAuditByDemande(
+    demandeId: number,
+    tx?: Transaction
+  ): Promise<Result<LabellisationAudit, GetDemandeOrAuditError>> {
+    try {
+      const audit = await (tx ?? this.db)
+        .select()
+        .from(auditTable)
+        .where(eq(auditTable.demandeId, demandeId))
+        .orderBy(desc(auditTable.dateDebut))
+        .limit(1);
+
+      if (!audit.length) {
+        return {
+          success: false,
+          error: 'NOT_FOUND',
+        };
+      }
+      return {
+        success: true,
+        data: audit[0],
+      };
+    } catch (error) {
+      this.logger.error(error);
+      return {
+        success: false,
+        error: 'DATABASE_ERROR',
+      };
+    }
+  }
+
   async getCurrentAudit(
     collectiviteId: number,
     referentielId: ReferentielId,

--- a/apps/backend/src/referentiels/labellisations/labellisations.test-fixture.ts
+++ b/apps/backend/src/referentiels/labellisations/labellisations.test-fixture.ts
@@ -68,6 +68,19 @@ export async function createAudit({
   return { audit, demande, cleanup };
 }
 
+export async function validateAudit({
+  databaseService,
+  auditId,
+}: {
+  databaseService: DatabaseServiceInterface;
+  auditId: number;
+}): Promise<void> {
+  await databaseService.db
+    .update(auditTable)
+    .set({ valide: true })
+    .where(eq(auditTable.id, auditId));
+}
+
 export async function seedLabellisationObtenue({
   databaseService,
   collectiviteId,

--- a/apps/backend/src/referentiels/labellisations/list-preuves/list-preuves.service.ts
+++ b/apps/backend/src/referentiels/labellisations/list-preuves/list-preuves.service.ts
@@ -19,10 +19,6 @@ import { getErrorMessage } from '@tet/domain/utils';
 import { and, eq, getTableColumns, sql } from 'drizzle-orm';
 import { ObjectToSnake, objectToSnake } from 'ts-case-convert';
 import { auditTable } from '../audit.table';
-import {
-  CreateLabellisationPreuveError,
-  CreateLabellisationPreuveErrorEnum,
-} from '../create-preuve/create-labellisation-preuve.errors';
 import { GetLabellisationService } from '../get-labellisation.service';
 import { labellisationDemandeTable } from '../labellisation-demande.table';
 import {
@@ -30,6 +26,10 @@ import {
   ListPreuvesAuditErrorEnum,
 } from './list-preuves-audit.errors';
 import { ListPreuvesAuditInput } from './list-preuves-audit.input';
+import {
+  ListPreuvesLabellisationError,
+  ListPreuvesLabellisationErrorEnum,
+} from './list-preuves-labellisation.errors';
 import { ListPreuvesLabellisationInput } from './list-preuves-labellisation.input';
 
 @Injectable()
@@ -150,7 +150,7 @@ export class ListPreuvesService {
   ): Promise<
     Result<
       ObjectToSnake<LegacyPreuveLabellisationWithFichier>[],
-      CreateLabellisationPreuveError
+      ListPreuvesLabellisationError
     >
   > {
     const demandeResult = await this.getLabellisationService.getDemande(
@@ -160,7 +160,7 @@ export class ListPreuvesService {
       if (demandeResult.error === 'NOT_FOUND') {
         return {
           success: false,
-          error: CreateLabellisationPreuveErrorEnum.DEMANDE_NOT_FOUND,
+          error: ListPreuvesLabellisationErrorEnum.DEMANDE_NOT_FOUND,
         };
       } else {
         return {

--- a/packages/domain/src/referentiels/index.ts
+++ b/packages/domain/src/referentiels/index.ts
@@ -28,6 +28,7 @@ export * from './labellisations/labellisation-etoile.enum.schema';
 export * from './labellisations/labellisation.schema';
 export * from './labellisations/parcours-labellisation-status.enum';
 export * from './labellisations/parcours-labellisation.schema';
+export * from './labellisations/can-modify-labellisation-preuves/can-modify-labellisation-preuves.rule';
 export * from './labellisations/request-labellisation/request-labellisation.rules';
 export * from './labellisations/request-labellisation/request-labellisation.rules-errors';
 export * from './labellisations/requestable-star';

--- a/packages/domain/src/referentiels/labellisations/can-modify-labellisation-preuves/can-modify-labellisation-preuves.rule.spec.ts
+++ b/packages/domain/src/referentiels/labellisations/can-modify-labellisation-preuves/can-modify-labellisation-preuves.rule.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { canModifyLabellisationPreuves } from './can-modify-labellisation-preuves.rule';
+
+describe('canModifyLabellisationPreuves', () => {
+  it("autorise quand il n'y a pas d'audit", () => {
+    expect(canModifyLabellisationPreuves({ audit: null })).toBe(true);
+  });
+
+  it("autorise tant que l'audit n'est pas validé (audit en cours)", () => {
+    expect(
+      canModifyLabellisationPreuves({ audit: { valide: false } })
+    ).toBe(true);
+  });
+
+  it("verrouille dès que l'audit est validé (labellisation en cours)", () => {
+    expect(
+      canModifyLabellisationPreuves({ audit: { valide: true } })
+    ).toBe(false);
+  });
+});

--- a/packages/domain/src/referentiels/labellisations/can-modify-labellisation-preuves/can-modify-labellisation-preuves.rule.ts
+++ b/packages/domain/src/referentiels/labellisations/can-modify-labellisation-preuves/can-modify-labellisation-preuves.rule.ts
@@ -1,0 +1,12 @@
+import { LabellisationAudit } from '../labellisation-audit.schema';
+
+export function canModifyLabellisationPreuves({
+  audit,
+}: {
+  audit: Pick<LabellisationAudit, 'valide'> | null;
+}): boolean {
+  if (audit === null) {
+    return true;
+  }
+  return audit.valide === false;
+}


### PR DESCRIPTION
## Nature & impact
`feat` — **changement de comportement prod, hors feature flag.** `createLabellisationPreuve`, `updatePreuve`, `removePreuve` (tRPC) sont servis à tous les clients, ancien layout inclus.

## Le changement
Nouvelle règle pure `canModifyLabellisationPreuves` (`packages/domain`) : une preuve de **type `labellisation`** n'est modifiable que **tant qu'aucun audit n'est validé** (`audit === null || audit.valide === false`).

Périmètre exact = `preuveType === 'labellisation'`, ce qui couvre **acte d'engagement + documents de candidature** (indistincts en base, cf. `DISCOVERED.md` — pas de discriminant). Le **rapport d'audit** (`preuveType` `rapport`/`audit`) **n'est pas concerné** : il a sa propre fenêtre de 15 j.

La règle gate les **trois** mutations (create / update / **remove**) ; d'où `Modify` (et pas `Upsert`, qui exclurait le delete). Les services retournent **`LABELLISATION_IN_PROGRESS`** si l'audit lié à la demande est validé.

> Nommage : verbe et code d'erreur en anglais (convention du repo, comme `canRequestAuditOrLabellisation` / `DEMANDE_NOT_FOUND`) ; `Labellisation`/`Preuve` restent (vocabulaire domaine) ; message d'erreur et descriptions de tests en français (user-facing / doc).

## Découplage du type d'erreur (inclus)
Ajouter `LABELLISATION_IN_PROGRESS` au type partagé `CreateLabellisationPreuveError` faisait hériter `list-preuves.router` d'une erreur qu'il ne sait pas gérer (CI rouge). `list-preuves.service` est donc basculé sur son **type d'erreur dédié** `ListPreuvesLabellisationError` (déjà présent sur main) → découplé.

## Surface de review
| Fichier | Attention |
|---|---|
| `domain/.../can-modify-labellisation-preuves.rule.ts` | humaine (règle pure, 10 lignes) |
| `backend/.../create-preuve.service.ts` | humaine (application du verrou) |
| `backend/.../edit-preuve-document.service.ts` | humaine (verrou update/remove via `canModifyPreuve`) |
| `backend/.../get-labellisation.service.ts` | humaine (`getAuditByDemande`, additif) |
| `backend/.../list-preuves/list-preuves.service.ts` | humaine (découplage type d'erreur) |
| `*.errors.ts`, `*.repository.ts` | mécanique |
| `labellisations.test-fixture.ts` | mécanique (helper `validateAudit`, par `auditId`) |

## Tests
- `can-modify-labellisation-preuves.rule.spec` (domain, unit) : la règle.
- `create-preuve` / `edit-preuve-document` **e2e** : refus **après** validation (rouge sur main).

## Vérifications
- `nx run backend:typecheck` (tsc --build, = CI) → 0 erreur ; `nx build domain` + `nx build backend` → OK ; `eslint` → 0.
- ⚠️ tests (vitest/e2e) non exécutés localement → CI.

## Notes / limites connues
- TOCTOU théorique entre le check `canModifyLabellisationPreuves` et l'insert/update (fenêtre de quelques ms, déclenchée par une validation d'audit). Jugé négligeable ; le fix conforme (transaction + verrou de ligne, règle gardée en domaine) est disproportionné ici → à traiter à part si besoin.
- Helper fixture `validateAudit` ajouté en **slice** (pas tout le `labellisations.test-fixture`), et filtre par `auditId` (déterministe, aligné sur le service prod).

> Nom de branche `feat/verrou-documents-candidature` resté (legacy) ; le vrai périmètre est les preuves de labellisation.

## Reviewers suggérés
`security-sentinel` (intégrité/faille API), backend domain.