### PR TITLE
fix(audit-labellisation): restaure l'ancien flux de validation d'audit sur l'ancien layout

### DIFF
--- a/apps/app/src/referentiels/audits/old/AddRapportButton.tsx
+++ b/apps/app/src/referentiels/audits/old/AddRapportButton.tsx
@@ -1,0 +1,40 @@
+import { AddPreuveModal } from '@/app/referentiels/preuves/AddPreuveModal';
+import { appLabels } from '@/app/labels/catalog';
+import { useCurrentCollectivite } from '@tet/api/collectivites';
+import { Button, Modal } from '@tet/ui';
+import { useState } from 'react';
+import { useAddPreuveToAudit } from './useAddPreuveToAudit';
+
+export type TAddDocsButtonProps = {
+  audit_id: number;
+};
+
+export const AddRapportButton = (props: TAddDocsButtonProps) => {
+  const [opened, setOpened] = useState(false);
+  const handlers = useAddPreuveToAudit(props.audit_id);
+  const { hasCollectivitePermission } = useCurrentCollectivite();
+  if (!hasCollectivitePermission('referentiels.mutate')) {
+    return null;
+  }
+
+  return (
+    <Modal
+      size="lg"
+      openState={{ isOpen: opened, setIsOpen: setOpened }}
+      title={appLabels.ajouterRapportAudit}
+      render={({ close }) => {
+        return <AddPreuveModal onClose={close} handlers={handlers} />;
+      }}
+    >
+      <Button
+        dataTest="AddRapportButton"
+        className="mb-6"
+        onClick={() => setOpened(true)}
+        variant="outlined"
+        size="sm"
+      >
+        {appLabels.ajouterRapportAudit}
+      </Button>
+    </Modal>
+  );
+};

--- a/apps/app/src/referentiels/audits/old/useAddPreuveToAudit.ts
+++ b/apps/app/src/referentiels/audits/old/useAddPreuveToAudit.ts
@@ -1,0 +1,30 @@
+import { TAddFileFromLib } from '@/app/referentiels/preuves/AddPreuveModal/AddFile';
+import { useAddPreuveAudit } from '@/app/referentiels/preuves/useAddPreuves';
+import { useCollectiviteId } from '@tet/api/collectivites';
+
+type TAddDocs = (demande_id: number) => {
+  /** ajoute un fichier sélectionné depuis la bibliothèque */
+  addFileFromLib: TAddFileFromLib;
+};
+
+/** Renvoie les gestionnaires d'événements du dialogue d'ajout de
+ * fichiers à l'audit en cours */
+export const useAddPreuveToAudit: TAddDocs = (audit_id: number) => {
+  const collectivite_id = useCollectiviteId();
+  const { mutate: addPreuve } = useAddPreuveAudit();
+
+  // associe un fichier de la bibliothèque à l'audit
+  const addFileFromLib: TAddFileFromLib = (fichier_id) => {
+    if (collectivite_id) {
+      addPreuve({
+        auditId: audit_id,
+        collectiviteId: collectivite_id,
+        commentaire: '',
+        fichierId: fichier_id,
+      });
+    }
+  };
+  return {
+    addFileFromLib,
+  };
+};

--- a/apps/app/src/referentiels/audits/old/valider-audit.button.tsx
+++ b/apps/app/src/referentiels/audits/old/valider-audit.button.tsx
@@ -1,0 +1,80 @@
+import PreuveDoc from '@/app/referentiels/preuves/Bibliotheque/PreuveDoc';
+import { appLabels } from '@/app/labels/catalog';
+import { Button, Modal, RenderProps } from '@tet/ui';
+import { auditReportToPreuve } from '@/app/referentiels/preuves/mappers/audit-report-to-preuve';
+import { AddRapportButton } from './AddRapportButton';
+import { useListReportsByAudit } from '../cloture/data/use-list-reports-by-audit';
+import { useValidateAudit } from '../cloture/data/use-validate-audit';
+
+type TValiderAuditProps = {
+  auditId: number;
+  demandeId: number | null;
+};
+
+export const ValiderAuditButton = ({
+  auditId,
+  demandeId,
+}: TValiderAuditProps) => (
+  <Modal
+    size="lg"
+    disableDismiss
+    render={(modalProps) => (
+      <ValiderAuditModal
+        {...modalProps}
+        auditId={auditId}
+        demandeId={demandeId}
+      />
+    )}
+  >
+    <Button dataTest="ValiderAuditBtn" size="sm">
+      {appLabels.validerAudit}
+    </Button>
+  </Modal>
+);
+
+export const ValiderAuditModal = ({
+  auditId,
+  demandeId,
+  close,
+}: RenderProps & TValiderAuditProps) => {
+  const { mutate: onValidateAudit } = useValidateAudit();
+
+  const { reports } = useListReportsByAudit(auditId);
+  const canValidate = reports.length > 0;
+
+  return (
+    <div data-test="ValiderAuditModal">
+      <h4 className="mb-6">{appLabels.validerAudit}</h4>
+      <p>{appLabels.validerAuditDescription}</p>
+      <AddRapportButton audit_id={auditId} />
+      {reports.length ? (
+        <div data-test="rapports-audit">
+          {reports.map((report) => (
+            <PreuveDoc key={report.id} preuve={auditReportToPreuve(report)} />
+          ))}
+        </div>
+      ) : null}
+      <p className="mt-4">
+        {demandeId
+          ? appLabels.auditLabellisationMessage
+          : appLabels.auditSansLabellisationMessage}
+      </p>
+      <div className="flex gap-4">
+        <Button
+          dataTest="validate"
+          size="sm"
+          onClick={() => {
+            onValidateAudit({ auditId });
+            close();
+          }}
+          disabled={!canValidate}
+        >
+          {appLabels.validerAudit}
+        </Button>
+        <Button size="sm" variant="outlined" onClick={() => close()}>
+          {appLabels.annuler}
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/apps/app/src/referentiels/labellisations/HeaderLabellisation.tsx
+++ b/apps/app/src/referentiels/labellisations/HeaderLabellisation.tsx
@@ -3,7 +3,7 @@ import { useCurrentCollectivite } from '@tet/api/collectivites';
 import { Button } from '@tet/ui';
 import { useState } from 'react';
 import { useAuditeurs } from '../audits/useAudit';
-import { CloturerAuditButton } from '../audits/cloture/cloturer-audit.button';
+import { ValiderAuditButton } from '../audits/old/valider-audit.button';
 import { DemandeAuditModal } from './DemandeAuditModal';
 import { DemandeLabellisationModal } from './DemandeLabellisationModal';
 import { numLabels } from './numLabels';
@@ -153,7 +153,7 @@ export const HeaderLabellisation = (props: THeaderLabellisationProps) => {
       )}
 
       {canValidateAuditReferentiel && audit && status === 'audit_en_cours' && (
-        <CloturerAuditButton auditId={audit.id} demandeId={audit.demande_id} />
+        <ValiderAuditButton auditId={audit.id} demandeId={audit.demande_id} />
       )}
     </div>
   );

--- a/e2e/tests/referentiels/labellisations/cloturer-audit.spec.ts
+++ b/e2e/tests/referentiels/labellisations/cloturer-audit.spec.ts
@@ -7,12 +7,15 @@ import { TEST_PDF_PATH } from './labellisation.pom';
 const referentiel: ReferentielId = 'eci';
 
 test.describe("Modale de clôture d'audit", () => {
+  let collectiviteId: number;
+
   test.beforeEach(async ({ page, collectivites, referentiels }) => {
     const { collectivite, user: editeurUser } =
       await collectivites.addCollectiviteAndUser({
         userArgs: { autoLogin: true },
         collectiviteArgs: { isCOT: true },
       });
+    collectiviteId = collectivite.data.id;
     await referentiels.requestLabellisationForCot(
       editeurUser,
       collectivite.data.id,
@@ -40,11 +43,11 @@ test.describe("Modale de clôture d'audit", () => {
   });
 
   test("Happy path : l'auditeur dépose un rapport, copie le template et clôture l'audit", async ({
+    page,
     labellisationPom,
-    collectivites,
+    newAuditLabellisationPom,
   }) => {
-    const auditeurUser = collectivites.getCollectivite().getUser(1);
-    await labellisationPom.goto(referentiel);
+    await newAuditLabellisationPom.goto(collectiviteId, referentiel);
 
     // Étape 1 — ouverture, dépôt rapport
     await expect(labellisationPom.cloturerAuditButton).toBeEnabled();
@@ -85,13 +88,16 @@ test.describe("Modale de clôture d'audit", () => {
     await labellisationPom.cloturerAuditValiderButton.click();
 
     // La modale ferme + l'audit est validé
-    await labellisationPom.checkLabellisationEnCoursAuditedBy(auditeurUser);
+    await expect(
+      page.getByRole('tab', { name: /Audit terminé/ })
+    ).toBeVisible();
   });
 
   test("Sad path : impossible de passer à l'étape 2 sans rapport", async ({
     labellisationPom,
+    newAuditLabellisationPom,
   }) => {
-    await labellisationPom.goto(referentiel);
+    await newAuditLabellisationPom.goto(collectiviteId, referentiel);
     await labellisationPom.cloturerAuditButton.click();
 
     await expect(labellisationPom.cloturerAuditSuivantButton).toBeDisabled();
@@ -102,8 +108,9 @@ test.describe("Modale de clôture d'audit", () => {
 
   test("Sad path : impossible de valider sans cocher l'engagement", async ({
     labellisationPom,
+    newAuditLabellisationPom,
   }) => {
-    await labellisationPom.goto(referentiel);
+    await newAuditLabellisationPom.goto(collectiviteId, referentiel);
     await labellisationPom.cloturerAuditButton.click();
 
     await labellisationPom.uploadCloturerAuditReport();
@@ -118,8 +125,9 @@ test.describe("Modale de clôture d'audit", () => {
 
   test("Sad path : annuler depuis l'étape 2 reset l'engagement à la ré-ouverture", async ({
     labellisationPom,
+    newAuditLabellisationPom,
   }) => {
-    await labellisationPom.goto(referentiel);
+    await newAuditLabellisationPom.goto(collectiviteId, referentiel);
     await labellisationPom.cloturerAuditButton.click();
 
     await labellisationPom.uploadCloturerAuditReport();
@@ -144,8 +152,9 @@ test.describe("Modale de clôture d'audit", () => {
 
   test("Un seul rapport : la dropzone disparaît une fois le rapport déposé", async ({
     labellisationPom,
+    newAuditLabellisationPom,
   }) => {
-    await labellisationPom.goto(referentiel);
+    await newAuditLabellisationPom.goto(collectiviteId, referentiel);
     await labellisationPom.cloturerAuditButton.click();
 
     await expect(labellisationPom.cloturerAuditFileInput).toBeAttached();
@@ -162,8 +171,9 @@ test.describe("Modale de clôture d'audit", () => {
 
   test("Suppression : supprimer le rapport réaffiche la dropzone et rebloque l'étape suivante", async ({
     labellisationPom,
+    newAuditLabellisationPom,
   }) => {
-    await labellisationPom.goto(referentiel);
+    await newAuditLabellisationPom.goto(collectiviteId, referentiel);
     await labellisationPom.cloturerAuditButton.click();
 
     await labellisationPom.uploadCloturerAuditReport();
@@ -186,8 +196,9 @@ test.describe("Modale de clôture d'audit", () => {
 
   test("Navigation : depuis l'étape 2, revenir à l'étape 1 conserve le rapport", async ({
     labellisationPom,
+    newAuditLabellisationPom,
   }) => {
-    await labellisationPom.goto(referentiel);
+    await newAuditLabellisationPom.goto(collectiviteId, referentiel);
     await labellisationPom.cloturerAuditButton.click();
 
     await labellisationPom.uploadCloturerAuditReport();
@@ -210,8 +221,9 @@ test.describe("Modale de clôture d'audit", () => {
 
   test("Le « x » ferme et réinitialise l'engagement comme « Annuler »", async ({
     labellisationPom,
+    newAuditLabellisationPom,
   }) => {
-    await labellisationPom.goto(referentiel);
+    await newAuditLabellisationPom.goto(collectiviteId, referentiel);
     await labellisationPom.cloturerAuditButton.click();
 
     await labellisationPom.uploadCloturerAuditReport();
@@ -234,6 +246,7 @@ test.describe("Modale de clôture d'audit", () => {
   test("Upload lent : un placeholder pulsant s'affiche pendant le téléversement", async ({
     page,
     labellisationPom,
+    newAuditLabellisationPom,
   }) => {
     // Retient l'upload Supabase Storage pendant 1.5 s pour laisser le temps
     // d'observer le placeholder.
@@ -242,7 +255,7 @@ test.describe("Modale de clôture d'audit", () => {
       await route.continue();
     });
 
-    await labellisationPom.goto(referentiel);
+    await newAuditLabellisationPom.goto(collectiviteId, referentiel);
     await labellisationPom.cloturerAuditButton.click();
 
     // Déclenche l'upload sans attendre sa fin


### PR DESCRIPTION
Restauration de l'ancienne manière de déposer un rapport dans la vue existante de l'audit/labellisation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Ajout d’actions pour joindre un rapport à un audit et ouvrir une modale dédiée.
  * Ajout d’un bouton de validation d’audit avec affichage des rapports associés.
  * Mise à jour de l’interface d’audit pour proposer la validation à la place de la clôture dans le bon contexte.

* **Bug Fixes**
  * Le bouton d’ajout de rapport n’apparaît que pour les utilisateurs ayant les droits nécessaires.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->