### PR TITLE
feat(audit-labellisation): badge de statut d'audit sur l'onglet

### DIFF
--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/new/[referentielId]/(overview)/@tabs/tabs-wrapper.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/new/[referentielId]/(overview)/@tabs/tabs-wrapper.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useAuditStatusBadge } from '@/app/referentiels/audit-labellisation/audit-badge/use-audit-status-badge';
 import { useIsVisitor } from '@/app/users/authorizations/use-is-visitor';
 import { Spacer } from '@tet/ui';
 import {
@@ -12,6 +13,7 @@ import { PropsWithChildren } from 'react';
 
 export const TabsWrapper = ({ children }: PropsWithChildren) => {
   const isVisitor = useIsVisitor();
+  const auditBadge = useAuditStatusBadge();
 
   return (
     <Tabs className="grow flex flex-col" size="sm">
@@ -21,7 +23,11 @@ export const TabsWrapper = ({ children }: PropsWithChildren) => {
         <TabsTab href="detail" label="Détail des statuts" />
         <TabsTab href="evolutions" label="Évolutions du score" />
         {!isVisitor && <TabsTab href="commentaires" label="Commentaires" />}
-        <TabsTab href="audit-labellisation" label="Audit et labellisation" />
+        <TabsTab
+          href="audit-labellisation"
+          label="Audit et labellisation"
+          badge={auditBadge ?? undefined}
+        />
       </TabsList>
       <Spacer height={1} />
       <TabsPanel>{children}</TabsPanel>

--- a/apps/app/src/labels/catalog.ts
+++ b/apps/app/src/labels/catalog.ts
@@ -85,6 +85,12 @@ export const appLabels = {
 
   auditNonAudite: 'Non audité',
   auditEnCours: 'Audit en cours',
+  auditDemande: 'Audit demandé',
+  auditAttribue: 'Audit attribué',
+  auditTermine: 'Audit terminé',
+  auditTermineLabellisationEnCours: 'Audit terminé et labellisation en cours',
+  auditEnCoursParAuditeur: ({ auditeur }: { auditeur: string }): string =>
+    `Audit en cours par ${auditeur}`,
   auditAudite: 'Audité',
 
   filtreAxesId: 'Axes',

--- a/apps/app/src/referentiels/audit-labellisation/audit-badge-status/index.ts
+++ b/apps/app/src/referentiels/audit-labellisation/audit-badge-status/index.ts
@@ -1,0 +1,3 @@
+export * from './types';
+export * from './parcours-to-audit-badge-status';
+export * from './get-viewer-role';

--- a/apps/app/src/referentiels/audit-labellisation/audit-badge-status/parcours-to-audit-badge-status.spec.ts
+++ b/apps/app/src/referentiels/audit-labellisation/audit-badge-status/parcours-to-audit-badge-status.spec.ts
@@ -1,15 +1,11 @@
 import {
-  ParcoursLabellisation,
   ParcoursLabellisationStatus,
   SujetDemande,
 } from '@tet/domain/referentiels';
-import { parcoursToAuditBadgeStatus } from './parcours-to-audit-badge-status';
-import { AuditViewerRole } from './types';
-
-type ParcoursForBadge = Pick<
-  ParcoursLabellisation,
-  'status' | 'auditeurs' | 'demande' | 'labellisation'
->;
+import {
+  ParcoursForAuditBadge,
+  parcoursToAuditBadgeStatus,
+} from './parcours-to-audit-badge-status';
 
 const buildParcours = ({
   status,
@@ -17,50 +13,41 @@ const buildParcours = ({
   envoyeeLe,
   obtenueLe,
   sujet,
+  etoiles,
 }: {
   status: ParcoursLabellisationStatus;
   auditeursCount?: number;
   envoyeeLe?: string;
   obtenueLe?: string;
   sujet?: SujetDemande;
-}): ParcoursLabellisation => {
-  const minimal: ParcoursForBadge = {
-    status,
-    auditeurs: Array.from({ length: auditeursCount }, (_, i) => ({
-      userId: `auditor-${i}`,
-      nom: `Auditor ${i}`,
-    })),
-    demande:
-      envoyeeLe || sujet
-        ? ({
-            en_cours: true,
-            envoyee_le: envoyeeLe ?? null,
-            sujet: sujet ?? null,
-          } as ParcoursForBadge['demande'])
-        : null,
-    labellisation: obtenueLe
+  etoiles?: string;
+}): ParcoursForAuditBadge => ({
+  status,
+  auditeurs: Array.from({ length: auditeursCount }, (_, i) => ({
+    userId: `auditor-${i}`,
+    nom: `Auditor ${i}`,
+  })),
+  demande:
+    envoyeeLe || sujet
       ? ({
-          obtenue_le: obtenueLe,
-        } as ParcoursForBadge['labellisation'])
+          en_cours: true,
+          envoyee_le: envoyeeLe ?? null,
+          sujet: sujet ?? null,
+          etoiles: etoiles ?? null,
+        } as ParcoursForAuditBadge['demande'])
       : null,
-  };
-  return minimal as ParcoursLabellisation;
-};
+  labellisation: obtenueLe
+    ? ({
+        obtenue_le: obtenueLe,
+      } as ParcoursForAuditBadge['labellisation'])
+    : null,
+});
 
 describe('parcoursToAuditBadgeStatus', () => {
   describe('cas généraux', () => {
     it('retourne null quand parcours est null', () => {
       expect(
-        parcoursToAuditBadgeStatus({ parcours: null, viewerRole: 'auditee' })
-      ).toBeNull();
-    });
-
-    it('retourne null quand viewerRole est `other`', () => {
-      expect(
-        parcoursToAuditBadgeStatus({
-          parcours: buildParcours({ status: 'demande_envoyee' }),
-          viewerRole: 'other',
-        })
+        parcoursToAuditBadgeStatus({ parcours: null, isAuditor: false })
       ).toBeNull();
     });
 
@@ -68,7 +55,7 @@ describe('parcoursToAuditBadgeStatus', () => {
       expect(
         parcoursToAuditBadgeStatus({
           parcours: buildParcours({ status: 'non_demandee' }),
-          viewerRole: 'auditee',
+          isAuditor: false,
         })
       ).toBeNull();
     });
@@ -81,15 +68,15 @@ describe('parcoursToAuditBadgeStatus', () => {
       envoyeeLe: '2026-01-01T00:00:00.000Z',
     });
 
-    it('auditee voit `auditRequested`', () => {
+    it('non-auditeur voit `auditRequested`', () => {
       expect(
-        parcoursToAuditBadgeStatus({ parcours, viewerRole: 'auditee' })
+        parcoursToAuditBadgeStatus({ parcours, isAuditor: false })
       ).toBe('auditRequested');
     });
 
     it("auditor ne voit rien (pas encore d'attribution)", () => {
       expect(
-        parcoursToAuditBadgeStatus({ parcours, viewerRole: 'auditor' })
+        parcoursToAuditBadgeStatus({ parcours, isAuditor: true })
       ).toBeNull();
     });
   });
@@ -101,16 +88,32 @@ describe('parcoursToAuditBadgeStatus', () => {
       envoyeeLe: '2026-01-01T00:00:00.000Z',
     });
 
-    it('auditee continue de voir `auditRequested` (pas de bascule visible)', () => {
+    it('non-auditeur continue de voir `auditRequested` (pas de bascule visible)', () => {
       expect(
-        parcoursToAuditBadgeStatus({ parcours, viewerRole: 'auditee' })
+        parcoursToAuditBadgeStatus({ parcours, isAuditor: false })
       ).toBe('auditRequested');
     });
 
     it('auditor voit `auditAssigned`', () => {
       expect(
-        parcoursToAuditBadgeStatus({ parcours, viewerRole: 'auditor' })
+        parcoursToAuditBadgeStatus({ parcours, isAuditor: true })
       ).toBe('auditAssigned');
+    });
+  });
+
+  describe('demande de 1ère étoile (vérification ADEME, sans audit)', () => {
+    const parcours = buildParcours({
+      status: 'demande_envoyee',
+      auditeursCount: 0,
+      envoyeeLe: '2026-01-01T00:00:00.000Z',
+      sujet: 'labellisation',
+      etoiles: '1',
+    });
+
+    it("non-auditeur ne voit pas de badge « Audit demandé »", () => {
+      expect(
+        parcoursToAuditBadgeStatus({ parcours, isAuditor: false })
+      ).toBeNull();
     });
   });
 
@@ -121,18 +124,18 @@ describe('parcoursToAuditBadgeStatus', () => {
       envoyeeLe: '2026-01-01T00:00:00.000Z',
     });
 
-    it.each(['auditee', 'auditor'] as const)(
-      'viewer %s voit `auditInProgress`',
-      (viewerRole: AuditViewerRole) => {
+    it.each([true, false])(
+      'viewer (isAuditor=%s) voit `auditInProgress`',
+      (isAuditor: boolean) => {
         expect(
-          parcoursToAuditBadgeStatus({ parcours, viewerRole })
+          parcoursToAuditBadgeStatus({ parcours, isAuditor })
         ).toBe('auditInProgress');
       }
     );
   });
 
   describe('phase audit_valide', () => {
-    it('auditor voit `auditCompleted`', () => {
+    it('auditor voit `auditCompleted` pour une demande de labellisation', () => {
       expect(
         parcoursToAuditBadgeStatus({
           parcours: buildParcours({
@@ -140,38 +143,12 @@ describe('parcoursToAuditBadgeStatus', () => {
             envoyeeLe: '2026-01-01T00:00:00.000Z',
             sujet: 'labellisation',
           }),
-          viewerRole: 'auditor',
+          isAuditor: true,
         })
       ).toBe('auditCompleted');
     });
 
-    it('auditee voit `auditCompletedLabellisationInProgress` quand la labellisation n\'a pas encore été obtenue', () => {
-      expect(
-        parcoursToAuditBadgeStatus({
-          parcours: buildParcours({
-            status: 'audit_valide',
-            envoyeeLe: '2026-01-01T00:00:00.000Z',
-            sujet: 'labellisation',
-          }),
-          viewerRole: 'auditee',
-        })
-      ).toBe('auditCompletedLabellisationInProgress');
-    });
-
-    it('auditee voit `auditCompletedLabellisationInProgress` même quand sujet=labellisation_cot', () => {
-      expect(
-        parcoursToAuditBadgeStatus({
-          parcours: buildParcours({
-            status: 'audit_valide',
-            envoyeeLe: '2026-01-01T00:00:00.000Z',
-            sujet: 'labellisation_cot',
-          }),
-          viewerRole: 'auditee',
-        })
-      ).toBe('auditCompletedLabellisationInProgress');
-    });
-
-    it("auditee ne voit pas de badge quand la labellisation a été obtenue (cycle terminé)", () => {
+    it('auditor voit `auditCompleted` même après labellisation obtenue', () => {
       expect(
         parcoursToAuditBadgeStatus({
           parcours: buildParcours({
@@ -180,12 +157,52 @@ describe('parcoursToAuditBadgeStatus', () => {
             obtenueLe: '2026-06-01T00:00:00.000Z',
             sujet: 'labellisation',
           }),
-          viewerRole: 'auditee',
+          isAuditor: true,
+        })
+      ).toBe('auditCompleted');
+    });
+
+    it("non-auditeur voit `auditCompletedLabellisationInProgress` quand la labellisation n'a pas encore été obtenue", () => {
+      expect(
+        parcoursToAuditBadgeStatus({
+          parcours: buildParcours({
+            status: 'audit_valide',
+            envoyeeLe: '2026-01-01T00:00:00.000Z',
+            sujet: 'labellisation',
+          }),
+          isAuditor: false,
+        })
+      ).toBe('auditCompletedLabellisationInProgress');
+    });
+
+    it('non-auditeur voit `auditCompletedLabellisationInProgress` même quand sujet=labellisation_cot', () => {
+      expect(
+        parcoursToAuditBadgeStatus({
+          parcours: buildParcours({
+            status: 'audit_valide',
+            envoyeeLe: '2026-01-01T00:00:00.000Z',
+            sujet: 'labellisation_cot',
+          }),
+          isAuditor: false,
+        })
+      ).toBe('auditCompletedLabellisationInProgress');
+    });
+
+    it('non-auditeur ne voit pas de badge quand la labellisation a été obtenue (cycle terminé)', () => {
+      expect(
+        parcoursToAuditBadgeStatus({
+          parcours: buildParcours({
+            status: 'audit_valide',
+            envoyeeLe: '2026-01-01T00:00:00.000Z',
+            obtenueLe: '2026-06-01T00:00:00.000Z',
+            sujet: 'labellisation',
+          }),
+          isAuditor: false,
         })
       ).toBeNull();
     });
 
-    it('auditee ne voit pas de badge pour un audit_valide avec sujet=cot (défensif)', () => {
+    it('non-auditeur ne voit pas de badge pour un audit_valide avec sujet=cot (défensif)', () => {
       expect(
         parcoursToAuditBadgeStatus({
           parcours: buildParcours({
@@ -193,7 +210,7 @@ describe('parcoursToAuditBadgeStatus', () => {
             envoyeeLe: '2026-01-01T00:00:00.000Z',
             sujet: 'cot',
           }),
-          viewerRole: 'auditee',
+          isAuditor: false,
         })
       ).toBeNull();
     });

--- a/apps/app/src/referentiels/audit-labellisation/audit-badge-status/parcours-to-audit-badge-status.ts
+++ b/apps/app/src/referentiels/audit-labellisation/audit-badge-status/parcours-to-audit-badge-status.ts
@@ -1,39 +1,62 @@
 import {
   canStartNewAuditCycle,
   ParcoursLabellisation,
+  StartNewAuditCycleRulesErrors,
 } from '@tet/domain/referentiels';
-import { AuditBadgeStatus, AuditViewerRole } from './types';
+import { match } from 'ts-pattern';
+import { isPremiereEtoileDemandePending } from '../premiere-etoile-demande-pending';
+import { AuditBadgeStatus } from './types';
+
+export type ParcoursForAuditBadge = Pick<
+  ParcoursLabellisation,
+  'status' | 'demande' | 'auditeurs' | 'labellisation'
+>;
 
 type Input = {
-  parcours: ParcoursLabellisation | null;
-  viewerRole: AuditViewerRole;
+  parcours: ParcoursForAuditBadge | null;
+  isAuditor: boolean;
+};
+
+const badgeStatusByUnavailabilityReason: Record<
+  StartNewAuditCycleRulesErrors,
+  AuditBadgeStatus | null
+> = {
+  AUDIT_REQUEST_PENDING: null,
+  AUDIT_IN_PROGRESS: null,
+  LABELLISATION_IN_PROGRESS: 'auditCompletedLabellisationInProgress',
+};
+
+const submittedRequestBadge = (
+  parcours: ParcoursForAuditBadge,
+  isAuditor: boolean
+): AuditBadgeStatus | null => {
+  if (isPremiereEtoileDemandePending(parcours)) return null;
+  if (!isAuditor) return 'auditRequested';
+  return parcours.auditeurs.length >= 1 ? 'auditAssigned' : null;
+};
+
+const validatedAuditBadge = (
+  parcours: ParcoursForAuditBadge,
+  isAuditor: boolean
+): AuditBadgeStatus | null => {
+  if (isAuditor) return 'auditCompleted';
+
+  const availability = canStartNewAuditCycle(parcours);
+  if (availability.canRequest) return null;
+  return badgeStatusByUnavailabilityReason[availability.reason];
 };
 
 export function parcoursToAuditBadgeStatus({
   parcours,
-  viewerRole,
+  isAuditor,
 }: Input): AuditBadgeStatus | null {
   if (!parcours) return null;
-  if (viewerRole === 'other') return null;
 
-  const { status } = parcours;
-
-  if (status === 'non_demandee') return null;
-  if (status === 'audit_en_cours') return 'auditInProgress';
-  if (status === 'demande_envoyee' && viewerRole === 'auditee') return 'auditRequested';
-  if (status === 'demande_envoyee') {
-    return parcours.auditeurs.length >= 1 ? 'auditAssigned' : null;
-  }
-
-  // status === 'audit_valide' (les autres ont été traités plus haut)
-  if (viewerRole === 'auditor') return 'auditCompleted';
-
-  const availability = canStartNewAuditCycle(parcours);
-  if (
-    !availability.canRequest &&
-    availability.reason === 'LABELLISATION_IN_PROGRESS'
-  ) {
-    return 'auditCompletedLabellisationInProgress';
-  }
-  return null;
+  return match(parcours.status)
+    .returnType<AuditBadgeStatus | null>()
+    .with('non_demandee', () => null)
+    .with('demande_envoyee', () => submittedRequestBadge(parcours, isAuditor))
+    .with('audit_en_cours', () => 'auditInProgress')
+    .with('audit_valide', () => validatedAuditBadge(parcours, isAuditor))
+    .exhaustive();
 }

--- a/apps/app/src/referentiels/audit-labellisation/audit-badge/use-audit-status-badge.ts
+++ b/apps/app/src/referentiels/audit-labellisation/audit-badge/use-audit-status-badge.ts
@@ -1,0 +1,44 @@
+import { appLabels } from '@/app/labels/catalog';
+import { BadgeProps } from '@tet/ui';
+import {
+  AuditBadgeStatus,
+  parcoursToAuditBadgeStatus,
+} from '../audit-badge-status';
+import { useChecklist } from '../checklist.context';
+
+const badgeByStatus: Record<
+  Exclude<AuditBadgeStatus, 'auditInProgress'>,
+  Omit<BadgeProps, 'size'>
+> = {
+  auditRequested: { title: appLabels.auditDemande, variant: 'info' },
+  auditAssigned: { title: appLabels.auditAttribue, variant: 'warning' },
+  auditCompleted: { title: appLabels.auditTermine, variant: 'success' },
+  auditCompletedLabellisationInProgress: {
+    title: appLabels.auditTermineLabellisationEnCours,
+    variant: 'success',
+  },
+};
+
+export function useAuditStatusBadge(): Omit<BadgeProps, 'size'> | null {
+  const { cycle } = useChecklist();
+
+  const status = parcoursToAuditBadgeStatus({
+    parcours: cycle.parcours,
+    isAuditor: cycle.isAuditeur,
+  });
+
+  if (!status) return null;
+
+  if (status === 'auditInProgress') {
+    const firstAuditeur = cycle.parcours?.auditeurs[0]?.nom;
+    return {
+      title:
+        firstAuditeur && !cycle.isAuditeur
+          ? appLabels.auditEnCoursParAuditeur({ auditeur: firstAuditeur })
+          : appLabels.auditEnCours,
+      variant: 'info',
+    };
+  }
+
+  return badgeByStatus[status];
+}

--- a/apps/app/src/referentiels/audit-labellisation/premiere-etoile-demande-pending.spec.ts
+++ b/apps/app/src/referentiels/audit-labellisation/premiere-etoile-demande-pending.spec.ts
@@ -1,0 +1,82 @@
+import {
+  ParcoursLabellisation,
+  ParcoursLabellisationStatus,
+  SujetDemande,
+} from '@tet/domain/referentiels';
+import { describe, expect, it } from 'vitest';
+import { isPremiereEtoileDemandePending } from './premiere-etoile-demande-pending';
+
+const buildParcours = ({
+  status,
+  sujet,
+  etoiles,
+}: {
+  status: ParcoursLabellisationStatus;
+  sujet?: SujetDemande | null;
+  etoiles?: string | null;
+}): Pick<ParcoursLabellisation, 'status' | 'demande'> => ({
+  status,
+  demande: sujet
+    ? ({ sujet, etoiles: etoiles ?? null } as ParcoursLabellisation['demande'])
+    : null,
+});
+
+describe('isPremiereEtoileDemandePending', () => {
+  it('est vrai pour une demande labellisation 1ère étoile envoyée', () => {
+    expect(
+      isPremiereEtoileDemandePending(
+        buildParcours({
+          status: 'demande_envoyee',
+          sujet: 'labellisation',
+          etoiles: '1',
+        })
+      )
+    ).toBe(true);
+  });
+
+  it('est vrai pour une demande labellisation_cot 1ère étoile envoyée', () => {
+    expect(
+      isPremiereEtoileDemandePending(
+        buildParcours({
+          status: 'demande_envoyee',
+          sujet: 'labellisation_cot',
+          etoiles: '1',
+        })
+      )
+    ).toBe(true);
+  });
+
+  it("est faux quand l'audit COT seul est en cours (sujet cot, pas une 1ère étoile)", () => {
+    expect(
+      isPremiereEtoileDemandePending(
+        buildParcours({
+          status: 'demande_envoyee',
+          sujet: 'cot',
+          etoiles: null,
+        })
+      )
+    ).toBe(false);
+  });
+
+  it('est faux pour une demande de labellisation 2e étoile envoyée', () => {
+    expect(
+      isPremiereEtoileDemandePending(
+        buildParcours({
+          status: 'demande_envoyee',
+          sujet: 'labellisation',
+          etoiles: '2',
+        })
+      )
+    ).toBe(false);
+  });
+
+  it("est faux quand aucune demande n'a été envoyée", () => {
+    expect(
+      isPremiereEtoileDemandePending(buildParcours({ status: 'non_demandee' }))
+    ).toBe(false);
+  });
+
+  it('est faux quand le parcours est absent', () => {
+    expect(isPremiereEtoileDemandePending(null)).toBe(false);
+  });
+});

--- a/apps/app/src/referentiels/audit-labellisation/premiere-etoile-demande-pending.ts
+++ b/apps/app/src/referentiels/audit-labellisation/premiere-etoile-demande-pending.ts
@@ -1,0 +1,16 @@
+import {
+  isPremiereEtoileDemande,
+  ParcoursLabellisation,
+} from '@tet/domain/referentiels';
+
+export function isPremiereEtoileDemandePending(
+  parcours: Pick<ParcoursLabellisation, 'status' | 'demande'> | null | undefined
+): boolean {
+  if (!parcours) {
+    return false;
+  }
+  return (
+    parcours.status === 'demande_envoyee' &&
+    isPremiereEtoileDemande(parcours.demande)
+  );
+}

--- a/package.json
+++ b/package.json
@@ -158,6 +158,7 @@
     "tailwind-merge": "2.6.0",
     "tailwindcss": "3.4.17",
     "ts-case-convert": "2.1.0",
+    "ts-pattern": "5.9.0",
     "tslib": "2.8.1",
     "use-debounce": "10.0.6",
     "uuid": "8.3.2",

--- a/packages/domain/src/referentiels/labellisations/request-labellisation/request-labellisation.rules.ts
+++ b/packages/domain/src/referentiels/labellisations/request-labellisation/request-labellisation.rules.ts
@@ -181,3 +181,18 @@ export function areAuditPrerequisitesMet(
 
   return { met: true, reason: null };
 }
+
+export function isPremiereEtoileDemande(
+  demande:
+    | Pick<ObjectToSnake<LabellisationDemande>, 'etoiles' | 'sujet'>
+    | null
+    | undefined
+): boolean {
+  if (!demande) {
+    return false;
+  }
+  return (
+    demande.etoiles === '1' &&
+    (demande.sujet === 'labellisation' || demande.sujet === 'labellisation_cot')
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -449,6 +449,9 @@ importers:
       ts-case-convert:
         specifier: 2.1.0
         version: 2.1.0
+      ts-pattern:
+        specifier: 5.9.0
+        version: 5.9.0
       tslib:
         specifier: 2.8.1
         version: 2.8.1
@@ -14275,6 +14278,9 @@ packages:
         optional: true
       '@swc/wasm':
         optional: true
+
+  ts-pattern@5.9.0:
+    resolution: {integrity: sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg==}
 
   tsafe@1.8.5:
     resolution: {integrity: sha512-LFWTWQrW6rwSY+IBNFl2ridGfUzVsPwrZ26T4KUJww/py8rzaQ/SY+MIz6YROozpUCaRcuISqagmlwub9YT9kw==}
@@ -31477,6 +31483,8 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.13.5(@swc/helpers@0.5.17)
     optional: true
+
+  ts-pattern@5.9.0: {}
 
   tsafe@1.8.5: {}
 


### PR DESCRIPTION
## Plan
`doc/plans/2026-05-20-001-feat-badges-etat-audit-labellisation-plan.md` — 1ʳᵉ marche (« badge sur l'onglet ») de la stack badges d'état.

## Scope
Affiche un **badge de statut d'audit** sur l'onglet *Audit et labellisation* de la vue checklist `/referentiel/new` : Audit demandé / attribué / en cours / terminé / labellisation en cours, différencié **CT vs auditeur vs visiteur**.

## Surface de review (9 fichiers)
- **Logique (attention humaine)** : `audit-badge-status/parcours-to-audit-badge-status.ts` (mapper pur, `match` exhaustif), `audit-badge/use-audit-status-badge.ts` (hook), `premiere-etoile-demande-pending.ts` (prédicat), `request-labellisation.rules.ts` (ajout domaine `isPremiereEtoileDemande`).
- **Mécaniques** : `@tabs/tabs-wrapper.tsx` (prop `badge`), `catalog.ts` (+5 libellés), `audit-badge-status/index.ts` (barrel).

## Hypothèses / décisions
- Le mapper `viewerRole`-based préexistant dans main était **dead code** (aucun consommateur) → remplacé par la version `isAuditor`, iso avec la branche source `audit-badge-component` (la plus avancée).
- `isPremiereEtoileDemande` **ajouté au domaine** (export additif non-cassant) pour rester iso.

## Risque
**Flag-only** (`/referentiel/new`, non rendu en prod par défaut), sauf l'ajout additif `isPremiereEtoileDemande` au domaine (non-cassant).

## Tests
**Iso unit** avec `audit-badge-component` :
- `parcoursToAuditBadgeStatus` : 15 tests
- `isPremiereEtoileDemandePending` : 6 tests
- `get-viewer-role` : déjà dans main
- domaine `request-labellisation` : 3 tests (pas de régression)
- `app:typecheck` (toutes deps) + eslint verts

## Hors scope (marches suivantes de la stack)
- onglets **Suivi / Cycles** (auditeur)
- **gating** « Demander un audit » (disabled + tooltips)
- **clôture** depuis la checklist
- **gestion documentaire** (rename/delete dans la checklist)
- **e2e** `audit-badge-tab.spec.ts` : test full-feature qui ne compile pas sur main (méthodes POM/fixtures `cloturerAuditButton`, `closeAuditWithReport`, `validateAudit`, `requestLabellisationAudit`, `seedRolePilotes`, `seedLabellisationPreuve` absentes) → dernière marche de la stack.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Nouvelles Versions

* **New Features**
  * Ajout d'indicateurs visuels pour les statuts d'audit (demandé, attribué, en cours, terminé) dans les onglets du référentiel.
  * Affichage amélioré de l'état d'avancement de l'audit avec informations sur l'auditeur responsable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->