### PR TITLE
feat(referentiels): scope les preuves de mesures a la fenetre de l'audit

### DIFF
--- a/apps/backend/src/referentiels/preuves-archive/generate-preuves-archive/generate-preuves-archive.service.ts
+++ b/apps/backend/src/referentiels/preuves-archive/generate-preuves-archive/generate-preuves-archive.service.ts
@@ -14,6 +14,7 @@ import { ResourceType } from '@tet/domain/users';
 import { getErrorMessage } from '@tet/domain/utils';
 import { GetReferentielService } from '../../get-referentiel/get-referentiel.service';
 import { BuildArchiveService } from '../build-archive/build-archive.service';
+import { type AuditPreuvesWindow } from '../list-audit-preuves/collect-preuves.repository';
 import { ListAuditPreuvesService } from '../list-audit-preuves/list-audit-preuves.service';
 import {
   AuditPreuvesArchiveStatusEnum,
@@ -30,6 +31,7 @@ interface JobContext {
   user: AuthenticatedUser;
   demandeId: number;
   referentielId: ReferentielId;
+  auditWindow: AuditPreuvesWindow;
 }
 
 /**
@@ -166,9 +168,9 @@ export class GeneratePreuvesArchiveService {
       );
     }
 
-    const demandeIdResult = await this.resolveDemandeId(archive.auditId);
-    if (!demandeIdResult.success) {
-      return demandeIdResult;
+    const auditContextResult = await this.resolveAuditContext(archive.auditId);
+    if (!auditContextResult.success) {
+      return auditContextResult;
     }
 
     const referentielIdResult = parseReferentielId(archive.referentielId);
@@ -178,30 +180,36 @@ export class GeneratePreuvesArchiveService {
 
     return success({
       user,
-      demandeId: demandeIdResult.data,
+      demandeId: auditContextResult.data.demandeId,
+      auditWindow: auditContextResult.data.auditWindow,
       referentielId: referentielIdResult.data,
     });
   }
 
-  private async resolveDemandeId(
+  private async resolveAuditContext(
     auditId: number
-  ): Promise<Result<number, GenerateArchiveFailure>> {
+  ): Promise<
+    Result<
+      { demandeId: number; auditWindow: AuditPreuvesWindow },
+      GenerateArchiveFailure
+    >
+  > {
     try {
       const auditDetails = await this.getLabellisationService.getAudit(auditId);
       if (!auditDetails.success) {
         return nonRetryableFailure(`Audit ${auditId} introuvable`);
       }
-      const demandeId = auditDetails.data.demandeId;
+      const { demandeId, dateDebut, dateFin } = auditDetails.data;
       if (demandeId == null) {
         return nonRetryableFailure(
           `Aucune demande de labellisation rattachée à l'audit ${auditId}`
         );
       }
-      return success(demandeId);
+      return success({ demandeId, auditWindow: { dateDebut, dateFin } });
     } catch (error) {
       // L'accès DB peut tomber transitoirement : laisser BullMQ relancer.
       return retryableFailure(
-        `Résolution de la demande échouée: ${getErrorMessage(error)}`
+        `Résolution de l'audit échouée: ${getErrorMessage(error)}`
       );
     }
   }
@@ -215,6 +223,7 @@ export class GeneratePreuvesArchiveService {
       referentielId: context.referentielId,
       auditId: archive.auditId,
       demandeId: context.demandeId,
+      auditWindow: context.auditWindow,
       user: context.user,
     });
     if (!preuvesResult.success) {

--- a/apps/backend/src/referentiels/preuves-archive/list-audit-preuves/collect-preuves.repository.e2e-spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/list-audit-preuves/collect-preuves.repository.e2e-spec.ts
@@ -12,7 +12,7 @@ import {
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { Collectivite } from '@tet/domain/collectivites';
 import { CollectiviteRole } from '@tet/domain/users';
-import { and, eq, like } from 'drizzle-orm';
+import { and, eq, like, sql } from 'drizzle-orm';
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import { PREUVES_ARCHIVES_BUCKET } from '../preuves-archive.constants';
 import { CollectPreuvesRepository } from './collect-preuves.repository';
@@ -115,6 +115,7 @@ describe('CollectPreuvesRepository - filtre confidentiel (SQL réel)', () => {
     const result = await repository.getComplementairePreuves({
       collectiviteId: collectivite.id,
       referentielId: 'cae',
+      auditWindow: { dateDebut: null, dateFin: null },
       canReadConfidentiel: true,
     });
 
@@ -129,6 +130,7 @@ describe('CollectPreuvesRepository - filtre confidentiel (SQL réel)', () => {
     const result = await repository.getComplementairePreuves({
       collectiviteId: collectivite.id,
       referentielId: 'cae',
+      auditWindow: { dateDebut: null, dateFin: null },
       canReadConfidentiel: false,
     });
 
@@ -141,6 +143,7 @@ describe('CollectPreuvesRepository - filtre confidentiel (SQL réel)', () => {
     const result = await repository.getComplementairePreuves({
       collectiviteId: collectivite.id,
       referentielId: 'cae',
+      auditWindow: { dateDebut: null, dateFin: null },
       canReadConfidentiel: false,
     });
 
@@ -248,6 +251,7 @@ describe('CollectPreuvesRepository - scope par référentiel (SQL réel)', () =>
     const result = await repository.getComplementairePreuves({
       collectiviteId: collectivite.id,
       referentielId: 'cae',
+      auditWindow: { dateDebut: null, dateFin: null },
       canReadConfidentiel: true,
     });
 
@@ -260,11 +264,148 @@ describe('CollectPreuvesRepository - scope par référentiel (SQL réel)', () =>
     const result = await repository.getComplementairePreuves({
       collectiviteId: collectivite.id,
       referentielId: 'eci',
+      auditWindow: { dateDebut: null, dateFin: null },
       canReadConfidentiel: true,
     });
 
     expect(result.success).toBe(true);
     if (!result.success) return;
     expect(result.data.files.map((file) => file.hash)).toEqual([eciHash]);
+  });
+});
+
+describe("CollectPreuvesRepository - scope par fenetre d'audit (SQL réel)", () => {
+  let app: INestApplication;
+  let db: DatabaseService;
+  let repository: CollectPreuvesRepository;
+  let collectivite: Collectivite;
+  let adminUserId: string;
+  let cleanupCollectivite: () => Promise<void>;
+
+  const dateDebut = '2024-01-01T00:00:00Z';
+  const dateFin = '2024-12-31T23:59:59Z';
+
+  let avantHash: string;
+  let dansHash: string;
+  let apresHash: string;
+  let futurHash: string;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    db = await getTestDatabase(app);
+    repository = app.get(CollectPreuvesRepository);
+
+    const fixture = await addTestCollectiviteAndUser(db, {
+      user: { role: CollectiviteRole.ADMIN },
+    });
+    collectivite = fixture.collectivite;
+    adminUserId = getAuthUserFromUserCredentials(fixture.user).id;
+    cleanupCollectivite = fixture.cleanup;
+
+    avantHash = `hash-avant-${collectivite.id}`;
+    dansHash = `hash-dans-${collectivite.id}`;
+    apresHash = `hash-apres-${collectivite.id}`;
+    futurHash = `hash-futur-${collectivite.id}`;
+
+    await db.db
+      .insert(collectiviteBucketTable)
+      .values({ bucketId: PREUVES_ARCHIVES_BUCKET, collectiviteId: collectivite.id });
+
+    const preuvesFixtures = [
+      { hash: avantHash, modifiedAt: '2023-06-01T00:00:00Z' },
+      { hash: dansHash, modifiedAt: '2024-06-15T00:00:00Z' },
+      { hash: apresHash, modifiedAt: '2025-06-01T00:00:00Z' },
+      { hash: futurHash, modifiedAt: '2099-01-01T00:00:00Z' },
+    ];
+
+    const fichiers = await db.db
+      .insert(bibliothequeFichierTable)
+      .values(
+        preuvesFixtures.map(({ hash }) => ({
+          collectiviteId: collectivite.id,
+          hash,
+          filename: `${hash}.pdf`,
+          confidentiel: false,
+        }))
+      )
+      .returning();
+
+    await db.db.insert(storageObjectTable).values(
+      fichiers.map((fichier) => ({
+        bucketId: PREUVES_ARCHIVES_BUCKET,
+        name: fichier.hash,
+        metadata: { size: 1024 },
+      }))
+    );
+
+    const preuves = await db.db
+      .insert(preuveComplementaireTable)
+      .values(
+        fichiers.map((fichier) => ({
+          collectiviteId: collectivite.id,
+          actionId: 'cae_1.1.3',
+          fichierId: fichier.id,
+          modifiedBy: adminUserId,
+        }))
+      )
+      .returning({ id: preuveComplementaireTable.id });
+
+    await db.db.transaction(async (tx) => {
+      await tx.execute(sql`set local session_replication_role = replica`);
+      await preuves.reduce(async (previous, preuve, index) => {
+        await previous;
+        await tx
+          .update(preuveComplementaireTable)
+          .set({ modifiedAt: preuvesFixtures[index].modifiedAt })
+          .where(eq(preuveComplementaireTable.id, preuve.id));
+      }, Promise.resolve());
+    });
+  });
+
+  afterAll(async () => {
+    await db.db
+      .delete(preuveComplementaireTable)
+      .where(eq(preuveComplementaireTable.collectiviteId, collectivite.id));
+    await db.db
+      .delete(storageObjectTable)
+      .where(
+        and(
+          eq(storageObjectTable.bucketId, PREUVES_ARCHIVES_BUCKET),
+          like(storageObjectTable.name, `%${collectivite.id}`)
+        )
+      );
+    await db.db
+      .delete(bibliothequeFichierTable)
+      .where(eq(bibliothequeFichierTable.collectiviteId, collectivite.id));
+    await cleanupCollectivite();
+    await app.close();
+  });
+
+  test('fenetre [date_debut, date_fin] : ne renvoie que la preuve modifiée dans la fenetre', async () => {
+    const result = await repository.getComplementairePreuves({
+      collectiviteId: collectivite.id,
+      referentielId: 'cae',
+      auditWindow: { dateDebut, dateFin },
+      canReadConfidentiel: true,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.files.map((file) => file.hash)).toEqual([dansHash]);
+  });
+
+  test('date_fin null : borne haute = now(), exclut une preuve future', async () => {
+    const result = await repository.getComplementairePreuves({
+      collectiviteId: collectivite.id,
+      referentielId: 'cae',
+      auditWindow: { dateDebut, dateFin: null },
+      canReadConfidentiel: true,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.files.map((file) => file.hash).sort()).toEqual(
+      [dansHash, apresHash].sort()
+    );
   });
 });

--- a/apps/backend/src/referentiels/preuves-archive/list-audit-preuves/collect-preuves.repository.ts
+++ b/apps/backend/src/referentiels/preuves-archive/list-audit-preuves/collect-preuves.repository.ts
@@ -12,7 +12,18 @@ import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { failure, success, type Result } from '@tet/backend/utils/result.type';
 import { ReferentielId } from '@tet/domain/referentiels';
 import { getErrorMessage } from '@tet/domain/utils';
-import { and, eq, inArray, isNull, or, sql, type Column, type SQL } from 'drizzle-orm';
+import {
+  and,
+  eq,
+  gte,
+  inArray,
+  isNull,
+  lte,
+  or,
+  sql,
+  type Column,
+  type SQL,
+} from 'drizzle-orm';
 import { z } from 'zod';
 import {
   PreuvesArchiveErrorEnum,
@@ -43,6 +54,11 @@ type CollectedPreuves = {
   links: CollectedLinkPreuve[];
 };
 
+export interface AuditPreuvesWindow {
+  dateDebut: string | null;
+  dateFin: string | null;
+}
+
 @Injectable()
 export class CollectPreuvesRepository {
   private readonly db = this.database.db;
@@ -53,9 +69,11 @@ export class CollectPreuvesRepository {
   async getComplementairePreuves(input: {
     collectiviteId: number;
     referentielId: ReferentielId;
+    auditWindow: AuditPreuvesWindow;
     canReadConfidentiel: boolean;
   }): Promise<Result<CollectedPreuves, PreuvesArchiveError>> {
-    const { collectiviteId, referentielId, canReadConfidentiel } = input;
+    const { collectiviteId, referentielId, auditWindow, canReadConfidentiel } =
+      input;
     try {
       const rows = await this.db
         .select({
@@ -94,6 +112,10 @@ export class CollectPreuvesRepository {
         .where(
           and(
             eq(preuveComplementaireTable.collectiviteId, collectiviteId),
+            this.auditWindowFilter(
+              preuveComplementaireTable.modifiedAt,
+              auditWindow
+            ),
             this.hideConfidentielFilter(
               preuveComplementaireTable.fichierId,
               canReadConfidentiel
@@ -116,9 +138,11 @@ export class CollectPreuvesRepository {
   async getReglementairePreuves(input: {
     collectiviteId: number;
     referentielId: ReferentielId;
+    auditWindow: AuditPreuvesWindow;
     canReadConfidentiel: boolean;
   }): Promise<Result<CollectedPreuves, PreuvesArchiveError>> {
-    const { collectiviteId, referentielId, canReadConfidentiel } = input;
+    const { collectiviteId, referentielId, auditWindow, canReadConfidentiel } =
+      input;
     try {
       const rows = await this.db
         .select({
@@ -161,6 +185,10 @@ export class CollectPreuvesRepository {
         .where(
           and(
             eq(preuveReglementaireTable.collectiviteId, collectiviteId),
+            this.auditWindowFilter(
+              preuveReglementaireTable.modifiedAt,
+              auditWindow
+            ),
             this.hideConfidentielFilter(
               preuveReglementaireTable.fichierId,
               canReadConfidentiel
@@ -292,6 +320,17 @@ export class CollectPreuvesRepository {
         error instanceof Error ? error : new Error(getErrorMessage(error))
       );
     }
+  }
+
+  private auditWindowFilter(
+    modifiedAtColumn: Column,
+    auditWindow: AuditPreuvesWindow
+  ): SQL | undefined {
+    const apresDebut = auditWindow.dateDebut
+      ? gte(modifiedAtColumn, auditWindow.dateDebut)
+      : undefined;
+    const avantFin = lte(modifiedAtColumn, auditWindow.dateFin ?? sql`now()`);
+    return and(apresDebut, avantFin);
   }
 
   private storageObjectInCollectiviteBuckets(collectiviteId: number): SQL {

--- a/apps/backend/src/referentiels/preuves-archive/list-audit-preuves/list-audit-preuves.service.spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/list-audit-preuves/list-audit-preuves.service.spec.ts
@@ -12,11 +12,17 @@ const user = { id: 'user-id' } as AuthenticatedUser;
 
 const referentielId: ReferentielId = 'cae';
 
+const auditWindow = {
+  dateDebut: '2024-01-01T00:00:00Z',
+  dateFin: '2024-12-31T23:59:59Z',
+};
+
 const baseInput = {
   collectiviteId: 1,
   referentielId,
   auditId: 10,
   demandeId: 20,
+  auditWindow,
   user,
 };
 
@@ -115,6 +121,20 @@ describe('ListAuditPreuvesService', () => {
     );
     expect(getReglementairePreuves).toHaveBeenCalledWith(
       expect.objectContaining({ referentielId })
+    );
+  });
+
+  it("transmet la fenetre de l'audit aux collectes mesure (complémentaire et réglementaire)", async () => {
+    const { service, getComplementairePreuves, getReglementairePreuves } =
+      buildService();
+
+    await service.list(baseInput);
+
+    expect(getComplementairePreuves).toHaveBeenCalledWith(
+      expect.objectContaining({ auditWindow })
+    );
+    expect(getReglementairePreuves).toHaveBeenCalledWith(
+      expect.objectContaining({ auditWindow })
     );
   });
 

--- a/apps/backend/src/referentiels/preuves-archive/list-audit-preuves/list-audit-preuves.service.ts
+++ b/apps/backend/src/referentiels/preuves-archive/list-audit-preuves/list-audit-preuves.service.ts
@@ -11,6 +11,7 @@ import {
 } from '../preuves-archive.errors';
 import {
   CollectPreuvesRepository,
+  type AuditPreuvesWindow,
   type CollectedFilePreuve,
   type CollectedLinkPreuve,
 } from './collect-preuves.repository';
@@ -31,6 +32,7 @@ export interface ListPreuvesForAuditInput {
   referentielId: ReferentielId;
   demandeId: number;
   auditId: number;
+  auditWindow: AuditPreuvesWindow;
   user: AuthenticatedUser;
 }
 
@@ -46,7 +48,14 @@ export class ListAuditPreuvesService {
   async list(
     input: ListPreuvesForAuditInput
   ): Promise<Result<PreuvesByOrigin, PreuvesArchiveError>> {
-    const { collectiviteId, referentielId, demandeId, auditId, user } = input;
+    const {
+      collectiviteId,
+      referentielId,
+      demandeId,
+      auditId,
+      auditWindow,
+      user,
+    } = input;
 
     try {
       const canReadConfidentiel = await this.permissions.isAllowed(
@@ -62,11 +71,13 @@ export class ListAuditPreuvesService {
           this.repository.getComplementairePreuves({
             collectiviteId,
             referentielId,
+            auditWindow,
             canReadConfidentiel,
           }),
           this.repository.getReglementairePreuves({
             collectiviteId,
             referentielId,
+            auditWindow,
             canReadConfidentiel,
           }),
           this.repository.getLabellisationPreuves({


### PR DESCRIPTION
## Contexte

Lors du téléchargement de l'archive des preuves d'un audit, les preuves de mesures (complémentaires + réglementaires) n'étaient scopées que par référentiel (cf. #039e03036). Une même collectivité accumulant des preuves au fil de plusieurs cycles d'audit, l'archive d'un audit donné remontait des preuves hors de son périmètre temporel.

## Changement

Les preuves de mesures sont désormais filtrées sur `modified_at` dans la fenêtre de l'audit : `[date_debut, COALESCE(date_fin, now())]`, en plus du référentiel.

- `audit en cours` (`date_fin` null) → borne haute = `now()` (toutes les preuves courantes)
- `audit clos` → borne haute = `date_fin` (snapshot à la clôture)

Les preuves de demande et d'audit restent scopées par `demandeId` / `auditId` (inchangé).

Côté flux : `resolveDemandeId` devient `resolveAuditContext` (récupère `demandeId` + dates en un seul `getAudit`), `auditWindow` est propagé du worker → `ListAuditPreuvesService` → `CollectPreuvesRepository`.

## Tests

- `collect-preuves.repository.e2e-spec.ts` : nouveau bloc `scope par fenetre d'audit` (fenêtre fermée → seule la preuve dans la fenêtre ; `date_fin` null → borne haute `now()`, exclut une preuve future). Le rouge a été vérifié en neutralisant le filtre.
- `list-audit-preuves.service.spec.ts` : propagation de `auditWindow` aux collectes mesure.

Note : un trigger `BEFORE INSERT OR UPDATE` force `modified_at = now()` sur les tables de preuves (ce qui fait fonctionner la feature en prod). La fixture e2e contourne ce trigger via `set local session_replication_role = replica` pour injecter des timestamps historiques.