### PR TITLE
chore(referentiels): réduit le TTL de l'URL de téléchargement d'archive à 10 min

### DIFF
--- a/apps/backend/src/referentiels/preuves-archive/preuves-archive.constants.ts
+++ b/apps/backend/src/referentiels/preuves-archive/preuves-archive.constants.ts
@@ -2,5 +2,5 @@ export const PREUVES_ARCHIVES_BUCKET = 'preuves-archives';
 
 export const ARCHIVE_ZIP_CONTENT_TYPE = 'application/zip';
 
-/** TTL de la signed URL retournée par `get` : 24h pour laisser à l'utilisateur le temps de télécharger son archive. Régénérée à chaque appel de `get`. */
-export const ARCHIVE_DOWNLOAD_TTL_SECONDS = 24 * 60 * 60;
+/** TTL de la signed URL retournée par `get`, générée à la demande au clic de téléchargement : 10 min suffisent. */
+export const ARCHIVE_DOWNLOAD_TTL_SECONDS = 10 * 60;


### PR DESCRIPTION
## Quoi
`ARCHIVE_DOWNLOAD_TTL_SECONDS` : **24h → 10 min**.

## Pourquoi
La signed URL de téléchargement d'une archive de preuves est générée **à la demande**, au moment du clic, par `GetPreuvesArchiveService.get` (régénérée à chaque appel). Une durée de 24h n'est donc pas nécessaire : 10 min couvrent largement le délai clic → début du téléchargement, tout en **resserrant la fenêtre d'exposition** du jeton porteur vers le bucket privé `preuves-archives` (OWASP A01 — moindre privilège temporel).

## Portée
- 1 ligne (`preuves-archive.constants.ts`) + commentaire mis à jour.
- Seul consommateur : `get-preuves-archive.service.ts` (vérifié). Aucun autre usage.
- Ship-alone : valide tel quel sur `main` aujourd'hui (`get` est déjà le chemin de téléchargement au clic).

## Hors scope
- Endpoint `preuvesArchive.list` (PR suivante).
- Branchement front du panel persisté (PR suivante).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notes de version

* **Chores**
  * Ajustement du délai d'expiration des téléchargements d'archives : réduit de 24 heures à 10 minutes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->