### PR TITLE
fix(audit-labellisation): invalide les caches croisés après mise à jour de statut

### DIFF
--- a/DISCOVERED.md
+++ b/DISCOVERED.md
@@ -1,13 +1,5 @@
 # Découvertes hors-scope
 
-## [bug] La checklist audit-labellisation ne se rafraîchit pas au retour SPA après une mise à jour de statut
-- **Symptôme** : depuis la checklist, ouvrir une mesure via « Voir la mesure », passer son statut à « Fait », puis revenir (`goBack`) ne met pas à jour l'icône du critère. Un rechargement manuel (`reload`) est nécessaire.
-- **Localisation** : `apps/app/src/referentiels/labellisations/useLabellisationParcours.ts` (query `getParcours`) + `apps/app/src/referentiels/actions/action-statut/use-action-statut.ts` (invalidation `getParcours` dans `onSuccess`).
-- **Diagnostic suspecté** : l'invalidation de `getParcours` est émise alors que l'utilisateur est sur la page mesure (aucun observer actif pour cette query, le `ChecklistProvider` est démonté). Au `goBack`, le subtree audit-labellisation remonte mais `refetchOnMount` ne re-déclenche pas la query (probablement cache de navigation Next.js App Router / BFCache). Trace réseau : aucun `getParcours` après `updateStatut` lors du retour. Piste de fix : `refetchOnMount: 'always'` sur la query parcours, ou refetch explicite sur changement de route.
-- **Impact** : utilisateur — données de critères périmées affichées après navigation retour, jusqu'à un refresh manuel.
-- **Découvert pendant** : audit-checklist-view-update (stabilisation des e2e labellisation)
-- **Découvert le** : 2026-05-21
-
 ## [bug] Plusieurs headings de niveau 1 sur la page d'un plan (titre + axes racine)
 - **Symptôme** : sur la page d'un plan, le titre (`<h1>`) et chaque axe racine sont tous des headings de niveau 1. `getByRole('heading', { level: 1 })` y résout plusieurs éléments (violation strict-mode Playwright). Une page devrait avoir un seul `h1`, les sous-sections incrémentant le niveau.
 - **Localisation** : `apps/app/src/plans/plans/show-plan/plan-arborescence.view/axe/axe-header.tsx:30` (`aria-level={axe.depth}` → niveau 1 pour les axes de profondeur 1, identique au titre de page).
@@ -23,12 +15,4 @@
 - **Impact** : utilisateur — un critère affiché peut être impossible à satisfaire en renseignant la seule mesure désignée ; dev — pièges de test (cf. `checklist-statut-refresh.spec.ts` qui doit passer les deux tâches).
 - **Découvert pendant** : audit-checklist-view-update (stabilisation des e2e labellisation)
 - **Découvert le** : 2026-05-21
-
-## [bug] Assigner un rôle depuis la checklist ne rafraîchit pas le statut de la tâche sur la page référentiel (sans reload)
-- **Symptôme** : assigner un pilote à une mesure de rôle depuis la checklist audit-labellisation passe la tâche associée (ex. `cae_5.1.1.1.3`) à « Fait ». En naviguant ensuite en client-side (sans `page.reload`) vers la page de cette action sur le référentiel, le sélecteur d'avancement affiche encore « Non renseigné ». Un rechargement complet montre le bon statut.
-- **Localisation** : flux d'assignation de rôle (upsert pilotes → `updateStatut`) côté checklist vs cache React Query `listActionsGroupedById` de la page référentiel. Invalidation manquante après l'écriture du statut déclenchée par l'assignation de rôle.
-- **Diagnostic suspecté** : l'`onSuccess` de la mutation d'assignation de rôle invalide `getParcours` mais pas `listActionsGroupedById` (ni les queries de score de la page action). Même famille que le bug de rafraîchissement SPA de la checklist ci-dessus. Piste : invalider `listActionsGroupedById` (et le snapshot de scores) dans l'`onSuccess`.
-- **Impact** : utilisateur — statut de tâche périmé sur la page référentiel après une assignation de rôle, jusqu'à un refresh manuel ; dev — empêche le portage du test e2e « assigner puis retirer … sans recharger » de `audit-badge-component` (rouge sur main).
-- **Découvert pendant** : k-audit-labellisation-e2e-coverage (portage des e2e role-mesures)
-- **Découvert le** : 2026-06-24
 

--- a/apps/app/src/referentiels/actions/action-statut/use-action-statut.ts
+++ b/apps/app/src/referentiels/actions/action-statut/use-action-statut.ts
@@ -26,6 +26,13 @@ export const useSaveActionStatut = () => {
         });
 
         queryClient.invalidateQueries({
+          queryKey: trpc.referentiels.actions.listActionsGroupedById.queryKey({
+            collectiviteId,
+            referentielId,
+          }),
+        });
+
+        queryClient.invalidateQueries({
           queryKey: trpc.referentiels.snapshots.getCurrent.queryKey({
             collectiviteId,
             referentielId,

--- a/apps/app/src/referentiels/actions/action-statut/use-update-action-statut.ts
+++ b/apps/app/src/referentiels/actions/action-statut/use-update-action-statut.ts
@@ -33,6 +33,13 @@ export const useUpdateActionStatut = () => {
             referentielId,
           }),
         });
+
+        queryClient.invalidateQueries({
+          queryKey: trpc.referentiels.labellisations.getParcours.queryKey({
+            collectiviteId,
+            referentielId,
+          }),
+        });
       },
       // Les invalidations de l'historique sont placées dans `onSettled` et
       // awaitées, alignées sur le pattern de

--- a/e2e/tests/referentiels/labellisations/checklist-role-mesures.spec.ts
+++ b/e2e/tests/referentiels/labellisations/checklist-role-mesures.spec.ts
@@ -244,4 +244,59 @@ test.describe('Checklist audit-labellisation — assignation rôle ↔ statut me
     await newAuditLabellisationPom.roleHeaderItem('eluReferent').click();
     await expect(newAuditLabellisationPom.roleSearchInput).toHaveCount(0);
   });
+
+  test("CAE référent technique : assigner puis retirer met à jour le statut de la mesure sur la page référentiel sans recharger", async ({
+    page,
+    newAuditLabellisationPom,
+    referentielScoresPom,
+    collectivites,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    referentiels, // déclenche le cleanup des action_statut (FK action_statut.modified_by → user)
+  }) => {
+    const collectivite = collectivites.getCollectivite();
+    const user = collectivite.getUser(0);
+    const userFullName = `${user.data.prenom} ${user.data.nom}`;
+
+    const AXE = 'Organisation interne';
+    const SOUS_AXE = 'Gouvernance';
+    const ACTION =
+      'Organiser les ressources humaines pour mener la politique climat-air-énergie';
+    const ROLE_TACHE = '5.1.1.1.3';
+
+    await newAuditLabellisationPom.goto(collectivite.data.id, 'cae');
+
+    await newAuditLabellisationPom.roleHeaderItem('referentTechnique').click();
+    const statutMisAFait = page.waitForResponse((response) =>
+      response.url().includes('updateStatut')
+    );
+    await page.getByRole('button', { name: userFullName }).click();
+    await page.keyboard.press('Escape');
+    await statutMisAFait;
+
+    // Navigation client-side (sans `page.goto`) : un rechargement complet
+    // viderait le cache React Query et masquerait la régression. L'assignation
+    // de rôle écrit un statut de tâche et doit invalider `listActionsGroupedById`.
+    await referentielScoresPom.goto('cae');
+    await referentielScoresPom.goToActionPage(AXE, SOUS_AXE, ACTION);
+    await referentielScoresPom.expandSousAction('5.1.1.1');
+    await expect(
+      referentielScoresPom.getTacheAvancementSelectLocator(ROLE_TACHE)
+    ).toContainText('Fait', { timeout: ASSIGNATION_REFRESH_TIMEOUT });
+
+    await newAuditLabellisationPom.goto(collectivite.data.id, 'cae');
+    await newAuditLabellisationPom.roleHeaderItem('referentTechnique').click();
+    const statutRemisANonRenseigne = page.waitForResponse((response) =>
+      response.url().includes('updateStatut')
+    );
+    await newAuditLabellisationPom.roleDropdownOption(userFullName).click();
+    await page.keyboard.press('Escape');
+    await statutRemisANonRenseigne;
+
+    await referentielScoresPom.goto('cae');
+    await referentielScoresPom.goToActionPage(AXE, SOUS_AXE, ACTION);
+    await referentielScoresPom.expandSousAction('5.1.1.1');
+    await expect(
+      referentielScoresPom.getTacheAvancementSelectLocator(ROLE_TACHE)
+    ).toContainText('Non renseigné', { timeout: ASSIGNATION_REFRESH_TIMEOUT });
+  });
 });

--- a/e2e/tests/referentiels/labellisations/checklist-statut-refresh.spec.ts
+++ b/e2e/tests/referentiels/labellisations/checklist-statut-refresh.spec.ts
@@ -50,14 +50,10 @@ test.describe('Checklist audit-labellisation — rafraîchissement après mise �
     await referentielScoresPom.updateTacheAvancement('1.1.2.0.1', 'fait');
     await referentielScoresPom.updateTacheAvancement('1.1.2.0.2', 'fait');
 
-    // Retour sur la checklist puis rechargement explicite : l'invalidation du
-    // parcours déclenchée par `updateStatut` ne refire pas tant qu'aucun
-    // observer n'est monté (l'utilisateur était sur la page mesure), et le
-    // retour SPA ne re-déclenche pas toujours le refetch (cache Next.js). Le
-    // `reload` garantit un fetch frais de `getParcours` reflétant le statut.
-    // cf. DISCOVERED.md : le rafraîchissement sans refresh reste à corriger.
+    // Retour SPA sur la checklist (sans `reload`) : la mise à jour du statut
+    // depuis la page mesure invalide `getParcours`, donc l'icône du critère
+    // doit refléter le nouveau statut au retour.
     await page.goBack();
-    await page.reload();
     await expect(row.getByLabel('Critère atteint')).toBeVisible({
       timeout: 15_000,
     });


### PR DESCRIPTION
## Nature

`fix` (+ tests de régression). Stackée sur #4606 (réutilise son infra e2e : POM `roleDropdownOption`, fixtures). À reباser sur `main` quand #4606 merge.

## Bugs corrigés (2 chemins de cache croisé)

Deux invalidations manquantes faisaient afficher des **statuts périmés sans rechargement complet** — découverts en comparant avec `audit-badge-component`, qui avait ces fixes non portés lors des lots D :

1. **`useUpdateActionStatut`** (mise à jour de statut depuis la page référentiel/mesure) n'invalidait pas `getParcours` → au retour SPA sur la checklist, l'icône du critère ne reflétait pas le statut modifié. *(Fermait le bug DISCOVERED « rafraîchissement SPA » du 2026-05-21.)*
2. **`useSaveActionStatut`** (assignation de rôle depuis la checklist, seul consommateur) n'invalidait pas `listActionsGroupedById` → la page référentiel gardait l'ancien statut de tâche.

## Fix

Une invalidation ajoutée dans chaque hook (`getParcours` dans l'un, `listActionsGroupedById` dans l'autre), **sans toucher à leur gestion d'erreur**.

> Choix d'implémentation : `audit-badge-component` consolidait `use-role-mesure` sur `useUpdateActionStatut` (suppression de `useSaveActionStatut`). On a préféré **ajouter l'invalidation manquante à chaque hook** plutôt que consolider, car `useUpdateActionStatut` n'a **pas** de gestion d'erreur per-call — y basculer l'assignation de rôle aurait supprimé son toast d'erreur (chemin d'erreur silencieux, interdit par les conventions). `useSaveActionStatut` n'est utilisé que par `use-role-mesure`, l'ajout y est donc scopé.

## Tests (test-first, rouge → vert)

- Commit 1 (`d26ba13`) — tests **rouges** sur main :
  - `checklist-statut-refresh` : retour SPA (sans `page.reload`) après mise à jour de statut.
  - `checklist-role-mesures` : assigner/retirer un pilote → statut de tâche sur la page référentiel sans recharger.
- Commit 2 (`f7dfc4c`) — le fix → les deux passent. Suite complète : **12/12** en local.

## Surface de review

- Attention humaine : les 2 hooks (`use-action-statut.ts`, `use-update-action-statut.ts`).
- Tests : les 2 specs e2e (1 rouge→vert chacun).