### PR TITLE
test(audit-labellisation): gating par role des sections candidature et acte d'engagement

### DIFF
--- a/apps/app/src/referentiels/audit-labellisation/checklist/table/sections/acte-engagement.section.spec.tsx
+++ b/apps/app/src/referentiels/audit-labellisation/checklist/table/sections/acte-engagement.section.spec.tsx
@@ -1,0 +1,116 @@
+import { render, screen } from '@testing-library/react';
+import { appLabels } from '../../../../../labels/catalog';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { usePreuvesLabellisation } from '../../../../labellisations/useCycleLabellisation';
+import { AuditViewerRole } from '../../../audit-badge-status/types';
+import { useChecklist } from '../../../checklist.context';
+import { ActeEngagementSection } from './acte-engagement.section';
+
+vi.mock('../../../checklist.context', () => ({
+  useChecklist: vi.fn(),
+}));
+
+vi.mock('../../../../labellisations/useCycleLabellisation', () => ({
+  usePreuvesLabellisation: vi.fn(),
+}));
+
+vi.mock('./upload-preuve-button', () => ({
+  UploadPreuveButton: ({ label }: { label: string }) => (
+    <button>{label}</button>
+  ),
+}));
+
+const mockedUseChecklist = vi.mocked(useChecklist);
+const mockedUsePreuvesLabellisation = vi.mocked(usePreuvesLabellisation);
+
+const setViewerRole = (viewerRole: AuditViewerRole): void => {
+  mockedUseChecklist.mockReturnValue({
+    cycle: { viewerRole },
+  } as unknown as ReturnType<typeof useChecklist>);
+};
+
+const setActeDepose = (filename: string): void => {
+  mockedUsePreuvesLabellisation.mockReturnValue({
+    data: [{ id: 99, fichier: { filename } }],
+    isLoading: false,
+  } as unknown as ReturnType<typeof usePreuvesLabellisation>);
+};
+
+beforeEach(() => {
+  mockedUsePreuvesLabellisation.mockReturnValue({
+    data: [],
+    isLoading: false,
+  } as unknown as ReturnType<typeof usePreuvesLabellisation>);
+});
+
+describe('ActeEngagementSection — acte signé (état signed)', () => {
+  it("affiche l'acte déposé et le bouton « Remplacer » pour un éditeur", () => {
+    setViewerRole('auditee');
+    setActeDepose('acte-signe.pdf');
+
+    render(<ActeEngagementSection signed={true} demandeId={42} />);
+
+    expect(screen.getByText('acte-signe.pdf')).toBeDefined();
+    expect(
+      screen.getByRole('button', { name: appLabels.remplacerLeFichier })
+    ).toBeDefined();
+  });
+
+  it("affiche l'acte déposé sans bouton « Remplacer » pour un auditeur", () => {
+    setViewerRole('auditor');
+    setActeDepose('acte-signe.pdf');
+
+    render(<ActeEngagementSection signed={true} demandeId={42} />);
+
+    expect(screen.getByText('acte-signe.pdf')).toBeDefined();
+    expect(
+      screen.queryByRole('button', { name: appLabels.remplacerLeFichier })
+    ).toBeNull();
+  });
+
+  it("affiche l'acte déposé sans bouton « Remplacer » pour un visiteur", () => {
+    setViewerRole('other');
+    setActeDepose('acte-signe.pdf');
+
+    render(<ActeEngagementSection signed={true} demandeId={42} />);
+
+    expect(screen.getByText('acte-signe.pdf')).toBeDefined();
+    expect(
+      screen.queryByRole('button', { name: appLabels.remplacerLeFichier })
+    ).toBeNull();
+  });
+});
+
+describe('ActeEngagementSection — acte non déposé (état uploadable)', () => {
+  it("affiche le bouton de téléversement de l'acte pour un éditeur", () => {
+    setViewerRole('auditee');
+
+    render(<ActeEngagementSection signed={false} demandeId={null} />);
+
+    expect(
+      screen.getByRole('button', { name: appLabels.acteEngagementUploadButton })
+    ).toBeDefined();
+  });
+});
+
+describe('ActeEngagementSection — masqué (état hidden)', () => {
+  it('ne rend rien pour un auditeur', () => {
+    setViewerRole('auditor');
+
+    const { container } = render(
+      <ActeEngagementSection signed={false} demandeId={null} />
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('ne rend rien pour un visiteur', () => {
+    setViewerRole('other');
+
+    const { container } = render(
+      <ActeEngagementSection signed={false} demandeId={null} />
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/apps/app/src/referentiels/audit-labellisation/checklist/table/sections/candidature-documents.section.spec.tsx
+++ b/apps/app/src/referentiels/audit-labellisation/checklist/table/sections/candidature-documents.section.spec.tsx
@@ -1,0 +1,243 @@
+import { render, screen } from '@testing-library/react';
+import { appLabels } from '../../../../../labels/catalog';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { usePreuvesLabellisation } from '../../../../labellisations/useCycleLabellisation';
+import { AuditViewerRole } from '../../../audit-badge-status/types';
+import { Parcours } from '../../../checklist-view-model';
+import { useChecklist } from '../../../checklist.context';
+import { CandidatureDocumentsRow } from './candidature-documents.section';
+
+vi.mock('../../../checklist.context', () => ({
+  useChecklist: vi.fn(),
+}));
+
+vi.mock('../../../../labellisations/useCycleLabellisation', () => ({
+  usePreuvesLabellisation: vi.fn(),
+}));
+
+vi.mock('./upload-preuve-button', () => ({
+  UploadPreuveButton: ({ label }: { label: string }) => (
+    <button>{label}</button>
+  ),
+}));
+
+vi.mock('./rename-preuve-button', () => ({
+  RenamePreuveButton: () => <button>{'Renommer le fichier'}</button>,
+}));
+
+vi.mock('./delete-preuve-button', () => ({
+  DeletePreuveButton: () => <button>{'Supprimer'}</button>,
+}));
+
+const mockedUseChecklist = vi.mocked(useChecklist);
+const mockedUsePreuvesLabellisation = vi.mocked(usePreuvesLabellisation);
+
+const setChecklist = (
+  parcours: Parcours | null,
+  viewerRole: AuditViewerRole = 'auditee'
+): void => {
+  mockedUseChecklist.mockReturnValue({
+    parcours,
+    referentielId: 'cae',
+    cycle: { viewerRole },
+  } as unknown as ReturnType<typeof useChecklist>);
+};
+
+const toParcours = ({
+  demandeId,
+  canModifyCandidatureDocuments,
+}: {
+  demandeId: number | null;
+  canModifyCandidatureDocuments: boolean;
+}): Parcours =>
+  ({
+    acteEngagement: { signed: true, demandeId },
+    canModifyCandidatureDocuments,
+  } as unknown as Parcours);
+
+const setPreuves = (
+  preuves: Array<{ id: number; fichier: { filename: string } }>
+): void => {
+  mockedUsePreuvesLabellisation.mockReturnValue({
+    data: preuves,
+  } as unknown as ReturnType<typeof usePreuvesLabellisation>);
+};
+
+const renderRow = () =>
+  render(
+    <table>
+      <CandidatureDocumentsRow />
+    </table>
+  );
+
+beforeEach(() => {
+  mockedUseChecklist.mockReset();
+  mockedUsePreuvesLabellisation.mockReturnValue({
+    data: [],
+  } as unknown as ReturnType<typeof usePreuvesLabellisation>);
+});
+
+describe('CandidatureDocumentsRow — bouton d\'ajout', () => {
+  it('ne rend rien quand le parcours est absent', () => {
+    setChecklist(null);
+
+    renderRow();
+
+    expect(
+      screen.queryByText(
+        appLabels.labellisationAjouterDocumentsOfficielsCandidature
+      )
+    ).toBeNull();
+  });
+
+  it("affiche le critère sans bouton d'ajout quand aucune demande n'existe", () => {
+    setChecklist(
+      toParcours({ demandeId: null, canModifyCandidatureDocuments: true })
+    );
+
+    renderRow();
+
+    expect(
+      screen.getByText(
+        appLabels.labellisationAjouterDocumentsOfficielsCandidature
+      )
+    ).toBeDefined();
+    expect(
+      screen.queryByRole('button', { name: appLabels.ajouterDocument })
+    ).toBeNull();
+  });
+
+  it("affiche le bouton d'ajout pour un éditeur quand les documents sont modifiables", () => {
+    setChecklist(
+      toParcours({ demandeId: 42, canModifyCandidatureDocuments: true })
+    );
+
+    renderRow();
+
+    expect(
+      screen.getByRole('button', { name: appLabels.ajouterDocument })
+    ).toBeDefined();
+  });
+
+  it("masque le bouton d'ajout une fois l'audit validé", () => {
+    setChecklist(
+      toParcours({ demandeId: 42, canModifyCandidatureDocuments: false })
+    );
+
+    renderRow();
+
+    expect(
+      screen.queryByRole('button', { name: appLabels.ajouterDocument })
+    ).toBeNull();
+  });
+
+  it("masque le bouton d'ajout pour un auditeur", () => {
+    setChecklist(
+      toParcours({ demandeId: 42, canModifyCandidatureDocuments: true }),
+      'auditor'
+    );
+
+    renderRow();
+
+    expect(
+      screen.queryByRole('button', { name: appLabels.ajouterDocument })
+    ).toBeNull();
+  });
+
+  it("masque le bouton d'ajout pour un visiteur", () => {
+    setChecklist(
+      toParcours({ demandeId: 42, canModifyCandidatureDocuments: true }),
+      'other'
+    );
+
+    renderRow();
+
+    expect(
+      screen.queryByRole('button', { name: appLabels.ajouterDocument })
+    ).toBeNull();
+  });
+});
+
+describe('CandidatureDocumentsRow — actions par document', () => {
+  it('affiche « Renommer » et « Supprimer » par document pour un éditeur quand les documents sont modifiables', () => {
+    setChecklist(
+      toParcours({ demandeId: 42, canModifyCandidatureDocuments: true })
+    );
+    setPreuves([
+      { id: 1, fichier: { filename: 'doc-a.pdf' } },
+      { id: 2, fichier: { filename: 'doc-b.pdf' } },
+    ]);
+
+    renderRow();
+
+    expect(
+      screen.getAllByRole('button', { name: appLabels.renommerLeFichier })
+    ).toHaveLength(2);
+    expect(
+      screen.getAllByRole('button', { name: appLabels.supprimer })
+    ).toHaveLength(2);
+  });
+
+  it("n'expose aucun bouton « Remplacer » par document de candidature", () => {
+    setChecklist(
+      toParcours({ demandeId: 42, canModifyCandidatureDocuments: true })
+    );
+    setPreuves([{ id: 1, fichier: { filename: 'doc-a.pdf' } }]);
+
+    renderRow();
+
+    expect(
+      screen.queryByRole('button', { name: appLabels.remplacerLeFichier })
+    ).toBeNull();
+  });
+
+  it("masque « Renommer » et « Supprimer » une fois l'audit validé", () => {
+    setChecklist(
+      toParcours({ demandeId: 42, canModifyCandidatureDocuments: false })
+    );
+    setPreuves([{ id: 1, fichier: { filename: 'doc-a.pdf' } }]);
+
+    renderRow();
+
+    expect(
+      screen.queryByRole('button', { name: appLabels.renommerLeFichier })
+    ).toBeNull();
+    expect(
+      screen.queryByRole('button', { name: appLabels.supprimer })
+    ).toBeNull();
+  });
+
+  it('masque « Renommer » et « Supprimer » pour un auditeur', () => {
+    setChecklist(
+      toParcours({ demandeId: 42, canModifyCandidatureDocuments: true }),
+      'auditor'
+    );
+    setPreuves([{ id: 1, fichier: { filename: 'doc-a.pdf' } }]);
+
+    renderRow();
+
+    expect(
+      screen.queryByRole('button', { name: appLabels.renommerLeFichier })
+    ).toBeNull();
+    expect(
+      screen.queryByRole('button', { name: appLabels.supprimer })
+    ).toBeNull();
+  });
+
+  it('masque « Renommer » et « Supprimer » pour un visiteur', () => {
+    setChecklist(
+      toParcours({ demandeId: 42, canModifyCandidatureDocuments: true }),
+      'other'
+    );
+    setPreuves([{ id: 1, fichier: { filename: 'doc-a.pdf' } }]);
+
+    renderRow();
+
+    expect(
+      screen.queryByRole('button', { name: appLabels.renommerLeFichier })
+    ).toBeNull();
+    expect(
+      screen.queryByRole('button', { name: appLabels.supprimer })
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Contexte

Audit de couverture de la branche courante contre \`audit-badge-component\` : le plus gros trou identifie etait le **gating par \`viewerRole\`** (auditee / auditeur / visiteur) des sections de la checklist de labellisation.

Les specs composant \`candidature-documents.section.spec.tsx\` et \`acte-engagement.section.spec.tsx\` (presentes dans \`audit-badge-component\`) avaient ete supprimees lors de la divergence. Elles etaient les **seules** a verifier que les boutons d'edition (ajouter / renommer / supprimer / remplacer) sont masques pour un auditeur et un visiteur. La regle domaine \`canModifyCandidatureDocuments\` est role-agnostique (elle ne regarde que \`audit.valide\`), donc le gate \`viewerRole === 'auditee'\` ne vivait plus que dans les composants, sans aucun test a aucune couche.

## Nature

\`test\` uniquement. Aucune ligne de code de production modifiee.

## Ce qui est couvert (17 tests)

**\`acte-engagement.section\`** (machine a etats signed / uploadable / hidden) :
- editeur : acte depose + bouton Remplacer ; etat uploadable affiche le bouton de televersement
- auditeur / visiteur : acte depose visible mais **sans** Remplacer ; etat non-depose entierement masque

**\`candidature-documents.section\`** :
- editeur : bouton d'ajout + Renommer/Supprimer par document
- audit valide : ajout et actions par document masques (verrou)
- auditeur / visiteur : ajout et actions par document masques (gate de role)
- invariant negatif : un document de candidature n'expose jamais de bouton Remplacer

## Surface de review

- 2 fichiers, purement mecaniques (specs colocalisees).
- Pattern calque sur le frere accepte \`checklist/checklist-actions.spec.tsx\` : on mocke \`useChecklist\` + \`usePreuvesLabellisation\` et on stube les boutons-feuilles porteurs de hooks/modales, conformement a la convention apps/app (\"les composants tRPC/React-Query ne sont pas testes unitairement ; on isole la logique\").

## Hypotheses / zones a confiance limitee

- Import de \`appLabels\` en chemin relatif (et non via l'alias \`@/app\`) car les \`.spec\` sont hors \`tsconfig.project.json\` : meme contrainte que \`archives-panel/data/use-download-archive.spec.ts\`.
- Les stubs rename/delete rendent les libelles litteraux (\"Renommer le fichier\", \"Supprimer\") egaux aux valeurs \`appLabels.*\` asserted : le test verifie le **gating** (presence/absence/comptage), pas le texte de copie.

## Recherche anti-duplication

- Cherche : specs existantes des deux sections (supprimees), \`checklist-actions.spec.tsx\` (pattern reutilise), e2e \`checklist-role-mesures\` / \`cloturer-audit\`. La branche soeur \`coverage/labellisation-status-candidature-verrou\` couvre le **verrou audit-valide** (dimension logique), distincte du **gating par role** couvert ici : pas de recouvrement.

## Note de base

Branche basee sur \`main\` (et non sur la branche de travail courante) car les deux composants testes sont deja sur \`main\`, identiques : les tests s'y appliquent tels quels et la PR reste un diff de 2 fichiers. Peut etre re-ciblee en stack si souhaite.