### PR TITLE
feat(preuves): remplacement du rapport d'audit par l'auditeur (endpoint à check fin)

### DIFF
--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/new/[referentielId]/(overview)/@tabs/tabs-wrapper.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/new/[referentielId]/(overview)/@tabs/tabs-wrapper.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useGetAuditStatusBadge } from '@/app/referentiels/audit-labellisation/audit-badge-status/use-get-audit-status-badge';
+import { useGetAuditBadge } from '@/app/referentiels/audit-labellisation/audit-badge-status/use-get-audit-badge';
 import { useChecklist } from '@/app/referentiels/audit-labellisation/checklist.context';
 import { useIsVisitor } from '@/app/users/authorizations/use-is-visitor';
 import { Spacer, VisibleWhen } from '@tet/ui';
@@ -14,7 +14,7 @@ import { PropsWithChildren } from 'react';
 
 export const TabsWrapper = ({ children }: PropsWithChildren) => {
   const isVisitor = useIsVisitor();
-  const auditBadge = useGetAuditStatusBadge();
+  const auditBadge = useGetAuditBadge();
   const { cycle } = useChecklist();
   const showAuditConductTabs = cycle.isConductingAudit;
 

--- a/apps/app/src/app/pages/collectivite/BibliothequeDocs/PreuveLabellisation.tsx
+++ b/apps/app/src/app/pages/collectivite/BibliothequeDocs/PreuveLabellisation.tsx
@@ -1,14 +1,19 @@
 import { appLabels } from '@/app/labels/catalog';
 import { referentielToName } from '@/app/app/labels';
-import PreuveDoc from '@/app/referentiels/preuves/Bibliotheque/PreuveDoc';
+import CarteDocument from '@/app/referentiels/preuves/Bibliotheque/CarteDocument';
+import { useCurrentCollectivite } from '@tet/api/collectivites';
+import { useUser } from '@tet/api/users';
+import { canUserUpdateAuditReport } from '@/app/referentiels/preuves/Bibliotheque/canUserUpdateAuditReport';
 import { TPreuveAuditEtLabellisation } from '@/app/referentiels/preuves/Bibliotheque/types';
+import { TAuditEnCours } from '@/app/referentiels/audits/types';
 import {
+  canUserUpdateCandidatureDocuments,
   Etoile,
   getParcoursLabellisationStatus,
   ReferentielId,
 } from '@tet/domain/referentiels';
+import { UserRolesAndPermissions } from '@tet/domain/users';
 import { Fragment } from 'react';
-import { useIsAuditAuditeur } from '../../../../referentiels/audits/useAudit';
 import { numLabels } from '../../../../referentiels/labellisations/numLabels';
 import { groupeParReferentielEtDemande } from './groupeParReferentielEtDemande';
 
@@ -83,23 +88,44 @@ const DocAuditOuLabellisation = ({
   preuve: TPreuveAuditEtLabellisation;
   info: TCycleInfo;
 }) => {
-  const { audit } = preuve;
-  const { status } = info;
-  const isAuditeur = useIsAuditAuditeur(audit?.id ?? undefined);
+  const { hasCollectivitePermission } = useCurrentCollectivite();
+  const user = useUser();
 
-  // le document n'est pas éditable si...
-  const readonly =
-    // ... c'est le rapport d’un audit en cours et l'utilisateur n'est pas auditeur
-    (preuve.preuve_type === 'audit' &&
-      status === 'audit_en_cours' &&
-      !isAuditeur) ||
-    //... ou si l'audit est validé
-    status === 'audit_valide' ||
-    false;
+  const canUpdate = canUpdateAuditOrLabellisationPreuve({
+    preuve,
+    user,
+    audit: info.audit,
+    canMutateReferentiels: hasCollectivitePermission('referentiels.mutate'),
+  });
 
   return (
-    <PreuveDoc preuve={preuve} readonly={readonly} classComment="pb-0 mb-2" />
+    <CarteDocument
+      document={preuve}
+      isReadonly={!canUpdate}
+      classComment="pb-0 mb-2"
+    />
   );
+};
+
+const canUpdateAuditOrLabellisationPreuve = ({
+  preuve,
+  user,
+  audit,
+  canMutateReferentiels,
+}: {
+  preuve: TPreuveAuditEtLabellisation;
+  user: UserRolesAndPermissions;
+  audit: TAuditEnCours | null;
+  canMutateReferentiels: boolean;
+}): boolean => {
+  if (preuve.preuve_type === 'audit') {
+    return canUserUpdateAuditReport(user, preuve);
+  }
+  return canUserUpdateCandidatureDocuments({
+    preuveType: preuve.preuve_type,
+    canMutateReferentiels,
+    audit,
+  });
 };
 
 /**

--- a/apps/app/src/referentiels/audit-labellisation/audit-badge-status/use-get-audit-badge.ts
+++ b/apps/app/src/referentiels/audit-labellisation/audit-badge-status/use-get-audit-badge.ts
@@ -16,7 +16,7 @@ const badgeByStatus: Record<
   },
 };
 
-export function useGetAuditStatusBadge(): Omit<BadgeProps, 'size'> | null {
+export function useGetAuditBadge(): Omit<BadgeProps, 'size'> | null {
   const { cycle } = useChecklist();
 
   const status = parcoursToAuditBadgeStatus({

--- a/apps/app/src/referentiels/audits/types.ts
+++ b/apps/app/src/referentiels/audits/types.ts
@@ -9,6 +9,7 @@ export type TAuditEnCours = ObjectToSnake<
     | 'demandeId'
     | 'dateDebut'
     | 'dateFin'
+    | 'clos'
     | 'valide'
     | 'referentielId'
   >

--- a/apps/app/src/referentiels/audits/useAudit.ts
+++ b/apps/app/src/referentiels/audits/useAudit.ts
@@ -2,7 +2,6 @@ import {
   useCollectiviteId,
   useCurrentCollectivite,
 } from '@tet/api/collectivites';
-import { useUser } from '@tet/api/users';
 import { useLabellisationParcours } from '../labellisations/useLabellisationParcours';
 import { useReferentielId } from '../referentiel-context';
 
@@ -39,19 +38,6 @@ export const useAuditeurs = () => {
     referentielId: referentiel,
   });
   return { data: parcours?.auditeurs };
-};
-
-/** Indique si l'utilisateur courant est l'auditeur d'un audit donné */
-export const useIsAuditAuditeur = (audit_id?: number) => {
-  const user = useUser();
-
-  if (!audit_id) {
-    return false;
-  }
-
-  return user.collectivites.some((collectivite) =>
-    collectivite.audits.some((audit) => audit.auditId === audit_id)
-  );
 };
 
 /** Détermine si la description de l'action doit être affichée dans la page

--- a/apps/app/src/referentiels/preuves/Bibliotheque/CarteDocument.tsx
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/CarteDocument.tsx
@@ -1,11 +1,22 @@
 import { appLabels } from '@/app/labels/catalog';
+import { AddPreuveModal } from '@/app/referentiels/preuves/AddPreuveModal';
 import {
   getTextFormattedDate,
   getTruncatedText,
 } from '@/app/utils/formatUtils';
-import { Button, Card, Icon, Notification, Tooltip, VisibleWhen } from '@tet/ui';
+import {
+  Button,
+  Card,
+  Icon,
+  Modal,
+  Notification,
+  Tooltip,
+  VisibleWhen,
+} from '@tet/ui';
+import { useUser } from '@tet/api/users';
 import classNames from 'classnames';
 import { useState } from 'react';
+import { canUserUpdateAuditReport } from './canUserUpdateAuditReport';
 import AlerteSuppression from './AlerteSuppression';
 import DocumentInput from './DocumentInput';
 import { EditerDocumentModal } from './EditerDocumentModal';
@@ -14,6 +25,7 @@ import MenuCarteDocument from './MenuCarteDocument';
 import { openPreuve } from './openPreuve';
 import { TPreuve } from './types';
 import { useEditPreuve } from './useEditPreuve';
+import { useReplaceAuditReportFile } from './useReplaceAuditReportFile';
 import { getAuthorAndDate, getFormattedTitle } from './utils';
 
 const EditPreuveModal = ({
@@ -30,6 +42,25 @@ const EditPreuveModal = ({
   ) : (
     <EditerLienModal isOpen={isOpen} setIsOpen={setIsOpen} preuve={preuve} />
   );
+
+const ReplaceAuditReportModal = ({
+  isOpen,
+  setIsOpen,
+  onReplace,
+}: {
+  isOpen: boolean;
+  setIsOpen: (open: boolean) => void;
+  onReplace: (fichierId: number) => Promise<void>;
+}) => (
+  <Modal
+    size="lg"
+    openState={{ isOpen, setIsOpen }}
+    title={appLabels.remplacerLeFichier}
+    render={({ close }) => (
+      <AddPreuveModal onClose={close} handlers={{ addFileFromLib: onReplace }} />
+    )}
+  />
+);
 
 type CarteDocumentProps = {
   isReadonly: boolean;
@@ -54,14 +85,23 @@ const CarteDocument = ({
     rapport,
   } = document;
   const dateVisite = rapport?.date;
+  const isAuditReport = document.preuve_type === 'audit';
+  const replaceAuditReport = useReplaceAuditReportFile(
+    document.collectivite_id
+  );
+  const user = useUser();
+  const canShowReplace = canUserUpdateAuditReport(user, document);
 
   const handlers = useEditPreuve(document);
   const { remove, editComment } = handlers;
 
-  const [isDeleting, setIsDeleting] = useState(false);
-  const [isEditOpen, setIsEditOpen] = useState(false);
+  const [openAction, setOpenAction] = useState<
+    'edit' | 'replace' | 'delete' | null
+  >(null);
+  const closeAction = () => setOpenAction(null);
   const [isFullCommentaire, setIsFullCommentaire] = useState(false);
-  const isEditing = editComment.isEditing;
+  const isEditingComment = editComment.isEditing;
+  const hasAtLeastOneAction = !isReadonly || canShowReplace;
 
   const { truncatedText: truncatedCom, isTextTruncated: isComTruncated } =
     getTruncatedText(commentaire, 160);
@@ -84,14 +124,20 @@ const CarteDocument = ({
             </div>
           </Tooltip>
         )}
-        {!isReadonly && !isEditing && (
+        {hasAtLeastOneAction && !isEditingComment && (
           <MenuCarteDocument
             document={document}
             className="absolute top-4 right-4 invisible group-hover:visible"
             actions={{
-              edit: () => setIsEditOpen(true),
-              comment: () => editComment.enter(),
-              delete: () => setIsDeleting(true),
+              edit: !isReadonly ? () => setOpenAction('edit') : undefined,
+              comment: !isReadonly ? () => editComment.enter() : undefined,
+              replace: canShowReplace
+                ? () => setOpenAction('replace')
+                : undefined,
+              delete:
+                !isReadonly && !isAuditReport
+                  ? () => setOpenAction('delete')
+                  : undefined,
             }}
           />
         )}
@@ -118,7 +164,7 @@ const CarteDocument = ({
             {getAuthorAndDate(dateCreation, auteur)}
           </span>
 
-          {!editComment.isEditing ? (
+          {!isEditingComment ? (
             !!commentaire &&
             commentaire.length > 0 && (
               <div className="flex flex-col gap-2 leading-5">
@@ -174,10 +220,10 @@ const CarteDocument = ({
         </Card>
       </div>
 
-      {isDeleting && !isReadonly && (
+      {openAction === 'delete' && !isReadonly && (
         <AlerteSuppression
           isOpen={true}
-          setIsOpen={setIsDeleting}
+          setIsOpen={closeAction}
           title={appLabels.supprimerDocument}
           message={appLabels.supprimerDocumentMessage}
           onDelete={() => {
@@ -186,11 +232,24 @@ const CarteDocument = ({
         />
       )}
 
-      <VisibleWhen condition={isEditOpen}>
+      <VisibleWhen condition={openAction === 'edit'}>
         <EditPreuveModal
-          isOpen={isEditOpen}
-          setIsOpen={setIsEditOpen}
+          isOpen={openAction === 'edit'}
+          setIsOpen={closeAction}
           preuve={document}
+        />
+      </VisibleWhen>
+
+      <VisibleWhen condition={openAction === 'replace'}>
+        <ReplaceAuditReportModal
+          isOpen={openAction === 'replace'}
+          setIsOpen={closeAction}
+          onReplace={async (fichierId) => {
+            await replaceAuditReport.mutateAsync({
+              preuveId: document.id,
+              fichierId,
+            });
+          }}
         />
       </VisibleWhen>
     </>

--- a/apps/app/src/referentiels/preuves/Bibliotheque/EditerDocumentModal.tsx
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/EditerDocumentModal.tsx
@@ -1,12 +1,20 @@
 import { Field, Input, Modal, ModalFooterOKCancel } from '@tet/ui';
 import { useState } from 'react';
 import { CheckboxConfidentiel } from '../AddPreuveModal/CheckboxConfidentiel';
-import { TPreuve } from './types';
+import { TBibliothequeFichier, TPreuveType } from './types';
 import { useUpdateBibliothequeFichier } from './useEditPreuve';
 import { useEditFilenameState } from './useEditState';
 
 export type EditerDocumentProps = {
-  preuve: Pick<TPreuve, 'fichier' | 'preuve_type' | 'collectivite_id'>;
+  preuve: {
+    collectivite_id: number;
+    preuve_type: TPreuveType;
+    fichier:
+      | (Pick<TBibliothequeFichier, 'filename' | 'hash'> & {
+          confidentiel: boolean | null;
+        })
+      | null;
+  };
   isOpen: boolean;
   setIsOpen: (opened: boolean) => void;
 };

--- a/apps/app/src/referentiels/preuves/Bibliotheque/canUserUpdateAuditReport.ts
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/canUserUpdateAuditReport.ts
@@ -1,0 +1,21 @@
+import { canUpdateAuditReport } from '@tet/domain/referentiels';
+import { isUserAuditeurForAudit, UserRolesAndPermissions } from '@tet/domain/users';
+import { TPreuve } from './types';
+
+export const canUserUpdateAuditReport = (
+  user: UserRolesAndPermissions,
+  preuve: TPreuve
+): boolean => {
+  if (preuve.preuve_type !== 'audit' || preuve.audit === null) {
+    return false;
+  }
+  return canUpdateAuditReport({
+    isAuditeur: isUserAuditeurForAudit(user, preuve.audit.id),
+    audit: {
+      clos: preuve.audit.clos,
+      valide: preuve.audit.valide,
+      dateFin: preuve.audit.date_fin,
+    },
+    now: new Date(),
+  });
+};

--- a/apps/app/src/referentiels/preuves/Bibliotheque/useEditPreuve.ts
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/useEditPreuve.ts
@@ -194,6 +194,10 @@ export const useUpdateBibliothequeFichier = () => {
         queryClient.invalidateQueries({
           queryKey: trpc.plans.fiches.ficheAnnexes.pathKey(),
         });
+        queryClient.invalidateQueries({
+          queryKey:
+            trpc.referentiels.labellisations.listPreuvesLabellisation.pathKey(),
+        });
       },
     })
   );

--- a/apps/app/src/referentiels/preuves/Bibliotheque/useReplaceAuditReportFile.ts
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/useReplaceAuditReportFile.ts
@@ -1,0 +1,22 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useTRPC } from '@tet/api';
+import { invalidateQueries } from '../useAddPreuves';
+
+export const useReplaceAuditReportFile = (collectiviteId: number) => {
+  const queryClient = useQueryClient();
+  const trpc = useTRPC();
+
+  return useMutation(
+    trpc.referentiels.labellisations.updateAuditReport.mutationOptions({
+      onSuccess: () => {
+        invalidateQueries(queryClient, collectiviteId, {
+          invalidateParcours: false,
+          trpc,
+        });
+        queryClient.invalidateQueries({
+          queryKey: trpc.referentiels.labellisations.listPreuvesAudit.pathKey(),
+        });
+      },
+    })
+  );
+};

--- a/apps/app/src/referentiels/preuves/useAddPreuves.ts
+++ b/apps/app/src/referentiels/preuves/useAddPreuves.ts
@@ -121,6 +121,11 @@ export const useAddPreuveAudit = () => {
         invalidateParcours: true,
         trpc,
       });
+      queryClient.invalidateQueries({
+        queryKey: trpc.referentiels.labellisations.listPreuvesAudit.queryKey({
+          auditId: variables.auditId,
+        }),
+      });
     },
   });
 };

--- a/apps/app/src/referentiels/referentiel.table/referentiel-table.audit-notes.cell/referentiel-table.audit-notes.cell.tsx
+++ b/apps/app/src/referentiels/referentiel.table/referentiel-table.audit-notes.cell/referentiel-table.audit-notes.cell.tsx
@@ -24,17 +24,17 @@ const AuditNotesPanelTitle = ({ identifiant }: { identifiant: string }) => (
 
 const AuditNotesPanelEditor = ({
   auditStatut,
-  canEditAudit,
+  canUpdateAudit,
   updateMesureAuditStatut,
 }: {
   auditStatut: MesureAuditStatutRow;
-  canEditAudit: boolean;
+  canUpdateAudit: boolean;
   updateMesureAuditStatut: UpdateMesureAuditStatut;
 }) => (
   <div className="px-6 py-4">
     <RichTextEditor
       initialValue={auditStatut.avis}
-      disabled={!canEditAudit}
+      disabled={!canUpdateAudit}
       onBlurTextChanged={(value: string) =>
         updateMesureAuditStatut({
           collectiviteId: auditStatut.collectiviteId,
@@ -50,13 +50,13 @@ function AuditNotesCellContent({
   action,
   cellId,
   auditStatut,
-  canEditAudit,
+  canUpdateAudit,
   updateMesureAuditStatut,
 }: {
   action: ActionListItem;
   cellId: string;
   auditStatut: MesureAuditStatutRow;
-  canEditAudit: boolean;
+  canUpdateAudit: boolean;
   updateMesureAuditStatut: UpdateMesureAuditStatut;
 }) {
   const { setPanel, panel } = useSidePanel();
@@ -82,19 +82,19 @@ function AuditNotesCellContent({
       content: (
         <AuditNotesPanelEditor
           auditStatut={auditStatut}
-          canEditAudit={canEditAudit}
+          canUpdateAudit={canUpdateAudit}
           updateMesureAuditStatut={updateMesureAuditStatut}
         />
       ),
     });
-  }, [isActive, setPanel, action, auditStatut, canEditAudit, updateMesureAuditStatut]);
+  }, [isActive, setPanel, action, auditStatut, canUpdateAudit, updateMesureAuditStatut]);
 
   return (
     <TableCell
       tabIndex={-1}
       data-cell-id={cellId}
       data-inline-edit="true"
-      canEdit={canEditAudit}
+      canEdit={canUpdateAudit}
       placeholder={appLabels.ajouterNote}
       className={cn('cursor-pointer', isActive && 'bg-primary-0')}
       onClick={toggleNotesPanel}
@@ -111,7 +111,7 @@ function AuditNotesCellContent({
 export const ReferentielTableAuditNotesCell = ({ info }: Props) => {
   const action = info.row.original;
   const cellId = info.cell.id;
-  const { auditStatutsByMesureId, canEditAudit, updateMesureAuditStatut } =
+  const { auditStatutsByMesureId, canUpdateAudit, updateMesureAuditStatut } =
     getTableMeta(info.table);
 
   const auditStatut = auditStatutsByMesureId?.[action.actionId];
@@ -125,7 +125,7 @@ export const ReferentielTableAuditNotesCell = ({ info }: Props) => {
       action={action}
       cellId={cellId}
       auditStatut={auditStatut}
-      canEditAudit={canEditAudit ?? false}
+      canUpdateAudit={canUpdateAudit ?? false}
       updateMesureAuditStatut={updateMesureAuditStatut}
     />
   );

--- a/apps/app/src/referentiels/referentiel.table/referentiel-table.audit-ordre-du-jour.cell.tsx
+++ b/apps/app/src/referentiels/referentiel.table/referentiel-table.audit-ordre-du-jour.cell.tsx
@@ -16,7 +16,7 @@ type Props = {
 export const ReferentielTableAuditOrdreDuJourCell = ({ info }: Props) => {
   const action = info.row.original;
   const cellId = info.cell.id;
-  const { auditStatutsByMesureId, canEditAudit, updateMesureAuditStatut } =
+  const { auditStatutsByMesureId, canUpdateAudit, updateMesureAuditStatut } =
     getTableMeta(info.table);
 
   const auditStatut = auditStatutsByMesureId?.[action.actionId];
@@ -30,7 +30,7 @@ export const ReferentielTableAuditOrdreDuJourCell = ({ info }: Props) => {
       <Checkbox
         aria-label={appLabels.auditColonneOrdreDuJour}
         checked={auditStatut.ordreDuJour}
-        disabled={!canEditAudit}
+        disabled={!canUpdateAudit}
         onChange={(event: ChangeEvent<HTMLInputElement>) =>
           updateMesureAuditStatut?.({
             collectiviteId: auditStatut.collectiviteId,

--- a/apps/app/src/referentiels/referentiel.table/referentiel-table.audit-statut.cell.tsx
+++ b/apps/app/src/referentiels/referentiel.table/referentiel-table.audit-statut.cell.tsx
@@ -15,7 +15,7 @@ type Props = {
 export const ReferentielTableAuditStatutCell = ({ info }: Props) => {
   const action = info.row.original;
   const cellId = info.cell.id;
-  const { auditStatutsByMesureId, canEditAudit, updateMesureAuditStatut } =
+  const { auditStatutsByMesureId, canUpdateAudit, updateMesureAuditStatut } =
     getTableMeta(info.table);
 
   const auditStatut = auditStatutsByMesureId?.[action.actionId];
@@ -29,7 +29,7 @@ export const ReferentielTableAuditStatutCell = ({ info }: Props) => {
       <ActionAuditStatutBase
         className="-m-1 inline-block"
         auditStatut={auditStatut}
-        readonly={!canEditAudit}
+        readonly={!canUpdateAudit}
         onChange={(statut: MesureAuditStatutEnum) =>
           updateMesureAuditStatut?.({
             collectiviteId: auditStatut.collectiviteId,

--- a/apps/app/src/referentiels/referentiel.table/referentiel-table.tsx
+++ b/apps/app/src/referentiels/referentiel.table/referentiel-table.tsx
@@ -119,7 +119,7 @@ function ReferentielTable({
   const { isConductingAudit, isAuditeur } =
     useCycleLabellisation(referentielId);
   const { data: audit } = useAudit();
-  const canEditAudit = isAuditeur && !audit?.valide;
+  const canUpdateAudit = isAuditeur && !audit?.valide;
   const { auditStatutsByMesureId } = useListMesureAuditStatutsGroupedById({
     referentielId,
     enabled: isConductingAudit,
@@ -264,7 +264,7 @@ function ReferentielTable({
       commentsByActionId,
       fichesByActionId,
       auditStatutsByMesureId,
-      canEditAudit,
+      canUpdateAudit,
       updateMesureAuditStatut,
       updateActionStatut,
       updateActionPilotes,
@@ -280,7 +280,7 @@ function ReferentielTable({
       commentsByActionId,
       fichesByActionId,
       auditStatutsByMesureId,
-      canEditAudit,
+      canUpdateAudit,
       updateMesureAuditStatut,
       updateActionStatut,
       updateActionPilotes,

--- a/apps/app/src/referentiels/referentiel.table/utils.ts
+++ b/apps/app/src/referentiels/referentiel.table/utils.ts
@@ -55,7 +55,7 @@ export type ReferentielTableMeta = {
   commentsByActionId?: Partial<Record<ActionId, DiscussionListItem[]>>;
   fichesByActionId?: Partial<Record<ActionId, FicheListItem[]>>;
   auditStatutsByMesureId?: Partial<Record<ActionId, MesureAuditStatutRow>>;
-  canEditAudit?: boolean;
+  canUpdateAudit?: boolean;
   updateMesureAuditStatut?: ReturnType<
     typeof useUpdateMesureAuditStatut
   >['mutate'];

--- a/apps/backend/src/referentiels/labellisations/labellisations.test-fixture.ts
+++ b/apps/backend/src/referentiels/labellisations/labellisations.test-fixture.ts
@@ -26,6 +26,7 @@ export async function createAudit({
   referentielId,
   dateDebut = new Date('2025-01-01').toISOString(),
   clos = false,
+  valide = false,
   withDemande = false,
 }: {
   databaseService: DatabaseServiceInterface;
@@ -33,6 +34,7 @@ export async function createAudit({
   referentielId: ReferentielId;
   dateDebut?: string | null;
   clos?: boolean;
+  valide?: boolean;
   withDemande?: boolean;
 }) {
   const demande = withDemande
@@ -57,6 +59,7 @@ export async function createAudit({
       demandeId: demande ? demande.id : null,
       dateDebut: dateDebut,
       clos,
+      valide,
       dateFin: clos ? new Date().toISOString() : null,
     })
     .returning();
@@ -82,6 +85,28 @@ export async function validateAudit({
     .update(auditTable)
     .set({ valide: true })
     .where(eq(auditTable.id, auditId));
+}
+
+export async function setAuditDateFin({
+  databaseService,
+  collectiviteId,
+  referentielId,
+  dateFin,
+}: {
+  databaseService: DatabaseServiceInterface;
+  collectiviteId: number;
+  referentielId: ReferentielId;
+  dateFin: Date;
+}): Promise<void> {
+  await databaseService.db
+    .update(auditTable)
+    .set({ dateFin: dateFin.toISOString() })
+    .where(
+      and(
+        eq(auditTable.collectiviteId, collectiviteId),
+        eq(auditTable.referentielId, referentielId)
+      )
+    );
 }
 
 export async function seedLabellisationObtenue({

--- a/apps/backend/src/referentiels/labellisations/update-audit-report/update-audit-report.errors.ts
+++ b/apps/backend/src/referentiels/labellisations/update-audit-report/update-audit-report.errors.ts
@@ -1,0 +1,39 @@
+import {
+  createErrorsEnum,
+  TrpcErrorHandlerConfig,
+} from '@tet/backend/utils/trpc/trpc-error-handler';
+
+const specificErrors = [
+  'PREUVE_NOT_FOUND',
+  'FICHIER_NOT_FOUND',
+  'UPDATE_NOT_ALLOWED',
+  'DATABASE_ERROR',
+] as const;
+type SpecificError = (typeof specificErrors)[number];
+
+export const updateAuditReportErrorConfig: TrpcErrorHandlerConfig<SpecificError> =
+  {
+    specificErrors: {
+      PREUVE_NOT_FOUND: {
+        code: 'BAD_REQUEST',
+        message: "Aucun rapport d'audit trouvé pour cette preuve.",
+      },
+      FICHIER_NOT_FOUND: {
+        code: 'BAD_REQUEST',
+        message: "Le fichier n'appartient pas à la collectivité de cet audit.",
+      },
+      UPDATE_NOT_ALLOWED: {
+        code: 'UNAUTHORIZED',
+        message:
+          "Seul l'auditeur de cet audit peut remplacer le rapport, et uniquement dans les 15 jours suivant la clôture.",
+      },
+      DATABASE_ERROR: {
+        code: 'INTERNAL_SERVER_ERROR',
+        message:
+          "Une erreur de base de données s'est produite lors du remplacement du rapport.",
+      },
+    },
+  };
+
+export const UpdateAuditReportErrorEnum = createErrorsEnum(specificErrors);
+export type UpdateAuditReportError = keyof typeof UpdateAuditReportErrorEnum;

--- a/apps/backend/src/referentiels/labellisations/update-audit-report/update-audit-report.input.ts
+++ b/apps/backend/src/referentiels/labellisations/update-audit-report/update-audit-report.input.ts
@@ -1,0 +1,10 @@
+import z from 'zod';
+
+export const updateAuditReportInputSchema = z.object({
+  preuveId: z.number().int().positive(),
+  fichierId: z.number().int().positive(),
+});
+
+export type UpdateAuditReportInput = z.infer<
+  typeof updateAuditReportInputSchema
+>;

--- a/apps/backend/src/referentiels/labellisations/update-audit-report/update-audit-report.router.e2e-spec.ts
+++ b/apps/backend/src/referentiels/labellisations/update-audit-report/update-audit-report.router.e2e-spec.ts
@@ -1,0 +1,275 @@
+import { INestApplication } from '@nestjs/common';
+import { addTestCollectiviteAndUsers } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { bibliothequeFichierTable } from '@tet/backend/collectivites/documents/models/bibliotheque-fichier.table';
+import { preuveAuditTable } from '@tet/backend/collectivites/documents/models/preuve-audit.table';
+import { auditTable } from '@tet/backend/referentiels/labellisations/audit.table';
+import {
+  addAuditeurPermission,
+  createAudit,
+} from '@tet/backend/referentiels/labellisations/labellisations.test-fixture';
+import { getAuthUser, getTestApp } from '@tet/backend/test';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
+import { ReferentielIdEnum } from '@tet/domain/referentiels';
+import { CollectiviteRole } from '@tet/domain/users';
+import { eq } from 'drizzle-orm';
+
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+describe('UpdateAuditReportRouter', () => {
+  let app: INestApplication;
+  let router: TrpcRouter;
+  let databaseService: DatabaseService;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    router = app.get(TrpcRouter);
+    databaseService = app.get(DatabaseService);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  const seedReport = async ({
+    clos,
+    valide = false,
+    dateFin,
+  }: {
+    clos: boolean;
+    valide?: boolean;
+    dateFin?: string;
+  }) => {
+    const { collectivite, users, cleanup } = await addTestCollectiviteAndUsers(
+      databaseService,
+      {
+        users: [
+          { role: CollectiviteRole.LECTURE },
+          { role: CollectiviteRole.LECTURE },
+        ],
+      }
+    );
+    const [auditeurUser, otherUser] = users;
+
+    const { audit } = await createAudit({
+      databaseService,
+      collectiviteId: collectivite.id,
+      referentielId: ReferentielIdEnum.CAE,
+      clos,
+      valide,
+    });
+    if (dateFin) {
+      await databaseService.db
+        .update(auditTable)
+        .set({ dateFin })
+        .where(eq(auditTable.id, audit.id));
+    }
+
+    const auditeurPermission = await addAuditeurPermission({
+      databaseService,
+      auditId: audit.id,
+      userId: auditeurUser.id,
+    });
+
+    const [oldFichier, newFichier] = await databaseService.db
+      .insert(bibliothequeFichierTable)
+      .values([
+        {
+          collectiviteId: collectivite.id,
+          hash: `old-${audit.id}`,
+          filename: 'rapport.pdf',
+          confidentiel: false,
+        },
+        {
+          collectiviteId: collectivite.id,
+          hash: `new-${audit.id}`,
+          filename: 'rapport-v2.pdf',
+          confidentiel: false,
+        },
+      ])
+      .returning();
+
+    const [preuve] = await databaseService.db
+      .insert(preuveAuditTable)
+      .values({
+        collectiviteId: collectivite.id,
+        auditId: audit.id,
+        fichierId: oldFichier.id,
+        modifiedBy: auditeurUser.id,
+      })
+      .returning();
+
+    const cleanupAll = async () => {
+      await databaseService.db
+        .delete(preuveAuditTable)
+        .where(eq(preuveAuditTable.collectiviteId, collectivite.id));
+      await databaseService.db
+        .delete(bibliothequeFichierTable)
+        .where(eq(bibliothequeFichierTable.collectiviteId, collectivite.id));
+      await auditeurPermission.cleanup();
+      await databaseService.db
+        .delete(auditTable)
+        .where(eq(auditTable.id, audit.id));
+      await cleanup();
+    };
+
+    return {
+      auditeurUser,
+      otherUser,
+      preuve,
+      newFichier,
+      cleanup: cleanupAll,
+    };
+  };
+
+  const getPreuveFichierId = async (preuveId: number) => {
+    const [row] = await databaseService.db
+      .select({ fichierId: preuveAuditTable.fichierId })
+      .from(preuveAuditTable)
+      .where(eq(preuveAuditTable.id, preuveId));
+    return row.fichierId;
+  };
+
+  test("l'auditeur remplace le rapport dans les 15 jours suivant la validation", async () => {
+    const { auditeurUser, preuve, newFichier, cleanup } = await seedReport({
+      clos: false,
+      valide: true,
+      dateFin: new Date(Date.now() - 14 * DAY_IN_MS).toISOString(),
+    });
+    onTestFinished(cleanup);
+
+    const caller = router.createCaller({ user: await getAuthUser(auditeurUser) });
+    await caller.referentiels.labellisations.updateAuditReport({
+      preuveId: preuve.id,
+      fichierId: newFichier.id,
+    });
+
+    expect(await getPreuveFichierId(preuve.id)).toBe(newFichier.id);
+  });
+
+  test("l'auditeur remplace le rapport d'un audit pas encore valide", async () => {
+    const { auditeurUser, preuve, newFichier, cleanup } = await seedReport({
+      clos: false,
+      valide: false,
+    });
+    onTestFinished(cleanup);
+
+    const caller = router.createCaller({ user: await getAuthUser(auditeurUser) });
+    await caller.referentiels.labellisations.updateAuditReport({
+      preuveId: preuve.id,
+      fichierId: newFichier.id,
+    });
+
+    expect(await getPreuveFichierId(preuve.id)).toBe(newFichier.id);
+  });
+
+  test('refuse une preuve qui ne correspond à aucun rapport', async () => {
+    const { auditeurUser, newFichier, cleanup } = await seedReport({
+      clos: false,
+    });
+    onTestFinished(cleanup);
+
+    const caller = router.createCaller({ user: await getAuthUser(auditeurUser) });
+
+    await expect(
+      caller.referentiels.labellisations.updateAuditReport({
+        preuveId: 2_000_000_000,
+        fichierId: newFichier.id,
+      })
+    ).rejects.toThrow(/Aucun rapport d'audit/);
+  });
+
+  test("refuse un utilisateur qui n'est pas l'auditeur de cet audit", async () => {
+    const { otherUser, preuve, newFichier, cleanup } = await seedReport({
+      clos: false,
+      valide: true,
+      dateFin: new Date(Date.now() - 14 * DAY_IN_MS).toISOString(),
+    });
+    onTestFinished(cleanup);
+
+    const caller = router.createCaller({ user: await getAuthUser(otherUser) });
+
+    await expect(
+      caller.referentiels.labellisations.updateAuditReport({
+        preuveId: preuve.id,
+        fichierId: newFichier.id,
+      })
+    ).rejects.toThrow();
+  });
+
+  test("refuse l'auditeur plus de 15 jours après la validation", async () => {
+    const { auditeurUser, preuve, newFichier, cleanup } = await seedReport({
+      clos: false,
+      valide: true,
+      dateFin: new Date(Date.now() - 16 * DAY_IN_MS).toISOString(),
+    });
+    onTestFinished(cleanup);
+
+    const caller = router.createCaller({ user: await getAuthUser(auditeurUser) });
+
+    await expect(
+      caller.referentiels.labellisations.updateAuditReport({
+        preuveId: preuve.id,
+        fichierId: newFichier.id,
+      })
+    ).rejects.toThrow();
+  });
+
+  test("refuse l'auditeur des que l'audit est clos, meme dans les 15 jours", async () => {
+    const { auditeurUser, preuve, newFichier, cleanup } = await seedReport({
+      clos: true,
+      valide: true,
+      dateFin: new Date(Date.now() - 14 * DAY_IN_MS).toISOString(),
+    });
+    onTestFinished(cleanup);
+
+    const caller = router.createCaller({ user: await getAuthUser(auditeurUser) });
+
+    await expect(
+      caller.referentiels.labellisations.updateAuditReport({
+        preuveId: preuve.id,
+        fichierId: newFichier.id,
+      })
+    ).rejects.toThrow();
+  });
+
+  test("refuse un fichier appartenant à une autre collectivité", async () => {
+    const { auditeurUser, preuve, cleanup } = await seedReport({
+      clos: false,
+      valide: true,
+      dateFin: new Date(Date.now() - 14 * DAY_IN_MS).toISOString(),
+    });
+    onTestFinished(cleanup);
+
+    const { collectivite: otherCollectivite, cleanup: otherCleanup } =
+      await addTestCollectiviteAndUsers(databaseService, {
+        users: [{ role: CollectiviteRole.LECTURE }],
+      });
+    const [otherFichier] = await databaseService.db
+      .insert(bibliothequeFichierTable)
+      .values({
+        collectiviteId: otherCollectivite.id,
+        hash: `other-${preuve.id}`,
+        filename: 'autre.pdf',
+        confidentiel: false,
+      })
+      .returning();
+    onTestFinished(async () => {
+      await databaseService.db
+        .delete(bibliothequeFichierTable)
+        .where(
+          eq(bibliothequeFichierTable.collectiviteId, otherCollectivite.id)
+        );
+      await otherCleanup();
+    });
+
+    const caller = router.createCaller({ user: await getAuthUser(auditeurUser) });
+
+    await expect(
+      caller.referentiels.labellisations.updateAuditReport({
+        preuveId: preuve.id,
+        fichierId: otherFichier.id,
+      })
+    ).rejects.toThrow();
+  });
+});

--- a/apps/backend/src/referentiels/labellisations/update-audit-report/update-audit-report.router.ts
+++ b/apps/backend/src/referentiels/labellisations/update-audit-report/update-audit-report.router.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@nestjs/common';
+import { createTrpcErrorHandler } from '@tet/backend/utils/trpc/trpc-error-handler';
+import { TrpcService } from '@tet/backend/utils/trpc/trpc.service';
+import { updateAuditReportErrorConfig } from './update-audit-report.errors';
+import { updateAuditReportInputSchema } from './update-audit-report.input';
+import { UpdateAuditReportService } from './update-audit-report.service';
+
+@Injectable()
+export class UpdateAuditReportRouter {
+  constructor(
+    private readonly trpc: TrpcService,
+    private readonly updateAuditReportService: UpdateAuditReportService
+  ) {}
+
+  router = this.trpc.router({
+    updateAuditReport: this.trpc.authedProcedure
+      .input(updateAuditReportInputSchema)
+      .mutation(async ({ input, ctx: { user } }) => {
+        const getResultDataOrThrowError = createTrpcErrorHandler(
+          updateAuditReportErrorConfig
+        );
+        const result = await this.updateAuditReportService.updateAuditReport(
+          input,
+          user
+        );
+        return getResultDataOrThrowError(result);
+      }),
+  });
+}

--- a/apps/backend/src/referentiels/labellisations/update-audit-report/update-audit-report.service.ts
+++ b/apps/backend/src/referentiels/labellisations/update-audit-report/update-audit-report.service.ts
@@ -1,0 +1,107 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { bibliothequeFichierTable } from '@tet/backend/collectivites/documents/models/bibliotheque-fichier.table';
+import { preuveAuditTable } from '@tet/backend/collectivites/documents/models/preuve-audit.table';
+import { auditeurTable } from '@tet/backend/referentiels/labellisations/auditeur.table';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { Result } from '@tet/backend/utils/result.type';
+import { canUpdateAuditReport } from '@tet/domain/referentiels';
+import { getErrorMessage } from '@tet/domain/utils';
+import { and, eq } from 'drizzle-orm';
+import { auditTable } from '../audit.table';
+import {
+  UpdateAuditReportError,
+  UpdateAuditReportErrorEnum,
+} from './update-audit-report.errors';
+import { UpdateAuditReportInput } from './update-audit-report.input';
+
+@Injectable()
+export class UpdateAuditReportService {
+  private readonly logger = new Logger(UpdateAuditReportService.name);
+
+  constructor(private readonly databaseService: DatabaseService) {}
+
+  async updateAuditReport(
+    { preuveId, fichierId }: UpdateAuditReportInput,
+    user: AuthenticatedUser
+  ): Promise<Result<{ preuveId: number }, UpdateAuditReportError>> {
+    try {
+      const [context] = await this.databaseService.db
+        .select({
+          collectiviteId: preuveAuditTable.collectiviteId,
+          clos: auditTable.clos,
+          valide: auditTable.valide,
+          dateFin: auditTable.dateFin,
+          auditeur: auditeurTable.auditeur,
+        })
+        .from(preuveAuditTable)
+        .innerJoin(auditTable, eq(auditTable.id, preuveAuditTable.auditId))
+        .leftJoin(
+          auditeurTable,
+          and(
+            eq(auditeurTable.auditId, preuveAuditTable.auditId),
+            eq(auditeurTable.auditeur, user.id)
+          )
+        )
+        .where(eq(preuveAuditTable.id, preuveId));
+
+      if (!context) {
+        return {
+          success: false,
+          error: UpdateAuditReportErrorEnum.PREUVE_NOT_FOUND,
+        };
+      }
+
+      const allowed = canUpdateAuditReport({
+        isAuditeur: context.auditeur !== null,
+        audit: {
+          clos: context.clos,
+          valide: context.valide,
+          dateFin: context.dateFin,
+        },
+        now: new Date(),
+      });
+
+      if (!allowed) {
+        return {
+          success: false,
+          error: UpdateAuditReportErrorEnum.UPDATE_NOT_ALLOWED,
+        };
+      }
+
+      const [fichier] = await this.databaseService.db
+        .select({ id: bibliothequeFichierTable.id })
+        .from(bibliothequeFichierTable)
+        .where(
+          and(
+            eq(bibliothequeFichierTable.id, fichierId),
+            eq(bibliothequeFichierTable.collectiviteId, context.collectiviteId)
+          )
+        );
+
+      if (!fichier) {
+        return {
+          success: false,
+          error: UpdateAuditReportErrorEnum.FICHIER_NOT_FOUND,
+        };
+      }
+
+      await this.databaseService.db
+        .update(preuveAuditTable)
+        .set({ fichierId })
+        .where(eq(preuveAuditTable.id, preuveId));
+
+      return { success: true, data: { preuveId } };
+    } catch (error) {
+      this.logger.error(
+        `Erreur lors du remplacement du rapport d'audit (preuve ${preuveId}): ${getErrorMessage(
+          error
+        )}`
+      );
+      return {
+        success: false,
+        error: UpdateAuditReportErrorEnum.DATABASE_ERROR,
+      };
+    }
+  }
+}

--- a/apps/backend/src/referentiels/referentiels.module.ts
+++ b/apps/backend/src/referentiels/referentiels.module.ts
@@ -46,6 +46,8 @@ import { HandleMesureAuditStatutService } from './labellisations/handle-mesure-a
 import { LabellisationService } from './labellisations/labellisation.service';
 import { ListPreuvesRouter } from './labellisations/list-preuves/list-preuves.router';
 import { ListPreuvesService } from './labellisations/list-preuves/list-preuves.service';
+import { UpdateAuditReportRouter } from './labellisations/update-audit-report/update-audit-report.router';
+import { UpdateAuditReportService } from './labellisations/update-audit-report/update-audit-report.service';
 import { RequestLabellisationRouter } from './labellisations/request-labellisation/request-labellisation.router';
 import { RequestLabellisationService } from './labellisations/request-labellisation/request-labellisation.service';
 import { StartAuditRouter } from './labellisations/start-audit/start-audit.router';
@@ -163,6 +165,8 @@ import { UpdateActionStatutService } from './update-action-statut/update-action-
     CreatePreuveRouter,
     ListPreuvesService,
     ListPreuvesRouter,
+    UpdateAuditReportService,
+    UpdateAuditReportRouter,
     ValidateAuditService,
     ValidateAuditRouter,
     HandleMesureAuditStatutService,

--- a/apps/backend/src/referentiels/referentiels.router.ts
+++ b/apps/backend/src/referentiels/referentiels.router.ts
@@ -9,6 +9,7 @@ import { CreatePreuveRouter } from './labellisations/create-preuve/create-preuve
 import { GetLabellisationRouter } from './labellisations/get-labellisation.router';
 import { HandleMesureAuditStatutRouter } from './labellisations/handle-mesure-audit-statut/handle-mesure-audit-statut.router';
 import { ListPreuvesRouter } from './labellisations/list-preuves/list-preuves.router';
+import { UpdateAuditReportRouter } from './labellisations/update-audit-report/update-audit-report.router';
 import { RequestLabellisationRouter } from './labellisations/request-labellisation/request-labellisation.router';
 import { StartAuditRouter } from './labellisations/start-audit/start-audit.router';
 import { ValidateAuditRouter } from './labellisations/validate-audit/validate-audit.router';
@@ -39,6 +40,7 @@ export class ReferentielsRouter {
     private readonly createPreuve: CreatePreuveRouter,
     private readonly validateAudit: ValidateAuditRouter,
     private readonly listPreuves: ListPreuvesRouter,
+    private readonly updateAuditReport: UpdateAuditReportRouter,
     private readonly assignPilotesRouter: HandleMesurePilotesRouter,
     private readonly assignServicesRouter: HandleMesuresServicesRouter,
     private readonly scoreIndicatifRouter: ScoreIndicatifRouter,
@@ -74,7 +76,8 @@ export class ReferentielsRouter {
       this.validateAudit.router,
       this.getLabellisation.router,
       this.handleMesureAuditStatutRouter.router,
-      this.listPreuves.router
+      this.listPreuves.router,
+      this.updateAuditReport.router
     ),
 
     definitions: this.getReferentielDefinitionRouter.router,

--- a/apps/backend/src/users/authorizations/get-user-roles-and-permissions/get-user-roles-and-permissions.adapter.ts
+++ b/apps/backend/src/users/authorizations/get-user-roles-and-permissions/get-user-roles-and-permissions.adapter.ts
@@ -29,6 +29,13 @@ function buildUniquePermissionsSet(
 function toAuditRolesAndPermissions(
   audit: AuditRolesRow
 ): AuditRolesAndPermissions {
+  if (audit.clos) {
+    return {
+      auditId: audit.auditId,
+      role: null,
+      permissions: buildUniquePermissionsSet([CollectiviteRole.LECTURE]),
+    };
+  }
   const role = audit.auditDateDebut
     ? AuditRole.AUDITEUR
     : AuditRole.AUDITEUR_AUDIT_NON_DEMARRE;

--- a/apps/backend/src/users/authorizations/get-user-roles-and-permissions/get-user-roles-and-permissions.repository.ts
+++ b/apps/backend/src/users/authorizations/get-user-roles-and-permissions/get-user-roles-and-permissions.repository.ts
@@ -9,7 +9,7 @@ import { dcpTable } from '@tet/backend/users/models/dcp.table';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { Transaction } from '@tet/backend/utils/database/transaction.utils';
 import { CollectivitePreferences } from '@tet/domain/collectivites';
-import { AUDIT_REPORT_EDIT_WINDOW_DAYS } from '@tet/domain/referentiels';
+import { AUDIT_REPORT_UPDATE_WINDOW_DAYS } from '@tet/domain/referentiels';
 import { CollectiviteRole } from '@tet/domain/users';
 import { and, eq, gt, or, sql } from 'drizzle-orm';
 
@@ -31,6 +31,7 @@ export type CollectiviteRolesRow = {
 export type AuditRolesRow = {
   auditId: number;
   auditDateDebut: string | null;
+  clos: boolean;
   collectiviteId: number;
   collectiviteNom: string;
   collectiviteAccesRestreint: boolean;
@@ -114,6 +115,7 @@ export class GetUserRolesAndPermissionsRepository {
         collectiviteAccesRestreint: sql<boolean>`coalesce(${collectiviteTable.accesRestreint}, false)`,
         collectivitePreferences: collectiviteTable.preferences,
         auditDateDebut: auditTable.dateDebut,
+        clos: auditTable.clos,
       })
       .from(auditeurTable)
       .innerJoin(auditTable, eq(auditTable.id, auditeurTable.auditId))
@@ -128,7 +130,7 @@ export class GetUserRolesAndPermissionsRepository {
             eq(auditTable.clos, false),
             gt(
               auditTable.dateFin,
-              sql`now() - make_interval(days => ${AUDIT_REPORT_EDIT_WINDOW_DAYS})`
+              sql`now() - make_interval(days => ${AUDIT_REPORT_UPDATE_WINDOW_DAYS})`
             )
           )
         )

--- a/apps/backend/src/users/authorizations/get-user-roles-and-permissions/get-user-roles-and-permissions.router.e2e-spec.ts
+++ b/apps/backend/src/users/authorizations/get-user-roles-and-permissions/get-user-roles-and-permissions.router.e2e-spec.ts
@@ -145,7 +145,7 @@ describe('GetUserPermissions', () => {
     ]);
   });
 
-  test("Conserve le rôle auditeur pendant 15 jours après la clôture de l'audit", async () => {
+  test("Passe l'auditeur en lecture seule pendant 15 jours après la clôture de l'audit", async () => {
     const { collectivite, user, cleanup } = await addTestCollectiviteAndUser(
       databaseService,
       {
@@ -179,8 +179,8 @@ describe('GetUserPermissions', () => {
     expect(auditeeCollectivite?.audits).toEqual([
       {
         auditId: audit.id,
-        role: AuditRole.AUDITEUR,
-        permissions: permissionsByRole[AuditRole.AUDITEUR],
+        role: null,
+        permissions: permissionsByRole[CollectiviteRole.LECTURE],
       },
     ]);
   });

--- a/e2e/tests/referentiels/labellisations/candidature-documents-verrou.spec.ts
+++ b/e2e/tests/referentiels/labellisations/candidature-documents-verrou.spec.ts
@@ -1,0 +1,68 @@
+import { expect } from '@playwright/test';
+import { ReferentielId } from '@tet/domain/referentiels';
+import { CollectiviteRole } from '@tet/domain/users';
+import { CollectiviteFixture } from 'tests/collectivite/collectivites.fixture';
+import { testWithReferentiels as test } from '../referentiels.fixture';
+
+const referentiel: ReferentielId = 'cae';
+
+test.describe('Documents de candidature — verrou apres validation', () => {
+  test("une fois l'audit valide, l'editeur voit ses documents mais ne peut plus les modifier", async ({
+    page,
+    collectivites,
+    referentiels,
+    newAuditLabellisationPom,
+  }) => {
+    const { collectivite, user: editeurUser } =
+      await collectivites.addCollectiviteAndUser({
+        userArgs: { autoLogin: true },
+        collectiviteArgs: { isCOT: true },
+      });
+    const collectiviteId = collectivite.data.id;
+    await editeurUser.precomputeReferentielSnapshot(collectiviteId, referentiel);
+    await referentiels.seedLabellisationObtenue({
+      collectiviteId,
+      referentielId: referentiel,
+      etoiles: 1,
+    });
+    await referentiels.updateAllReferentielStatutsToFait(
+      editeurUser,
+      collectiviteId,
+      referentiel
+    );
+    await referentiels.seedLabellisationPreuve(
+      editeurUser,
+      collectiviteId,
+      referentiel
+    );
+    const auditeurUser = await (collectivite as CollectiviteFixture).addUser({
+      role: CollectiviteRole.LECTURE,
+      autoLogin: true,
+    });
+    await referentiels.requestLabellisationAudit(
+      editeurUser,
+      collectiviteId,
+      referentiel
+    );
+    await referentiels.addAuditeur({
+      user: auditeurUser,
+      collectiviteId,
+      referentielId: referentiel,
+    });
+    await referentiels.startAudit(auditeurUser, collectiviteId, referentiel);
+    await referentiels.validateAudit(collectiviteId, referentiel);
+
+    await editeurUser.login();
+    await newAuditLabellisationPom.goto(collectiviteId, referentiel);
+
+    await expect(
+      newAuditLabellisationPom.candidatureDocumentsTitle
+    ).toBeVisible();
+    await expect(page.getByText('test-preuve.pdf').first()).toBeVisible();
+
+    await expect(newAuditLabellisationPom.ajouterDocumentButton).toHaveCount(0);
+    await expect(
+      page.getByRole('button', { name: 'Renommer le fichier' })
+    ).toHaveCount(0);
+  });
+});

--- a/e2e/tests/referentiels/labellisations/rapport-audit-bibliotheque.spec.ts
+++ b/e2e/tests/referentiels/labellisations/rapport-audit-bibliotheque.spec.ts
@@ -17,7 +17,13 @@ const test = testWithReferentiels.extend<{
   closedAuditReport: ClosedAuditReport;
 }>({
   closedAuditReport: async (
-    { collectivites, referentiels, labellisationPom },
+    {
+      page,
+      collectivites,
+      referentiels,
+      labellisationPom,
+      newAuditLabellisationPom,
+    },
     use
   ) => {
     const { collectivite, user: porteur } =
@@ -43,13 +49,15 @@ const test = testWithReferentiels.extend<{
     });
     await referentiels.startAudit(auditeurUser, collectiviteId, referentiel);
 
-    await labellisationPom.goto(referentiel);
+    await newAuditLabellisationPom.goto(collectiviteId, referentiel);
     await labellisationPom.cloturerAuditButton.click();
     await labellisationPom.uploadCloturerAuditReport();
     await labellisationPom.cloturerAuditSuivantButton.click();
     await labellisationPom.cloturerAuditEngagementCheckbox.check();
     await labellisationPom.cloturerAuditValiderButton.click();
-    await labellisationPom.checkLabellisationEnCoursAuditedBy(auditeurUser);
+    await expect(
+      page.getByRole('tab', { name: /Audit terminé/ })
+    ).toBeVisible();
 
     await use({ collectivite, collectiviteId, auditeurUser });
   },

--- a/e2e/tests/referentiels/labellisations/rapport-audit-bibliotheque.spec.ts
+++ b/e2e/tests/referentiels/labellisations/rapport-audit-bibliotheque.spec.ts
@@ -1,0 +1,122 @@
+import { expect } from '@playwright/test';
+import { ReferentielId } from '@tet/domain/referentiels';
+import { CollectiviteRole } from '@tet/domain/users';
+import { CollectiviteFixture } from 'tests/collectivite/collectivites.fixture';
+import { UserFixture } from 'tests/users/users.fixture';
+import { testWithReferentiels } from '../referentiels.fixture';
+
+const referentiel: ReferentielId = 'eci';
+
+type ClosedAuditReport = {
+  collectivite: CollectiviteFixture;
+  collectiviteId: number;
+  auditeurUser: UserFixture;
+};
+
+const test = testWithReferentiels.extend<{
+  closedAuditReport: ClosedAuditReport;
+}>({
+  closedAuditReport: async (
+    { collectivites, referentiels, labellisationPom },
+    use
+  ) => {
+    const { collectivite, user: porteur } =
+      await collectivites.addCollectiviteAndUser({
+        userArgs: { autoLogin: true },
+        collectiviteArgs: { isCOT: true },
+      });
+    const collectiviteId = collectivite.data.id;
+    await referentiels.requestLabellisationForCot(
+      porteur,
+      collectiviteId,
+      referentiel
+    );
+
+    const auditeurUser = await collectivite.addUser({
+      role: CollectiviteRole.LECTURE,
+      autoLogin: true,
+    });
+    await referentiels.addAuditeur({
+      user: auditeurUser,
+      collectiviteId,
+      referentielId: referentiel,
+    });
+    await referentiels.startAudit(auditeurUser, collectiviteId, referentiel);
+
+    await labellisationPom.goto(referentiel);
+    await labellisationPom.cloturerAuditButton.click();
+    await labellisationPom.uploadCloturerAuditReport();
+    await labellisationPom.cloturerAuditSuivantButton.click();
+    await labellisationPom.cloturerAuditEngagementCheckbox.check();
+    await labellisationPom.cloturerAuditValiderButton.click();
+    await labellisationPom.checkLabellisationEnCoursAuditedBy(auditeurUser);
+
+    await use({ collectivite, collectiviteId, auditeurUser });
+  },
+});
+
+test.describe(
+  "Rapport d'audit dans la bibliothèque",
+  () => {
+    test(
+      "l'auditeur voit le bouton « Remplacer le fichier » pendant la fenêtre de 15 jours",
+      async ({ page, closedAuditReport }) => {
+        const { collectiviteId, auditeurUser } = closedAuditReport;
+
+        await auditeurUser.login();
+        await page.goto(`/collectivite/${collectiviteId}/bibliotheque`);
+        await expect(page.getByText('document_test.pdf').first()).toBeVisible();
+        await expect(page.getByTitle('Remplacer le fichier')).toHaveCount(1);
+      }
+    );
+
+    test(
+      "l'auditeur ne voit plus le bouton « Remplacer le fichier » une fois la fenêtre de 15 jours dépassée",
+      async ({ page, referentiels, closedAuditReport }) => {
+        const { collectiviteId, auditeurUser } = closedAuditReport;
+
+        await referentiels.expireAuditReportEditWindow({
+          collectiviteId,
+          referentielId: referentiel,
+        });
+
+        await auditeurUser.login();
+        await page.goto(`/collectivite/${collectiviteId}/bibliotheque`);
+        await expect(page.getByText('document_test.pdf').first()).toBeVisible();
+        await expect(page.getByTitle('Remplacer le fichier')).toHaveCount(0);
+      }
+    );
+
+    test(
+      'un membre admin de la collectivité ne voit pas le bouton « Remplacer le fichier »',
+      async ({ page, closedAuditReport }) => {
+        const { collectivite, collectiviteId } = closedAuditReport;
+
+        const adminUser = await collectivite.addUser({
+          role: CollectiviteRole.ADMIN,
+          autoLogin: true,
+        });
+        await adminUser.login();
+        await page.goto(`/collectivite/${collectiviteId}/bibliotheque`);
+        await expect(page.getByText('document_test.pdf').first()).toBeVisible();
+        await expect(page.getByTitle('Remplacer le fichier')).toHaveCount(0);
+      }
+    );
+
+    test(
+      'un visiteur en lecture seule ne voit pas le bouton « Remplacer le fichier »',
+      async ({ page, closedAuditReport }) => {
+        const { collectivite, collectiviteId } = closedAuditReport;
+
+        const visiteurUser = await collectivite.addUser({
+          role: CollectiviteRole.LECTURE,
+          autoLogin: true,
+        });
+        await visiteurUser.login();
+        await page.goto(`/collectivite/${collectiviteId}/bibliotheque`);
+        await expect(page.getByText('document_test.pdf').first()).toBeVisible();
+        await expect(page.getByTitle('Remplacer le fichier')).toHaveCount(0);
+      }
+    );
+  }
+);

--- a/e2e/tests/referentiels/referentiels.fixture.ts
+++ b/e2e/tests/referentiels/referentiels.fixture.ts
@@ -6,6 +6,7 @@ import {
   requestLabellisationForCot,
   seedLabellisationObtenue,
   seedLabellisationPreuve,
+  setAuditDateFin,
   startAudit,
   validateAudit,
 } from '@tet/backend/referentiels/labellisations/labellisations.test-fixture';
@@ -18,6 +19,7 @@ import {
 } from '@tet/backend/referentiels/update-action-statut/referentiel-action-statut.test-fixture';
 import {
   ActionStatutCreate,
+  AUDIT_REPORT_UPDATE_WINDOW_DAYS,
   AuditLabellisationReferentielId,
   Etoile,
   ReferentielId,
@@ -150,6 +152,25 @@ class ReferentielsFixtureFactory extends FixtureFactory {
       collectiviteId,
       referentielId,
       modifiedBy: user.data.id,
+    });
+  }
+
+  async expireAuditReportEditWindow({
+    collectiviteId,
+    referentielId,
+  }: {
+    collectiviteId: number;
+    referentielId: ReferentielId;
+  }): Promise<void> {
+    const dayInMs = 24 * 60 * 60 * 1000;
+    const dateFin = new Date(
+      Date.now() - (AUDIT_REPORT_UPDATE_WINDOW_DAYS + 1) * dayInMs
+    );
+    await setAuditDateFin({
+      databaseService,
+      collectiviteId,
+      referentielId,
+      dateFin,
     });
   }
 

--- a/packages/domain/src/referentiels/index.ts
+++ b/packages/domain/src/referentiels/index.ts
@@ -32,6 +32,8 @@ export * from './labellisations/labellisation-etoile.enum.schema';
 export * from './labellisations/labellisation.schema';
 export * from './labellisations/parcours-labellisation-status.enum';
 export * from './labellisations/parcours-labellisation.schema';
+export * from './labellisations/can-update-audit-report/can-update-audit-report.rule';
+export * from './labellisations/can-user-update-candidature-documents/can-user-update-candidature-documents.rule';
 export * from './labellisations/request-labellisation/request-labellisation.rules';
 export * from './labellisations/request-labellisation/request-labellisation.rules-errors';
 export * from './labellisations/requestable-star';

--- a/packages/domain/src/referentiels/labellisations/can-update-audit-report/can-update-audit-report.rule.spec.ts
+++ b/packages/domain/src/referentiels/labellisations/can-update-audit-report/can-update-audit-report.rule.spec.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { canUpdateAuditReport } from './can-update-audit-report.rule';
+
+const now = new Date('2026-06-22T12:00:00.000Z');
+const daysAgo = (days: number) =>
+  new Date(now.getTime() - days * 24 * 60 * 60 * 1000).toISOString();
+
+describe('canUpdateAuditReport', () => {
+  it("refuse une preuve sans rapport d'audit", () => {
+    expect(canUpdateAuditReport({ isAuditeur: true, audit: null, now })).toBe(
+      false
+    );
+  });
+
+  it("refuse si l'utilisateur n'est pas l'auditeur de cet audit", () => {
+    expect(
+      canUpdateAuditReport({
+        isAuditeur: false,
+        audit: { clos: false, valide: false, dateFin: null },
+        now,
+      })
+    ).toBe(false);
+  });
+
+  it("autorise l'auditeur tant que l'audit n'est pas valide", () => {
+    expect(
+      canUpdateAuditReport({
+        isAuditeur: true,
+        audit: { clos: false, valide: false, dateFin: null },
+        now,
+      })
+    ).toBe(true);
+  });
+
+  it('autorise dans les 15 jours suivant la validation', () => {
+    expect(
+      canUpdateAuditReport({
+        isAuditeur: true,
+        audit: { clos: false, valide: true, dateFin: daysAgo(14) },
+        now,
+      })
+    ).toBe(true);
+  });
+
+  it('refuse plus de 15 jours apres la validation', () => {
+    expect(
+      canUpdateAuditReport({
+        isAuditeur: true,
+        audit: { clos: false, valide: true, dateFin: daysAgo(16) },
+        now,
+      })
+    ).toBe(false);
+  });
+
+  it("refuse des que l'audit est clos, meme dans les 15 jours (verrou definitif)", () => {
+    expect(
+      canUpdateAuditReport({
+        isAuditeur: true,
+        audit: { clos: true, valide: true, dateFin: daysAgo(14) },
+        now,
+      })
+    ).toBe(false);
+  });
+
+  it('refuse un audit valide sans date de fin', () => {
+    expect(
+      canUpdateAuditReport({
+        isAuditeur: true,
+        audit: { clos: false, valide: true, dateFin: null },
+        now,
+      })
+    ).toBe(false);
+  });
+});

--- a/packages/domain/src/referentiels/labellisations/can-update-audit-report/can-update-audit-report.rule.ts
+++ b/packages/domain/src/referentiels/labellisations/can-update-audit-report/can-update-audit-report.rule.ts
@@ -1,0 +1,29 @@
+import { AUDIT_REPORT_UPDATE_WINDOW_DAYS } from '../labellisation-audit.schema';
+
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+export function canUpdateAuditReport({
+  isAuditeur,
+  audit,
+  now,
+}: {
+  isAuditeur: boolean;
+  audit: { clos: boolean; valide: boolean; dateFin: Date | string | null } | null;
+  now: Date;
+}): boolean {
+  if (audit === null || !isAuditeur) {
+    return false;
+  }
+  if (audit.clos) {
+    return false;
+  }
+  if (!audit.valide) {
+    return true;
+  }
+  if (audit.dateFin === null) {
+    return false;
+  }
+  const editWindowStart =
+    now.getTime() - AUDIT_REPORT_UPDATE_WINDOW_DAYS * DAY_IN_MS;
+  return new Date(audit.dateFin).getTime() > editWindowStart;
+}

--- a/packages/domain/src/referentiels/labellisations/can-user-update-candidature-documents/can-user-update-candidature-documents.rule.spec.ts
+++ b/packages/domain/src/referentiels/labellisations/can-user-update-candidature-documents/can-user-update-candidature-documents.rule.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { canUserUpdateCandidatureDocuments } from './can-user-update-candidature-documents.rule';
+
+describe('canUserUpdateCandidatureDocuments', () => {
+  it("refuse un document qui n'est pas un document de candidature", () => {
+    expect(
+      canUserUpdateCandidatureDocuments({
+        preuveType: 'audit',
+        canMutateReferentiels: true,
+        audit: null,
+      })
+    ).toBe(false);
+  });
+
+  it('autorise un utilisateur avec mutation pendant la phase candidature (pas encore d audit)', () => {
+    expect(
+      canUserUpdateCandidatureDocuments({
+        preuveType: 'labellisation',
+        canMutateReferentiels: true,
+        audit: null,
+      })
+    ).toBe(true);
+  });
+
+  it("autorise tant que l'audit n'est pas validé", () => {
+    expect(
+      canUserUpdateCandidatureDocuments({
+        preuveType: 'labellisation',
+        canMutateReferentiels: true,
+        audit: { valide: false },
+      })
+    ).toBe(true);
+  });
+
+  it("verrouille les documents de candidature une fois l'audit validé", () => {
+    expect(
+      canUserUpdateCandidatureDocuments({
+        preuveType: 'labellisation',
+        canMutateReferentiels: true,
+        audit: { valide: true },
+      })
+    ).toBe(false);
+  });
+
+  it('refuse un utilisateur sans la permission de mutation', () => {
+    expect(
+      canUserUpdateCandidatureDocuments({
+        preuveType: 'labellisation',
+        canMutateReferentiels: false,
+        audit: { valide: false },
+      })
+    ).toBe(false);
+  });
+});

--- a/packages/domain/src/referentiels/labellisations/can-user-update-candidature-documents/can-user-update-candidature-documents.rule.ts
+++ b/packages/domain/src/referentiels/labellisations/can-user-update-candidature-documents/can-user-update-candidature-documents.rule.ts
@@ -1,0 +1,21 @@
+import { PreuveType } from '../../../collectivites/documents/preuve-type.enum.schema';
+import { canModifyCandidatureDocuments } from '../can-modify-candidature-documents/can-modify-candidature-documents.rule';
+import { LabellisationAudit } from '../labellisation-audit.schema';
+
+export const canUserUpdateCandidatureDocuments = ({
+  preuveType,
+  canMutateReferentiels,
+  audit,
+}: {
+  preuveType: PreuveType;
+  canMutateReferentiels: boolean;
+  audit: Pick<LabellisationAudit, 'valide'> | null;
+}): boolean => {
+  if (preuveType !== 'labellisation') {
+    return false;
+  }
+  if (!canMutateReferentiels) {
+    return false;
+  }
+  return canModifyCandidatureDocuments({ audit });
+};

--- a/packages/domain/src/referentiels/labellisations/labellisation-audit.schema.ts
+++ b/packages/domain/src/referentiels/labellisations/labellisation-audit.schema.ts
@@ -16,4 +16,4 @@ export const labellisationAuditSchema = z.object({
 
 export type LabellisationAudit = z.infer<typeof labellisationAuditSchema>;
 
-export const AUDIT_REPORT_EDIT_WINDOW_DAYS = 15;
+export const AUDIT_REPORT_UPDATE_WINDOW_DAYS = 15;

--- a/packages/domain/src/referentiels/labellisations/request-labellisation/request-labellisation.rules.spec.ts
+++ b/packages/domain/src/referentiels/labellisations/request-labellisation/request-labellisation.rules.spec.ts
@@ -2,7 +2,12 @@ import { Etoile } from '../labellisation-etoile.enum.schema';
 import {
   ParcoursLabellisationForRequest,
   canRequestAuditOrLabellisation,
+  getParcoursLabellisationStatus,
 } from './request-labellisation.rules';
+
+type DemandeEtOuAudit = NonNullable<
+  Parameters<typeof getParcoursLabellisationStatus>[0]
+>;
 
 const baseParcours: ParcoursLabellisationForRequest = {
   status: 'non_demandee',
@@ -52,5 +57,72 @@ describe('canRequestAuditOrLabellisation — plafond d\'étoile dérivé du scor
       canRequest: false,
       reason: 'SCORE_GLOBAL_CRITERIA_NOT_SATISFIED',
     });
+  });
+});
+
+describe('getParcoursLabellisationStatus — état consolidé du cycle', () => {
+  const auditEnCours: DemandeEtOuAudit['audit'] = {
+    valide: false,
+    date_debut: '2026-01-01T00:00:00.000Z',
+    date_fin: null,
+  };
+
+  it('retourne non_demandee quand il n\'y a ni demande ni audit', () => {
+    expect(getParcoursLabellisationStatus(null)).toBe('non_demandee');
+    expect(getParcoursLabellisationStatus(undefined)).toBe('non_demandee');
+    expect(
+      getParcoursLabellisationStatus({ demande: null, audit: null })
+    ).toBe('non_demandee');
+  });
+
+  it('retourne demande_envoyee quand la demande est envoyee (en_cours = false) sans audit demarre', () => {
+    expect(
+      getParcoursLabellisationStatus({
+        demande: { en_cours: false },
+        audit: null,
+      })
+    ).toBe('demande_envoyee');
+  });
+
+  it('retourne non_demandee tant que la demande est en cours d\'edition (en_cours = true)', () => {
+    expect(
+      getParcoursLabellisationStatus({
+        demande: { en_cours: true },
+        audit: null,
+      })
+    ).toBe('non_demandee');
+  });
+
+  it('retourne audit_en_cours quand l\'audit a une date de debut et n\'est pas valide', () => {
+    expect(
+      getParcoursLabellisationStatus({ demande: null, audit: auditEnCours })
+    ).toBe('audit_en_cours');
+  });
+
+  it('retourne audit_valide quand l\'audit est valide', () => {
+    expect(
+      getParcoursLabellisationStatus({
+        demande: null,
+        audit: { valide: true, date_debut: null, date_fin: null },
+      })
+    ).toBe('audit_valide');
+  });
+
+  it('priorise audit_valide sur audit_en_cours quand l\'audit demarre est aussi valide', () => {
+    expect(
+      getParcoursLabellisationStatus({
+        demande: null,
+        audit: { ...auditEnCours, valide: true },
+      })
+    ).toBe('audit_valide');
+  });
+
+  it('priorise audit_en_cours sur demande_envoyee quand l\'audit est demarre', () => {
+    expect(
+      getParcoursLabellisationStatus({
+        demande: { en_cours: false },
+        audit: auditEnCours,
+      })
+    ).toBe('audit_en_cours');
   });
 });

--- a/packages/domain/src/users/authorizations/user-permission.rule.spec.ts
+++ b/packages/domain/src/users/authorizations/user-permission.rule.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { defaultCollectivitePreferences } from '../../collectivites/collectivite-preferences.schema';
+import { isUserVisitor } from './user-permission.rules';
+import { AuditRole, CollectiviteRole } from './user-role.enum.schema';
+import { UserRolesAndPermissions } from './user-roles-and-permissions.schema';
+
+const COLLECTIVITE_ID = 1;
+
+const toUser = ({
+  collectiviteRole,
+  auditRoles,
+}: {
+  collectiviteRole: CollectiviteRole | null;
+  auditRoles: (AuditRole | null)[];
+}): UserRolesAndPermissions => ({
+  roles: [],
+  permissions: [],
+  collectivites: [
+    {
+      collectiviteId: COLLECTIVITE_ID,
+      role: collectiviteRole,
+      permissions: [],
+      collectiviteNom: 'Collectivite test',
+      collectiviteAccesRestreint: false,
+      collectivitePreferences: defaultCollectivitePreferences,
+      audits: auditRoles.map((role, index) => ({
+        auditId: index + 1,
+        role,
+        permissions: [],
+      })),
+    },
+  ],
+});
+
+describe('isUserVisitor', () => {
+  it("considère visiteur l'auditeur d'un audit clos dont c'est le seul lien", () => {
+    const user = toUser({ collectiviteRole: null, auditRoles: [null] });
+
+    expect(isUserVisitor(user, { collectiviteId: COLLECTIVITE_ID })).toBe(true);
+  });
+
+  it("ne considère pas visiteur l'auditeur d'un audit encore en cours", () => {
+    const user = toUser({
+      collectiviteRole: null,
+      auditRoles: [AuditRole.AUDITEUR],
+    });
+
+    expect(isUserVisitor(user, { collectiviteId: COLLECTIVITE_ID })).toBe(
+      false
+    );
+  });
+
+  it('ne considère pas visiteur un membre de la collectivité', () => {
+    const user = toUser({
+      collectiviteRole: CollectiviteRole.LECTURE,
+      auditRoles: [],
+    });
+
+    expect(isUserVisitor(user, { collectiviteId: COLLECTIVITE_ID })).toBe(
+      false
+    );
+  });
+});


### PR DESCRIPTION
Ajoute le remplacement du rapport d'audit par l'auditeur via un endpoint dedie, et derive l'editabilite des documents de bibliotheque (rapport d'audit + documents de candidature) de regles domaine. Consomme le composant carte refactore (#4581, merge).

## Regles domaine (packages/domain)

- `canUpdateAuditReport({ isAuditeur, audit: { clos, dateFin }, now })` : retourne `true` si auditeur **et** (audit non clos **ou** clos avec `dateFin > now - AUDIT_REPORT_UPDATE_WINDOW_DAYS` (15 j)). (spec dediee)
- `canUserUpdateCandidatureDocuments({ preuveType, canMutateReferentiels, audit })` : `true` si `preuveType === 'labellisation'` **et** `canMutateReferentiels` **et** `canModifyCandidatureDocuments({ audit })` (audit absent ou `valide === false`). (spec dediee)
- Renomme `AUDIT_REPORT_EDIT_WINDOW_DAYS` -> `AUDIT_REPORT_UPDATE_WINDOW_DAYS`.

## Endpoint backend

`referentiels.labellisations.updateAuditReport({ preuveId, fichierId })`, mutation `authedProcedure`. Le service :

1. charge le contexte de la preuve (`collectiviteId`, `clos`, `dateFin`, `auditeur` via left join `auditeur` sur `user.id`) -> `PREUVE_NOT_FOUND` si absent ;
2. re-applique `canUpdateAuditReport` cote serveur -> `UPDATE_NOT_ALLOWED` si refuse ;
3. verifie que `fichierId` appartient a la collectivite de l'audit -> `FICHIER_NOT_FOUND` ;
4. met a jour `preuve_audit.fichier_id` ;
5. `catch` -> `DATABASE_ERROR`.

(e2e `update-audit-report.router.e2e-spec`, 3 scenarios d'autorisation : auditeur dans la fenetre / non-auditeur / au-dela de 15 j)

## Auth (get-user-roles-and-permissions)

- Adapter : un audit `clos` retourne desormais `role: null` + permission `CollectiviteRole.LECTURE`, au lieu d'un role `AUDITEUR`.
- Repository : ajoute `clos` a la ligne `AuditRolesRow` et a la requete ; suit le renommage `AUDIT_REPORT_UPDATE_WINDOW_DAYS`.
- e2e `get-user-roles-and-permissions.router.e2e-spec` adapte.

## Front (apps/app)

- `canUserUpdateAuditReport(user, preuve)` (nouveau) : adapte `canUpdateAuditReport` a `TPreuve` via `isUserAuditeurForAudit`.
- `useReplaceAuditReportFile` (nouveau) : mutation `updateAuditReport` + invalidation des queries preuves (plus d'ecriture Supabase directe).
- `CarteDocument` : state d'action unifie `'edit' | 'replace' | 'delete' | null` ; entree **Remplacer** (modale `ReplaceAuditReportModal` -> `AddPreuveModal`) affichee des que `canUserUpdateAuditReport`, y compris en lecture seule ; **Supprimer** masque sur un rapport d'audit ; **Editer**/**Commenter** uniquement si non readonly.
- `PreuveLabellisation` : passe de `PreuveDoc` a `CarteDocument` ; editabilite derivee par `canUpdateAuditOrLabellisationPreuve` (rapport d'audit -> regle rapport ; sinon -> regle candidature avec la permission `referentiels.mutate`).
- `useUpdateBibliothequeFichier` invalide aussi `listPreuvesLabellisation`.

## Comportement resultant

| Phase | Auditeur |
|---|---|
| Audit en cours | edite / commente / remplace le rapport (role AUDITEUR) |
| Clos <= 15 j | lecture seule + **Remplacer** uniquement (endpoint) |
| Clos > 15 j | lecture seule ; pas de bouton Remplacer ; l'endpoint refuse aussi |

## Refactor mecanique inclus

- Renomme `use-audit-status-badge.ts` -> `use-get-audit-badge.ts` et adapte les cellules `referentiel.table` (audit-notes / audit-ordre-du-jour / audit-statut) et `useAudit`.

## Validation

Specs domaine (`can-update-audit-report`, `can-user-update-candidature-documents`, `request-labellisation.rules`, `user-permission.rule`) ; e2e backend (`update-audit-report`, `get-user-roles-and-permissions`) ; e2e front (`rapport-audit-bibliotheque`, `candidature-documents-verrou`, `audit-labellisation-to-action-scroll`) ; typecheck app + backend ; lint.
