### PR TITLE
test(audit-labellisation): e2e scroll SPA checklist vers la mesure (header sticky)

### DIFF
--- a/e2e/tests/referentiels/labellisations/audit-labellisation-to-action-scroll.spec.ts
+++ b/e2e/tests/referentiels/labellisations/audit-labellisation-to-action-scroll.spec.ts
@@ -1,0 +1,57 @@
+import { expect } from '@playwright/test';
+import { ReferentielId } from '@tet/domain/referentiels';
+import { testWithReferentiels as test } from '../referentiels.fixture';
+import {
+  stickyHeaderBottom,
+  waitForScrollSettled,
+} from '../sticky-header.helpers';
+
+const referentiel: ReferentielId = 'eci';
+
+test.describe(
+  "Navigation client-side audit-labellisation → page action : scroll vers le hash",
+  () => {
+    test(
+      "clic « Voir la mesure » : le header de la sous-action cible n'est pas masqué par le header sticky",
+      async ({ page, collectivites, newAuditLabellisationPom }) => {
+        const { collectivite, user } =
+          await collectivites.addCollectiviteAndUser({
+            userArgs: { autoLogin: true },
+          });
+        const collectiviteId = collectivite.data.id;
+        await user.precomputeReferentielSnapshot(collectiviteId, referentiel);
+
+        await newAuditLabellisationPom.goto(collectiviteId, referentiel);
+
+        const voirLaMesureLink = page
+          .getByRole('link', { name: 'Voir la mesure' })
+          .first();
+        await expect(voirLaMesureLink).toBeVisible();
+        await voirLaMesureLink.click();
+
+        await expect(page).toHaveURL(/#eci_/);
+        const hash = new URL(page.url()).hash.slice(1);
+
+        const segments = hash.split('.');
+        const candidateIds = Array.from({ length: 3 }, (_, depth) =>
+          segments.slice(0, segments.length - depth).join('.')
+        ).filter(Boolean);
+        const targetCard = page
+          .locator(candidateIds.map((id) => `[id="${id}"]`).join(', '))
+          .first();
+        await expect(targetCard).toBeVisible();
+
+        const resolvedId = await targetCard.getAttribute('id');
+        if (!resolvedId) throw new Error('id introuvable sur la carte cible');
+
+        await waitForScrollSettled(page, resolvedId);
+
+        const stickyBottom = await stickyHeaderBottom(page);
+        const targetBox = await targetCard.boundingBox();
+        if (!targetBox) throw new Error('Sous-action cible introuvable');
+
+        expect(targetBox.y).toBeGreaterThanOrEqual(stickyBottom);
+      }
+    );
+  }
+);


### PR DESCRIPTION
## Contexte

Dernier trou de l'audit contre \`audit-badge-component\` (n°6, PARTIEL).

L'invariant *« le header de la sous-action ciblee n'est pas masque par le header sticky »* n'est teste sur main que par \`scores/hash-navigation.spec.ts\`, via une entree **chargement plein** (\`page.goto(url#cae_1.1.1.3)\`). Le vecteur **navigation client-side** — clic « Voir la mesure » depuis la checklist d'audit-labellisation, ou le hash arrive sans rechargement — etait garde par \`audit-labellisation-to-action-scroll.spec.ts\`, supprime lors de la divergence. \`checklist-statut-refresh.spec.ts\` fait bien ce clic SPA mais n'assert que le rafraichissement des criteres, pas la position de scroll.

## Nature

\`test\` uniquement (e2e Playwright). Aucune ligne de production modifiee.

## Ce qui est verifie

\`goto\` de la page new-audit-labellisation -> clic du premier lien « Voir la mesure » -> navigation SPA vers la page mesure avec hash -> resolution de la carte cible (hash et parents) -> \`waitForScrollSettled\` -> assertion \`targetBox.y >= stickyHeaderBottom\`.

## Surface de review

- 1 fichier, **porte verbatim** depuis \`audit-badge-component\` (source de verite, port iso).
- Dependances confirmees presentes sur main : fixture \`testWithReferentiels\` (+ \`addCollectiviteAndUser\`, \`precomputeReferentielSnapshot\`), \`NewAuditLabellisationPom.goto(collectiviteId, referentielId)\`, helpers \`sticky-header.helpers.ts\` (\`stickyHeaderBottom\`, \`waitForScrollSettled\`), lien « Voir la mesure » (\`PillButton href\` -> role link) rendu dans \`labellisation-checklist.table.tsx\`.

## Verification effectuee

- typecheck e2e : OK.
- lint e2e : OK (exit 0). Deux warnings \`playwright/no-conditional-in-test\` sur les gardes \`if (!x) throw\` — **identiques au frere deja sur main** \`hash-navigation.spec.ts\`, donc conformes au precedent accepte.
- **Non execute via le runner Playwright** (necessite app + DB + services). Validation statique + portage verbatim d'un test qui passait sur la branche source.

## Recherche anti-duplication

\`hash-navigation.spec.ts\` couvre le vecteur chargement-plein ; ce test couvre le vecteur SPA. Complementaires, pas de doublon (entrees distinctes du meme invariant).

## Note de perimetre

3e PR issue du meme audit, avec #4633 (gating par role des sections) et #4634 (badge MetadataItem). Les points n°2/n°7 sont absorbes par #4575.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Ajout d’un test de bout en bout couvrant la navigation depuis une page d’audit vers une page de détail via un lien avec ancre.
  * Vérifie que la cible affichée est bien atteignable après défilement et qu’elle reste visible à l’écran malgré l’en-tête fixe.
  * Renforce la fiabilité de la navigation côté client sur ces parcours.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->