### PR TITLE
feat(preuves): empeche la suppression du rapport d'audit dans la bibliotheque

### DIFF
--- a/apps/app/src/referentiels/preuves/Bibliotheque/CarteDocument.tsx
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/CarteDocument.tsx
@@ -70,8 +70,10 @@ const CarteDocument = ({
           <MenuCarteDocument
             document={document}
             className="absolute top-4 right-4 invisible group-hover:visible"
-            onComment={() => editComment.enter()}
-            onDelete={() => setIsDeleting(true)}
+            actions={{
+              comment: () => editComment.enter(),
+              delete: () => setIsDeleting(true),
+            }}
           />
         )}
 

--- a/apps/app/src/referentiels/preuves/Bibliotheque/CommentAction.tsx
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/CommentAction.tsx
@@ -1,0 +1,17 @@
+import { appLabels } from '@/app/labels/catalog';
+import { Button } from '@tet/ui';
+
+type CommentActionProps = {
+  onComment: () => void;
+};
+
+export const CommentAction = ({ onComment }: CommentActionProps) => (
+  <Button
+    data-test="btn-comment"
+    icon="discuss-line"
+    title={appLabels.commenter}
+    variant="grey"
+    size="xs"
+    onClick={onComment}
+  />
+);

--- a/apps/app/src/referentiels/preuves/Bibliotheque/DeleteDocumentAction.tsx
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/DeleteDocumentAction.tsx
@@ -1,0 +1,17 @@
+import { appLabels } from '@/app/labels/catalog';
+import DeleteButton from '@/app/ui/buttons/DeleteButton';
+
+type DeleteDocumentActionProps = {
+  onDelete: () => void;
+};
+
+export const DeleteDocumentAction = ({
+  onDelete,
+}: DeleteDocumentActionProps) => (
+  <DeleteButton
+    data-test="btn-delete"
+    title={appLabels.supprimer}
+    size="xs"
+    onClick={onDelete}
+  />
+);

--- a/apps/app/src/referentiels/preuves/Bibliotheque/EditDocumentAction.tsx
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/EditDocumentAction.tsx
@@ -1,0 +1,45 @@
+import { appLabels } from '@/app/labels/catalog';
+import { Button } from '@tet/ui';
+import { useState } from 'react';
+import { EditerDocumentModal } from './EditerDocumentModal';
+import { EditerLienModal } from './EditerLienModal';
+import { TPreuve } from './types';
+
+type EditDocumentActionProps = {
+  document: Pick<
+    TPreuve,
+    'id' | 'fichier' | 'lien' | 'collectivite_id' | 'preuve_type'
+  >;
+};
+
+export const EditDocumentAction = ({ document }: EditDocumentActionProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const { fichier } = document;
+
+  return (
+    <>
+      <Button
+        data-test="btn-edit"
+        icon="edit-line"
+        title={fichier ? appLabels.editerDocument : appLabels.editerLien}
+        variant="grey"
+        size="xs"
+        onClick={() => setIsOpen(true)}
+      />
+      {isOpen &&
+        (fichier ? (
+          <EditerDocumentModal
+            isOpen={isOpen}
+            setIsOpen={setIsOpen}
+            preuve={document}
+          />
+        ) : (
+          <EditerLienModal
+            isOpen={isOpen}
+            setIsOpen={setIsOpen}
+            preuve={document}
+          />
+        ))}
+    </>
+  );
+};

--- a/apps/app/src/referentiels/preuves/Bibliotheque/MenuCarteDocument.tsx
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/MenuCarteDocument.tsx
@@ -1,11 +1,13 @@
-import { appLabels } from '@/app/labels/catalog';
-import { EditerDocumentModal } from '@/app/referentiels/preuves/Bibliotheque/EditerDocumentModal';
-import { TPreuve } from '@/app/referentiels/preuves/Bibliotheque/types';
-import DeleteButton from '@/app/ui/buttons/DeleteButton';
-import { Button } from '@tet/ui';
 import classNames from 'classnames';
-import { useState } from 'react';
-import { EditerLienModal } from './EditerLienModal';
+import { CommentAction } from './CommentAction';
+import { DeleteDocumentAction } from './DeleteDocumentAction';
+import { EditDocumentAction } from './EditDocumentAction';
+import { TPreuve } from './types';
+
+export type CarteDocumentActions = {
+  comment?: () => void;
+  delete?: () => void;
+};
 
 type MenuCarteDocumentProps = {
   document: Pick<
@@ -13,68 +15,19 @@ type MenuCarteDocumentProps = {
     'id' | 'fichier' | 'lien' | 'collectivite_id' | 'preuve_type'
   >;
   className?: string;
-  onComment: () => void;
-  onDelete: () => void;
+  actions: CarteDocumentActions;
 };
 
 const MenuCarteDocument = ({
   document,
   className,
-  onComment,
-  onDelete,
-}: MenuCarteDocumentProps) => {
-  const { fichier, lien } = document;
-  const [isOpen, setIsOpen] = useState(false);
-
-  if (!fichier && !lien) return null;
-
-  return (
-    <>
-      <div className={classNames('flex gap-2', className)}>
-        {/* Modifier le titre du document */}
-        <Button
-          data-test="btn-edit"
-          icon="edit-line"
-          title={fichier ? appLabels.editerDocument : appLabels.editerLien}
-          variant="grey"
-          size="xs"
-          onClick={() => setIsOpen(true)}
-        />
-        {isOpen &&
-          (fichier ? (
-            <EditerDocumentModal
-              isOpen={isOpen}
-              setIsOpen={setIsOpen}
-              preuve={document}
-            />
-          ) : (
-            <EditerLienModal
-              isOpen={isOpen}
-              setIsOpen={setIsOpen}
-              preuve={document}
-            />
-          ))}
-
-        {/* Commenter */}
-        <Button
-          data-test="btn-comment"
-          icon="discuss-line"
-          title={appLabels.commenter}
-          variant="grey"
-          size="xs"
-          onClick={onComment}
-        />
-
-        {/* Supprimer le document */}
-        <DeleteButton
-          data-test="btn-delete"
-          title={appLabels.supprimer}
-          size="xs"
-          onClick={onDelete}
-        />
-      </div>
-    </>
-  );
-};
+  actions,
+}: MenuCarteDocumentProps) => (
+  <div className={classNames('flex gap-2', className)}>
+    <EditDocumentAction document={document} />
+    {actions.comment && <CommentAction onComment={actions.comment} />}
+    {actions.delete && <DeleteDocumentAction onDelete={actions.delete} />}
+  </div>
+);
 
 export default MenuCarteDocument;

--- a/apps/backend/src/referentiels/preuves-archive/list-preuves-archive/list-preuves-archive.input.ts
+++ b/apps/backend/src/referentiels/preuves-archive/list-preuves-archive/list-preuves-archive.input.ts
@@ -1,0 +1,11 @@
+import { referentielIdEnumSchema } from '@tet/domain/referentiels';
+import { z } from 'zod';
+
+export const listPreuvesArchiveInputSchema = z.object({
+  collectiviteId: z.number().int().positive(),
+  referentielId: referentielIdEnumSchema,
+});
+
+export type ListPreuvesArchiveInput = z.infer<
+  typeof listPreuvesArchiveInputSchema
+>;

--- a/apps/backend/src/referentiels/preuves-archive/list-preuves-archive/list-preuves-archive.output.ts
+++ b/apps/backend/src/referentiels/preuves-archive/list-preuves-archive/list-preuves-archive.output.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+import { auditPreuvesArchiveStatusSchema } from '../models/audit-preuves-archive.table';
+
+export const listPreuvesArchiveOutputSchema = z.array(
+  z.object({
+    archiveId: z.string().uuid(),
+    status: auditPreuvesArchiveStatusSchema,
+    totalFiles: z.number().int().nonnegative(),
+    processedFiles: z.number().int().nonnegative(),
+    createdAt: z.string(),
+  })
+);
+
+export type ListPreuvesArchiveOutput = z.infer<
+  typeof listPreuvesArchiveOutputSchema
+>;

--- a/apps/backend/src/referentiels/preuves-archive/list-preuves-archive/list-preuves-archive.router.ts
+++ b/apps/backend/src/referentiels/preuves-archive/list-preuves-archive/list-preuves-archive.router.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@nestjs/common';
+import { createTrpcErrorHandler } from '@tet/backend/utils/trpc/trpc-error-handler';
+import { TrpcService } from '@tet/backend/utils/trpc/trpc.service';
+import { preuvesArchiveErrorConfig } from '../preuves-archive.trpc-errors';
+import { listPreuvesArchiveInputSchema } from './list-preuves-archive.input';
+import { listPreuvesArchiveOutputSchema } from './list-preuves-archive.output';
+import { ListPreuvesArchiveService } from './list-preuves-archive.service';
+
+@Injectable()
+export class ListPreuvesArchiveRouter {
+  constructor(
+    private readonly trpc: TrpcService,
+    private readonly listPreuvesArchiveService: ListPreuvesArchiveService
+  ) {}
+
+  private readonly getResultDataOrThrowError = createTrpcErrorHandler(
+    preuvesArchiveErrorConfig
+  );
+
+  router = this.trpc.router({
+    list: this.trpc.authedProcedure
+      .input(listPreuvesArchiveInputSchema)
+      .output(listPreuvesArchiveOutputSchema)
+      .query(async ({ input, ctx: { user } }) => {
+        const result = await this.listPreuvesArchiveService.list({
+          collectiviteId: input.collectiviteId,
+          referentielId: input.referentielId,
+          user,
+        });
+        return this.getResultDataOrThrowError(result);
+      }),
+  });
+}

--- a/apps/backend/src/referentiels/preuves-archive/list-preuves-archive/list-preuves-archive.service.ts
+++ b/apps/backend/src/referentiels/preuves-archive/list-preuves-archive/list-preuves-archive.service.ts
@@ -1,0 +1,67 @@
+import { Injectable } from '@nestjs/common';
+import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { failure, success, type Result } from '@tet/backend/utils/result.type';
+import { ReferentielId } from '@tet/domain/referentiels';
+import { ResourceType } from '@tet/domain/users';
+import {
+  PreuvesArchiveErrorEnum,
+  type PreuvesArchiveError,
+} from '../preuves-archive.errors';
+import { PreuvesArchiveRepository } from '../preuves-archive.repository';
+import type { ListPreuvesArchiveOutput } from './list-preuves-archive.output';
+
+export interface ListPreuvesArchiveServiceInput {
+  collectiviteId: number;
+  referentielId: ReferentielId;
+  user: AuthenticatedUser;
+}
+
+@Injectable()
+export class ListPreuvesArchiveService {
+  constructor(
+    private readonly permissions: PermissionService,
+    private readonly repository: PreuvesArchiveRepository
+  ) {}
+
+  async list(
+    input: ListPreuvesArchiveServiceInput
+  ): Promise<Result<ListPreuvesArchiveOutput, PreuvesArchiveError>> {
+    const { collectiviteId, referentielId, user } = input;
+
+    const isAllowed = await this.permissions.isAllowed(
+      user,
+      'referentiels.read',
+      ResourceType.COLLECTIVITE,
+      collectiviteId,
+      true
+    );
+    if (!isAllowed) {
+      return failure(
+        PreuvesArchiveErrorEnum.UNAUTHORIZED,
+        new Error(
+          `L'utilisateur ${user.id} n'a pas le droit referentiels.read sur la collectivité ${collectiviteId}`
+        )
+      );
+    }
+
+    const archivesResult = await this.repository.list({
+      collectiviteId,
+      referentielId,
+      requestedBy: user.id,
+    });
+    if (!archivesResult.success) {
+      return archivesResult;
+    }
+
+    return success(
+      archivesResult.data.map((archive) => ({
+        archiveId: archive.id,
+        status: archive.status,
+        totalFiles: archive.totalFiles,
+        processedFiles: archive.processedFiles,
+        createdAt: archive.createdAt,
+      }))
+    );
+  }
+}

--- a/apps/backend/src/referentiels/preuves-archive/preuves-archive.constants.ts
+++ b/apps/backend/src/referentiels/preuves-archive/preuves-archive.constants.ts
@@ -2,5 +2,5 @@ export const PREUVES_ARCHIVES_BUCKET = 'preuves-archives';
 
 export const ARCHIVE_ZIP_CONTENT_TYPE = 'application/zip';
 
-/** TTL de la signed URL retournée par `get` : 24h pour laisser à l'utilisateur le temps de télécharger son archive. Régénérée à chaque appel de `get`. */
-export const ARCHIVE_DOWNLOAD_TTL_SECONDS = 24 * 60 * 60;
+/** TTL de la signed URL retournée par `get`, générée à la demande au clic de téléchargement : 10 min suffisent. */
+export const ARCHIVE_DOWNLOAD_TTL_SECONDS = 10 * 60;

--- a/apps/backend/src/referentiels/preuves-archive/preuves-archive.repository.ts
+++ b/apps/backend/src/referentiels/preuves-archive/preuves-archive.repository.ts
@@ -3,7 +3,7 @@ import { auditeurTable } from '@tet/backend/referentiels/labellisations/auditeur
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { failure, success, type Result } from '@tet/backend/utils/result.type';
 import { getErrorMessage } from '@tet/domain/utils';
-import { and, eq, inArray } from 'drizzle-orm';
+import { and, desc, eq, gt, inArray } from 'drizzle-orm';
 import {
   AuditPreuvesArchive,
   auditPreuvesArchiveStatusSchema,
@@ -143,6 +143,46 @@ export class PreuvesArchiveRepository {
     } catch (error) {
       this.logger.error(
         `Lecture du job d'archive ${input.id}: ${getErrorMessage(error)}`
+      );
+      return failure(
+        PreuvesArchiveErrorEnum.GET_ARCHIVE_ERROR,
+        error instanceof Error ? error : new Error(getErrorMessage(error))
+      );
+    }
+  }
+
+  async list(input: {
+    collectiviteId: number;
+    referentielId: string;
+    requestedBy: string;
+  }): Promise<Result<AuditPreuvesArchive[], PreuvesArchiveError>> {
+    try {
+      const rows = await this.db
+        .select()
+        .from(auditPreuvesArchiveTable)
+        .where(
+          and(
+            eq(auditPreuvesArchiveTable.collectiviteId, input.collectiviteId),
+            eq(auditPreuvesArchiveTable.referentielId, input.referentielId),
+            eq(auditPreuvesArchiveTable.requestedBy, input.requestedBy),
+            gt(auditPreuvesArchiveTable.expiresAt, new Date().toISOString())
+          )
+        )
+        .orderBy(desc(auditPreuvesArchiveTable.createdAt));
+
+      const parsed = rows.map((row) => this.parseRow(row));
+      const failed = parsed.find((result) => !result.success);
+      if (failed && !failed.success) {
+        return failed;
+      }
+      return success(
+        parsed.flatMap((result) => (result.success ? [result.data] : []))
+      );
+    } catch (error) {
+      this.logger.error(
+        `Liste des archives (collectivité ${input.collectiviteId}, référentiel ${input.referentielId}, user ${input.requestedBy}): ${getErrorMessage(
+          error
+        )}`
       );
       return failure(
         PreuvesArchiveErrorEnum.GET_ARCHIVE_ERROR,

--- a/apps/backend/src/referentiels/preuves-archive/preuves-archive.router.e2e-spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/preuves-archive.router.e2e-spec.ts
@@ -35,6 +35,7 @@ describe('Archive de preuves - tRPC', () => {
   let unauthorizedUser: AuthenticatedUser;
   let readerNonAuditeur: AuthenticatedUser;
   let auditeurCleanup: () => Promise<void>;
+  let auditId: number;
 
   beforeAll(async () => {
     app = await getTestApp({
@@ -81,6 +82,7 @@ describe('Archive de preuves - tRPC', () => {
       .insert(auditTable)
       .values({ collectiviteId: collectivite.id, referentielId: 'cae' })
       .returning();
+    auditId = audit.id;
 
     ({ cleanup: auditeurCleanup } = await addAuditeurPermission({
       databaseService: db,
@@ -232,6 +234,117 @@ describe('Archive de preuves - tRPC', () => {
         downloadUrl: null,
       });
       expect(result.errorMessage).not.toContain('getAudit');
+    });
+  });
+
+  describe('Archive de preuves - list (historique persisté)', () => {
+    test('renvoie mes archives du référentiel (métadonnée, sans downloadUrl)', async () => {
+      const caller = router.createCaller({ user: adminUser });
+      const { archiveId } = await caller.referentiels.preuvesArchive.request({
+        collectiviteId: collectivite.id,
+        referentielId: 'cae',
+      });
+
+      const result = await caller.referentiels.preuvesArchive.list({
+        collectiviteId: collectivite.id,
+        referentielId: 'cae',
+      });
+
+      const mine = result.find((archive) => archive.archiveId === archiveId);
+      expect(mine).toMatchObject({
+        archiveId,
+        status: expect.any(String),
+        totalFiles: expect.any(Number),
+        processedFiles: expect.any(Number),
+        createdAt: expect.any(String),
+      });
+      expect(mine).not.toHaveProperty('downloadUrl');
+    });
+
+    test("exclut les archives d'un·e autre utilisateur·ice", async () => {
+      const [other] = await db.db
+        .insert(auditPreuvesArchiveTable)
+        .values({
+          collectiviteId: collectivite.id,
+          referentielId: 'cae',
+          auditId,
+          requestedBy: readerNonAuditeur.id,
+          status: AuditPreuvesArchiveStatusEnum.COMPLETED,
+          expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+        })
+        .returning();
+
+      const caller = router.createCaller({ user: adminUser });
+      const result = await caller.referentiels.preuvesArchive.list({
+        collectiviteId: collectivite.id,
+        referentielId: 'cae',
+      });
+
+      expect(result.map((archive) => archive.archiveId)).not.toContain(
+        other.id
+      );
+    });
+
+    test("exclut les archives d'un autre référentiel", async () => {
+      const [eci] = await db.db
+        .insert(auditPreuvesArchiveTable)
+        .values({
+          collectiviteId: collectivite.id,
+          referentielId: 'eci',
+          auditId,
+          requestedBy: adminUser.id,
+          status: AuditPreuvesArchiveStatusEnum.COMPLETED,
+          expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+        })
+        .returning();
+
+      const caller = router.createCaller({ user: adminUser });
+      const cae = await caller.referentiels.preuvesArchive.list({
+        collectiviteId: collectivite.id,
+        referentielId: 'cae',
+      });
+      expect(cae.map((archive) => archive.archiveId)).not.toContain(eci.id);
+
+      const eciList = await caller.referentiels.preuvesArchive.list({
+        collectiviteId: collectivite.id,
+        referentielId: 'eci',
+      });
+      expect(eciList.map((archive) => archive.archiveId)).toContain(eci.id);
+    });
+
+    test('exclut les archives expirées', async () => {
+      const [expired] = await db.db
+        .insert(auditPreuvesArchiveTable)
+        .values({
+          collectiviteId: collectivite.id,
+          referentielId: 'cae',
+          auditId,
+          requestedBy: adminUser.id,
+          status: AuditPreuvesArchiveStatusEnum.COMPLETED,
+          expiresAt: new Date(Date.now() - 1000).toISOString(),
+        })
+        .returning();
+
+      const caller = router.createCaller({ user: adminUser });
+      const result = await caller.referentiels.preuvesArchive.list({
+        collectiviteId: collectivite.id,
+        referentielId: 'cae',
+      });
+
+      expect(result.map((archive) => archive.archiveId)).not.toContain(
+        expired.id
+      );
+    });
+
+    test('refuse un utilisateur sans referentiels.read', async () => {
+      const caller = router.createCaller({ user: unauthorizedUser });
+
+      await expect(
+        caller.referentiels.preuvesArchive.list({
+          collectiviteId: collectivite.id,
+          referentielId: 'cae',
+        })
+      ).rejects.toThrow("Vous n'avez pas les permissions nécessaires");
     });
   });
 });

--- a/apps/backend/src/referentiels/referentiels.module.ts
+++ b/apps/backend/src/referentiels/referentiels.module.ts
@@ -63,6 +63,8 @@ import { GetPreuvesArchiveRouter } from './preuves-archive/get-preuves-archive/g
 import { GetPreuvesArchiveService } from './preuves-archive/get-preuves-archive/get-preuves-archive.service';
 import { CollectPreuvesRepository } from './preuves-archive/list-audit-preuves/collect-preuves.repository';
 import { ListAuditPreuvesService } from './preuves-archive/list-audit-preuves/list-audit-preuves.service';
+import { ListPreuvesArchiveRouter } from './preuves-archive/list-preuves-archive/list-preuves-archive.router';
+import { ListPreuvesArchiveService } from './preuves-archive/list-preuves-archive/list-preuves-archive.service';
 import { PreuvesArchiveRepository } from './preuves-archive/preuves-archive.repository';
 import {
   PREUVES_ARCHIVE_JOB_OPTIONS,
@@ -121,6 +123,8 @@ import { UpdateActionStatutService } from './update-action-statut/update-action-
     RequestPreuvesArchiveRouter,
     GetPreuvesArchiveService,
     GetPreuvesArchiveRouter,
+    ListPreuvesArchiveService,
+    ListPreuvesArchiveRouter,
     GeneratePreuvesArchiveService,
     GeneratePreuvesArchiveWorker,
 

--- a/apps/backend/src/referentiels/referentiels.router.ts
+++ b/apps/backend/src/referentiels/referentiels.router.ts
@@ -15,6 +15,7 @@ import { ValidateAuditRouter } from './labellisations/validate-audit/validate-au
 import { CountPreuvesRouter } from './count-preuve/count-preuves.router';
 import { ListActionsRouter } from './list-actions/list-actions.router';
 import { GetPreuvesArchiveRouter } from './preuves-archive/get-preuves-archive/get-preuves-archive.router';
+import { ListPreuvesArchiveRouter } from './preuves-archive/list-preuves-archive/list-preuves-archive.router';
 import { RequestPreuvesArchiveRouter } from './preuves-archive/request-preuves-archive/request-preuves-archive.router';
 import { ResetDisplayPreferencesRouter } from './reset-display-preferences/reset-display-preferences.router';
 import { ActionPersonnalisationsRouter } from './action-personnalisations/action-personnalisations.router';
@@ -47,7 +48,8 @@ export class ReferentielsRouter {
     private readonly resetDisplayPreferencesRouter: ResetDisplayPreferencesRouter,
     private readonly historiqueRouter: HistoriqueRouter,
     private readonly requestPreuvesArchiveRouter: RequestPreuvesArchiveRouter,
-    private readonly getPreuvesArchiveRouter: GetPreuvesArchiveRouter
+    private readonly getPreuvesArchiveRouter: GetPreuvesArchiveRouter,
+    private readonly listPreuvesArchiveRouter: ListPreuvesArchiveRouter
   ) {}
 
   router = this.trpc.router({
@@ -83,7 +85,8 @@ export class ReferentielsRouter {
 
     preuvesArchive: this.trpc.mergeRouters(
       this.requestPreuvesArchiveRouter.router,
-      this.getPreuvesArchiveRouter.router
+      this.getPreuvesArchiveRouter.router,
+      this.listPreuvesArchiveRouter.router
     ),
   });
 


### PR DESCRIPTION
Stackée sur #4575 (le menu Remplacer et le fichier e2e n'existent que sur cette base). GitHub retargetera vers \`main\` au merge de #4575.

## Intention

Fermer une porte à sens unique : un auditeur pouvait **supprimer** le rapport d'audit depuis la bibliothèque, sans aucun moyen de le redéposer (la bibliothèque ne propose que le **remplacement**, qui exige un fichier existant).

## Changements

- `MenuCarteDocument` : actions pilotées par props. `Supprimer` rendu seulement si `onDelete` fourni ; `Remplacer` seulement si `withReplaceAuditReport`. Plus de `isAuditReport` interne.
- `CarteDocument` : un seul point de décision (`preuve_type === 'audit'`) — le rapport d'audit reçoit le remplacement mais pas la suppression, les autres preuves l'inverse (comportement inchangé).

## Surface de review

- Attention humaine : `MenuCarteDocument.tsx`, `CarteDocument.tsx` (~25 lignes de logique).
- Tests : `rapport-audit-bibliotheque.spec.ts` restructuré (beforeEach + visibilité de Remplacer par rôle) **+ test** « l'auditeur ne peut pas supprimer le rapport » (fiable : le COT ne dépose aucun autre document, donc `Supprimer` count 0 prouve le fix).

## Validation

`app:typecheck` ✅ · `e2e:typecheck` ✅ · eslint ✅