### PR TITLE
feat(app): archive téléchargeable des preuves d'un audit

### DIFF
--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/new/[referentielId]/layout.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/new/[referentielId]/layout.tsx
@@ -1,3 +1,4 @@
+import { PreuvesArchiveGenerationProvider } from '@/app/referentiels/preuves-archive/preuves-archive-generation.provider';
 import { ReferentielProvider } from '@/app/referentiels/referentiel-context';
 import { referentielIdEnumSchema } from '@tet/domain/referentiels';
 import { ReactNode } from 'react';
@@ -14,7 +15,9 @@ export default async function Layout({
 
   return (
     <ReferentielProvider referentielId={referentielId}>
-      {children}
+      <PreuvesArchiveGenerationProvider>
+        {children}
+      </PreuvesArchiveGenerationProvider>
     </ReferentielProvider>
   );
 }

--- a/apps/app/src/labels/catalog.ts
+++ b/apps/app/src/labels/catalog.ts
@@ -275,6 +275,38 @@ export const appLabels = {
   editerReferentiel: 'Éditer le référentiel',
   enregistrer: 'Enregistrer',
 
+  preuvesArchiveTelechargerTout: 'Télécharger toutes les preuves',
+  preuvesArchiveGenerer: 'Générer une archive',
+  preuvesArchiveAucune: 'Aucune archive générée pour le moment.',
+  mesTelechargements: 'Mes téléchargements',
+  preuvesArchiveFermerPanel: 'Fermer le panneau de téléchargements',
+  preuvesArchiveLigneTitre: ({
+    referentiel,
+    collectivite,
+  }: {
+    referentiel: string;
+    collectivite: string;
+  }): string => `${referentiel} · ${collectivite}`,
+  preuvesArchiveProgression: ({
+    processed,
+    total,
+  }: {
+    processed: number;
+    total: number;
+  }): string => `${processed} / ${total} fichiers`,
+  preuvesArchiveNombreFichiers: ({ count }: { count: number }): string =>
+    `${count} fichier${count > 1 ? 's' : ''}`,
+  preuvesArchiveTelecharger: "Télécharger l'archive",
+  preuvesArchiveReessayer: 'Réessayer',
+  preuvesArchiveErreurGenerique: "La génération de l'archive a échoué.",
+  preuvesArchiveAnnonceEnCours: ({ count }: { count: number }): string =>
+    `${count} archive${count > 1 ? 's' : ''} de preuves en cours de génération.`,
+  preuvesArchiveAnnoncePretes: ({ count }: { count: number }): string =>
+    `${count} archive${count > 1 ? 's' : ''} de preuves prête${
+      count > 1 ? 's' : ''
+    } au téléchargement.`,
+  preuvesArchiveAnnonceEchec: "La génération d'une archive de preuves a échoué.",
+
   erreurConnexionReseau:
     "Erreur de connexion réseau. Veuillez attendre que votre connexion soit rétablie pour utiliser l'application.",
 

--- a/apps/app/src/referentiels/audit-labellisation/checklist-page-header/referentiel-menu.button.tsx
+++ b/apps/app/src/referentiels/audit-labellisation/checklist-page-header/referentiel-menu.button.tsx
@@ -1,6 +1,9 @@
 import { DownloadScoreModal } from '@/app/app/pages/collectivite/Referentiels/DownloadScore/download-score.modal';
 import { SaveScoreModal } from '@/app/app/pages/collectivite/Referentiels/SaveScore/save-score.modal';
 import { appLabels } from '@/app/labels/catalog';
+import { useChecklist } from '@/app/referentiels/audit-labellisation/checklist.context';
+import { isAuditActif } from '@/app/referentiels/audit-labellisation/checklist/is-audit-actif';
+import { usePreuvesArchiveGeneration } from '@/app/referentiels/preuves-archive/preuves-archive-generation.provider';
 import { useCurrentCollectivite } from '@tet/api/collectivites';
 import { ReferentielId } from '@tet/domain/referentiels';
 import { ButtonMenu, MenuAction } from '@tet/ui';
@@ -13,8 +16,14 @@ export const ReferentielMenuButton = ({
   referentielId: ReferentielId;
   collectiviteId: number;
 }): ReactElement => {
-  const { hasCollectivitePermission } = useCurrentCollectivite();
+  const { hasCollectivitePermission, nom: collectiviteNom } =
+    useCurrentCollectivite();
   const canMutate = hasCollectivitePermission('referentiels.mutate');
+
+  const { cycle } = useChecklist();
+  const isAuditeur = cycle.isAuditeur;
+  const auditActif = isAuditActif(cycle);
+  const { openPanel } = usePreuvesArchiveGeneration();
 
   const [isDownloadOpen, setIsDownloadOpen] = useState(false);
   const [isSaveOpen, setIsSaveOpen] = useState(false);
@@ -29,10 +38,23 @@ export const ReferentielMenuButton = ({
     icon: 'camera-line',
     onClick: () => setIsSaveOpen(true),
   };
+  const telechargerArchiveAction: MenuAction = {
+    label: appLabels.preuvesArchiveTelechargerTout,
+    icon: 'folder-zip-line',
+    onClick: () =>
+      openPanel({
+        collectiviteId,
+        collectiviteNom,
+        referentielId,
+        canGenerate: auditActif,
+      }),
+  };
 
-  const menuActions: MenuAction[] = canMutate
-    ? [telechargerAction, figerAction]
-    : [telechargerAction];
+  const menuActions: MenuAction[] = [
+    telechargerAction,
+    ...(canMutate ? [figerAction] : []),
+    ...(isAuditeur ? [telechargerArchiveAction] : []),
+  ];
 
   return (
     <>

--- a/apps/app/src/referentiels/audit-labellisation/checklist/is-audit-actif.spec.ts
+++ b/apps/app/src/referentiels/audit-labellisation/checklist/is-audit-actif.spec.ts
@@ -1,0 +1,73 @@
+import { TCycleLabellisation } from '@/app/referentiels/labellisations/useCycleLabellisation';
+import { describe, expect, it } from 'vitest';
+import { isAuditActif } from './is-audit-actif';
+
+function makeCycle(
+  overrides: Partial<TCycleLabellisation> & {
+    parcoursOverrides?: Partial<NonNullable<TCycleLabellisation['parcours']>>;
+  } = {}
+): TCycleLabellisation {
+  const { parcoursOverrides, ...rest } = overrides;
+  const audit = {
+    id: 42,
+    collectivite_id: 1,
+    referentiel_id: 'cae',
+    demande_id: null,
+    date_debut: null,
+    date_fin: null,
+    date_cnl: null,
+    valide: false,
+    valide_labellisation: false,
+    clos: false,
+  } as NonNullable<TCycleLabellisation['parcours']>['audit'];
+
+  const defaultParcours = {
+    status: 'audit_en_cours',
+    audit,
+  } as NonNullable<TCycleLabellisation['parcours']>;
+
+  return {
+    parcours: { ...defaultParcours, ...parcoursOverrides },
+    isLoading: false,
+    isError: false,
+    status: 'audit_en_cours',
+    isAuditeur: true,
+    isCOT: false,
+    labellisable: true,
+    peutDemanderEtoile: false,
+    peutCommencerAudit: false,
+    peutDemander1ereEtoileCOT: false,
+    ...rest,
+  } as TCycleLabellisation;
+}
+
+describe('isAuditActif', () => {
+  it("est vrai quand le statut est audit_en_cours et l'audit existe", () => {
+    expect(isAuditActif(makeCycle())).toBe(true);
+  });
+
+  it("est faux quand le statut n'est pas audit_en_cours", () => {
+    const statutsNonAuditEnCours = [
+      'non_demandee',
+      'demande_envoyee',
+      'audit_valide',
+      'labellisation_en_cours',
+    ] as const;
+
+    statutsNonAuditEnCours.forEach((status) => {
+      expect(
+        isAuditActif(makeCycle({ parcoursOverrides: { status } }))
+      ).toBe(false);
+    });
+  });
+
+  it("est faux quand le parcours n'est pas chargé", () => {
+    expect(isAuditActif(makeCycle({ parcours: null }))).toBe(false);
+  });
+
+  it("est faux quand l'audit est null malgré le statut audit_en_cours", () => {
+    expect(
+      isAuditActif(makeCycle({ parcoursOverrides: { audit: null } }))
+    ).toBe(false);
+  });
+});

--- a/apps/app/src/referentiels/audit-labellisation/checklist/is-audit-actif.ts
+++ b/apps/app/src/referentiels/audit-labellisation/checklist/is-audit-actif.ts
@@ -1,0 +1,7 @@
+import { TCycleLabellisation } from '@/app/referentiels/labellisations/useCycleLabellisation';
+
+export function isAuditActif(cycle: TCycleLabellisation): boolean {
+  const { parcours } = cycle;
+  if (!parcours) return false;
+  return parcours.status === 'audit_en_cours' && parcours.audit !== null;
+}

--- a/apps/app/src/referentiels/preuves-archive/archive-output-to-row-state.spec.ts
+++ b/apps/app/src/referentiels/preuves-archive/archive-output-to-row-state.spec.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import {
+  archiveOutputToRowState,
+  isArchiveInFlight,
+  PreuvesArchiveListItem,
+} from './archive-output-to-row-state';
+
+type ItemOverrides = Partial<Omit<PreuvesArchiveListItem, 'status'>> & {
+  status?: 'pending' | 'processing' | 'completed' | 'failed';
+};
+
+function makeItem(overrides: ItemOverrides = {}): PreuvesArchiveListItem {
+  return {
+    archiveId: '11111111-1111-1111-1111-111111111111',
+    status: 'processing',
+    totalFiles: 10,
+    processedFiles: 3,
+    createdAt: '2026-06-16 08:00:00+00',
+    ...overrides,
+  } as unknown as PreuvesArchiveListItem;
+}
+
+describe('archiveOutputToRowState', () => {
+  it('mappe pending vers preparing avec progression', () => {
+    const state = archiveOutputToRowState(
+      makeItem({ status: 'pending', totalFiles: 8, processedFiles: 0 })
+    );
+
+    expect(state).toEqual({
+      kind: 'preparing',
+      processed: 0,
+      total: 8,
+      indeterminate: false,
+    });
+  });
+
+  it('mappe processing vers preparing avec progression', () => {
+    const state = archiveOutputToRowState(
+      makeItem({ status: 'processing', totalFiles: 10, processedFiles: 4 })
+    );
+
+    expect(state).toEqual({
+      kind: 'preparing',
+      processed: 4,
+      total: 10,
+      indeterminate: false,
+    });
+  });
+
+  it('marque la progression indeterminée tant que totalFiles vaut 0', () => {
+    const state = archiveOutputToRowState(
+      makeItem({ status: 'processing', totalFiles: 0, processedFiles: 0 })
+    );
+
+    expect(state).toEqual({
+      kind: 'preparing',
+      processed: 0,
+      total: 0,
+      indeterminate: true,
+    });
+  });
+
+  it('mappe completed vers ready en conservant le nombre de fichiers', () => {
+    const state = archiveOutputToRowState(
+      makeItem({ status: 'completed', totalFiles: 12 })
+    );
+
+    expect(state).toEqual({ kind: 'ready', totalFiles: 12 });
+  });
+
+  it('mappe failed vers error retryable', () => {
+    const state = archiveOutputToRowState(makeItem({ status: 'failed' }));
+
+    expect(state).toEqual({
+      kind: 'error',
+      backendMessage: null,
+      retryable: true,
+    });
+  });
+});
+
+describe('isArchiveInFlight', () => {
+  it('est vrai pour pending et processing', () => {
+    expect(isArchiveInFlight(makeItem({ status: 'pending' }))).toBe(true);
+    expect(isArchiveInFlight(makeItem({ status: 'processing' }))).toBe(true);
+  });
+
+  it('est faux pour completed et failed', () => {
+    expect(isArchiveInFlight(makeItem({ status: 'completed' }))).toBe(false);
+    expect(isArchiveInFlight(makeItem({ status: 'failed' }))).toBe(false);
+  });
+});

--- a/apps/app/src/referentiels/preuves-archive/archive-output-to-row-state.ts
+++ b/apps/app/src/referentiels/preuves-archive/archive-output-to-row-state.ts
@@ -1,0 +1,36 @@
+import { RouterOutput } from '@tet/api';
+import { match } from 'ts-pattern';
+
+export type PreuvesArchiveListItem =
+  RouterOutput['referentiels']['preuvesArchive']['list'][number];
+
+export type ArchiveRowState =
+  | { kind: 'preparing'; processed: number; total: number; indeterminate: boolean }
+  | { kind: 'ready'; totalFiles: number }
+  | { kind: 'error'; backendMessage: string | null; retryable: boolean };
+
+export function isArchiveInFlight(item: PreuvesArchiveListItem): boolean {
+  return item.status === 'pending' || item.status === 'processing';
+}
+
+export function archiveOutputToRowState(
+  item: PreuvesArchiveListItem
+): ArchiveRowState {
+  return match(item.status)
+    .with('pending', 'processing', () => ({
+      kind: 'preparing' as const,
+      processed: item.processedFiles,
+      total: item.totalFiles,
+      indeterminate: item.totalFiles === 0,
+    }))
+    .with('completed', () => ({
+      kind: 'ready' as const,
+      totalFiles: item.totalFiles,
+    }))
+    .with('failed', () => ({
+      kind: 'error' as const,
+      backendMessage: null,
+      retryable: true,
+    }))
+    .exhaustive();
+}

--- a/apps/app/src/referentiels/preuves-archive/archives-panel.tsx
+++ b/apps/app/src/referentiels/preuves-archive/archives-panel.tsx
@@ -1,0 +1,113 @@
+import { referentielToName } from '@/app/app/labels';
+import { appLabels } from '@/app/labels/catalog';
+import { ReferentielId } from '@tet/domain/referentiels';
+import { Button } from '@tet/ui';
+import { JSX, ReactNode } from 'react';
+import {
+  archiveOutputToRowState,
+  isArchiveInFlight,
+  PreuvesArchiveListItem,
+} from './archive-output-to-row-state';
+import { useListPreuvesArchive } from './data/use-list-preuves-archive';
+import { DownloadsPanel } from './downloads-panel';
+import { ReferentielArchiveRow } from './referentiel-archive-row';
+import { useDownloadArchive } from './use-download-archive';
+import { useGenerateArchive } from './use-generate-archive';
+import { useTickingNow } from './use-ticking-now';
+
+export type ArchivesPanelParams = {
+  collectiviteId: number;
+  collectiviteNom: string;
+  referentielId: ReferentielId;
+  canGenerate: boolean;
+};
+
+function NoArchivePlaceholder(): JSX.Element {
+  return (
+    <li className="m-0 text-sm text-grey-7">{appLabels.preuvesArchiveAucune}</li>
+  );
+}
+
+function ScreenReaderAnnouncement({
+  message,
+}: {
+  message: string;
+}): JSX.Element {
+  return (
+    <span role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+      {message}
+    </span>
+  );
+}
+
+function archivesAnnouncement(archives: PreuvesArchiveListItem[]): string {
+  const kinds = archives.map((archive) => archiveOutputToRowState(archive).kind);
+  const enCours = kinds.filter((kind) => kind === 'preparing').length;
+  if (enCours > 0) {
+    return appLabels.preuvesArchiveAnnonceEnCours({ count: enCours });
+  }
+  if (kinds.includes('error')) {
+    return appLabels.preuvesArchiveAnnonceEchec;
+  }
+  const pretes = kinds.filter((kind) => kind === 'ready').length;
+  if (pretes > 0) {
+    return appLabels.preuvesArchiveAnnoncePretes({ count: pretes });
+  }
+  return '';
+}
+
+export function ArchivesPanel({
+  collectiviteId,
+  collectiviteNom,
+  referentielId,
+  canGenerate,
+  onClose,
+}: ArchivesPanelParams & { onClose: () => void }): ReactNode {
+  const { data: archives = [] } = useListPreuvesArchive(
+    collectiviteId,
+    referentielId
+  );
+  const { generate, isGenerating } = useGenerateArchive({
+    collectiviteId,
+    referentielId,
+  });
+  const downloadArchive = useDownloadArchive();
+  const nowMs = useTickingNow(archives.some(isArchiveInFlight));
+  const getElapsedTime = (sinceMs: number): number => nowMs - sinceMs;
+
+  const generateButton = (
+    <Button
+      size="sm"
+      variant="outlined"
+      icon="folder-zip-line"
+      disabled={!canGenerate || isGenerating}
+      onClick={generate}
+    >
+      {appLabels.preuvesArchiveGenerer}
+    </Button>
+  );
+
+  return (
+    <>
+      <ScreenReaderAnnouncement message={archivesAnnouncement(archives)} />
+      <DownloadsPanel onClose={onClose} action={generateButton}>
+        {archives.length === 0 ? (
+          <NoArchivePlaceholder />
+        ) : (
+          archives.map((item) => (
+            <ReferentielArchiveRow
+              key={item.archiveId}
+              state={archiveOutputToRowState(item)}
+              referentielLabel={referentielToName[referentielId]}
+              collectiviteNom={collectiviteNom}
+              startedAtMs={new Date(item.createdAt).getTime()}
+              getElapsedTime={getElapsedTime}
+              onDownload={() => downloadArchive(item.archiveId)}
+              onRetry={generate}
+            />
+          ))
+        )}
+      </DownloadsPanel>
+    </>
+  );
+}

--- a/apps/app/src/referentiels/preuves-archive/data/use-fetch-archive-download-url.ts
+++ b/apps/app/src/referentiels/preuves-archive/data/use-fetch-archive-download-url.ts
@@ -1,0 +1,16 @@
+import { useTRPC } from '@tet/api';
+import { useQueryClient } from '@tanstack/react-query';
+
+export function useFetchArchiveDownloadUrl(): (
+  archiveId: string
+) => Promise<string | null> {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  return async (archiveId) => {
+    const archive = await queryClient.fetchQuery({
+      ...trpc.referentiels.preuvesArchive.get.queryOptions({ archiveId }),
+      staleTime: 0,
+    });
+    return archive.downloadUrl;
+  };
+}

--- a/apps/app/src/referentiels/preuves-archive/data/use-list-preuves-archive.ts
+++ b/apps/app/src/referentiels/preuves-archive/data/use-list-preuves-archive.ts
@@ -1,0 +1,21 @@
+import { useTRPC } from '@tet/api';
+import { useQuery } from '@tanstack/react-query';
+import { ReferentielId } from '@tet/domain/referentiels';
+import { isArchiveInFlight } from '../archive-output-to-row-state';
+
+const POLLING_INTERVAL_MS = 2000;
+
+export function useListPreuvesArchive(
+  collectiviteId: number,
+  referentielId: ReferentielId
+) {
+  const trpc = useTRPC();
+  return useQuery({
+    ...trpc.referentiels.preuvesArchive.list.queryOptions({
+      collectiviteId,
+      referentielId,
+    }),
+    refetchInterval: (query) =>
+      query.state.data?.some(isArchiveInFlight) ? POLLING_INTERVAL_MS : false,
+  });
+}

--- a/apps/app/src/referentiels/preuves-archive/data/use-request-preuves-archive.ts
+++ b/apps/app/src/referentiels/preuves-archive/data/use-request-preuves-archive.ts
@@ -1,0 +1,19 @@
+import { useTRPC } from '@tet/api';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+export function useRequestPreuvesArchive() {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  return useMutation(
+    trpc.referentiels.preuvesArchive.request.mutationOptions({
+      onSuccess: (_, { collectiviteId, referentielId }) => {
+        queryClient.invalidateQueries({
+          queryKey: trpc.referentiels.preuvesArchive.list.queryKey({
+            collectiviteId,
+            referentielId,
+          }),
+        });
+      },
+    })
+  );
+}

--- a/apps/app/src/referentiels/preuves-archive/downloads-panel.tsx
+++ b/apps/app/src/referentiels/preuves-archive/downloads-panel.tsx
@@ -1,0 +1,26 @@
+import { appLabels } from '@/app/labels/catalog';
+import { FloatingPanel } from '@tet/ui';
+import { JSX, ReactNode } from 'react';
+
+type DownloadsPanelProps = {
+  children: ReactNode;
+  onClose: () => void;
+  action?: ReactNode;
+};
+
+export function DownloadsPanel({
+  children,
+  onClose,
+  action,
+}: DownloadsPanelProps): JSX.Element {
+  return (
+    <FloatingPanel
+      title={appLabels.mesTelechargements}
+      onClose={onClose}
+      closeLabel={appLabels.preuvesArchiveFermerPanel}
+    >
+      <ul className="m-0 flex list-none flex-col gap-6 p-0">{children}</ul>
+      {action && <div className="mt-4 flex justify-end">{action}</div>}
+    </FloatingPanel>
+  );
+}

--- a/apps/app/src/referentiels/preuves-archive/preuves-archive-generation.provider.tsx
+++ b/apps/app/src/referentiels/preuves-archive/preuves-archive-generation.provider.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import {
+  JSX,
+  ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
+import { ArchivesPanel, ArchivesPanelParams } from './archives-panel';
+
+type PreuvesArchiveGenerationContextValue = {
+  openPanel: (params: ArchivesPanelParams) => void;
+};
+
+const PreuvesArchiveGenerationContext =
+  createContext<PreuvesArchiveGenerationContextValue | null>(null);
+
+export function usePreuvesArchiveGeneration(): PreuvesArchiveGenerationContextValue {
+  const context = useContext(PreuvesArchiveGenerationContext);
+  if (!context) {
+    throw new Error(
+      'usePreuvesArchiveGeneration doit être utilisé dans un PreuvesArchiveGenerationProvider'
+    );
+  }
+  return context;
+}
+
+export function PreuvesArchiveGenerationProvider({
+  children,
+}: {
+  children: ReactNode;
+}): JSX.Element {
+  const [panelParams, setPanelParams] = useState<ArchivesPanelParams | null>(
+    null
+  );
+
+  const openPanel = useCallback(
+    (params: ArchivesPanelParams) => setPanelParams(params),
+    []
+  );
+  const closePanel = useCallback(() => setPanelParams(null), []);
+
+  const value = useMemo(() => ({ openPanel }), [openPanel]);
+
+  return (
+    <PreuvesArchiveGenerationContext.Provider value={value}>
+      {children}
+      {panelParams !== null && (
+        <ArchivesPanel
+          collectiviteId={panelParams.collectiviteId}
+          collectiviteNom={panelParams.collectiviteNom}
+          referentielId={panelParams.referentielId}
+          canGenerate={panelParams.canGenerate}
+          onClose={closePanel}
+        />
+      )}
+    </PreuvesArchiveGenerationContext.Provider>
+  );
+}

--- a/apps/app/src/referentiels/preuves-archive/referentiel-archive-row.spec.tsx
+++ b/apps/app/src/referentiels/preuves-archive/referentiel-archive-row.spec.tsx
@@ -1,0 +1,111 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ReferentielArchiveRow } from './referentiel-archive-row';
+
+const noop = () => undefined;
+
+const baseProps = {
+  referentielLabel: 'Climat Air Énergie',
+  collectiviteNom: 'Ville Test',
+  startedAtMs: 1_700_000_000_000,
+  getElapsedTime: () => 2 * 60 * 1000,
+  onDownload: noop,
+  onRetry: noop,
+};
+
+describe('ReferentielArchiveRow', () => {
+  it('affiche référentiel · collectivité et le temps écoulé', () => {
+    render(
+      <ReferentielArchiveRow
+        {...baseProps}
+        state={{ kind: 'preparing', processed: 0, total: 0, indeterminate: true }}
+      />
+    );
+
+    expect(screen.getByText('Climat Air Énergie · Ville Test')).toBeTruthy();
+    expect(screen.getByText('il y a 2 minutes')).toBeTruthy();
+  });
+
+  it('affiche le ratio de progression en préparation déterminée', () => {
+    render(
+      <ReferentielArchiveRow
+        {...baseProps}
+        state={{ kind: 'preparing', processed: 3, total: 10, indeterminate: false }}
+      />
+    );
+
+    expect(screen.getByText(/3 \/ 10 fichiers/)).toBeTruthy();
+  });
+
+  it('masque le ratio en préparation indéterminée', () => {
+    render(
+      <ReferentielArchiveRow
+        {...baseProps}
+        state={{ kind: 'preparing', processed: 0, total: 0, indeterminate: true }}
+      />
+    );
+
+    expect(screen.queryByText(/fichiers/)).toBeNull();
+  });
+
+  it('clamp à zéro quand le temps écoulé est négatif (décalage d horloge)', () => {
+    render(
+      <ReferentielArchiveRow
+        {...baseProps}
+        getElapsedTime={() => -1000}
+        state={{ kind: 'preparing', processed: 0, total: 0, indeterminate: true }}
+      />
+    );
+
+    expect(screen.getByText(/il y a/)).toBeTruthy();
+    expect(screen.queryByText(/dans/)).toBeNull();
+  });
+
+  it("affiche le nombre de fichiers et déclenche onDownload depuis l'état prêt", () => {
+    const onDownload = vi.fn();
+    render(
+      <ReferentielArchiveRow
+        {...baseProps}
+        onDownload={onDownload}
+        state={{ kind: 'ready', totalFiles: 12 }}
+      />
+    );
+
+    expect(screen.getByText(/12 fichiers/)).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: /Télécharger/ }));
+
+    expect(onDownload).toHaveBeenCalledTimes(1);
+  });
+
+  it('affiche le message backend et déclenche onRetry en erreur retryable', () => {
+    const onRetry = vi.fn();
+    render(
+      <ReferentielArchiveRow
+        {...baseProps}
+        onRetry={onRetry}
+        state={{
+          kind: 'error',
+          backendMessage: 'Le stockage est indisponible.',
+          retryable: true,
+        }}
+      />
+    );
+
+    expect(screen.getByText('Le stockage est indisponible.')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: /Réessayer/ }));
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('utilise le message générique et masque Réessayer en erreur non-retryable', () => {
+    render(
+      <ReferentielArchiveRow
+        {...baseProps}
+        state={{ kind: 'error', backendMessage: null, retryable: false }}
+      />
+    );
+
+    expect(screen.getByText("La génération de l'archive a échoué.")).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /Réessayer/ })).toBeNull();
+  });
+});

--- a/apps/app/src/referentiels/preuves-archive/referentiel-archive-row.tsx
+++ b/apps/app/src/referentiels/preuves-archive/referentiel-archive-row.tsx
@@ -1,0 +1,174 @@
+import { appLabels } from '@/app/labels/catalog';
+import { Button, Icon } from '@tet/ui';
+import { formatDistance } from 'date-fns';
+import { fr } from 'date-fns/locale';
+import { JSX, ReactNode } from 'react';
+import { ArchiveRowState } from './archive-output-to-row-state';
+
+type ReferentielArchiveRowProps = {
+  state: ArchiveRowState;
+  referentielLabel: string;
+  collectiviteNom: string;
+  startedAtMs: number;
+  getElapsedTime: (sinceMs: number) => number;
+  onDownload: () => void;
+  onRetry: () => void;
+};
+
+const iconByKind: Record<
+  ArchiveRowState['kind'],
+  { icon: string; className: string }
+> = {
+  preparing: { icon: 'loader-4-line', className: 'animate-spin text-primary-7' },
+  ready: { icon: 'check-line', className: 'text-success' },
+  error: { icon: 'error-warning-line', className: 'text-error-1' },
+};
+
+function ArchiveStatusIcon({
+  kind,
+}: {
+  kind: ArchiveRowState['kind'];
+}): JSX.Element {
+  const { icon, className } = iconByKind[kind];
+  return <Icon icon={icon} size="md" className={className} aria-hidden="true" />;
+}
+
+function ArchiveTitle({
+  referentielLabel,
+  collectiviteNom,
+}: {
+  referentielLabel: string;
+  collectiviteNom: string;
+}): JSX.Element {
+  return (
+    <span className="truncate text-sm font-semibold leading-tight text-primary-9">
+      {appLabels.preuvesArchiveLigneTitre({
+        referentiel: referentielLabel,
+        collectivite: collectiviteNom,
+      })}
+    </span>
+  );
+}
+
+function ArchiveStatusLine({
+  elapsedLabel,
+  progressLabel,
+}: {
+  elapsedLabel: string;
+  progressLabel: string | null;
+}): JSX.Element {
+  return (
+    <span className="text-xs leading-tight text-grey-7">
+      {elapsedLabel}
+      {progressLabel !== null && (
+        <>
+          {' · '}
+          {progressLabel}
+        </>
+      )}
+    </span>
+  );
+}
+
+function ArchiveErrorLine({ message }: { message: string }): JSX.Element {
+  return (
+    <span className="mt-1 text-xs leading-tight text-error-1">{message}</span>
+  );
+}
+
+function ArchiveRowAction({
+  state,
+  onDownload,
+  onRetry,
+}: {
+  state: ArchiveRowState;
+  onDownload: () => void;
+  onRetry: () => void;
+}): ReactNode {
+  switch (state.kind) {
+    case 'preparing':
+      return null;
+    case 'ready':
+      return (
+        <Button
+          size="xs"
+          variant="outlined"
+          icon="download-line"
+          title={appLabels.preuvesArchiveTelecharger}
+          aria-label={appLabels.preuvesArchiveTelecharger}
+          onClick={onDownload}
+        />
+      );
+    case 'error':
+      return state.retryable ? (
+        <Button
+          size="xs"
+          variant="outlined"
+          icon="refresh-line"
+          title={appLabels.preuvesArchiveReessayer}
+          aria-label={appLabels.preuvesArchiveReessayer}
+          onClick={onRetry}
+        />
+      ) : null;
+  }
+}
+
+function progressLabelFor(state: ArchiveRowState): string | null {
+  if (state.kind === 'preparing' && !state.indeterminate) {
+    return appLabels.preuvesArchiveProgression({
+      processed: state.processed,
+      total: state.total,
+    });
+  }
+  if (state.kind === 'ready') {
+    return appLabels.preuvesArchiveNombreFichiers({
+      count: state.totalFiles,
+    });
+  }
+  return null;
+}
+
+export function ReferentielArchiveRow({
+  state,
+  referentielLabel,
+  collectiviteNom,
+  startedAtMs,
+  getElapsedTime,
+  onDownload,
+  onRetry,
+}: ReferentielArchiveRowProps): JSX.Element {
+  const elapsedLabel = formatDistance(
+    0,
+    Math.max(getElapsedTime(startedAtMs), 0),
+    { locale: fr, addSuffix: true, includeSeconds: true }
+  );
+
+  const progressLabel = progressLabelFor(state);
+
+  const errorMessage =
+    state.kind === 'error'
+      ? state.backendMessage ?? appLabels.preuvesArchiveErreurGenerique
+      : null;
+
+  return (
+    <li className="flex items-center gap-3">
+      <ArchiveStatusIcon kind={state.kind} />
+      <div className="flex min-w-0 flex-1 flex-col">
+        <ArchiveTitle
+          referentielLabel={referentielLabel}
+          collectiviteNom={collectiviteNom}
+        />
+        <ArchiveStatusLine
+          elapsedLabel={elapsedLabel}
+          progressLabel={progressLabel}
+        />
+        {errorMessage !== null && <ArchiveErrorLine message={errorMessage} />}
+      </div>
+      <ArchiveRowAction
+        state={state}
+        onDownload={onDownload}
+        onRetry={onRetry}
+      />
+    </li>
+  );
+}

--- a/apps/app/src/referentiels/preuves-archive/use-download-archive.spec.ts
+++ b/apps/app/src/referentiels/preuves-archive/use-download-archive.spec.ts
@@ -1,0 +1,57 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { appLabels } from '../../labels/catalog';
+import { useDownloadArchive } from './use-download-archive';
+
+const { fetchDownloadUrl, setToast } = vi.hoisted(() => ({
+  fetchDownloadUrl: vi.fn(),
+  setToast: vi.fn(),
+}));
+
+vi.mock('./data/use-fetch-archive-download-url', () => ({
+  useFetchArchiveDownloadUrl: () => fetchDownloadUrl,
+}));
+vi.mock('../../utils/toast/toast-context', () => ({
+  useToastContext: () => ({ setToast }),
+}));
+
+describe('useDownloadArchive', () => {
+  beforeEach(() => {
+    fetchDownloadUrl.mockReset();
+    setToast.mockReset();
+  });
+
+  it("récupère l'URL signée par archiveId et n'affiche pas de toast", async () => {
+    fetchDownloadUrl.mockResolvedValue('https://signed.test/archive.zip');
+    const { result } = renderHook(() => useDownloadArchive());
+
+    await result.current('a1');
+
+    expect(fetchDownloadUrl).toHaveBeenCalledWith('a1');
+    expect(setToast).not.toHaveBeenCalled();
+  });
+
+  it("affiche un toast d'erreur quand l'URL est nulle (archive indisponible)", async () => {
+    fetchDownloadUrl.mockResolvedValue(null);
+    const { result } = renderHook(() => useDownloadArchive());
+
+    await result.current('a1');
+
+    expect(setToast).toHaveBeenCalledWith(
+      'error',
+      appLabels.preuvesArchiveErreurGenerique
+    );
+  });
+
+  it("affiche un toast d'erreur quand la récupération de l'URL échoue", async () => {
+    fetchDownloadUrl.mockRejectedValue(new Error('network'));
+    const { result } = renderHook(() => useDownloadArchive());
+
+    await result.current('a1');
+
+    expect(setToast).toHaveBeenCalledWith(
+      'error',
+      appLabels.preuvesArchiveErreurGenerique
+    );
+  });
+});

--- a/apps/app/src/referentiels/preuves-archive/use-download-archive.ts
+++ b/apps/app/src/referentiels/preuves-archive/use-download-archive.ts
@@ -1,0 +1,31 @@
+import { appLabels } from '@/app/labels/catalog';
+import { useToastContext } from '@/app/utils/toast/toast-context';
+import { useFetchArchiveDownloadUrl } from './data/use-fetch-archive-download-url';
+
+function triggerBrowserDownload(url: string): void {
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.target = '_blank';
+  anchor.rel = 'noopener noreferrer';
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+}
+
+export function useDownloadArchive(): (archiveId: string) => Promise<void> {
+  const { setToast } = useToastContext();
+  const fetchDownloadUrl = useFetchArchiveDownloadUrl();
+
+  return async (archiveId) => {
+    try {
+      const downloadUrl = await fetchDownloadUrl(archiveId);
+      if (downloadUrl === null) {
+        setToast('error', appLabels.preuvesArchiveErreurGenerique);
+        return;
+      }
+      triggerBrowserDownload(downloadUrl);
+    } catch {
+      setToast('error', appLabels.preuvesArchiveErreurGenerique);
+    }
+  };
+}

--- a/apps/app/src/referentiels/preuves-archive/use-generate-archive.ts
+++ b/apps/app/src/referentiels/preuves-archive/use-generate-archive.ts
@@ -1,0 +1,28 @@
+import { appLabels } from '@/app/labels/catalog';
+import { useToastContext } from '@/app/utils/toast/toast-context';
+import { ReferentielId } from '@tet/domain/referentiels';
+import { useRequestPreuvesArchive } from './data/use-request-preuves-archive';
+
+export function useGenerateArchive({
+  collectiviteId,
+  referentielId,
+}: {
+  collectiviteId: number;
+  referentielId: ReferentielId;
+}): { generate: () => void; isGenerating: boolean } {
+  const { setToast } = useToastContext();
+  const { mutate, isPending } = useRequestPreuvesArchive();
+
+  const generate = (): void => {
+    if (isPending) return;
+    mutate(
+      { collectiviteId, referentielId },
+      {
+        onError: () =>
+          setToast('error', appLabels.preuvesArchiveErreurGenerique),
+      }
+    );
+  };
+
+  return { generate, isGenerating: isPending };
+}

--- a/apps/app/src/referentiels/preuves-archive/use-ticking-now.ts
+++ b/apps/app/src/referentiels/preuves-archive/use-ticking-now.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from 'react';
+
+const TICK_INTERVAL_MS = 30_000;
+
+export function useTickingNow(isActive: boolean): number {
+  const [nowMs, setNowMs] = useState<number>(() => Date.now());
+
+  useEffect(() => {
+    if (!isActive) return;
+    const interval = setInterval(() => setNowMs(Date.now()), TICK_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [isActive]);
+
+  return nowMs;
+}

--- a/apps/backend/src/referentiels/preuves-archive/models/audit-preuves-archive.table.ts
+++ b/apps/backend/src/referentiels/preuves-archive/models/audit-preuves-archive.table.ts
@@ -17,12 +17,12 @@ import {
 } from 'drizzle-orm/pg-core';
 import { z } from 'zod';
 
-export enum AuditPreuvesArchiveStatusEnum {
-  PENDING = 'pending',
-  PROCESSING = 'processing',
-  COMPLETED = 'completed',
-  FAILED = 'failed',
-}
+export const AuditPreuvesArchiveStatusEnum = {
+  PENDING: 'pending',
+  PROCESSING: 'processing',
+  COMPLETED: 'completed',
+  FAILED: 'failed',
+} as const;
 
 const orderedAuditPreuvesArchiveStatus = [
   AuditPreuvesArchiveStatusEnum.PENDING,

--- a/package.json
+++ b/package.json
@@ -158,6 +158,7 @@
     "tailwind-merge": "2.6.0",
     "tailwindcss": "3.4.17",
     "ts-case-convert": "2.1.0",
+    "ts-pattern": "5.9.0",
     "tslib": "2.8.1",
     "use-debounce": "10.0.6",
     "uuid": "8.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -449,6 +449,9 @@ importers:
       ts-case-convert:
         specifier: 2.1.0
         version: 2.1.0
+      ts-pattern:
+        specifier: 5.9.0
+        version: 5.9.0
       tslib:
         specifier: 2.8.1
         version: 2.8.1
@@ -14272,6 +14275,9 @@ packages:
         optional: true
       '@swc/wasm':
         optional: true
+
+  ts-pattern@5.9.0:
+    resolution: {integrity: sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg==}
 
   tsafe@1.8.5:
     resolution: {integrity: sha512-LFWTWQrW6rwSY+IBNFl2ridGfUzVsPwrZ26T4KUJww/py8rzaQ/SY+MIz6YROozpUCaRcuISqagmlwub9YT9kw==}
@@ -31464,6 +31470,8 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.13.5(@swc/helpers@0.5.17)
     optional: true
+
+  ts-pattern@5.9.0: {}
 
   tsafe@1.8.5: {}
 


### PR DESCRIPTION
Stackée sur #4590 (FloatingPanel).

Génération + suivi + téléchargement des archives de preuves d'un audit, dans le panel « Mes téléchargements » :
- mapper `archive-output-to-row-state` (ts-pattern), hooks `useGenerateArchive` / `useDownloadArchive` / `useListPreuvesArchive`, panel + `ReferentielArchiveRow`, provider, entrée de menu.
- **refactor backend inclus** : `AuditPreuvesArchiveStatusEnum` enum TS → objet `as const` (union de littéraux), pour que le front matche le statut sans cast déguisé (corrige aussi No-TS-enum). Runtime identique.

Vérifs : typecheck app (graphe complet), tests backend 69/69 + front 17/17, lint.