### PR TITLE
feat(referentiels): endpoint preuvesArchive.list (mes archives par référentiel)

### DIFF
--- a/apps/backend/src/referentiels/preuves-archive/list-preuves-archive/list-preuves-archive.input.ts
+++ b/apps/backend/src/referentiels/preuves-archive/list-preuves-archive/list-preuves-archive.input.ts
@@ -1,0 +1,11 @@
+import { referentielIdEnumSchema } from '@tet/domain/referentiels';
+import { z } from 'zod';
+
+export const listPreuvesArchiveInputSchema = z.object({
+  collectiviteId: z.number().int().positive(),
+  referentielId: referentielIdEnumSchema,
+});
+
+export type ListPreuvesArchiveInput = z.infer<
+  typeof listPreuvesArchiveInputSchema
+>;

--- a/apps/backend/src/referentiels/preuves-archive/list-preuves-archive/list-preuves-archive.output.ts
+++ b/apps/backend/src/referentiels/preuves-archive/list-preuves-archive/list-preuves-archive.output.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+import { auditPreuvesArchiveStatusSchema } from '../models/audit-preuves-archive.table';
+
+export const listPreuvesArchiveOutputSchema = z.array(
+  z.object({
+    archiveId: z.string().uuid(),
+    status: auditPreuvesArchiveStatusSchema,
+    totalFiles: z.number().int().nonnegative(),
+    processedFiles: z.number().int().nonnegative(),
+    createdAt: z.string(),
+  })
+);
+
+export type ListPreuvesArchiveOutput = z.infer<
+  typeof listPreuvesArchiveOutputSchema
+>;

--- a/apps/backend/src/referentiels/preuves-archive/list-preuves-archive/list-preuves-archive.router.ts
+++ b/apps/backend/src/referentiels/preuves-archive/list-preuves-archive/list-preuves-archive.router.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@nestjs/common';
+import { createTrpcErrorHandler } from '@tet/backend/utils/trpc/trpc-error-handler';
+import { TrpcService } from '@tet/backend/utils/trpc/trpc.service';
+import { preuvesArchiveErrorConfig } from '../preuves-archive.trpc-errors';
+import { listPreuvesArchiveInputSchema } from './list-preuves-archive.input';
+import { listPreuvesArchiveOutputSchema } from './list-preuves-archive.output';
+import { ListPreuvesArchiveService } from './list-preuves-archive.service';
+
+@Injectable()
+export class ListPreuvesArchiveRouter {
+  constructor(
+    private readonly trpc: TrpcService,
+    private readonly listPreuvesArchiveService: ListPreuvesArchiveService
+  ) {}
+
+  private readonly getResultDataOrThrowError = createTrpcErrorHandler(
+    preuvesArchiveErrorConfig
+  );
+
+  router = this.trpc.router({
+    list: this.trpc.authedProcedure
+      .input(listPreuvesArchiveInputSchema)
+      .output(listPreuvesArchiveOutputSchema)
+      .query(async ({ input, ctx: { user } }) => {
+        const result = await this.listPreuvesArchiveService.list({
+          collectiviteId: input.collectiviteId,
+          referentielId: input.referentielId,
+          user,
+        });
+        return this.getResultDataOrThrowError(result);
+      }),
+  });
+}

--- a/apps/backend/src/referentiels/preuves-archive/list-preuves-archive/list-preuves-archive.service.ts
+++ b/apps/backend/src/referentiels/preuves-archive/list-preuves-archive/list-preuves-archive.service.ts
@@ -1,0 +1,67 @@
+import { Injectable } from '@nestjs/common';
+import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { failure, success, type Result } from '@tet/backend/utils/result.type';
+import { ReferentielId } from '@tet/domain/referentiels';
+import { ResourceType } from '@tet/domain/users';
+import {
+  PreuvesArchiveErrorEnum,
+  type PreuvesArchiveError,
+} from '../preuves-archive.errors';
+import { PreuvesArchiveRepository } from '../preuves-archive.repository';
+import type { ListPreuvesArchiveOutput } from './list-preuves-archive.output';
+
+export interface ListPreuvesArchiveServiceInput {
+  collectiviteId: number;
+  referentielId: ReferentielId;
+  user: AuthenticatedUser;
+}
+
+@Injectable()
+export class ListPreuvesArchiveService {
+  constructor(
+    private readonly permissions: PermissionService,
+    private readonly repository: PreuvesArchiveRepository
+  ) {}
+
+  async list(
+    input: ListPreuvesArchiveServiceInput
+  ): Promise<Result<ListPreuvesArchiveOutput, PreuvesArchiveError>> {
+    const { collectiviteId, referentielId, user } = input;
+
+    const isAllowed = await this.permissions.isAllowed(
+      user,
+      'referentiels.read',
+      ResourceType.COLLECTIVITE,
+      collectiviteId,
+      true
+    );
+    if (!isAllowed) {
+      return failure(
+        PreuvesArchiveErrorEnum.UNAUTHORIZED,
+        new Error(
+          `L'utilisateur ${user.id} n'a pas le droit referentiels.read sur la collectivité ${collectiviteId}`
+        )
+      );
+    }
+
+    const archivesResult = await this.repository.list({
+      collectiviteId,
+      referentielId,
+      requestedBy: user.id,
+    });
+    if (!archivesResult.success) {
+      return archivesResult;
+    }
+
+    return success(
+      archivesResult.data.map((archive) => ({
+        archiveId: archive.id,
+        status: archive.status,
+        totalFiles: archive.totalFiles,
+        processedFiles: archive.processedFiles,
+        createdAt: archive.createdAt,
+      }))
+    );
+  }
+}

--- a/apps/backend/src/referentiels/preuves-archive/preuves-archive.repository.ts
+++ b/apps/backend/src/referentiels/preuves-archive/preuves-archive.repository.ts
@@ -3,7 +3,7 @@ import { auditeurTable } from '@tet/backend/referentiels/labellisations/auditeur
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { failure, success, type Result } from '@tet/backend/utils/result.type';
 import { getErrorMessage } from '@tet/domain/utils';
-import { and, eq, inArray } from 'drizzle-orm';
+import { and, desc, eq, gt, inArray } from 'drizzle-orm';
 import {
   AuditPreuvesArchive,
   auditPreuvesArchiveStatusSchema,
@@ -143,6 +143,46 @@ export class PreuvesArchiveRepository {
     } catch (error) {
       this.logger.error(
         `Lecture du job d'archive ${input.id}: ${getErrorMessage(error)}`
+      );
+      return failure(
+        PreuvesArchiveErrorEnum.GET_ARCHIVE_ERROR,
+        error instanceof Error ? error : new Error(getErrorMessage(error))
+      );
+    }
+  }
+
+  async list(input: {
+    collectiviteId: number;
+    referentielId: string;
+    requestedBy: string;
+  }): Promise<Result<AuditPreuvesArchive[], PreuvesArchiveError>> {
+    try {
+      const rows = await this.db
+        .select()
+        .from(auditPreuvesArchiveTable)
+        .where(
+          and(
+            eq(auditPreuvesArchiveTable.collectiviteId, input.collectiviteId),
+            eq(auditPreuvesArchiveTable.referentielId, input.referentielId),
+            eq(auditPreuvesArchiveTable.requestedBy, input.requestedBy),
+            gt(auditPreuvesArchiveTable.expiresAt, new Date().toISOString())
+          )
+        )
+        .orderBy(desc(auditPreuvesArchiveTable.createdAt));
+
+      const parsed = rows.map((row) => this.parseRow(row));
+      const failed = parsed.find((result) => !result.success);
+      if (failed && !failed.success) {
+        return failed;
+      }
+      return success(
+        parsed.flatMap((result) => (result.success ? [result.data] : []))
+      );
+    } catch (error) {
+      this.logger.error(
+        `Liste des archives (collectivité ${input.collectiviteId}, référentiel ${input.referentielId}, user ${input.requestedBy}): ${getErrorMessage(
+          error
+        )}`
       );
       return failure(
         PreuvesArchiveErrorEnum.GET_ARCHIVE_ERROR,

--- a/apps/backend/src/referentiels/preuves-archive/preuves-archive.router.e2e-spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/preuves-archive.router.e2e-spec.ts
@@ -35,6 +35,7 @@ describe('Archive de preuves - tRPC', () => {
   let unauthorizedUser: AuthenticatedUser;
   let readerNonAuditeur: AuthenticatedUser;
   let auditeurCleanup: () => Promise<void>;
+  let auditId: number;
 
   beforeAll(async () => {
     app = await getTestApp({
@@ -81,6 +82,7 @@ describe('Archive de preuves - tRPC', () => {
       .insert(auditTable)
       .values({ collectiviteId: collectivite.id, referentielId: 'cae' })
       .returning();
+    auditId = audit.id;
 
     ({ cleanup: auditeurCleanup } = await addAuditeurPermission({
       databaseService: db,
@@ -232,6 +234,117 @@ describe('Archive de preuves - tRPC', () => {
         downloadUrl: null,
       });
       expect(result.errorMessage).not.toContain('getAudit');
+    });
+  });
+
+  describe('Archive de preuves - list (historique persisté)', () => {
+    test('renvoie mes archives du référentiel (métadonnée, sans downloadUrl)', async () => {
+      const caller = router.createCaller({ user: adminUser });
+      const { archiveId } = await caller.referentiels.preuvesArchive.request({
+        collectiviteId: collectivite.id,
+        referentielId: 'cae',
+      });
+
+      const result = await caller.referentiels.preuvesArchive.list({
+        collectiviteId: collectivite.id,
+        referentielId: 'cae',
+      });
+
+      const mine = result.find((archive) => archive.archiveId === archiveId);
+      expect(mine).toMatchObject({
+        archiveId,
+        status: expect.any(String),
+        totalFiles: expect.any(Number),
+        processedFiles: expect.any(Number),
+        createdAt: expect.any(String),
+      });
+      expect(mine).not.toHaveProperty('downloadUrl');
+    });
+
+    test("exclut les archives d'un·e autre utilisateur·ice", async () => {
+      const [other] = await db.db
+        .insert(auditPreuvesArchiveTable)
+        .values({
+          collectiviteId: collectivite.id,
+          referentielId: 'cae',
+          auditId,
+          requestedBy: readerNonAuditeur.id,
+          status: AuditPreuvesArchiveStatusEnum.COMPLETED,
+          expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+        })
+        .returning();
+
+      const caller = router.createCaller({ user: adminUser });
+      const result = await caller.referentiels.preuvesArchive.list({
+        collectiviteId: collectivite.id,
+        referentielId: 'cae',
+      });
+
+      expect(result.map((archive) => archive.archiveId)).not.toContain(
+        other.id
+      );
+    });
+
+    test("exclut les archives d'un autre référentiel", async () => {
+      const [eci] = await db.db
+        .insert(auditPreuvesArchiveTable)
+        .values({
+          collectiviteId: collectivite.id,
+          referentielId: 'eci',
+          auditId,
+          requestedBy: adminUser.id,
+          status: AuditPreuvesArchiveStatusEnum.COMPLETED,
+          expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+        })
+        .returning();
+
+      const caller = router.createCaller({ user: adminUser });
+      const cae = await caller.referentiels.preuvesArchive.list({
+        collectiviteId: collectivite.id,
+        referentielId: 'cae',
+      });
+      expect(cae.map((archive) => archive.archiveId)).not.toContain(eci.id);
+
+      const eciList = await caller.referentiels.preuvesArchive.list({
+        collectiviteId: collectivite.id,
+        referentielId: 'eci',
+      });
+      expect(eciList.map((archive) => archive.archiveId)).toContain(eci.id);
+    });
+
+    test('exclut les archives expirées', async () => {
+      const [expired] = await db.db
+        .insert(auditPreuvesArchiveTable)
+        .values({
+          collectiviteId: collectivite.id,
+          referentielId: 'cae',
+          auditId,
+          requestedBy: adminUser.id,
+          status: AuditPreuvesArchiveStatusEnum.COMPLETED,
+          expiresAt: new Date(Date.now() - 1000).toISOString(),
+        })
+        .returning();
+
+      const caller = router.createCaller({ user: adminUser });
+      const result = await caller.referentiels.preuvesArchive.list({
+        collectiviteId: collectivite.id,
+        referentielId: 'cae',
+      });
+
+      expect(result.map((archive) => archive.archiveId)).not.toContain(
+        expired.id
+      );
+    });
+
+    test('refuse un utilisateur sans referentiels.read', async () => {
+      const caller = router.createCaller({ user: unauthorizedUser });
+
+      await expect(
+        caller.referentiels.preuvesArchive.list({
+          collectiviteId: collectivite.id,
+          referentielId: 'cae',
+        })
+      ).rejects.toThrow("Vous n'avez pas les permissions nécessaires");
     });
   });
 });

--- a/apps/backend/src/referentiels/referentiels.module.ts
+++ b/apps/backend/src/referentiels/referentiels.module.ts
@@ -63,6 +63,8 @@ import { GetPreuvesArchiveRouter } from './preuves-archive/get-preuves-archive/g
 import { GetPreuvesArchiveService } from './preuves-archive/get-preuves-archive/get-preuves-archive.service';
 import { CollectPreuvesRepository } from './preuves-archive/list-audit-preuves/collect-preuves.repository';
 import { ListAuditPreuvesService } from './preuves-archive/list-audit-preuves/list-audit-preuves.service';
+import { ListPreuvesArchiveRouter } from './preuves-archive/list-preuves-archive/list-preuves-archive.router';
+import { ListPreuvesArchiveService } from './preuves-archive/list-preuves-archive/list-preuves-archive.service';
 import { PreuvesArchiveRepository } from './preuves-archive/preuves-archive.repository';
 import {
   PREUVES_ARCHIVE_JOB_OPTIONS,
@@ -121,6 +123,8 @@ import { UpdateActionStatutService } from './update-action-statut/update-action-
     RequestPreuvesArchiveRouter,
     GetPreuvesArchiveService,
     GetPreuvesArchiveRouter,
+    ListPreuvesArchiveService,
+    ListPreuvesArchiveRouter,
     GeneratePreuvesArchiveService,
     GeneratePreuvesArchiveWorker,
 

--- a/apps/backend/src/referentiels/referentiels.router.ts
+++ b/apps/backend/src/referentiels/referentiels.router.ts
@@ -15,6 +15,7 @@ import { ValidateAuditRouter } from './labellisations/validate-audit/validate-au
 import { CountPreuvesRouter } from './count-preuve/count-preuves.router';
 import { ListActionsRouter } from './list-actions/list-actions.router';
 import { GetPreuvesArchiveRouter } from './preuves-archive/get-preuves-archive/get-preuves-archive.router';
+import { ListPreuvesArchiveRouter } from './preuves-archive/list-preuves-archive/list-preuves-archive.router';
 import { RequestPreuvesArchiveRouter } from './preuves-archive/request-preuves-archive/request-preuves-archive.router';
 import { ResetDisplayPreferencesRouter } from './reset-display-preferences/reset-display-preferences.router';
 import { ActionPersonnalisationsRouter } from './action-personnalisations/action-personnalisations.router';
@@ -47,7 +48,8 @@ export class ReferentielsRouter {
     private readonly resetDisplayPreferencesRouter: ResetDisplayPreferencesRouter,
     private readonly historiqueRouter: HistoriqueRouter,
     private readonly requestPreuvesArchiveRouter: RequestPreuvesArchiveRouter,
-    private readonly getPreuvesArchiveRouter: GetPreuvesArchiveRouter
+    private readonly getPreuvesArchiveRouter: GetPreuvesArchiveRouter,
+    private readonly listPreuvesArchiveRouter: ListPreuvesArchiveRouter
   ) {}
 
   router = this.trpc.router({
@@ -83,7 +85,8 @@ export class ReferentielsRouter {
 
     preuvesArchive: this.trpc.mergeRouters(
       this.requestPreuvesArchiveRouter.router,
-      this.getPreuvesArchiveRouter.router
+      this.getPreuvesArchiveRouter.router,
+      this.listPreuvesArchiveRouter.router
     ),
   });
 


### PR DESCRIPTION
## Quoi
Nouvelle query tRPC **`referentiels.preuvesArchive.list({ collectiviteId, referentielId })`** : renvoie **mes** archives de preuves (utilisateur courant) pour ce **référentiel**, non expirées, triées par date desc.

Permet à terme de **persister la liste « Mes téléchargements » entre navigations/reloads** (la source de vérité passe de l'état client à la base). Le branchement front est une PR séparée.

## Détails
- **Repository** `listForRequester` : `where requested_by = user AND referentiel_id = X AND collectivite_id = Y AND expires_at > now()`, `order by created_at desc`.
- **Service** : authz `referentiels.read` sur la collectivité **+** scope `requested_by = user` (un·e utilisateur·ice ne voit que ses propres archives — aucune fuite inter-utilisateur). Denial → `UNAUTHORIZED`.
- **Output métadonnée seule** : `{ archiveId, status, totalFiles, processedFiles, createdAt }`. **Pas d'`downloadUrl`** : le téléchargement reste généré à la demande au clic via `get` (URL signée courte, cf. PR #4576). Évite de signer N URLs à chaque fetch/poll.

## Tests (e2e ajoutés au spec router existant)
- renvoie mes archives du référentiel (shape métadonnée, sans `downloadUrl`)
- **exclut** les archives d'un·e autre utilisateur·ice
- **exclut** les archives d'un autre référentiel (et les renvoie pour le bon référentiel)
- **exclut** les archives expirées
- **refuse** un utilisateur sans `referentiels.read`

Backend typecheck ✅, e2e `preuves-archive.router.e2e-spec` **13/13** ✅, lint ✅.

## Hors scope
- Branchement front du panel persisté → PR suivante (`feat/app-archive-list-persistee`).
- Réduction du TTL de l'URL de téléchargement → PR #4576.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notes de version

* **New Features**
  * Ajout d'une fonctionnalité de listing des archives de preuves pour les référentiels, permettant de consulter l'historique persisté des archives avec statut, nombre de fichiers et date de création.
  * Implémentation de contrôles d'accès : seuls les utilisateurs autorisés peuvent accéder aux archives, les archives expirées sont automatiquement exclues, et les données sont isolées par utilisateur et référentiel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->