### PR TITLE
fix(rls): autorise les utilisateurs ADEME a lire storage.objects

### DIFF
--- a/data_layer/sqitch/deploy/collectivite/bucket_rls_ademe_read.sql
+++ b/data_layer/sqitch/deploy/collectivite/bucket_rls_ademe_read.sql
@@ -1,0 +1,44 @@
+-- Deploy tet:collectivite/bucket_rls_ademe_read to pg
+-- requires: collectivite/bucket_rls_strict_read
+
+BEGIN;
+
+-- Helper : vrai si l'utilisateur courant a une adresse @ademe.fr. Le rôle
+-- plateforme ADEME (cf. permission.models.ts) donne un accès en lecture aux
+-- documents de toutes les collectivités.
+create or replace function
+    is_ademe()
+    returns boolean
+    stable
+as
+$$
+select coalesce(d.email like '%@ademe.fr', false)
+from dcp d
+where d.user_id = auth.uid()
+$$ language sql;
+comment on function is_ademe is
+    'Vrai si l''utilisateur courant a une adresse email @ademe.fr (rôle plateforme ADEME).';
+
+-- Rétablit l'accès en lecture aux objets de stockage pour les utilisateurs
+-- ADEME : la policy stricte introduite par bucket_rls_strict_read leur
+-- interdisait de télécharger les preuves.
+drop policy if exists allow_read on storage.objects;
+create policy allow_read
+    on storage.objects for select
+    using (is_bucket_writer(bucket_id) or is_ademe());
+
+-- Idem sur la table héritée labellisation_preuve_fichier si elle existe.
+do $$
+begin
+    if to_regclass('public.labellisation_preuve_fichier') is not null then
+        execute 'drop policy if exists allow_read on public.labellisation_preuve_fichier';
+        execute $policy$
+            create policy allow_read
+                on public.labellisation_preuve_fichier for select
+                using (have_lecture_acces(collectivite_id) or is_ademe())
+        $policy$;
+    end if;
+end
+$$;
+
+COMMIT;

--- a/data_layer/sqitch/revert/collectivite/bucket_rls_ademe_read.sql
+++ b/data_layer/sqitch/revert/collectivite/bucket_rls_ademe_read.sql
@@ -1,0 +1,25 @@
+-- Revert tet:collectivite/bucket_rls_ademe_read from pg
+
+BEGIN;
+
+drop policy if exists allow_read on storage.objects;
+create policy allow_read
+    on storage.objects for select
+    using (is_bucket_writer(bucket_id));
+
+do $$
+begin
+    if to_regclass('public.labellisation_preuve_fichier') is not null then
+        execute 'drop policy if exists allow_read on public.labellisation_preuve_fichier';
+        execute $policy$
+            create policy allow_read
+                on public.labellisation_preuve_fichier for select
+                using (have_lecture_acces(collectivite_id))
+        $policy$;
+    end if;
+end
+$$;
+
+drop function if exists is_ademe();
+
+COMMIT;

--- a/data_layer/sqitch/sqitch.plan
+++ b/data_layer/sqitch/sqitch.plan
@@ -996,3 +996,5 @@ collectivite/bucket_rls_strict_read [collectivite/bucket] 2026-05-29T12:00:00Z F
 
 referentiel/add_adaptation_niveau 2026-06-02T17:55:00Z Marc Rutkowski <marc@attractive-media.fr> # Ajoute la colonne pour stocker le niveau d'exposition au changement climatique associé à une mesure
 plan_action/ai_plan_import_job_created_plan [plan_action/ai_plan_import_job] 2026-06-15T08:59:54Z Gaël Servaud <gaelservaud@Host-002.lan> # Ajoute created_plan_id (plan cree par le worker d'import IA) a ai_plan_import_job
+
+collectivite/bucket_rls_ademe_read [collectivite/bucket_rls_strict_read] 2026-06-16T12:00:00Z Frederic Arnoux <frederic.arnoux@beta.gouv.fr> # Autorise les utilisateurs ADEME (@ademe.fr) a lire storage.objects malgre la policy stricte Pentest V5

--- a/data_layer/sqitch/verify/collectivite/bucket_rls_ademe_read.sql
+++ b/data_layer/sqitch/verify/collectivite/bucket_rls_ademe_read.sql
@@ -1,0 +1,27 @@
+-- Verify tet:collectivite/bucket_rls_ademe_read on pg
+
+BEGIN;
+
+do $$
+declare
+    qual text;
+begin
+    select pg_get_expr(p.polqual, p.polrelid)
+      into qual
+      from pg_policy p
+      join pg_class c on c.oid = p.polrelid
+      join pg_namespace n on n.oid = c.relnamespace
+     where n.nspname = 'storage'
+       and c.relname = 'objects'
+       and p.polname = 'allow_read';
+
+    assert qual is not null,
+        'La policy allow_read sur storage.objects doit exister';
+    assert qual ilike '%is_bucket_writer%',
+        format('La policy allow_read sur storage.objects doit toujours utiliser is_bucket_writer (actuel: %s)', qual);
+    assert qual ilike '%is_ademe%',
+        format('La policy allow_read sur storage.objects doit autoriser is_ademe (actuel: %s)', qual);
+end
+$$;
+
+ROLLBACK;

--- a/data_layer/tests/collectivite/bucket_rls.sql
+++ b/data_layer/tests/collectivite/bucket_rls.sql
@@ -1,5 +1,5 @@
 begin;
-select plan(4);
+select plan(6);
 
 truncate storage.objects cascade;
 
@@ -47,6 +47,28 @@ select is_empty(
 select isnt_empty(
        $$ select name from storage.objects where name = 'private-collectivite-3.pdf' $$,
        'Yulu (edition sur 3) doit pouvoir lire un fichier de son bucket'
+   );
+
+
+-- En tant qu'utilisateur ADEME (email @ademe.fr), aucun droit sur 1 ni 3
+do $$
+declare
+    new_user_id uuid := gen_random_uuid();
+begin
+    perform test_create_user(new_user_id, 'Ada', 'Lovelace', 'ada.lovelace@ademe.fr');
+end
+$$;
+
+select test.identify_as('ada.lovelace@ademe.fr');
+
+select isnt_empty(
+       $$ select name from storage.objects where name = 'private-collectivite-1.pdf' $$,
+       'Un utilisateur ADEME doit pouvoir lire un fichier de n''importe quelle collectivité (1)'
+   );
+
+select isnt_empty(
+       $$ select name from storage.objects where name = 'private-collectivite-3.pdf' $$,
+       'Un utilisateur ADEME doit pouvoir lire un fichier de n''importe quelle collectivité (3)'
    );
 
 rollback;

--- a/e2e/tests/collectivite/documents/preuve-storage-access.spec.ts
+++ b/e2e/tests/collectivite/documents/preuve-storage-access.spec.ts
@@ -95,6 +95,45 @@ test.describe('Accès aux preuves privées (storage bucket RLS)', () => {
     expect(result.errorMessage).toBeTruthy();
   });
 
+  test('Un utilisateur ADEME (email @ademe.fr) peut télécharger via bucket_id/hash', async ({
+    referentielScoresPom,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    referentiels,
+    collectivites,
+    users,
+  }) => {
+    const collectivite: CollectiviteFixture = collectivites.getCollectivite();
+
+    // L'éditeur membre de la collectivité ajoute une preuve via l'UI.
+    await gotoActionWithDocuments(referentielScoresPom);
+    await referentielScoresPom.uploadPreuveReglementaire(preuveReglementaireId);
+
+    const { bucketId, hash } = await getCollectivitePreuveFileInfo(
+      collectivite.data.id
+    );
+
+    // Un utilisateur ADEME (non membre, email @ademe.fr) tente de
+    // télécharger le fichier directement via l'API Supabase Storage
+    // — exactement ce que fait `supabase.storage.from(...).download(...)`
+    // côté client. La RLS sur storage.objects doit l'autoriser.
+    const ademeUser = await users.addUser({ nom: 'ademe' });
+    expect(ademeUser.data.email).toMatch(/@ademe\.fr$/);
+
+    const { accessToken } = await ademeUser.supabaseClient.authenticateUser(
+      ademeUser.data.email,
+      ademeUser.data.password
+    );
+
+    const result = await attemptSupabaseStorageDownload(
+      accessToken,
+      bucketId,
+      hash
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.errorMessage).toBeUndefined();
+  });
+
   test('Un auditeur conserve l\'accès aux preuves de la collectivité auditée', async ({
     referentielScoresPom,
     referentiels,


### PR DESCRIPTION
La policy stricte introduite par bucket_rls_strict_read (Pentest V5)
empechait les utilisateurs ADEME (@ademe.fr) de telecharger les
documents de la bibliotheque. Cette migration ajoute un helper is_ademe()
et autorise ces utilisateurs dans la policy allow_read de storage.objects
(et de la table heritee labellisation_preuve_fichier si elle existe).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Autorisation d’accès à la lecture des fichiers de stockage pour les utilisateurs ADEME (email se terminant par `@ademe.fr`), y compris pour les preuves associées lorsque disponibles.

* **Tests**
  * Ajout de tests end-to-end pour valider le téléchargement Supabase Storage par un utilisateur ADEME.
  * Mise à jour/extension des tests de permissions pour couvrir davantage de cas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->