### PR TITLE
perf(ci): parallelise la suite de tests e2e Playwright

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -117,22 +117,37 @@ jobs:
       - name: Install Playwright deps
         run: pnpm exec playwright install --with-deps chromium
 
-      - name: Run tests
-        id: test
+      - name: Run isolated tests (parallel)
+        id: test-isolated
         env:
+          PW_ARTIFACTS_SUFFIX: isolated
           SUPABASE_API_URL: ${{ vars.SUPABASE_API_URL }}
           SUPABASE_MAILPIT_URL: ${{ vars.SUPABASE_MAILPIT_URL }}
           SUPABASE_DATABASE_URL: ${{ secrets.SUPABASE_DATABASE_URL }}
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
         run: |
-          pnpm exec playwright test --config ./e2e/playwright.config.ts
+          pnpm exec playwright test --config ./e2e/playwright.config.ts --grep-invert @serial --workers=4
+
+      - name: Run serial tests (non isolés)
+        id: test-serial
+        if: ${{ !cancelled() }}
+        env:
+          PW_ARTIFACTS_SUFFIX: serial
+          SUPABASE_API_URL: ${{ vars.SUPABASE_API_URL }}
+          SUPABASE_MAILPIT_URL: ${{ vars.SUPABASE_MAILPIT_URL }}
+          SUPABASE_DATABASE_URL: ${{ secrets.SUPABASE_DATABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: |
+          pnpm exec playwright test --config ./e2e/playwright.config.ts --grep @serial --workers=1 --pass-with-no-tests
 
       - uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
           name: report
           path: |
-            ./e2e/playwright-report
+            ./e2e/playwright-report-isolated
+            ./e2e/playwright-report-serial
             ${{ env.LOGS }}
           retention-days: 7

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -7,6 +7,14 @@ dotenv.config({ path: path.resolve(__dirname, '.env') });
 // For CI, you may want to set BASE_URL to the deployed application.
 const baseURL = process.env.BASE_URL || 'http://localhost:3000';
 
+const artifactsSuffix = process.env.PW_ARTIFACTS_SUFFIX;
+const reportDir = artifactsSuffix
+  ? `playwright-report-${artifactsSuffix}`
+  : 'playwright-report';
+const resultsDir = artifactsSuffix
+  ? `test-results-${artifactsSuffix}`
+  : 'test-results';
+
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
@@ -16,7 +24,7 @@ export default defineConfig({
   tsconfig: 'tsconfig.spec.json',
 
   // Folder for test artifacts such as screenshots, videos, traces, etc.
-  outputDir: 'test-results',
+  outputDir: resultsDir,
 
   // Fail the build on CI if you accidentally left test.only in the source code.
   forbidOnly: !!process.env.CI,
@@ -24,8 +32,8 @@ export default defineConfig({
   // Retry on CI only.
   retries: process.env.CI ? 2 : 0,
 
-  // Opt out of parallel tests on CI.
-  workers: process.env.CI ? 1 : undefined,
+  fullyParallel: true,
+  workers: process.env.CI ? 4 : undefined,
 
   // Reporter to use
   reporter: [
@@ -36,7 +44,7 @@ export default defineConfig({
       'html',
       {
         open: process.env.CI ? 'never' : 'on-failure',
-        outputFolder: path.resolve(__dirname, 'playwright-report'),
+        outputFolder: path.resolve(__dirname, reportDir),
       },
     ],
   ],

--- a/e2e/tests/users/users/signin-user.spec.ts
+++ b/e2e/tests/users/users/signin-user.spec.ts
@@ -56,45 +56,57 @@ test.describe('Login avec mot de passe', () => {
     );
   });
 
-  test('réinitialiser son mot de passe', async ({ page }) => {
-    await expect(page.locator('[data-test="PasswordRecovery"]')).toBeHidden();
+  test(
+    'réinitialiser son mot de passe',
+    { tag: '@serial' },
+    async ({ page }) => {
+      await expect(page.locator('[data-test="PasswordRecovery"]')).toBeHidden();
 
-    await page.locator('[data-test="forgotten-pwd"]').click();
+      await page.locator('[data-test="forgotten-pwd"]').click();
 
-    await expect(page.locator('[data-test="PasswordRecovery"]')).toBeVisible();
+      await expect(
+        page.locator('[data-test="PasswordRecovery"]')
+      ).toBeVisible();
 
-    await page
-      .locator('[data-test="PasswordRecovery"] input[name=email]')
-      .fill(EXISTING_USER_EMAIL);
-    await page
-      .locator('[data-test="PasswordRecovery"] button[type=submit]')
-      .click();
+      await page
+        .locator('[data-test="PasswordRecovery"] input[name=email]')
+        .fill(EXISTING_USER_EMAIL);
+      await page
+        .locator('[data-test="PasswordRecovery"] button[type=submit]')
+        .click();
 
-    await expect(page.locator('[data-test="msg_init_mdp"]')).toBeVisible();
-    await expect(page.locator('[data-test="PasswordRecovery"]')).toBeHidden();
-  });
+      await expect(page.locator('[data-test="msg_init_mdp"]')).toBeVisible();
+      await expect(page.locator('[data-test="PasswordRecovery"]')).toBeHidden();
+    }
+  );
 
-  test('réinitialiser son mot de passe avec une erreur', async ({ page }) => {
-    await page.locator('[data-test="forgotten-pwd"]').click();
+  test(
+    'réinitialiser son mot de passe avec une erreur',
+    { tag: '@serial' },
+    async ({ page }) => {
+      await page.locator('[data-test="forgotten-pwd"]').click();
 
-    await page
-      .locator('[data-test="PasswordRecovery"] input[name=email]')
-      .fill(EXISTING_USER_EMAIL);
+      await page
+        .locator('[data-test="PasswordRecovery"] input[name=email]')
+        .fill(EXISTING_USER_EMAIL);
 
-    await page.route('**/auth/v*/recover*', (route) => {
-      route.fulfill({ status: 400, body: '{}' });
-    });
+      await page.route('**/auth/v*/recover*', (route) => {
+        route.fulfill({ status: 400, body: '{}' });
+      });
 
-    await page
-      .locator('[data-test="PasswordRecovery"] button[type=submit]')
-      .click();
+      await page
+        .locator('[data-test="PasswordRecovery"] button[type=submit]')
+        .click();
 
-    await expect(page.locator('[data-test="msg_init_mdp"]')).toBeHidden();
-    await expect(page.locator('[data-test="PasswordRecovery"]')).toBeVisible();
-    await expect(page.locator('[data-test="PasswordRecovery"]')).toContainText(
-      "L'envoi du lien de réinitialisation a échoué"
-    );
-  });
+      await expect(page.locator('[data-test="msg_init_mdp"]')).toBeHidden();
+      await expect(
+        page.locator('[data-test="PasswordRecovery"]')
+      ).toBeVisible();
+      await expect(
+        page.locator('[data-test="PasswordRecovery"]')
+      ).toContainText("L'envoi du lien de réinitialisation a échoué");
+    }
+  );
 });
 
 test.describe('Login sans mot de passe', () => {
@@ -105,11 +117,15 @@ test.describe('Login sans mot de passe', () => {
     await pom.goToAuthUrl({ tab: 'sans-mdp' });
   });
 
-  test("en tant qu'utilisateur déjà rattaché", async ({ page }) => {
-    await pom.fillAndSubmitLoginForm(EXISTING_USER_EMAIL);
+  test(
+    "en tant qu'utilisateur déjà rattaché",
+    { tag: '@serial' },
+    async ({ page }) => {
+      await pom.fillAndSubmitLoginForm(EXISTING_USER_EMAIL);
 
-    await expect(page.locator('[data-test="msg_lien_envoye"]')).toBeVisible();
-  });
+      await expect(page.locator('[data-test="msg_lien_envoye"]')).toBeVisible();
+    }
+  );
 
   test("en tant qu'utilisateur non encore rattaché", async ({
     page,


### PR DESCRIPTION
Parallelise la suite Playwright (`e2e/`) en CI, en isolant en serie les rares tests non isoles (compte seede partage).

## Quoi

- `playwright.config.ts` : `fullyParallel: true`, workers CI `1 -> 4`. Dossiers d'artefacts via `PW_ARTIFACTS_SUFFIX` (sinon le 2e run ecrase le rapport du 1er).
- `test-e2e.yml` : un job, meme stack, deux runs sequentiels
  - `--grep-invert @serial --workers=4` (~184 tests isoles)
  - `--grep @serial --workers=1 --pass-with-no-tests` (les non isoles)
- Tag `@serial` sur les 3 tests utilisant le compte seede `YoLO@dodo.com`.

Partition verifiee : 3 (@serial) + 184 (isoles).

## Suites possibles

- Ajuster `--workers` selon CPU/RAM du runner (4 vCPU) si timeouts.
- Migrer les 3 tests `@serial` vers des fixtures propres pour vider la voie serie.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Les tests de bout en bout sont désormais mieux séparés entre scénarios isolés et séquentiels, ce qui améliore la fiabilité des vérifications en intégration.
  * Les rapports d’échec sont maintenant plus précis, avec des artefacts distincts pour faciliter le diagnostic.
* **Tests**
  * L’exécution des tests en environnement CI a été optimisée pour mieux répartir la charge et réduire les conflits entre scénarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->