### PR TITLE
fix(ai-plan-import): reessaie le parsing PDF sur echec transitoire de pdfjs

### DIFF
--- a/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/extract-text.spec.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/extract-text.spec.ts
@@ -50,6 +50,42 @@ describe('extractText', () => {
     }
   });
 
+  it('reessaie le parsing PDF et reussit apres un echec transitoire', async () => {
+    let attempts = 0;
+    const result = await extractText({
+      buffer: samplePdf,
+      mimeType: PDF_MIME,
+      parsePdf: async () => {
+        attempts += 1;
+        if (attempts < 2) {
+          throw new Error('bad XRef entry');
+        }
+        return { text: 'DOCUMENT DE TEST' };
+      },
+    });
+    expect(result).toEqual({ success: true, data: 'DOCUMENT DE TEST' });
+    expect(attempts).toBe(2);
+  });
+
+  it('renvoie parse_failed avec la cause apres 3 echecs consecutifs', async () => {
+    let attempts = 0;
+    const cause = new Error('bad XRef entry');
+    const result = await extractText({
+      buffer: samplePdf,
+      mimeType: PDF_MIME,
+      parsePdf: async () => {
+        attempts += 1;
+        throw cause;
+      },
+    });
+    expect(result).toEqual({
+      success: false,
+      error: { kind: 'parse_failed' },
+      cause,
+    });
+    expect(attempts).toBe(3);
+  });
+
   it('extrait le texte d un CSV', async () => {
     const result = await extractText({
       buffer: Buffer.from('axe;titre\nMobilité;Covoiturage', 'utf-8'),

--- a/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/extract-text.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/generate-import-draft/extract-text.ts
@@ -1,10 +1,14 @@
 import { failure, Result, success } from '@tet/backend/utils/result.type';
-import { TimeoutError, withTimeout } from 'es-toolkit';
+import { delay, TimeoutError, withTimeout } from 'es-toolkit';
 import ExcelJS from 'exceljs';
 import pdf from 'pdf-parse-debugging-disabled';
 
 const PDF_TIMEOUT_MS = 30_000;
 const EXCEL_TIMEOUT_MS = 30_000;
+const PDF_PARSE_ATTEMPTS = 3;
+const PDF_RETRY_DELAY_MS = 50;
+
+type PdfParser = (buffer: Buffer) => Promise<{ text: string }>;
 
 export type ExtractionError =
   | { kind: 'unsupported_mime'; mimeType: string }
@@ -17,6 +21,7 @@ type DocumentKind = 'pdf' | 'csv' | 'excel';
 export const extractText = async (args: {
   buffer: Buffer;
   mimeType: string;
+  parsePdf?: PdfParser;
 }): Promise<Result<string, ExtractionError>> => {
   const kind = classifyMimeType(args.mimeType);
   if (kind === null) {
@@ -25,7 +30,7 @@ export const extractText = async (args: {
 
   switch (kind) {
     case 'pdf':
-      return extractPdf(args.buffer);
+      return extractPdf(args.parsePdf ?? pdf, args.buffer);
     case 'csv':
       return extractCsv(args.buffer);
     case 'excel':
@@ -50,17 +55,33 @@ const classifyMimeType = (mimeType: string): DocumentKind | null => {
   return null;
 };
 
-const extractPdf = async (
+const extractPdf = (
+  parse: PdfParser,
   buffer: Buffer
-): Promise<Result<string, ExtractionError>> => {
+): Promise<Result<string, ExtractionError>> =>
+  attemptParsePdf({ parse, buffer, attemptsLeft: PDF_PARSE_ATTEMPTS });
+
+const attemptParsePdf = async (args: {
+  parse: PdfParser;
+  buffer: Buffer;
+  attemptsLeft: number;
+}): Promise<Result<string, ExtractionError>> => {
   try {
-    const parsed = await withTimeout(() => pdf(buffer), PDF_TIMEOUT_MS);
+    const parsed = await withTimeout(
+      () => args.parse(args.buffer),
+      PDF_TIMEOUT_MS
+    );
     return fromExtractedText(parsed.text);
   } catch (error) {
     if (error instanceof TimeoutError) {
       return failure({ kind: 'timeout' });
     }
-    return failure({ kind: 'parse_failed' });
+    const cause = error instanceof Error ? error : new Error(String(error));
+    if (args.attemptsLeft <= 1) {
+      return failure({ kind: 'parse_failed' }, cause);
+    }
+    await delay(PDF_RETRY_DELAY_MS);
+    return attemptParsePdf({ ...args, attemptsLeft: args.attemptsLeft - 1 });
   }
 };
 


### PR DESCRIPTION
## Symptôme

`extract-text.spec.ts > extrait le texte d un PDF` échoue **uniquement en CI**, par intermittence, sur un PDF valide. Code d'extraction inchangé depuis le 11 juin.

## Diagnostic (par sondes successives en CI)

Le test passe en local : isolation, suite complète locale, et **300 parses concurrents sous charge CPU → 0 échec**. Spécifique à la pression de ressources du runner CI (le run fautif avait une phase `import` à ~1177 s).

Chaque hypothèse a été vérifiée plutôt que devinée :

1. **Pas un timeout** — un essai `timeoutMs: Infinity` (bypass du `withTimeout`) échouait toujours.
2. **Pas un texte vide** — une sonde sur le `Result` complet a montré `error.kind = parse_failed`, pas `empty_text`.
3. **Un throw** — en attachant l'erreur capturée comme `cause`, CI a affiché : `FormatError: "bad XRef entry"`, depuis le lecteur xref de **pdfjs v1.10.100** (worker émulé, `disableWorker = true`), bundlé dans `pdf-parse-debugging-disabled`.

Conclusion : pdfjs (2018, worker émulé) lance par intermittence `bad XRef entry` sur un PDF **pourtant valide** quand le runner est sous pression. Ni la fixture, ni notre code.

## Fix

`extractPdf` **réessaie jusqu'à 3 fois** (délai 50 ms) avant d'abandonner, et **attache l'erreur pdfjs comme `cause`** du Result au lieu de la jeter silencieusement (utile pour le futur). Durcit aussi la prod : les vrais utilisateurs uploadent des PDF que pdfjs rate parfois.

Le parser est **injectable** (`parsePdf`, défaut = pdf réel) → le retry est testé de façon **déterministe** sans dépendre de pdfjs : succès après un échec transitoire, et `parse_failed` + `cause` après 3 échecs.

## Décision sur la fixture (vs le plan initial « retry + fixture minimale »)

Fixture **non régénérée**, à dessein. Preuves recueillies :
- La fixture actuelle parse sur le **happy-path** pdfjs (xref valide, sans recovery) — elle n'est pas marginale.
- Une fixture minimale faite main déclenche **déterministiquement** `bad XRef entry` avec ce pdfjs (reproduit en local) — elle serait pire.
- L'échec CI vient du **worker émulé sous charge**, indépendant de la complexité du document → une fixture minimale ne l'empêcherait pas.

## Surface de review

- `extract-text.ts` : `extractPdf` → recursion de retry `attemptParsePdf` + injection `parsePdf` (attention humaine).
- `extract-text.spec.ts` : 2 tests de retry déterministes.

## Validation

`nx test backend extract-text` → 10 verts. `nx run backend:typecheck` OK. Lint 0 erreur. **Validation finale = le run CI sur cette PR** (le flake étant irreproductible en local).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Amélioration de l’extraction de texte des PDF avec plusieurs tentatives automatiques en cas d’échec temporaire.
  * Les échecs liés au délai d’attente sont désormais mieux signalés, avec une erreur plus claire si l’extraction ne peut pas aboutir.
  * Le comportement est plus fiable pour les PDF difficiles à analyser.

* **Tests**
  * Ajout de tests couvrant la reprise après un premier échec et l’échec définitif après plusieurs tentatives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->