### PR TITLE
test(audit-labellisation): porte les e2e badge / demandes / acte auditeur + couverture canStartAudit

### DIFF
--- a/DISCOVERED.md
+++ b/DISCOVERED.md
@@ -24,10 +24,3 @@
 - **Découvert pendant** : audit-checklist-view-update (stabilisation des e2e labellisation)
 - **Découvert le** : 2026-05-21
 
-## [bug] Après un audit COT terminé, le bouton « Demander un audit » reste désactivé alors que le domaine autorise la redemande
-- **Symptôme** : une fois un audit COT validé/clôturé (que ce soit via le raccourci `validateAudit` posant `valide=true`, ou via la vraie clôture 2-étapes par l'auditeur), le bouton « Demander un audit » côté CT reste **désactivé**. La CT ne peut pas redemander un audit.
-- **Localisation** : `packages/domain/src/referentiels/labellisations/audit-request-availability/audit-request-availability.rules.ts` (consommé par le gating du bouton) vs `start-new-audit-cycle.rules.ts` (`availabilityAfterValidatedAudit` : `demande.sujet === 'cot'` → `canRequest: true`). Statut dérivé par `getParcoursLabellisationStatus` dans `request-labellisation.rules.ts` (`audit.valide` → `'audit_valide'`).
-- **Diagnostic suspecté** : décalage entre la règle `canStartNewAuditCycle` (qui rouvre explicitement le cycle pour un audit COT validé) et l'état réel du bouton. Le statut devrait être `audit_valide` (puisque `valide=true`), `demande.sujet` est bien `'cot'` (`requestCotAudit`), donc `canStartNewAuditCycle` devrait renvoyer `canRequest: true`. Une des autres conditions de `getAuditRequestAvailability` (`availableAuditTypes` vide ? prérequis ? `allReferentRolesDefined` ?) bloque peut-être, OU le bouton lit une autre source de disponibilité. À confirmer en traçant `getAuditRequestAvailability` sur un parcours COT post-validation.
-- **Impact** : utilisateur — une CT en COT ne peut pas relancer d'audit après clôture, contrairement au comportement attendu (confirmé produit). Bloquant fonctionnel.
-- **Découvert pendant** : k-audit-labellisation-e2e-coverage (portage des e2e badge d'audit). Le test « audit COT terminé : le cycle se referme et la CT peut redemander » est **écarté du PR** (rouge sur main) en attendant le fix — il documente exactement ce mode de défaillance.
-- **Découvert le** : 2026-06-24

--- a/DISCOVERED.md
+++ b/DISCOVERED.md
@@ -24,3 +24,11 @@
 - **Découvert pendant** : audit-checklist-view-update (stabilisation des e2e labellisation)
 - **Découvert le** : 2026-05-21
 
+## [bug] Assigner un rôle depuis la checklist ne rafraîchit pas le statut de la tâche sur la page référentiel (sans reload)
+- **Symptôme** : assigner un pilote à une mesure de rôle depuis la checklist audit-labellisation passe la tâche associée (ex. `cae_5.1.1.1.3`) à « Fait ». En naviguant ensuite en client-side (sans `page.reload`) vers la page de cette action sur le référentiel, le sélecteur d'avancement affiche encore « Non renseigné ». Un rechargement complet montre le bon statut.
+- **Localisation** : flux d'assignation de rôle (upsert pilotes → `updateStatut`) côté checklist vs cache React Query `listActionsGroupedById` de la page référentiel. Invalidation manquante après l'écriture du statut déclenchée par l'assignation de rôle.
+- **Diagnostic suspecté** : l'`onSuccess` de la mutation d'assignation de rôle invalide `getParcours` mais pas `listActionsGroupedById` (ni les queries de score de la page action). Même famille que le bug de rafraîchissement SPA de la checklist ci-dessus. Piste : invalider `listActionsGroupedById` (et le snapshot de scores) dans l'`onSuccess`.
+- **Impact** : utilisateur — statut de tâche périmé sur la page référentiel après une assignation de rôle, jusqu'à un refresh manuel ; dev — empêche le portage du test e2e « assigner puis retirer … sans recharger » de `audit-badge-component` (rouge sur main).
+- **Découvert pendant** : k-audit-labellisation-e2e-coverage (portage des e2e role-mesures)
+- **Découvert le** : 2026-06-24
+

--- a/DISCOVERED.md
+++ b/DISCOVERED.md
@@ -23,3 +23,11 @@
 - **Impact** : utilisateur — un critère affiché peut être impossible à satisfaire en renseignant la seule mesure désignée ; dev — pièges de test (cf. `checklist-statut-refresh.spec.ts` qui doit passer les deux tâches).
 - **Découvert pendant** : audit-checklist-view-update (stabilisation des e2e labellisation)
 - **Découvert le** : 2026-05-21
+
+## [bug] Après un audit COT terminé, le bouton « Demander un audit » reste désactivé alors que le domaine autorise la redemande
+- **Symptôme** : une fois un audit COT validé/clôturé (que ce soit via le raccourci `validateAudit` posant `valide=true`, ou via la vraie clôture 2-étapes par l'auditeur), le bouton « Demander un audit » côté CT reste **désactivé**. La CT ne peut pas redemander un audit.
+- **Localisation** : `packages/domain/src/referentiels/labellisations/audit-request-availability/audit-request-availability.rules.ts` (consommé par le gating du bouton) vs `start-new-audit-cycle.rules.ts` (`availabilityAfterValidatedAudit` : `demande.sujet === 'cot'` → `canRequest: true`). Statut dérivé par `getParcoursLabellisationStatus` dans `request-labellisation.rules.ts` (`audit.valide` → `'audit_valide'`).
+- **Diagnostic suspecté** : décalage entre la règle `canStartNewAuditCycle` (qui rouvre explicitement le cycle pour un audit COT validé) et l'état réel du bouton. Le statut devrait être `audit_valide` (puisque `valide=true`), `demande.sujet` est bien `'cot'` (`requestCotAudit`), donc `canStartNewAuditCycle` devrait renvoyer `canRequest: true`. Une des autres conditions de `getAuditRequestAvailability` (`availableAuditTypes` vide ? prérequis ? `allReferentRolesDefined` ?) bloque peut-être, OU le bouton lit une autre source de disponibilité. À confirmer en traçant `getAuditRequestAvailability` sur un parcours COT post-validation.
+- **Impact** : utilisateur — une CT en COT ne peut pas relancer d'audit après clôture, contrairement au comportement attendu (confirmé produit). Bloquant fonctionnel.
+- **Découvert pendant** : k-audit-labellisation-e2e-coverage (portage des e2e badge d'audit). Le test « audit COT terminé : le cycle se referme et la CT peut redemander » est **écarté du PR** (rouge sur main) en attendant le fix — il documente exactement ce mode de défaillance.
+- **Découvert le** : 2026-06-24

--- a/apps/backend/src/referentiels/labellisations/labellisations.test-fixture.ts
+++ b/apps/backend/src/referentiels/labellisations/labellisations.test-fixture.ts
@@ -89,17 +89,19 @@ export async function seedLabellisationObtenue({
   collectiviteId,
   referentielId,
   etoiles,
+  obtenueLe,
 }: {
   databaseService: DatabaseServiceInterface;
   collectiviteId: number;
   referentielId: ReferentielId;
   etoiles: Etoile;
+  obtenueLe?: string;
 }): Promise<void> {
   await databaseService.db.insert(labellisationTable).values({
     collectiviteId,
     referentiel: referentielId,
     etoiles,
-    obtenueLe: new Date().toISOString(),
+    obtenueLe: obtenueLe ?? new Date().toISOString(),
   });
 }
 

--- a/e2e/tests/referentiels/labellisations/acte-engagement-auditeur.spec.ts
+++ b/e2e/tests/referentiels/labellisations/acte-engagement-auditeur.spec.ts
@@ -1,0 +1,62 @@
+import { expect } from '@playwright/test';
+import { ReferentielId } from '@tet/domain/referentiels';
+import { CollectiviteRole } from '@tet/domain/users';
+import { CollectiviteFixture } from 'tests/collectivite/collectivites.fixture';
+import { testWithReferentiels as test } from '../referentiels.fixture';
+
+const referentiel: ReferentielId = 'eci';
+
+test.describe("Acte d'engagement — accès auditeur", () => {
+  test("l'auditeur ne voit pas le bouton « Remplacer le fichier » sur l'acte déposé", async ({
+    collectivites,
+    referentiels,
+    newAuditLabellisationPom,
+  }) => {
+    const { collectivite, user: editeurUser } =
+      await collectivites.addCollectiviteAndUser({
+        userArgs: { autoLogin: true },
+        collectiviteArgs: { isCOT: true },
+      });
+    const collectiviteId = collectivite.data.id;
+    await editeurUser.precomputeReferentielSnapshot(
+      collectiviteId,
+      referentiel
+    );
+    await referentiels.seedLabellisationObtenue({
+      collectiviteId,
+      referentielId: referentiel,
+      etoiles: 1,
+    });
+    await referentiels.updateAllReferentielStatutsToFait(
+      editeurUser,
+      collectiviteId,
+      referentiel
+    );
+    await referentiels.seedLabellisationPreuve(
+      editeurUser,
+      collectiviteId,
+      referentiel
+    );
+    const auditeurUser = await (collectivite as CollectiviteFixture).addUser({
+      role: CollectiviteRole.LECTURE,
+      autoLogin: true,
+    });
+    await referentiels.requestLabellisationAudit(
+      editeurUser,
+      collectiviteId,
+      referentiel
+    );
+    await referentiels.addAuditeur({
+      user: auditeurUser,
+      collectiviteId,
+      referentielId: referentiel,
+    });
+
+    await auditeurUser.login();
+    await newAuditLabellisationPom.goto(collectiviteId, referentiel);
+
+    await expect(newAuditLabellisationPom.remplacerFichierButton).toHaveCount(
+      0
+    );
+  });
+});

--- a/e2e/tests/referentiels/labellisations/audit-badge-tab.spec.ts
+++ b/e2e/tests/referentiels/labellisations/audit-badge-tab.spec.ts
@@ -216,6 +216,42 @@ test.describe("Badge d'état d'audit : tous les états CT vs auditeur vs visiteu
     await expect(newAuditLabellisationPom.demanderAuditButton).toHaveCount(0);
   });
 
+  test('audit COT terminé : le cycle se referme et la CT peut redemander', async ({
+    page,
+    referentiels,
+    newAuditLabellisationPom,
+  }) => {
+    await referentiels.requestCotAudit(editeurUser, collectiviteId, referentiel);
+    await referentiels.updateAllReferentielStatutsToFait(
+      editeurUser,
+      collectiviteId,
+      referentiel
+    );
+    await referentiels.addAuditeur({
+      user: auditeurUser,
+      collectiviteId,
+      referentielId: referentiel,
+    });
+    await referentiels.startAudit(auditeurUser, collectiviteId, referentiel);
+    await referentiels.validateAudit(collectiviteId, referentiel);
+    await referentiels.seedRolePilotes(
+      editeurUser,
+      collectiviteId,
+      referentiel
+    );
+
+    await viewAs(editeurUser, newAuditLabellisationPom, collectiviteId);
+    await expect(newAuditLabellisationPom.demanderAuditButton).toBeEnabled();
+    await expect(auditBadgeTab(page, /Audit terminé/)).toHaveCount(0);
+
+    await viewAs(auditeurUser, newAuditLabellisationPom, collectiviteId);
+    await expect(auditBadgeTab(page, /Audit terminé/)).toHaveCount(0);
+
+    await viewAsNonMember(nonMembreUser, page, collectiviteId);
+    await expect(auditBadgeTab(page, /Audit terminé/)).toHaveCount(0);
+    await expect(newAuditLabellisationPom.demanderAuditButton).toHaveCount(0);
+  });
+
   test("audit en cours : l'auditeur voit « Clôturer l'audit », la CT voit la demande", async ({
     referentiels,
     newAuditLabellisationPom,

--- a/e2e/tests/referentiels/labellisations/audit-badge-tab.spec.ts
+++ b/e2e/tests/referentiels/labellisations/audit-badge-tab.spec.ts
@@ -1,0 +1,276 @@
+import { expect, Page } from '@playwright/test';
+import { AuditLabellisationReferentielId } from '@tet/domain/referentiels';
+import { CollectiviteRole } from '@tet/domain/users';
+import { CollectiviteFixture } from 'tests/collectivite/collectivites.fixture';
+import { UserFixture } from 'tests/users/users.fixture';
+import { testWithReferentiels as test } from '../referentiels.fixture';
+import { NewAuditLabellisationPom } from './new-audit-labellisation.pom';
+
+const referentiel: AuditLabellisationReferentielId = 'eci';
+
+const auditBadgeTab = (page: Page, label: string | RegExp) =>
+  page.getByRole('tab', { name: label });
+
+async function viewAs(
+  user: UserFixture,
+  pom: NewAuditLabellisationPom,
+  collectiviteId: number
+): Promise<void> {
+  await user.login();
+  await pom.goto(collectiviteId, referentiel);
+}
+
+async function viewAsNonMember(
+  user: UserFixture,
+  page: Page,
+  collectiviteId: number
+): Promise<void> {
+  await user.login();
+  await page.goto(
+    `/collectivite/${collectiviteId}/referentiel/new/${referentiel}/audit-labellisation`
+  );
+  await expect(
+    page.getByRole('tab', { name: /Audit et labellisation/ })
+  ).toBeVisible({ timeout: 15_000 });
+}
+
+test.describe("Badge d'état d'audit : tous les états CT vs auditeur vs visiteur", () => {
+  let collectiviteId: number;
+  let editeurUser: UserFixture;
+  let auditeurUser: UserFixture;
+  let nonMembreUser: UserFixture;
+
+  test.beforeEach(async ({ collectivites, referentiels }) => {
+    const { collectivite, user } = await collectivites.addCollectiviteAndUser({
+      userArgs: { autoLogin: true },
+      collectiviteArgs: { isCOT: true },
+    });
+    collectiviteId = collectivite.data.id;
+    editeurUser = user;
+    await editeurUser.precomputeReferentielSnapshot(
+      collectiviteId,
+      referentiel
+    );
+    await referentiels.seedLabellisationObtenue({
+      collectiviteId,
+      referentielId: referentiel,
+      etoiles: 1,
+    });
+    await referentiels.updateAllReferentielStatutsToFait(
+      editeurUser,
+      collectiviteId,
+      referentiel
+    );
+    await referentiels.seedLabellisationPreuve(
+      editeurUser,
+      collectiviteId,
+      referentiel
+    );
+    auditeurUser = await (collectivite as CollectiviteFixture).addUser({
+      role: CollectiviteRole.LECTURE,
+      autoLogin: true,
+    });
+    nonMembreUser = (
+      await collectivites.addCollectiviteAndUser({
+        userArgs: { autoLogin: true },
+      })
+    ).user;
+  });
+
+  test('demande envoyée et auditeur attribué', async ({
+    page,
+    referentiels,
+    newAuditLabellisationPom,
+  }) => {
+    await referentiels.requestLabellisationAudit(
+      editeurUser,
+      collectiviteId,
+      referentiel
+    );
+    await referentiels.addAuditeur({
+      user: auditeurUser,
+      collectiviteId,
+      referentielId: referentiel,
+    });
+
+    await viewAs(editeurUser, newAuditLabellisationPom, collectiviteId);
+    await expect(auditBadgeTab(page, /Audit demandé/)).toBeVisible();
+    await expect(newAuditLabellisationPom.demanderAuditButton).toBeDisabled();
+
+    await viewAs(auditeurUser, newAuditLabellisationPom, collectiviteId);
+    await expect(auditBadgeTab(page, /Audit attribué/)).toBeVisible();
+
+    await viewAsNonMember(nonMembreUser, page, collectiviteId);
+    await expect(auditBadgeTab(page, /Audit demandé/)).toBeVisible();
+    await expect(newAuditLabellisationPom.demanderAuditButton).toHaveCount(0);
+  });
+
+  test('audit en cours', async ({
+    page,
+    referentiels,
+    newAuditLabellisationPom,
+  }) => {
+    await referentiels.requestLabellisationAudit(
+      editeurUser,
+      collectiviteId,
+      referentiel
+    );
+    await referentiels.addAuditeur({
+      user: auditeurUser,
+      collectiviteId,
+      referentielId: referentiel,
+    });
+    await referentiels.startAudit(auditeurUser, collectiviteId, referentiel);
+
+    const badgeAuditEnCours = `Audit en cours par ${auditeurUser.data.prenom} ${auditeurUser.data.nom}`;
+
+    await viewAs(editeurUser, newAuditLabellisationPom, collectiviteId);
+    await expect(auditBadgeTab(page, badgeAuditEnCours)).toBeVisible();
+    await expect(newAuditLabellisationPom.demanderAuditButton).toBeDisabled();
+
+    await viewAs(auditeurUser, newAuditLabellisationPom, collectiviteId);
+    await expect(auditBadgeTab(page, /Audit en cours/)).toBeVisible();
+    await expect(auditBadgeTab(page, badgeAuditEnCours)).toHaveCount(0);
+
+    await viewAsNonMember(nonMembreUser, page, collectiviteId);
+    await expect(auditBadgeTab(page, badgeAuditEnCours)).toBeVisible();
+    await expect(newAuditLabellisationPom.demanderAuditButton).toHaveCount(0);
+  });
+
+  test('audit terminé pour une demande de labellisation', async ({
+    page,
+    referentiels,
+    newAuditLabellisationPom,
+  }) => {
+    await referentiels.requestLabellisationAudit(
+      editeurUser,
+      collectiviteId,
+      referentiel
+    );
+    await referentiels.addAuditeur({
+      user: auditeurUser,
+      collectiviteId,
+      referentielId: referentiel,
+    });
+    await referentiels.startAudit(auditeurUser, collectiviteId, referentiel);
+    await referentiels.validateAudit(collectiviteId, referentiel);
+
+    await viewAs(editeurUser, newAuditLabellisationPom, collectiviteId);
+    await expect(
+      auditBadgeTab(page, /Audit terminé et labellisation en cours/)
+    ).toBeVisible();
+    await expect(newAuditLabellisationPom.demanderAuditButton).toBeDisabled();
+
+    await viewAs(auditeurUser, newAuditLabellisationPom, collectiviteId);
+    await expect(auditBadgeTab(page, /Audit terminé/)).toBeVisible();
+
+    await viewAsNonMember(nonMembreUser, page, collectiviteId);
+    await expect(
+      auditBadgeTab(page, /Audit terminé et labellisation en cours/)
+    ).toBeVisible();
+    await expect(newAuditLabellisationPom.demanderAuditButton).toHaveCount(0);
+  });
+
+  test('audit terminé + labellisation obtenue : badge auditeur toujours visible mais plus de badge pour la CT', async ({
+    page,
+    referentiels,
+    newAuditLabellisationPom,
+  }) => {
+    await referentiels.requestLabellisationAudit(
+      editeurUser,
+      collectiviteId,
+      referentiel
+    );
+    await referentiels.addAuditeur({
+      user: auditeurUser,
+      collectiviteId,
+      referentielId: referentiel,
+    });
+    await referentiels.startAudit(auditeurUser, collectiviteId, referentiel);
+    await referentiels.validateAudit(collectiviteId, referentiel);
+    await referentiels.seedLabellisationObtenue({
+      collectiviteId,
+      referentielId: referentiel,
+      etoiles: 2,
+      obtenueLe: '2027-01-01T00:00:00.000Z',
+    });
+    await referentiels.seedRolePilotes(
+      editeurUser,
+      collectiviteId,
+      referentiel
+    );
+
+    await viewAs(editeurUser, newAuditLabellisationPom, collectiviteId);
+    await expect(
+      auditBadgeTab(page, /Audit (demandé|attribué|en cours|terminé)/)
+    ).toHaveCount(0);
+    await expect(newAuditLabellisationPom.demanderAuditButton).toBeEnabled();
+
+    await viewAs(auditeurUser, newAuditLabellisationPom, collectiviteId);
+    await expect(auditBadgeTab(page, /Audit terminé/)).toBeVisible();
+
+    await viewAsNonMember(nonMembreUser, page, collectiviteId);
+    await expect(
+      auditBadgeTab(page, /Audit (demandé|attribué|en cours|terminé)/)
+    ).toHaveCount(0);
+    await expect(newAuditLabellisationPom.demanderAuditButton).toHaveCount(0);
+  });
+
+  test("audit en cours : l'auditeur voit « Clôturer l'audit », la CT voit la demande", async ({
+    referentiels,
+    newAuditLabellisationPom,
+    labellisationPom,
+  }) => {
+    await referentiels.requestLabellisationAudit(
+      editeurUser,
+      collectiviteId,
+      referentiel
+    );
+    await referentiels.addAuditeur({
+      user: auditeurUser,
+      collectiviteId,
+      referentielId: referentiel,
+    });
+    await referentiels.startAudit(auditeurUser, collectiviteId, referentiel);
+
+    await viewAs(editeurUser, newAuditLabellisationPom, collectiviteId);
+    await expect(labellisationPom.cloturerAuditButton).toHaveCount(0);
+    await expect(newAuditLabellisationPom.demanderAuditButton).toBeDisabled();
+
+    await viewAs(auditeurUser, newAuditLabellisationPom, collectiviteId);
+    await expect(labellisationPom.cloturerAuditButton).toBeVisible();
+    await expect(
+      newAuditLabellisationPom.demanderPremiereEtoileButton
+    ).toHaveCount(0);
+    await expect(newAuditLabellisationPom.demanderAuditButton).toHaveCount(0);
+  });
+
+  test("l'auditeur clôture l'audit en déposant un rapport et la CT voit « Audit terminé et labellisation en cours »", async ({
+    page,
+    referentiels,
+    newAuditLabellisationPom,
+    labellisationPom,
+  }) => {
+    await referentiels.requestLabellisationAudit(
+      editeurUser,
+      collectiviteId,
+      referentiel
+    );
+    await referentiels.addAuditeur({
+      user: auditeurUser,
+      collectiviteId,
+      referentielId: referentiel,
+    });
+    await referentiels.startAudit(auditeurUser, collectiviteId, referentiel);
+
+    await viewAs(auditeurUser, newAuditLabellisationPom, collectiviteId);
+    await labellisationPom.closeAuditWithReport();
+
+    await expect(auditBadgeTab(page, /Audit terminé/)).toBeVisible();
+
+    await viewAs(editeurUser, newAuditLabellisationPom, collectiviteId);
+    await expect(
+      auditBadgeTab(page, /Audit terminé et labellisation en cours/)
+    ).toBeVisible();
+  });
+});

--- a/e2e/tests/referentiels/labellisations/checklist-role-mesures.spec.ts
+++ b/e2e/tests/referentiels/labellisations/checklist-role-mesures.spec.ts
@@ -150,4 +150,98 @@ test.describe('Checklist audit-labellisation — assignation rôle ↔ statut me
 
     await expect(newAuditLabellisationPom.roleSearchInput).toBeVisible();
   });
+
+  test('CAE eluReferent : retirer le pilote refait passer le critère de atteint à non atteint', async ({
+    page,
+    newAuditLabellisationPom,
+    collectivites,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    referentiels, // déclenche le cleanup des action_statut (FK action_statut.modified_by → user)
+  }) => {
+    const collectivite = collectivites.getCollectivite();
+    const user = collectivite.getUser(0);
+    const userFullName = `${user.data.prenom} ${user.data.nom}`;
+
+    await newAuditLabellisationPom.goto(collectivite.data.id, 'cae');
+
+    const row = newAuditLabellisationPom.checklistRow(
+      /Identifier un.+lu.+r.+f.+rent/i
+    );
+    await expect(row.getByLabel('Critère non atteint')).toBeVisible();
+
+    await newAuditLabellisationPom.roleHeaderItem('eluReferent').click();
+    const statutSaved = page.waitForResponse((response) =>
+      response.url().includes('updateStatut')
+    );
+    const parcoursReloaded = page.waitForResponse((response) =>
+      response.url().includes('getParcours')
+    );
+    await page.getByRole('button', { name: userFullName }).click();
+    await statutSaved;
+    await parcoursReloaded;
+    await page.keyboard.press('Escape');
+    await expect(row.getByLabel('Critère atteint')).toBeVisible({
+      timeout: ASSIGNATION_REFRESH_TIMEOUT,
+    });
+
+    await newAuditLabellisationPom.roleHeaderItem('eluReferent').click();
+    await newAuditLabellisationPom.roleDropdownOption(userFullName).click();
+    await page.keyboard.press('Escape');
+
+    await expect(row.getByLabel('Critère non atteint')).toBeVisible({
+      timeout: ASSIGNATION_REFRESH_TIMEOUT,
+    });
+  });
+
+  test("Visiteur — pas de bouton « Renseigner » sur une mesure de rôle", async ({
+    page,
+    newAuditLabellisationPom,
+    collectivites,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    referentiels,
+  }) => {
+    const editeurCollectivite = collectivites.getCollectivite();
+
+    await collectivites.addCollectiviteAndUser({
+      userArgs: { autoLogin: true },
+    });
+
+    await newAuditLabellisationPom.goto(editeurCollectivite.data.id, 'cae');
+
+    await expect(
+      page.getByRole('button', { name: `${editeurCollectivite.data.nom} visite` })
+    ).toBeVisible();
+
+    const row = newAuditLabellisationPom.checklistRow(
+      /Identifier un.+lu.+r.+f.+rent/i
+    );
+    await row.hover();
+
+    await expect(
+      row.getByRole('button', { name: 'Renseigner' })
+    ).toHaveCount(0);
+  });
+
+  test("Visiteur — le trigger d'édition du rôle dans le header n'ouvre pas le dropdown", async ({
+    page,
+    newAuditLabellisationPom,
+    collectivites,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    referentiels,
+  }) => {
+    const editeurCollectivite = collectivites.getCollectivite();
+
+    await collectivites.addCollectiviteAndUser({
+      userArgs: { autoLogin: true },
+    });
+
+    await newAuditLabellisationPom.goto(editeurCollectivite.data.id, 'cae');
+
+    await expect(
+      page.getByRole('button', { name: `${editeurCollectivite.data.nom} visite` })
+    ).toBeVisible();
+
+    await newAuditLabellisationPom.roleHeaderItem('eluReferent').click();
+    await expect(newAuditLabellisationPom.roleSearchInput).toHaveCount(0);
+  });
 });

--- a/e2e/tests/referentiels/labellisations/checklist-statut-refresh.spec.ts
+++ b/e2e/tests/referentiels/labellisations/checklist-statut-refresh.spec.ts
@@ -3,6 +3,8 @@ import { ReferentielId } from '@tet/domain/referentiels';
 import { testWithReferentiels as test } from '../referentiels.fixture';
 
 const referentiel: ReferentielId = 'cae';
+const equipeProjetReferentiel: ReferentielId = 'eci';
+const equipeProjetActionId = 'eci_1.1.3.1';
 
 test.describe('Checklist audit-labellisation — rafraîchissement après mise à jour de statut', () => {
   test.beforeEach(async ({ page, collectivites }) => {
@@ -10,6 +12,10 @@ test.describe('Checklist audit-labellisation — rafraîchissement après mise �
       userArgs: { autoLogin: true },
     });
     await user.precomputeReferentielSnapshot(collectivite.data.id, referentiel);
+    await user.precomputeReferentielSnapshot(
+      collectivite.data.id,
+      equipeProjetReferentiel
+    );
     await page.goto('/');
   });
 
@@ -52,6 +58,39 @@ test.describe('Checklist audit-labellisation — rafraîchissement après mise �
     // cf. DISCOVERED.md : le rafraîchissement sans refresh reste à corriger.
     await page.goBack();
     await page.reload();
+    await expect(row.getByLabel('Critère atteint')).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+
+  test("Passer la mesure de statut « Mettre en place une équipe projet » à Fait fait basculer son critère à atteint", async ({
+    newAuditLabellisationPom,
+    collectivites,
+    referentiels,
+  }) => {
+    const collectivite = collectivites.getCollectivite();
+    const user = collectivite.getUser(0);
+
+    await newAuditLabellisationPom.goto(
+      collectivite.data.id,
+      equipeProjetReferentiel
+    );
+
+    const row = newAuditLabellisationPom.checklistRow(
+      /Mettre en place une équipe projet/i
+    );
+    await expect(row.getByLabel('Critère non atteint')).toBeVisible();
+
+    await referentiels.updateActionStatut(user, {
+      collectiviteId: collectivite.data.id,
+      actionId: equipeProjetActionId,
+      statut: 'fait',
+    });
+
+    await newAuditLabellisationPom.goto(
+      collectivite.data.id,
+      equipeProjetReferentiel
+    );
     await expect(row.getByLabel('Critère atteint')).toBeVisible({
       timeout: 15_000,
     });

--- a/e2e/tests/referentiels/labellisations/demandes-audit-labellisation.spec.ts
+++ b/e2e/tests/referentiels/labellisations/demandes-audit-labellisation.spec.ts
@@ -1,0 +1,166 @@
+import { expect } from '@playwright/test';
+import { AuditLabellisationReferentielId } from '@tet/domain/referentiels';
+import { testWithReferentiels as test } from '../referentiels.fixture';
+
+const referentiel: AuditLabellisationReferentielId = 'cae';
+
+test.describe('Demandes depuis la nouvelle vue audit-labellisation', () => {
+  test('visiteur : ni « Obtenir la première étoile » ni « Demander un audit »', async ({
+    page,
+    collectivites,
+    newAuditLabellisationPom,
+  }) => {
+    const { collectivite, user } = await collectivites.addCollectiviteAndUser({
+      userArgs: { autoLogin: true },
+    });
+    const collectiviteId = collectivite.data.id;
+    await user.precomputeReferentielSnapshot(collectiviteId, referentiel);
+
+    await collectivites.addCollectiviteAndUser({
+      userArgs: { autoLogin: true },
+    });
+
+    await newAuditLabellisationPom.goto(collectiviteId, referentiel);
+
+    await expect(
+      page.getByRole('button', { name: `${collectivite.data.nom} visite` })
+    ).toBeVisible();
+
+    await expect(
+      newAuditLabellisationPom.demanderPremiereEtoileButton
+    ).toHaveCount(0);
+    await expect(newAuditLabellisationPom.demanderAuditButton).toHaveCount(0);
+  });
+
+  test('audit COT sans labellisation : envoi ferme la modale', async ({
+    collectivites,
+    referentiels,
+    newAuditLabellisationPom,
+  }) => {
+    const { collectivite, user } = await collectivites.addCollectiviteAndUser({
+      userArgs: { autoLogin: true },
+      collectiviteArgs: { isCOT: true },
+    });
+    const collectiviteId = collectivite.data.id;
+    await user.precomputeReferentielSnapshot(collectiviteId, referentiel);
+    await referentiels.seedLabellisationObtenue({
+      collectiviteId,
+      referentielId: referentiel,
+      etoiles: 1,
+    });
+    await referentiels.updateAllReferentielStatutsToFait(
+      user,
+      collectiviteId,
+      referentiel
+    );
+    await referentiels.seedRolePilotes(user, collectiviteId, referentiel);
+
+    await newAuditLabellisationPom.goto(collectiviteId, referentiel);
+    await expect(
+      newAuditLabellisationPom.demanderPremiereEtoileButton
+    ).toHaveCount(0);
+    await newAuditLabellisationPom.openAuditModal();
+    await newAuditLabellisationPom.auditTypeCotRadio.click();
+    await newAuditLabellisationPom.envoyerAuditButton.click();
+
+    await expect(newAuditLabellisationPom.auditSuccessToast).toBeVisible();
+    await expect(newAuditLabellisationPom.auditModal).toHaveCount(0);
+  });
+
+  test('audit COT avec labellisation pour la deuxième étoile', async ({
+    collectivites,
+    referentiels,
+    newAuditLabellisationPom,
+  }) => {
+    const { collectivite, user } = await collectivites.addCollectiviteAndUser({
+      userArgs: { autoLogin: true },
+      collectiviteArgs: { isCOT: true },
+    });
+    const collectiviteId = collectivite.data.id;
+    await user.precomputeReferentielSnapshot(collectiviteId, referentiel);
+    await referentiels.seedLabellisationObtenue({
+      collectiviteId,
+      referentielId: referentiel,
+      etoiles: 1,
+    });
+    await referentiels.updateAllReferentielStatutsToFait(
+      user,
+      collectiviteId,
+      referentiel
+    );
+    await referentiels.seedRolePilotes(user, collectiviteId, referentiel);
+
+    await newAuditLabellisationPom.goto(collectiviteId, referentiel);
+    await newAuditLabellisationPom.uploadCandidatureDocument();
+    await newAuditLabellisationPom.openAuditModal();
+    await newAuditLabellisationPom.auditTypeCotAvecLabellisationRadio.click();
+    await newAuditLabellisationPom.selectTargetStar(2);
+    await newAuditLabellisationPom.envoyerAuditButton.click();
+
+    await expect(newAuditLabellisationPom.auditSuccessToast).toBeVisible();
+  });
+
+  for (const ref of ['cae', 'eci'] as const) {
+    test(`audit de labellisation ${ref} pour la deuxième étoile`, async ({
+      collectivites,
+      referentiels,
+      newAuditLabellisationPom,
+    }) => {
+      const { collectivite, user } = await collectivites.addCollectiviteAndUser(
+        { userArgs: { autoLogin: true } }
+      );
+      const collectiviteId = collectivite.data.id;
+      await user.precomputeReferentielSnapshot(collectiviteId, ref);
+      await referentiels.seedLabellisationObtenue({
+        collectiviteId,
+        referentielId: ref,
+        etoiles: 1,
+      });
+      await referentiels.updateAllReferentielStatutsToFait(
+        user,
+        collectiviteId,
+        ref
+      );
+      await referentiels.seedRolePilotes(user, collectiviteId, ref);
+
+      await newAuditLabellisationPom.goto(collectiviteId, ref);
+      await newAuditLabellisationPom.uploadCandidatureDocument();
+      await newAuditLabellisationPom.openAuditModal();
+      await newAuditLabellisationPom.selectTargetStar(2);
+      await newAuditLabellisationPom.envoyerAuditButton.click();
+
+      await expect(newAuditLabellisationPom.auditSuccessToast).toBeVisible();
+    });
+
+    test(`audit de labellisation ${ref} pour la cinquième étoile`, async ({
+      collectivites,
+      referentiels,
+      newAuditLabellisationPom,
+    }) => {
+      const { collectivite, user } = await collectivites.addCollectiviteAndUser(
+        { userArgs: { autoLogin: true } }
+      );
+      const collectiviteId = collectivite.data.id;
+      await user.precomputeReferentielSnapshot(collectiviteId, ref);
+      await referentiels.seedLabellisationObtenue({
+        collectiviteId,
+        referentielId: ref,
+        etoiles: 1,
+      });
+      await referentiels.updateAllReferentielStatutsToFait(
+        user,
+        collectiviteId,
+        ref
+      );
+      await referentiels.seedRolePilotes(user, collectiviteId, ref);
+
+      await newAuditLabellisationPom.goto(collectiviteId, ref);
+      await newAuditLabellisationPom.uploadCandidatureDocument();
+      await newAuditLabellisationPom.openAuditModal();
+      await newAuditLabellisationPom.selectTargetStar(5);
+      await newAuditLabellisationPom.envoyerAuditButton.click();
+
+      await expect(newAuditLabellisationPom.auditSuccessToast).toBeVisible();
+    });
+  }
+});

--- a/e2e/tests/referentiels/labellisations/labellisation.pom.ts
+++ b/e2e/tests/referentiels/labellisations/labellisation.pom.ts
@@ -165,6 +165,14 @@ export class LabellisationPom {
     ).toBeVisible();
   }
 
+  async closeAuditWithReport(): Promise<void> {
+    await this.cloturerAuditButton.click();
+    await this.uploadCloturerAuditReport();
+    await this.cloturerAuditSuivantButton.click();
+    await this.cloturerAuditEngagementCheckbox.check();
+    await this.cloturerAuditValiderButton.click();
+  }
+
   cloturerAuditDeleteReportButton(filename: string): Locator {
     return this.cloturerAuditModal.getByRole('button', {
       name: `Supprimer le rapport d'audit « ${filename} »`,

--- a/e2e/tests/referentiels/labellisations/new-audit-labellisation.pom.ts
+++ b/e2e/tests/referentiels/labellisations/new-audit-labellisation.pom.ts
@@ -101,6 +101,12 @@ export class NewAuditLabellisationPom {
     return this.page.getByText(`${ROLE_LABEL[role]} :`);
   }
 
+  roleDropdownOption(name: string): Locator {
+    return this.page
+      .getByTestId('personnes-options')
+      .getByRole('button', { name });
+  }
+
   /** Ligne du tableau checklist pour une mesure, identifiée par une formulation partielle */
   checklistRow(formulationPattern: string | RegExp): Locator {
     return this.page.getByRole('row', { name: formulationPattern });

--- a/e2e/tests/referentiels/labellisations/new-audit-labellisation.pom.ts
+++ b/e2e/tests/referentiels/labellisations/new-audit-labellisation.pom.ts
@@ -26,6 +26,9 @@ export class NewAuditLabellisationPom {
   readonly demanderAuditButton: Locator;
   readonly auditModal: Locator;
   readonly auditTypeGroup: Locator;
+  readonly auditTypeCotRadio: Locator;
+  readonly auditTypeCotAvecLabellisationRadio: Locator;
+  readonly targetStarSelect: Locator;
   readonly envoyerAuditButton: Locator;
   readonly auditSuccessToast: Locator;
   readonly documentsPom: DocumentsPom;
@@ -73,6 +76,14 @@ export class NewAuditLabellisationPom {
     this.auditTypeGroup = page.getByRole('group', {
       name: "Quel type d'audit souhaitez-vous demander ?",
     });
+    this.auditTypeCotRadio = this.auditModal.getByRole('radio', {
+      name: 'Audit COT sans labellisation',
+    });
+    this.auditTypeCotAvecLabellisationRadio = this.auditModal.getByRole(
+      'radio',
+      { name: 'Audit COT avec labellisation' }
+    );
+    this.targetStarSelect = this.auditModal.getByTestId('target-star');
     this.envoyerAuditButton = this.auditModal.getByRole('button', {
       name: 'Envoyer ma demande',
     });
@@ -118,9 +129,19 @@ export class NewAuditLabellisationPom {
     await this.documentsPom.setTestDocument();
   }
 
+  async uploadCandidatureDocument(): Promise<void> {
+    await this.ajouterDocumentButton.click();
+    await this.documentsPom.setTestDocument();
+  }
+
   /** Ouvre la modale « Demander un audit » depuis l'en-tête de la checklist */
   async openAuditModal(): Promise<void> {
     await this.demanderAuditButton.click();
     await expect(this.auditModal).toBeVisible();
+  }
+
+  async selectTargetStar(star: 2 | 3 | 4 | 5): Promise<void> {
+    await this.targetStarSelect.click();
+    await this.auditModal.getByTestId(String(star)).click();
   }
 }

--- a/e2e/tests/referentiels/referentiels.fixture.ts
+++ b/e2e/tests/referentiels/referentiels.fixture.ts
@@ -1,3 +1,4 @@
+import { auditTable } from '@tet/backend/referentiels/labellisations/audit.table';
 import {
   addAuditeur,
   requestCotAudit,
@@ -6,7 +7,9 @@ import {
   seedLabellisationObtenue,
   seedLabellisationPreuve,
   startAudit,
+  validateAudit,
 } from '@tet/backend/referentiels/labellisations/labellisations.test-fixture';
+import { and, desc, eq } from 'drizzle-orm';
 import {
   cleanupReferentielActionStatutsAndLabellisations,
   updateAllNeedReferentielStatutsToCompleteReferentiel,
@@ -15,8 +18,10 @@ import {
 } from '@tet/backend/referentiels/update-action-statut/referentiel-action-statut.test-fixture';
 import {
   ActionStatutCreate,
+  AuditLabellisationReferentielId,
   Etoile,
   ReferentielId,
+  ROLE_IDENTIFIANTS,
   ScoreSnapshot,
 } from '@tet/domain/referentiels';
 import { testWithCollectivites } from 'tests/collectivite/collectivites.fixture';
@@ -102,6 +107,29 @@ class ReferentielsFixtureFactory extends FixtureFactory {
     await startAudit(trpcClient, collectiviteId, referentielId);
   }
 
+  async validateAudit(
+    collectiviteId: number,
+    referentielId: ReferentielId
+  ): Promise<void> {
+    const [audit] = await databaseService.db
+      .select({ id: auditTable.id })
+      .from(auditTable)
+      .where(
+        and(
+          eq(auditTable.collectiviteId, collectiviteId),
+          eq(auditTable.referentielId, referentielId)
+        )
+      )
+      .orderBy(desc(auditTable.id))
+      .limit(1);
+    if (!audit) {
+      throw new Error(
+        `Aucun audit a valider pour la collectivite ${collectiviteId} (${referentielId})`
+      );
+    }
+    await validateAudit({ databaseService, auditId: audit.id });
+  }
+
   async requestLabellisationAudit(
     user: UserFixture,
     collectiviteId: number,
@@ -142,17 +170,38 @@ class ReferentielsFixtureFactory extends FixtureFactory {
     collectiviteId,
     referentielId,
     etoiles,
+    obtenueLe,
   }: {
     collectiviteId: number;
     referentielId: ReferentielId;
     etoiles: Etoile;
+    obtenueLe?: string;
   }): Promise<void> {
     await seedLabellisationObtenue({
       databaseService,
       collectiviteId,
       referentielId,
       etoiles,
+      obtenueLe,
     });
+  }
+
+  async seedRolePilotes(
+    user: UserFixture,
+    collectiviteId: number,
+    referentielId: AuditLabellisationReferentielId
+  ): Promise<void> {
+    const trpcClient = user.getTrpcClient();
+    const { eluReferent, referentTechnique } = ROLE_IDENTIFIANTS[referentielId];
+    await Promise.all(
+      [eluReferent, referentTechnique].map((identifiant) =>
+        trpcClient.referentiels.actions.upsertPilotes.mutate({
+          collectiviteId,
+          mesureId: `${referentielId}_${identifiant}`,
+          pilotes: [{ userId: user.data.id }],
+        })
+      )
+    );
   }
 
   async updateActionStatut(

--- a/packages/domain/src/referentiels/labellisations/audit-request-availability/audit-request-availability.rules.spec.ts
+++ b/packages/domain/src/referentiels/labellisations/audit-request-availability/audit-request-availability.rules.spec.ts
@@ -165,6 +165,22 @@ describe('getAuditRequestAvailability', () => {
     ).toEqual({ canRequest: true, reason: null });
   });
 
+  it('cycle clos après audit COT terminé : disponible (la CT peut redemander)', () => {
+    expect(
+      availabilityOf(
+        makeParcours({
+          status: 'audit_valide',
+          isCot: true,
+          demande: {
+            sujet: 'cot',
+            envoyee_le: '2026-01-01T00:00:00.000Z',
+          } as ParcoursForAuditRequest['demande'],
+        }),
+        { isCOT: true, maximumRequestableStar: 2 }
+      )
+    ).toEqual({ canRequest: true, reason: null });
+  });
+
   it("non-COT + étoile 2, critères atteints mais élu référent non désigné : indisponible (pilotes de rôle incomplets)", () => {
     expect(
       availabilityOf(

--- a/packages/domain/src/referentiels/labellisations/start-audit/start-audit.rules.spec.ts
+++ b/packages/domain/src/referentiels/labellisations/start-audit/start-audit.rules.spec.ts
@@ -1,0 +1,78 @@
+import { ParcoursLabellisation } from '../parcours-labellisation.schema';
+import { ParcoursLabellisationStatus } from '../parcours-labellisation-status.enum';
+import { canStartAudit } from './start-audit.rules';
+import { StartAuditRulesErrorsEnum } from './start-audit.rules-errors';
+
+type MinimalParcours = Pick<ParcoursLabellisation, 'status' | 'auditeurs'>;
+
+const auditeurId = 'auditeur-1';
+
+const buildParcours = ({
+  status = 'demande_envoyee',
+  auditeurIds = [auditeurId],
+}: {
+  status?: ParcoursLabellisationStatus;
+  auditeurIds?: string[];
+} = {}): MinimalParcours => ({
+  status,
+  auditeurs: auditeurIds.map((userId) => ({ userId, nom: userId })),
+});
+
+describe('canStartAudit', () => {
+  it('returns AUDIT_NOT_FOUND when parcours is null', () => {
+    const result = canStartAudit(null, auditeurId);
+    expect(result).toEqual({
+      canRequest: false,
+      reason: StartAuditRulesErrorsEnum.AUDIT_NOT_FOUND,
+    });
+  });
+
+  it('returns AUDIT_NOT_REQUESTED when status is not demande_envoyee', () => {
+    const result = canStartAudit(
+      buildParcours({ status: 'non_demandee' }),
+      auditeurId
+    );
+    expect(result).toEqual({
+      canRequest: false,
+      reason: StartAuditRulesErrorsEnum.AUDIT_NOT_REQUESTED,
+    });
+  });
+
+  it("returns AUDIT_NOT_REQUESTED when an audit is already en cours", () => {
+    const result = canStartAudit(
+      buildParcours({ status: 'audit_en_cours' }),
+      auditeurId
+    );
+    expect(result).toEqual({
+      canRequest: false,
+      reason: StartAuditRulesErrorsEnum.AUDIT_NOT_REQUESTED,
+    });
+  });
+
+  it("returns USER_NOT_AUDITOR when the user is not among the parcours auditeurs", () => {
+    const result = canStartAudit(
+      buildParcours({ auditeurIds: ['un-autre-auditeur'] }),
+      auditeurId
+    );
+    expect(result).toEqual({
+      canRequest: false,
+      reason: StartAuditRulesErrorsEnum.USER_NOT_AUDITOR,
+    });
+  });
+
+  it("returns USER_NOT_AUDITOR when no auditeur is assigned", () => {
+    const result = canStartAudit(
+      buildParcours({ auditeurIds: [] }),
+      auditeurId
+    );
+    expect(result).toEqual({
+      canRequest: false,
+      reason: StartAuditRulesErrorsEnum.USER_NOT_AUDITOR,
+    });
+  });
+
+  it('autorise le démarrage quand la demande est envoyée et que le user est auditeur assigné', () => {
+    const result = canStartAudit(buildParcours(), auditeurId);
+    expect(result).toEqual({ canRequest: true, reason: null });
+  });
+});


### PR DESCRIPTION
## Intention

Atteindre la **parité e2e** avec `audit-badge-component` pour les features déjà sur main, et compléter la couverture domaine. Aucun code de prod modifié : tout est test + infra de test.

## e2e ajoutés / complétés (verts en local, `workers=1`)

- `audit-badge-tab` (**7/7, iso**) — états du badge (demande, attribué, en cours, terminé, labellisation obtenue) pour CT / auditeur / visiteur, clôture 2-étapes, **et « audit COT terminé → la CT peut redemander »**.
- `demandes-audit-labellisation` (7) — visiteur, audit COT sans/avec labellisation, labellisation 2ᵉ/5ᵉ étoile (CAE + ECI). 1ʳᵉ étoile déjà couverte par `request-labellisation-from-new-checklist`.
- `acte-engagement-auditeur` (1) — l'auditeur ne voit pas « Remplacer le fichier ».
- `checklist-role-mesures` (**+3**) — retirer un pilote → critère repasse non atteint ; visiteur sans CTA « Renseigner » ; clic visiteur n'ouvre pas le dropdown (adapté au markup MetadataItem de main).
- `checklist-statut-refresh` (**+1**) — « Mettre en place une équipe projet » (ECI) à Fait → critère atteint.

## Domaine

- `start-audit.rules.spec.ts` — couverture `canStartAudit`.
- `audit-request-availability.rules.spec.ts` — cas « COT validé → `canRequest: true` ».

## Infra de test ajoutée

- `referentiels.fixture` : `validateAudit` (résout l'audit par collectivité/référentiel), `seedRolePilotes`, `obtenueLe` sur `seedLabellisationObtenue`.
- Backend `labellisations.test-fixture` : `obtenueLe` optionnel.
- `LabellisationPom` : wrapper `closeAuditWithReport()` (clôture 2-étapes, réutilise les sélecteurs existants).
- `NewAuditLabellisationPom` : radios type d'audit, étoile cible, `selectTargetStar`, `uploadCandidatureDocument`, `roleDropdownOption`.

## Détail notable (badge COT terminé)

Le scénario échouait initialement à cause du **setup**, pas de la prod : `requestCotAudit` réapplique des statuts « complet » qui abaissent le score Fait → `maximumRequestableStar` retombe à 1 → `availableAuditTypes` vide. On restaure les statuts Fait après la demande COT → `maximumRequestableStar` repasse à 5 → bouton actif. (Diagnostiqué en instrumentant `getAuditRequestAvailability`.)

## Écarts restants (assumés)

- `audit-labellisation-to-action-scroll` : **vérifié, échoue sur main** (cible sous le header sticky) — le latch de scroll sticky-aware n'est pas sur main → lot futur.
- `audit-rapport-edit-window-auditeur` : géré ailleurs (fenêtre 15 j).
- `checklist-role-mesures` « référent technique : assigner puis retirer sans recharger » : non porté — vérifie un fix d'invalidation `listActionsGroupedById` dont la présence sur main est incertaine.
- `checklist-statut-refresh` : le test de refresh garde le `page.reload()` (workaround du bug de refresh SPA documenté dans `DISCOVERED.md`), au lieu du retour SPA attendu par la branche.

## Surface de review

- Attention humaine : les specs e2e + l'infra de test (`referentiels.fixture`, POMs, backend test-fixture).
- Mécanique : les 2 specs domaine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Les parcours d’audit et de labellisation couvrent désormais davantage de cas, avec un meilleur support des demandes d’audit, de la clôture avec rapport et du choix de la cible d’étoile.
  * L’interface affiche mieux les badges et états liés à l’audit selon le profil et l’avancement du dossier.

* **Bug fixes**
  * Le statut des tâches se rafraîchit désormais plus correctement après certaines actions d’assignation.
  * Des règles d’accès et de disponibilité d’audit ont été ajustées pour refléter les bons comportements selon l’état du cycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->