### PR TITLE
feat(authorizations): conserve le rôle auditeur 15 jours après la clôture de l'audit

### DIFF
--- a/apps/backend/src/users/authorizations/get-user-roles-and-permissions/get-user-roles-and-permissions.repository.ts
+++ b/apps/backend/src/users/authorizations/get-user-roles-and-permissions/get-user-roles-and-permissions.repository.ts
@@ -9,8 +9,9 @@ import { dcpTable } from '@tet/backend/users/models/dcp.table';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { Transaction } from '@tet/backend/utils/database/transaction.utils';
 import { CollectivitePreferences } from '@tet/domain/collectivites';
+import { AUDIT_REPORT_EDIT_WINDOW_DAYS } from '@tet/domain/referentiels';
 import { CollectiviteRole } from '@tet/domain/users';
-import { and, eq, sql } from 'drizzle-orm';
+import { and, eq, gt, or, sql } from 'drizzle-orm';
 
 export type PlatformRolesRow = {
   isVerified: boolean;
@@ -121,7 +122,16 @@ export class GetUserRolesAndPermissionsRepository {
         eq(collectiviteTable.id, auditTable.collectiviteId)
       )
       .where(
-        and(eq(auditeurTable.auditeur, userId), eq(auditTable.clos, false))
+        and(
+          eq(auditeurTable.auditeur, userId),
+          or(
+            eq(auditTable.clos, false),
+            gt(
+              auditTable.dateFin,
+              sql`now() - make_interval(days => ${AUDIT_REPORT_EDIT_WINDOW_DAYS})`
+            )
+          )
+        )
       )
       .orderBy(collectiviteTable.nom);
   }

--- a/apps/backend/src/users/authorizations/get-user-roles-and-permissions/get-user-roles-and-permissions.router.e2e-spec.ts
+++ b/apps/backend/src/users/authorizations/get-user-roles-and-permissions/get-user-roles-and-permissions.router.e2e-spec.ts
@@ -1,5 +1,6 @@
 import { INestApplication } from '@nestjs/common';
 import { addTestCollectiviteAndUser } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { auditTable } from '@tet/backend/referentiels/labellisations/audit.table';
 import { addAuditeurPermission } from '@tet/backend/referentiels/labellisations/labellisations.test-fixture';
 import { createAuditWithOnTestFinished } from '@tet/backend/referentiels/referentiels.test-fixture';
 import { getAuthUser, getTestApp } from '@tet/backend/test';
@@ -12,6 +13,7 @@ import {
   permissionsByRole,
   PlatformRole,
 } from '@tet/domain/users';
+import { eq } from 'drizzle-orm';
 
 describe('GetUserPermissions', () => {
   let app: INestApplication;
@@ -156,5 +158,88 @@ describe('GetUserPermissions', () => {
         ],
       },
     ]);
+  });
+
+  test("Conserve le rôle auditeur pendant 15 jours après la clôture de l'audit", async () => {
+    const { collectivite, user, cleanup } = await addTestCollectiviteAndUser(
+      databaseService,
+      {
+        user: {
+          role: CollectiviteRole.EDITION,
+        },
+      }
+    );
+    onTestFinished(cleanup);
+
+    const { audit } = await createAuditWithOnTestFinished({
+      databaseService,
+      collectiviteId: collectivite.id,
+      referentielId: ReferentielIdEnum.CAE,
+      clos: true,
+    });
+
+    await addAuditeurPermission({
+      databaseService,
+      auditId: audit.id,
+      userId: user.id,
+    });
+
+    const caller = router.createCaller({ user: await getAuthUser(user) });
+
+    const result = await caller.users.users.get();
+
+    const auditeeCollectivite = result.collectivites.find(
+      (c) => c.collectiviteId === collectivite.id
+    );
+    expect(auditeeCollectivite?.audits).toEqual([
+      {
+        auditId: audit.id,
+        role: AuditRole.AUDITEUR,
+        permissions: permissionsByRole[AuditRole.AUDITEUR],
+      },
+    ]);
+  });
+
+  test("Retire le rôle auditeur plus de 15 jours après la clôture de l'audit", async () => {
+    const { collectivite, user, cleanup } = await addTestCollectiviteAndUser(
+      databaseService,
+      {
+        user: {
+          role: CollectiviteRole.EDITION,
+        },
+      }
+    );
+    onTestFinished(cleanup);
+
+    const { audit } = await createAuditWithOnTestFinished({
+      databaseService,
+      collectiviteId: collectivite.id,
+      referentielId: ReferentielIdEnum.CAE,
+      clos: true,
+    });
+
+    await databaseService.db
+      .update(auditTable)
+      .set({
+        dateFin: new Date(
+          Date.now() - 16 * 24 * 60 * 60 * 1000
+        ).toISOString(),
+      })
+      .where(eq(auditTable.id, audit.id));
+
+    await addAuditeurPermission({
+      databaseService,
+      auditId: audit.id,
+      userId: user.id,
+    });
+
+    const caller = router.createCaller({ user: await getAuthUser(user) });
+
+    const result = await caller.users.users.get();
+
+    const auditeeCollectivite = result.collectivites.find(
+      (c) => c.collectiviteId === collectivite.id
+    );
+    expect(auditeeCollectivite?.audits).toEqual([]);
   });
 });

--- a/packages/domain/src/referentiels/labellisations/labellisation-audit.schema.ts
+++ b/packages/domain/src/referentiels/labellisations/labellisation-audit.schema.ts
@@ -15,3 +15,5 @@ export const labellisationAuditSchema = z.object({
 });
 
 export type LabellisationAudit = z.infer<typeof labellisationAuditSchema>;
+
+export const AUDIT_REPORT_EDIT_WINDOW_DAYS = 15;


### PR DESCRIPTION
## Nature & impact
`feat` — **changement de permission (authz) prod, hors feature flag.** `getUserRolesAndPermissions` est consommé par toutes les requêtes ; ce diff change directement les rôles renvoyés en production.

## Le changement
Le rôle **auditeur** était accordé uniquement tant que l'audit n'était pas clos (`eq(audit.clos, false)`). Il est désormais aussi conservé pendant une **fenêtre de 15 jours après la date de fin**, pour permettre le remplacement du rapport d'audit :

```
- eq(auditeur, userId) AND clos = false
+ eq(auditeur, userId) AND ( clos = false OR dateFin > now() - 15 jours )
```

Constante `AUDIT_REPORT_EDIT_WINDOW_DAYS = 15` (nouvelle, `packages/domain`).

## ⚠️ Limite connue (à arbitrer produit)
La fenêtre restitue le rôle **auditeur plein** (avec `referentiels.mutate`) pendant 15 j, alors que le besoin métier ne concerne que le **remplacement du rapport**. L'auditeur peut donc, pendant cette fenêtre, modifier statuts/scores au-delà du seul rapport. Hypothèse prise faute de décision produit : prolongation simple du rôle existant. Le durcissement (rôle post-clôture dégradé / permission dédiée `modify_validated_audit_report`) est à trancher séparément — cf. `DISCOVERED.md`.

## Surface de review
| Fichier | Attention |
|---|---|
| `backend/.../get-user-roles-and-permissions.repository.ts` | **humaine** (requête de permission) |
| `domain/.../labellisation-audit.schema.ts` | mécanique (constante `= 15`) |
| `backend/.../get-user-roles-and-permissions.router.e2e-spec.ts` | humaine (2 cas : conservé à J+x, retiré au-delà de 15 j) |

## Tests
- e2e : rôle **conservé** sur un audit clos récent ; **retiré** quand `dateFin` est antérieure à 15 j (mise à jour `dateFin` inline dans le test).

## Vérifications
- `nx run backend:typecheck` (= CI) → 0 erreur ; `nx build domain` → OK ; `eslint` → 0.
- ⚠️ e2e non exécuté localement → CI.

## Closure
3 fichiers, indépendant. La constante s'auto-exporte (`labellisation-audit.schema` déjà dans le barrel domain). Aucun helper fixture neuf (`createAuditWithOnTestFinished` existant + `db.update` inline).

## Reviewers suggérés
`security-sentinel` (élargissement de permission / authz).