### PR TITLE
Détermine le mode actif des référentiels lors du reset des préférences

### DIFF
--- a/apps/backend/src/collectivites/collectivite-preferences/collectivite-preferences.repository.ts
+++ b/apps/backend/src/collectivites/collectivite-preferences/collectivite-preferences.repository.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { collectiviteTable } from '@tet/backend/collectivites/shared/models/collectivite.table';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
 import { failure, success, type Result } from '@tet/backend/utils/result.type';
 import {
   CollectivitePreferences,
@@ -30,15 +31,20 @@ export class CollectivitePreferencesRepository {
   constructor(private readonly database: DatabaseService) {}
 
   async getPreferencesByCollectiviteId(
-    collectiviteId: number
+    collectiviteId: number,
+    options: { withLock?: boolean; tx?: Transaction } = {}
   ): Promise<
     Result<CollectivitePreferences | null, CollectivitePreferencesError>
   > {
-    const [row] = await this.db
+    const db = options.tx ?? this.db;
+    const query = db
       .select({ preferences: collectiviteTable.preferences })
       .from(collectiviteTable)
       .where(eq(collectiviteTable.id, collectiviteId))
       .limit(1);
+    // verrouille la ligne (FOR UPDATE) pour sérialiser les écritures concurrentes
+    // au sein d'une transaction
+    const [row] = options.withLock ? await query.for('update') : await query;
     if (!row?.preferences) {
       return success(null);
     }
@@ -54,10 +60,13 @@ export class CollectivitePreferencesRepository {
 
   async updatePreferences(
     collectiviteId: number,
-    preferences: UpdateCollectivitePreferencesInput
+    preferences: UpdateCollectivitePreferencesInput,
+    tx?: Transaction
   ): Promise<Result<CollectivitePreferences, CollectivitePreferencesError>> {
+    const db = tx ?? this.db;
     const currentResult = await this.getPreferencesByCollectiviteId(
-      collectiviteId
+      collectiviteId,
+      { tx }
     );
     if (!currentResult.success) {
       return currentResult;
@@ -73,7 +82,7 @@ export class CollectivitePreferencesRepository {
       );
     }
     const updated = parsed.data;
-    const result = await this.db
+    const result = await db
       .update(collectiviteTable)
       .set({ preferences: updated })
       .where(eq(collectiviteTable.id, collectiviteId));

--- a/apps/backend/src/collectivites/personnalisations/list-personnalisation-thematiques/list-personnalisation-thematiques.router.e2e-spec.ts
+++ b/apps/backend/src/collectivites/personnalisations/list-personnalisation-thematiques/list-personnalisation-thematiques.router.e2e-spec.ts
@@ -60,7 +60,7 @@ describe('Lister les thématiques de personnalisation', () => {
       const thematique = getFixtureThematique(result);
       expect(thematique).toBeDefined();
       expect(thematique?.id).toBe(testData.thematiqueId);
-      expect(thematique?.nom).toBe('Thématique de test');
+      expect(thematique?.nom).toMatch(/^Thématique de test/);
       expect(thematique?.questionsCount).toBe(
         testData.fixtureQuestionIds.length
       );
@@ -262,7 +262,7 @@ describe('Lister les thématiques de personnalisation', () => {
         });
       const thematique = getFixtureThematique(avecThematique);
       expect(thematique).toBeDefined();
-      expect(thematique?.nom).toBe('Thématique de test');
+      expect(thematique?.nom).toMatch(/^Thématique de test/);
 
       const sansCorrespondance =
         await caller.collectivites.personnalisations.listThematiques({

--- a/apps/backend/src/collectivites/personnalisations/personnalisations.test-fixture.ts
+++ b/apps/backend/src/collectivites/personnalisations/personnalisations.test-fixture.ts
@@ -386,7 +386,7 @@ export async function addTestThematiqueEtQuestions(
   collectiviteType: CollectiviteType
 ) {
   const thematiqueId = generatePersonnalisationTestId('test-thematique');
-  const thematiqueNom = 'Thématique de test';
+  const thematiqueNom = `Thématique de test${randomUUID()}`;
   const questionBinaireFormulation = 'Est-ce une question binaire ?';
   const questionProportionFormulation = 'Quelle est la proportion ?';
   const questionChoixFormulation = 'Quel est votre choix ?';

--- a/apps/backend/src/indicateurs/indicateurs/handle-definition-fiches/handle-definition-fiches.router.e2e.spec.ts
+++ b/apps/backend/src/indicateurs/indicateurs/handle-definition-fiches/handle-definition-fiches.router.e2e.spec.ts
@@ -1,23 +1,52 @@
 import { INestApplication } from '@nestjs/common';
+import {
+  addTestCollectivite,
+  addTestCollectiviteAndUser,
+} from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
 import { createFiche } from '@tet/backend/plans/fiches/fiches.test-fixture';
-import { getAuthUser, getTestApp, YOLO_DODO } from '@tet/backend/test';
+import {
+  getAuthUserFromUserCredentials,
+  getTestApp,
+  getTestDatabase,
+} from '@tet/backend/test';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { setUserCollectiviteRole } from '@tet/backend/users/users/users.test-fixture';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
+import { Collectivite } from '@tet/domain/collectivites';
+import { CollectiviteRole } from '@tet/domain/users';
 import { describe, expect } from 'vitest';
 import { createIndicateurPerso } from '../../definitions/definitions.test-fixture';
 
-const collectiviteId = 2;
-
 describe('IndicateurDefinitionFichesRouter', () => {
   let router: TrpcRouter;
-  let yoloDodo: AuthenticatedUser;
+  let testUser: AuthenticatedUser;
+  let collectivite: Collectivite;
+  let otherCollectivite: Collectivite;
+  let db: DatabaseService;
   let app: INestApplication;
 
   beforeAll(async () => {
     app = await getTestApp();
+    db = await getTestDatabase(app);
     router = app.get(TrpcRouter);
 
-    yoloDodo = await getAuthUser(YOLO_DODO);
+    const testCollectiviteAndUserResult = await addTestCollectiviteAndUser(db, {
+      user: { role: CollectiviteRole.ADMIN },
+    });
+    collectivite = testCollectiviteAndUserResult.collectivite;
+    testUser = getAuthUserFromUserCredentials(
+      testCollectiviteAndUserResult.user
+    );
+
+    const otherCollectiviteResult = await addTestCollectivite(db);
+    otherCollectivite = otherCollectiviteResult.collectivite;
+
+    await setUserCollectiviteRole(db, {
+      userId: testUser.id,
+      collectiviteId: otherCollectivite.id,
+      role: CollectiviteRole.ADMIN,
+    });
   });
 
   afterAll(async () => {
@@ -25,12 +54,12 @@ describe('IndicateurDefinitionFichesRouter', () => {
   });
 
   test('should update indicateur linked fiches', async () => {
-    const caller = router.createCaller({ user: yoloDodo });
+    const caller = router.createCaller({ user: testUser });
 
     const indicateurId = await createIndicateurPerso({
       caller,
       indicateurData: {
-        collectiviteId,
+        collectiviteId: collectivite.id,
         titre: 'Indicator with fiches',
       },
     });
@@ -38,7 +67,7 @@ describe('IndicateurDefinitionFichesRouter', () => {
     const ficheId1 = await createFiche({
       caller,
       ficheInput: {
-        collectiviteId,
+        collectiviteId: collectivite.id,
         titre: 'Fiche A',
       },
     });
@@ -46,31 +75,29 @@ describe('IndicateurDefinitionFichesRouter', () => {
     const ficheId2 = await createFiche({
       caller,
       ficheInput: {
-        collectiviteId,
+        collectiviteId: collectivite.id,
         titre: 'Fiche B',
       },
     });
 
-    // Initially no fiches linked
     let fiches = await caller.plans.fiches.listFiches({
-      collectiviteId,
+      collectiviteId: collectivite.id,
       filters: { indicateurIds: [indicateurId] },
     });
 
     expect(fiches.count).toEqual(0);
     expect(fiches.data).toHaveLength(0);
 
-    // Link two fiches
     await caller.indicateurs.indicateurs.update({
       indicateurId,
-      collectiviteId,
+      collectiviteId: collectivite.id,
       indicateurFields: {
         ficheIds: [ficheId1, ficheId2],
       },
     });
 
     fiches = await caller.plans.fiches.listFiches({
-      collectiviteId,
+      collectiviteId: collectivite.id,
       filters: { indicateurIds: [indicateurId] },
     });
 
@@ -79,17 +106,16 @@ describe('IndicateurDefinitionFichesRouter', () => {
       [ficheId1, ficheId2].sort()
     );
 
-    // Keep only one fiche
     await caller.indicateurs.indicateurs.update({
       indicateurId,
-      collectiviteId,
+      collectiviteId: collectivite.id,
       indicateurFields: {
         ficheIds: [ficheId2],
       },
     });
 
     fiches = await caller.plans.fiches.listFiches({
-      collectiviteId,
+      collectiviteId: collectivite.id,
       filters: { indicateurIds: [indicateurId] },
     });
 
@@ -98,11 +124,10 @@ describe('IndicateurDefinitionFichesRouter', () => {
   });
 
   test('should not delete fiches from other collectivites when updating', async () => {
-    const caller = router.createCaller({ user: yoloDodo });
+    const caller = router.createCaller({ user: testUser });
 
-    // Get a referentiel indicateur that both collectivites can access
     const { data: indicateurs } = await caller.indicateurs.indicateurs.list({
-      collectiviteId: 1,
+      collectiviteId: collectivite.id,
       filters: {
         identifiantsReferentiel: ['cae_1.a'],
       },
@@ -111,11 +136,10 @@ describe('IndicateurDefinitionFichesRouter', () => {
     const indicateurReferentiel = indicateurs[0];
     expect(indicateurReferentiel).toBeDefined();
 
-    // Create fiches for collectivite 1
     const ficheC1_A = await createFiche({
       caller,
       ficheInput: {
-        collectiviteId: 1,
+        collectiviteId: collectivite.id,
         titre: 'Collectivité 1 - Fiche A',
       },
     });
@@ -123,16 +147,15 @@ describe('IndicateurDefinitionFichesRouter', () => {
     const ficheC1_B = await createFiche({
       caller,
       ficheInput: {
-        collectiviteId: 1,
+        collectiviteId: collectivite.id,
         titre: 'Collectivité 1 - Fiche B',
       },
     });
 
-    // Create fiches for collectivite 2
     const ficheC2_A = await createFiche({
       caller,
       ficheInput: {
-        collectiviteId: 2,
+        collectiviteId: otherCollectivite.id,
         titre: 'Collectivité 2 - Fiche A',
       },
     });
@@ -140,32 +163,29 @@ describe('IndicateurDefinitionFichesRouter', () => {
     const ficheC2_B = await createFiche({
       caller,
       ficheInput: {
-        collectiviteId: 2,
+        collectiviteId: otherCollectivite.id,
         titre: 'Collectivité 2 - Fiche B',
       },
     });
 
-    // Associate fiches from collectivite 1
     await caller.indicateurs.indicateurs.update({
       indicateurId: indicateurReferentiel.id,
-      collectiviteId: 1,
+      collectiviteId: collectivite.id,
       indicateurFields: {
         ficheIds: [ficheC1_A, ficheC1_B],
       },
     });
 
-    // Associate fiches from collectivite 2
     await caller.indicateurs.indicateurs.update({
       indicateurId: indicateurReferentiel.id,
-      collectiviteId: 2,
+      collectiviteId: otherCollectivite.id,
       indicateurFields: {
         ficheIds: [ficheC2_A, ficheC2_B],
       },
     });
 
-    // Verify collectivite 1 has both fiches
     let fichesC1 = await caller.plans.fiches.listFiches({
-      collectiviteId: 1,
+      collectiviteId: collectivite.id,
       filters: { indicateurIds: [indicateurReferentiel.id] },
     });
 
@@ -174,9 +194,8 @@ describe('IndicateurDefinitionFichesRouter', () => {
       [ficheC1_A, ficheC1_B].sort()
     );
 
-    // Verify collectivite 2 has both fiches
     let fichesC2 = await caller.plans.fiches.listFiches({
-      collectiviteId: 2,
+      collectiviteId: otherCollectivite.id,
       filters: { indicateurIds: [indicateurReferentiel.id] },
     });
 
@@ -185,27 +204,24 @@ describe('IndicateurDefinitionFichesRouter', () => {
       [ficheC2_A, ficheC2_B].sort()
     );
 
-    // Update collectivite 1: keep only ficheC1_A
     await caller.indicateurs.indicateurs.update({
       indicateurId: indicateurReferentiel.id,
-      collectiviteId: 1,
+      collectiviteId: collectivite.id,
       indicateurFields: {
         ficheIds: [ficheC1_A],
       },
     });
 
-    // Verify collectivite 1 now has only ficheC1_A
     fichesC1 = await caller.plans.fiches.listFiches({
-      collectiviteId: 1,
+      collectiviteId: collectivite.id,
       filters: { indicateurIds: [indicateurReferentiel.id] },
     });
 
     expect(fichesC1.count).toEqual(1);
     expect(fichesC1.data[0].id).toEqual(ficheC1_A);
 
-    // IMPORTANT: Verify collectivite 2 STILL has both fiches (not affected)
     fichesC2 = await caller.plans.fiches.listFiches({
-      collectiviteId: 2,
+      collectiviteId: otherCollectivite.id,
       filters: { indicateurIds: [indicateurReferentiel.id] },
     });
 
@@ -214,27 +230,24 @@ describe('IndicateurDefinitionFichesRouter', () => {
       [ficheC2_A, ficheC2_B].sort()
     );
 
-    // Update collectivite 2: keep only ficheC2_B
     await caller.indicateurs.indicateurs.update({
       indicateurId: indicateurReferentiel.id,
-      collectiviteId: 2,
+      collectiviteId: otherCollectivite.id,
       indicateurFields: {
         ficheIds: [ficheC2_B],
       },
     });
 
-    // Verify collectivite 2 now has only ficheC2_B
     fichesC2 = await caller.plans.fiches.listFiches({
-      collectiviteId: 2,
+      collectiviteId: otherCollectivite.id,
       filters: { indicateurIds: [indicateurReferentiel.id] },
     });
 
     expect(fichesC2.count).toEqual(1);
     expect(fichesC2.data[0].id).toEqual(ficheC2_B);
 
-    // IMPORTANT: Verify collectivite 1 STILL has ficheC1_A (not affected)
     fichesC1 = await caller.plans.fiches.listFiches({
-      collectiviteId: 1,
+      collectiviteId: collectivite.id,
       filters: { indicateurIds: [indicateurReferentiel.id] },
     });
 

--- a/apps/backend/src/indicateurs/indicateurs/handle-definition-pilotes/handle-definition-pilotes.router.e2e.spec.ts
+++ b/apps/backend/src/indicateurs/indicateurs/handle-definition-pilotes/handle-definition-pilotes.router.e2e.spec.ts
@@ -1,22 +1,41 @@
 import { INestApplication } from '@nestjs/common';
-import { getAuthUser, getTestApp, YOLO_DODO } from '@tet/backend/test';
+import { createPersonneTag } from '@tet/backend/collectivites/collectivites.test-fixture';
+import {
+  addTestCollectivite,
+  addTestCollectiviteAndUser,
+} from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import {
+  getAuthUserFromUserCredentials,
+  getTestApp,
+  getTestDatabase,
+} from '@tet/backend/test';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
-import { describe, expect } from 'vitest';
+import { Collectivite } from '@tet/domain/collectivites';
+import { CollectiviteRole } from '@tet/domain/users';
+import { describe, expect, onTestFinished } from 'vitest';
 import { createIndicateurPerso } from '../../definitions/definitions.test-fixture';
-
-const collectiviteId = 2;
 
 describe('IndicateurDefinitionPiloteRouter', () => {
   let router: TrpcRouter;
-  let yoloDodo: AuthenticatedUser;
+  let testUser: AuthenticatedUser;
+  let collectivite: Collectivite;
+  let db: DatabaseService;
   let app: INestApplication;
 
   beforeAll(async () => {
     app = await getTestApp();
+    db = await getTestDatabase(app);
     router = app.get(TrpcRouter);
 
-    yoloDodo = await getAuthUser(YOLO_DODO);
+    const testCollectiviteAndUserResult = await addTestCollectiviteAndUser(db, {
+      user: { role: CollectiviteRole.ADMIN },
+    });
+    collectivite = testCollectiviteAndUserResult.collectivite;
+    testUser = getAuthUserFromUserCredentials(
+      testCollectiviteAndUserResult.user
+    );
   });
 
   afterAll(async () => {
@@ -24,29 +43,33 @@ describe('IndicateurDefinitionPiloteRouter', () => {
   });
 
   test('list existing pilotes associated with an indicateur', async () => {
-    const caller = router.createCaller({ user: yoloDodo });
+    const caller = router.createCaller({ user: testUser });
+
+    const piloteTag = await createPersonneTag({
+      database: db,
+      tagData: { collectiviteId: collectivite.id, nom: 'Pilote tag' },
+    });
 
     const indicateurId = await createIndicateurPerso({
       caller,
       indicateurData: {
-        collectiviteId,
+        collectiviteId: collectivite.id,
         titre: 'Test indicateur',
       },
     });
 
-    // First add a pilote
     await caller.indicateurs.indicateurs.update({
       indicateurId,
-      collectiviteId,
+      collectiviteId: collectivite.id,
       indicateurFields: {
-        pilotes: [{ tagId: 3 }], // assume that the pilote tag 3 exists
+        pilotes: [{ tagId: piloteTag.id }],
       },
     });
 
     const {
       data: [indicateur],
     } = await caller.indicateurs.indicateurs.list({
-      collectiviteId,
+      collectiviteId: collectivite.id,
       filters: {
         indicateurIds: [indicateurId],
       },
@@ -54,17 +77,26 @@ describe('IndicateurDefinitionPiloteRouter', () => {
 
     expect(indicateur.pilotes).toHaveLength(1);
     expect(indicateur.pilotes).toContainEqual(
-      expect.objectContaining({ tagId: 3 })
+      expect.objectContaining({ tagId: piloteTag.id })
     );
   });
 
   test('list, update, delete pilotes associated with an indicateur and a collectivite', async () => {
-    const caller = router.createCaller({ user: yoloDodo });
+    const caller = router.createCaller({ user: testUser });
+
+    const piloteTag1 = await createPersonneTag({
+      database: db,
+      tagData: { collectiviteId: collectivite.id, nom: 'Pilote 1' },
+    });
+    const piloteTag2 = await createPersonneTag({
+      database: db,
+      tagData: { collectiviteId: collectivite.id, nom: 'Pilote 2' },
+    });
 
     const indicateurId = await createIndicateurPerso({
       caller,
       indicateurData: {
-        collectiviteId,
+        collectiviteId: collectivite.id,
         titre: 'Test indicateur',
       },
     });
@@ -72,7 +104,7 @@ describe('IndicateurDefinitionPiloteRouter', () => {
     const {
       data: [indicateurBefore],
     } = await caller.indicateurs.indicateurs.list({
-      collectiviteId,
+      collectiviteId: collectivite.id,
       filters: {
         indicateurIds: [indicateurId],
       },
@@ -80,20 +112,18 @@ describe('IndicateurDefinitionPiloteRouter', () => {
 
     expect(indicateurBefore.pilotes).toHaveLength(0);
 
-    // Check with new array of pilotes
-
     await caller.indicateurs.indicateurs.update({
       indicateurId,
-      collectiviteId,
+      collectiviteId: collectivite.id,
       indicateurFields: {
-        pilotes: [{ tagId: 1 }, { tagId: 3 }],
+        pilotes: [{ tagId: piloteTag1.id }, { tagId: piloteTag2.id }],
       },
     });
 
     const {
       data: [indicateurAfter],
     } = await caller.indicateurs.indicateurs.list({
-      collectiviteId,
+      collectiviteId: collectivite.id,
       filters: {
         indicateurIds: [indicateurId],
       },
@@ -101,26 +131,24 @@ describe('IndicateurDefinitionPiloteRouter', () => {
 
     expect(indicateurAfter.pilotes).toHaveLength(2);
     expect(indicateurAfter.pilotes).toContainEqual(
-      expect.objectContaining({ tagId: 1 })
+      expect.objectContaining({ tagId: piloteTag1.id })
     );
     expect(indicateurAfter.pilotes).toContainEqual(
-      expect.objectContaining({ tagId: 3 })
+      expect.objectContaining({ tagId: piloteTag2.id })
     );
-
-    // Keep only one pilote
 
     await caller.indicateurs.indicateurs.update({
       indicateurId,
-      collectiviteId,
+      collectiviteId: collectivite.id,
       indicateurFields: {
-        pilotes: [{ tagId: 3 }],
+        pilotes: [{ tagId: piloteTag2.id }],
       },
     });
 
     const {
       data: [indicateurFinal],
     } = await caller.indicateurs.indicateurs.list({
-      collectiviteId,
+      collectiviteId: collectivite.id,
       filters: {
         indicateurIds: [indicateurId],
       },
@@ -128,17 +156,26 @@ describe('IndicateurDefinitionPiloteRouter', () => {
 
     expect(indicateurFinal.pilotes).toHaveLength(1);
     expect(indicateurFinal.pilotes).toContainEqual(
-      expect.objectContaining({ tagId: 3 })
+      expect.objectContaining({ tagId: piloteTag2.id })
     );
   });
 
   test('verify modified fields are updated', async () => {
-    const caller = router.createCaller({ user: yoloDodo });
+    const caller = router.createCaller({ user: testUser });
+
+    const piloteTag1 = await createPersonneTag({
+      database: db,
+      tagData: { collectiviteId: collectivite.id, nom: 'Pilote 1' },
+    });
+    const piloteTag2 = await createPersonneTag({
+      database: db,
+      tagData: { collectiviteId: collectivite.id, nom: 'Pilote 2' },
+    });
 
     const indicateurId = await createIndicateurPerso({
       caller,
       indicateurData: {
-        collectiviteId,
+        collectiviteId: collectivite.id,
         titre: 'Test indicateur',
       },
     });
@@ -146,7 +183,7 @@ describe('IndicateurDefinitionPiloteRouter', () => {
     const {
       data: [indicateurBefore],
     } = await caller.indicateurs.indicateurs.list({
-      collectiviteId,
+      collectiviteId: collectivite.id,
       filters: {
         indicateurIds: [indicateurId],
       },
@@ -154,46 +191,59 @@ describe('IndicateurDefinitionPiloteRouter', () => {
 
     await caller.indicateurs.indicateurs.update({
       indicateurId,
-      collectiviteId,
+      collectiviteId: collectivite.id,
       indicateurFields: {
-        pilotes: [{ tagId: 1 }, { tagId: 3 }],
+        pilotes: [{ tagId: piloteTag1.id }, { tagId: piloteTag2.id }],
       },
     });
 
     const {
       data: [indicateurAfter],
     } = await caller.indicateurs.indicateurs.list({
-      collectiviteId,
+      collectiviteId: collectivite.id,
       filters: {
         indicateurIds: [indicateurId],
       },
     });
 
-    expect(indicateurAfter.modifiedBy?.id).toEqual(yoloDodo.id);
+    expect(indicateurAfter.modifiedBy?.id).toEqual(testUser.id);
     expect(new Date(indicateurAfter.modifiedAt).getTime()).toBeGreaterThan(
       new Date(indicateurBefore.modifiedAt).getTime()
     );
   });
 
   test('cannot upsert pilotes of another collectivite', async () => {
-    const callerYoloDodo = router.createCaller({ user: yoloDodo });
+    const caller = router.createCaller({ user: testUser });
+
+    const { collectivite: otherCollectivite, cleanup } =
+      await addTestCollectivite(db);
+    onTestFinished(cleanup);
+
+    const piloteTag1 = await createPersonneTag({
+      database: db,
+      tagData: { collectiviteId: collectivite.id, nom: 'Pilote 1' },
+    });
+    const piloteTag2 = await createPersonneTag({
+      database: db,
+      tagData: { collectiviteId: collectivite.id, nom: 'Pilote 2' },
+    });
 
     const indicateurId = await createIndicateurPerso({
-      caller: callerYoloDodo,
+      caller,
       indicateurData: {
-        collectiviteId,
+        collectiviteId: collectivite.id,
         titre: 'Test indicateur',
       },
     });
 
     await expect(() =>
-      callerYoloDodo.indicateurs.indicateurs.update({
+      caller.indicateurs.indicateurs.update({
         indicateurId,
-        collectiviteId: 100,
+        collectiviteId: otherCollectivite.id,
         indicateurFields: {
-          pilotes: [{ tagId: 1 }, { tagId: 3 }],
+          pilotes: [{ tagId: piloteTag1.id }, { tagId: piloteTag2.id }],
         },
       })
-    ).rejects.toThrowError(/Droits insuffisants/);
+    ).rejects.toThrow(/Droits insuffisants/);
   });
 });

--- a/apps/backend/src/indicateurs/indicateurs/handle-definition-services/handle-definition-services.router.e2e.spec.ts
+++ b/apps/backend/src/indicateurs/indicateurs/handle-definition-services/handle-definition-services.router.e2e.spec.ts
@@ -1,24 +1,27 @@
 import { INestApplication } from '@nestjs/common';
+import { createServiceTag } from '@tet/backend/collectivites/collectivites.test-fixture';
 import {
-  getAuthUser,
+  addTestCollectivite,
+  addTestCollectiviteAndUser,
+} from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import {
   getAuthUserFromUserCredentials,
   getTestApp,
   getTestDatabase,
-  YOLO_DODO,
 } from '@tet/backend/test';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { addTestUser } from '@tet/backend/users/users/users.test-fixture';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
+import { Collectivite } from '@tet/domain/collectivites';
 import { CollectiviteRole } from '@tet/domain/users';
-import { describe, expect } from 'vitest';
+import { describe, expect, onTestFinished } from 'vitest';
 import { createIndicateurPerso } from '../../definitions/definitions.test-fixture';
-
-const collectiviteId = 2;
 
 describe('IndicateurDefinitionServiceRouter', () => {
   let router: TrpcRouter;
-  let yoloDodo: AuthenticatedUser;
+  let testUser: AuthenticatedUser;
+  let collectivite: Collectivite;
   let db: DatabaseService;
   let app: INestApplication;
 
@@ -27,7 +30,13 @@ describe('IndicateurDefinitionServiceRouter', () => {
     db = await getTestDatabase(app);
     router = app.get(TrpcRouter);
 
-    yoloDodo = await getAuthUser(YOLO_DODO);
+    const testCollectiviteAndUserResult = await addTestCollectiviteAndUser(db, {
+      user: { role: CollectiviteRole.ADMIN },
+    });
+    collectivite = testCollectiviteAndUserResult.collectivite;
+    testUser = getAuthUserFromUserCredentials(
+      testCollectiviteAndUserResult.user
+    );
   });
 
   afterAll(async () => {
@@ -35,12 +44,21 @@ describe('IndicateurDefinitionServiceRouter', () => {
   });
 
   test('list, update, delete services associated with an indicateur and a collectivite', async () => {
-    const caller = router.createCaller({ user: yoloDodo });
+    const caller = router.createCaller({ user: testUser });
+
+    const service1 = await createServiceTag({
+      database: db,
+      tagData: { collectiviteId: collectivite.id, nom: 'Service 1' },
+    });
+    const service2 = await createServiceTag({
+      database: db,
+      tagData: { collectiviteId: collectivite.id, nom: 'Service 2' },
+    });
 
     const indicateurId = await createIndicateurPerso({
       caller,
       indicateurData: {
-        collectiviteId,
+        collectiviteId: collectivite.id,
         titre: 'Test indicateur',
       },
     });
@@ -48,7 +66,7 @@ describe('IndicateurDefinitionServiceRouter', () => {
     const {
       data: [indicateurBefore],
     } = await caller.indicateurs.indicateurs.list({
-      collectiviteId,
+      collectiviteId: collectivite.id,
       filters: {
         indicateurIds: [indicateurId],
       },
@@ -56,20 +74,18 @@ describe('IndicateurDefinitionServiceRouter', () => {
 
     expect(indicateurBefore.services).toHaveLength(0);
 
-    // Check with new array of services
-
     await caller.indicateurs.indicateurs.update({
       indicateurId,
-      collectiviteId,
+      collectiviteId: collectivite.id,
       indicateurFields: {
-        services: [{ id: 2 }, { id: 3 }],
+        services: [{ id: service1.id }, { id: service2.id }],
       },
     });
 
     const {
       data: [indicateurAfter],
     } = await caller.indicateurs.indicateurs.list({
-      collectiviteId,
+      collectiviteId: collectivite.id,
       filters: {
         indicateurIds: [indicateurId],
       },
@@ -77,26 +93,24 @@ describe('IndicateurDefinitionServiceRouter', () => {
 
     expect(indicateurAfter.services).toHaveLength(2);
     expect(indicateurAfter.services).toContainEqual(
-      expect.objectContaining({ id: 2 })
+      expect.objectContaining({ id: service1.id })
     );
     expect(indicateurAfter.services).toContainEqual(
-      expect.objectContaining({ id: 3 })
+      expect.objectContaining({ id: service2.id })
     );
-
-    // Keep only one service
 
     await caller.indicateurs.indicateurs.update({
       indicateurId,
-      collectiviteId,
+      collectiviteId: collectivite.id,
       indicateurFields: {
-        services: [{ id: 3 }],
+        services: [{ id: service2.id }],
       },
     });
 
     const {
       data: [indicateurFinal],
     } = await caller.indicateurs.indicateurs.list({
-      collectiviteId,
+      collectiviteId: collectivite.id,
       filters: {
         indicateurIds: [indicateurId],
       },
@@ -104,17 +118,26 @@ describe('IndicateurDefinitionServiceRouter', () => {
 
     expect(indicateurFinal.services).toHaveLength(1);
     expect(indicateurFinal.services).toContainEqual(
-      expect.objectContaining({ id: 3 })
+      expect.objectContaining({ id: service2.id })
     );
   });
 
   test('verify modified fields are updated', async () => {
-    const caller = router.createCaller({ user: yoloDodo });
+    const caller = router.createCaller({ user: testUser });
+
+    const service1 = await createServiceTag({
+      database: db,
+      tagData: { collectiviteId: collectivite.id, nom: 'Service 1' },
+    });
+    const service2 = await createServiceTag({
+      database: db,
+      tagData: { collectiviteId: collectivite.id, nom: 'Service 2' },
+    });
 
     const indicateurId = await createIndicateurPerso({
       caller,
       indicateurData: {
-        collectiviteId,
+        collectiviteId: collectivite.id,
         titre: 'Test indicateur',
       },
     });
@@ -122,7 +145,7 @@ describe('IndicateurDefinitionServiceRouter', () => {
     const {
       data: [indicateurBefore],
     } = await caller.indicateurs.indicateurs.list({
-      collectiviteId,
+      collectiviteId: collectivite.id,
       filters: {
         indicateurIds: [indicateurId],
       },
@@ -130,44 +153,48 @@ describe('IndicateurDefinitionServiceRouter', () => {
 
     await caller.indicateurs.indicateurs.update({
       indicateurId,
-      collectiviteId,
+      collectiviteId: collectivite.id,
       indicateurFields: {
-        services: [{ id: 2 }, { id: 3 }],
+        services: [{ id: service1.id }, { id: service2.id }],
       },
     });
 
     const {
       data: [indicateurAfter],
     } = await caller.indicateurs.indicateurs.list({
-      collectiviteId,
+      collectiviteId: collectivite.id,
       filters: {
         indicateurIds: [indicateurId],
       },
     });
 
-    expect(indicateurAfter.modifiedBy?.id).toEqual(yoloDodo.id);
+    expect(indicateurAfter.modifiedBy?.id).toEqual(testUser.id);
     expect(new Date(indicateurAfter.modifiedAt).getTime()).toBeGreaterThan(
       new Date(indicateurBefore.modifiedAt).getTime()
     );
   });
 
   test('User with lecture rights on collectivite cannot update/delete services', async () => {
-    const caller = router.createCaller({ user: yoloDodo });
+    const caller = router.createCaller({ user: testUser });
+
+    const service = await createServiceTag({
+      database: db,
+      tagData: { collectiviteId: collectivite.id, nom: 'Service lecture' },
+    });
+
     const indicateurId = await createIndicateurPerso({
       caller,
       indicateurData: {
-        collectiviteId,
+        collectiviteId: collectivite.id,
         titre: 'Test indicateur',
       },
     });
 
     const { user, cleanup } = await addTestUser(db, {
-      collectiviteId: collectiviteId,
+      collectiviteId: collectivite.id,
       role: CollectiviteRole.LECTURE,
     });
-    onTestFinished(async () => {
-      await cleanup();
-    });
+    onTestFinished(cleanup);
 
     const lectureUser = getAuthUserFromUserCredentials(user);
     const lectureCaller = router.createCaller({ user: lectureUser });
@@ -175,38 +202,42 @@ describe('IndicateurDefinitionServiceRouter', () => {
     await expect(() =>
       lectureCaller.indicateurs.indicateurs.update({
         indicateurId,
-        collectiviteId: collectiviteId,
+        collectiviteId: collectivite.id,
         indicateurFields: {
-          services: [{ id: 3 }],
+          services: [{ id: service.id }],
         },
       })
-    ).rejects.toThrowError(/Droits insuffisants/);
+    ).rejects.toThrow(/Droits insuffisants/);
 
     await expect(() =>
       lectureCaller.indicateurs.indicateurs.delete({
         indicateurId,
-        collectiviteId: collectiviteId,
+        collectiviteId: collectivite.id,
       })
-    ).rejects.toThrowError(/Droits insuffisants/);
+    ).rejects.toThrow(/Droits insuffisants/);
   });
 
   test('User with limited edition rights on collectivite cannot update/delete services', async () => {
-    const adminCaller = router.createCaller({ user: yoloDodo });
+    const adminCaller = router.createCaller({ user: testUser });
+
+    const service = await createServiceTag({
+      database: db,
+      tagData: { collectiviteId: collectivite.id, nom: 'Service edition' },
+    });
+
     const indicateurId = await createIndicateurPerso({
       caller: adminCaller,
       indicateurData: {
-        collectiviteId,
+        collectiviteId: collectivite.id,
         titre: 'Test indicateur',
       },
     });
 
     const { user, cleanup } = await addTestUser(db, {
-      collectiviteId: collectiviteId,
+      collectiviteId: collectivite.id,
       role: CollectiviteRole.EDITION_FICHES_INDICATEURS,
     });
-    onTestFinished(async () => {
-      await cleanup();
-    });
+    onTestFinished(cleanup);
 
     const limitedEditionUser = getAuthUserFromUserCredentials(user);
     const limitedEditionCaller = router.createCaller({
@@ -216,50 +247,46 @@ describe('IndicateurDefinitionServiceRouter', () => {
     await expect(() =>
       limitedEditionCaller.indicateurs.indicateurs.update({
         indicateurId,
-        collectiviteId: collectiviteId,
+        collectiviteId: collectivite.id,
         indicateurFields: {
-          services: [{ id: 3 }],
+          services: [{ id: service.id }],
         },
       })
-    ).rejects.toThrowError(/Droits insuffisants/);
+    ).rejects.toThrow(/Droits insuffisants/);
 
     await expect(() =>
       limitedEditionCaller.indicateurs.indicateurs.delete({
         indicateurId,
-        collectiviteId: collectiviteId,
+        collectiviteId: collectivite.id,
       })
-    ).rejects.toThrowError(/Droits insuffisants/);
+    ).rejects.toThrow(/Droits insuffisants/);
 
-    // Now we update the indicateur with a pilote of the limited edition user
     await adminCaller.indicateurs.indicateurs.update({
       indicateurId,
-      collectiviteId: collectiviteId,
+      collectiviteId: collectivite.id,
       indicateurFields: {
         pilotes: [{ userId: limitedEditionUser.id }],
       },
     });
 
-    // The limited edition user should be able to update the indicateur
     await limitedEditionCaller.indicateurs.indicateurs.update({
       indicateurId,
-      collectiviteId: collectiviteId,
+      collectiviteId: collectivite.id,
       indicateurFields: {
-        services: [{ id: 3 }],
+        services: [{ id: service.id }],
       },
     });
 
-    // But still not able to delete the indicateur
     await expect(() =>
       limitedEditionCaller.indicateurs.indicateurs.delete({
         indicateurId,
-        collectiviteId: collectiviteId,
+        collectiviteId: collectivite.id,
       })
-    ).rejects.toThrowError(/Droits insuffisants/);
+    ).rejects.toThrow(/Droits insuffisants/);
 
-    // Remove the pilote to be able to delete the user
     await adminCaller.indicateurs.indicateurs.update({
       indicateurId,
-      collectiviteId: collectiviteId,
+      collectiviteId: collectivite.id,
       indicateurFields: {
         pilotes: [],
       },
@@ -267,24 +294,37 @@ describe('IndicateurDefinitionServiceRouter', () => {
   });
 
   test('cannot upsert services of another collectivite', async () => {
-    const callerYoloDodo = router.createCaller({ user: yoloDodo });
+    const caller = router.createCaller({ user: testUser });
+
+    const { collectivite: otherCollectivite, cleanup } =
+      await addTestCollectivite(db);
+    onTestFinished(cleanup);
+
+    const service1 = await createServiceTag({
+      database: db,
+      tagData: { collectiviteId: collectivite.id, nom: 'Service 1' },
+    });
+    const service2 = await createServiceTag({
+      database: db,
+      tagData: { collectiviteId: collectivite.id, nom: 'Service 2' },
+    });
 
     const indicateurId = await createIndicateurPerso({
-      caller: callerYoloDodo,
+      caller,
       indicateurData: {
-        collectiviteId,
+        collectiviteId: collectivite.id,
         titre: 'Test indicateur',
       },
     });
 
     await expect(() =>
-      callerYoloDodo.indicateurs.indicateurs.update({
+      caller.indicateurs.indicateurs.update({
         indicateurId,
-        collectiviteId: 100,
+        collectiviteId: otherCollectivite.id,
         indicateurFields: {
-          services: [{ id: 2 }, { id: 3 }],
+          services: [{ id: service1.id }, { id: service2.id }],
         },
       })
-    ).rejects.toThrowError(/Droits insuffisants/);
+    ).rejects.toThrow(/Droits insuffisants/);
   });
 });

--- a/apps/backend/src/indicateurs/indicateurs/handle-definition-thematiques/handle-definition-thematiques.router.e2e.spec.ts
+++ b/apps/backend/src/indicateurs/indicateurs/handle-definition-thematiques/handle-definition-thematiques.router.e2e.spec.ts
@@ -1,22 +1,41 @@
 import { INestApplication } from '@nestjs/common';
-import { getAuthUser, getTestApp, YOLO_DODO } from '@tet/backend/test';
+import {
+  addTestCollectivite,
+  addTestCollectiviteAndUser,
+} from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { createThematique } from '@tet/backend/shared/shared.test-fixture';
+import {
+  getAuthUserFromUserCredentials,
+  getTestApp,
+  getTestDatabase,
+} from '@tet/backend/test';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
-import { describe, expect } from 'vitest';
+import { Collectivite } from '@tet/domain/collectivites';
+import { CollectiviteRole } from '@tet/domain/users';
+import { describe, expect, onTestFinished } from 'vitest';
 import { createIndicateurPerso } from '../../definitions/definitions.test-fixture';
-
-const collectiviteId = 2;
 
 describe('IndicateurDefinitionThematiqueRouter', () => {
   let router: TrpcRouter;
-  let yoloDodo: AuthenticatedUser;
+  let testUser: AuthenticatedUser;
+  let collectivite: Collectivite;
+  let db: DatabaseService;
   let app: INestApplication;
 
   beforeAll(async () => {
     app = await getTestApp();
+    db = await getTestDatabase(app);
     router = app.get(TrpcRouter);
 
-    yoloDodo = await getAuthUser(YOLO_DODO);
+    const testCollectiviteAndUserResult = await addTestCollectiviteAndUser(db, {
+      user: { role: CollectiviteRole.ADMIN },
+    });
+    collectivite = testCollectiviteAndUserResult.collectivite;
+    testUser = getAuthUserFromUserCredentials(
+      testCollectiviteAndUserResult.user
+    );
   });
 
   afterAll(async () => {
@@ -24,21 +43,26 @@ describe('IndicateurDefinitionThematiqueRouter', () => {
   });
 
   test('list existing thematiques associated with an indicateur', async () => {
-    const caller = router.createCaller({ user: yoloDodo });
+    const caller = router.createCaller({ user: testUser });
+
+    const thematique = await createThematique({
+      database: db,
+      thematiqueData: { nom: 'Thematique test' },
+    });
 
     const indicateurId = await createIndicateurPerso({
       caller,
       indicateurData: {
-        collectiviteId,
+        collectiviteId: collectivite.id,
         titre: 'Test indicateur',
-        thematiques: [{ id: 3 }], // assume that the thematique 3 exists
+        thematiques: [{ id: thematique.id }],
       },
     });
 
     const {
       data: [indicateur],
     } = await caller.indicateurs.indicateurs.list({
-      collectiviteId,
+      collectiviteId: collectivite.id,
       filters: {
         indicateurIds: [indicateurId],
       },
@@ -46,17 +70,26 @@ describe('IndicateurDefinitionThematiqueRouter', () => {
 
     expect(indicateur.thematiques).toHaveLength(1);
     expect(indicateur.thematiques).toContainEqual(
-      expect.objectContaining({ id: 3 })
+      expect.objectContaining({ id: thematique.id })
     );
   });
 
   test('list, update, delete thematiques associated with an indicateur and a collectivite', async () => {
-    const caller = router.createCaller({ user: yoloDodo });
+    const caller = router.createCaller({ user: testUser });
+
+    const thematique1 = await createThematique({
+      database: db,
+      thematiqueData: { nom: 'Thematique 1' },
+    });
+    const thematique2 = await createThematique({
+      database: db,
+      thematiqueData: { nom: 'Thematique 2' },
+    });
 
     const indicateurId = await createIndicateurPerso({
       caller,
       indicateurData: {
-        collectiviteId,
+        collectiviteId: collectivite.id,
         titre: 'Test indicateur',
       },
     });
@@ -64,7 +97,7 @@ describe('IndicateurDefinitionThematiqueRouter', () => {
     const {
       data: [indicateurBefore],
     } = await caller.indicateurs.indicateurs.list({
-      collectiviteId,
+      collectiviteId: collectivite.id,
       filters: {
         indicateurIds: [indicateurId],
       },
@@ -72,20 +105,18 @@ describe('IndicateurDefinitionThematiqueRouter', () => {
 
     expect(indicateurBefore.thematiques).toHaveLength(0);
 
-    // Check with new array of thematiques
-
     await caller.indicateurs.indicateurs.update({
       indicateurId,
-      collectiviteId,
+      collectiviteId: collectivite.id,
       indicateurFields: {
-        thematiques: [{ id: 4 }, { id: 5 }],
+        thematiques: [{ id: thematique1.id }, { id: thematique2.id }],
       },
     });
 
     const {
       data: [indicateurAfter],
     } = await caller.indicateurs.indicateurs.list({
-      collectiviteId,
+      collectiviteId: collectivite.id,
       filters: {
         indicateurIds: [indicateurId],
       },
@@ -93,26 +124,24 @@ describe('IndicateurDefinitionThematiqueRouter', () => {
 
     expect(indicateurAfter.thematiques).toHaveLength(2);
     expect(indicateurAfter.thematiques).toContainEqual(
-      expect.objectContaining({ id: 4 })
+      expect.objectContaining({ id: thematique1.id })
     );
     expect(indicateurAfter.thematiques).toContainEqual(
-      expect.objectContaining({ id: 5 })
+      expect.objectContaining({ id: thematique2.id })
     );
-
-    // Keep only one thematique
 
     await caller.indicateurs.indicateurs.update({
       indicateurId,
-      collectiviteId,
+      collectiviteId: collectivite.id,
       indicateurFields: {
-        thematiques: [{ id: 5 }],
+        thematiques: [{ id: thematique2.id }],
       },
     });
 
     const {
       data: [indicateurEmpty],
     } = await caller.indicateurs.indicateurs.list({
-      collectiviteId,
+      collectiviteId: collectivite.id,
       filters: {
         indicateurIds: [indicateurId],
       },
@@ -120,17 +149,26 @@ describe('IndicateurDefinitionThematiqueRouter', () => {
 
     expect(indicateurEmpty.thematiques).toHaveLength(1);
     expect(indicateurEmpty.thematiques).toContainEqual(
-      expect.objectContaining({ id: 5 })
+      expect.objectContaining({ id: thematique2.id })
     );
   });
 
   test('verify modified fields are updated', async () => {
-    const caller = router.createCaller({ user: yoloDodo });
+    const caller = router.createCaller({ user: testUser });
+
+    const thematique1 = await createThematique({
+      database: db,
+      thematiqueData: { nom: 'Thematique 1' },
+    });
+    const thematique2 = await createThematique({
+      database: db,
+      thematiqueData: { nom: 'Thematique 2' },
+    });
 
     const indicateurId = await createIndicateurPerso({
       caller,
       indicateurData: {
-        collectiviteId,
+        collectiviteId: collectivite.id,
         titre: 'Test indicateur',
       },
     });
@@ -138,7 +176,7 @@ describe('IndicateurDefinitionThematiqueRouter', () => {
     const {
       data: [indicateurBefore],
     } = await caller.indicateurs.indicateurs.list({
-      collectiviteId,
+      collectiviteId: collectivite.id,
       filters: {
         indicateurIds: [indicateurId],
       },
@@ -146,46 +184,59 @@ describe('IndicateurDefinitionThematiqueRouter', () => {
 
     await caller.indicateurs.indicateurs.update({
       indicateurId,
-      collectiviteId,
+      collectiviteId: collectivite.id,
       indicateurFields: {
-        thematiques: [{ id: 4 }, { id: 5 }],
+        thematiques: [{ id: thematique1.id }, { id: thematique2.id }],
       },
     });
 
     const {
       data: [indicateurAfter],
     } = await caller.indicateurs.indicateurs.list({
-      collectiviteId,
+      collectiviteId: collectivite.id,
       filters: {
         indicateurIds: [indicateurId],
       },
     });
 
-    expect(indicateurAfter.modifiedBy?.id).toEqual(yoloDodo.id);
+    expect(indicateurAfter.modifiedBy?.id).toEqual(testUser.id);
     expect(new Date(indicateurAfter.modifiedAt).getTime()).toBeGreaterThan(
       new Date(indicateurBefore.modifiedAt).getTime()
     );
   });
 
   test('cannot upsert thematiques of another collectivite', async () => {
-    const callerYoloDodo = router.createCaller({ user: yoloDodo });
+    const caller = router.createCaller({ user: testUser });
+
+    const { collectivite: otherCollectivite, cleanup } =
+      await addTestCollectivite(db);
+    onTestFinished(cleanup);
+
+    const thematique1 = await createThematique({
+      database: db,
+      thematiqueData: { nom: 'Thematique 1' },
+    });
+    const thematique2 = await createThematique({
+      database: db,
+      thematiqueData: { nom: 'Thematique 2' },
+    });
 
     const indicateurId = await createIndicateurPerso({
-      caller: callerYoloDodo,
+      caller,
       indicateurData: {
-        collectiviteId,
+        collectiviteId: collectivite.id,
         titre: 'Test indicateur',
       },
     });
 
     await expect(() =>
-      callerYoloDodo.indicateurs.indicateurs.update({
+      caller.indicateurs.indicateurs.update({
         indicateurId,
-        collectiviteId: 100,
+        collectiviteId: otherCollectivite.id,
         indicateurFields: {
-          thematiques: [{ id: 4 }, { id: 5 }],
+          thematiques: [{ id: thematique1.id }, { id: thematique2.id }],
         },
       })
-    ).rejects.toThrowError(/Droits insuffisants/);
+    ).rejects.toThrow(/Droits insuffisants/);
   });
 });

--- a/apps/backend/src/referentiels/referentiels.module.ts
+++ b/apps/backend/src/referentiels/referentiels.module.ts
@@ -16,6 +16,7 @@ import { ListSnapshotsController } from '@tet/backend/referentiels/snapshots/lis
 import { CollectivitesModule } from '../collectivites/collectivites.module';
 import { PersonnalisationsModule } from '../collectivites/personnalisations/personnalisations.module';
 import { SheetModule } from '../utils/google-sheets/sheet.module';
+import { TransactionModule } from '../utils/transaction/transaction.module';
 import { ActionPersonnalisationsRouter } from './action-personnalisations/action-personnalisations.router';
 import { ActionPersonnalisationsService } from './action-personnalisations/action-personnalisations.service';
 import ScoresService from './compute-score/scores.service';
@@ -97,6 +98,7 @@ import { UpdateActionStatutService } from './update-action-statut/update-action-
     IndicateursModule,
     FichesModule,
     ReferentielsCoreModule,
+    TransactionModule,
     BullModule.registerQueue({
       name: PREUVES_ARCHIVE_QUEUE_NAME,
       defaultJobOptions: PREUVES_ARCHIVE_JOB_OPTIONS,

--- a/apps/backend/src/referentiels/reset-display-preferences/reset-display-preferences.router.e2e-spec.ts
+++ b/apps/backend/src/referentiels/reset-display-preferences/reset-display-preferences.router.e2e-spec.ts
@@ -77,6 +77,11 @@ describe('ResetDisplayPreferencesRouter', () => {
       eci: false,
       te: true,
     });
+    expect(result.referentiels).toEqual({
+      cae: { display: false, mode: 'archived' },
+      eci: { display: false, mode: 'archived' },
+      te: { display: true, mode: 'write' },
+    });
   });
 
   test('Support user can reset collectivite referentiels display preferences', async () => {
@@ -98,6 +103,45 @@ describe('ResetDisplayPreferencesRouter', () => {
       cae: false,
       eci: false,
       te: true,
+    });
+    expect(result.referentiels).toEqual({
+      cae: { display: false, mode: 'archived' },
+      eci: { display: false, mode: 'archived' },
+      te: { display: true, mode: 'write' },
+    });
+  });
+
+  test('CAE is displayed when collectivite has enough CAE activity and support user resets display preferences', async () => {
+    const editorUserCaller = router.createCaller({ user: editorUser });
+    const trpcClient = createTRPCClientFromCaller(editorUserCaller);
+    await seedCollectiviteReferentielDisplayActivity({
+      trpcClient,
+      collectiviteId: collectivite.id,
+      referentiel: ReferentielIdEnum.CAE,
+    });
+    const caller = router.createCaller({ user: authUser });
+    const { cleanup } = await addAndEnableUserSuperAdminMode({
+      app,
+      caller,
+      userId: authUser.id,
+    });
+    onTestFinished(cleanup);
+
+    const result =
+      await caller.referentiels.preferences.resetCollectiviteDisplayPreferences(
+        {
+          collectiviteId: collectivite.id,
+        }
+      );
+    expect(getReferentielDisplayMap(result.referentiels)).toEqual({
+      cae: true,
+      eci: false,
+      te: true,
+    });
+    expect(result.referentiels).toEqual({
+      cae: { display: true, mode: 'write' },
+      eci: { display: false, mode: 'archived' },
+      te: { display: true, mode: 'readonly' },
     });
   });
 
@@ -128,6 +172,52 @@ describe('ResetDisplayPreferencesRouter', () => {
       eci: true,
       te: true,
     });
+    expect(result.referentiels).toEqual({
+      cae: { display: false, mode: 'archived' },
+      eci: { display: true, mode: 'write' },
+      te: { display: true, mode: 'readonly' },
+    });
+  });
+
+  test('Reset is a no-op when te.populatedFromCaeEci is already set', async () => {
+    const { collectivite: isolatedCollectivite, cleanup: collectiviteCleanup } =
+      await addTestCollectiviteAndUser(databaseService);
+    onTestFinished(collectiviteCleanup);
+
+    const caller = router.createCaller({ user: authUser });
+    const { cleanup } = await addAndEnableUserSuperAdminMode({
+      app,
+      caller,
+      userId: authUser.id,
+    });
+    onTestFinished(cleanup);
+
+    const postSwitchPreferences = {
+      cae: { display: false, mode: 'archived' as const },
+      eci: { display: false, mode: 'archived' as const },
+      te: {
+        display: true,
+        mode: 'write' as const,
+        populatedFromCaeEci: {
+          populatedAt: '2026-06-01T00:00:00.000Z',
+          populatedBy: authUser.id,
+        },
+      },
+    };
+
+    await caller.collectivites.preferences.update({
+      collectiviteId: isolatedCollectivite.id,
+      preferences: { referentiels: postSwitchPreferences },
+    });
+
+    const result =
+      await caller.referentiels.preferences.resetCollectiviteDisplayPreferences(
+        {
+          collectiviteId: isolatedCollectivite.id,
+        }
+      );
+
+    expect(result.referentiels).toEqual(postSwitchPreferences);
   });
 
   test('Non-support user cannot reset collectivite referentiels display preferences', async () => {

--- a/apps/backend/src/referentiels/reset-display-preferences/reset-display-preferences.service.ts
+++ b/apps/backend/src/referentiels/reset-display-preferences/reset-display-preferences.service.ts
@@ -7,10 +7,13 @@ import { actionRelationTable } from '@tet/backend/referentiels/models/action-rel
 import { actionStatutTable } from '@tet/backend/referentiels/models/action-statut.table';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import type { Result } from '@tet/backend/utils/result.type';
+import { success } from '@tet/backend/utils/result.type';
+import { TransactionManager } from '@tet/backend/utils/transaction/transaction-manager.service';
 import {
   collectiviteReferentielDisplayIds,
+  defaultCollectivitePreferences,
+  deriveReferentielPreferences,
   getReferentielDisplayMap,
-  referentielPreferencesFromDisplayMap,
   type CollectivitePreferences,
   type CollectiviteReferentielDisplayId,
 } from '@tet/domain/collectivites';
@@ -44,12 +47,57 @@ export class ResetDisplayPreferencesService {
 
   constructor(
     private readonly databaseService: DatabaseService,
-    private readonly repository: CollectivitePreferencesRepository
+    private readonly repository: CollectivitePreferencesRepository,
+    private readonly transactionManager: TransactionManager
   ) {}
 
   async resetCollectiviteDisplayPreferences(
     collectiviteId: number
   ): Promise<Result<CollectivitePreferences, CollectivitePreferencesError>> {
+    // le calcul de l'affichage ne dépend que de l'activité (statuts/commentaires),
+    // pas des préférences : on peut le faire hors transaction pour réduire la durée du verrou
+    const display = await this.computeReferentielDisplay(collectiviteId);
+
+    // verrou + revalidation + écriture dans une transaction : la lecture verrouillée
+    // (FOR UPDATE) sérialise les resets/bascules concurrents, et on revalide
+    // `populatedFromCaeEci` juste avant de persister pour éviter d'écraser une bascule
+    return this.transactionManager.executeSingle<
+      CollectivitePreferences,
+      CollectivitePreferencesError
+    >(async (tx) => {
+      const existingResult =
+        await this.repository.getPreferencesByCollectiviteId(collectiviteId, {
+          withLock: true,
+          tx,
+        });
+      if (!existingResult.success) {
+        return existingResult;
+      }
+
+      const existingPreferences =
+        existingResult.data ?? defaultCollectivitePreferences;
+      // revalide l'état courant immédiatement avant l'écriture : si la collectivité
+      // a déjà basculé vers TE, le reset est un no-op
+      if (existingPreferences.referentiels.te.populatedFromCaeEci) {
+        return success(existingPreferences);
+      }
+
+      return this.repository.updatePreferences(
+        collectiviteId,
+        {
+          referentiels: deriveReferentielPreferences(
+            { caeEngaged: display.cae, eciEngaged: display.eci },
+            existingPreferences.referentiels
+          ),
+        },
+        tx
+      );
+    });
+  }
+
+  private async computeReferentielDisplay(
+    collectiviteId: number
+  ): Promise<Record<CollectiviteReferentielDisplayId, boolean>> {
     const statutRows = await this.databaseService.db
       .select({
         referentiel: actionRelationTable.referentiel,
@@ -129,9 +177,7 @@ export class ResetDisplayPreferencesService {
       });
     }
 
-    return this.repository.updatePreferences(collectiviteId, {
-      referentiels: referentielPreferencesFromDisplayMap(display),
-    });
+    return display;
   }
 
   async resetAllCollectivitesDisplayPreferences(): Promise<ResetAllCollectivitesDisplayPreferencesOutput> {

--- a/packages/domain/src/collectivites/collectivite-referentiel-preferences.rules.spec.ts
+++ b/packages/domain/src/collectivites/collectivite-referentiel-preferences.rules.spec.ts
@@ -1,11 +1,86 @@
 import { describe, expect, it } from 'vitest';
+import type { CollectiviteReferentielPreferences } from './collectivite-preferences.schema';
 import {
+  deriveReferentielPreferences,
   referentielPreferencesFromDisplayMap,
   toggleReferentielDisplayPreference,
 } from './collectivite-referentiel-preferences.rules';
 
+const postSwitchTePreferences: CollectiviteReferentielPreferences = {
+  cae: { display: false, mode: 'archived' },
+  eci: { display: false, mode: 'archived' },
+  te: {
+    display: true,
+    mode: 'write',
+    populatedFromCaeEci: {
+      populatedAt: '2026-06-01T00:00:00.000Z',
+      populatedBy: 'user-id',
+    },
+  },
+};
+
+describe('deriveReferentielPreferences', () => {
+  it('positionne te en write et masque cae/eci quand aucun référentiel engagé', () => {
+    expect(
+      deriveReferentielPreferences({ caeEngaged: false, eciEngaged: false })
+    ).toEqual({
+      cae: { display: false, mode: 'archived' },
+      eci: { display: false, mode: 'archived' },
+      te: { display: true, mode: 'write' },
+    });
+  });
+
+  it('positionne te en readonly quand au moins un référentiel est engagé', () => {
+    expect(
+      deriveReferentielPreferences({ caeEngaged: true, eciEngaged: false })
+    ).toEqual({
+      cae: { display: true, mode: 'write' },
+      eci: { display: false, mode: 'archived' },
+      te: { display: true, mode: 'readonly' },
+    });
+
+    expect(
+      deriveReferentielPreferences({ caeEngaged: false, eciEngaged: true })
+    ).toEqual({
+      cae: { display: false, mode: 'archived' },
+      eci: { display: true, mode: 'write' },
+      te: { display: true, mode: 'readonly' },
+    });
+
+    expect(
+      deriveReferentielPreferences({ caeEngaged: true, eciEngaged: true })
+    ).toEqual({
+      cae: { display: true, mode: 'write' },
+      eci: { display: true, mode: 'write' },
+      te: { display: true, mode: 'readonly' },
+    });
+  });
+
+  it('retourne les prefs existantes inchangées si populatedFromCaeEci est renseigné', () => {
+    expect(
+      deriveReferentielPreferences(
+        { caeEngaged: true, eciEngaged: true },
+        postSwitchTePreferences
+      )
+    ).toBe(postSwitchTePreferences);
+  });
+
+  it('respecte l’invariant archived implique display false', () => {
+    const result = deriveReferentielPreferences({
+      caeEngaged: false,
+      eciEngaged: false,
+    });
+
+    for (const pref of Object.values(result)) {
+      if (pref.mode === 'archived') {
+        expect(pref.display).toBe(false);
+      }
+    }
+  });
+});
+
 describe('collectivite-referentiel-preferences.rules', () => {
-  it('mappe display vers mode (te en readonly)', () => {
+  it('mappe display vers mode (te en readonly si engagée)', () => {
     expect(
       referentielPreferencesFromDisplayMap({
         cae: false,
@@ -19,7 +94,21 @@ describe('collectivite-referentiel-preferences.rules', () => {
     });
   });
 
-  it('préserve populatedFromCaeEci lors du mapping display', () => {
+  it('mappe display vers mode (te en write si non engagée)', () => {
+    expect(
+      referentielPreferencesFromDisplayMap({
+        cae: false,
+        eci: false,
+        te: true,
+      })
+    ).toEqual({
+      cae: { display: false, mode: 'archived' },
+      eci: { display: false, mode: 'archived' },
+      te: { display: true, mode: 'write' },
+    });
+  });
+
+  it('retourne les prefs existantes inchangées si populatedFromCaeEci est renseigné', () => {
     const existing = {
       cae: { display: true, mode: 'write' as const },
       eci: { display: true, mode: 'write' as const },
@@ -37,8 +126,8 @@ describe('collectivite-referentiel-preferences.rules', () => {
       referentielPreferencesFromDisplayMap(
         { cae: true, eci: true, te: true },
         existing
-      ).te.populatedFromCaeEci
-    ).toEqual(existing.te.populatedFromCaeEci);
+      )
+    ).toBe(existing);
   });
 
   it('bascule le display d’un référentiel', () => {

--- a/packages/domain/src/collectivites/collectivite-referentiel-preferences.rules.ts
+++ b/packages/domain/src/collectivites/collectivite-referentiel-preferences.rules.ts
@@ -16,20 +16,56 @@ export function preferenceFromDisplay(
     : { display: false, mode: 'archived' };
 }
 
-/** Mapping display → { display, mode } — PR3 remplacera te.mode par deriveReferentielPreferences. */
+export type DeriveReferentielPreferencesInput = {
+  caeEngaged: boolean;
+  eciEngaged: boolean;
+};
+
+export function deriveReferentielPreferences(
+  input: DeriveReferentielPreferencesInput,
+  existing?: CollectiviteReferentielPreferences
+): CollectiviteReferentielPreferences {
+  if (existing?.te.populatedFromCaeEci) {
+    return existing;
+  }
+
+  const { caeEngaged, eciEngaged } = input;
+  const collectiviteEngaged = caeEngaged || eciEngaged;
+
+  if (collectiviteEngaged) {
+    return {
+      cae: preferenceFromDisplay(caeEngaged, 'write'),
+      eci: preferenceFromDisplay(eciEngaged, 'write'),
+      te: preferenceFromDisplay(true, 'readonly'),
+    };
+  }
+
+  return {
+    cae: preferenceFromDisplay(false, 'write'),
+    eci: preferenceFromDisplay(false, 'write'),
+    te: preferenceFromDisplay(true, 'write'),
+  };
+}
+
 export function referentielPreferencesFromDisplayMap(
   display: ReferentielDisplayMap,
   existing?: CollectiviteReferentielPreferences
 ): CollectiviteReferentielPreferences {
+  const derived = deriveReferentielPreferences(
+    { caeEngaged: display.cae, eciEngaged: display.eci },
+    existing
+  );
+
+  if (existing?.te.populatedFromCaeEci) {
+    return derived;
+  }
+
   return {
-    cae: preferenceFromDisplay(display.cae, 'write'),
-    eci: preferenceFromDisplay(display.eci, 'write'),
-    te: {
-      ...preferenceFromDisplay(display.te, 'readonly'),
-      ...(existing?.te.populatedFromCaeEci && {
-        populatedFromCaeEci: existing.te.populatedFromCaeEci,
-      }),
-    },
+    ...derived,
+    te: preferenceFromDisplay(
+      display.te,
+      derived.te.mode as Exclude<ReferentielMode, 'archived'>
+    ),
   };
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Les préférences d’affichage des référentiels sont désormais dérivées plus finement à partir de l’engagement CAE/ECI, avec un mode TE mieux harmonisé (lecture seule vs écriture) et des référentiels archivés masqués.
* **Corrections de bugs**
  * La réinitialisation devient un no-op lorsque TE est déjà renseigné à partir CAE/ECI, et conserve strictement les préférences existantes quand aucun recalcul n’est requis.
  * Les mises à jour après réinitialisation reflètent plus précisément l’état CAE/ECI.
* **Tests**
  * Renforcement des tests métier et e2e, avec davantage d’assertions détaillées et une couverture dédiée au cas no-op.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->