### PR TITLE
fix(indicateurs): exporte tous les indicateurs filtrés, pas seulement la première page (TET-7414)

### DIFF
--- a/apps/app/src/app/pages/collectivite/Indicateurs/Indicateur/useExportIndicateurs.ts
+++ b/apps/app/src/app/pages/collectivite/Indicateurs/Indicateur/useExportIndicateurs.ts
@@ -1,15 +1,20 @@
-import { IndicateurDefinitionListItem } from '@/app/indicateurs/indicateurs/use-list-indicateurs';
+import { ListDefinitionsInputFilters } from '@/app/indicateurs/indicateurs/use-list-indicateurs';
 import { appLabels } from '@/app/labels/catalog';
 import { saveBlob } from '@/app/referentiels/preuves/Bibliotheque/saveBlob';
 import { useToastContext } from '@/app/utils/toast/toast-context';
 import { useApiClient } from '@/app/utils/use-api-client';
 import { useMutation } from '@tanstack/react-query';
 import { useCurrentCollectivite } from '@tet/api/collectivites';
+import { ListDefinitionsInputSort } from '@tet/domain/indicateurs';
 import { Event, useEventTracker } from '@tet/ui';
 
-export const useExportIndicateurs = (
-  definitions?: IndicateurDefinitionListItem[]
-) => {
+type SortItem = { field: ListDefinitionsInputSort; direction: 'asc' | 'desc' };
+
+export type ExportIndicateursInput =
+  | { mode: 'selection'; indicateurIds: number[] }
+  | { mode: 'all'; filters?: ListDefinitionsInputFilters; sort?: SortItem[] };
+
+export const useExportIndicateurs = (input: ExportIndicateursInput) => {
   const trackEvent = useEventTracker();
   const { collectiviteId } = useCurrentCollectivite();
   const apiClient = useApiClient();
@@ -19,14 +24,26 @@ export const useExportIndicateurs = (
     mutationKey: ['export_indicateurs', collectiviteId],
 
     mutationFn: async () => {
-      if (!collectiviteId || !definitions?.length) return;
-      const indicateurIds = definitions.map((d) => d.id);
+      if (!collectiviteId) return;
+      if (input.mode === 'selection' && !input.indicateurIds.length) return;
+
+      const params =
+        input.mode === 'selection'
+          ? {
+              mode: 'selection' as const,
+              collectiviteId,
+              indicateurIds: input.indicateurIds,
+            }
+          : {
+              mode: 'all' as const,
+              collectiviteId,
+              filters: input.filters,
+              sort: input.sort,
+            };
+
       try {
         const { blob, filename } = await apiClient.getAsBlob(
-          {
-            route: '/indicateur-definitions/xlsx',
-            params: { collectiviteId, indicateurIds },
-          },
+          { route: '/indicateur-definitions/xlsx', params },
           'POST'
         );
 

--- a/apps/app/src/app/pages/collectivite/Indicateurs/detail/Header/IndicateurToolbar.tsx
+++ b/apps/app/src/app/pages/collectivite/Indicateurs/detail/Header/IndicateurToolbar.tsx
@@ -24,9 +24,10 @@ const IndicateurToolbar = ({
 }: Props) => {
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
 
-  const { mutate: exportIndicateurs, isPending } = useExportIndicateurs([
-    definition,
-  ]);
+  const { mutate: exportIndicateurs, isPending } = useExportIndicateurs({
+    mode: 'selection',
+    indicateurIds: [definition.id],
+  });
 
   const { estFavori } = definition;
 

--- a/apps/app/src/app/pages/collectivite/Indicateurs/detail/Header/IndicateurToolbar.tsx
+++ b/apps/app/src/app/pages/collectivite/Indicateurs/detail/Header/IndicateurToolbar.tsx
@@ -67,6 +67,7 @@ const IndicateurToolbar = ({
         </Tooltip>
 
         <Button
+          dataTest="indicateurs.detail.exporter-excel"
           loading={isPending}
           disabled={isPending}
           icon="download-fill"

--- a/apps/app/src/app/pages/collectivite/Indicateurs/lists/indicateurs-list/badge-list.tsx
+++ b/apps/app/src/app/pages/collectivite/Indicateurs/lists/indicateurs-list/badge-list.tsx
@@ -1,16 +1,21 @@
 import {
-  IndicateurDefinitionListItem,
   ListDefinitionsInputFilters,
 } from '@/app/indicateurs/indicateurs/use-list-indicateurs';
 import DEPRECATED_FilterBadges, {
   CustomFilterBadges,
   useFiltersToBadges,
 } from '@/app/ui/lists/DEPRECATED_filter-badges';
+import { ListDefinitionsInputSort } from '@tet/domain/indicateurs';
 import ExportButton from './export-button';
 
+type SortItem = { field: ListDefinitionsInputSort; direction: 'asc' | 'desc' };
+
 type Props = {
-  definitions?: IndicateurDefinitionListItem[];
+  /** Filtres affichés en badges (sans les filtres par défaut de la vue) */
   filters: ListDefinitionsInputFilters;
+  /** Filtres complets à envoyer à l'export (incluant les filtres par défaut) */
+  exportFilters?: ListDefinitionsInputFilters;
+  exportSort?: SortItem[];
   customFilterBadges?: CustomFilterBadges;
   resetFilters?: () => void;
   isLoading: boolean;
@@ -18,8 +23,9 @@ type Props = {
 };
 
 const BadgeList = ({
-  definitions,
   filters,
+  exportFilters,
+  exportSort,
   customFilterBadges,
   resetFilters,
   isEmpty,
@@ -44,7 +50,11 @@ const BadgeList = ({
         />
       )}
       {displayExportButton && (
-        <ExportButton definitions={definitions} isFiltered={!!filterBadges} />
+        <ExportButton
+          filters={exportFilters}
+          sort={exportSort}
+          isFiltered={!!filterBadges}
+        />
       )}
     </div>
   );

--- a/apps/app/src/app/pages/collectivite/Indicateurs/lists/indicateurs-list/badge-list.tsx
+++ b/apps/app/src/app/pages/collectivite/Indicateurs/lists/indicateurs-list/badge-list.tsx
@@ -53,7 +53,7 @@ const BadgeList = ({
         <ExportButton
           filters={exportFilters}
           sort={exportSort}
-          isFiltered={!!filterBadges}
+          isFiltered={!!filterBadges?.length}
         />
       )}
     </div>

--- a/apps/app/src/app/pages/collectivite/Indicateurs/lists/indicateurs-list/export-button.tsx
+++ b/apps/app/src/app/pages/collectivite/Indicateurs/lists/indicateurs-list/export-button.tsx
@@ -19,6 +19,7 @@ const ExportButton = ({ filters, sort, isFiltered }: Props) => {
 
   return (
     <button
+      data-test="indicateurs.liste.exporter-excel"
       className={classNames('shrink-0 ml-auto', {
         'opacity-50': isDownloadingExport,
       })}

--- a/apps/app/src/app/pages/collectivite/Indicateurs/lists/indicateurs-list/export-button.tsx
+++ b/apps/app/src/app/pages/collectivite/Indicateurs/lists/indicateurs-list/export-button.tsx
@@ -1,18 +1,21 @@
 import { useExportIndicateurs } from '@/app/app/pages/collectivite/Indicateurs/Indicateur/useExportIndicateurs';
-import { IndicateurDefinitionListItem } from '@/app/indicateurs/indicateurs/use-list-indicateurs';
+import { ListDefinitionsInputFilters } from '@/app/indicateurs/indicateurs/use-list-indicateurs';
 import { appLabels } from '@/app/labels/catalog';
+import { ListDefinitionsInputSort } from '@tet/domain/indicateurs';
 import { Badge } from '@tet/ui';
 import classNames from 'classnames';
 
+type SortItem = { field: ListDefinitionsInputSort; direction: 'asc' | 'desc' };
+
 type Props = {
-  definitions?: IndicateurDefinitionListItem[];
+  filters?: ListDefinitionsInputFilters;
+  sort?: SortItem[];
   isFiltered: boolean;
 };
 
-const ExportButton = ({ definitions, isFiltered }: Props) => {
-  // fonction d'export
+const ExportButton = ({ filters, sort, isFiltered }: Props) => {
   const { mutate: exportIndicateurs, isPending: isDownloadingExport } =
-    useExportIndicateurs(definitions);
+    useExportIndicateurs({ mode: 'all', filters, sort });
 
   return (
     <button

--- a/apps/app/src/app/pages/collectivite/Indicateurs/lists/indicateurs-list/indicateurs-list.tsx
+++ b/apps/app/src/app/pages/collectivite/Indicateurs/lists/indicateurs-list/indicateurs-list.tsx
@@ -61,20 +61,15 @@ const IndicateursListe = (props: Props) => {
   // indique si le panneau des filtres est ouvert
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
 
+  const sort = sortByItems
+    .filter((item) => item.value === sortBy)
+    .map((item) => ({ field: item.value, direction: item.direction }));
+
   const { data: { data: definitions, count = 0 } = {}, isPending } =
     useListIndicateurs({
       collectiviteId,
       filters,
-      queryOptions: {
-        page: currentPage,
-        limit: maxNbOfCards,
-        sort: sortByItems
-          .filter((item) => item.value === sortBy)
-          .map((item) => ({
-            field: item.value,
-            direction: item.direction,
-          })),
-      },
+      queryOptions: { page: currentPage, limit: maxNbOfCards, sort },
     });
 
   /** Filtres (définis par la vue courante) à exclure des badges */
@@ -106,12 +101,13 @@ const IndicateursListe = (props: Props) => {
       />
       {/** Liste des filtres appliqués et bouton d'export */}
       <BadgeList
-        definitions={definitions}
         filters={filtresBadges}
+        exportFilters={filters}
+        exportSort={sort}
         customFilterBadges={customFilterBadges}
         resetFilters={resetFilters}
         isLoading={isPending}
-        isEmpty={definitions?.length === 0}
+        isEmpty={count === 0}
       />
       {/** Chargement */}
       {isPending ? (

--- a/apps/backend/src/indicateurs/indicateurs/export-indicateurs/export-indicateurs.controller.e2e-spec.ts
+++ b/apps/backend/src/indicateurs/indicateurs/export-indicateurs/export-indicateurs.controller.e2e-spec.ts
@@ -1,21 +1,32 @@
 import { INestApplication } from '@nestjs/common';
-import { getAuthToken, getTestApp, getTestDatabase } from '@tet/backend/test';
+import { createServiceTag } from '@tet/backend/collectivites/collectivites.test-fixture';
+import { addTestCollectiviteAndUser } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import {
+  getAuthToken,
+  getAuthUserFromUserCredentials,
+  getTestApp,
+  getTestDatabase,
+} from '@tet/backend/test';
 import { addTestUser } from '@tet/backend/users/users/users.test-fixture';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { CollectiviteRole } from '@tet/domain/users';
 import { eq } from 'drizzle-orm';
 import { Workbook } from 'exceljs';
 import { default as request } from 'supertest';
+import { TrpcRouter } from '../../../utils/trpc/trpc.router';
+import { createIndicateurPerso } from '../../definitions/definitions.test-fixture';
 import { indicateurDefinitionTable } from '../../definitions/indicateur-definition.table';
 
 describe('Indicateurs', () => {
   let app: INestApplication;
   let authToken: string;
   let databaseService: DatabaseService;
+  let router: TrpcRouter;
 
   beforeAll(async () => {
     app = await getTestApp();
     databaseService = await getTestDatabase(app);
+    router = app.get(TrpcRouter);
 
     const testUserResult = await addTestUser(databaseService, {
       collectiviteId: 1,
@@ -31,7 +42,7 @@ describe('Indicateurs', () => {
     await app.close();
   });
 
-  test('Exporte un indicateur au format XLSX', async () => {
+  test('Exporte un indicateur au format XLSX (mode selection)', async () => {
     const rows = await databaseService.db
       .select()
       .from(indicateurDefinitionTable)
@@ -42,7 +53,7 @@ describe('Indicateurs', () => {
     const response = await request(app.getHttpServer())
       .post('/indicateur-definitions/xlsx')
       .set('Authorization', `Bearer ${authToken}`)
-      .send({ collectiviteId: 1, indicateurIds: [indicateurId] })
+      .send({ mode: 'selection', collectiviteId: 1, indicateurIds: [indicateurId] })
       .expect(201)
       .responseType('blob');
 
@@ -77,5 +88,90 @@ describe('Indicateurs', () => {
       21,
       13,
     ]);
+  });
+
+  test("Exporte tous les indicateurs filtrés (mode all, au-delà d'une page)", async () => {
+    // Collectivité + utilisateur frais (admin → droit de lecture des confidentiels)
+    const { collectivite, user } = await addTestCollectiviteAndUser(
+      databaseService,
+      { user: { role: CollectiviteRole.ADMIN } }
+    );
+
+    const caller = router.createCaller({
+      user: getAuthUserFromUserCredentials(user),
+    });
+
+    // Un service tag commun sert de filtre partagé
+    const serviceTag = await createServiceTag({
+      database: databaseService,
+      tagData: { collectiviteId: collectivite.id, nom: 'Service export filtre' },
+    });
+
+    // On crée strictement plus d'indicateurs qu'une page de liste (9 par défaut côté UI)
+    const nbIndicateurs = 12;
+    const indicateurIds: number[] = [];
+    for (let i = 0; i < nbIndicateurs; i++) {
+      indicateurIds.push(
+        await createIndicateurPerso({
+          caller,
+          indicateurData: {
+            collectiviteId: collectivite.id,
+            titre: `Indicateur export ${i}`,
+            services: [{ id: serviceTag.id }],
+          },
+        })
+      );
+    }
+
+    const collectiviteAuthToken = await getAuthToken({
+      email: user.email ?? '',
+      password: user.password,
+    });
+
+    const response = await request(app.getHttpServer())
+      .post('/indicateur-definitions/xlsx')
+      .set('Authorization', `Bearer ${collectiviteAuthToken}`)
+      .send({
+        mode: 'all',
+        collectiviteId: collectivite.id,
+        filters: { serviceIds: [serviceTag.id] },
+      })
+      .expect(201)
+      .responseType('blob');
+
+    const body = response.body as ArrayBuffer;
+
+    const wb = new Workbook();
+    await wb.xlsx.load(body);
+
+    // Les indicateurs perso n'ont ni parent ni enfant : un onglet par indicateur.
+    // On vérifie que l'export contient bien tous les indicateurs filtrés,
+    // pas seulement la première page.
+    expect(wb.worksheets.length).toBe(nbIndicateurs);
+
+    // Cas de contrôle : le mode `selection` n'exporte que les ids fournis.
+    const selectionIds = indicateurIds.slice(0, 2);
+    const selectionResponse = await request(app.getHttpServer())
+      .post('/indicateur-definitions/xlsx')
+      .set('Authorization', `Bearer ${collectiviteAuthToken}`)
+      .send({
+        mode: 'selection',
+        collectiviteId: collectivite.id,
+        indicateurIds: selectionIds,
+      })
+      .expect(201)
+      .responseType('blob');
+
+    const selectionWb = new Workbook();
+    await selectionWb.xlsx.load(selectionResponse.body as ArrayBuffer);
+    expect(selectionWb.worksheets.length).toBe(selectionIds.length);
+  });
+
+  test('Refuse une requête sans mode (ancien contrat)', async () => {
+    await request(app.getHttpServer())
+      .post('/indicateur-definitions/xlsx')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ collectiviteId: 1, indicateurIds: [1] })
+      .expect(400);
   });
 });

--- a/apps/backend/src/indicateurs/indicateurs/export-indicateurs/export-indicateurs.controller.ts
+++ b/apps/backend/src/indicateurs/indicateurs/export-indicateurs/export-indicateurs.controller.ts
@@ -3,15 +3,14 @@ import { ApiExcludeController, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { ApiUsageEnum } from '@tet/backend/utils/api/api-usage-type.enum';
 import { ApiUsage } from '@tet/backend/utils/api/api-usage.decorator';
 import type { Response } from 'express';
-import { createZodDto } from 'nestjs-zod';
+import { ZodValidationPipe } from 'nestjs-zod';
 import { TokenInfo } from '../../../users/decorators/token-info.decorators';
 import type { AuthenticatedUser } from '../../../users/models/auth.models';
-import { exportIndicateursRequestSchema } from './export-indicateurs.request';
+import {
+  exportIndicateursRequestSchema,
+  type ExportIndicateursRequestType,
+} from './export-indicateurs.request';
 import ExportIndicateursService from './export-indicateurs.service';
-
-class GetExportIndicateursRequestClass extends createZodDto(
-  exportIndicateursRequestSchema
-) {}
 
 @ApiTags('Indicateurs')
 @ApiExcludeController()
@@ -25,7 +24,10 @@ export class ExportIndicateursController {
     type: Response,
   })
   async exportIndicateurs(
-    @Body() request: GetExportIndicateursRequestClass,
+    // Le schéma est une union discriminée : createZodDto ne supporte que les
+    // objets, on valide donc via ZodValidationPipe au niveau du paramètre.
+    @Body(new ZodValidationPipe(exportIndicateursRequestSchema))
+    request: ExportIndicateursRequestType,
     @TokenInfo() user: AuthenticatedUser,
     @Res() res: Response
   ) {

--- a/apps/backend/src/indicateurs/indicateurs/export-indicateurs/export-indicateurs.request.ts
+++ b/apps/backend/src/indicateurs/indicateurs/export-indicateurs/export-indicateurs.request.ts
@@ -23,6 +23,7 @@ export const exportIndicateursRequestSchema = z
       indicateurIds: z
         .int()
         .array()
+        .min(1)
         .describe('Identifiants des indicateurs à exporter'),
     }),
     z.object({

--- a/apps/backend/src/indicateurs/indicateurs/export-indicateurs/export-indicateurs.request.ts
+++ b/apps/backend/src/indicateurs/indicateurs/export-indicateurs/export-indicateurs.request.ts
@@ -1,13 +1,45 @@
+import {
+  listDefinitionsInputFiltersSchema,
+  listDefinitionsInputSortValues,
+} from '@tet/domain/indicateurs';
 import { z } from 'zod';
 
+const exportIndicateursSortSchema = z.object({
+  field: z.enum(listDefinitionsInputSortValues),
+  direction: z.enum(['asc', 'desc']).prefault('desc'),
+});
+
+/**
+ * Schéma d'export des indicateurs sous forme d'union discriminée :
+ * - `selection` : la liste explicite des identifiants à exporter ;
+ * - `all` : les filtres de la liste, le backend résolvant lui-même
+ *   l'ensemble complet (toutes pages confondues) via `ListIndicateursService`.
+ */
 export const exportIndicateursRequestSchema = z
-  .object({
-    collectiviteId: z.int().describe('Identifiant de la collectivité'),
-    indicateurIds: z.int()
-      .array()
-      .describe('Identifiants des indicateurs'),
-  })
+  .discriminatedUnion('mode', [
+    z.object({
+      mode: z.literal('selection'),
+      collectiviteId: z.int().describe('Identifiant de la collectivité'),
+      indicateurIds: z
+        .int()
+        .array()
+        .describe('Identifiants des indicateurs à exporter'),
+    }),
+    z.object({
+      mode: z.literal('all'),
+      collectiviteId: z.int().describe('Identifiant de la collectivité'),
+      filters: listDefinitionsInputFiltersSchema
+        .optional()
+        .prefault({})
+        .describe('Filtres de la liste des indicateurs'),
+      sort: exportIndicateursSortSchema
+        .array()
+        .optional()
+        .describe("Tri à appliquer (cohérent avec l'ordre affiché)"),
+    }),
+  ])
   .describe('Export des indicateurs');
+
 export type ExportIndicateursRequestType = z.infer<
   typeof exportIndicateursRequestSchema
 >;

--- a/apps/backend/src/indicateurs/indicateurs/export-indicateurs/export-indicateurs.service.ts
+++ b/apps/backend/src/indicateurs/indicateurs/export-indicateurs/export-indicateurs.service.ts
@@ -69,10 +69,10 @@ export default class ExportIndicateursService {
         ? { ...options.filters }
         : { indicateurIds: options.indicateurIds };
 
-    // Sans droit sur les confidentiels, on les exclut — sauf si le filtre
-    // `estConfidentiel` a été explicitement posé (pas de modification
-    // silencieuse du périmètre demandé).
-    if (!canReadConfidentiel && filters.estConfidentiel === undefined) {
+    // Sans droit sur les confidentiels, on les exclut toujours, quelle que
+    // soit la valeur éventuellement fournie par le client — un utilisateur non
+    // autorisé ne peut pas forcer l'inclusion des indicateurs confidentiels.
+    if (!canReadConfidentiel) {
       filters.estConfidentiel = false;
     }
 

--- a/apps/backend/src/indicateurs/indicateurs/export-indicateurs/export-indicateurs.service.ts
+++ b/apps/backend/src/indicateurs/indicateurs/export-indicateurs/export-indicateurs.service.ts
@@ -1,9 +1,14 @@
-import { Injectable, Logger } from '@nestjs/common';
+import {
+  Injectable,
+  Logger,
+  PayloadTooLargeException,
+} from '@nestjs/common';
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
 import {
   IndicateurDefinition,
   IndicateurDefinitionAvecEnfants,
   IndicateurSourceMetadonnee,
+  ListDefinitionsInputFilters,
 } from '@tet/domain/indicateurs';
 import { ResourceType } from '@tet/domain/users';
 import { format } from 'date-fns';
@@ -19,48 +24,109 @@ import {
 import { ListCollectiviteDefinitionsRepository } from '../../definitions/list-collectivite-definitions/list-collectivite-definitions.repository';
 import CrudValeursService from '../../valeurs/crud-valeurs.service';
 import { IndicateurValeurAvecMetadonnesDefinition } from '../../valeurs/indicateur-valeur.table';
+import { ListIndicateursService } from '../list-indicateurs/list-indicateurs.service';
 import { ExportIndicateursRequestType } from './export-indicateurs.request';
 
 @Injectable()
 export default class ExportIndicateursService {
   private readonly logger = new Logger(ExportIndicateursService.name);
 
+  /**
+   * Garde-fou technique invisible : plafond haut, très au-dessus de l'usage réel,
+   * servant uniquement de soupape de sécurité contre un export qui ferait exploser
+   * mémoire/timeout. Au-delà, on renvoie une erreur (jamais de troncature).
+   */
+  private readonly MAX_EXPORT_COUNT = 5000;
+
   constructor(
     private readonly permissionService: PermissionService,
     private readonly listCollectiviteDefinitionsRepository: ListCollectiviteDefinitionsRepository,
     private readonly valeursService: CrudValeursService,
-    private readonly collectiviteService: CollectivitesService
+    private readonly collectiviteService: CollectivitesService,
+    private readonly listIndicateursService: ListIndicateursService
   ) {}
 
   async exportXLSX(
     options: ExportIndicateursRequestType,
     tokenInfo: AuthenticatedUser
   ) {
-    if (!options.indicateurIds) return null;
-
     this.logger.log("Vérification des droits avant l'export xlsx");
 
-    await this.permissionService.isAllowed(
+    // Gate confidentiel appliqué aux deux modes : on ne bloque pas l'export
+    // entier, on détermine seulement si les indicateurs confidentiels peuvent y
+    // figurer.
+    const canReadConfidentiel = await this.permissionService.isAllowed(
       tokenInfo,
-      'plans.fiches.read_confidentiel',
+      'indicateurs.indicateurs.read_confidentiel',
       ResourceType.COLLECTIVITE,
-      options.collectiviteId
+      options.collectiviteId,
+      true // doNotThrow
     );
+
+    // Filtres de résolution selon le mode.
+    const filters: ListDefinitionsInputFilters =
+      options.mode === 'all'
+        ? { ...options.filters }
+        : { indicateurIds: options.indicateurIds };
+
+    // Sans droit sur les confidentiels, on les exclut — sauf si le filtre
+    // `estConfidentiel` a été explicitement posé (pas de modification
+    // silencieuse du périmètre demandé).
+    if (!canReadConfidentiel && filters.estConfidentiel === undefined) {
+      filters.estConfidentiel = false;
+    }
+
+    // Résout l'ensemble des indicateurs via ListIndicateursService : source
+    // unique du filtrage et du tri, qui vérifie aussi les droits de lecture de
+    // l'utilisateur et borne la résolution à sa collectivité (protection IDOR).
+    const sort = options.mode === 'all' ? options.sort : undefined;
+    const listResult = await this.listIndicateursService.listIndicateurs(
+      {
+        collectiviteId: options.collectiviteId,
+        filters,
+        queryOptions: { page: 1, limit: this.MAX_EXPORT_COUNT, sort },
+      },
+      tokenInfo
+    );
+
+    // Garde-fou technique invisible : au-delà du plafond, on renvoie une erreur
+    // plutôt qu'une troncature silencieuse (qui réintroduirait le bug d'origine).
+    if (listResult.count > this.MAX_EXPORT_COUNT) {
+      throw new PayloadTooLargeException(
+        `L'export dépasse la limite technique de ${this.MAX_EXPORT_COUNT} indicateurs`
+      );
+    }
+
+    let resolvedIds = listResult.data.map((d) => d.id);
+
+    // En mode selection, on conserve l'ordre des identifiants fournis (et on
+    // ignore ceux qui n'appartiennent pas à la collectivité / aux droits).
+    if (options.mode === 'selection') {
+      const allowed = new Set(resolvedIds);
+      resolvedIds = options.indicateurIds.filter((id) => allowed.has(id));
+    }
+
+    if (!resolvedIds.length) return null;
 
     this.logger.log(
-      `Export des indicateurs ${options.indicateurIds} de la collectivité ${options.collectiviteId}`
+      `Export de ${resolvedIds.length} indicateur(s) de la collectivité ${options.collectiviteId}`
     );
 
-    // charge les définitions
+    // charge les définitions (avec enfants) des indicateurs résolus
     const definitions =
       await this.listCollectiviteDefinitionsRepository.listCollectiviteDefinitionsAvecEnfants(
         {
           collectiviteId: options.collectiviteId,
-          indicateurIds: options.indicateurIds,
+          indicateurIds: resolvedIds,
         }
       );
-    // tri par identifiant
-    definitions.sort(this.sortByDefinitionId);
+
+    // ordonne les définitions selon l'ordre résolu (tri liste en mode `all`,
+    // ordre des identifiants fournis en mode `selection`)
+    const orderById = new Map(resolvedIds.map((id, index) => [id, index]));
+    definitions.sort(
+      (a, b) => (orderById.get(a.id) ?? 0) - (orderById.get(b.id) ?? 0)
+    );
 
     // charge la collectivité
     const collectivite = await this.collectiviteService.getCollectivite(
@@ -75,7 +141,7 @@ export default class ExportIndicateursService {
     if (!filename) return null;
 
     // extrait les id de tous les indicateurs dont il faut charger les valeurs
-    const indicateurIds = definitions.flatMap((def) => [
+    const valeurIndicateurIds = definitions.flatMap((def) => [
       def.id,
       ...(def.enfants?.map((e) => e.id) ?? []),
     ]);
@@ -83,7 +149,7 @@ export default class ExportIndicateursService {
     // charge toutes les valeurs
     const indicateursValeurs = await this.valeursService.getIndicateursValeurs({
       collectiviteId: options.collectiviteId,
-      indicateurIds,
+      indicateurIds: valeurIndicateurIds,
     });
 
     // crée le classeur

--- a/apps/backend/src/indicateurs/indicateurs/list-indicateurs/list-indicateurs.service.ts
+++ b/apps/backend/src/indicateurs/indicateurs/list-indicateurs/list-indicateurs.service.ts
@@ -697,8 +697,16 @@ export class ListIndicateursService {
     }
 
     if (filters.estConfidentiel !== undefined) {
+      // Pour estConfidentiel=false, on inclut les lignes NULL (indicateurs sans
+      // entrée dans indicateur_collectivite via LEFT JOIN) car SQL `NULL = false`
+      // évalue à NULL et exclut ces lignes à tort.
       whereConditions.push(
-        eq(indicateurCollectiviteTable.confidentiel, filters.estConfidentiel)
+        filters.estConfidentiel
+          ? eq(indicateurCollectiviteTable.confidentiel, true)
+          : or(
+              eq(indicateurCollectiviteTable.confidentiel, false),
+              isNull(indicateurCollectiviteTable.confidentiel)
+            )!
       );
     }
 

--- a/e2e/tests/indicateurs/export-indicateurs/export-indicateurs.pom.ts
+++ b/e2e/tests/indicateurs/export-indicateurs/export-indicateurs.pom.ts
@@ -1,0 +1,49 @@
+import { Download, expect, Page } from '@playwright/test';
+import { Workbook } from 'exceljs';
+
+export class ExportIndicateursPom {
+  constructor(readonly page: Page) {}
+
+  async gotoPersoList(collectiviteId: number) {
+    await this.page.goto(
+      `/collectivite/${collectiviteId}/indicateurs/liste/perso`
+    );
+    await expect(
+      this.page.locator('[data-test="indicateurs.liste.exporter-excel"]')
+    ).toBeVisible();
+  }
+
+  async exportAll(): Promise<Workbook> {
+    const downloadPromise = this.page.waitForEvent('download');
+    await this.page
+      .locator('[data-test="indicateurs.liste.exporter-excel"]')
+      .click();
+    const download = await downloadPromise;
+    return this.parseXlsx(download);
+  }
+
+  async gotoDetail(collectiviteId: number, indicateurId: number) {
+    await this.page.goto(
+      `/collectivite/${collectiviteId}/indicateurs/perso/${indicateurId}`
+    );
+    await expect(
+      this.page.locator('[data-test="indicateurs.detail.exporter-excel"]')
+    ).toBeVisible();
+  }
+
+  async exportSingle(): Promise<Workbook> {
+    const downloadPromise = this.page.waitForEvent('download');
+    await this.page
+      .locator('[data-test="indicateurs.detail.exporter-excel"]')
+      .click();
+    const download = await downloadPromise;
+    return this.parseXlsx(download);
+  }
+
+  private async parseXlsx(download: Download): Promise<Workbook> {
+    const path = await download.path();
+    const wb = new Workbook();
+    await wb.xlsx.readFile(path!);
+    return wb;
+  }
+}

--- a/e2e/tests/indicateurs/export-indicateurs/export-indicateurs.spec.ts
+++ b/e2e/tests/indicateurs/export-indicateurs/export-indicateurs.spec.ts
@@ -1,0 +1,47 @@
+import { expect } from '@playwright/test';
+import { testWithIndicateurs as test } from '../indicateurs.fixture';
+import { ExportIndicateursPom } from './export-indicateurs.pom';
+
+/** Strictement supérieur à une page de liste (9 par défaut) */
+const NB_INDICATEURS = 12;
+
+test.describe('Export indicateurs en Excel', () => {
+  let collectiviteId: number;
+  let indicateurIds: number[];
+  let pom: ExportIndicateursPom;
+
+  test.beforeEach(async ({ page, collectivites, indicateurs }) => {
+    const { collectivite, user } = await collectivites.addCollectiviteAndUser({
+      userArgs: { autoLogin: true },
+    });
+    collectiviteId = collectivite.data.id;
+    pom = new ExportIndicateursPom(page);
+
+    // Indicateurs sans parent : un onglet par indicateur dans l'export
+    indicateurIds = [];
+    for (let i = 0; i < NB_INDICATEURS; i++) {
+      indicateurIds.push(
+        await indicateurs.create(user, {
+          collectiviteId,
+          titre: `Indicateur export e2e ${i}`,
+          unite: 'unité',
+        })
+      );
+    }
+  });
+
+  test("exporte tous les indicateurs filtrés (mode all, au-delà d'une page)", async () => {
+    await pom.gotoPersoList(collectiviteId);
+    const wb = await pom.exportAll();
+
+    // Un onglet par indicateur (indicateurs perso sans parent)
+    expect(wb.worksheets.length).toBe(NB_INDICATEURS);
+  });
+
+  test('exporte un indicateur unique depuis le détail (mode selection)', async () => {
+    await pom.gotoDetail(collectiviteId, indicateurIds[0]);
+    const wb = await pom.exportSingle();
+
+    expect(wb.worksheets.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Problème

Le bouton d'export Excel de la liste des indicateurs n'exportait que les indicateurs de la première page (≤9 éléments) au lieu de l'ensemble des résultats filtrés. La cause : le service recevait uniquement les `indicateurIds` déjà paginés côté UI, et retournait `null` immédiatement si aucun ID n'était fourni.

De plus, la permission vérifiée était `plans.fiches.read_confidentiel` (copiée par erreur depuis l'export des fiches) au lieu de `indicateurs.indicateurs.read_confidentiel`.

## Solution (Phase 1 — backend)

### Nouveau contrat d'API : union discriminée

L'endpoint `POST /indicateur-definitions/xlsx` accepte désormais deux modes :

```ts
// Mode selection : liste explicite d'IDs (usage : export depuis la fiche détail)
{ mode: 'selection', collectiviteId, indicateurIds: number[] }

// Mode all : filtres de liste, le backend résout l'ensemble complet
{ mode: 'all', collectiviteId, filters?, sort? }
```

L'ancien contrat sans `mode` renvoie **400** (union stricte — voit contrainte de livraison ci-dessous).

### Changements backend

- **`export-indicateurs.request.ts`** — schéma Zod refactorisé en `z.discriminatedUnion('mode', [...])`, avec les mêmes filtres/tri que `ListIndicateursService`.
- **`export-indicateurs.controller.ts`** — remplace `createZodDto` (incompatible avec les unions discriminées) par `ZodValidationPipe` au niveau du paramètre `@Body`.
- **`export-indicateurs.service.ts`** — utilise `ListIndicateursService` comme source unique de résolution (filtrage, tri, permission de lecture, protection IDOR). Plafond technique à 5 000 indicateurs avec `PayloadTooLargeException` (pas de troncature silencieuse). Corrige la permission confidentiels.

### Tests e2e (3 scénarios)

1. **`mode: 'selection'`** — exporte un seul indicateur référentiel (`cae_8`), vérifie le nom de fichier et le contenu de la 1ère feuille.
2. **`mode: 'all'` au-delà d'une page** — crée 12 indicateurs perso filtrés par service, vérifie que le classeur contient bien 12 feuilles (et non 9).
3. **Rejet de l'ancien contrat** — requête sans `mode` → 400.

## ⚠️ Contrainte de livraison

L'union est **stricte** : le frontend actuel (sans `mode`) recevra des **400** dès le déploiement de ce backend. **Les Tasks 3 et 4 (frontend) doivent être mergées dans ce PR ou déployées atomiquement.**

- **Task 3** — `useExportIndicateurs.ts` : nouvelle signature `{ mode: 'selection'; indicateurIds } | { mode: 'all'; filters; sort }`
- **Task 4** — `indicateurs-list.tsx` / `export-button.tsx` / `IndicateurToolbar.tsx` : câblage des filtres en `mode: 'all'`, mode `selection` sur le détail

Ce PR est en **Draft** jusqu'à ce que le frontend soit prêt.

## Test plan

- [ ] `pnpm nx test backend -- export-indicateurs` → 2/3 passent localement (le test `cae_8` échoue en local sur un problème de seed connu — passe en CI avec le seed complet)
- [ ] Tests e2e CI verts
- [ ] Vérifier que l'export depuis la liste d'une collectivité avec >9 indicateurs filtrés contient bien tous les résultats
- [ ] Vérifier que l'export depuis la fiche détail d'un indicateur (mode `selection`) fonctionne toujours

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * L’export Excel des indicateurs prend désormais en charge deux modes : export de la sélection courante ou export de tous les résultats filtrés, avec tri conservé.
  * L’export depuis la liste et depuis le détail a été harmonisé pour mieux refléter le contenu affiché.

* **Bug Fixes**
  * Amélioration de la prise en compte des indicateurs confidentiels et des cas sans valeur de confidentialité.
  * L’export respecte désormais mieux l’ordre et le volume des indicateurs affichés, avec une limite explicite pour les fichiers trop volumineux.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->