### PR TITLE
test(backend): parallelise les tests et isole les fichiers a users seedes

### DIFF
--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -41,8 +41,19 @@ jobs:
       # on ne repasse pas les tests d'import puisqu'on les a déjà
       # passés lors du seed de la base de test
       # le `--` est requis : sans lui, Nx intercepte --exclude au lieu de Vitest
-      - run: >
+      - name: Tests backend isolés (parallèle)
+        env:
+          TEST_LANE: parallel
+        run: >
           pnpm test:backend --
           --exclude '**/import-indicateur-definition.controller.e2e-spec.ts'
           --exclude '**/import-personnalisation-question.controller.e2e-spec.ts'
           --exclude '**/import-referentiel.controller.e2e-spec.ts'
+
+      # les fichiers s'appuyant sur les users seedés partagés (collectivité 1/10)
+      # ne sont pas isolés : on les passe en série, sans concurrence entre eux
+      - name: Tests backend à état partagé (users seedés, série)
+        if: ${{ !cancelled() }}
+        env:
+          TEST_LANE: serial
+        run: pnpm test:backend

--- a/apps/backend/vitest.config.mts
+++ b/apps/backend/vitest.config.mts
@@ -1,7 +1,33 @@
+import { globSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import swc from 'unplugin-swc';
 import { loadEnv } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
-import { defineConfig } from 'vitest/config';
+import { configDefaults, defineConfig } from 'vitest/config';
+
+const specGlob = 'src/**/*.{test,spec,e2e-spec}.{ts,mts,cts}';
+const sharedSampleUsers = ['YOLO_DODO', 'YALA_DADA', 'YOULOU_DOUDOU'];
+const sharedSampleUsersPattern = new RegExp(
+  `\\b(${sharedSampleUsers.join('|')})\\b`
+);
+
+const isSpecFile = (path: string): boolean =>
+  /\.(test|spec|e2e-spec)\.(ts|mts|cts)$/.test(path);
+
+const usesSharedSampleUsers = (relativeSpecPath: string): boolean =>
+  sharedSampleUsersPattern.test(
+    readFileSync(join(__dirname, relativeSpecPath), 'utf8')
+  );
+
+const sharedStateSpecs = globSync('src/**/*', { cwd: __dirname })
+  .filter(isSpecFile)
+  .filter(usesSharedSampleUsers);
+
+const testLane = process.env.TEST_LANE;
+const isSerialLane = testLane === 'serial';
+const isParallelLane = testLane === 'parallel';
+
+const parallelMaxWorkers = Number(process.env.TEST_MAX_WORKERS) || 6;
 
 export default defineConfig(({ mode }) => ({
   root: __dirname,
@@ -13,20 +39,24 @@ export default defineConfig(({ mode }) => ({
   ],
 
   test: {
-    fileParallelism: true,
+    fileParallelism: !isSerialLane,
     watch: false,
     globals: true,
     testTimeout: 20000, // milliseconds (default is 5000)
     hookTimeout: 60000, // milliseconds (default is 10000)
     env: loadEnv(mode, __dirname, ''),
 
-    // Limit parallelism: each test file creates its own NestJS app with a DB pool
-    // of 20 connections. Too many parallel files saturate PostgreSQL.
-    maxWorkers: 4,
+    // Chaque fichier cree sa propre app NestJS avec un pool de 5 connexions
+    // (cf. database.service.ts). On plafonne les workers pour ne pas saturer
+    // PostgreSQL.
+    maxWorkers: isSerialLane ? 1 : parallelMaxWorkers,
 
     setupFiles: ['./test/vitest-matchers.ts'],
 
-    include: ['src/**/*.{test,spec,e2e-spec}.{ts,mts,cts}'],
+    include: isSerialLane ? sharedStateSpecs : [specGlob],
+    exclude: isParallelLane
+      ? [...configDefaults.exclude, ...sharedStateSpecs]
+      : configDefaults.exclude,
 
     reporters: ['default'],
   },


### PR DESCRIPTION
## Pourquoi

Les tests backend (215 fichiers vitest) tournaient a `maxWorkers: 4`, plafond justifie par un commentaire devenu faux (pool PG de 20) alors que le pool est `max: 5` sous VITEST (`database.service.ts`). Et 14 fichiers s'appuient sur des users seedes partages (collectivite 1/10) : sous `fileParallelism: true`, deux d'entre eux peuvent deja tourner en concurrence aujourd'hui et se marcher dessus.

## Quoi

Deux voies pilotees par `TEST_LANE`, dans `vitest.config.mts` :

| Lane | Fichiers | fileParallelism | maxWorkers |
|------|----------|-----------------|------------|
| `parallel` | 201 isoles | true | 6 (`TEST_MAX_WORKERS` overridable) |
| `serial` | 14 a users seedes | false | 1 |
| (defaut, local) | 215 (toute la suite) | true | 6 |

- **Partitionnement = source de verite unique** : un fichier est "serie" s'il reference un user seede (`YOLO_DODO`/`YALA_DADA`/`YOULOU_DOUDOU`). Pas de liste a maintenir a la main.
- **Securite locale** : sans `TEST_LANE`, `nx test backend` lance toute la suite (sinon on masquerait silencieusement les 14 fichiers).
- **CI** (`test-backend.yml`) : run parallele puis run serie sequentiel sur la meme stack.

Partition verifiee via `vitest list --filesOnly` : 14 + 201 = 215.

## Suites possibles

- Ajuster `TEST_MAX_WORKERS` selon CPU/RAM du runner (4 vCPU) si timeouts/OOM.
- Si la voie serie (14 fichiers) devient la traine, la lancer en parallele de la voie isolee (pas de collision : donnees disjointes).
- Migrer les 14 fichiers vers des fixtures propres pour vider la voie serie.
