### PR TITLE
test(ui): badge « À compléter » de MetadataItem

### DIFF
--- a/apps/app/src/ui/metadata-line/metadata-item.spec.tsx
+++ b/apps/app/src/ui/metadata-line/metadata-item.spec.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { appLabels } from '../../labels/catalog';
+import { MetadataItem } from './metadata-item';
+
+describe('MetadataItem — valeur à compléter', () => {
+  it('affiche le badge « À compléter » quand la valeur est nulle', () => {
+    render(<MetadataItem icon="user-line" label="Pilote" value={null} />);
+
+    expect(screen.getByText(appLabels.aCompleterMaj)).toBeDefined();
+  });
+
+  it('affiche le badge « À compléter » quand la valeur est une chaîne vide', () => {
+    render(<MetadataItem icon="user-line" label="Pilote" value="" />);
+
+    expect(screen.getByText(appLabels.aCompleterMaj)).toBeDefined();
+  });
+
+  it('affiche la valeur et masque le badge quand une valeur est présente', () => {
+    render(
+      <MetadataItem icon="user-line" label="Pilote" value="Jean Dupont" />
+    );
+
+    expect(screen.getByText('Jean Dupont')).toBeDefined();
+    expect(screen.queryByText(appLabels.aCompleterMaj)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Contexte

Trou de couverture identifie lors de l'audit contre \`audit-badge-component\`.

Le badge \"À compléter\" affiche depuis le primitif partage \`MetadataItem\` quand sa valeur est nulle ou vide (\`isNil(value) || value === '' ? appLabels.aCompleterMaj : value\`). Cette logique vivait auparavant dans \`RoleMesureItem\` (teste via \`role-mesure.item.spec.tsx\`, supprimee lors de la divergence) ; depuis qu'elle a ete extraite dans \`MetadataItem\`, **aucun test ne la couvre** (aucune spec ne reference \`MetadataItem\` ni \`aCompleterMaj\`).

## Nature

\`test\` uniquement. Aucune ligne de production modifiee.

## Cible choisie

\`MetadataItem\` est un **composant feuille pur** (aucun hook tRPC/React-Query). On le teste directement plutot que de restaurer l'ancienne spec \`RoleMesureItem\` qui mockait \`useRoleMesure\` + \`useRoleDropdown\` : conforme a la convention apps/app (\"prefer pure leaf components and pure-logic specs\") et au principe \"devoir mocker signale une fonction qui devrait retourner la donnee\". Tester le primitif protege en plus **tous** ses consommateurs (header de checklist, ligne de metadonnees), pas seulement \`RoleMesureItem\`.

## Couverture (3 tests)

- valeur \`null\` -> badge « À compléter »
- valeur \`''\` -> badge « À compléter »
- valeur presente -> la valeur s'affiche, pas de badge

## Surface de review

- 1 fichier, spec colocalisee.
- Import de \`appLabels\` en chemin relatif (les \`.spec\` sont hors \`tsconfig.project.json\`, l'alias \`@/app\` n'y resout pas).

## Recherche anti-duplication

Cherche : \`rg \"MetadataItem\" --glob '*.spec.*'\` -> aucune spec existante ; \`aCompleterMaj\` reference nulle part en test. Pas de doublon.

## Note de perimetre

Issu du meme audit que #4633 (gating par role des sections checklist). Le point n°2 de l'audit (edition du rapport d'audit par l'auditeur, fenetre 15j) est couvert par #4575 et sort de ce perimetre.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Ajout de tests unitaires pour vérifier l’affichage de `MetadataItem` selon la valeur reçue.
  * Le composant affiche désormais un badge lorsque la valeur est vide ou absente, et affiche correctement la valeur lorsqu’elle est renseignée.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->