### PR TITLE
perf(backend): desactive l'isolation vitest entre fichiers de test

### DIFF
--- a/apps/backend/vitest.config.mts
+++ b/apps/backend/vitest.config.mts
@@ -14,6 +14,7 @@ export default defineConfig(({ mode }) => ({
 
   test: {
     fileParallelism: true,
+    isolate: false,
     watch: false,
     globals: true,
     testTimeout: 20000, // milliseconds (default is 5000)


### PR DESCRIPTION
## Pourquoi

Profilage du temps CI backend : le bootstrap NestJS (compile DI + `app.init`) ne coute que **~30 ms**. Le poste dominant est **l'import/evaluation du graphe de modules** (AppModule -> toutes les features -> tous les services), **ré-execute a chaque fichier** car vitest isole le registre de modules par fichier (`isolate: true` par defaut). Mesure : ~6 s CPU/fichier, x123 fichiers qui bootstrap l'app.

## Quoi

Une ligne : `isolate: false` dans `vitest.config.mts`. Le graphe est evalue **une fois par worker** au lieu d'une fois par fichier.

### Mesure (repertoire `src/plans`, 79 fichiers)

| Mode | Wall-clock | import (CPU cumule) |
|------|-----------|---------------------|
| `isolate: true` (avant) | 47.8s | 130.8s |
| `isolate: false` (apres) | **23.4s** | **20.3s** |

~50% de wall-clock, import CPU /6.5, **sans nouvelle casse** (les memes echecs preexistants dans les deux modes).

## Surface de review / risque

`isolate: false` partage l'etat **module-level JavaScript** entre fichiers d'un meme worker. Chaque test garde son propre conteneur DI NestJS (`getTestApp` recompile a chaque `beforeAll`), donc l'etat applicatif reste frais ; seul l'etat de module JS est partage. Points de vigilance, a valider par le run CI complet (pass/fail vs baseline) :

- `vi.mock` / `vi.spyOn` non nettoyes entre fichiers
- singletons / caches au niveau module
- mutation d'un module importe

**La validation, c'est ce run CI** : si la suite passe comme sur `main`, la non-isolation est sûre.

## Hors scope

Pas de changement de partitionnement / workers ici (la voie parallele/serie est traitee separement). Uniquement le mode d'isolation.
