### PR TITLE
refactor(preuves): compose les actions de la carte via un objet actions

### DIFF
--- a/apps/app/src/referentiels/preuves/Bibliotheque/CarteDocument.tsx
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/CarteDocument.tsx
@@ -3,16 +3,33 @@ import {
   getTextFormattedDate,
   getTruncatedText,
 } from '@/app/utils/formatUtils';
-import { Button, Card, Icon, Notification, Tooltip } from '@tet/ui';
+import { Button, Card, Icon, Notification, Tooltip, VisibleWhen } from '@tet/ui';
 import classNames from 'classnames';
 import { useState } from 'react';
 import AlerteSuppression from './AlerteSuppression';
 import DocumentInput from './DocumentInput';
+import { EditerDocumentModal } from './EditerDocumentModal';
+import { EditerLienModal } from './EditerLienModal';
 import MenuCarteDocument from './MenuCarteDocument';
 import { openPreuve } from './openPreuve';
 import { TPreuve } from './types';
 import { useEditPreuve } from './useEditPreuve';
 import { getAuthorAndDate, getFormattedTitle } from './utils';
+
+const EditPreuveModal = ({
+  isOpen,
+  setIsOpen,
+  preuve,
+}: {
+  isOpen: boolean;
+  setIsOpen: (open: boolean) => void;
+  preuve: TPreuve;
+}) =>
+  preuve.fichier ? (
+    <EditerDocumentModal isOpen={isOpen} setIsOpen={setIsOpen} preuve={preuve} />
+  ) : (
+    <EditerLienModal isOpen={isOpen} setIsOpen={setIsOpen} preuve={preuve} />
+  );
 
 type CarteDocumentProps = {
   isReadonly: boolean;
@@ -42,6 +59,7 @@ const CarteDocument = ({
   const { remove, editComment } = handlers;
 
   const [isDeleting, setIsDeleting] = useState(false);
+  const [isEditOpen, setIsEditOpen] = useState(false);
   const [isFullCommentaire, setIsFullCommentaire] = useState(false);
   const isEditing = editComment.isEditing;
 
@@ -70,8 +88,11 @@ const CarteDocument = ({
           <MenuCarteDocument
             document={document}
             className="absolute top-4 right-4 invisible group-hover:visible"
-            onComment={() => editComment.enter()}
-            onDelete={() => setIsDeleting(true)}
+            actions={{
+              edit: () => setIsEditOpen(true),
+              comment: () => editComment.enter(),
+              delete: () => setIsDeleting(true),
+            }}
           />
         )}
 
@@ -164,6 +185,14 @@ const CarteDocument = ({
           }}
         />
       )}
+
+      <VisibleWhen condition={isEditOpen}>
+        <EditPreuveModal
+          isOpen={isEditOpen}
+          setIsOpen={setIsEditOpen}
+          preuve={document}
+        />
+      </VisibleWhen>
     </>
   );
 };

--- a/apps/app/src/referentiels/preuves/Bibliotheque/MenuCarteDocument.tsx
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/MenuCarteDocument.tsx
@@ -1,80 +1,75 @@
 import { appLabels } from '@/app/labels/catalog';
-import { EditerDocumentModal } from '@/app/referentiels/preuves/Bibliotheque/EditerDocumentModal';
-import { TPreuve } from '@/app/referentiels/preuves/Bibliotheque/types';
 import DeleteButton from '@/app/ui/buttons/DeleteButton';
 import { Button } from '@tet/ui';
 import classNames from 'classnames';
-import { useState } from 'react';
-import { EditerLienModal } from './EditerLienModal';
+import { TPreuve } from './types';
+
+const EditDocumentButton = ({
+  document,
+  onEdit,
+}: {
+  document: Pick<TPreuve, 'fichier'>;
+  onEdit: () => void;
+}) => (
+  <Button
+    icon="edit-line"
+    title={document.fichier ? appLabels.editerDocument : appLabels.editerLien}
+    variant="grey"
+    size="xs"
+    onClick={onEdit}
+  />
+);
+
+const ReplaceFileButton = ({ onReplace }: { onReplace: () => void }) => (
+  <Button
+    icon="file-transfer-line"
+    title={appLabels.remplacerLeFichier}
+    variant="grey"
+    size="xs"
+    onClick={onReplace}
+  />
+);
+
+const CommentButton = ({ onComment }: { onComment: () => void }) => (
+  <Button
+    icon="discuss-line"
+    title={appLabels.commenter}
+    variant="grey"
+    size="xs"
+    onClick={onComment}
+  />
+);
+
+const DeleteDocumentButton = ({ onDelete }: { onDelete: () => void }) => (
+  <DeleteButton title={appLabels.supprimer} size="xs" onClick={onDelete} />
+);
+
+export type CarteDocumentActions = {
+  edit?: () => void;
+  replace?: () => void;
+  comment?: () => void;
+  delete?: () => void;
+};
 
 type MenuCarteDocumentProps = {
-  document: Pick<
-    TPreuve,
-    'id' | 'fichier' | 'lien' | 'collectivite_id' | 'preuve_type'
-  >;
+  document: Pick<TPreuve, 'fichier'>;
   className?: string;
-  onComment: () => void;
-  onDelete: () => void;
+  actions: CarteDocumentActions;
 };
 
 const MenuCarteDocument = ({
   document,
   className,
-  onComment,
-  onDelete,
-}: MenuCarteDocumentProps) => {
-  const { fichier, lien } = document;
-  const [isOpen, setIsOpen] = useState(false);
-
-  if (!fichier && !lien) return null;
-
-  return (
-    <>
-      <div className={classNames('flex gap-2', className)}>
-        {/* Modifier le titre du document */}
-        <Button
-          data-test="btn-edit"
-          icon="edit-line"
-          title={fichier ? appLabels.editerDocument : appLabels.editerLien}
-          variant="grey"
-          size="xs"
-          onClick={() => setIsOpen(true)}
-        />
-        {isOpen &&
-          (fichier ? (
-            <EditerDocumentModal
-              isOpen={isOpen}
-              setIsOpen={setIsOpen}
-              preuve={document}
-            />
-          ) : (
-            <EditerLienModal
-              isOpen={isOpen}
-              setIsOpen={setIsOpen}
-              preuve={document}
-            />
-          ))}
-
-        {/* Commenter */}
-        <Button
-          data-test="btn-comment"
-          icon="discuss-line"
-          title={appLabels.commenter}
-          variant="grey"
-          size="xs"
-          onClick={onComment}
-        />
-
-        {/* Supprimer le document */}
-        <DeleteButton
-          data-test="btn-delete"
-          title={appLabels.supprimer}
-          size="xs"
-          onClick={onDelete}
-        />
-      </div>
-    </>
-  );
-};
+  actions,
+}: MenuCarteDocumentProps) => (
+  <div className={classNames('flex gap-2', className)}>
+    {actions.edit && (
+      <EditDocumentButton document={document} onEdit={actions.edit} />
+    )}
+    {actions.replace && <ReplaceFileButton onReplace={actions.replace} />}
+    {actions.comment && <CommentButton onComment={actions.comment} />}
+    {actions.delete && <DeleteDocumentButton onDelete={actions.delete} />}
+  </div>
+);
 
 export default MenuCarteDocument;

--- a/e2e/tests/collectivite/documents/documents.pom.ts
+++ b/e2e/tests/collectivite/documents/documents.pom.ts
@@ -20,8 +20,8 @@ export class DocumentsPom {
 
   constructor(readonly page: Page) {
     this.fileTab = page.getByRole('tab', { name: 'Fichier' });
-    this.deleteButton = page.locator('[data-test="btn-delete"]');
-    this.editButton = page.locator('[data-test="btn-edit"]');
+    this.deleteButton = page.getByTitle('Supprimer');
+    this.editButton = page.getByTitle('Éditer le document');
     this.editModalTitle = page.getByRole('heading', {
       name: 'Editer le document',
     });


### PR DESCRIPTION
Refacto **front-only** depuis `main`, **zéro changement de comportement** : transforme le menu d'actions de la carte de document en un composant présentationnel piloté par un objet `actions`, réutilisable. Prépare la consommation par #4575 (remplacement du rapport d'audit).

Remplace l'ex-#4580 (fermée par un renommage de branche).

## Intention

`MenuCarteDocument` passait un prop par action (`onComment`, `onDelete`). Il devient un **conteneur purement présentationnel** recevant un objet `actions` ; chaque action est un **bouton** rendu seulement si son handler est fourni. Le caller compose les actions disponibles — ajouter une action ne demande plus un nouveau prop sur le menu.

```ts
export type CarteDocumentActions = {
  edit?: () => void;
  replace?: () => void;
  comment?: () => void;
  delete?: () => void;
};
```

## Changements

- `MenuCarteDocument` → conteneur + `actions`. Boutons privés nommés pour la lecture JSX : `EditDocumentButton`, `ReplaceFileButton`, `CommentButton`, `DeleteDocumentButton`.
- Les **flux** (modale d'édition `EditPreuveModal`, confirmation `AlerteSuppression`, éditeur de commentaire `DocumentInput`) vivent dans le caller `CarteDocument` — pattern déjà en place pour delete/comment, étendu à edit.
- `EditPreuveModal` groupe le choix document vs lien (un seul ternaire) et s'affiche via `VisibleWhen`.
- Callbacks setter typés `(open: boolean) => void`, pas `Dispatch<SetStateAction<boolean>>` (pas de leak React).

## Ciblage de test (data-test → sémantique)

- **Plus aucun `data-test` dans le menu.**
- `documents.pom.ts` : `editButton`/`deleteButton` ciblés par **`getByTitle('…')`** (l'attribut `title` réel du bouton), pas par data-test.
- Note : un bouton-icône DS avec seulement un `title` n'a pas de *nom accessible* fiable → `getByRole({ name })` ne matche pas ; `getByTitle` cible l'attribut directement.

## Hors scope (→ #4575)

Le slot `replace` est présent (bouton pur) mais **non câblé** côté `main` : `ReplaceFileButton` ne dépend d'aucune modale. #4575 fournira `actions.replace`, la modale de sélection de fichier (`AddPreuveModal`) et la mutation — plus le masquage de `delete` pour le rapport d'audit et l'e2e. (`AddPreuveModal` et `useReplaceAuditReportFile` n'existent pas sur `main`.)

## Surface de review

- `MenuCarteDocument.tsx` (réécrit), `CarteDocument.tsx` (compose les actions + porte les flux).
- `documents.pom.ts` (2 locators migrés vers `getByTitle`).

## Validation

`app:typecheck` ✅ · `e2e:typecheck` ✅ · eslint ✅
e2e `documents` / `scores` : validé par la CI (le ciblage `getByTitle` corrige l'échec d'un premier essai `getByRole`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimisation de la gestion des modales d'édition et des actions sur les documents au sein de la bibliothèque de preuves. Simplification de l'interface interne avec une meilleure organisation des fonctionnalités d'édition, de commentaire et de suppression.

* **Tests**
  * Mise à jour des tests de bout en bout pour garantir la fiabilité des interactions utilisateur avec les documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->