### PR TITLE
feat(audit-labellisation): assemble le cycle de vie de l'audit dans ChecklistActions

### DIFF
--- a/apps/app/src/referentiels/audit-labellisation/checklist.context.tsx
+++ b/apps/app/src/referentiels/audit-labellisation/checklist.context.tsx
@@ -24,6 +24,7 @@ type ChecklistContextValue = {
   cycle: TCycleLabellisation;
   parcours: Parcours | null;
   referentielId: AuditLabellisationReferentielId;
+  premiereEtoileObtenue: boolean;
 };
 
 type RoleDropdownContextValue = {
@@ -52,9 +53,11 @@ const ChecklistParcoursProvider = ({
     [cycle.parcours]
   );
 
+  const premiereEtoileObtenue = cycle.parcours?.labellisation != null;
+
   const value = useMemo(
-    () => ({ cycle, parcours, referentielId }),
-    [cycle, parcours, referentielId]
+    () => ({ cycle, parcours, referentielId, premiereEtoileObtenue }),
+    [cycle, parcours, referentielId, premiereEtoileObtenue]
   );
 
   return (

--- a/apps/app/src/referentiels/audit-labellisation/checklist/actions/begin-audit.button.tsx
+++ b/apps/app/src/referentiels/audit-labellisation/checklist/actions/begin-audit.button.tsx
@@ -1,0 +1,17 @@
+import { appLabels } from '@/app/labels/catalog';
+import { Button } from '@tet/ui';
+import { ReactElement } from 'react';
+import { useStartAudit } from '../../../labellisations/useStartAudit';
+
+export const BeginAuditButton = ({
+  auditId,
+}: {
+  auditId: number;
+}): ReactElement => {
+  const { mutate, isPending } = useStartAudit();
+  return (
+    <Button size="xs" disabled={isPending} onClick={() => mutate({ auditId })}>
+      {appLabels.commencerLAudit}
+    </Button>
+  );
+};

--- a/apps/app/src/referentiels/audit-labellisation/checklist/checklist-actions.spec.tsx
+++ b/apps/app/src/referentiels/audit-labellisation/checklist/checklist-actions.spec.tsx
@@ -1,0 +1,178 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TCycleLabellisation } from '../../labellisations/useCycleLabellisation';
+import { useChecklist } from '../checklist.context';
+import { ChecklistActions } from './checklist-actions';
+
+vi.mock('../checklist.context', () => ({
+  useChecklist: vi.fn(),
+}));
+
+vi.mock('../../labellisations/DemandeLabellisationModal', () => ({
+  DemandeLabellisationModal: () => null,
+}));
+
+vi.mock('../../labellisations/start-audit/start-audit.button', () => ({
+  StartAuditButton: () => null,
+}));
+
+vi.mock('./actions/begin-audit.button', async () => {
+  const { createElement } = await import('react');
+  return {
+    BeginAuditButton: () => createElement('span', null, 'begin-audit-button'),
+  };
+});
+
+vi.mock('../../audits/cloture/cloturer-audit.button', async () => {
+  const { createElement } = await import('react');
+  return {
+    CloturerAuditButton: () =>
+      createElement('span', null, 'cloturer-audit-button'),
+  };
+});
+
+const mockedUseChecklist = vi.mocked(useChecklist);
+
+const obtenirPremiereEtoile = 'Obtenir la première étoile';
+
+const setContext = ({
+  cycle,
+  premiereEtoileObtenue = false,
+}: {
+  cycle: Partial<TCycleLabellisation>;
+  premiereEtoileObtenue?: boolean;
+}): void => {
+  mockedUseChecklist.mockReturnValue({
+    cycle: {
+      isAuditeur: false,
+      viewerRole: 'auditee',
+      isCOT: false,
+      canStartAudit: false,
+      isConductingAudit: false,
+      parcours: null,
+      ...cycle,
+    } as TCycleLabellisation,
+    parcours: null,
+    referentielId: 'cae',
+    premiereEtoileObtenue,
+  } as unknown as ReturnType<typeof useChecklist>);
+};
+
+const auditEnCours = {
+  status: 'audit_en_cours',
+  audit: { id: 1, demande_id: 2 },
+} as TCycleLabellisation['parcours'];
+
+const premiereEtoileDemandeEnvoyee = {
+  status: 'demande_envoyee',
+  audit: null,
+  demande: { sujet: 'labellisation', etoiles: '1' },
+} as TCycleLabellisation['parcours'];
+
+const requestablePremiereEtoile = {
+  status: 'non_demandee',
+  audit: null,
+  demande: null,
+} as TCycleLabellisation['parcours'];
+
+beforeEach(() => {
+  mockedUseChecklist.mockReset();
+});
+
+describe('ChecklistActions — bouton « Obtenir la première étoile »', () => {
+  it('désactive le bouton quand une demande de première étoile est déjà en cours', () => {
+    setContext({
+      cycle: {
+        canAskFirstStar: true,
+        status: 'demande_envoyee',
+        parcours: premiereEtoileDemandeEnvoyee,
+      },
+    });
+
+    render(<ChecklistActions />);
+
+    const button = screen.getByRole('button', { name: obtenirPremiereEtoile });
+    expect(button.hasAttribute('disabled')).toBe(true);
+  });
+
+  it("garde le bouton actif quand aucune demande première étoile n'a été envoyée", () => {
+    setContext({
+      cycle: {
+        canAskFirstStar: true,
+        status: 'non_demandee',
+        parcours: requestablePremiereEtoile,
+      },
+    });
+
+    render(<ChecklistActions />);
+
+    const button = screen.getByRole('button', { name: obtenirPremiereEtoile });
+    expect(button.hasAttribute('disabled')).toBe(false);
+  });
+
+  it('masque le bouton une fois la première étoile obtenue', () => {
+    setContext({
+      cycle: {
+        canAskFirstStar: false,
+        status: 'non_demandee',
+        parcours: requestablePremiereEtoile,
+      },
+      premiereEtoileObtenue: true,
+    });
+
+    render(<ChecklistActions />);
+
+    expect(
+      screen.queryByRole('button', { name: obtenirPremiereEtoile })
+    ).toBeNull();
+  });
+});
+
+describe("ChecklistActions — aiguillage selon le rôle et l'état du cycle", () => {
+  it('ne rend aucune action collectivité pour un auditeur', () => {
+    setContext({
+      cycle: {
+        viewerRole: 'auditor',
+        canAskFirstStar: true,
+        status: 'non_demandee',
+        parcours: requestablePremiereEtoile,
+      },
+    });
+
+    render(<ChecklistActions />);
+
+    expect(
+      screen.queryByRole('button', { name: obtenirPremiereEtoile })
+    ).toBeNull();
+  });
+
+  it("rend « Commencer l'audit » quand l'auditeur peut démarrer un audit", () => {
+    setContext({
+      cycle: {
+        viewerRole: 'auditor',
+        canStartAudit: true,
+        parcours: auditEnCours,
+      },
+    });
+
+    render(<ChecklistActions />);
+
+    expect(screen.getByText('begin-audit-button')).toBeDefined();
+    expect(screen.queryByText('cloturer-audit-button')).toBeNull();
+  });
+
+  it("rend « Clôturer l'audit » quand un audit est en cours pour l'auditeur", () => {
+    setContext({
+      cycle: {
+        viewerRole: 'auditor',
+        isConductingAudit: true,
+        parcours: auditEnCours,
+      },
+    });
+
+    render(<ChecklistActions />);
+
+    expect(screen.getByText('cloturer-audit-button')).toBeDefined();
+    expect(screen.queryByText('begin-audit-button')).toBeNull();
+  });
+});

--- a/apps/app/src/referentiels/audit-labellisation/checklist/checklist-actions.tsx
+++ b/apps/app/src/referentiels/audit-labellisation/checklist/checklist-actions.tsx
@@ -1,34 +1,66 @@
 'use client';
 
+import { CloturerAuditButton } from '@/app/referentiels/audits/cloture/cloturer-audit.button';
 import { DemandeLabellisationModal } from '@/app/referentiels/labellisations/DemandeLabellisationModal';
 import { StartAuditButton } from '@/app/referentiels/labellisations/start-audit/start-audit.button';
+import { VisibleWhen } from '@tet/ui';
 import { ReactElement, useState } from 'react';
 import { useChecklist } from '../checklist.context';
 import { getAskPremiereEtoileButtonState } from './actions/ask-premiere-etoile-button-state';
 import { AskPremiereEtoileButton } from './actions/ask-premiere-etoile.button';
+import { BeginAuditButton } from './actions/begin-audit.button';
 
-export const ChecklistActions = (): ReactElement => {
-  const { cycle, referentielId } = useChecklist();
-  const { canAskFirstStar, isCOT, parcours } = cycle;
+const CollectiviteActions = (): ReactElement => {
+  const { cycle, referentielId, premiereEtoileObtenue } = useChecklist();
   const [isOpen, setIsOpen] = useState(false);
-  const askPremiereEtoileState = getAskPremiereEtoileButtonState({
-    canAskFirstStar,
-    parcours,
-  });
 
   return (
     <>
-      <AskPremiereEtoileButton
-        state={askPremiereEtoileState}
-        onClick={() => setIsOpen(true)}
-      />
+      <VisibleWhen condition={!premiereEtoileObtenue}>
+        <AskPremiereEtoileButton
+          state={getAskPremiereEtoileButtonState({
+            canAskFirstStar: cycle.canAskFirstStar,
+            parcours: cycle.parcours,
+          })}
+          onClick={() => setIsOpen(true)}
+        />
+        <DemandeLabellisationModal
+          parcoursLabellisation={cycle}
+          isCOT={cycle.isCOT}
+          opened={isOpen}
+          setOpened={setIsOpen}
+        />
+      </VisibleWhen>
       <StartAuditButton referentielId={referentielId} />
-      <DemandeLabellisationModal
-        parcoursLabellisation={cycle}
-        isCOT={isCOT}
-        opened={isOpen}
-        setOpened={setIsOpen}
-      />
+    </>
+  );
+};
+
+export const ChecklistActions = (): ReactElement => {
+  const { cycle } = useChecklist();
+
+  const auditEnCours = cycle.isConductingAudit
+    ? cycle.parcours?.audit ?? null
+    : null;
+
+  const auditADemarrer =
+    cycle.canStartAudit && cycle.parcours?.audit
+      ? cycle.parcours.audit
+      : null;
+
+  return (
+    <>
+      <VisibleWhen condition={cycle.viewerRole === 'auditee'}>
+        <CollectiviteActions />
+      </VisibleWhen>
+      {auditADemarrer && <BeginAuditButton auditId={auditADemarrer.id} />}
+      {auditEnCours && (
+        <CloturerAuditButton
+          auditId={auditEnCours.id}
+          demandeId={auditEnCours.demande_id}
+          size="xs"
+        />
+      )}
     </>
   );
 };

--- a/apps/app/src/referentiels/audits/cloture/cloturer-audit.button.tsx
+++ b/apps/app/src/referentiels/audits/cloture/cloturer-audit.button.tsx
@@ -1,19 +1,21 @@
 import { appLabels } from '@/app/labels/catalog';
-import { Button } from '@tet/ui';
+import { Button, ButtonSize } from '@tet/ui';
 import { JSX, useState } from 'react';
 import { CloturerAuditModal } from './cloturer-audit.modal';
 
 export const CloturerAuditButton = ({
   auditId,
   demandeId,
+  size = 'sm',
 }: {
   auditId: number;
   demandeId: number | null;
+  size?: ButtonSize;
 }): JSX.Element => {
   const [isOpen, setIsOpen] = useState(false);
   return (
     <>
-      <Button size="sm" onClick={() => setIsOpen(true)}>
+      <Button size={size} onClick={() => setIsOpen(true)}>
         {appLabels.cloturerAudit}
       </Button>
       <CloturerAuditModal


### PR DESCRIPTION
## Nature

**Feature** — lot C : convergence de `ChecklistActions` sur le cycle de vie complet de l'audit.

> Stack : basée sur #4599 (gating bouton). À merger après #4599.

## Comportement

`ChecklistActions` aiguille les actions selon le rôle (`viewerRole`) et l'état du cycle :

| Acteur / état | Action |
|---|---|
| Collectivité auditée | « Obtenir la première étoile » (masqué une fois la 1re étoile obtenue) + « Demander un audit » |
| Auditeur, audit à démarrer (`peutCommencerAudit`) | **« Commencer l'audit »** (`BeginAuditButton`) |
| Auditeur, audit en cours (`isConductingAudit`) | « Clôturer l'audit » (`CloturerAuditButton`) |

La clôture (modale 2 étapes dépôt rapport + mail) est **déjà sur main** ; cette PR la câble dans la barre d'actions.

## Surface de review

| Fichier | Changement |
|---|---|
| `checklist/actions/begin-audit.button.tsx` | **nouveau** — « Commencer l'audit » (`useStartAudit`) |
| `checklist-actions.tsx` | split `CollectiviteActions` + gate `viewerRole==='auditee'` + `BeginAudit`/`Cloturer` selon l'état |
| `checklist.context.tsx` | expose `premiereEtoileObtenue` (`parcours.labellisation != null`) |
| `audits/cloture/cloturer-audit.button.tsx` | prop `size?` optionnelle (défaut `sm`), rétrocompatible |

## Écart assumé vs branche

`BeginAuditButton` **sans `dataTest="StartAuditBtn"`** : ciblable par son label accessible (« Commencer l'audit »), conforme à la convention repo (pas de `data-test` en code neuf).

## Tests

`checklist-actions.spec.tsx` (porté) : 2 tests — bouton première étoile désactivé si demande en cours, actif sinon. Verts. `app:typecheck` + eslint verts.

## Anti-scope

- Champs context `showActeEngagement`/`showCandidatureDocuments` + règles `is-*-visible` → lot D.
- Refactor table/sections (boutons upload/rename/delete preuve) → lot D.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notes de Version

* **New Features**
  * Ajout d'un nouveau bouton pour commencer un audit avec gestion d'état pendant le traitement.
  * Amélioration de la logique de gestion de l'obtention de la première étoile avec visibilité conditionnelle des actions.

* **Improvements**
  * Refactorisation de l'affichage des actions d'audit selon le rôle et l'état du cycle.
  * Paramétrage flexible de la taille du bouton de clôture d'audit.

* **Tests**
  * Ajout de tests unitaires complets pour les actions de checklist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->