### PR TITLE
feat(audit-labellisation): integre les infos d'audit dans la vue tableau et retire l'onglet Suivi

### DIFF
--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/new/[referentielId]/(overview)/@tabs/layout.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/new/[referentielId]/(overview)/@tabs/layout.tsx
@@ -1,5 +1,6 @@
 import { ChecklistProvider } from '@/app/referentiels/audit-labellisation/checklist.context';
 import { ChecklistPageHeader } from '@/app/referentiels/audit-labellisation/checklist-page-header/checklist-page-header';
+import { ReferentielViewModeProvider } from '@/app/referentiels/referentiel.table/use-referentiel-view-mode';
 import {
   isAuditLabellisationReferentiel,
   referentielIdEnumSchema,
@@ -29,9 +30,11 @@ export default async function Layout({
 
   return (
     <ChecklistProvider referentielId={referentielId}>
-      <ChecklistPageHeader referentielId={referentielId} />
-      <Spacer height={1} />
-      <TabsWrapper>{children}</TabsWrapper>
+      <ReferentielViewModeProvider>
+        <ChecklistPageHeader referentielId={referentielId} />
+        <Spacer height={1} />
+        <TabsWrapper>{children}</TabsWrapper>
+      </ReferentielViewModeProvider>
     </ChecklistProvider>
   );
 }

--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/new/[referentielId]/(overview)/@tabs/progression/page.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/new/[referentielId]/(overview)/@tabs/progression/page.tsx
@@ -1,5 +1,5 @@
-import ActionList from '../../../../../[referentielId]/(overview)/@tabs/progression/_components/action.list';
+import { ReferentielViewSwitcher } from '../../../../../[referentielId]/(overview)/@tabs/progression/_components/referentiel-view-switcher';
 
 export default async function Page() {
-  return <ActionList />;
+  return <ReferentielViewSwitcher />;
 }

--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/new/[referentielId]/(overview)/@tabs/suivi/page.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/new/[referentielId]/(overview)/@tabs/suivi/page.tsx
@@ -1,5 +1,0 @@
-import { AuditSuivi } from '@/app/referentiels/audits/AuditSuivi';
-
-export default function Page() {
-  return <AuditSuivi />;
-}

--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/new/[referentielId]/(overview)/@tabs/tabs-wrapper.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/new/[referentielId]/(overview)/@tabs/tabs-wrapper.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useAuditStatusBadge } from '@/app/referentiels/audit-labellisation/audit-badge/use-audit-status-badge';
+import { useGetAuditStatusBadge } from '@/app/referentiels/audit-labellisation/audit-badge-status/use-get-audit-status-badge';
 import { useChecklist } from '@/app/referentiels/audit-labellisation/checklist.context';
 import { useIsVisitor } from '@/app/users/authorizations/use-is-visitor';
 import { Spacer, VisibleWhen } from '@tet/ui';
@@ -14,7 +14,7 @@ import { PropsWithChildren } from 'react';
 
 export const TabsWrapper = ({ children }: PropsWithChildren) => {
   const isVisitor = useIsVisitor();
-  const auditBadge = useAuditStatusBadge();
+  const auditBadge = useGetAuditStatusBadge();
   const { cycle } = useChecklist();
   const showAuditConductTabs = cycle.isConductingAudit;
 
@@ -32,7 +32,6 @@ export const TabsWrapper = ({ children }: PropsWithChildren) => {
           badge={auditBadge ?? undefined}
         />
         <VisibleWhen condition={showAuditConductTabs}>
-          <TabsTab href="suivi" label="Suivi de l'audit" />
           <TabsTab href="cycles" label="Cycles et comparaison" />
         </VisibleWhen>
       </TabsList>

--- a/apps/app/src/app/paths.ts
+++ b/apps/app/src/app/paths.ts
@@ -90,6 +90,7 @@ const referentielVueParam = 'referentielVue';
 
 const referentielRootPath = `${collectivitePath}/referentiel`;
 const referentielPath = `${referentielRootPath}/:${referentielIdParam}/:${referentielVueParam}`;
+const referentielNewPath = `${referentielRootPath}/new/:${referentielIdParam}/:${referentielVueParam}`;
 const referentielActionPath = `${referentielRootPath}/:${referentielIdParam}/action/:${actionParam}`;
 const referentielLabellisationRootPath = `${referentielRootPath}/:${referentielIdParam}/labellisation`;
 const referentielLabellisationPath = `${referentielLabellisationRootPath}/:${labellisationVueParam}?`;
@@ -224,6 +225,20 @@ export const makeReferentielUrl = ({
 
   return pathName;
 };
+
+export const makeReferentielNewUrl = ({
+  collectiviteId,
+  referentielId,
+  referentielTab = 'progression',
+}: {
+  collectiviteId: number;
+  referentielId: ReferentielId;
+  referentielTab?: ReferentielTab;
+}) =>
+  referentielNewPath
+    .replace(`:${collectiviteParam}`, collectiviteId.toString())
+    .replace(`:${referentielIdParam}`, referentielId)
+    .replace(`:${referentielVueParam}`, referentielTab);
 
 export const makeReferentielActionUrl = ({
   collectiviteId,

--- a/apps/app/src/labels/catalog.ts
+++ b/apps/app/src/labels/catalog.ts
@@ -426,6 +426,14 @@ export const appLabels = {
     "Remarques sur la mesure, questions pour la séance d'audit",
   ajouterMesureOrdreDuJour:
     "Ajouter cette mesure à l'ordre du jour de la séance d'audit",
+  auditColonneStatut: "Statut d'audit",
+  auditColonneOrdreDuJour: 'À discuter en séance',
+  auditColonneNotes: "Notes de l'auditeur·ice",
+  decouvrirInfosAuditTableauTitre:
+    "Retrouvez le suivi de l'audit dans la vue tableau",
+  decouvrirInfosAuditTableauDescription:
+    "Le statut d'audit, les points à discuter en séance et les notes de l'auditeur·ice sont désormais disponibles directement dans la vue tableau des mesures.",
+  decouvrirInfosAuditTableauCta: 'Découvrir la vue tableau',
   detaillerAvancementTache: "Détailler l'avancement à la tâche",
   detaillerAvancement: "Détailler l'avancement",
   detaillerAvancementPourcentage: "Détailler l'avancement au pourcentage",
@@ -1573,7 +1581,6 @@ export const appLabels = {
   completudeCritere:
     'Renseigner les statuts de toutes les mesures du référentiel',
   completudeReponse: 'Ne plus avoir de statuts non renseignés',
-  voirLaListe: 'Voir la liste',
   voirLaMesure: 'Voir la mesure',
   renseigner: 'Renseigner',
   chargement: 'Chargement…',

--- a/apps/app/src/referentiels/audit-labellisation/audit-badge-status/use-get-audit-status-badge.ts
+++ b/apps/app/src/referentiels/audit-labellisation/audit-badge-status/use-get-audit-status-badge.ts
@@ -1,9 +1,6 @@
 import { appLabels } from '@/app/labels/catalog';
 import { BadgeProps } from '@tet/ui';
-import {
-  AuditBadgeStatus,
-  parcoursToAuditBadgeStatus,
-} from '../audit-badge-status';
+import { AuditBadgeStatus, parcoursToAuditBadgeStatus } from '.';
 import { useChecklist } from '../checklist.context';
 
 const badgeByStatus: Record<
@@ -19,7 +16,7 @@ const badgeByStatus: Record<
   },
 };
 
-export function useAuditStatusBadge(): Omit<BadgeProps, 'size'> | null {
+export function useGetAuditStatusBadge(): Omit<BadgeProps, 'size'> | null {
   const { cycle } = useChecklist();
 
   const status = parcoursToAuditBadgeStatus({

--- a/apps/app/src/referentiels/audit-labellisation/checklist/audit-table-hint.banner.tsx
+++ b/apps/app/src/referentiels/audit-labellisation/checklist/audit-table-hint.banner.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { makeReferentielNewUrl } from '@/app/app/paths';
+import { appLabels } from '@/app/labels/catalog';
+import { ReferentielId } from '@tet/domain/referentiels';
+import { Alert, Button } from '@tet/ui';
+import { ReactElement } from 'react';
+
+export const AuditTableHintBanner = ({
+  collectiviteId,
+  referentielId,
+}: {
+  collectiviteId: number;
+  referentielId: ReferentielId;
+}): ReactElement => (
+  <Alert
+    title={appLabels.decouvrirInfosAuditTableauTitre}
+    description={appLabels.decouvrirInfosAuditTableauDescription}
+    footer={
+      <Button
+        size="xs"
+        variant="primary"
+        href={makeReferentielNewUrl({ collectiviteId, referentielId })}
+      >
+        {appLabels.decouvrirInfosAuditTableauCta}
+      </Button>
+    }
+  />
+);

--- a/apps/app/src/referentiels/audit-labellisation/checklist/index.tsx
+++ b/apps/app/src/referentiels/audit-labellisation/checklist/index.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import { makeReferentielUrl } from '@/app/app/paths';
 import { appLabels } from '@/app/labels/catalog';
 import { useCollectiviteId } from '@tet/api/collectivites';
 import { Divider, Spacer, VisibleWhen } from '@tet/ui';
 import { ReactElement } from 'react';
 import { Parcours } from '../checklist-view-model';
 import { useChecklist } from '../checklist.context';
+import { AuditTableHintBanner } from './audit-table-hint.banner';
 import { ChecklistActions } from './checklist-actions';
 import { Container } from './layout/container';
 import { Header } from './layout/header';
@@ -18,13 +18,20 @@ export const ChecklistView = ({
   viewModel: Parcours;
 }): ReactElement => {
   const collectiviteId = useCollectiviteId();
-  const { referentielId, showActeEngagement, showCandidatureDocuments } =
+  const { referentielId, cycle, showActeEngagement, showCandidatureDocuments } =
     useChecklist();
 
   const isPremiereEtoile = viewModel.etoileObjectif === 1;
 
   return (
     <Container>
+      <VisibleWhen condition={cycle.isConductingAudit}>
+        <AuditTableHintBanner
+          collectiviteId={collectiviteId}
+          referentielId={referentielId}
+        />
+        <Spacer height={1} />
+      </VisibleWhen>
       <Header
         title={appLabels.demandeAuditOuLabellisation}
         subtitle={appLabels.renseignerCriteresPourDemande}
@@ -43,11 +50,6 @@ export const ChecklistView = ({
         viewModel={viewModel}
         collectiviteId={collectiviteId}
         referentielId={referentielId}
-        referentielUrl={makeReferentielUrl({
-          collectiviteId,
-          referentielId,
-          referentielTab: 'detail',
-        })}
         showActeEngagement={showActeEngagement}
         showCandidatureDocuments={showCandidatureDocuments}
       />

--- a/apps/app/src/referentiels/audit-labellisation/checklist/table/labellisation-checklist.table.tsx
+++ b/apps/app/src/referentiels/audit-labellisation/checklist/table/labellisation-checklist.table.tsx
@@ -102,24 +102,13 @@ const MesureActionButton = ({
 
 const CompletudeRow = ({
   completude,
-  referentielUrl,
 }: {
   completude: Parcours['completude'];
-  referentielUrl: string;
 }): ReactElement => (
   <ChecklistTable.Row
     done={completude.done}
     criterion={{
       label: appLabels.completudeCritere,
-      action: (
-        <PillButton
-          icon="list-check"
-          iconPosition="right"
-          href={referentielUrl}
-        >
-          {appLabels.voirLaListe}
-        </PillButton>
-      ),
     }}
     answer={
       <span className="inline-flex flex-wrap items-center gap-1">
@@ -231,7 +220,6 @@ type LabellisationChecklistTableProps = {
   viewModel: Parcours;
   collectiviteId: number;
   referentielId: ReferentielId;
-  referentielUrl: string;
   showActeEngagement: boolean;
   showCandidatureDocuments: boolean;
 };
@@ -240,7 +228,6 @@ export const LabellisationChecklistTable = ({
   viewModel,
   collectiviteId,
   referentielId,
-  referentielUrl,
   showActeEngagement,
   showCandidatureDocuments,
 }: LabellisationChecklistTableProps): ReactElement => {
@@ -253,10 +240,7 @@ export const LabellisationChecklistTable = ({
         labelHeader={appLabels.criteres}
         answerHeader={appLabels.elementsAttendus}
       />
-      <CompletudeRow
-        completude={viewModel.completude}
-        referentielUrl={referentielUrl}
-      />
+      <CompletudeRow completude={viewModel.completude} />
       <MinimumScoreRow minimumScore={viewModel.minimumScore} />
       <MesuresRows
         mesures={viewModel.mesures}

--- a/apps/app/src/referentiels/audits/use-list-mesure-audit-statuts-grouped-by-id.ts
+++ b/apps/app/src/referentiels/audits/use-list-mesure-audit-statuts-grouped-by-id.ts
@@ -1,0 +1,33 @@
+import { useQuery } from '@tanstack/react-query';
+import { RouterOutput, useTRPC } from '@tet/api';
+import { useCollectiviteId } from '@tet/api/collectivites';
+import { ActionId, ReferentielId } from '@tet/domain/referentiels';
+import { keyBy } from 'es-toolkit';
+
+export type MesureAuditStatutRow =
+  RouterOutput['referentiels']['labellisations']['listMesureAuditStatuts'][number];
+
+export const useListMesureAuditStatutsGroupedById = ({
+  referentielId,
+  enabled,
+}: {
+  referentielId: ReferentielId;
+  enabled: boolean;
+}): {
+  auditStatutsByMesureId: Partial<Record<ActionId, MesureAuditStatutRow>>;
+  isLoading: boolean;
+} => {
+  const collectiviteId = useCollectiviteId();
+  const trpc = useTRPC();
+
+  const { data, isLoading } = useQuery(
+    trpc.referentiels.labellisations.listMesureAuditStatuts.queryOptions(
+      { collectiviteId, referentielId },
+      { enabled }
+    )
+  );
+
+  const auditStatutsByMesureId = keyBy(data ?? [], (row) => row.mesureId);
+
+  return { auditStatutsByMesureId, isLoading };
+};

--- a/apps/app/src/referentiels/audits/use-update-mesure-audit-statut.ts
+++ b/apps/app/src/referentiels/audits/use-update-mesure-audit-statut.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTRPC } from '@tet/api';
+import { getReferentielIdFromActionId } from '@tet/domain/referentiels';
 
 export const useUpdateMesureAuditStatut = () => {
   const queryClient = useQueryClient();
@@ -14,13 +15,26 @@ export const useUpdateMesureAuditStatut = () => {
             mesureId: newActionStatut.mesureId,
           });
 
-        await queryClient.cancelQueries({
-          queryKey: queryKeyGetMesureAuditStatut,
-        });
+        const queryKeyListMesureAuditStatuts =
+          trpc.referentiels.labellisations.listMesureAuditStatuts.queryKey({
+            collectiviteId: newActionStatut.collectiviteId,
+            referentielId: getReferentielIdFromActionId(
+              newActionStatut.mesureId
+            ),
+          });
+
+        await Promise.all([
+          queryClient.cancelQueries({ queryKey: queryKeyGetMesureAuditStatut }),
+          queryClient.cancelQueries({
+            queryKey: queryKeyListMesureAuditStatuts,
+          }),
+        ]);
 
         const previous = queryClient.getQueryData(queryKeyGetMesureAuditStatut);
+        const previousList = queryClient.getQueryData(
+          queryKeyListMesureAuditStatuts
+        );
 
-        // Optimistically update the cache
         queryClient.setQueryData<
           Omit<Extract<typeof previous, { collectiviteId: number }>, 'avis'>
         >(queryKeyGetMesureAuditStatut, (old) => ({
@@ -31,7 +45,21 @@ export const useUpdateMesureAuditStatut = () => {
           ordreDuJour: newActionStatut.ordreDuJour ?? old?.ordreDuJour ?? false,
         }));
 
-        return { previous };
+        queryClient.setQueryData(queryKeyListMesureAuditStatuts, (old) =>
+          old?.map((row) =>
+            row.mesureId === newActionStatut.mesureId
+              ? {
+                  ...row,
+                  statut: newActionStatut.statut ?? row.statut,
+                  avis: newActionStatut.avis ?? row.avis,
+                  ordreDuJour:
+                    newActionStatut.ordreDuJour ?? row.ordreDuJour,
+                }
+              : row
+          )
+        );
+
+        return { previous, previousList };
       },
       onSettled: (_data, error, { mesureId, collectiviteId }, context) => {
         const queryKeyGetMesureAuditStatut =
@@ -40,13 +68,30 @@ export const useUpdateMesureAuditStatut = () => {
             mesureId,
           });
 
+        const queryKeyListMesureAuditStatuts =
+          trpc.referentiels.labellisations.listMesureAuditStatuts.queryKey({
+            collectiviteId,
+            referentielId: getReferentielIdFromActionId(mesureId),
+          });
+
         if (error && context?.previous) {
           queryClient.setQueryData(
             queryKeyGetMesureAuditStatut,
             context.previous
           );
         }
+
+        if (error && context?.previousList) {
+          queryClient.setQueryData(
+            queryKeyListMesureAuditStatuts,
+            context.previousList
+          );
+        }
       },
     })
   );
 };
+
+export type UpdateMesureAuditStatut = ReturnType<
+  typeof useUpdateMesureAuditStatut
+>['mutate'];

--- a/apps/app/src/referentiels/referentiel.table/audit-input-cell.tsx
+++ b/apps/app/src/referentiels/referentiel.table/audit-input-cell.tsx
@@ -1,0 +1,16 @@
+import { TableCell } from '@tet/ui';
+import { PropsWithChildren } from 'react';
+
+export const AuditInputCell = ({
+  cellId,
+  children,
+}: PropsWithChildren<{ cellId: string }>) => (
+  <TableCell
+    className="!text-center"
+    tabIndex={-1}
+    data-cell-id={cellId}
+    onClick={(event) => event.stopPropagation()}
+  >
+    {children}
+  </TableCell>
+);

--- a/apps/app/src/referentiels/referentiel.table/empty-cell.tsx
+++ b/apps/app/src/referentiels/referentiel.table/empty-cell.tsx
@@ -1,0 +1,5 @@
+import { TableCell } from '@tet/ui';
+
+export const EmptyCell = ({ cellId }: { cellId: string }) => (
+  <TableCell tabIndex={-1} data-cell-id={cellId} />
+);

--- a/apps/app/src/referentiels/referentiel.table/referentiel-table.audit-notes.cell/get-audit-note-preview-content.spec.ts
+++ b/apps/app/src/referentiels/referentiel.table/referentiel-table.audit-notes.cell/get-audit-note-preview-content.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { getAuditNotePreviewContent } from './get-audit-note-preview-content';
+
+describe('getAuditNotePreviewContent', () => {
+  it('retourne une chaine vide quand la note est absente', () => {
+    expect(getAuditNotePreviewContent('')).toBe('');
+    expect(getAuditNotePreviewContent(null)).toBe('');
+    expect(getAuditNotePreviewContent(undefined)).toBe('');
+  });
+
+  it('retire les balises HTML', () => {
+    expect(getAuditNotePreviewContent('<p>Bonjour</p>')).toBe('Bonjour');
+  });
+
+  it('retourne une chaine vide quand le HTML ne contient aucun texte', () => {
+    expect(getAuditNotePreviewContent('<p></p>')).toBe('');
+    expect(getAuditNotePreviewContent('<ul><li></li></ul>')).toBe('');
+  });
+
+  it('ne garde que le premier paragraphe', () => {
+    expect(
+      getAuditNotePreviewContent('<p>Premiere ligne</p><p>Deuxieme ligne</p>')
+    ).toBe('Premiere ligne');
+  });
+
+  it('ne garde que le premier element d une liste', () => {
+    expect(
+      getAuditNotePreviewContent(
+        '<ul><li>Un</li><li>Deux</li><li>Trois</li></ul>'
+      )
+    ).toBe('Un');
+  });
+
+  it('utilise le titre comme premiere ligne avant une liste', () => {
+    expect(
+      getAuditNotePreviewContent('<h1>Titre</h1><ul><li>Un</li><li>Deux</li></ul>')
+    ).toBe('Titre');
+  });
+
+  it('coupe sur un saut de ligne <br>', () => {
+    expect(getAuditNotePreviewContent('<p>Avant<br>Apres</p>')).toBe('Avant');
+  });
+
+  it('ignore les premieres lignes vides', () => {
+    expect(getAuditNotePreviewContent('<p></p><p>Contenu</p>')).toBe('Contenu');
+  });
+
+  it('normalise les espaces multiples', () => {
+    expect(getAuditNotePreviewContent('<p>Trop    d   espaces</p>')).toBe(
+      'Trop d espaces'
+    );
+  });
+
+  it('preserve les accents francais', () => {
+    expect(getAuditNotePreviewContent('<p>Evalue a debote</p>')).toBe(
+      'Evalue a debote'
+    );
+    expect(getAuditNotePreviewContent('<p>Évalué à débôté</p>')).toBe(
+      'Évalué à débôté'
+    );
+  });
+});

--- a/apps/app/src/referentiels/referentiel.table/referentiel-table.audit-notes.cell/get-audit-note-preview-content.ts
+++ b/apps/app/src/referentiels/referentiel.table/referentiel-table.audit-notes.cell/get-audit-note-preview-content.ts
@@ -1,0 +1,30 @@
+import DOMPurify from 'dompurify';
+
+function blockTagsToLineBreaks(html: string): string {
+  return html
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/(p|div|li|h[1-6]|blockquote)>/gi, '\n');
+}
+
+function stripHtmlTags(html: string): string {
+  return DOMPurify.sanitize(html, { ALLOWED_TAGS: [], ALLOWED_ATTR: [] });
+}
+
+function collapseWhitespace(line: string): string {
+  return line.replace(/\s+/g, ' ').trim();
+}
+
+export function getAuditNotePreviewContent(
+  avis: string | null | undefined
+): string {
+  if (!avis) {
+    return '';
+  }
+
+  const lines = stripHtmlTags(blockTagsToLineBreaks(avis)).split('\n');
+  const firstLineWithContent = lines
+    .map(collapseWhitespace)
+    .find((line) => line.length > 0);
+
+  return firstLineWithContent ?? '';
+}

--- a/apps/app/src/referentiels/referentiel.table/referentiel-table.audit-notes.cell/referentiel-table.audit-notes.cell.tsx
+++ b/apps/app/src/referentiels/referentiel.table/referentiel-table.audit-notes.cell/referentiel-table.audit-notes.cell.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import { appLabels } from '@/app/labels/catalog';
+import { ActionListItem } from '@/app/referentiels/actions/use-list-actions';
+import { MesureAuditStatutRow } from '@/app/referentiels/audits/use-list-mesure-audit-statuts-grouped-by-id';
+import { UpdateMesureAuditStatut } from '@/app/referentiels/audits/use-update-mesure-audit-statut';
+import { useSidePanel } from '@/app/ui/layout/side-panel/side-panel.context';
+import { CellContext } from '@tanstack/react-table';
+import { cn, RichTextEditor, TableCell } from '@tet/ui';
+import { useCallback, useMemo } from 'react';
+import { EmptyCell } from '../empty-cell';
+import { getAuditNotePreviewContent } from './get-audit-note-preview-content';
+import { getTableMeta, isAuditableMesure } from '../utils';
+
+type Props = {
+  info: CellContext<ActionListItem, unknown>;
+};
+
+const AuditNotesPanelTitle = ({ identifiant }: { identifiant: string }) => (
+  <h5 className="text-primary-9 font-bold leading-7 text-xl">
+    {identifiant} {appLabels.auditColonneNotes}
+  </h5>
+);
+
+const AuditNotesPanelEditor = ({
+  auditStatut,
+  canEditAudit,
+  updateMesureAuditStatut,
+}: {
+  auditStatut: MesureAuditStatutRow;
+  canEditAudit: boolean;
+  updateMesureAuditStatut: UpdateMesureAuditStatut;
+}) => (
+  <div className="px-6 py-4">
+    <RichTextEditor
+      initialValue={auditStatut.avis}
+      disabled={!canEditAudit}
+      onBlurTextChanged={(value: string) =>
+        updateMesureAuditStatut({
+          collectiviteId: auditStatut.collectiviteId,
+          mesureId: auditStatut.mesureId,
+          avis: value,
+        })
+      }
+    />
+  </div>
+);
+
+function AuditNotesCellContent({
+  action,
+  cellId,
+  auditStatut,
+  canEditAudit,
+  updateMesureAuditStatut,
+}: {
+  action: ActionListItem;
+  cellId: string;
+  auditStatut: MesureAuditStatutRow;
+  canEditAudit: boolean;
+  updateMesureAuditStatut: UpdateMesureAuditStatut;
+}) {
+  const { setPanel, panel } = useSidePanel();
+
+  const isActive =
+    panel.isOpen && panel.title === `audit-notes-${action.actionId}`;
+
+  const avisPreview = useMemo(
+    () => getAuditNotePreviewContent(auditStatut.avis),
+    [auditStatut.avis]
+  );
+
+  const toggleNotesPanel = useCallback(() => {
+    if (isActive) {
+      setPanel({ type: 'close' });
+      return;
+    }
+
+    setPanel({
+      type: 'open',
+      title: `audit-notes-${action.actionId}`,
+      Title: () => <AuditNotesPanelTitle identifiant={action.identifiant} />,
+      content: (
+        <AuditNotesPanelEditor
+          auditStatut={auditStatut}
+          canEditAudit={canEditAudit}
+          updateMesureAuditStatut={updateMesureAuditStatut}
+        />
+      ),
+    });
+  }, [isActive, setPanel, action, auditStatut, canEditAudit, updateMesureAuditStatut]);
+
+  return (
+    <TableCell
+      tabIndex={-1}
+      data-cell-id={cellId}
+      data-inline-edit="true"
+      canEdit={canEditAudit}
+      placeholder={appLabels.ajouterNote}
+      className={cn('cursor-pointer', isActive && 'bg-primary-0')}
+      onClick={toggleNotesPanel}
+    >
+      {avisPreview && (
+        <span className="block truncate text-sm text-grey-8">
+          {avisPreview}
+        </span>
+      )}
+    </TableCell>
+  );
+}
+
+export const ReferentielTableAuditNotesCell = ({ info }: Props) => {
+  const action = info.row.original;
+  const cellId = info.cell.id;
+  const { auditStatutsByMesureId, canEditAudit, updateMesureAuditStatut } =
+    getTableMeta(info.table);
+
+  const auditStatut = auditStatutsByMesureId?.[action.actionId];
+
+  if (!isAuditableMesure(action, auditStatut) || !updateMesureAuditStatut) {
+    return <EmptyCell cellId={cellId} />;
+  }
+
+  return (
+    <AuditNotesCellContent
+      action={action}
+      cellId={cellId}
+      auditStatut={auditStatut}
+      canEditAudit={canEditAudit ?? false}
+      updateMesureAuditStatut={updateMesureAuditStatut}
+    />
+  );
+};

--- a/apps/app/src/referentiels/referentiel.table/referentiel-table.audit-ordre-du-jour.cell.tsx
+++ b/apps/app/src/referentiels/referentiel.table/referentiel-table.audit-ordre-du-jour.cell.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { appLabels } from '@/app/labels/catalog';
+import { ActionListItem } from '@/app/referentiels/actions/use-list-actions';
+import { CellContext } from '@tanstack/react-table';
+import { Checkbox } from '@tet/ui';
+import { ChangeEvent } from 'react';
+import { AuditInputCell } from './audit-input-cell';
+import { EmptyCell } from './empty-cell';
+import { getTableMeta, isAuditableMesure } from './utils';
+
+type Props = {
+  info: CellContext<ActionListItem, unknown>;
+};
+
+export const ReferentielTableAuditOrdreDuJourCell = ({ info }: Props) => {
+  const action = info.row.original;
+  const cellId = info.cell.id;
+  const { auditStatutsByMesureId, canEditAudit, updateMesureAuditStatut } =
+    getTableMeta(info.table);
+
+  const auditStatut = auditStatutsByMesureId?.[action.actionId];
+
+  if (!isAuditableMesure(action, auditStatut)) {
+    return <EmptyCell cellId={cellId} />;
+  }
+
+  return (
+    <AuditInputCell cellId={cellId}>
+      <Checkbox
+        aria-label={appLabels.auditColonneOrdreDuJour}
+        checked={auditStatut.ordreDuJour}
+        disabled={!canEditAudit}
+        onChange={(event: ChangeEvent<HTMLInputElement>) =>
+          updateMesureAuditStatut?.({
+            collectiviteId: auditStatut.collectiviteId,
+            mesureId: auditStatut.mesureId,
+            ordreDuJour: event.currentTarget.checked,
+          })
+        }
+      />
+    </AuditInputCell>
+  );
+};

--- a/apps/app/src/referentiels/referentiel.table/referentiel-table.audit-statut.cell.tsx
+++ b/apps/app/src/referentiels/referentiel.table/referentiel-table.audit-statut.cell.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { ActionListItem } from '@/app/referentiels/actions/use-list-actions';
+import { ActionAuditStatutBase } from '@/app/referentiels/audits/ActionAuditStatut';
+import { CellContext } from '@tanstack/react-table';
+import { MesureAuditStatutEnum } from '@tet/domain/referentiels';
+import { AuditInputCell } from './audit-input-cell';
+import { EmptyCell } from './empty-cell';
+import { getTableMeta, isAuditableMesure } from './utils';
+
+type Props = {
+  info: CellContext<ActionListItem, unknown>;
+};
+
+export const ReferentielTableAuditStatutCell = ({ info }: Props) => {
+  const action = info.row.original;
+  const cellId = info.cell.id;
+  const { auditStatutsByMesureId, canEditAudit, updateMesureAuditStatut } =
+    getTableMeta(info.table);
+
+  const auditStatut = auditStatutsByMesureId?.[action.actionId];
+
+  if (!isAuditableMesure(action, auditStatut)) {
+    return <EmptyCell cellId={cellId} />;
+  }
+
+  return (
+    <AuditInputCell cellId={cellId}>
+      <ActionAuditStatutBase
+        className="-m-1 inline-block"
+        auditStatut={auditStatut}
+        readonly={!canEditAudit}
+        onChange={(statut: MesureAuditStatutEnum) =>
+          updateMesureAuditStatut?.({
+            collectiviteId: auditStatut.collectiviteId,
+            mesureId: auditStatut.mesureId,
+            statut,
+          })
+        }
+      />
+    </AuditInputCell>
+  );
+};

--- a/apps/app/src/referentiels/referentiel.table/referentiel-table.comments.cell.tsx
+++ b/apps/app/src/referentiels/referentiel.table/referentiel-table.comments.cell.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { EmptyCell } from './empty-cell';
 import { ActionProvider } from '@/app/referentiels/actions/action-context';
 import { ActionCommentsSidePanelContent } from '@/app/referentiels/actions/comments/action-comments-side-panel-content';
 import { ActionListItem } from '@/app/referentiels/actions/use-list-actions';
@@ -135,5 +136,5 @@ export const ReferentielTableCommentsCell = ({ info }: Props) => {
     return <CommentsCellContent info={info} action={data} cellId={cellId} />;
   }
 
-  return <TableCell tabIndex={-1} data-cell-id={cellId} />;
+  return <EmptyCell cellId={cellId} />;
 };

--- a/apps/app/src/referentiels/referentiel.table/referentiel-table.description.cell.tsx
+++ b/apps/app/src/referentiels/referentiel.table/referentiel-table.description.cell.tsx
@@ -1,3 +1,4 @@
+import { EmptyCell } from './empty-cell';
 import { CellContext } from '@tanstack/react-table';
 import { TableCell, Tooltip } from '@tet/ui';
 import { ActionListItem } from '../actions/use-list-actions';
@@ -11,7 +12,7 @@ export const ReferentielTableDescriptionCell = ({ info }: Props) => {
   const cellId = info.cell.id;
 
   if (!value) {
-    return <TableCell tabIndex={-1} data-cell-id={cellId} />;
+    return <EmptyCell cellId={cellId} />;
   }
 
   return (

--- a/apps/app/src/referentiels/referentiel.table/referentiel-table.documents.cell.tsx
+++ b/apps/app/src/referentiels/referentiel.table/referentiel-table.documents.cell.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { EmptyCell } from './empty-cell';
 import { DownloadDocs } from '@/app/referentiels/actions/action-documents.download-button';
 import ActionPreuvePanel from '@/app/referentiels/actions/action-preuve.panel';
 import { ActionListItem } from '@/app/referentiels/actions/use-list-actions';
@@ -101,5 +102,5 @@ export const ReferentielTableDocumentsCell = ({ info }: Props) => {
     return <DocumentsCellContent action={data} cellId={cellId} />;
   }
 
-  return <TableCell tabIndex={-1} data-cell-id={cellId} />;
+  return <EmptyCell cellId={cellId} />;
 };

--- a/apps/app/src/referentiels/referentiel.table/referentiel-table.explication.cell.tsx
+++ b/apps/app/src/referentiels/referentiel.table/referentiel-table.explication.cell.tsx
@@ -1,6 +1,7 @@
+import { EmptyCell } from './empty-cell';
 import { CellContext } from '@tanstack/react-table';
 import { ActionType, ActionTypeEnum } from '@tet/domain/referentiels';
-import { TableCell, TableCellRichTextEditor } from '@tet/ui';
+import { TableCellRichTextEditor } from '@tet/ui';
 import { ActionListItem } from '../actions/use-list-actions';
 import { getTableMeta } from './utils';
 
@@ -19,7 +20,7 @@ export const ReferentielTableExplicationCell = ({ info }: Props) => {
   const cellId = info.cell.id;
 
   if (!actionTypesWithExplication.has(action.actionType)) {
-    return <TableCell tabIndex={-1} data-cell-id={cellId} />;
+    return <EmptyCell cellId={cellId} />;
   }
 
   const {

--- a/apps/app/src/referentiels/referentiel.table/referentiel-table.fiches.cell.tsx
+++ b/apps/app/src/referentiels/referentiel.table/referentiel-table.fiches.cell.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { EmptyCell } from './empty-cell';
 import { FichesActionLiees } from '@/app/referentiels/action.show/FichesActionLiees';
 import { ActionListItem } from '@/app/referentiels/actions/use-list-actions';
 import { useSidePanel } from '@/app/ui/layout/side-panel/side-panel.context';
@@ -94,5 +95,5 @@ export const ReferentielTableFichesCell = ({ info }: Props) => {
     return <FichesCellContent info={info} action={data} cellId={cellId} />;
   }
 
-  return <TableCell tabIndex={-1} data-cell-id={cellId} />;
+  return <EmptyCell cellId={cellId} />;
 };

--- a/apps/app/src/referentiels/referentiel.table/referentiel-table.header-filters.tsx
+++ b/apps/app/src/referentiels/referentiel.table/referentiel-table.header-filters.tsx
@@ -14,7 +14,7 @@ import { Button, Input, SelectFilter } from '@tet/ui';
 import { useState } from 'react';
 import { categorieToLabel } from '../utils';
 import { scoreRangeItems } from './referentiel-table.score-ranges';
-import { useGetReferentielTableFiltersState } from './use-get-referentiel-table-filters-state';
+import { ReferentielTableFiltersState } from './use-get-referentiel-table-filters-state';
 import { appLabels } from '@/app/labels/catalog';
 
 const statutOptions = (
@@ -42,7 +42,7 @@ const categorieOptions = [
 }));
 
 type FiltersState = Pick<
-  ReturnType<typeof useGetReferentielTableFiltersState>,
+  ReferentielTableFiltersState,
   'filters' | 'setFilters'
 >;
 

--- a/apps/app/src/referentiels/referentiel.table/referentiel-table.personnes-pilotes.cell.tsx
+++ b/apps/app/src/referentiels/referentiel.table/referentiel-table.personnes-pilotes.cell.tsx
@@ -1,3 +1,4 @@
+import { EmptyCell } from './empty-cell';
 import PersonneTagDropdown from '@/app/collectivites/tags/personne-tag.dropdown';
 import { getPersonneStringId } from '@/app/collectivites/tags/personnes.utils';
 import ListWithTooltip from '@/app/ui/lists/ListWithTooltip';
@@ -21,7 +22,7 @@ export const ReferentielTablePersonnesPilotesCell = ({ info }: Props) => {
   } = getTableMeta(info.table);
 
   if (actionType !== ActionTypeEnum.ACTION) {
-    return <TableCell tabIndex={-1} data-cell-id={cellId} />;
+    return <EmptyCell cellId={cellId} />;
   }
 
   return (

--- a/apps/app/src/referentiels/referentiel.table/referentiel-table.services-pilotes.cell.tsx
+++ b/apps/app/src/referentiels/referentiel.table/referentiel-table.services-pilotes.cell.tsx
@@ -1,3 +1,4 @@
+import { EmptyCell } from './empty-cell';
 import ServiceTagDropdown from '@/app/collectivites/tags/service-tag.dropdown';
 import ListWithTooltip from '@/app/ui/lists/ListWithTooltip';
 import { CellContext } from '@tanstack/react-table';
@@ -15,7 +16,7 @@ export const ReferentielTableServicesPilotesCell = ({ info }: Props) => {
   const cellId = info.cell.id;
 
   if (actionType !== ActionTypeEnum.ACTION) {
-    return <TableCell tabIndex={-1} data-cell-id={cellId} />;
+    return <EmptyCell cellId={cellId} />;
   }
 
   const {

--- a/apps/app/src/referentiels/referentiel.table/referentiel-table.statut-detaille.cell.tsx
+++ b/apps/app/src/referentiels/referentiel.table/referentiel-table.statut-detaille.cell.tsx
@@ -1,3 +1,4 @@
+import { EmptyCell } from './empty-cell';
 import { CellContext } from '@tanstack/react-table';
 import { StatutAvancementEnum } from '@tet/domain/referentiels';
 import { cn, TableCell } from '@tet/ui';
@@ -25,7 +26,7 @@ export const ReferentielTableStatutDetailleCell = ({ cell }: Props) => {
   } = getTableMeta(cell.table);
 
   if (!hasStatutDetaille || !canMutateReferentiel) {
-    return <TableCell tabIndex={-1} data-cell-id={cellId} />;
+    return <EmptyCell cellId={cellId} />;
   }
 
   const openModal = () => {

--- a/apps/app/src/referentiels/referentiel.table/referentiel-table.statut.cell.tsx
+++ b/apps/app/src/referentiels/referentiel.table/referentiel-table.statut.cell.tsx
@@ -1,3 +1,4 @@
+import { EmptyCell } from './empty-cell';
 import { CellContext, Row } from '@tanstack/react-table';
 import {
   ActionType,
@@ -51,7 +52,7 @@ export const ReferentielTableStatutCell = ({ info }: Props) => {
     !actionTypesWithStatut.has(actionType) ||
     statut === StatutAvancementEnum.NON_RENSEIGNABLE
   ) {
-    return <TableCell tabIndex={-1} data-cell-id={cellId} />;
+    return <EmptyCell cellId={cellId} />;
   }
 
   return (

--- a/apps/app/src/referentiels/referentiel.table/referentiel-table.tsx
+++ b/apps/app/src/referentiels/referentiel.table/referentiel-table.tsx
@@ -36,6 +36,10 @@ import React, {
 } from 'react';
 import { useListFichesGroupedByActionId } from '../../plans/fiches/data/use-list-fiches-grouped-by-action-id';
 import { useSidePanel } from '../../ui/layout/side-panel/side-panel.context';
+import { useListMesureAuditStatutsGroupedById } from '../audits/use-list-mesure-audit-statuts-grouped-by-id';
+import { useUpdateMesureAuditStatut } from '../audits/use-update-mesure-audit-statut';
+import { useAudit } from '../audits/useAudit';
+import { useCycleLabellisation } from '../labellisations/useCycleLabellisation';
 import { useUpdateActionStatut } from '../actions/action-statut/use-update-action-statut';
 import { useListCommentsGroupedByActionId } from '../actions/comments/hooks/use-list-comments-grouped-by-action-id';
 import { ActionListItem } from '../actions/use-list-actions';
@@ -47,7 +51,10 @@ import { useReferentielId } from '../referentiel-context';
 import { ReferentielTableFiltersForm } from './referentiel-table.filters.form';
 import { getTextFilterFn } from './referentiel-table.filters.utils';
 import { ReferentielTablePointsCell } from './referentiel-table.points.cell';
-import { useGetReferentielTableFiltersState } from './use-get-referentiel-table-filters-state';
+import {
+  ReferentielTableFiltersState,
+  useGetReferentielTableFiltersState,
+} from './use-get-referentiel-table-filters-state';
 import { useListReferentielTableColumns } from './use-list-referentiel-table-columns';
 import { useReferentielTableColumnVisibility } from './use-referentiel-table-column-visibility';
 import { useReferentielTablePendingCellFocus } from './use-referentiel-table-pending-cell-focus';
@@ -98,7 +105,7 @@ function ReferentielTable({
   actions: Record<string, ActionListItem>;
   referentielId: ReferentielId;
   isPending: boolean;
-  filtersState: ReturnType<typeof useGetReferentielTableFiltersState>;
+  filtersState: ReferentielTableFiltersState;
   columnVisibility: VisibilityState;
 }) {
   const { collectiviteId, hasCollectivitePermission } =
@@ -107,6 +114,16 @@ function ReferentielTable({
   const { mutate: updateActionPilotes } = useUpsertMesurePilotes();
   const { mutate: updateActionServices } = useUpsertMesureServicesPilotes();
   const { mutate: updateActionExplication } = useUpdateActionExplication();
+  const { mutate: updateMesureAuditStatut } = useUpdateMesureAuditStatut();
+
+  const { isConductingAudit, isAuditeur } =
+    useCycleLabellisation(referentielId);
+  const { data: audit } = useAudit();
+  const canEditAudit = isAuditeur && !audit?.valide;
+  const { auditStatutsByMesureId } = useListMesureAuditStatutsGroupedById({
+    referentielId,
+    enabled: isConductingAudit,
+  });
 
   const { filters, hasActiveFilters } = filtersState;
 
@@ -246,6 +263,9 @@ function ReferentielTable({
       },
       commentsByActionId,
       fichesByActionId,
+      auditStatutsByMesureId,
+      canEditAudit,
+      updateMesureAuditStatut,
       updateActionStatut,
       updateActionPilotes,
       updateActionServices,
@@ -259,6 +279,9 @@ function ReferentielTable({
       referentielId,
       commentsByActionId,
       fichesByActionId,
+      auditStatutsByMesureId,
+      canEditAudit,
+      updateMesureAuditStatut,
       updateActionStatut,
       updateActionPilotes,
       updateActionServices,
@@ -270,7 +293,11 @@ function ReferentielTable({
     ]
   );
 
-  const { columns } = useListReferentielTableColumns(actions, filtersState);
+  const { columns } = useListReferentielTableColumns({
+    actions,
+    filtersState,
+    showAuditRelatedColumns: isConductingAudit,
+  });
 
   const table = useReactTable({
     columns,

--- a/apps/app/src/referentiels/referentiel.table/use-get-referentiel-table-filters-state.ts
+++ b/apps/app/src/referentiels/referentiel.table/use-get-referentiel-table-filters-state.ts
@@ -48,3 +48,7 @@ export function useGetReferentielTableFiltersState() {
 
   return { filters, setFilters, hasActiveFilters };
 }
+
+export type ReferentielTableFiltersState = ReturnType<
+  typeof useGetReferentielTableFiltersState
+>;

--- a/apps/app/src/referentiels/referentiel.table/use-list-referentiel-table-columns.tsx
+++ b/apps/app/src/referentiels/referentiel.table/use-list-referentiel-table-columns.tsx
@@ -1,8 +1,12 @@
+import { appLabels } from '@/app/labels/catalog';
 import { createColumnHelper } from '@tanstack/react-table';
 import { divisionOrZero } from '@tet/domain/utils';
 import { cn, TableHeaderCell } from '@tet/ui';
 import { useMemo } from 'react';
 import { ActionListItem } from '../actions/use-list-actions';
+import { ReferentielTableAuditNotesCell } from './referentiel-table.audit-notes.cell/referentiel-table.audit-notes.cell';
+import { ReferentielTableAuditOrdreDuJourCell } from './referentiel-table.audit-ordre-du-jour.cell';
+import { ReferentielTableAuditStatutCell } from './referentiel-table.audit-statut.cell';
 import { ReferentielTableCategorieCell } from './referentiel-table.categorie.cell';
 import { ReferentielTableCommentsCell } from './referentiel-table.comments.cell';
 import { ReferentielTableDescriptionCell } from './referentiel-table.description.cell';
@@ -33,16 +37,52 @@ import { ReferentielTableServicesPilotesCell } from './referentiel-table.service
 import { ReferentielTableStatutDetailleCell } from './referentiel-table.statut-detaille.cell';
 import { ReferentielTableStatutCell } from './referentiel-table.statut.cell';
 import { ReferentielTableTitleCell } from './referentiel-table.title.cell';
-import { useGetReferentielTableFiltersState } from './use-get-referentiel-table-filters-state';
+import { ReferentielTableFiltersState } from './use-get-referentiel-table-filters-state';
 
 const columnHelper = createColumnHelper<ActionListItem>();
+
+const getAuditColumns = () => [
+  columnHelper.display({
+    id: 'auditStatut',
+    header: () => (
+      <TableHeaderCell
+        title={appLabels.auditColonneStatut}
+        className={cn('w-44')}
+      />
+    ),
+    cell: (info) => <ReferentielTableAuditStatutCell info={info} />,
+  }),
+  columnHelper.display({
+    id: 'auditOrdreDuJour',
+    header: () => (
+      <TableHeaderCell
+        title={appLabels.auditColonneOrdreDuJour}
+        className={cn('w-40')}
+        titleClassName="m-auto text-center"
+      />
+    ),
+    cell: (info) => <ReferentielTableAuditOrdreDuJourCell info={info} />,
+  }),
+  columnHelper.display({
+    id: 'auditNotes',
+    header: () => (
+      <TableHeaderCell
+        title={appLabels.auditColonneNotes}
+        className={cn('w-80')}
+      />
+    ),
+    cell: (info) => <ReferentielTableAuditNotesCell info={info} />,
+  }),
+];
 
 const getColumns = ({
   actions,
   filtersState,
+  showAuditRelatedColumns,
 }: {
   actions: Record<string, ActionListItem>;
-  filtersState: ReturnType<typeof useGetReferentielTableFiltersState>;
+  filtersState: ReferentielTableFiltersState;
+  showAuditRelatedColumns: boolean;
 }) => [
   columnHelper.accessor('nom', {
     size: 512,
@@ -396,19 +436,27 @@ const getColumns = ({
     ),
     cell: (info) => <ReferentielTableFichesCell info={info} />,
   }),
+
+  ...(showAuditRelatedColumns ? getAuditColumns() : []),
 ];
 
-export function useListReferentielTableColumns(
-  actions: Record<string, ActionListItem>,
-  filtersState: ReturnType<typeof useGetReferentielTableFiltersState>
-) {
+export function useListReferentielTableColumns({
+  actions,
+  filtersState,
+  showAuditRelatedColumns,
+}: {
+  actions: Record<string, ActionListItem>;
+  filtersState: ReferentielTableFiltersState;
+  showAuditRelatedColumns: boolean;
+}) {
   const columns = useMemo(
     () =>
       getColumns({
         actions,
         filtersState,
+        showAuditRelatedColumns,
       }),
-    [actions, filtersState]
+    [actions, filtersState, showAuditRelatedColumns]
   );
 
   return { columns };

--- a/apps/app/src/referentiels/referentiel.table/utils.ts
+++ b/apps/app/src/referentiels/referentiel.table/utils.ts
@@ -9,6 +9,8 @@ import {
 } from '@tet/domain/referentiels';
 import { DiscussionListItem } from '../actions/comments/hooks/use-list-discussions';
 import { useUpdateActionStatut } from '../actions/action-statut/use-update-action-statut';
+import { MesureAuditStatutRow } from '../audits/use-list-mesure-audit-statuts-grouped-by-id';
+import { useUpdateMesureAuditStatut } from '../audits/use-update-mesure-audit-statut';
 import { ActionListItem } from '../actions/use-list-actions';
 import { useUpsertMesurePilotes } from '../actions/use-mesure-pilotes';
 import { useUpsertMesureServicesPilotes } from '../actions/use-mesure-services-pilotes';
@@ -52,6 +54,11 @@ export type ReferentielTableMeta = {
 
   commentsByActionId?: Partial<Record<ActionId, DiscussionListItem[]>>;
   fichesByActionId?: Partial<Record<ActionId, FicheListItem[]>>;
+  auditStatutsByMesureId?: Partial<Record<ActionId, MesureAuditStatutRow>>;
+  canEditAudit?: boolean;
+  updateMesureAuditStatut?: ReturnType<
+    typeof useUpdateMesureAuditStatut
+  >['mutate'];
   updateActionStatut: ReturnType<typeof useUpdateActionStatut>['mutate'];
   updateActionPilotes: ReturnType<typeof useUpsertMesurePilotes>['mutate'];
   updateActionServices: ReturnType<
@@ -82,6 +89,12 @@ export const getTableMeta = (
   }
   return meta;
 };
+
+export const isAuditableMesure = (
+  action: ActionListItem,
+  auditStatut: MesureAuditStatutRow | undefined
+): auditStatut is MesureAuditStatutRow =>
+  action.actionType === ActionTypeEnum.ACTION && auditStatut !== undefined;
 
 export const rowClassNameByActionType: Record<ActionType, string> = {
   [ActionTypeEnum.AXE]:

--- a/e2e/tests/referentiels/labellisations/audit-conduct-tabs-auditeur.spec.ts
+++ b/e2e/tests/referentiels/labellisations/audit-conduct-tabs-auditeur.spec.ts
@@ -6,8 +6,8 @@ import { testWithReferentiels as test } from '../referentiels.fixture';
 
 const referentiel: ReferentielId = 'cae';
 
-test.describe("Onglets de conduite d'audit (Suivi / Cycles)", () => {
-  test("audit en cours : visibles pour l'auditeur, masqués pour l'admin et le visiteur de la collectivité", async ({
+test.describe("Conduite d'audit (onglet Cycles et bandeau vue tableau)", () => {
+  test("audit en cours : onglet Suivi retire, Cycles et bandeau visibles pour l'auditeur, masques pour l'admin et le visiteur", async ({
     page,
     collectivites,
     referentiels,
@@ -57,11 +57,15 @@ test.describe("Onglets de conduite d'audit (Suivi / Cycles)", () => {
 
     const suiviTab = page.getByRole('tab', { name: "Suivi de l'audit" });
     const cyclesTab = page.getByRole('tab', { name: 'Cycles et comparaison' });
+    const tableHintBanner = page.getByText(
+      "Retrouvez le suivi de l'audit dans la vue tableau"
+    );
 
     await auditeurUser.login();
     await newAuditLabellisationPom.goto(collectiviteId, referentiel);
-    await expect(suiviTab).toBeVisible();
+    await expect(suiviTab).toHaveCount(0);
     await expect(cyclesTab).toBeVisible();
+    await expect(tableHintBanner).toBeVisible();
 
     await editeurUser.login();
     await newAuditLabellisationPom.goto(collectiviteId, referentiel);
@@ -70,6 +74,7 @@ test.describe("Onglets de conduite d'audit (Suivi / Cycles)", () => {
     ).toBeVisible({ timeout: 15_000 });
     await expect(suiviTab).toHaveCount(0);
     await expect(cyclesTab).toHaveCount(0);
+    await expect(tableHintBanner).toHaveCount(0);
 
     await visiteurUser.login();
     await newAuditLabellisationPom.goto(collectiviteId, referentiel);
@@ -78,5 +83,6 @@ test.describe("Onglets de conduite d'audit (Suivi / Cycles)", () => {
     ).toBeVisible({ timeout: 15_000 });
     await expect(suiviTab).toHaveCount(0);
     await expect(cyclesTab).toHaveCount(0);
+    await expect(tableHintBanner).toHaveCount(0);
   });
 });


### PR DESCRIPTION
## Contexte

Consolidation des informations d'audit dans la vue tableau (bêta) du **nouveau layout** référentiel, et suppression de l'onglet « Suivi de l'audit » devenu redondant.

## Changements

### Vue tableau (bêta)
- Ajout de 3 colonnes, rendues au niveau **mesure** et visibles uniquement pendant l'audit pour l'auditeur (`isConductingAudit`) :
  - **Statut d'audit** — éditable inline (badge ↔ dropdown, réutilise `ActionAuditStatutBase`), comme les autres statuts
  - **À discuter en séance** (`ordreDuJour`) — case à cocher éditable
  - **Notes de l'auditeur·ice** (`avis`) — colonne dédiée, édition du texte riche dans un side-panel
- Données via `use-list-mesure-audit-statuts-grouped-by-id` ; mise à jour optimiste du cache de la liste dans `use-update-mesure-audit-statut`
- Branchement de la vue tableau bêta dans l'onglet **Mesures** du nouveau layout (`ReferentielViewModeProvider` + `ReferentielViewSwitcher`)

### Onglet « Suivi de l'audit »
- Retiré du nouveau layout (onglet + page). Les composants `AuditSuivi/*` sont conservés car toujours utilisés par l'ancien layout `/labellisation`.

### Onglet « Audit et labellisation »
- Bandeau de découverte de la vue tableau, affiché pendant l'audit, renvoyant vers l'onglet Mesures
- Suppression du lien « voir la liste » sur le critère de complétude (+ nettoyage du prop `referentielUrl` et du label orphelin)

## Notes d'implémentation
- Le gating se fait par **état d'audit** (auditeur + audit en cours), pas par layout : la vue tableau étant partagée, les colonnes apparaissent aussi dans le Mesures de l'ancien layout pour l'auditeur pendant un audit.

## Vérifications
- `nx run app:typecheck` ✅
- `eslint` sur les fichiers touchés ✅
- e2e `audit-conduct-tabs-auditeur.spec.ts` mis à jour (onglet Suivi absent partout, Cycles + bandeau auditeur-only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * La vue d’audit du référentiel affiche désormais un bandeau d’aide et de nouvelles colonnes pour suivre le statut, l’ordre du jour et les notes.
  * La table de suivi permet de modifier directement certains éléments d’audit depuis les cellules.
  * Le bouton et le formulaire de demande d’audit ont été renommés et harmonisés dans l’interface.

* **Bug fixes**
  * Le défilement vers une ancre tient mieux compte de l’en-tête fixe.
  * L’onglet “Suivi de l’audit” n’apparaît plus dans certains contextes de conduite d’audit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->