### PR TITLE
ci(e2e): reduit la voie parallele a 2 workers et elargit les timeouts

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -127,7 +127,7 @@ jobs:
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
         run: |
-          pnpm exec playwright test --config ./e2e/playwright.config.ts --grep-invert @serial --workers=4
+          pnpm exec playwright test --config ./e2e/playwright.config.ts --grep-invert @serial --workers=2
 
       - name: Run serial tests (non isolés)
         id: test-serial

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -33,7 +33,9 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
 
   fullyParallel: true,
-  workers: process.env.CI ? 4 : undefined,
+  workers: process.env.CI ? 2 : undefined,
+
+  expect: { timeout: 15_000 },
 
   // Reporter to use
   reporter: [
@@ -51,6 +53,10 @@ export default defineConfig({
 
   use: {
     baseURL,
+
+    navigationTimeout: 30_000,
+    actionTimeout: 15_000,
+
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
 


### PR DESCRIPTION
## Contexte

Le commit `49d89ed2a` a active `fullyParallel` + `workers=4` sur la voie isolee. Plusieurs jobs CI tombent depuis sur les tests les plus lourds (signup, `invite-membre` multi-contexte, `personnalisation`), avec une signature du type :

```
expect(page).toHaveURL(/finaliser-mon-inscription/) failed
Received: http://localhost:3003/signup?redirect_to=http%3A%2F%2Flocalhost%3A3000%2F
```

## Diagnostic

Cause racine : **sur-souscription CPU**. Le runner `ubuntu-latest` a 2 vCPU et heberge deja app (3000) + auth (3003) + backend (8080) + la stack Supabase Docker + Redis. A 4 workers Playwright — dont certains (`invite-membre`) ouvrent un 2e/3e `browser.newContext()` — on demande ~6-8 Chromium concurrents sur 2 coeurs. Les redirections d'auth depassent les timeouts et echouent meme apres les 2 retries (l'environnement reste sature pendant tout le run).

Ecarte pendant l'analyse :
- **Isolation des donnees** : chaque test cree sa propre collectivite + users (IDs/emails uniques), cleanup scoped. Pas de collision entre workers.
- **Rate-limit GoTrue** : `supabase/config.toml` monte deja `sign_in_sign_ups=50` / `email_sent=50`. Loin du plafond.
- **Mailpit** : lookups scopes par email unique.

## Changements

- `workers` CI : 4 -> 2 (config + flag CLI de la voie isolee), aligne sur les 2 vCPU.
- Timeouts elargis : `expect` 15s, `navigationTimeout` 30s, `actionTimeout` 15s.
- Voie `@serial` inchangee (`--workers=1`).

## Validation

Le repro tient a la charge concurrente du runner CI ; non reproductible en local. La validation reelle est le run CI de cette PR.

## Surface de review

Deux fichiers d'infra e2e uniquement (`playwright.config.ts`, `test-e2e.yml`). Aucun code applicatif, donc pas de test de regression au sens test-first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Améliorations de fiabilité**
  * Réduction de la parallélisation des tests de bout en bout en environnement d’intégration continue pour limiter les instabilités.
  * Ajustement des délais d’attente globaux des tests afin de mieux gérer les chargements de page et les actions utilisateur.
  * Les vérifications automatisées devraient désormais être plus stables et moins sujettes aux faux échecs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->