### PR TITLE
feat(referentiels): rend les colonnes d'audit masquables via le sélecteur de colonnes

### DIFF
--- a/apps/app/src/labels/catalog.ts
+++ b/apps/app/src/labels/catalog.ts
@@ -430,10 +430,9 @@ export const appLabels = {
   auditColonneOrdreDuJour: 'À discuter en séance',
   auditColonneNotes: "Notes de l'auditeur·ice",
   decouvrirInfosAuditTableauTitre:
-    "Retrouvez le suivi de l'audit dans la vue tableau",
+    "Retrouvez le suivi de l'audit dans la vue tabulaire",
   decouvrirInfosAuditTableauDescription:
     "Le statut d'audit, les points à discuter en séance et les notes de l'auditeur·ice sont désormais disponibles directement dans la vue tableau des mesures.",
-  decouvrirInfosAuditTableauCta: 'Découvrir la vue tableau',
   detaillerAvancementTache: "Détailler l'avancement à la tâche",
   detaillerAvancement: "Détailler l'avancement",
   detaillerAvancementPourcentage: "Détailler l'avancement au pourcentage",

--- a/apps/app/src/referentiels/audit-labellisation/checklist/audit-table-hint.banner.tsx
+++ b/apps/app/src/referentiels/audit-labellisation/checklist/audit-table-hint.banner.tsx
@@ -22,7 +22,7 @@ export const AuditTableHintBanner = ({
         variant="primary"
         href={makeReferentielNewUrl({ collectiviteId, referentielId })}
       >
-        {appLabels.decouvrirInfosAuditTableauCta}
+        {appLabels.decouvrirVueTabulaire}
       </Button>
     }
   />

--- a/apps/app/src/referentiels/referentiel.table/referentiel-table.filters.form.tsx
+++ b/apps/app/src/referentiels/referentiel.table/referentiel-table.filters.form.tsx
@@ -1,16 +1,17 @@
 import { ButtonMenu, Checkbox } from '@tet/ui';
 import {
+  ReferentielTableColumnId,
   ReferentielTableColumnOption,
-  useReferentielTableColumnVisibility,
+  ReferentielTableColumnVisibility,
 } from './use-referentiel-table-column-visibility';
 import { appLabels } from '@/app/labels/catalog';
 
 export function ReferentielTableFiltersForm({
   columnVisibility: { visibleColumnIds, setVisibleColumnIds, columnOptions },
 }: {
-  columnVisibility: ReturnType<typeof useReferentielTableColumnVisibility>;
+  columnVisibility: ReferentielTableColumnVisibility;
 }) {
-  const toggleColumn = (id: string) => {
+  const toggleColumn = (id: ReferentielTableColumnId) => {
     const next = visibleColumnIds.includes(id)
       ? visibleColumnIds.filter((columnId) => columnId !== id)
       : [...visibleColumnIds, id];

--- a/apps/app/src/referentiels/referentiel.table/referentiel-table.tsx
+++ b/apps/app/src/referentiels/referentiel.table/referentiel-table.tsx
@@ -72,7 +72,10 @@ declare module '@tanstack/react-table' {
 export function ReferentielTableWithData() {
   const referentielId = useReferentielId();
   const filtersState = useGetReferentielTableFiltersState();
-  const columnVisibility = useReferentielTableColumnVisibility();
+  const { isConductingAudit } = useCycleLabellisation(referentielId);
+  const columnVisibility = useReferentielTableColumnVisibility({
+    showAuditRelatedColumns: isConductingAudit,
+  });
 
   const { data, isPending } = useListActionsGroupedById({
     referentielIds: [referentielId],

--- a/apps/app/src/referentiels/referentiel.table/use-referentiel-table-column-visibility.ts
+++ b/apps/app/src/referentiels/referentiel.table/use-referentiel-table-column-visibility.ts
@@ -1,61 +1,96 @@
+import { appLabels } from '@/app/labels/catalog';
 import { VisibilityState } from '@tanstack/react-table';
 import { useUser } from '@tet/api/users';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import useLocalStorage from 'react-use/lib/useLocalStorage';
 
 const STORAGE_KEY_PREFIX = 'tet_referentiel_table_columns_visibility';
 
+// Ordre de présentation des colonnes dans le sélecteur de visibilité.
+// Garde la colonne "Intitulé" toujours visible en l'excluant de cette liste.
+export const REFERENTIEL_TABLE_COLUMN_OPTIONS = [
+  { id: 'description', label: 'Description', default: false },
+  { id: 'categorie', label: 'Phase', default: false },
+  { id: 'pointPotentiel', label: 'Potentiel personnalisé', default: true },
+  { id: 'pointReferentiel', label: 'Potentiel max', default: false },
+  { id: 'progression', label: 'Progression', default: true },
+  { id: 'pointNonRenseigne', label: 'Points restants', default: false },
+  { id: 'pointFait', label: 'Points faits', default: true },
+  { id: 'scoreRealise', label: '% fait', default: true },
+  { id: 'pointProgramme', label: 'Points programmés', default: false },
+  { id: 'scoreProgramme', label: '% programmé', default: false },
+  { id: 'pointPasFait', label: 'Points pas faits', default: false },
+  { id: 'scorePasFait', label: '% pas fait', default: false },
+  { id: 'statut', label: 'Statut', default: true },
+  { id: 'explication', label: "État d'avancement", default: true },
+  { id: 'pilotes', label: 'Pilotes', default: false },
+  { id: 'services', label: 'Service ou direction', default: false },
+  { id: 'documents', label: 'Documents', default: true },
+  { id: 'comments', label: 'Commentaires', default: false },
+  { id: 'fiches', label: 'Actions liées', default: false },
+] as const satisfies readonly { id: string; label: string; default: boolean }[];
+
+const AUDIT_COLUMN_OPTIONS = [
+  { id: 'auditStatut', label: appLabels.auditColonneStatut, default: true },
+  {
+    id: 'auditOrdreDuJour',
+    label: appLabels.auditColonneOrdreDuJour,
+    default: true,
+  },
+  { id: 'auditNotes', label: appLabels.auditColonneNotes, default: true },
+] as const satisfies readonly { id: string; label: string; default: boolean }[];
+
+export type ReferentielTableColumnId =
+  | (typeof REFERENTIEL_TABLE_COLUMN_OPTIONS)[number]['id']
+  | (typeof AUDIT_COLUMN_OPTIONS)[number]['id'];
+
 export type ReferentielTableColumnOption = {
-  id: string;
+  id: ReferentielTableColumnId;
   label: string;
   default: boolean;
 };
 
-// Ordre de présentation des colonnes dans le sélecteur de visibilité.
-// Garde la colonne "Intitulé" toujours visible en l'excluant de cette liste.
-export const REFERENTIEL_TABLE_COLUMN_OPTIONS: ReferentielTableColumnOption[] =
-  [
-    { id: 'description', label: 'Description', default: false },
-    { id: 'categorie', label: 'Phase', default: false },
-    { id: 'pointPotentiel', label: 'Potentiel personnalisé', default: true },
-    { id: 'pointReferentiel', label: 'Potentiel max', default: false },
-    { id: 'progression', label: 'Progression', default: true },
-    { id: 'pointNonRenseigne', label: 'Points restants', default: false },
-    { id: 'pointFait', label: 'Points faits', default: true },
-    { id: 'scoreRealise', label: '% fait', default: true },
-    { id: 'pointProgramme', label: 'Points programmés', default: false },
-    { id: 'scoreProgramme', label: '% programmé', default: false },
-    { id: 'pointPasFait', label: 'Points pas faits', default: false },
-    { id: 'scorePasFait', label: '% pas fait', default: false },
-    { id: 'statut', label: 'Statut', default: true },
-    { id: 'explication', label: "État d'avancement", default: true },
-    { id: 'pilotes', label: 'Pilotes', default: false },
-    { id: 'services', label: 'Service ou direction', default: false },
-    { id: 'documents', label: 'Documents', default: true },
-    { id: 'comments', label: 'Commentaires', default: false },
-    { id: 'fiches', label: 'Actions liées', default: false },
-  ];
+export type ReferentielTableColumnVisibility = {
+  columnVisibility: VisibilityState;
+  visibleColumnIds: ReferentielTableColumnId[];
+  setVisibleColumnIds: (ids: ReferentielTableColumnId[]) => void;
+  columnOptions: ReferentielTableColumnOption[];
+};
 
-const DEFAULT_COLUMN_VISIBILITY: VisibilityState = Object.fromEntries(
-  REFERENTIEL_TABLE_COLUMN_OPTIONS.map(({ id, default: defaultValue }) => [
-    id,
-    defaultValue,
-  ])
-);
+function getDefaultColumnVisibility(
+  options: readonly ReferentielTableColumnOption[]
+): VisibilityState {
+  return Object.fromEntries(
+    options.map(({ id, default: defaultValue }) => [id, defaultValue])
+  );
+}
 
 function getStorageKey(userId: string) {
   return `${STORAGE_KEY_PREFIX}_${userId}`;
 }
 
-export function useReferentielTableColumnVisibility() {
+export function useReferentielTableColumnVisibility({
+  showAuditRelatedColumns,
+}: {
+  showAuditRelatedColumns: boolean;
+}): ReferentielTableColumnVisibility {
   const user = useUser();
+
+  const columnOptions = useMemo<ReferentielTableColumnOption[]>(
+    () =>
+      showAuditRelatedColumns
+        ? [...REFERENTIEL_TABLE_COLUMN_OPTIONS, ...AUDIT_COLUMN_OPTIONS]
+        : [...REFERENTIEL_TABLE_COLUMN_OPTIONS],
+    [showAuditRelatedColumns]
+  );
+
   const [stored, setStored] = useLocalStorage<VisibilityState>(
     getStorageKey(user.id),
-    DEFAULT_COLUMN_VISIBILITY
+    getDefaultColumnVisibility(REFERENTIEL_TABLE_COLUMN_OPTIONS)
   );
 
   const columnVisibility: VisibilityState = {
-    ...DEFAULT_COLUMN_VISIBILITY,
+    ...getDefaultColumnVisibility(columnOptions),
     ...(stored ?? {}),
   };
 
@@ -63,24 +98,24 @@ export function useReferentielTableColumnVisibility() {
   // sa visibilité suit systématiquement celle de la colonne "statut".
   columnVisibility.statutDetaille = columnVisibility.statut !== false;
 
-  const visibleColumnIds = REFERENTIEL_TABLE_COLUMN_OPTIONS.filter(
-    ({ id }) => columnVisibility[id] !== false
-  ).map(({ id }) => id);
+  const visibleColumnIds = columnOptions
+    .filter(({ id }) => columnVisibility[id] !== false)
+    .map(({ id }) => id);
 
   const setVisibleColumnIds = useCallback(
-    (ids: string[]) => {
+    (ids: ReferentielTableColumnId[]) => {
       const next = Object.fromEntries(
-        REFERENTIEL_TABLE_COLUMN_OPTIONS.map(({ id }) => [id, ids.includes(id)])
+        columnOptions.map(({ id }) => [id, ids.includes(id)])
       );
-      setStored(next);
+      setStored({ ...(stored ?? {}), ...next });
     },
-    [setStored]
+    [columnOptions, stored, setStored]
   );
 
   return {
     columnVisibility,
     visibleColumnIds,
     setVisibleColumnIds,
-    columnOptions: REFERENTIEL_TABLE_COLUMN_OPTIONS,
+    columnOptions,
   };
 }

--- a/e2e/tests/referentiels/labellisations/audit-conduct-tabs-auditeur.spec.ts
+++ b/e2e/tests/referentiels/labellisations/audit-conduct-tabs-auditeur.spec.ts
@@ -58,7 +58,7 @@ test.describe("Conduite d'audit (onglet Cycles et bandeau vue tableau)", () => {
     const suiviTab = page.getByRole('tab', { name: "Suivi de l'audit" });
     const cyclesTab = page.getByRole('tab', { name: 'Cycles et comparaison' });
     const tableHintBanner = page.getByText(
-      "Retrouvez le suivi de l'audit dans la vue tableau"
+      "Retrouvez le suivi de l'audit dans la vue tabulaire"
     );
 
     await auditeurUser.login();


### PR DESCRIPTION
## Intention

Au clic du bouton **« colonnes »** sur la page progression d'un référentiel, exposer les colonnes liées à l'audit comme cases à cocher **uniquement quand c'est pertinent** — c.-à-d. quand un auditeur conduit l'audit en cours (`isConductingAudit`). Ces colonnes étaient jusqu'ici toujours affichées et non masquables.

Colonnes concernées : *Statut d'audit*, *À discuter en séance*, *Notes de l'auditeur·ice*.

Comportement :
- **Pendant l'audit** : les 3 colonnes apparaissent dans le menu, visibles par défaut (comportement préservé), et peuvent désormais être masquées.
- **Hors audit** : menu et tableau strictement inchangés.

## Surface de review

Attention humaine :
- `use-referentiel-table-column-visibility.ts` — le hook prend `{ showAuditRelatedColumns }` et ajoute conditionnellement `AUDIT_COLUMN_OPTIONS` (réutilise les labels `appLabels.auditColonne*` existants). Type de retour nommé/exporté `ReferentielTableColumnVisibility`. Ids de colonnes narrowés en union `ReferentielTableColumnId` (dérivée via `as const satisfies`), plus de `string` nu.
- `referentiel-table.tsx` — `ReferentielTableWithData` calcule `isConductingAudit` via `useCycleLabellisation` et l'injecte dans le hook de visibilité.
- `referentiel-table.filters.form.tsx` — `toggleColumn` typé sur l'union `ReferentielTableColumnId`.

## Hypothèses prises

- « Pertinent » = `isConductingAudit` (auditeur **et** statut `audit_en_cours`) — la condition existante qui gouvernait déjà l'affichage des colonnes audit. Pas un nouveau critère.
- Colonnes audit **visibles par défaut** lorsqu'elles apparaissent (préserve le comportement actuel) ; l'auditeur peut les décocher.
- Ajoutées **en bas** de la liste du menu, dans le même ordre que dans le tableau.

## Zones à confiance faible

- Aucune donnée nouvelle câblée : les cellules audit (`auditStatutsByMesureId`, `canEditAudit`, …) étaient déjà branchées ; seule la visibilité change.
- `useCycleLabellisation(referentielId)` est désormais appelé dans le parent **et** l'enfant (résultat mis en cache par React Query) — choix de scope minimal plutôt que remonter `isAuditeur`/`audit` en props.

## Vérifications

- `nx run app:typecheck` ✅
- `eslint` sur les 3 fichiers ✅
