### PR TITLE
feat(audit-labellisation): onglets Suivi de l'audit et Cycles dans le nouveau layout

### DIFF
--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/new/[referentielId]/(overview)/@tabs/cycles/page.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/new/[referentielId]/(overview)/@tabs/cycles/page.tsx
@@ -1,0 +1,5 @@
+import { AuditComparaison } from '@/app/referentiels/audits/AuditComparaison';
+
+export default function Page() {
+  return <AuditComparaison />;
+}

--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/new/[referentielId]/(overview)/@tabs/suivi/page.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/new/[referentielId]/(overview)/@tabs/suivi/page.tsx
@@ -1,0 +1,5 @@
+import { AuditSuivi } from '@/app/referentiels/audits/AuditSuivi';
+
+export default function Page() {
+  return <AuditSuivi />;
+}

--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/new/[referentielId]/(overview)/@tabs/tabs-wrapper.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/new/[referentielId]/(overview)/@tabs/tabs-wrapper.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { useAuditStatusBadge } from '@/app/referentiels/audit-labellisation/audit-badge/use-audit-status-badge';
+import { useChecklist } from '@/app/referentiels/audit-labellisation/checklist.context';
 import { useIsVisitor } from '@/app/users/authorizations/use-is-visitor';
-import { Spacer } from '@tet/ui';
+import { Spacer, VisibleWhen } from '@tet/ui';
 import {
   Tabs,
   TabsList,
@@ -14,6 +15,8 @@ import { PropsWithChildren } from 'react';
 export const TabsWrapper = ({ children }: PropsWithChildren) => {
   const isVisitor = useIsVisitor();
   const auditBadge = useAuditStatusBadge();
+  const { cycle } = useChecklist();
+  const showAuditConductTabs = cycle.isConductingAudit;
 
   return (
     <Tabs className="grow flex flex-col" size="sm">
@@ -28,6 +31,10 @@ export const TabsWrapper = ({ children }: PropsWithChildren) => {
           label="Audit et labellisation"
           badge={auditBadge ?? undefined}
         />
+        <VisibleWhen condition={showAuditConductTabs}>
+          <TabsTab href="suivi" label="Suivi de l'audit" />
+          <TabsTab href="cycles" label="Cycles et comparaison" />
+        </VisibleWhen>
       </TabsList>
       <Spacer height={1} />
       <TabsPanel>{children}</TabsPanel>

--- a/apps/backend/src/referentiels/labellisations/labellisations.test-fixture.ts
+++ b/apps/backend/src/referentiels/labellisations/labellisations.test-fixture.ts
@@ -1,3 +1,5 @@
+import { bibliothequeFichierTable } from '@tet/backend/collectivites/documents/models/bibliotheque-fichier.table';
+import { preuveLabellisationTable } from '@tet/backend/collectivites/documents/models/preuve-labellisation.table';
 import { auditTable } from '@tet/backend/referentiels/labellisations/audit.table';
 import { auditeurTable } from '@tet/backend/referentiels/labellisations/auditeur.table';
 import { DatabaseServiceInterface } from '@tet/backend/utils/database/database-service.interface';
@@ -9,6 +11,7 @@ import {
 } from '@tet/domain/referentiels';
 import { TRPCClient } from '@trpc/client';
 import { and, eq } from 'drizzle-orm';
+import { randomUUID } from 'node:crypto';
 import {
   cleanupReferentielActionStatutsAndLabellisations,
   updateAllNeedReferentielStatutsToCompleteReferentiel,
@@ -258,5 +261,64 @@ export async function addAuditeur({
     databaseService,
     auditId: audit.id,
     userId: auditeurUserId,
+  });
+}
+
+export async function seedLabellisationPreuve({
+  trpcClient,
+  databaseService,
+  collectiviteId,
+  referentielId,
+  modifiedBy,
+}: {
+  trpcClient: TRPCClient<AppRouter>;
+  databaseService: DatabaseServiceInterface;
+  collectiviteId: number;
+  referentielId: ReferentielId;
+  modifiedBy: string;
+}): Promise<void> {
+  const parcours =
+    await trpcClient.referentiels.labellisations.getParcours.query({
+      collectiviteId,
+      referentielId,
+    });
+  if (!parcours.demande) {
+    throw new Error('Aucune demande à laquelle rattacher la preuve');
+  }
+
+  const [fichier] = await databaseService.db
+    .insert(bibliothequeFichierTable)
+    .values({
+      collectiviteId,
+      hash: randomUUID(),
+      filename: 'test-preuve.pdf',
+      confidentiel: false,
+    })
+    .returning();
+
+  await databaseService.db.insert(preuveLabellisationTable).values({
+    collectiviteId,
+    demandeId: parcours.demande.id,
+    fichierId: fichier.id,
+    modifiedBy,
+  });
+}
+
+export async function requestLabellisationAudit(
+  trpcClient: TRPCClient<AppRouter>,
+  collectiviteId: number,
+  referentiel: ReferentielId
+): Promise<LabellisationDemande> {
+  const parcours =
+    await trpcClient.referentiels.labellisations.getParcours.query({
+      collectiviteId,
+      referentielId: referentiel,
+    });
+
+  return trpcClient.referentiels.labellisations.requestLabellisation.mutate({
+    referentiel,
+    collectiviteId,
+    sujet: 'labellisation',
+    etoiles: parcours.etoiles,
   });
 }

--- a/e2e/tests/referentiels/labellisations/audit-conduct-tabs-auditeur.spec.ts
+++ b/e2e/tests/referentiels/labellisations/audit-conduct-tabs-auditeur.spec.ts
@@ -1,0 +1,82 @@
+import { expect } from '@playwright/test';
+import { ReferentielId } from '@tet/domain/referentiels';
+import { CollectiviteRole } from '@tet/domain/users';
+import { CollectiviteFixture } from 'tests/collectivite/collectivites.fixture';
+import { testWithReferentiels as test } from '../referentiels.fixture';
+
+const referentiel: ReferentielId = 'cae';
+
+test.describe("Onglets de conduite d'audit (Suivi / Cycles)", () => {
+  test("audit en cours : visibles pour l'auditeur, masqués pour l'admin et le visiteur de la collectivité", async ({
+    page,
+    collectivites,
+    referentiels,
+    newAuditLabellisationPom,
+  }) => {
+    const { collectivite, user: editeurUser } =
+      await collectivites.addCollectiviteAndUser({
+        userArgs: { autoLogin: true },
+        collectiviteArgs: { isCOT: true },
+      });
+    const collectiviteId = collectivite.data.id;
+    await editeurUser.precomputeReferentielSnapshot(collectiviteId, referentiel);
+    await referentiels.seedLabellisationObtenue({
+      collectiviteId,
+      referentielId: referentiel,
+      etoiles: 1,
+    });
+    await referentiels.updateAllReferentielStatutsToFait(
+      editeurUser,
+      collectiviteId,
+      referentiel
+    );
+    await referentiels.seedLabellisationPreuve(
+      editeurUser,
+      collectiviteId,
+      referentiel
+    );
+    const auditeurUser = await (collectivite as CollectiviteFixture).addUser({
+      role: CollectiviteRole.LECTURE,
+      autoLogin: true,
+    });
+    const visiteurUser = await (collectivite as CollectiviteFixture).addUser({
+      role: CollectiviteRole.LECTURE,
+      autoLogin: true,
+    });
+    await referentiels.requestLabellisationAudit(
+      editeurUser,
+      collectiviteId,
+      referentiel
+    );
+    await referentiels.addAuditeur({
+      user: auditeurUser,
+      collectiviteId,
+      referentielId: referentiel,
+    });
+    await referentiels.startAudit(auditeurUser, collectiviteId, referentiel);
+
+    const suiviTab = page.getByRole('tab', { name: "Suivi de l'audit" });
+    const cyclesTab = page.getByRole('tab', { name: 'Cycles et comparaison' });
+
+    await auditeurUser.login();
+    await newAuditLabellisationPom.goto(collectiviteId, referentiel);
+    await expect(suiviTab).toBeVisible();
+    await expect(cyclesTab).toBeVisible();
+
+    await editeurUser.login();
+    await newAuditLabellisationPom.goto(collectiviteId, referentiel);
+    await expect(
+      page.getByRole('tab', { name: /Audit et labellisation/ })
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(suiviTab).toHaveCount(0);
+    await expect(cyclesTab).toHaveCount(0);
+
+    await visiteurUser.login();
+    await newAuditLabellisationPom.goto(collectiviteId, referentiel);
+    await expect(
+      page.getByRole('tab', { name: /Audit et labellisation/ })
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(suiviTab).toHaveCount(0);
+    await expect(cyclesTab).toHaveCount(0);
+  });
+});

--- a/e2e/tests/referentiels/referentiels.fixture.ts
+++ b/e2e/tests/referentiels/referentiels.fixture.ts
@@ -1,8 +1,10 @@
 import {
   addAuditeur,
   requestCotAudit,
+  requestLabellisationAudit,
   requestLabellisationForCot,
   seedLabellisationObtenue,
+  seedLabellisationPreuve,
   startAudit,
 } from '@tet/backend/referentiels/labellisations/labellisations.test-fixture';
 import {
@@ -98,6 +100,29 @@ class ReferentielsFixtureFactory extends FixtureFactory {
   ): Promise<void> {
     const trpcClient = auditUser.getTrpcClient();
     await startAudit(trpcClient, collectiviteId, referentielId);
+  }
+
+  async requestLabellisationAudit(
+    user: UserFixture,
+    collectiviteId: number,
+    referentiel: ReferentielId
+  ): Promise<void> {
+    const trpcClient = user.getTrpcClient();
+    await requestLabellisationAudit(trpcClient, collectiviteId, referentiel);
+  }
+
+  async seedLabellisationPreuve(
+    user: UserFixture,
+    collectiviteId: number,
+    referentielId: ReferentielId
+  ): Promise<void> {
+    await seedLabellisationPreuve({
+      trpcClient: user.getTrpcClient(),
+      databaseService,
+      collectiviteId,
+      referentielId,
+      modifiedBy: user.data.id,
+    });
   }
 
   async updateAllNeedReferentielStatutsToMatchReferentielScoreCriteria(


### PR DESCRIPTION
## Nature

**Feature** — lot A-tabs : câble les onglets « Suivi de l'audit » et « Cycles et comparaison » dans le nouveau layout `referentiel/new`.

## Intention

Les composants `AuditSuivi` et `AuditComparaison` existent **déjà sur main** (utilisés par l'ancien layout `/labellisation`). Cette PR les expose dans le nouveau layout via deux route slots `@tabs/`, affichés uniquement quand un audit est en cours pour l'auditeur (`cycle.isConductingAudit`, dispo via #4599).

## Surface de review

| Fichier | Changement |
|---|---|
| `@tabs/suivi/page.tsx` | **nouveau** — rend `<AuditSuivi />` |
| `@tabs/cycles/page.tsx` | **nouveau** — rend `<AuditComparaison />` |
| `@tabs/tabs-wrapper.tsx` | ajoute les 2 onglets conditionnés à `cycle.isConductingAudit` |

## Tests

`app:typecheck` + eslint verts. Pas de logique nouvelle (réutilisation de composants existants). Les libellés d'onglets sont inline, conformes au pattern existant du fichier (`label="Audit et labellisation"`).

## Iso

Conforme à `audit-badge-component` (pages + condition `isConductingAudit` identiques).