### PR TITLE
feat(ui): FloatingPanel primitive non-modale

### DIFF
--- a/packages/ui/src/design-system/FloatingPanel/FloatingPanel.stories.tsx
+++ b/packages/ui/src/design-system/FloatingPanel/FloatingPanel.stories.tsx
@@ -1,0 +1,44 @@
+import { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { FloatingPanel } from '.';
+
+const meta: Meta<typeof FloatingPanel> = {
+  component: FloatingPanel,
+  args: {
+    title: 'Mes téléchargements',
+    onClose: () => undefined,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof FloatingPanel>;
+
+export const Default: Story = {
+  render: (args) => (
+    <FloatingPanel {...args}>
+      <p className="m-0 text-sm text-grey-8">
+        {"Contenu du panel — typiquement une liste d'éléments en attente."}
+      </p>
+    </FloatingPanel>
+  ),
+};
+
+export const ContenuLong: Story = {
+  render: (args) => (
+    <FloatingPanel {...args}>
+      <ul className="m-0 flex list-none flex-col gap-4 p-0">
+        {Array.from({ length: 12 }, (_, index) => (
+          <li key={index} className="flex flex-col gap-1">
+            <span className="text-sm font-semibold text-primary-9">
+              Élément #{index + 1}
+            </span>
+            <span className="text-xs text-grey-7">
+              {"Description courte de l'élément."}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </FloatingPanel>
+  ),
+};

--- a/packages/ui/src/design-system/FloatingPanel/FloatingPanel.tsx
+++ b/packages/ui/src/design-system/FloatingPanel/FloatingPanel.tsx
@@ -1,0 +1,40 @@
+import { uiLabels } from '@tet/ui/labels/catalog';
+import { JSX, ReactNode } from 'react';
+import { Button } from '../Button';
+import { Divider } from '../Divider';
+
+export type FloatingPanelProps = {
+  title: string;
+  onClose: () => void;
+  closeLabel?: string;
+  children: ReactNode;
+};
+
+export const FloatingPanel = ({
+  title,
+  onClose,
+  closeLabel,
+  children,
+}: FloatingPanelProps): JSX.Element => (
+  <aside
+    aria-label={title}
+    className="fixed bottom-6 right-6 z-modal flex max-w-modal-xs flex-col gap-3 rounded-md border border-grey-4 bg-white p-6 shadow-[0_4px_30px_0px_rgba(0,0,0,0.02)]"
+  >
+    <div className="flex shrink-0 items-start justify-between gap-3">
+      <h3 className="mb-0 text-base font-semibold leading-6 text-primary-9">
+        {title}
+      </h3>
+      <Button
+        title={closeLabel ?? uiLabels.fermer}
+        onClick={onClose}
+        icon="close-line"
+        variant="unstyled"
+        size="xs"
+      />
+    </div>
+    <Divider />
+    <div className="flex max-h-[70vh] flex-col gap-6 overflow-y-auto">
+      {children}
+    </div>
+  </aside>
+);

--- a/packages/ui/src/design-system/FloatingPanel/index.ts
+++ b/packages/ui/src/design-system/FloatingPanel/index.ts
@@ -1,0 +1,1 @@
+export * from './FloatingPanel';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -30,6 +30,7 @@ export * from './design-system/ChecklistTable';
 export * from './design-system/DEPRECATED_Table';
 export * from './design-system/Divider';
 export * from './design-system/Field';
+export * from './design-system/FloatingPanel';
 export * from './design-system/Footer';
 export * from './design-system/FormSection';
 export * from './design-system/Header';


### PR DESCRIPTION
Primitive DS `FloatingPanel` non-modale (panneau flottant ancré, sans focus-trap ni overlay bloquant) + stories. Brique réutilisable, indépendante.

Consommée par la PR stackée #feat/app-preuves-archive (panel Mes téléchargements).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notes de version

* **Nouvelles Fonctionnalités**
  * Ajout d'un composant de panneau flottant permettant d'afficher du contenu dans une fenêtre positionnée en bas à droite de l'écran, avec titre, bouton de fermeture et zone de contenu défilable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->