### PR TITLE
Ajoute les jalons pre/post bascule vers le référentiel TE

### DIFF
--- a/apps/backend/src/referentiels/snapshots/list-snapshots/list-snapshots.api-query.ts
+++ b/apps/backend/src/referentiels/snapshots/list-snapshots/list-snapshots.api-query.ts
@@ -7,6 +7,8 @@ import z from 'zod';
 export const LIST_DEFAULT_JALONS = [
   SnapshotJalonEnum.PRE_AUDIT,
   SnapshotJalonEnum.POST_AUDIT,
+  SnapshotJalonEnum.PRE_SWITCH_TE,
+  SnapshotJalonEnum.POST_SWITCH_TE,
   SnapshotJalonEnum.DATE_PERSONNALISEE,
   SnapshotJalonEnum.LABELLISATION_EMT,
   SnapshotJalonEnum.COURANT,

--- a/packages/domain/src/referentiels/scores/snapshot-jalon.enum.ts
+++ b/packages/domain/src/referentiels/scores/snapshot-jalon.enum.ts
@@ -5,6 +5,8 @@ export const SnapshotJalonEnum = {
   DATE_PERSONNALISEE: 'date_personnalisee',
   PRE_AUDIT: 'pre_audit',
   POST_AUDIT: 'post_audit',
+  PRE_SWITCH_TE: 'pre_switch_te',
+  POST_SWITCH_TE: 'post_switch_te',
   LABELLISATION_EMT: 'labellisation_emt',
 } as const;
 
@@ -13,6 +15,8 @@ export const snapshotJalonEnumValues = [
   SnapshotJalonEnum.DATE_PERSONNALISEE,
   SnapshotJalonEnum.PRE_AUDIT,
   SnapshotJalonEnum.POST_AUDIT,
+  SnapshotJalonEnum.PRE_SWITCH_TE,
+  SnapshotJalonEnum.POST_SWITCH_TE,
   SnapshotJalonEnum.LABELLISATION_EMT,
 ] as const;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Deux nouveaux jalons sont désormais disponibles : **PRE_SWITCH_TE** et **POST_SWITCH_TE**.
  * Lors de la consultation des snapshots, la sélection par défaut des jalons inclut maintenant automatiquement ces nouvelles valeurs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->