### PR TITLE
refactor(audit-labellisation): extrait ChecklistActions de la vue checklist

### DIFF
--- a/apps/app/src/referentiels/audit-labellisation/checklist/checklist-actions.tsx
+++ b/apps/app/src/referentiels/audit-labellisation/checklist/checklist-actions.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { DemandeLabellisationModal } from '@/app/referentiels/labellisations/DemandeLabellisationModal';
+import { StartAuditButton } from '@/app/referentiels/labellisations/start-audit/start-audit.button';
+import { ReactElement, useState } from 'react';
+import { useChecklist } from '../checklist.context';
+import { getAskPremiereEtoileButtonState } from './actions/ask-premiere-etoile-button-state';
+import { AskPremiereEtoileButton } from './actions/ask-premiere-etoile.button';
+
+export const ChecklistActions = (): ReactElement => {
+  const { cycle, referentielId } = useChecklist();
+  const { peutDemanderEtoile, peutDemander1ereEtoileCOT, isCOT, parcours } =
+    cycle;
+  const [isOpen, setIsOpen] = useState(false);
+  const askPremiereEtoileState = getAskPremiereEtoileButtonState({
+    canAskFirstStar: peutDemanderEtoile || peutDemander1ereEtoileCOT,
+    parcours,
+  });
+
+  return (
+    <>
+      <AskPremiereEtoileButton
+        state={askPremiereEtoileState}
+        onClick={() => setIsOpen(true)}
+      />
+      <StartAuditButton referentielId={referentielId} />
+      <DemandeLabellisationModal
+        parcoursLabellisation={cycle}
+        isCOT={isCOT}
+        opened={isOpen}
+        setOpened={setIsOpen}
+      />
+    </>
+  );
+};

--- a/apps/app/src/referentiels/audit-labellisation/checklist/index.tsx
+++ b/apps/app/src/referentiels/audit-labellisation/checklist/index.tsx
@@ -2,52 +2,31 @@
 
 import { makeReferentielUrl } from '@/app/app/paths';
 import { appLabels } from '@/app/labels/catalog';
-import { DemandeLabellisationModal } from '@/app/referentiels/labellisations/DemandeLabellisationModal';
-import { StartAuditButton } from '@/app/referentiels/labellisations/start-audit/start-audit.button';
-import { TCycleLabellisation } from '@/app/referentiels/labellisations/useCycleLabellisation';
 import { useReferentielId } from '@/app/referentiels/referentiel-context';
 import { useCollectiviteId } from '@tet/api/collectivites';
 import { Divider, Spacer } from '@tet/ui';
-import { ReactElement, useState } from 'react';
+import { ReactElement } from 'react';
 import { Parcours } from '../checklist-view-model';
-import { getAskPremiereEtoileButtonState } from './actions/ask-premiere-etoile-button-state';
-import { AskPremiereEtoileButton } from './actions/ask-premiere-etoile.button';
 import { CandidatureDocumentsSection } from './candidature-documents.section';
+import { ChecklistActions } from './checklist-actions';
 import { Container } from './container';
 import { Header } from './header';
 import { LabellisationChecklistTable } from './labellisation-checklist.table';
 
 export const ChecklistView = ({
-  cycle,
   viewModel,
 }: {
-  cycle: TCycleLabellisation;
   viewModel: Parcours;
 }): ReactElement => {
   const collectiviteId = useCollectiviteId();
   const referentielId = useReferentielId();
-  const { peutDemanderEtoile, peutDemander1ereEtoileCOT, isCOT, parcours } =
-    cycle;
-  const [isOpen, setIsOpen] = useState(false);
-  const askPremiereEtoileState = getAskPremiereEtoileButtonState({
-    canAskFirstStar: peutDemanderEtoile || peutDemander1ereEtoileCOT,
-    parcours,
-  });
 
   return (
     <Container>
       <Header
         title={appLabels.demandePremiereEtoile}
         subtitle={appLabels.renseignerCriteresPourPremiereEtoile}
-        action={
-          <>
-            <AskPremiereEtoileButton
-              state={askPremiereEtoileState}
-              onClick={() => setIsOpen(true)}
-            />
-            <StartAuditButton referentielId={referentielId} />
-          </>
-        }
+        action={<ChecklistActions />}
       />
       <Spacer height={1} />
       <Divider />
@@ -68,12 +47,6 @@ export const ChecklistView = ({
       />
       <Spacer height={1} />
       <CandidatureDocumentsSection />
-      <DemandeLabellisationModal
-        parcoursLabellisation={cycle}
-        isCOT={isCOT}
-        opened={isOpen}
-        setOpened={setIsOpen}
-      />
     </Container>
   );
 };

--- a/apps/app/src/referentiels/audit-labellisation/criteres-labellisation.view.tsx
+++ b/apps/app/src/referentiels/audit-labellisation/criteres-labellisation.view.tsx
@@ -25,5 +25,5 @@ export const CriteresLabellisationView = (): ReactElement | null => {
     return null;
   }
 
-  return <ChecklistView cycle={cycle} viewModel={parcours} />;
+  return <ChecklistView viewModel={parcours} />;
 };


### PR DESCRIPTION
## Nature

**Refactor pur** — aucun changement de comportement. Première PR de la stack B2 (la suivante, B2b, ajoutera le gating « Demander un audit » sur la présence des rôles pilotes).

## Intention

Extraire la barre d'actions de l'en-tête de `checklist/index.tsx` dans un composant dédié `ChecklistActions`, qui lit le `cycle` et le `referentielId` via `useChecklist()` (context déjà présent sur `main`) plutôt que par props/`useReferentielId`.

Conséquence : `ChecklistView` ne reçoit plus `cycle` en prop (il ne servait qu'à la barre d'actions et à la modale, tous deux déplacés) → signature réduite à `{ viewModel }`. `CriteresLabellisationView` ne transmet plus `cycle`.

Cette découpe converge vers la structure de la branche `audit-badge-component` (composant `ChecklistActions` lisant le context), en restant strictement sur le view-model actuel de `main`.

## Surface de review

| Fichier | Nature |
|---|---|
| `checklist/checklist-actions.tsx` | **nouveau** — barre d'actions extraite (logique inchangée) |
| `checklist/index.tsx` | allègement : `action={<ChecklistActions />}`, prop `cycle` retirée |
| `criteres-labellisation.view.tsx` | n'envoie plus `cycle` à `ChecklistView` |

## Anti-scope (reste pour A/C/D)

- Le `ChecklistActions` de la branche enveloppe les actions collectivité dans `CollectiviteActions` gardé par `cycle.viewerRole === 'auditee'`, et ajoute `BeginAuditButton` (`peutCommencerAudit`) + `CloturerAuditButton` (`isConductingAudit`). Ces champs de view-model (**lot A**) et `CloturerAuditButton` (**lot C**) n'existent pas sur `main` → non inclus ici.
- Gating rôles pilotes du bouton « Demander un audit » → **lot B2b** (PR suivante).

## Tests

Aucun test ne consommait `ChecklistView`/`CriteresLabellisationView` sur `main` (rien à mettre à jour). Extraction mécanique couverte par `nx run app:typecheck` + eslint (verts). Pas de logique nouvelle → pas de nouveau spec ajouté pour cette PR de refactor.