### PR TITLE
fix(ci): epingle Node a 24.18.0 pour corriger la regression node-fetch

### DIFF
--- a/.github/actions/pnpm-install/action.yml
+++ b/.github/actions/pnpm-install/action.yml
@@ -16,7 +16,7 @@ runs:
     - name: Use Node.js 24
       uses: actions/setup-node@v5
       with:
-        node-version: 24
+        node-version: 24.18.0
         cache: pnpm
 
     - name: Install dependencies


### PR DESCRIPTION
## Symptome

Depuis ~09:20 le 25/06/2026, **toutes les PRs** (toutes branches) ont leur job `test-backend` rouge avec la meme signature, sans le moindre commit applicatif :

```
GaxiosError: Invalid response body while trying to fetch
https://www.googleapis.com/oauth2/v4/token: Premature close
ERR_STREAM_PREMATURE_CLOSE
  at Gunzip.<anonymous> (node-fetch/lib/index.js:400:12)
```

4 fichiers de tests trajectoires SNBC qui tapent l'API Google live tombent, + 79 unhandled rejections.

## Cause racine (regression Node connue : nodejs/node#63989)

`.github/actions/pnpm-install/action.yml` utilisait `node-version: 24` (non epingle) : `setup-node` resolvait vers la derniere 24.x au runtime du job.

| Run CI | Node | Resultat |
|---|---|---|
| Dernier vert (~09:17) | 24.16.0 | OK |
| Premier rouge (~09:20) | 24.17.0 | KO |

Node **24.17.0** a ete happe automatiquement. Son fix de securite *"http: fix response queue poisoning in `http.Agent`"* (CVE-2026-48931) change la reutilisation des sockets keep-alive et expose un faux positif de premature-close dans `node-fetch@2.7.0` (tire transitivement par `gaxios@6.7.1` / `google-auth-library`) -> echec fleet-wide sur le endpoint token Google.

## Fix

```diff
-        node-version: 24
+        node-version: 24.18.0
```

**24.18.0** (sortie le 23/06/2026) contient a la fois le fix de securite CVE-2026-48931 ET le correctif [nodejs/node#64004](https://github.com/nodejs/node/pull/64004) qui resout la regression. Preferable a un retour sur 24.16.0, qui reverdirait la CI mais perdrait le patch de securite.

A valider : la run CI de cette PR doit confirmer le vert sur 24.18.0.

## Suites (hors scope, fragilite de fond)

- Les tests trajectoires dependent de l'API Google **live** -> les mocker (pattern deja present dans `import-referentiel.repository.e2e-spec.ts`).
- Promesse flottante `trajectoires-xlsx.service.ts:31` (`this.initXlsxBuffers()` non await) -> amplifie chaque hoquet en cascade de rejections.
- Sortir de `node-fetch` v2 (Node 24 a `fetch` natif) traiterait le declencheur pour tout le repo.

## Surface de review

1 fichier CI, 1 ligne. Aucun code applicatif. (Le nom de branche reste `...24-16-0` pour ne pas casser la PR ; le pin est bien 24.18.0.)

Refs : nodejs/node#63989, nodejs/node#64004