### PR TITLE
perf(backend): differe le chargement des deps lourdes hors hot path

### DIFF
--- a/apps/backend/src/utils/banner/banner.service.ts
+++ b/apps/backend/src/utils/banner/banner.service.ts
@@ -14,7 +14,6 @@ import {
 } from '@tet/domain/utils';
 import createDOMPurify from 'dompurify';
 import { eq, sql, SQL } from 'drizzle-orm';
-import { JSDOM } from 'jsdom';
 import { bannerInfoTable } from './banner-info.table';
 import type { BannerError } from './banner.errors';
 
@@ -32,11 +31,17 @@ const MODIFIED_BY_SENTINEL = 'Équipe support';
 @Injectable()
 export class BannerService {
   private readonly logger = new Logger(BannerService.name);
-  private readonly purify = (() => {
-    const instance = createDOMPurify(new JSDOM('').window);
-    installSafeLinksHook(instance);
-    return instance;
-  })();
+  private purify: ReturnType<typeof createDOMPurify> | null = null;
+
+  private async getPurify(): Promise<ReturnType<typeof createDOMPurify>> {
+    if (!this.purify) {
+      const { JSDOM } = await import('jsdom');
+      const instance = createDOMPurify(new JSDOM('').window);
+      installSafeLinksHook(instance);
+      this.purify = instance;
+    }
+    return this.purify;
+  }
 
   constructor(
     private readonly databaseService: DatabaseService,
@@ -110,7 +115,8 @@ export class BannerService {
         return failure('BANNER_NOT_AUTHORIZED');
       }
 
-      const safeInfo = this.purify.sanitize(input.info, SAFE_HTML_CONFIG);
+      const purify = await this.getPurify();
+      const safeInfo = purify.sanitize(input.info, SAFE_HTML_CONFIG);
 
       // Reject script-only payloads that DOMPurify reduces fully to empty.
       // A legit "clear my draft" save sends input.info='' and bypasses this

--- a/apps/backend/src/utils/google-sheets/sheet.service.ts
+++ b/apps/backend/src/utils/google-sheets/sheet.service.ts
@@ -4,8 +4,8 @@ import { isNil } from 'es-toolkit';
 import { set } from 'es-toolkit/compat';
 import type { Response } from 'express';
 import * as gaxios from 'gaxios';
-import * as auth from 'google-auth-library';
-import { drive_v3, google, sheets_v4 } from 'googleapis';
+import type * as auth from 'google-auth-library';
+import type { drive_v3, sheets_v4 } from 'googleapis';
 import * as zCore from 'zod/v4/core';
 import { getPropertyPaths } from '../zod.utils';
 import { initGoogleCloudCredentials } from './gcloud.helper';
@@ -14,12 +14,28 @@ import {
   SheetValueRenderOption,
 } from './sheet-options.models';
 
-const sheets = google.sheets({ version: 'v4' });
-const drive = google.drive({ version: 'v3' });
-
 @Injectable()
 export default class SheetService {
   private readonly logger = new Logger(SheetService.name);
+
+  private googleClients: {
+    sheets: sheets_v4.Sheets;
+    drive: drive_v3.Drive;
+  } | null = null;
+
+  private async getGoogleClients(): Promise<{
+    sheets: sheets_v4.Sheets;
+    drive: drive_v3.Drive;
+  }> {
+    if (!this.googleClients) {
+      const { google } = await import('googleapis');
+      this.googleClients = {
+        sheets: google.sheets({ version: 'v4' }),
+        drive: google.drive({ version: 'v3' }),
+      };
+    }
+    return this.googleClients;
+  }
 
   readonly RETRY_STRATEGY: Options = {
     minTimeout: 60000, // Wait for 1min due to sheet api quota limitation
@@ -45,6 +61,7 @@ export default class SheetService {
   > {
     if (!this.authClient) {
       initGoogleCloudCredentials();
+      const { google } = await import('googleapis');
       this.authClient = await google.auth.getClient({
         scopes: [
           'https://www.googleapis.com/auth/spreadsheets',
@@ -65,6 +82,7 @@ export default class SheetService {
 
   async downloadFile(fileId: string, fileName: string, res: Response) {
     const authClient = await this.getAuthClient();
+    const { drive } = await this.getGoogleClients();
 
     const mimeType = this.getMimeTypeFromFileName(fileName);
     this.logger.log(
@@ -95,6 +113,7 @@ export default class SheetService {
     parentFolderId?: string
   ): Promise<string | null> {
     const authClient = await this.getAuthClient();
+    const { drive } = await this.getGoogleClients();
 
     this.logger.log(`Recherche du fichier avec le nom ${fileName}`);
 
@@ -116,6 +135,7 @@ export default class SheetService {
     parents?: string[]
   ): Promise<string> {
     const authClient = await this.getAuthClient();
+    const { drive } = await this.getGoogleClients();
 
     this.logger.log(
       `Copie du Spreadsheet ${fileId} vers un nouveau fichier avec le nom ${copyTitle}`
@@ -136,6 +156,7 @@ export default class SheetService {
 
   async deleteFile(fileId: string) {
     const authClient = await this.getAuthClient();
+    const { drive } = await this.getGoogleClients();
     const deleteOptions: drive_v3.Params$Resource$Files$Delete = {
       auth: authClient,
       fileId: fileId,
@@ -147,6 +168,7 @@ export default class SheetService {
 
   async getFileName(fileId: string): Promise<string> {
     const authClient = await this.getAuthClient();
+    const { drive } = await this.getGoogleClients();
     const getOptions: drive_v3.Params$Resource$Files$Get = {
       auth: authClient,
       fileId: fileId,
@@ -159,6 +181,7 @@ export default class SheetService {
 
   async getFileData(fileId: string): Promise<Buffer> {
     const authClient = await this.getAuthClient();
+    const { drive } = await this.getGoogleClients();
     const getOptions: drive_v3.Params$Resource$Files$Get = {
       auth: authClient,
       fileId: fileId,
@@ -182,6 +205,7 @@ export default class SheetService {
     data: any[][] | null;
   }> {
     const authClient = await this.getAuthClient();
+    const { sheets } = await this.getGoogleClients();
 
     const sheetValues = await this.executeWithQuotaRetry(
       async (
@@ -273,6 +297,7 @@ export default class SheetService {
     valueInputOption?: SheetValueInputOption
   ) {
     const authClient = await this.getAuthClient();
+    const { sheets } = await this.getGoogleClients();
     await this.executeWithQuotaRetry(
       async (bail: (e: Error) => void, num: number): Promise<void> => {
         this.logger.log(

--- a/apps/backend/src/utils/sentry-init.ts
+++ b/apps/backend/src/utils/sentry-init.ts
@@ -5,33 +5,35 @@ import { ApplicationContext } from '@tet/backend/utils/context/application-conte
 export const SENTRY_DSN = process.env.SENTRY_DSN || '';
 
 // Ensure to call this before requiring any other modules!
-Sentry.init({
-  dsn: SENTRY_DSN,
+if (SENTRY_DSN) {
+  Sentry.init({
+    dsn: SENTRY_DSN,
 
-  // Add Tracing by setting tracesSampleRate
-  // We recommend adjusting this value in production
-  tracesSampleRate: 0.1,
+    // Add Tracing by setting tracesSampleRate
+    // We recommend adjusting this value in production
+    tracesSampleRate: 0.1,
 
-  // Set sampling rate for profiling
-  // This is relative to tracesSampleRate
-  profilesSampleRate: 0.25,
+    // Set sampling rate for profiling
+    // This is relative to tracesSampleRate
+    profilesSampleRate: 0.25,
 
-  // Enable Sentry Logs
-  // https://docs.sentry.io/platforms/javascript/guides/nestjs/logs/
-  enableLogs: true,
+    // Enable Sentry Logs
+    // https://docs.sentry.io/platforms/javascript/guides/nestjs/logs/
+    enableLogs: true,
 
-  // See here, node profiling not auto enabled by default
-  // https://docs.sentry.io/platforms/javascript/guides/nestjs/configuration/integrations/
-  integrations: [
-    Sentry.pinoIntegration({
-      error: { levels: ['error'] },
-      log: { levels: ['info', 'warn'] },
-    }),
+    // See here, node profiling not auto enabled by default
+    // https://docs.sentry.io/platforms/javascript/guides/nestjs/configuration/integrations/
+    integrations: [
+      Sentry.pinoIntegration({
+        error: { levels: ['error'] },
+        log: { levels: ['info', 'warn'] },
+      }),
 
-    // Add Sentry Profiling integration
-    nodeProfilingIntegration(),
-  ],
-});
+      // Add Sentry Profiling integration
+      nodeProfilingIntegration(),
+    ],
+  });
+}
 
 export const getSentryContextFromApplicationContext = (
   context: ApplicationContext,


### PR DESCRIPTION
## Pourquoi

Profilage des tests backend : le poste dominant est l'**evaluation du graphe de modules** au moment ou chaque fichier de test importe `AppModule` (~6s CPU/fichier), pas le demarrage NestJS (compile DI + `app.init` ≈ 30ms). Des deps lourdes etaient chargees au **top-level** alors qu'elles ne servent que dans des chemins rarement exerces en test.

isolate:true est conserve (cf. l'avertissement sur isolate:false + le registre de modules NestJS). On attaque le cout *autrement* : alleger le graphe evalue.

## Quoi (3 fichiers, deps lourdes -> chargement paresseux)

| Fichier | Dep | Avant | Apres | Gain/import |
|---|---|---|---|---|
| `sheet.service.ts` | googleapis | import top-level + clients construits au load | import dynamique dans les methodes, types en `import type` | ~373ms |
| `banner.service.ts` | jsdom | `new JSDOM` dans un champ synchrone | `await import('jsdom')` a la 1ere sanitisation | ~229ms |
| `sentry-init.ts` | @sentry init + profiling natif | `Sentry.init()` en side-effect au load | execute seulement si `SENTRY_DSN` defini | ~91ms |

**~693ms/fichier de test deferes** (mesure `await import` apres AppModule). Bonus : allege le cold-start prod.

## Validation

- Typecheck backend : PASS.
- `banner.router.e2e-spec` : 32/32 (la sanitisation async preservee).
- Mesure de deferral : googleapis/jsdom non charges par AppModule (377/229ms a la demande) ; sentry-init 375ms -> 284ms.

## Comportement prod inchange

googleapis/jsdom : memes methodes, juste import differe. Sentry : DSN present en prod -> init comme avant ; le guard ne change que test/dev sans DSN (ou l'init etait deja un quasi no-op) et supprime un side-effect au chargement.

## Hors scope

`@sentry/nestjs` core (~267ms) reste eager : utilise dans des hot paths (logger par log, filtres d'exception) -> pas deferable proprement. echarts/exceljs (7/8 fichiers) ecartes : rendement decroissant.
