### PR TITLE
feat(audit-labellisation): affiche le conseiller referent dans le header de la checklist

### DIFF
--- a/apps/app/src/referentiels/audit-labellisation/checklist-page-header/checklist-page-header.tsx
+++ b/apps/app/src/referentiels/audit-labellisation/checklist-page-header/checklist-page-header.tsx
@@ -8,6 +8,11 @@ import {
 } from '@/app/referentiels/actions/use-list-actions';
 import { ScoreProgressBar } from '@/app/referentiels/scores/score.progress-bar';
 import { ScoreRatioBadge } from '@/app/referentiels/scores/score.ratio-badge';
+import {
+  groupeParFonction,
+  useMembres,
+} from '@/app/referentiels/tableau-de-bord/referents/useMembres';
+import { Membre } from '@/app/collectivites/membres/list-membres/use-list-membres';
 import { useCurrentCollectivite } from '@tet/api/collectivites';
 import { ActionTypeEnum, ReferentielId } from '@tet/domain/referentiels';
 import { PageHeader } from '@tet/ui';
@@ -15,7 +20,7 @@ import { ReactElement } from 'react';
 import { RoleMesures } from '../checklist-view-model';
 import { useChecklist } from '../checklist.context';
 import { ReferentielMenuButton } from './referentiel-menu.button';
-import { RoleMesuresLine } from './role-mesures-line';
+import { ReferentsLine } from './referents-line';
 
 const ReferentielScoreLine = ({
   action,
@@ -33,11 +38,13 @@ const ChecklistPageHeaderView = ({
   collectiviteId,
   referentiel,
   roleMesures,
+  conseillers,
 }: {
   referentielId: ReferentielId;
   collectiviteId: number;
   referentiel: ActionListItem | undefined;
   roleMesures: RoleMesures | null;
+  conseillers: Membre[];
 }): ReactElement => (
   <PageHeader>
     <PageHeader.Title>
@@ -50,7 +57,7 @@ const ChecklistPageHeaderView = ({
       />
     </PageHeader.Actions>
     <PageHeader.Metadata>
-      {roleMesures !== null && <RoleMesuresLine roleMesures={roleMesures} />}
+      <ReferentsLine roleMesures={roleMesures} conseillers={conseillers} />
       {referentiel !== undefined && <ReferentielScoreLine action={referentiel} />}
     </PageHeader.Metadata>
   </PageHeader>
@@ -67,6 +74,9 @@ export const ChecklistPageHeader = ({
     referentielIds: [referentielId],
     actionTypes: [ActionTypeEnum.REFERENTIEL],
   });
+  const { data: referents } = useMembres({ collectiviteId, estReferent: true });
+  const conseillers =
+    groupeParFonction(referents?.membres ?? [])?.conseiller ?? [];
 
   return (
     <ChecklistPageHeaderView
@@ -74,6 +84,7 @@ export const ChecklistPageHeader = ({
       collectiviteId={collectiviteId}
       referentiel={actions[0]}
       roleMesures={parcours?.roleMesures ?? null}
+      conseillers={conseillers}
     />
   );
 };

--- a/apps/app/src/referentiels/audit-labellisation/checklist-page-header/conseiller-referent.item.tsx
+++ b/apps/app/src/referentiels/audit-labellisation/checklist-page-header/conseiller-referent.item.tsx
@@ -1,0 +1,26 @@
+import { Membre } from '@/app/collectivites/membres/list-membres/use-list-membres';
+import { appLabels } from '@/app/labels/catalog';
+import { MetadataItem } from '@/app/ui/metadata-line';
+import { ReactElement } from 'react';
+
+export const ConseillerReferentItem = ({
+  conseillers,
+  hideSeparator,
+}: {
+  conseillers: Membre[];
+  hideSeparator?: boolean;
+}): ReactElement => {
+  const names = conseillers
+    .map((membre) => [membre.prenom, membre.nom].filter(Boolean).join(' '))
+    .filter(Boolean)
+    .join(', ');
+
+  return (
+    <MetadataItem
+      hideSeparator={hideSeparator}
+      icon="user-star-line"
+      label={appLabels.membreTeteFonctionConseiller}
+      value={names || <i>{appLabels.nonRenseigne}</i>}
+    />
+  );
+};

--- a/apps/app/src/referentiels/audit-labellisation/checklist-page-header/referents-line.tsx
+++ b/apps/app/src/referentiels/audit-labellisation/checklist-page-header/referents-line.tsx
@@ -1,11 +1,13 @@
 'use client';
 
+import { Membre } from '@/app/collectivites/membres/list-membres/use-list-membres';
 import { appLabels } from '@/app/labels/catalog';
 import { MetadataLine } from '@/app/ui/metadata-line';
 import { RoleKey } from '@tet/domain/referentiels';
 import { IconValue } from '@tet/ui';
 import { ReactElement } from 'react';
 import { RoleMesures } from '../checklist-view-model';
+import { ConseillerReferentItem } from './conseiller-referent.item';
 import { RoleMesureItem } from './role-mesure.item';
 
 type RoleConfig = {
@@ -27,38 +29,36 @@ const ROLE_CONFIGS: RoleConfig[] = [
   },
 ];
 
-export const RoleMesuresLine = ({
+export const ReferentsLine = ({
   roleMesures,
+  conseillers,
 }: {
-  roleMesures: RoleMesures;
-}): ReactElement | null => {
+  roleMesures: RoleMesures | null;
+  conseillers: Membre[];
+}): ReactElement => {
   const visibleRoles = ROLE_CONFIGS.map((config) => ({
     config,
-    mesure: roleMesures[config.key],
+    mesure: roleMesures?.[config.key],
   })).filter(
     (
       entry
     ): entry is {
       config: RoleConfig;
       mesure: NonNullable<typeof entry.mesure>;
-    } => entry.mesure !== null
+    } => entry.mesure != null
   );
-
-  if (visibleRoles.length === 0) {
-    return null;
-  }
 
   return (
     <MetadataLine>
-      {visibleRoles.map(({ config, mesure }, index) => (
+      {visibleRoles.map(({ config, mesure }) => (
         <RoleMesureItem
           key={config.key}
           actionId={mesure.actionId}
           icon={config.icon}
           label={config.label}
-          hideSeparator={index === visibleRoles.length - 1}
         />
       ))}
+      <ConseillerReferentItem conseillers={conseillers} hideSeparator />
     </MetadataLine>
   );
 };


### PR DESCRIPTION
## Intention

Afficher le **conseiller referent** dans le header de la checklist (nouveau layout `referentiel/new/[referentielId]`), a cote des roles elu/technique. Donnee jusqu'ici visible uniquement dans l'ancien `TableauDeBordShow`.

Choix valides avec le demandeur :
- source = referent **membre** (`fonction=conseiller` + `estReferent`), pas un role-mesure ;
- **toujours affiche, non editable** (pas de dropdown) ;
- pas de badge orange "A completer" quand vide (le conseiller n'est pas un pre-requis de la demande) -> "Non renseigne" neutre en italique.

## Surface de review

Attention humaine :
- `checklist-page-header.tsx` — wiring `useMembres` + `groupeParFonction(...).conseiller`, passage a la vue.
- `referents-line.tsx` — ex-`RoleMesuresLine` renomme (usage unique) ; rend les roles-mesures **et** le conseiller dans une seule `MetadataLine`, conseiller toujours dernier (`hideSeparator`). Gestion du null en un seul passage : `roleMesures?.[key]` dans le `map`, puis `.filter(... != null)` qui elimine d'un coup les roles non definis (`null`, cas reel : cf `EMPTY_ROLE_MESURES`) et le parcours non charge (`undefined`).
- `conseiller-referent.item.tsx` (nouveau) — item read-only ; "Non renseigne" si aucun conseiller (jamais la branche warning de `MetadataItem`).

## Anti-duplication

Reutilise `useMembres` + `groupeParFonction` (memes hooks que `TableauDeBordShow`), `MetadataItem`/`MetadataLine`, label `appLabels.membreTeteFonctionConseiller`, icone `user-star-line`. Aucune utility nouvelle.

## Decisions de naming

- `RoleMesuresLine` -> `ReferentsLine` : la ligne agrege desormais plusieurs natures d'items (role-mesure editable + conseiller membre read-only).
- `RoleMesureItem` **non renomme** : reste lie a une *mesure* (`useRoleMesure(actionId)`, `parcours.roleMesures`, module domaine `role-mesures/`). Le renommer en `RoleReferentItem` desyncroniserait du vocabulaire domaine et gommerait la distinction avec `ConseillerReferentItem` (source membre).

## Hypotheses / zones a valider

- L'ancien `TableauDeBordShow` n'est **pas** touche : le conseiller y reste affiche et reste l'unique surface d'edition (`ModaleReferents` -> `collectivites.membres.update`). Si l'ancien layout disparait avec la bascule, il faudra prevoir ou designer le conseiller referent dans le nouveau layout.
- Le conseiller etant collectivite-level, il apparait dans le header CAE **et** ECI.

## Verifs

- `nx run app:typecheck` OK
- eslint OK sur les fichiers touches

Pas de plan formel (changement ciblé discuté en direct). Pas de `fix`, donc pas de test de regression rouge attendu.