### PR TITLE
feat(audit-labellisation): enrichit le view-model de la checklist et centralise la visibilité des sections

### DIFF
--- a/apps/app/src/referentiels/audit-labellisation/checklist-view-model.ts
+++ b/apps/app/src/referentiels/audit-labellisation/checklist-view-model.ts
@@ -24,8 +24,10 @@ export type RoleMesures = Record<RoleKey, RoleMesureViewModel | null>;
 export type Parcours = {
   etoileObjectif: Etoile;
   completude: { done: boolean };
-  minimumScore: MinimumScoreViewModel | null;
+  minimumScore: MinimumScoreViewModel;
+  scoreFait: number;
   mesures: MesureViewModel[];
   roleMesures: RoleMesures;
   acteEngagement: { signed: boolean; demandeId: number | null };
+  canModifyCandidatureDocuments: boolean;
 };

--- a/apps/app/src/referentiels/audit-labellisation/checklist.context.tsx
+++ b/apps/app/src/referentiels/audit-labellisation/checklist.context.tsx
@@ -18,13 +18,18 @@ import {
   useState,
 } from 'react';
 import { Parcours } from './checklist-view-model';
+import { isActeEngagementVisible } from './checklist/rules/is-acte-engagement-visible';
+import { isCandidatureDocumentsVisible } from './checklist/rules/is-candidature-documents-visible';
 import { parcoursToChecklist } from './parcours-to-checklist';
+import { useReferentRolesDefined } from './use-referent-roles-defined';
 
 type ChecklistContextValue = {
   cycle: TCycleLabellisation;
   parcours: Parcours | null;
   referentielId: AuditLabellisationReferentielId;
   premiereEtoileObtenue: boolean;
+  showActeEngagement: boolean;
+  showCandidatureDocuments: boolean;
 };
 
 type RoleDropdownContextValue = {
@@ -47,17 +52,49 @@ const ChecklistParcoursProvider = ({
   children: ReactNode;
 }): ReactElement => {
   const cycle = useCycleLabellisation(referentielId);
+  const referentRoles = useReferentRolesDefined(referentielId);
 
   const parcours = useMemo(
-    () => (cycle.parcours ? parcoursToChecklist(cycle.parcours) : null),
-    [cycle.parcours]
+    () =>
+      cycle.parcours && referentRoles.isLoaded
+        ? parcoursToChecklist(cycle.parcours, referentRoles.referentRolesDefined)
+        : null,
+    [cycle.parcours, referentRoles.isLoaded, referentRoles.referentRolesDefined]
+  );
+
+  const cycleWithRolesLoading = useMemo(
+    () => ({
+      ...cycle,
+      isLoading: cycle.isLoading || !referentRoles.isLoaded,
+    }),
+    [cycle, referentRoles.isLoaded]
   );
 
   const premiereEtoileObtenue = cycle.parcours?.labellisation != null;
+  const showActeEngagement = isActeEngagementVisible({
+    isCOT: cycle.isCOT,
+    hasAtLeastOneStar: premiereEtoileObtenue,
+  });
+  const showCandidatureDocuments =
+    parcours != null && isCandidatureDocumentsVisible(parcours.etoileObjectif);
 
   const value = useMemo(
-    () => ({ cycle, parcours, referentielId, premiereEtoileObtenue }),
-    [cycle, parcours, referentielId, premiereEtoileObtenue]
+    () => ({
+      cycle: cycleWithRolesLoading,
+      parcours,
+      referentielId,
+      premiereEtoileObtenue,
+      showActeEngagement,
+      showCandidatureDocuments,
+    }),
+    [
+      cycleWithRolesLoading,
+      parcours,
+      referentielId,
+      premiereEtoileObtenue,
+      showActeEngagement,
+      showCandidatureDocuments,
+    ]
   );
 
   return (

--- a/apps/app/src/referentiels/audit-labellisation/checklist/candidature-documents.section.tsx
+++ b/apps/app/src/referentiels/audit-labellisation/checklist/candidature-documents.section.tsx
@@ -86,10 +86,10 @@ const AddDocumentsButton = (): ReactElement => {
 };
 
 export const CandidatureDocumentsSection = (): ReactElement | null => {
-  const { parcours, referentielId } = useChecklist();
+  const { parcours, referentielId, showCandidatureDocuments } = useChecklist();
   const { hasCollectivitePermission } = useCurrentCollectivite();
 
-  if (!parcours || parcours.etoileObjectif === 1) {
+  if (!parcours || !showCandidatureDocuments) {
     return null;
   }
 

--- a/apps/app/src/referentiels/audit-labellisation/checklist/labellisation-checklist.table.tsx
+++ b/apps/app/src/referentiels/audit-labellisation/checklist/labellisation-checklist.table.tsx
@@ -3,7 +3,7 @@
 import { makeReferentielTacheUrl } from '@/app/app/paths';
 import { appLabels } from '@/app/labels/catalog';
 import { ActionId, ReferentielId } from '@tet/domain/referentiels';
-import { ChecklistTable, InlineLink, PillButton } from '@tet/ui';
+import { ChecklistTable, InlineLink, PillButton, VisibleWhen } from '@tet/ui';
 import { ReactElement } from 'react';
 import {
   MesureViewModel,
@@ -11,7 +11,7 @@ import {
   Parcours,
   RoleMesures,
 } from '../checklist-view-model';
-import { useRoleDropdown } from '../checklist.context';
+import { useChecklist, useRoleDropdown } from '../checklist.context';
 import { ActeEngagementSection } from './acte-engagement.section';
 import { formatReponseAttendue } from './format-reponse-attendue';
 
@@ -215,6 +215,7 @@ export const LabellisationChecklistTable = ({
   referentielUrl,
 }: LabellisationChecklistTableProps): ReactElement => {
   const { openDropdown } = useRoleDropdown();
+  const { showActeEngagement } = useChecklist();
   const roleActionIds = collectRoleActionIds(viewModel.roleMesures);
 
   return (
@@ -227,9 +228,7 @@ export const LabellisationChecklistTable = ({
         completude={viewModel.completude}
         referentielUrl={referentielUrl}
       />
-      {viewModel.minimumScore && (
-        <ScoreMinimumRow scoreMinimum={viewModel.minimumScore} />
-      )}
+      <ScoreMinimumRow scoreMinimum={viewModel.minimumScore} />
       <MesuresRows
         mesures={viewModel.mesures}
         roleActionIds={roleActionIds}
@@ -237,10 +236,12 @@ export const LabellisationChecklistTable = ({
         referentielId={referentielId}
         onOpenDropdown={openDropdown}
       />
-      <ActeEngagementRow
-        acteEngagement={viewModel.acteEngagement}
-        referentielId={referentielId}
-      />
+      <VisibleWhen condition={showActeEngagement}>
+        <ActeEngagementRow
+          acteEngagement={viewModel.acteEngagement}
+          referentielId={referentielId}
+        />
+      </VisibleWhen>
     </ChecklistTable>
   );
 };

--- a/apps/app/src/referentiels/audit-labellisation/checklist/rules/is-acte-engagement-visible.spec.ts
+++ b/apps/app/src/referentiels/audit-labellisation/checklist/rules/is-acte-engagement-visible.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { isActeEngagementVisible } from './is-acte-engagement-visible';
+
+describe('isActeEngagementVisible', () => {
+  it("visible pour un non-COT qui n'a pas encore d'étoile", () => {
+    expect(
+      isActeEngagementVisible({
+        isCOT: false,
+        hasAtLeastOneStar: false,
+      })
+    ).toBe(true);
+  });
+
+  it('masqué pour un COT', () => {
+    expect(
+      isActeEngagementVisible({
+        isCOT: true,
+        hasAtLeastOneStar: false,
+      })
+    ).toBe(false);
+  });
+
+  it("masqué dès qu'au moins une étoile est obtenue", () => {
+    expect(
+      isActeEngagementVisible({
+        isCOT: false,
+        hasAtLeastOneStar: true,
+      })
+    ).toBe(false);
+  });
+
+  it('masqué pour un COT ayant déjà une étoile', () => {
+    expect(
+      isActeEngagementVisible({
+        isCOT: true,
+        hasAtLeastOneStar: true,
+      })
+    ).toBe(false);
+  });
+});

--- a/apps/app/src/referentiels/audit-labellisation/checklist/rules/is-acte-engagement-visible.ts
+++ b/apps/app/src/referentiels/audit-labellisation/checklist/rules/is-acte-engagement-visible.ts
@@ -1,0 +1,7 @@
+export const isActeEngagementVisible = ({
+  isCOT,
+  hasAtLeastOneStar,
+}: {
+  isCOT: boolean;
+  hasAtLeastOneStar: boolean;
+}): boolean => !isCOT && !hasAtLeastOneStar;

--- a/apps/app/src/referentiels/audit-labellisation/checklist/rules/is-candidature-documents-visible.spec.ts
+++ b/apps/app/src/referentiels/audit-labellisation/checklist/rules/is-candidature-documents-visible.spec.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { isCandidatureDocumentsVisible } from './is-candidature-documents-visible';
+
+describe('isCandidatureDocumentsVisible', () => {
+  it('masque les documents de candidature à la première étoile', () => {
+    expect(isCandidatureDocumentsVisible(1)).toBe(false);
+  });
+
+  it('affiche les documents de candidature dès la deuxième étoile', () => {
+    expect(isCandidatureDocumentsVisible(2)).toBe(true);
+  });
+});

--- a/apps/app/src/referentiels/audit-labellisation/checklist/rules/is-candidature-documents-visible.ts
+++ b/apps/app/src/referentiels/audit-labellisation/checklist/rules/is-candidature-documents-visible.ts
@@ -1,0 +1,4 @@
+import { Etoile } from '@tet/domain/referentiels';
+
+export const isCandidatureDocumentsVisible = (etoile: Etoile): boolean =>
+  etoile > 1;

--- a/apps/app/src/referentiels/audit-labellisation/parcours-to-checklist.spec.ts
+++ b/apps/app/src/referentiels/audit-labellisation/parcours-to-checklist.spec.ts
@@ -1,4 +1,7 @@
-import { ParcoursLabellisation } from '@tet/domain/referentiels';
+import {
+  ParcoursLabellisation,
+  ReferentRolesDefined,
+} from '@tet/domain/referentiels';
 import { describe, expect, it } from 'vitest';
 import { parcoursToChecklist } from './parcours-to-checklist';
 
@@ -33,18 +36,34 @@ const makeParcours = (
     ...overrides,
   } as unknown as ParcoursLabellisation);
 
+const noReferentRoles: ReferentRolesDefined = {
+  eluReferent: false,
+  referentTechnique: false,
+};
+
+const bothReferentRoles: ReferentRolesDefined = {
+  eluReferent: true,
+  referentTechnique: true,
+};
+
 describe('parcoursToChecklist', () => {
   it('renvoie completude.done depuis completude_ok', () => {
-    const view = parcoursToChecklist(makeParcours({ completude_ok: true }));
+    const view = parcoursToChecklist(
+      makeParcours({ completude_ok: true }),
+      noReferentRoles
+    );
     expect(view.completude).toEqual({ done: true });
   });
 
-  it('omet minimumScore quand etoiles === 1', () => {
-    const view = parcoursToChecklist(makeParcours({ etoiles: 1 }));
-    expect(view.minimumScore).toBeNull();
+  it('affiche minimumScore au seuil 35 % (2e étoile, non atteint) quand la CT est sans étoile (etoiles === 1)', () => {
+    const view = parcoursToChecklist(
+      makeParcours({ etoiles: 1 }),
+      noReferentRoles
+    );
+    expect(view.minimumScore).toEqual({ done: false, seuilPercent: 35 });
   });
 
-  it('inclut minimumScore avec seuil en % quand etoiles > 1', () => {
+  it('inclut minimumScore avec seuil en % quand etoileObjectif > 1', () => {
     const view = parcoursToChecklist(
       makeParcours({
         etoiles: 2,
@@ -54,9 +73,25 @@ describe('parcoursToChecklist', () => {
           atteint: true,
           etoiles: 2,
         },
-      })
+      }),
+      noReferentRoles
     );
     expect(view.minimumScore).toEqual({ done: true, seuilPercent: 35 });
+  });
+
+  it('renvoie scoreFait depuis critere_score.score_fait', () => {
+    const view = parcoursToChecklist(
+      makeParcours({
+        critere_score: {
+          score_a_realiser: 0.35,
+          score_fait: 0.42,
+          atteint: true,
+          etoiles: 2,
+        },
+      }),
+      noReferentRoles
+    );
+    expect(view.scoreFait).toBe(0.42);
   });
 
   it('mappe chaque critere_action en camelCase avec identifiant extrait', () => {
@@ -78,7 +113,8 @@ describe('parcoursToChecklist', () => {
             statut_ou_score: '',
           },
         ] as unknown as ParcoursLabellisation['criteres_action'],
-      })
+      }),
+      noReferentRoles
     );
     expect(view.mesures).toEqual([
       {
@@ -139,7 +175,8 @@ describe('parcoursToChecklist', () => {
             statut_ou_score: '',
           },
         ] as unknown as ParcoursLabellisation['criteres_action'],
-      })
+      }),
+      noReferentRoles
     );
     expect(view.mesures.map((m) => m.actionId)).toEqual([
       'cae_1',
@@ -149,7 +186,10 @@ describe('parcoursToChecklist', () => {
   });
 
   it('renvoie acteEngagement.signed et demandeId null quand pas de demande', () => {
-    const view = parcoursToChecklist(makeParcours({ demande: null }));
+    const view = parcoursToChecklist(
+      makeParcours({ demande: null }),
+      noReferentRoles
+    );
     expect(view.acteEngagement).toEqual({ signed: false, demandeId: null });
   });
 
@@ -162,9 +202,40 @@ describe('parcoursToChecklist', () => {
           preuve_nombre: 1,
           atteint: true,
         },
-      })
+      }),
+      noReferentRoles
     );
     expect(view.acteEngagement).toEqual({ signed: true, demandeId: 42 });
+  });
+
+  describe('canModifyCandidatureDocuments', () => {
+    it('true quand aucun audit', () => {
+      const view = parcoursToChecklist(
+        makeParcours({ audit: null }),
+        noReferentRoles
+      );
+      expect(view.canModifyCandidatureDocuments).toBe(true);
+    });
+
+    it("true quand l'audit n'est pas validé", () => {
+      const view = parcoursToChecklist(
+        makeParcours({
+          audit: { valide: false } as ParcoursLabellisation['audit'],
+        }),
+        noReferentRoles
+      );
+      expect(view.canModifyCandidatureDocuments).toBe(true);
+    });
+
+    it("false quand l'audit est validé", () => {
+      const view = parcoursToChecklist(
+        makeParcours({
+          audit: { valide: true } as ParcoursLabellisation['audit'],
+        }),
+        noReferentRoles
+      );
+      expect(view.canModifyCandidatureDocuments).toBe(false);
+    });
   });
 
   describe('roleMesures', () => {
@@ -189,7 +260,7 @@ describe('parcoursToChecklist', () => {
         statut_ou_score: '',
       } as unknown as ParcoursLabellisation['criteres_action'][number]);
 
-    it('mappe les 2 rôles CAE quand les 2 mesures sont présentes', () => {
+    it('mappe les 2 rôles CAE quand les 2 mesures sont présentes et pilotes désignés', () => {
       const view = parcoursToChecklist(
         makeParcours({
           referentiel: 'cae',
@@ -197,7 +268,8 @@ describe('parcoursToChecklist', () => {
             makeCritereAction('cae_5.1.2.1.1', true, 1),
             makeCritereAction('cae_5.1.1.1.3', false, 2),
           ] as ParcoursLabellisation['criteres_action'],
-        })
+        }),
+        bothReferentRoles
       );
       expect(view.roleMesures).toEqual({
         eluReferent: { actionId: 'cae_5.1.2.1.1', done: true },
@@ -205,7 +277,7 @@ describe('parcoursToChecklist', () => {
       });
     });
 
-    it('mappe les 2 rôles ECI quand les 2 mesures sont présentes', () => {
+    it('mappe les 2 rôles ECI quand les 2 mesures sont présentes et pilotes désignés', () => {
       const view = parcoursToChecklist(
         makeParcours({
           referentiel: 'eci',
@@ -213,7 +285,8 @@ describe('parcoursToChecklist', () => {
             makeCritereAction('eci_1.1.1.1', true, 1),
             makeCritereAction('eci_1.1.1.3', true, 2),
           ] as ParcoursLabellisation['criteres_action'],
-        })
+        }),
+        bothReferentRoles
       );
       expect(view.roleMesures).toEqual({
         eluReferent: { actionId: 'eci_1.1.1.1', done: true },
@@ -228,7 +301,8 @@ describe('parcoursToChecklist', () => {
           criteres_action: [
             makeCritereAction('cae_5.1.2.1.1', false, 1),
           ] as ParcoursLabellisation['criteres_action'],
-        })
+        }),
+        bothReferentRoles
       );
       expect(view.roleMesures).toEqual({
         eluReferent: { actionId: 'cae_5.1.2.1.1', done: false },
@@ -241,14 +315,126 @@ describe('parcoursToChecklist', () => {
         makeParcours({
           referentiel: 'te',
           criteres_action: [
-            makeCritereAction('te_5.1.1.3.2', true, 1),
+            makeCritereAction('te_5.1.2.1.1', true, 1),
           ] as ParcoursLabellisation['criteres_action'],
-        })
+        }),
+        bothReferentRoles
       );
       expect(view.roleMesures).toEqual({
         eluReferent: null,
         referentTechnique: null,
       });
+    });
+
+    it('done=false sur le rôle quand atteint=true mais aucun pilote désigné', () => {
+      const view = parcoursToChecklist(
+        makeParcours({
+          referentiel: 'cae',
+          criteres_action: [
+            makeCritereAction('cae_5.1.2.1.1', true, 1),
+            makeCritereAction('cae_5.1.1.1.3', true, 2),
+          ] as ParcoursLabellisation['criteres_action'],
+        }),
+        noReferentRoles
+      );
+      expect(view.roleMesures).toEqual({
+        eluReferent: { actionId: 'cae_5.1.2.1.1', done: false },
+        referentTechnique: { actionId: 'cae_5.1.1.1.3', done: false },
+      });
+    });
+
+    it('done=true uniquement sur le rôle dont le pilote est désigné', () => {
+      const view = parcoursToChecklist(
+        makeParcours({
+          referentiel: 'cae',
+          criteres_action: [
+            makeCritereAction('cae_5.1.2.1.1', true, 1),
+            makeCritereAction('cae_5.1.1.1.3', true, 2),
+          ] as ParcoursLabellisation['criteres_action'],
+        }),
+        { eluReferent: false, referentTechnique: true }
+      );
+      expect(view.roleMesures).toEqual({
+        eluReferent: { actionId: 'cae_5.1.2.1.1', done: false },
+        referentTechnique: { actionId: 'cae_5.1.1.1.3', done: true },
+      });
+    });
+  });
+
+  describe('mesures rows pour actions de rôle', () => {
+    const makeRoleCritere = (
+      action_id: string,
+      atteint: boolean
+    ): ParcoursLabellisation['criteres_action'][number] =>
+      ({
+        action_id,
+        formulation: '',
+        priorite: 1,
+        atteint,
+        rempli: false,
+        min_realise_percentage: 100,
+        min_programme_percentage: null,
+        etoile: 1,
+        referentiel_id: 'cae',
+        proportion_fait: 1,
+        proportion_programme: 0,
+        statut_ou_score: 'Fait',
+      } as unknown as ParcoursLabellisation['criteres_action'][number]);
+
+    it('row done=false sur action de rôle atteinte mais sans pilote', () => {
+      const view = parcoursToChecklist(
+        makeParcours({
+          referentiel: 'cae',
+          criteres_action: [
+            makeRoleCritere('cae_5.1.1.1.3', true),
+          ] as ParcoursLabellisation['criteres_action'],
+        }),
+        noReferentRoles
+      );
+      const row = view.mesures.find((m) => m.actionId === 'cae_5.1.1.1.3');
+      expect(row?.done).toBe(false);
+    });
+
+    it('row done=true sur action de rôle atteinte avec pilote', () => {
+      const view = parcoursToChecklist(
+        makeParcours({
+          referentiel: 'cae',
+          criteres_action: [
+            makeRoleCritere('cae_5.1.1.1.3', true),
+          ] as ParcoursLabellisation['criteres_action'],
+        }),
+        { eluReferent: false, referentTechnique: true }
+      );
+      const row = view.mesures.find((m) => m.actionId === 'cae_5.1.1.1.3');
+      expect(row?.done).toBe(true);
+    });
+
+    it('row done=false sur action de rôle non atteinte même avec pilote', () => {
+      const view = parcoursToChecklist(
+        makeParcours({
+          referentiel: 'cae',
+          criteres_action: [
+            makeRoleCritere('cae_5.1.1.1.3', false),
+          ] as ParcoursLabellisation['criteres_action'],
+        }),
+        bothReferentRoles
+      );
+      const row = view.mesures.find((m) => m.actionId === 'cae_5.1.1.1.3');
+      expect(row?.done).toBe(false);
+    });
+
+    it('row done suit atteint pour une action non-rôle peu importe la presence pilote', () => {
+      const view = parcoursToChecklist(
+        makeParcours({
+          referentiel: 'cae',
+          criteres_action: [
+            makeRoleCritere('cae_5.1.1.3.2', true),
+          ] as ParcoursLabellisation['criteres_action'],
+        }),
+        noReferentRoles
+      );
+      const row = view.mesures.find((m) => m.actionId === 'cae_5.1.1.3.2');
+      expect(row?.done).toBe(true);
     });
   });
 });

--- a/apps/app/src/referentiels/audit-labellisation/parcours-to-checklist.ts
+++ b/apps/app/src/referentiels/audit-labellisation/parcours-to-checklist.ts
@@ -1,10 +1,17 @@
 import {
+  ETOILE_MIN_REALISE_SCORE,
+  EtoileEnum,
   getIdentifiantFromActionId,
   isAuditLabellisationReferentiel,
+  isReferentRoleDefined,
   ParcoursLabellisation,
+  canModifyCandidatureDocuments,
+  ReferentRolesDefined,
   ROLE_IDENTIFIANTS,
+  RoleKey,
 } from '@tet/domain/referentiels';
 import {
+  MinimumScoreViewModel,
   Parcours,
   RoleMesures,
   RoleMesureViewModel,
@@ -16,7 +23,8 @@ const EMPTY_ROLE_MESURES: RoleMesures = {
 };
 
 const extractRoleMesures = (
-  parcours: ParcoursLabellisation
+  parcours: ParcoursLabellisation,
+  referentRolesDefined: ReferentRolesDefined
 ): RoleMesures => {
   if (!isAuditLabellisationReferentiel(parcours.referentiel)) {
     return EMPTY_ROLE_MESURES;
@@ -31,35 +39,56 @@ const extractRoleMesures = (
     ])
   );
 
-  const toRoleMesure = (identifiant: string): RoleMesureViewModel | null => {
+  const toRoleMesure = (
+    identifiant: string,
+    roleKey: RoleKey
+  ): RoleMesureViewModel | null => {
     const critere = critereByIdentifiant.get(identifiant);
     if (!critere) {
       return null;
     }
-    return { actionId: critere.action_id, done: critere.atteint };
+    return {
+      actionId: critere.action_id,
+      done: critere.atteint && referentRolesDefined[roleKey],
+    };
   };
 
   return {
-    eluReferent: toRoleMesure(mappingForReferentiel.eluReferent),
-    referentTechnique: toRoleMesure(mappingForReferentiel.referentTechnique),
+    eluReferent: toRoleMesure(mappingForReferentiel.eluReferent, 'eluReferent'),
+    referentTechnique: toRoleMesure(
+      mappingForReferentiel.referentTechnique,
+      'referentTechnique'
+    ),
+  };
+};
+
+const getMinimumScore = (
+  critereScore: ParcoursLabellisation['critere_score'],
+  etoiles: ParcoursLabellisation['etoiles']
+): MinimumScoreViewModel => {
+  if (etoiles > 1) {
+    return {
+      done: critereScore.atteint,
+      seuilPercent: Math.round(critereScore.score_a_realiser * 100),
+    };
+  }
+  const seuilDeuxiemeEtoile =
+    ETOILE_MIN_REALISE_SCORE[EtoileEnum.DEUXIEME_ETOILE];
+  return {
+    done: critereScore.score_fait >= seuilDeuxiemeEtoile,
+    seuilPercent: Math.round(seuilDeuxiemeEtoile * 100),
   };
 };
 
 export const parcoursToChecklist = (
-  parcours: ParcoursLabellisation
+  parcours: ParcoursLabellisation,
+  referentRolesDefined: ReferentRolesDefined
 ): Parcours => {
   return {
     etoileObjectif: parcours.etoiles,
     completude: { done: parcours.completude_ok },
-    minimumScore:
-      parcours.etoiles > 1
-        ? {
-            done: parcours.critere_score.atteint,
-            seuilPercent: Math.round(
-              parcours.critere_score.score_a_realiser * 100
-            ),
-          }
-        : null,
+    minimumScore: getMinimumScore(parcours.critere_score, parcours.etoiles),
+    scoreFait: parcours.critere_score.score_fait,
     mesures: [...parcours.criteres_action]
       .sort((a, b) => a.priorite - b.priorite)
       .map((critereAction) => ({
@@ -68,14 +97,23 @@ export const parcoursToChecklist = (
           getIdentifiantFromActionId(critereAction.action_id) ??
           critereAction.action_id,
         formulation: critereAction.formulation,
-        done: critereAction.atteint,
+        done:
+          critereAction.atteint &&
+          isReferentRoleDefined(
+            critereAction,
+            parcours.referentiel,
+            referentRolesDefined
+          ),
         minRealisePercentage: critereAction.min_realise_percentage,
         minProgrammePercentage: critereAction.min_programme_percentage,
       })),
-    roleMesures: extractRoleMesures(parcours),
+    roleMesures: extractRoleMesures(parcours, referentRolesDefined),
     acteEngagement: {
       signed: parcours.conditionFichiers.atteint,
       demandeId: parcours.demande?.id ?? null,
     },
+    canModifyCandidatureDocuments: canModifyCandidatureDocuments({
+      audit: parcours.audit ? { valide: parcours.audit.valide } : null,
+    }),
   };
 };

--- a/e2e/tests/referentiels/labellisations/checklist-acte-engagement.spec.ts
+++ b/e2e/tests/referentiels/labellisations/checklist-acte-engagement.spec.ts
@@ -8,7 +8,7 @@ const DOCUMENT_TEST_2_PATH =
   'apps/backend/src/collectivites/documents/samples/document_test_2.pdf';
 
 test.describe("Checklist audit-labellisation — acte d'engagement", () => {
-  test.beforeEach(async ({ page, collectivites }) => {
+  test.beforeEach(async ({ collectivites }) => {
     const { collectivite, user } = await collectivites.addCollectiviteAndUser({
       userArgs: { autoLogin: true },
     });
@@ -17,7 +17,6 @@ test.describe("Checklist audit-labellisation — acte d'engagement", () => {
     // Le pré-calcul ici évite que ce coût retombe sur le premier `goto` du test
     // et fasse flaker l'attente du heading.
     await user.precomputeReferentielSnapshot(collectivite.data.id, referentiel);
-    await page.goto('/');
   });
 
   test("Échec de l'envoi du fichier : la modale reste ouverte et une erreur est affichée", async ({
@@ -61,47 +60,5 @@ test.describe("Checklist audit-labellisation — acte d'engagement", () => {
 
     await expect(page.getByText('document_test_2.pdf')).toBeVisible();
     await expect(page.getByText('document_test.pdf')).toHaveCount(0);
-  });
-
-  test("Remplacer l'acte d'engagement ne supprime pas les documents de candidature de la demande", async ({
-    page,
-    newAuditLabellisationPom,
-    referentiels,
-    collectivites,
-  }) => {
-    const collectivite = collectivites.getCollectivite();
-    // Étoile 1 obtenue → la demande vise l'étoile 2 : la section documents de
-    // candidature devient visible. Acte d'engagement et documents de
-    // candidature partagent la table `preuve_labellisation` sous le même
-    // `demandeId`, sans discriminateur.
-    await referentiels.seedLabellisationObtenue({
-      collectiviteId: collectivite.data.id,
-      referentielId: referentiel,
-      etoiles: 1,
-    });
-
-    await newAuditLabellisationPom.goto(collectivite.data.id, referentiel);
-
-    // Acte d'engagement : 1ʳᵉ preuve de la demande (donc `preuves[0]`, ciblée
-    // par le bouton « Remplacer le fichier »).
-    await newAuditLabellisationPom.uploadActeEngagement();
-    await expect(page.getByText('document_test.pdf').first()).toBeVisible();
-
-    // Document de candidature distinct : 2ᵉ preuve de la même demande.
-    await newAuditLabellisationPom.ajouterDocumentButton.click();
-    await newAuditLabellisationPom.documentsPom.setDocument(
-      DOCUMENT_TEST_2_PATH,
-      'document_test_2.pdf'
-    );
-    await expect(page.getByText('document_test_2.pdf')).toBeVisible();
-
-    // Remplacement de l'acte : doit ne supprimer que l'acte ciblé. L'ancien
-    // comportement (`replace` supprimant toutes les preuves du `demandeId`)
-    // effaçait silencieusement le document de candidature.
-    await newAuditLabellisationPom.remplacerFichierButton.click();
-    await newAuditLabellisationPom.documentsPom.setTestDocument();
-
-    // Le document de candidature survit au remplacement de l'acte.
-    await expect(page.getByText('document_test_2.pdf')).toBeVisible();
   });
 });

--- a/e2e/tests/referentiels/labellisations/checklist-score-minimum.spec.ts
+++ b/e2e/tests/referentiels/labellisations/checklist-score-minimum.spec.ts
@@ -31,7 +31,7 @@ test.describe('Checklist audit-labellisation — ligne score minimum', () => {
   });
 
   for (const referentielId of referentielIds) {
-    test(`${referentielId.toUpperCase()} — 1ʳᵉ étoile : la ligne score minimum est absente`, async ({
+    test(`${referentielId.toUpperCase()} — 1ʳᵉ étoile : la ligne score minimum affiche le seuil de la 2ᵉ étoile (35 %)`, async ({
       newAuditLabellisationPom,
       collectivites,
     }) => {
@@ -39,7 +39,11 @@ test.describe('Checklist audit-labellisation — ligne score minimum', () => {
 
       await newAuditLabellisationPom.goto(collectivite.data.id, referentielId);
 
-      await expect(newAuditLabellisationPom.scoreMinimumRow).toHaveCount(0);
+      const row = newAuditLabellisationPom.scoreMinimumRow;
+      await expect(row).toContainText(
+        `Atteindre un score réalisé (statut Fait) d'au moins 35 % et le prouver (via les documents preuves ou un texte justificatif)`
+      );
+      await expect(row).toContainText(`35% fait minimum`);
     });
 
     for (const { etoileDemandee, seuilPercent } of casPresents) {


### PR DESCRIPTION
## Nature

**Feature** — lot D2 : enrichit le view-model `Parcours` et centralise la visibilité des sections de la checklist. Empilée sur D1 (#4602, rename `canModifyCandidatureDocuments`).

## Contenu

- **`parcoursToChecklist`** prend désormais la **présence des rôles référents** (`ReferentRolesDefined`) en 2ᵉ argument et l'intègre au `done` des mesures et des mesures de rôle. Ajoute `scoreFait`, rend `minimumScore` **non-null** (seuil 2ᵉ étoile affiché dès la 1re), expose `canModifyCandidatureDocuments`.
- **`checklist.context`** câble `useReferentRolesDefined`, calcule `showActeEngagement` / `showCandidatureDocuments` via les règles pures `is-acte-engagement-visible` / `is-candidature-documents-visible`, et propage le chargement des rôles.
- **Consommateurs** : la section documents de candidature et la ligne acte d'engagement sont gardées par ces drapeaux (`VisibleWhen`).

## Nommage

Anglais : `isReferentRoleDefined`/`ReferentRolesDefined`, `canModifyCandidatureDocuments` (pas `peutModifier…`).

## Tests

`parcours-to-checklist.spec` (21 tests, porté + adapté), `is-acte-engagement-visible.spec` (4), `is-candidature-documents-visible.spec` (2) → **27 verts**. `app:typecheck` + eslint verts.

## Anti-scope (→ D3)

Reorg `table/`+`layout/`, refonte des sections en `table/sections/`, boutons doc (upload/rename/delete-preuve), refonte `role-mesure.item`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * La checklist affiche désormais automatiquement certains éléments selon le contexte, dont l’« acte d’engagement » et les documents de candidature.
  * La ligne de score minimum est maintenant visible avec un libellé plus clair sur le seuil attendu.

* **Bug Fixes**
  * Les critères de réalisation tiennent mieux compte des rôles référents et de l’état du dossier.
  * L’affichage des sections de la checklist est mieux synchronisé avec les données chargées.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->