### PR TITLE
feat(referentiels): conseiller·ère éditable inline depuis le header

### DIFF
--- a/apps/app/src/referentiels/audit-labellisation/checklist-page-header/checklist-page-header.tsx
+++ b/apps/app/src/referentiels/audit-labellisation/checklist-page-header/checklist-page-header.tsx
@@ -8,11 +8,6 @@ import {
 } from '@/app/referentiels/actions/use-list-actions';
 import { ScoreProgressBar } from '@/app/referentiels/scores/score.progress-bar';
 import { ScoreRatioBadge } from '@/app/referentiels/scores/score.ratio-badge';
-import {
-  groupeParFonction,
-  useMembres,
-} from '@/app/referentiels/tableau-de-bord/referents/useMembres';
-import { Membre } from '@/app/collectivites/membres/list-membres/use-list-membres';
 import { useCurrentCollectivite } from '@tet/api/collectivites';
 import { ActionTypeEnum, ReferentielId } from '@tet/domain/referentiels';
 import { PageHeader } from '@tet/ui';
@@ -38,13 +33,11 @@ const ChecklistPageHeaderView = ({
   collectiviteId,
   referentiel,
   roleMesures,
-  conseillers,
 }: {
   referentielId: ReferentielId;
   collectiviteId: number;
   referentiel: ActionListItem | undefined;
   roleMesures: RoleMesures | null;
-  conseillers: Membre[];
 }): ReactElement => (
   <PageHeader>
     <PageHeader.Title>
@@ -57,7 +50,7 @@ const ChecklistPageHeaderView = ({
       />
     </PageHeader.Actions>
     <PageHeader.Metadata>
-      <ReferentsLine roleMesures={roleMesures} conseillers={conseillers} />
+      <ReferentsLine roleMesures={roleMesures} />
       {referentiel !== undefined && <ReferentielScoreLine action={referentiel} />}
     </PageHeader.Metadata>
   </PageHeader>
@@ -74,9 +67,6 @@ export const ChecklistPageHeader = ({
     referentielIds: [referentielId],
     actionTypes: [ActionTypeEnum.REFERENTIEL],
   });
-  const { data: referents } = useMembres({ collectiviteId, estReferent: true });
-  const conseillers =
-    groupeParFonction(referents?.membres ?? [])?.conseiller ?? [];
 
   return (
     <ChecklistPageHeaderView
@@ -84,7 +74,6 @@ export const ChecklistPageHeader = ({
       collectiviteId={collectiviteId}
       referentiel={actions[0]}
       roleMesures={parcours?.roleMesures ?? null}
-      conseillers={conseillers}
     />
   );
 };

--- a/apps/app/src/referentiels/audit-labellisation/checklist-page-header/conseiller-referent.item.tsx
+++ b/apps/app/src/referentiels/audit-labellisation/checklist-page-header/conseiller-referent.item.tsx
@@ -1,26 +1,61 @@
-import { Membre } from '@/app/collectivites/membres/list-membres/use-list-membres';
+'use client';
+
 import { appLabels } from '@/app/labels/catalog';
+import ReferentsDropdown from '@/app/referentiels/tableau-de-bord/referents/ReferentsDropdown';
 import { MetadataItem } from '@/app/ui/metadata-line';
-import { ReactElement } from 'react';
+import { InlineEditWrapper } from '@tet/ui';
+import { ReactElement, useState } from 'react';
+import { useConseillerReferent } from './use-conseiller-referent';
 
 export const ConseillerReferentItem = ({
-  conseillers,
   hideSeparator,
 }: {
-  conseillers: Membre[];
   hideSeparator?: boolean;
 }): ReactElement => {
-  const names = conseillers
+  const {
+    conseillers,
+    referents,
+    areConseillersLoading,
+    isReadOnly,
+    isMutating,
+    saveConseillers,
+  } = useConseillerReferent();
+
+  const [isOpen, setIsOpen] = useState(false);
+
+  const names = referents
     .map((membre) => [membre.prenom, membre.nom].filter(Boolean).join(' '))
     .filter(Boolean)
     .join(', ');
 
+  const isInteractive = !isReadOnly && conseillers.length > 0;
+
   return (
-    <MetadataItem
-      hideSeparator={hideSeparator}
-      icon="user-star-line"
-      label={appLabels.membreTeteFonctionConseiller}
-      value={names || <i>{appLabels.nonRenseigne}</i>}
-    />
+    <InlineEditWrapper
+      disabled={!isInteractive || isMutating}
+      openState={{ isOpen, setIsOpen }}
+      renderOnEdit={({ openState }) => (
+        <ReferentsDropdown
+          buttonClassName="border-none"
+          membres={conseillers}
+          onChange={({ values }) =>
+            saveConseillers((values ?? []).map(String))
+          }
+          openState={openState}
+        />
+      )}
+    >
+      <MetadataItem
+        interactive={isInteractive}
+        hideSeparator={hideSeparator}
+        icon="user-star-line"
+        label={appLabels.membreTeteFonctionConseiller}
+        value={
+          areConseillersLoading
+            ? appLabels.chargement
+            : names || <i>{appLabels.nonRenseigne}</i>
+        }
+      />
+    </InlineEditWrapper>
   );
 };

--- a/apps/app/src/referentiels/audit-labellisation/checklist-page-header/referents-line.tsx
+++ b/apps/app/src/referentiels/audit-labellisation/checklist-page-header/referents-line.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { Membre } from '@/app/collectivites/membres/list-membres/use-list-membres';
 import { appLabels } from '@/app/labels/catalog';
 import { MetadataLine } from '@/app/ui/metadata-line';
 import { RoleKey } from '@tet/domain/referentiels';
@@ -31,10 +30,8 @@ const ROLE_CONFIGS: RoleConfig[] = [
 
 export const ReferentsLine = ({
   roleMesures,
-  conseillers,
 }: {
   roleMesures: RoleMesures | null;
-  conseillers: Membre[];
 }): ReactElement => {
   const visibleRoles = ROLE_CONFIGS.map((config) => ({
     config,
@@ -58,7 +55,7 @@ export const ReferentsLine = ({
           label={config.label}
         />
       ))}
-      <ConseillerReferentItem conseillers={conseillers} hideSeparator />
+      <ConseillerReferentItem hideSeparator />
     </MetadataLine>
   );
 };

--- a/apps/app/src/referentiels/audit-labellisation/checklist-page-header/use-conseiller-referent.ts
+++ b/apps/app/src/referentiels/audit-labellisation/checklist-page-header/use-conseiller-referent.ts
@@ -1,0 +1,51 @@
+import {
+  Membre,
+  useListMembres,
+} from '@/app/collectivites/membres/list-membres/use-list-membres';
+import { useUpdateMembres } from '@/app/collectivites/membres/use-update-membres';
+import { groupeParFonction } from '@/app/referentiels/tableau-de-bord/referents/useMembres';
+import {
+  useCollectiviteId,
+  useCurrentCollectivite,
+} from '@tet/api/collectivites';
+
+export const useConseillerReferent = (): {
+  conseillers: Membre[];
+  referents: Membre[];
+  areConseillersLoading: boolean;
+  isReadOnly: boolean;
+  isMutating: boolean;
+  saveConseillers: (userIds: string[]) => void;
+} => {
+  const collectiviteId = useCollectiviteId();
+  const { hasCollectivitePermission } = useCurrentCollectivite();
+  const isReadOnly = !hasCollectivitePermission('collectivites.membres.mutate');
+
+  const { data: membres, isLoading: areConseillersLoading } = useListMembres();
+  const conseillers = groupeParFonction(membres ?? [])?.conseiller ?? [];
+  const referents = conseillers.filter((membre) => membre.estReferent);
+
+  const { mutate: updateMembres, isPending: isMutating } = useUpdateMembres();
+
+  const saveConseillers = (userIds: string[]): void => {
+    const toUpdate = conseillers
+      .filter((membre) => membre.estReferent !== userIds.includes(membre.userId))
+      .map((membre) => ({
+        userId: membre.userId,
+        estReferent: userIds.includes(membre.userId),
+        collectiviteId,
+      }));
+    if (toUpdate.length > 0) {
+      updateMembres(toUpdate);
+    }
+  };
+
+  return {
+    conseillers,
+    referents,
+    areConseillersLoading,
+    isReadOnly,
+    isMutating,
+    saveConseillers,
+  };
+};


### PR DESCRIPTION
## Contexte

Aujourd'hui la conseiller·ère se modifie via la modale "Associer des référents" (tableau de bord). Cette PR ajoute l'édition directe depuis le header de la route `/new/[referentielId]`, via le `MetadataItem` "Conseiller·ère".

## Changements

- `conseiller-referent.item.tsx` : l'item passe de lecture seule à éditable inline (`InlineEditWrapper` + `ReferentsDropdown`), en miroir du `RoleMesureItem` voisin.
- `use-conseiller-referent.ts` (nouveau) : hook self-fetch des membres `fonction === conseiller` (via `useListMembres`), expose `isReadOnly` / `isMutating` / `saveConseillers`. La sauvegarde diffe le flag `estReferent` et appelle la mutation existante `collectivites.membres.update` (aucun changement backend).
- `referents-line.tsx` / `checklist-page-header.tsx` : l'item se charge lui-même, suppression du threading du prop `conseillers` et du fetch devenu inutile.

## Décisions

- **Permission** : édition réservée aux administrateurs de la collectivité (`collectivites.membres.mutate`). Lecture seule sinon.
- L'item n'est interactif que s'il existe au moins un membre conseiller (la création de membres reste hors de ce dropdown).
- La modale "Associer des référents" est **laissée intacte** : le conseiller reste modifiable des deux côtés.
- L'édition modifie le conseiller **au niveau collectivité** (comme la modale), pas par référentiel.

## Vérifications

- `tsc --build` : OK
- eslint : OK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * La section des référents dans l’en-tête de checklist devient modifiable directement depuis l’interface.
  * Les conseillers/référents s’affichent désormais avec un état de chargement et un mode lecture seule selon les droits.

* **Bug Fixes**
  * L’affichage et la mise à jour des référents sont désormais plus cohérents, avec une sauvegarde des changements uniquement lorsqu’une modification est nécessaire.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->