### PR TITLE
feat(indicateurs): format Excel consolidé — 1 onglet, 1 ligne par indicateur (TET-7414)

### DIFF
--- a/apps/app/src/app/pages/collectivite/Indicateurs/Indicateur/useExportIndicateurs.ts
+++ b/apps/app/src/app/pages/collectivite/Indicateurs/Indicateur/useExportIndicateurs.ts
@@ -1,15 +1,20 @@
-import { IndicateurDefinitionListItem } from '@/app/indicateurs/indicateurs/use-list-indicateurs';
+import { ListDefinitionsInputFilters } from '@/app/indicateurs/indicateurs/use-list-indicateurs';
 import { appLabels } from '@/app/labels/catalog';
 import { saveBlob } from '@/app/referentiels/preuves/Bibliotheque/saveBlob';
 import { useToastContext } from '@/app/utils/toast/toast-context';
 import { useApiClient } from '@/app/utils/use-api-client';
 import { useMutation } from '@tanstack/react-query';
 import { useCurrentCollectivite } from '@tet/api/collectivites';
+import { ListDefinitionsInputSort } from '@tet/domain/indicateurs';
 import { Event, useEventTracker } from '@tet/ui';
 
-export const useExportIndicateurs = (
-  definitions?: IndicateurDefinitionListItem[]
-) => {
+type SortItem = { field: ListDefinitionsInputSort; direction: 'asc' | 'desc' };
+
+export type ExportIndicateursInput =
+  | { mode: 'selection'; indicateurIds: number[] }
+  | { mode: 'all'; filters?: ListDefinitionsInputFilters; sort?: SortItem[] };
+
+export const useExportIndicateurs = (input: ExportIndicateursInput) => {
   const trackEvent = useEventTracker();
   const { collectiviteId } = useCurrentCollectivite();
   const apiClient = useApiClient();
@@ -19,14 +24,26 @@ export const useExportIndicateurs = (
     mutationKey: ['export_indicateurs', collectiviteId],
 
     mutationFn: async () => {
-      if (!collectiviteId || !definitions?.length) return;
-      const indicateurIds = definitions.map((d) => d.id);
+      if (!collectiviteId) return;
+      if (input.mode === 'selection' && !input.indicateurIds.length) return;
+
+      const params =
+        input.mode === 'selection'
+          ? {
+              mode: 'selection' as const,
+              collectiviteId,
+              indicateurIds: input.indicateurIds,
+            }
+          : {
+              mode: 'all' as const,
+              collectiviteId,
+              filters: input.filters,
+              sort: input.sort,
+            };
+
       try {
         const { blob, filename } = await apiClient.getAsBlob(
-          {
-            route: '/indicateur-definitions/xlsx',
-            params: { collectiviteId, indicateurIds },
-          },
+          { route: '/indicateur-definitions/xlsx', params },
           'POST'
         );
 

--- a/apps/app/src/app/pages/collectivite/Indicateurs/detail/Header/IndicateurToolbar.tsx
+++ b/apps/app/src/app/pages/collectivite/Indicateurs/detail/Header/IndicateurToolbar.tsx
@@ -24,9 +24,10 @@ const IndicateurToolbar = ({
 }: Props) => {
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
 
-  const { mutate: exportIndicateurs, isPending } = useExportIndicateurs([
-    definition,
-  ]);
+  const { mutate: exportIndicateurs, isPending } = useExportIndicateurs({
+    mode: 'selection',
+    indicateurIds: [definition.id],
+  });
 
   const { estFavori } = definition;
 
@@ -66,6 +67,7 @@ const IndicateurToolbar = ({
         </Tooltip>
 
         <Button
+          dataTest="indicateurs.detail.exporter-excel"
           loading={isPending}
           disabled={isPending}
           icon="download-fill"

--- a/apps/app/src/app/pages/collectivite/Indicateurs/lists/indicateurs-list/badge-list.tsx
+++ b/apps/app/src/app/pages/collectivite/Indicateurs/lists/indicateurs-list/badge-list.tsx
@@ -1,16 +1,21 @@
 import {
-  IndicateurDefinitionListItem,
   ListDefinitionsInputFilters,
 } from '@/app/indicateurs/indicateurs/use-list-indicateurs';
 import DEPRECATED_FilterBadges, {
   CustomFilterBadges,
   useFiltersToBadges,
 } from '@/app/ui/lists/DEPRECATED_filter-badges';
+import { ListDefinitionsInputSort } from '@tet/domain/indicateurs';
 import ExportButton from './export-button';
 
+type SortItem = { field: ListDefinitionsInputSort; direction: 'asc' | 'desc' };
+
 type Props = {
-  definitions?: IndicateurDefinitionListItem[];
+  /** Filtres affichés en badges (sans les filtres par défaut de la vue) */
   filters: ListDefinitionsInputFilters;
+  /** Filtres complets à envoyer à l'export (incluant les filtres par défaut) */
+  exportFilters?: ListDefinitionsInputFilters;
+  exportSort?: SortItem[];
   customFilterBadges?: CustomFilterBadges;
   resetFilters?: () => void;
   isLoading: boolean;
@@ -18,8 +23,9 @@ type Props = {
 };
 
 const BadgeList = ({
-  definitions,
   filters,
+  exportFilters,
+  exportSort,
   customFilterBadges,
   resetFilters,
   isEmpty,
@@ -44,7 +50,11 @@ const BadgeList = ({
         />
       )}
       {displayExportButton && (
-        <ExportButton definitions={definitions} isFiltered={!!filterBadges} />
+        <ExportButton
+          filters={exportFilters}
+          sort={exportSort}
+          isFiltered={!!filterBadges?.length}
+        />
       )}
     </div>
   );

--- a/apps/app/src/app/pages/collectivite/Indicateurs/lists/indicateurs-list/export-button.tsx
+++ b/apps/app/src/app/pages/collectivite/Indicateurs/lists/indicateurs-list/export-button.tsx
@@ -1,22 +1,25 @@
 import { useExportIndicateurs } from '@/app/app/pages/collectivite/Indicateurs/Indicateur/useExportIndicateurs';
-import { IndicateurDefinitionListItem } from '@/app/indicateurs/indicateurs/use-list-indicateurs';
+import { ListDefinitionsInputFilters } from '@/app/indicateurs/indicateurs/use-list-indicateurs';
 import { appLabels } from '@/app/labels/catalog';
-import { Badge } from '@tet/ui';
-import classNames from 'classnames';
+import { ListDefinitionsInputSort } from '@tet/domain/indicateurs';
+import { Badge, cn } from '@tet/ui';
+
+type SortItem = { field: ListDefinitionsInputSort; direction: 'asc' | 'desc' };
 
 type Props = {
-  definitions?: IndicateurDefinitionListItem[];
+  filters?: ListDefinitionsInputFilters;
+  sort?: SortItem[];
   isFiltered: boolean;
 };
 
-const ExportButton = ({ definitions, isFiltered }: Props) => {
-  // fonction d'export
+const ExportButton = ({ filters, sort, isFiltered }: Props) => {
   const { mutate: exportIndicateurs, isPending: isDownloadingExport } =
-    useExportIndicateurs(definitions);
+    useExportIndicateurs({ mode: 'all', filters, sort });
 
   return (
     <button
-      className={classNames('shrink-0 ml-auto', {
+      data-test="indicateurs.liste.exporter-excel"
+      className={cn('shrink-0 ml-auto', {
         'opacity-50': isDownloadingExport,
       })}
       disabled={isDownloadingExport}

--- a/apps/app/src/app/pages/collectivite/Indicateurs/lists/indicateurs-list/indicateurs-list.tsx
+++ b/apps/app/src/app/pages/collectivite/Indicateurs/lists/indicateurs-list/indicateurs-list.tsx
@@ -61,20 +61,15 @@ const IndicateursListe = (props: Props) => {
   // indique si le panneau des filtres est ouvert
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
 
+  const sort = sortByItems
+    .filter((item) => item.value === sortBy)
+    .map((item) => ({ field: item.value, direction: item.direction }));
+
   const { data: { data: definitions, count = 0 } = {}, isPending } =
     useListIndicateurs({
       collectiviteId,
       filters,
-      queryOptions: {
-        page: currentPage,
-        limit: maxNbOfCards,
-        sort: sortByItems
-          .filter((item) => item.value === sortBy)
-          .map((item) => ({
-            field: item.value,
-            direction: item.direction,
-          })),
-      },
+      queryOptions: { page: currentPage, limit: maxNbOfCards, sort },
     });
 
   /** Filtres (définis par la vue courante) à exclure des badges */
@@ -106,12 +101,13 @@ const IndicateursListe = (props: Props) => {
       />
       {/** Liste des filtres appliqués et bouton d'export */}
       <BadgeList
-        definitions={definitions}
         filters={filtresBadges}
+        exportFilters={filters}
+        exportSort={sort}
         customFilterBadges={customFilterBadges}
         resetFilters={resetFilters}
         isLoading={isPending}
-        isEmpty={definitions?.length === 0}
+        isEmpty={count === 0}
       />
       {/** Chargement */}
       {isPending ? (

--- a/apps/backend/src/indicateurs/indicateurs/export-indicateurs/export-indicateurs.builder.spec.ts
+++ b/apps/backend/src/indicateurs/indicateurs/export-indicateurs/export-indicateurs.builder.spec.ts
@@ -1,0 +1,128 @@
+import { Workbook } from 'exceljs';
+import { describe, expect, it } from 'vitest';
+import { IndicateurValeurAvecMetadonnesDefinition } from '../../valeurs/indicateur-valeur.table';
+import { buildConsolidatedSheet } from './export-indicateurs.builder';
+
+/**
+ * Construit une valeur minimale pour le builder : seuls `dateValeur`,
+ * `resultat`, `objectif`, l'id de définition et la source sont lus.
+ */
+function makeValeur(params: {
+  indicateurId: number;
+  annee: number;
+  resultat?: number | null;
+  objectif?: number | null;
+  sourceId?: string;
+}): IndicateurValeurAvecMetadonnesDefinition {
+  const { indicateurId, annee, resultat, objectif, sourceId } = params;
+  return {
+    indicateur_valeur: {
+      dateValeur: `${annee}-01-01`,
+      resultat: resultat ?? null,
+      objectif: objectif ?? null,
+    },
+    indicateur_definition: { id: indicateurId },
+    indicateur_source_metadonnee: sourceId
+      ? { id: 1, sourceId, dateVersion: `${annee}-01-01` }
+      : null,
+  } as unknown as IndicateurValeurAvecMetadonnesDefinition;
+}
+
+const parent = {
+  id: 1,
+  identifiantReferentiel: 'cae_1',
+  titre: 'Indicateur test',
+  unite: 'kg',
+  pilotes: [],
+  services: [],
+  commentaire: 'Commentaire collectivité',
+  enfants: [],
+};
+
+const SOURCE_COL = 8; // colonne "Source" (après les 7 colonnes fixes)
+
+function getSheet(valeurs: IndicateurValeurAvecMetadonnesDefinition[]) {
+  const workbook = new Workbook();
+  buildConsolidatedSheet(
+    workbook,
+    [parent],
+    valeurs,
+    new Map([['rare', 'RARE']])
+  );
+  const ws = workbook.getWorksheet(1);
+  if (!ws) throw new Error('Worksheet not found');
+  return ws;
+}
+
+describe('buildConsolidatedSheet — sources open-data', () => {
+  it('ajoute une ligne par source open-data en plus de la ligne collectivité', () => {
+    const ws = getSheet([
+      // saisie collectivité
+      makeValeur({ indicateurId: 1, annee: 2022, resultat: 100, objectif: 120 }),
+      // open-data (source "rare")
+      makeValeur({
+        indicateurId: 1,
+        annee: 2022,
+        resultat: 90,
+        sourceId: 'rare',
+      }),
+    ]);
+
+    // 1 en-tête + 1 ligne collectivité + 1 ligne open-data
+    expect(ws.rowCount).toBe(3);
+
+    const collectiviteRow = ws.getRow(2).values as unknown[];
+    expect(collectiviteRow[SOURCE_COL]).toBe('Collectivité');
+    expect(collectiviteRow[7]).toBe('Commentaire collectivité');
+
+    const openDataRow = ws.getRow(3).values as unknown[];
+    // Le libellé lisible de la source remplace l'identifiant technique.
+    expect(openDataRow[SOURCE_COL]).toBe('RARE');
+    // Les métadonnées (commentaire, pilote…) ne concernent que la collectivité.
+    expect(openDataRow[7]).toBe('');
+  });
+
+  it('inclut les années présentes uniquement en open-data dans les colonnes', () => {
+    const ws = getSheet([
+      makeValeur({ indicateurId: 1, annee: 2020, resultat: 10 }),
+      makeValeur({
+        indicateurId: 1,
+        annee: 2030,
+        resultat: 42,
+        objectif: 50,
+        sourceId: 'rare',
+      }),
+    ]);
+
+    const headerValues = ws.getRow(1).values as unknown[];
+    // Libellé : année en premier.
+    expect(headerValues).toContain('2020 Résultat');
+    expect(headerValues).toContain('2030 Résultat');
+    expect(headerValues).toContain('2030 Objectif');
+  });
+
+  it("ne crée pas de colonne pour un type/année sans aucune valeur", () => {
+    const ws = getSheet([
+      // Uniquement des résultats (aucun objectif nulle part) → aucune colonne Objectif.
+      makeValeur({ indicateurId: 1, annee: 2020, resultat: 10 }),
+      makeValeur({ indicateurId: 1, annee: 2021, resultat: 20 }),
+    ]);
+
+    const headerValues = (ws.getRow(1).values as unknown[]).filter(
+      (v) => typeof v === 'string'
+    ) as string[];
+    expect(headerValues).toContain('2020 Résultat');
+    expect(headerValues).toContain('2021 Résultat');
+    expect(headerValues.some((h) => h.includes('Objectif'))).toBe(false);
+  });
+
+  it("n'ajoute aucune ligne open-data quand il n'y en a pas", () => {
+    const ws = getSheet([
+      makeValeur({ indicateurId: 1, annee: 2022, resultat: 100 }),
+    ]);
+
+    // 1 en-tête + 1 ligne collectivité uniquement
+    expect(ws.rowCount).toBe(2);
+    expect((ws.getRow(2).values as unknown[])[SOURCE_COL]).toBe('Collectivité');
+  });
+});

--- a/apps/backend/src/indicateurs/indicateurs/export-indicateurs/export-indicateurs.builder.ts
+++ b/apps/backend/src/indicateurs/indicateurs/export-indicateurs/export-indicateurs.builder.ts
@@ -1,0 +1,245 @@
+import { PersonneTagOrUser, Tag } from '@tet/domain/collectivites';
+import { Workbook, Worksheet } from 'exceljs';
+import {
+  adjustColumnWidth,
+  BOLD,
+} from '../../../utils/excel/export-excel.utils';
+import { IndicateurValeurAvecMetadonnesDefinition } from '../../valeurs/indicateur-valeur.table';
+
+type EnfantRow = {
+  id: number;
+  identifiantReferentiel: string | null;
+  titre: string;
+};
+
+type RowData = EnfantRow & {
+  unite: string;
+  pilotes: PersonneTagOrUser[];
+  services: Tag[];
+  commentaire: string | null;
+};
+
+type ParentRow = RowData & {
+  enfants: EnfantRow[];
+};
+
+/** Regroupement des valeurs d'un indicateur : la saisie de la collectivité et
+ * les valeurs open-data ventilées par source. */
+type IndicateurValeurs = {
+  collectivite: IndicateurValeurAvecMetadonnesDefinition[];
+  parSource: Map<string, IndicateurValeurAvecMetadonnesDefinition[]>;
+};
+
+/** Libellé de la colonne Source pour la ligne de saisie de la collectivité. */
+const SOURCE_COLLECTIVITE = 'Collectivité';
+
+const FIXED_HEADERS = [
+  'Identifiant',
+  "Nom de l'indicateur",
+  'Indicateur parent',
+  'Unité',
+  'Pilote',
+  'Direction ou service pilote',
+  'Commentaire',
+  'Source',
+] as const;
+
+/** Années effectivement présentes, séparées par type de valeur. Une année
+ * n'apparaît que si au moins une valeur (toutes lignes confondues) l'alimente. */
+type YearsByType = {
+  resultat: number[];
+  objectif: number[];
+};
+
+/**
+ * Construit une feuille unique consolidée dans le classeur :
+ * - Une ligne par indicateur pour la saisie de la collectivité (parent puis
+ *   chaque enfant sur sa propre ligne)
+ * - Une ligne supplémentaire par source open-data disposant de valeurs
+ * - Colonnes dynamiques `<année> Résultat` / `<année> Objectif`, créées
+ *   uniquement pour les années comportant au moins une valeur du type concerné
+ * - En-tête figé (freeze panes)
+ */
+export function buildConsolidatedSheet(
+  workbook: Workbook,
+  parents: ParentRow[],
+  indicateursValeurs: IndicateurValeurAvecMetadonnesDefinition[],
+  sourceLabels: Map<string, string> = new Map()
+): void {
+  const worksheet = workbook.addWorksheet('Indicateurs');
+
+  // Années réellement renseignées (saisie collectivité + open-data), séparées
+  // par type : une colonne n'est créée que si elle contient au moins une valeur.
+  const years = collectYears(indicateursValeurs);
+
+  addHeaderRow(worksheet, years);
+
+  // Index des valeurs par identifiant d'indicateur, séparant saisie
+  // collectivité et sources open-data.
+  const valeursByIndicateurId = indexValeurs(indicateursValeurs);
+
+  for (const parent of parents) {
+    addIndicateurRows(
+      worksheet,
+      parent,
+      null,
+      years,
+      valeursByIndicateurId,
+      sourceLabels
+    );
+
+    for (const enfant of parent.enfants ?? []) {
+      addIndicateurRows(
+        worksheet,
+        {
+          ...enfant,
+          unite: parent.unite, // héritage de l'unité du parent
+          pilotes: [],
+          services: [],
+          commentaire: null,
+        },
+        parent.titre,
+        years,
+        valeursByIndicateurId,
+        sourceLabels
+      );
+    }
+  }
+
+  worksheet.getRow(1).font = BOLD;
+  // Figer la ligne d'en-tête pour la lisibilité sur les exports volumineux
+  worksheet.views = [{ state: 'frozen', ySplit: 1 }];
+  adjustColumnWidth(worksheet);
+}
+
+// --- helpers privés ---
+
+function collectYears(
+  indicateursValeurs: IndicateurValeurAvecMetadonnesDefinition[]
+): YearsByType {
+  const resultat = new Set<number>();
+  const objectif = new Set<number>();
+  for (const v of indicateursValeurs) {
+    const annee = new Date(v.indicateur_valeur.dateValeur).getFullYear();
+    if (v.indicateur_valeur.resultat !== null) resultat.add(annee);
+    if (v.indicateur_valeur.objectif !== null) objectif.add(annee);
+  }
+  return {
+    resultat: [...resultat].sort((a, b) => a - b),
+    objectif: [...objectif].sort((a, b) => a - b),
+  };
+}
+
+function indexValeurs(
+  indicateursValeurs: IndicateurValeurAvecMetadonnesDefinition[]
+): Map<number, IndicateurValeurs> {
+  const map = new Map<number, IndicateurValeurs>();
+  for (const v of indicateursValeurs) {
+    const id = v.indicateur_definition?.id;
+    if (!id) continue;
+    const entry = map.get(id) ?? {
+      collectivite: [],
+      parSource: new Map<string, IndicateurValeurAvecMetadonnesDefinition[]>(),
+    };
+    const metadonnee = v.indicateur_source_metadonnee;
+    if (metadonnee) {
+      const bucket = entry.parSource.get(metadonnee.sourceId) ?? [];
+      bucket.push(v);
+      entry.parSource.set(metadonnee.sourceId, bucket);
+    } else {
+      entry.collectivite.push(v);
+    }
+    map.set(id, entry);
+  }
+  return map;
+}
+
+function addHeaderRow(worksheet: Worksheet, years: YearsByType): void {
+  worksheet.addRow([
+    ...FIXED_HEADERS,
+    ...years.resultat.map((y) => `${y} Résultat`),
+    ...years.objectif.map((y) => `${y} Objectif`),
+  ]);
+}
+
+/**
+ * Ajoute la ligne de saisie de la collectivité puis, quand elles existent, une
+ * ligne par source open-data (résultats et/ou objectifs).
+ */
+function addIndicateurRows(
+  worksheet: Worksheet,
+  indicator: RowData,
+  parentTitre: string | null,
+  years: YearsByType,
+  valeursByIndicateurId: Map<number, IndicateurValeurs>,
+  sourceLabels: Map<string, string>
+): void {
+  const valeurs = valeursByIndicateurId.get(indicator.id);
+
+  // Ligne de la collectivité : toujours présente (colonnes valeurs vides si
+  // aucune saisie), elle porte les métadonnées de l'indicateur (pilote, etc.).
+  addValeursRow(
+    worksheet,
+    indicator,
+    parentTitre,
+    SOURCE_COLLECTIVITE,
+    valeurs?.collectivite ?? [],
+    years,
+    { withMeta: true }
+  );
+
+  // Lignes open-data : une par source disposant d'au moins une valeur.
+  const sources = [...(valeurs?.parSource.entries() ?? [])].sort(([a], [b]) =>
+    a.localeCompare(b)
+  );
+  for (const [sourceId, sourceValeurs] of sources) {
+    addValeursRow(
+      worksheet,
+      indicator,
+      parentTitre,
+      sourceLabels.get(sourceId) ?? sourceId,
+      sourceValeurs,
+      years,
+      { withMeta: false }
+    );
+  }
+}
+
+function addValeursRow(
+  worksheet: Worksheet,
+  indicator: RowData,
+  parentTitre: string | null,
+  source: string,
+  valeurs: IndicateurValeurAvecMetadonnesDefinition[],
+  years: YearsByType,
+  { withMeta }: { withMeta: boolean }
+): void {
+  const resultatByYear = new Map<number, number | null>();
+  const objectifByYear = new Map<number, number | null>();
+
+  for (const v of valeurs) {
+    const annee = new Date(v.indicateur_valeur.dateValeur).getFullYear();
+    if (v.indicateur_valeur.resultat !== null) {
+      resultatByYear.set(annee, v.indicateur_valeur.resultat);
+    }
+    if (v.indicateur_valeur.objectif !== null) {
+      objectifByYear.set(annee, v.indicateur_valeur.objectif);
+    }
+  }
+
+  const titre = parentTitre ? `  ${indicator.titre}` : indicator.titre;
+
+  worksheet.addRow([
+    indicator.identifiantReferentiel ?? String(indicator.id),
+    titre,
+    parentTitre ?? '',
+    indicator.unite,
+    // Pilote / service / commentaire ne concernent que la saisie collectivité.
+    withMeta ? indicator.pilotes.map((p) => p.nom).join(', ') : '',
+    withMeta ? indicator.services.map((s) => s.nom).join(', ') : '',
+    withMeta ? indicator.commentaire ?? '' : '',
+    source,
+    ...years.resultat.map((y) => resultatByYear.get(y) ?? null),
+    ...years.objectif.map((y) => objectifByYear.get(y) ?? null),
+  ]);
+}

--- a/apps/backend/src/indicateurs/indicateurs/export-indicateurs/export-indicateurs.controller.e2e-spec.ts
+++ b/apps/backend/src/indicateurs/indicateurs/export-indicateurs/export-indicateurs.controller.e2e-spec.ts
@@ -1,21 +1,32 @@
 import { INestApplication } from '@nestjs/common';
-import { getAuthToken, getTestApp, getTestDatabase } from '@tet/backend/test';
+import { createServiceTag } from '@tet/backend/collectivites/collectivites.test-fixture';
+import { addTestCollectiviteAndUser } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import {
+  getAuthToken,
+  getAuthUserFromUserCredentials,
+  getTestApp,
+  getTestDatabase,
+} from '@tet/backend/test';
 import { addTestUser } from '@tet/backend/users/users/users.test-fixture';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { CollectiviteRole } from '@tet/domain/users';
 import { eq } from 'drizzle-orm';
 import { Workbook } from 'exceljs';
 import { default as request } from 'supertest';
+import { TrpcRouter } from '../../../utils/trpc/trpc.router';
+import { createIndicateurPerso } from '../../definitions/definitions.test-fixture';
 import { indicateurDefinitionTable } from '../../definitions/indicateur-definition.table';
 
 describe('Indicateurs', () => {
   let app: INestApplication;
   let authToken: string;
   let databaseService: DatabaseService;
+  let router: TrpcRouter;
 
   beforeAll(async () => {
     app = await getTestApp();
     databaseService = await getTestDatabase(app);
+    router = app.get(TrpcRouter);
 
     const testUserResult = await addTestUser(databaseService, {
       collectiviteId: 1,
@@ -31,7 +42,7 @@ describe('Indicateurs', () => {
     await app.close();
   });
 
-  test('Exporte un indicateur au format XLSX', async () => {
+  test('Exporte un indicateur au format XLSX (mode selection)', async () => {
     const rows = await databaseService.db
       .select()
       .from(indicateurDefinitionTable)
@@ -42,7 +53,7 @@ describe('Indicateurs', () => {
     const response = await request(app.getHttpServer())
       .post('/indicateur-definitions/xlsx')
       .set('Authorization', `Bearer ${authToken}`)
-      .send({ collectiviteId: 1, indicateurIds: [indicateurId] })
+      .send({ mode: 'selection', collectiviteId: 1, indicateurIds: [indicateurId] })
       .expect(201)
       .responseType('blob');
 
@@ -77,5 +88,90 @@ describe('Indicateurs', () => {
       21,
       13,
     ]);
+  });
+
+  test("Exporte tous les indicateurs filtrés (mode all, au-delà d'une page)", async () => {
+    // Collectivité + utilisateur frais (admin → droit de lecture des confidentiels)
+    const { collectivite, user } = await addTestCollectiviteAndUser(
+      databaseService,
+      { user: { role: CollectiviteRole.ADMIN } }
+    );
+
+    const caller = router.createCaller({
+      user: getAuthUserFromUserCredentials(user),
+    });
+
+    // Un service tag commun sert de filtre partagé
+    const serviceTag = await createServiceTag({
+      database: databaseService,
+      tagData: { collectiviteId: collectivite.id, nom: 'Service export filtre' },
+    });
+
+    // On crée strictement plus d'indicateurs qu'une page de liste (9 par défaut côté UI)
+    const nbIndicateurs = 12;
+    const indicateurIds: number[] = [];
+    for (let i = 0; i < nbIndicateurs; i++) {
+      indicateurIds.push(
+        await createIndicateurPerso({
+          caller,
+          indicateurData: {
+            collectiviteId: collectivite.id,
+            titre: `Indicateur export ${i}`,
+            services: [{ id: serviceTag.id }],
+          },
+        })
+      );
+    }
+
+    const collectiviteAuthToken = await getAuthToken({
+      email: user.email ?? '',
+      password: user.password,
+    });
+
+    const response = await request(app.getHttpServer())
+      .post('/indicateur-definitions/xlsx')
+      .set('Authorization', `Bearer ${collectiviteAuthToken}`)
+      .send({
+        mode: 'all',
+        collectiviteId: collectivite.id,
+        filters: { serviceIds: [serviceTag.id] },
+      })
+      .expect(201)
+      .responseType('blob');
+
+    const body = response.body as ArrayBuffer;
+
+    const wb = new Workbook();
+    await wb.xlsx.load(body);
+
+    // Les indicateurs perso n'ont ni parent ni enfant : un onglet par indicateur.
+    // On vérifie que l'export contient bien tous les indicateurs filtrés,
+    // pas seulement la première page.
+    expect(wb.worksheets.length).toBe(nbIndicateurs);
+
+    // Cas de contrôle : le mode `selection` n'exporte que les ids fournis.
+    const selectionIds = indicateurIds.slice(0, 2);
+    const selectionResponse = await request(app.getHttpServer())
+      .post('/indicateur-definitions/xlsx')
+      .set('Authorization', `Bearer ${collectiviteAuthToken}`)
+      .send({
+        mode: 'selection',
+        collectiviteId: collectivite.id,
+        indicateurIds: selectionIds,
+      })
+      .expect(201)
+      .responseType('blob');
+
+    const selectionWb = new Workbook();
+    await selectionWb.xlsx.load(selectionResponse.body as ArrayBuffer);
+    expect(selectionWb.worksheets.length).toBe(selectionIds.length);
+  });
+
+  test('Refuse une requête sans mode (ancien contrat)', async () => {
+    await request(app.getHttpServer())
+      .post('/indicateur-definitions/xlsx')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ collectiviteId: 1, indicateurIds: [1] })
+      .expect(400);
   });
 });

--- a/apps/backend/src/indicateurs/indicateurs/export-indicateurs/export-indicateurs.controller.e2e-spec.ts
+++ b/apps/backend/src/indicateurs/indicateurs/export-indicateurs/export-indicateurs.controller.e2e-spec.ts
@@ -1,5 +1,8 @@
 import { INestApplication } from '@nestjs/common';
-import { createServiceTag } from '@tet/backend/collectivites/collectivites.test-fixture';
+import {
+  createPersonneTag,
+  createServiceTag,
+} from '@tet/backend/collectivites/collectivites.test-fixture';
 import { addTestCollectiviteAndUser } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
 import {
   getAuthToken,
@@ -16,6 +19,7 @@ import { default as request } from 'supertest';
 import { TrpcRouter } from '../../../utils/trpc/trpc.router';
 import { createIndicateurPerso } from '../../definitions/definitions.test-fixture';
 import { indicateurDefinitionTable } from '../../definitions/indicateur-definition.table';
+import { indicateurGroupeTable } from '../../shared/models/indicateur-groupe.table';
 
 describe('Indicateurs', () => {
   let app: INestApplication;
@@ -53,7 +57,11 @@ describe('Indicateurs', () => {
     const response = await request(app.getHttpServer())
       .post('/indicateur-definitions/xlsx')
       .set('Authorization', `Bearer ${authToken}`)
-      .send({ mode: 'selection', collectiviteId: 1, indicateurIds: [indicateurId] })
+      .send({
+        mode: 'selection',
+        collectiviteId: 1,
+        indicateurIds: [indicateurId],
+      })
       .expect(201)
       .responseType('blob');
 
@@ -69,25 +77,29 @@ describe('Indicateurs', () => {
     expect(fileName).toMatch(
       /^Ambérieu-en-Bugey - cae_8 - Rénovation énergétique des logements - \d{4}-\d{2}-\d{2}.*\.xlsx$/
     );
-    // poids approximitatif du fichier attendu car la date de génération peut le faire un peu varier
-    expect(body.byteLength).toBeGreaterThanOrEqual(6700);
-    expect(body.byteLength).toBeLessThanOrEqual(6800);
 
-    // crée le classeur et vérifie le contenu de la 2ème ligne de la 1ère feuille
+    // Format consolidé : 1 onglet unique pour tous les indicateurs
     const wb = new Workbook();
     await wb.xlsx.load(body);
+    expect(wb.worksheets.length).toBe(1);
     const ws = wb.getWorksheet(1);
-    expect(ws).toBeDefined();
-    const row = ws?.getRow(2);
-    expect(row?.values).toEqual([
-      undefined, // index des colonnes à partir de 1
-      'cae_8',
-      'Rénovation énergétique des logements',
-      'Mes objectifs',
-      'nombre logements rénovés/100 logements existants',
-      21,
-      13,
-    ]);
+    if (!ws) {
+      throw new Error('Worksheet not found');
+    }
+
+    // En-tête (row 1) — colonnes fixes du format consolidé
+    const headerValues = ws.getRow(1).values as unknown[];
+    expect(headerValues[1]).toBe('Identifiant');
+    expect(headerValues[2]).toBe("Nom de l'indicateur");
+    expect(headerValues[3]).toBe('Indicateur parent');
+    expect(headerValues[4]).toBe('Unité');
+
+    // Ligne de données (row 2) — identifiant, titre, pas de parent, unité
+    const dataRow = ws.getRow(2).values as unknown[];
+    expect(dataRow[1]).toBe('cae_8');
+    expect(dataRow[2]).toBe('Rénovation énergétique des logements');
+    expect(dataRow[3]).toBe(''); // cae_8 n'a pas de parent
+    expect(dataRow[4]).toBe('nombre logements rénovés/100 logements existants');
   });
 
   test("Exporte tous les indicateurs filtrés (mode all, au-delà d'une page)", async () => {
@@ -104,7 +116,10 @@ describe('Indicateurs', () => {
     // Un service tag commun sert de filtre partagé
     const serviceTag = await createServiceTag({
       database: databaseService,
-      tagData: { collectiviteId: collectivite.id, nom: 'Service export filtre' },
+      tagData: {
+        collectiviteId: collectivite.id,
+        nom: 'Service export filtre',
+      },
     });
 
     // On crée strictement plus d'indicateurs qu'une page de liste (9 par défaut côté UI)
@@ -144,10 +159,12 @@ describe('Indicateurs', () => {
     const wb = new Workbook();
     await wb.xlsx.load(body);
 
-    // Les indicateurs perso n'ont ni parent ni enfant : un onglet par indicateur.
+    // Format consolidé : 1 onglet unique, 1 ligne par indicateur.
     // On vérifie que l'export contient bien tous les indicateurs filtrés,
     // pas seulement la première page.
-    expect(wb.worksheets.length).toBe(nbIndicateurs);
+    expect(wb.worksheets.length).toBe(1);
+    // header + nbIndicateurs lignes de données
+    expect(wb.getWorksheet(1)?.rowCount).toBe(nbIndicateurs + 1);
 
     // Cas de contrôle : le mode `selection` n'exporte que les ids fournis.
     const selectionIds = indicateurIds.slice(0, 2);
@@ -164,7 +181,117 @@ describe('Indicateurs', () => {
 
     const selectionWb = new Workbook();
     await selectionWb.xlsx.load(selectionResponse.body as ArrayBuffer);
-    expect(selectionWb.worksheets.length).toBe(selectionIds.length);
+    expect(selectionWb.worksheets.length).toBe(1);
+    expect(selectionWb.getWorksheet(1)?.rowCount).toBe(selectionIds.length + 1);
+  });
+
+  test('Format consolidé : 1 onglet, 1 ligne par indicateur avec lien parent/enfant', async () => {
+    const { collectivite, user } = await addTestCollectiviteAndUser(
+      databaseService,
+      { user: { role: CollectiviteRole.ADMIN } }
+    );
+
+    const caller = router.createCaller({
+      user: getAuthUserFromUserCredentials(user),
+    });
+
+    const serviceTag = await createServiceTag({
+      database: databaseService,
+      tagData: {
+        collectiviteId: collectivite.id,
+        nom: 'Service format consolidé',
+      },
+    });
+
+    const personneTag = await createPersonneTag({
+      database: databaseService,
+      tagData: { collectiviteId: collectivite.id, nom: 'Pilote Dupont' },
+    });
+
+    const parentId = await createIndicateurPerso({
+      caller,
+      indicateurData: {
+        collectiviteId: collectivite.id,
+        titre: 'Indicateur parent',
+        unite: 'kg CO2',
+        commentaire: 'Commentaire parent',
+        services: [{ id: serviceTag.id }],
+        pilotes: [{ tagId: personneTag.id }],
+        valeurs: [
+          { dateValeur: '2022-01-01', resultat: 100, objectif: 120 },
+          { dateValeur: '2023-01-01', resultat: 80, objectif: 90 },
+        ],
+      },
+    });
+
+    const childId = await createIndicateurPerso({
+      caller,
+      indicateurData: {
+        collectiviteId: collectivite.id,
+        titre: 'Indicateur enfant',
+        unite: 'kg CO2',
+        valeurs: [
+          { dateValeur: '2022-01-01', resultat: 40 },
+          { dateValeur: '2023-01-01', resultat: 35 },
+        ],
+      },
+    });
+
+    await databaseService.db
+      .insert(indicateurGroupeTable)
+      .values({ parent: parentId, enfant: childId });
+
+    const collectiviteAuthToken = await getAuthToken({
+      email: user.email ?? '',
+      password: user.password,
+    });
+
+    const response = await request(app.getHttpServer())
+      .post('/indicateur-definitions/xlsx')
+      .set('Authorization', `Bearer ${collectiviteAuthToken}`)
+      .send({
+        mode: 'all',
+        collectiviteId: collectivite.id,
+        filters: { serviceIds: [serviceTag.id] },
+      })
+      .expect(201)
+      .responseType('blob');
+
+    const wb = new Workbook();
+    await wb.xlsx.load(response.body as ArrayBuffer);
+
+    // Format consolidé : 1 seul onglet (remplace le multi-onglets)
+    expect(wb.worksheets.length).toBe(1);
+
+    const ws = wb.getWorksheet(1);
+    if (!ws) {
+      throw new Error('Worksheet not found');
+    }
+
+    // L'en-tête (row 1) doit contenir les nouvelles colonnes fixes
+    const headerValues = ws.getRow(1).values as unknown[];
+    expect(headerValues).toContain('Indicateur parent');
+    expect(headerValues).toContain('Pilote');
+    expect(headerValues).toContain('Direction ou service pilote');
+    expect(headerValues).toContain('Commentaire');
+    expect(headerValues).toContain('2022 Résultat');
+    expect(headerValues).toContain('2022 Objectif');
+
+    // 1 ligne d'en-tête + 1 ligne parent + 1 ligne enfant = 3 lignes
+    expect(ws.rowCount).toBe(3);
+
+    // Ligne parent (row 2) : nom, pilotes, services, commentaire, pas d'indicateur parent
+    const parentRow = ws.getRow(2).values as unknown[];
+    expect(parentRow[2]).toBe('Indicateur parent');
+    expect(parentRow[3]).toBe(''); // Indicateur parent vide pour un parent
+    expect(parentRow[5]).toBe('Pilote Dupont'); // Pilotes
+    expect(parentRow[6]).toBe('Service format consolidé'); // Services
+    expect(parentRow[7]).toBe('Commentaire parent'); // Commentaire
+
+    // Ligne enfant (row 3) : indentée, indicateur parent rempli
+    const childRow = ws.getRow(3).values as unknown[];
+    expect(String(childRow[2])).toContain('Indicateur enfant');
+    expect(childRow[3]).toBe('Indicateur parent'); // Indicateur parent = titre du parent
   });
 
   test('Refuse une requête sans mode (ancien contrat)', async () => {

--- a/apps/backend/src/indicateurs/indicateurs/export-indicateurs/export-indicateurs.controller.ts
+++ b/apps/backend/src/indicateurs/indicateurs/export-indicateurs/export-indicateurs.controller.ts
@@ -3,15 +3,14 @@ import { ApiExcludeController, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { ApiUsageEnum } from '@tet/backend/utils/api/api-usage-type.enum';
 import { ApiUsage } from '@tet/backend/utils/api/api-usage.decorator';
 import type { Response } from 'express';
-import { createZodDto } from 'nestjs-zod';
+import { ZodValidationPipe } from 'nestjs-zod';
 import { TokenInfo } from '../../../users/decorators/token-info.decorators';
 import type { AuthenticatedUser } from '../../../users/models/auth.models';
-import { exportIndicateursRequestSchema } from './export-indicateurs.request';
+import {
+  exportIndicateursRequestSchema,
+  type ExportIndicateursRequestType,
+} from './export-indicateurs.request';
 import ExportIndicateursService from './export-indicateurs.service';
-
-class GetExportIndicateursRequestClass extends createZodDto(
-  exportIndicateursRequestSchema
-) {}
 
 @ApiTags('Indicateurs')
 @ApiExcludeController()
@@ -25,7 +24,10 @@ export class ExportIndicateursController {
     type: Response,
   })
   async exportIndicateurs(
-    @Body() request: GetExportIndicateursRequestClass,
+    // Le schéma est une union discriminée : createZodDto ne supporte que les
+    // objets, on valide donc via ZodValidationPipe au niveau du paramètre.
+    @Body(new ZodValidationPipe(exportIndicateursRequestSchema))
+    request: ExportIndicateursRequestType,
     @TokenInfo() user: AuthenticatedUser,
     @Res() res: Response
   ) {

--- a/apps/backend/src/indicateurs/indicateurs/export-indicateurs/export-indicateurs.request.ts
+++ b/apps/backend/src/indicateurs/indicateurs/export-indicateurs/export-indicateurs.request.ts
@@ -1,13 +1,46 @@
+import {
+  listDefinitionsInputFiltersSchema,
+  listDefinitionsInputSortValues,
+} from '@tet/domain/indicateurs';
 import { z } from 'zod';
 
+const exportIndicateursSortSchema = z.object({
+  field: z.enum(listDefinitionsInputSortValues),
+  direction: z.enum(['asc', 'desc']).prefault('desc'),
+});
+
+/**
+ * Schéma d'export des indicateurs sous forme d'union discriminée :
+ * - `selection` : la liste explicite des identifiants à exporter ;
+ * - `all` : les filtres de la liste, le backend résolvant lui-même
+ *   l'ensemble complet (toutes pages confondues) via `ListIndicateursService`.
+ */
 export const exportIndicateursRequestSchema = z
-  .object({
-    collectiviteId: z.int().describe('Identifiant de la collectivité'),
-    indicateurIds: z.int()
-      .array()
-      .describe('Identifiants des indicateurs'),
-  })
+  .discriminatedUnion('mode', [
+    z.object({
+      mode: z.literal('selection'),
+      collectiviteId: z.int().describe('Identifiant de la collectivité'),
+      indicateurIds: z
+        .int()
+        .array()
+        .min(1)
+        .describe('Identifiants des indicateurs à exporter'),
+    }),
+    z.object({
+      mode: z.literal('all'),
+      collectiviteId: z.int().describe('Identifiant de la collectivité'),
+      filters: listDefinitionsInputFiltersSchema
+        .optional()
+        .prefault({})
+        .describe('Filtres de la liste des indicateurs'),
+      sort: exportIndicateursSortSchema
+        .array()
+        .optional()
+        .describe("Tri à appliquer (cohérent avec l'ordre affiché)"),
+    }),
+  ])
   .describe('Export des indicateurs');
+
 export type ExportIndicateursRequestType = z.infer<
   typeof exportIndicateursRequestSchema
 >;

--- a/apps/backend/src/indicateurs/indicateurs/export-indicateurs/export-indicateurs.service.ts
+++ b/apps/backend/src/indicateurs/indicateurs/export-indicateurs/export-indicateurs.service.ts
@@ -1,26 +1,15 @@
 import { Injectable, Logger, PayloadTooLargeException } from '@nestjs/common';
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
-import {
-  IndicateurDefinition,
-  IndicateurDefinitionAvecEnfants,
-  IndicateurSourceMetadonnee,
-  ListDefinitionsInputFilters,
-} from '@tet/domain/indicateurs';
+import { ListDefinitionsInputFilters } from '@tet/domain/indicateurs';
 import { ResourceType } from '@tet/domain/users';
 import { format } from 'date-fns';
-import { uniq } from 'es-toolkit';
 import { Workbook } from 'exceljs';
 import CollectivitesService from '../../../collectivites/services/collectivites.service';
 import { AuthenticatedUser } from '../../../users/models/auth.models';
-import {
-  adjustColumnWidth,
-  BOLD,
-  normalizeWorksheetName,
-} from '../../../utils/excel/export-excel.utils';
-import { ListCollectiviteDefinitionsRepository } from '../../definitions/list-collectivite-definitions/list-collectivite-definitions.repository';
+import IndicateurSourcesService from '../../sources/indicateur-sources.service';
 import CrudValeursService from '../../valeurs/crud-valeurs.service';
-import { IndicateurValeurAvecMetadonnesDefinition } from '../../valeurs/indicateur-valeur.table';
 import { ListIndicateursService } from '../list-indicateurs/list-indicateurs.service';
+import { buildConsolidatedSheet } from './export-indicateurs.builder';
 import { ExportIndicateursRequestType } from './export-indicateurs.request';
 
 @Injectable()
@@ -36,10 +25,10 @@ export default class ExportIndicateursService {
 
   constructor(
     private readonly permissionService: PermissionService,
-    private readonly listCollectiviteDefinitionsRepository: ListCollectiviteDefinitionsRepository,
     private readonly valeursService: CrudValeursService,
     private readonly collectiviteService: CollectivitesService,
-    private readonly listIndicateursService: ListIndicateursService
+    private readonly listIndicateursService: ListIndicateursService,
+    private readonly sourcesService: IndicateurSourcesService
   ) {}
 
   async exportXLSX(
@@ -108,19 +97,10 @@ export default class ExportIndicateursService {
       `Export de ${resolvedIds.length} indicateur(s) de la collectivité ${options.collectiviteId}`
     );
 
-    // charge les définitions (avec enfants) des indicateurs résolus
-    const definitions =
-      await this.listCollectiviteDefinitionsRepository.listCollectiviteDefinitionsAvecEnfants(
-        {
-          collectiviteId: options.collectiviteId,
-          indicateurIds: resolvedIds,
-        }
-      );
-
-    // ordonne les définitions selon l'ordre résolu (tri liste en mode `all`,
-    // ordre des identifiants fournis en mode `selection`)
-    const orderById = new Map(resolvedIds.map((id, index) => [id, index]));
-    definitions.sort(
+    // Ordonne les parents selon resolvedIds (cohérence avec le tri de la liste
+    // en mode `all`, et avec l'ordre fourni par l'appelant en mode `selection`).
+    const orderById = new Map(resolvedIds.map((id, idx) => [id, idx]));
+    const parents = [...listResult.data].sort(
       (a, b) => (orderById.get(a.id) ?? 0) - (orderById.get(b.id) ?? 0)
     );
 
@@ -158,55 +138,55 @@ export default class ExportIndicateursService {
       options.collectiviteId
     );
 
-    // génère le nom du fichier
     const filename = this.getFilename(
-      definitions,
-      collectivite.collectivite.nom || ''
+      parents,
+      collectivite.collectivite.nom ?? ''
     );
     if (!filename) return null;
 
-    // extrait les id de tous les indicateurs dont il faut charger les valeurs
-    const valeurIndicateurIds = definitions.flatMap((def) => [
-      def.id,
-      ...(def.enfants?.map((e) => e.id) ?? []),
+    // Charge les valeurs pour tous les indicateurs (parents + enfants).
+    const allIndicateurIds = parents.flatMap((p) => [
+      p.id,
+      ...(p.enfants?.map((e) => e.id) ?? []),
     ]);
 
-    // charge toutes les valeurs
     const indicateursValeurs = await this.valeursService.getIndicateursValeurs({
       collectiviteId: options.collectiviteId,
-      indicateurIds: valeurIndicateurIds,
+      indicateurIds: allIndicateurIds,
     });
 
-    // crée le classeur
-    const workbook = new Workbook();
+    // Libellés des sources open-data (identifiant technique → libellé lisible)
+    // pour nommer les lignes open-data dans l'export.
+    const sources = await this.sourcesService.getAllSources();
+    const sourceLabels = new Map(sources.map((s) => [s.id, s.libelle]));
 
-    // ajoute dans le classeur chaque indicateur
-    definitions.forEach((def) =>
-      this.addIndicateurToWorkbook(workbook, def, indicateursValeurs)
+    // Génère le classeur consolidé (1 onglet, 1 ligne par indicateur + 1 ligne
+    // par source open-data disposant de valeurs).
+    const workbook = new Workbook();
+    buildConsolidatedSheet(
+      workbook,
+      parents,
+      indicateursValeurs,
+      sourceLabels
     );
 
-    // et renvoi le résultat
     const buffer = await workbook.xlsx.writeBuffer();
     return { buffer, filename };
   }
 
   getFilename(
-    definitions: IndicateurDefinitionAvecEnfants[],
+    definitions: { identifiantReferentiel: string | null; titre: string }[],
     nomCollectivite: string
   ) {
-    // aucun indicateur
-    if (!definitions?.length) {
-      return null;
-    }
+    if (!definitions?.length) return null;
 
     const exportedAt = format(new Date(), 'yyyy-MM-dd');
-    const segments = [];
+    const segments: string[] = [];
 
     if (nomCollectivite) {
       segments.push(nomCollectivite);
     }
 
-    // 1 seul
     if (definitions.length === 1) {
       const definition = definitions[0];
       if (definition.identifiantReferentiel) {
@@ -214,167 +194,9 @@ export default class ExportIndicateursService {
       }
       segments.push(definition.titre ?? 'Sans titre', exportedAt);
     } else {
-      // plusieurs
       segments.push('Indicateurs', exportedAt);
     }
 
     return `${segments.join(' - ')}.xlsx`;
-  }
-
-  async addIndicateurToWorkbook(
-    workbook: Workbook,
-    definition: IndicateurDefinitionAvecEnfants,
-    indicateursValeurs: IndicateurValeurAvecMetadonnesDefinition[]
-  ) {
-    const worksheet = workbook.addWorksheet(
-      normalizeWorksheetName(
-        `${definition.identifiantReferentiel ?? definition.id}-${
-          definition.titre
-        }`
-      )
-    );
-
-    // extrait les ids des définitions
-    const definitions = [
-      definition,
-      ...(definition.enfants?.sort(this.sortByDefinitionId) || []),
-    ];
-    const indicateurIds = definitions.map((d) => d.id);
-
-    // filtre les données
-    const subset = indicateursValeurs.filter(
-      (ind) =>
-        ind.indicateur_definition &&
-        indicateurIds.includes(ind.indicateur_definition.id)
-    );
-
-    // extrait les années (pour créer les colonnes)
-    const annees = uniq(
-      subset.map((ind) =>
-        new Date(ind.indicateur_valeur.dateValeur).getFullYear()
-      )
-    ).sort();
-
-    // utilisé ensuite pour remplir les colonnes par années
-    const valeurParAnnee = new Map();
-    annees.forEach((annee) => valeurParAnnee.set(annee, ''));
-
-    // indexe les données par id d'indicateur et par type de données
-    // (objectif/résultat/commentaire/source)
-    const indexedRows = new Map();
-    definitions.forEach((definition) => {
-      const { id, identifiantReferentiel, titre, unite } = definition;
-      const identifiant = identifiantReferentiel ?? id;
-
-      const entries = subset.filter((s) => s.indicateur_definition?.id === id);
-
-      // ajoute quand même une ligne si il n'y a pas de valeur pour cet indicateur
-      if (!entries?.length) {
-        indexedRows.set(identifiant, {
-          identifiant,
-          titre,
-          unite,
-          annees: new Map(),
-        });
-        return;
-      }
-
-      // sinon ajoute/complète une ligne pour chaque valeur
-      entries.forEach((entry) => {
-        const {
-          indicateur_valeur: valeur,
-          indicateur_source_metadonnee: source,
-        } = entry;
-        const annee = new Date(valeur.dateValeur).getFullYear();
-        if (valeur.objectif !== null) {
-          const typeDonnee = source
-            ? `Objectifs ${this.getSourceName(source)}`
-            : 'Mes objectifs';
-          const rowKey = `${identifiant}${typeDonnee}`;
-          const row = indexedRows.get(rowKey) || {
-            identifiant,
-            titre,
-            typeDonnee,
-            unite,
-            annees: new Map(valeurParAnnee),
-          };
-          row.annees.set(annee, valeur.objectif);
-          indexedRows.set(rowKey, row);
-
-          if (valeur.objectifCommentaire && !source) {
-            const rowKeyComment = `${rowKey}-comment`;
-            const rowComment = indexedRows.get(rowKeyComment) || {
-              identifiant,
-              titre,
-              typeDonnee: `${typeDonnee} / Commentaire`,
-              unite,
-              annees: new Map(valeurParAnnee),
-            };
-            rowComment.annees.set(annee, valeur.objectifCommentaire);
-            indexedRows.set(rowKeyComment, rowComment);
-          }
-        }
-
-        if (valeur.resultat !== null) {
-          const typeDonnee = source
-            ? this.getSourceName(source)
-            : 'Mes resultats';
-          const rowKey = `${identifiant}${typeDonnee}`;
-          const row = indexedRows.get(rowKey) || {
-            identifiant,
-            titre,
-            typeDonnee,
-            unite,
-            annees: new Map(valeurParAnnee),
-          };
-          row.annees.set(annee, valeur.resultat);
-          indexedRows.set(rowKey, row);
-
-          if (valeur.resultatCommentaire && !source) {
-            const rowKeyComment = `${rowKey}-comment`;
-            const rowComment = indexedRows.get(rowKeyComment) || {
-              identifiant,
-              titre,
-              typeDonnee: `${typeDonnee} / Commentaire`,
-              unite,
-              annees: new Map(valeurParAnnee),
-            };
-            rowComment.annees.set(annee, valeur.resultatCommentaire);
-            indexedRows.set(rowKeyComment, rowComment);
-          }
-        }
-      });
-    });
-
-    // transforme les Map en Array
-    const rows = [...indexedRows.values()].map((row) => [
-      row.identifiant,
-      row.titre,
-      row.typeDonnee,
-      row.unite,
-      ...row.annees.values(),
-    ]);
-
-    // ajoute les lignes
-    worksheet.addRows([
-      ['Identifiant', 'Nom', 'Type de données', 'Unité', ...annees],
-      ...rows,
-    ]);
-
-    // applique les styles
-    worksheet.getRow(1).font = BOLD;
-    adjustColumnWidth(worksheet);
-  }
-
-  private getSourceName(source: IndicateurSourceMetadonnee) {
-    return source.nomDonnees || source.diffuseur || source.producteur;
-  }
-
-  private sortByDefinitionId(a: IndicateurDefinition, b: IndicateurDefinition) {
-    return `${a.identifiantReferentiel ?? a.id}`.localeCompare(
-      `${b.identifiantReferentiel ?? b.id}`,
-      undefined,
-      { numeric: true, sensitivity: 'base' }
-    );
   }
 }

--- a/apps/backend/src/indicateurs/indicateurs/export-indicateurs/export-indicateurs.service.ts
+++ b/apps/backend/src/indicateurs/indicateurs/export-indicateurs/export-indicateurs.service.ts
@@ -1,9 +1,10 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, PayloadTooLargeException } from '@nestjs/common';
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
 import {
   IndicateurDefinition,
   IndicateurDefinitionAvecEnfants,
   IndicateurSourceMetadonnee,
+  ListDefinitionsInputFilters,
 } from '@tet/domain/indicateurs';
 import { ResourceType } from '@tet/domain/users';
 import { format } from 'date-fns';
@@ -19,50 +20,140 @@ import {
 import { ListCollectiviteDefinitionsRepository } from '../../definitions/list-collectivite-definitions/list-collectivite-definitions.repository';
 import CrudValeursService from '../../valeurs/crud-valeurs.service';
 import { IndicateurValeurAvecMetadonnesDefinition } from '../../valeurs/indicateur-valeur.table';
+import { ListIndicateursService } from '../list-indicateurs/list-indicateurs.service';
 import { ExportIndicateursRequestType } from './export-indicateurs.request';
 
 @Injectable()
 export default class ExportIndicateursService {
   private readonly logger = new Logger(ExportIndicateursService.name);
 
+  /**
+   * Garde-fou technique invisible : plafond haut, très au-dessus de l'usage réel,
+   * servant uniquement de soupape de sécurité contre un export qui ferait exploser
+   * mémoire/timeout. Au-delà, on renvoie une erreur (jamais de troncature).
+   */
+  private readonly MAX_EXPORT_COUNT = 5000;
+
   constructor(
     private readonly permissionService: PermissionService,
     private readonly listCollectiviteDefinitionsRepository: ListCollectiviteDefinitionsRepository,
     private readonly valeursService: CrudValeursService,
-    private readonly collectiviteService: CollectivitesService
+    private readonly collectiviteService: CollectivitesService,
+    private readonly listIndicateursService: ListIndicateursService
   ) {}
 
   async exportXLSX(
     options: ExportIndicateursRequestType,
     tokenInfo: AuthenticatedUser
   ) {
-    if (!options.indicateurIds) return null;
-
     this.logger.log("Vérification des droits avant l'export xlsx");
 
-    await this.permissionService.isAllowed(
+    // Gate confidentiel appliqué aux deux modes : on ne bloque pas l'export
+    // entier, on détermine seulement si les indicateurs confidentiels peuvent y
+    // figurer.
+    const canReadConfidentiel = await this.permissionService.isAllowed(
       tokenInfo,
-      'plans.fiches.read_confidentiel',
+      'indicateurs.indicateurs.read_confidentiel',
       ResourceType.COLLECTIVITE,
-      options.collectiviteId
+      options.collectiviteId,
+      true // doNotThrow
     );
+
+    // Filtres de résolution selon le mode.
+    const filters: ListDefinitionsInputFilters =
+      options.mode === 'all'
+        ? { ...options.filters }
+        : { indicateurIds: options.indicateurIds };
+
+    // Sans droit sur les confidentiels, on les exclut toujours, quelle que
+    // soit la valeur éventuellement fournie par le client — un utilisateur non
+    // autorisé ne peut pas forcer l'inclusion des indicateurs confidentiels.
+    if (!canReadConfidentiel) {
+      filters.estConfidentiel = false;
+    }
+
+    // Résout l'ensemble des indicateurs via ListIndicateursService : source
+    // unique du filtrage et du tri, qui vérifie aussi les droits de lecture de
+    // l'utilisateur et borne la résolution à sa collectivité (protection IDOR).
+    const sort = options.mode === 'all' ? options.sort : undefined;
+    const listResult = await this.listIndicateursService.listIndicateurs(
+      {
+        collectiviteId: options.collectiviteId,
+        filters,
+        queryOptions: { page: 1, limit: this.MAX_EXPORT_COUNT, sort },
+      },
+      tokenInfo
+    );
+
+    // Garde-fou technique invisible : au-delà du plafond, on renvoie une erreur
+    // plutôt qu'une troncature silencieuse (qui réintroduirait le bug d'origine).
+    if (listResult.count > this.MAX_EXPORT_COUNT) {
+      throw new PayloadTooLargeException(
+        `L'export dépasse la limite technique de ${this.MAX_EXPORT_COUNT} indicateurs`
+      );
+    }
+
+    let resolvedIds = listResult.data.map((d) => d.id);
+
+    // En mode selection, on conserve l'ordre des identifiants fournis (et on
+    // ignore ceux qui n'appartiennent pas à la collectivité / aux droits).
+    if (options.mode === 'selection') {
+      const allowed = new Set(resolvedIds);
+      resolvedIds = options.indicateurIds.filter((id) => allowed.has(id));
+    }
+
+    if (!resolvedIds.length) return null;
 
     this.logger.log(
-      `Export des indicateurs ${options.indicateurIds} de la collectivité ${options.collectiviteId}`
+      `Export de ${resolvedIds.length} indicateur(s) de la collectivité ${options.collectiviteId}`
     );
 
-    // charge les définitions
+    // charge les définitions (avec enfants) des indicateurs résolus
     const definitions =
       await this.listCollectiviteDefinitionsRepository.listCollectiviteDefinitionsAvecEnfants(
         {
           collectiviteId: options.collectiviteId,
-          indicateurIds: options.indicateurIds,
+          indicateurIds: resolvedIds,
         }
       );
-    // tri par identifiant
-    definitions.sort(this.sortByDefinitionId);
 
-    // charge la collectivité
+    // ordonne les définitions selon l'ordre résolu (tri liste en mode `all`,
+    // ordre des identifiants fournis en mode `selection`)
+    const orderById = new Map(resolvedIds.map((id, index) => [id, index]));
+    definitions.sort(
+      (a, b) => (orderById.get(a.id) ?? 0) - (orderById.get(b.id) ?? 0)
+    );
+
+    // Les enfants proviennent de la projection de ListIndicateursService qui
+    // n'applique pas le filtrage de confidentialité. On les repasse donc par le
+    // même service (mêmes droits + gate estConfidentiel) pour exclure à la source
+    // les enfants confidentiels, avant de les conserver et d'alimenter les
+    // valeurs exportées.
+    const enfantIds = parents.flatMap((p) => p.enfants?.map((e) => e.id) ?? []);
+    if (enfantIds.length) {
+      const enfantsFilters: ListDefinitionsInputFilters = {
+        indicateurIds: enfantIds,
+      };
+      if (!canReadConfidentiel) {
+        enfantsFilters.estConfidentiel = false;
+      }
+      const enfantsResult = await this.listIndicateursService.listIndicateurs(
+        {
+          collectiviteId: options.collectiviteId,
+          filters: enfantsFilters,
+          queryOptions: { page: 1, limit: this.MAX_EXPORT_COUNT },
+        },
+        tokenInfo
+      );
+      const allowedEnfantIds = new Set(enfantsResult.data.map((d) => d.id));
+      for (const parent of parents) {
+        parent.enfants = (parent.enfants ?? []).filter((e) =>
+          allowedEnfantIds.has(e.id)
+        );
+      }
+    }
+
+    // Charge la collectivité
     const collectivite = await this.collectiviteService.getCollectivite(
       options.collectiviteId
     );
@@ -75,7 +166,7 @@ export default class ExportIndicateursService {
     if (!filename) return null;
 
     // extrait les id de tous les indicateurs dont il faut charger les valeurs
-    const indicateurIds = definitions.flatMap((def) => [
+    const valeurIndicateurIds = definitions.flatMap((def) => [
       def.id,
       ...(def.enfants?.map((e) => e.id) ?? []),
     ]);
@@ -83,7 +174,7 @@ export default class ExportIndicateursService {
     // charge toutes les valeurs
     const indicateursValeurs = await this.valeursService.getIndicateursValeurs({
       collectiviteId: options.collectiviteId,
-      indicateurIds,
+      indicateurIds: valeurIndicateurIds,
     });
 
     // crée le classeur

--- a/apps/backend/src/indicateurs/indicateurs/list-indicateurs/list-indicateurs.router.e2e-spec.ts
+++ b/apps/backend/src/indicateurs/indicateurs/list-indicateurs/list-indicateurs.router.e2e-spec.ts
@@ -1598,6 +1598,50 @@ describe('ListIndicateursRouter', () => {
       });
       expect(descData.map((i) => i.id)).toEqual([zId, aId]);
     });
+
+    test("pas de doublons entre les pages en triant par un champ non unique (estRempli)", async () => {
+      const caller = router.createCaller({ user: testUser });
+
+      // Crée plusieurs indicateurs qui ont tous la même valeur `estRempli`
+      // (tous vides) pour provoquer des égalités sur la clé de tri. Sans
+      // départage stable, l'ordre des lignes à égalité peut varier d'une
+      // requête paginée à l'autre et produire des doublons entre les pages.
+      const nbIndicateurs = 10;
+      const indicateurIds = await Promise.all(
+        Array.from({ length: nbIndicateurs }, (_, i) =>
+          createIndicateurPerso({
+            caller,
+            indicateurData: {
+              collectiviteId: 1,
+              titre: `Indicateur tri stable ${i}`,
+            },
+          })
+        )
+      );
+
+      const limit = 3;
+      const pageCount = Math.ceil(nbIndicateurs / limit);
+
+      const idsAcrossPages: number[] = [];
+      for (let page = 1; page <= pageCount; page++) {
+        const { data } = await caller.indicateurs.indicateurs.list({
+          collectiviteId: 1,
+          filters: { indicateurIds },
+          queryOptions: {
+            page,
+            limit,
+            sort: [{ field: 'estRempli', direction: 'desc' }],
+          },
+        });
+        idsAcrossPages.push(...data.map((i) => i.id));
+      }
+
+      // Toutes les pages réunies doivent contenir chaque indicateur exactement
+      // une fois (aucun doublon, aucun manquant).
+      expect(idsAcrossPages).toHaveLength(nbIndicateurs);
+      expect(new Set(idsAcrossPages).size).toBe(nbIndicateurs);
+      expect([...idsAcrossPages].sort()).toEqual([...indicateurIds].sort());
+    });
   });
 
   describe('Payload structure and linked entities tests', () => {

--- a/apps/backend/src/indicateurs/indicateurs/list-indicateurs/list-indicateurs.service.ts
+++ b/apps/backend/src/indicateurs/indicateurs/list-indicateurs/list-indicateurs.service.ts
@@ -21,7 +21,6 @@ import {
   and,
   arrayContains,
   count,
-  desc,
   eq,
   getTableColumns,
   ilike,
@@ -915,9 +914,17 @@ export class ListIndicateursService {
       { field: 'identifiantReferentiel', direction: 'asc' },
     ];
 
+    // Drizzle's `.orderBy()` overwrites any previous call, so all sort
+    // expressions must be collected into a single array. A unique tiebreaker
+    // (`id`) is always appended to guarantee a deterministic total order:
+    // sorting on a non-unique column (e.g. the boolean `estRempli`) otherwise
+    // leaves tied rows in an arbitrary order that can differ between LIMIT/OFFSET
+    // queries, producing duplicates and gaps across pages.
+    const orderByExpressions: SQL[] = [];
+
     sorts.forEach((sort) => {
       if (sort.field === 'estRempli') {
-        definitionsQuery.orderBy(
+        orderByExpressions.push(
           sort.direction === 'asc'
             ? sql`${indicateurCompleted.estRempli} asc nulls last`
             : sql`${indicateurCompleted.estRempli} desc nulls last`
@@ -925,21 +932,25 @@ export class ListIndicateursService {
       } else if (sort.field === 'titre') {
         const column = indicateurDefinitionTable.titre;
         const columnWithCollation = sql`${column} collate numeric_with_case_and_accent_insensitive`;
-        definitionsQuery.orderBy(
+        orderByExpressions.push(
           sort.direction === 'asc'
             ? columnWithCollation
-            : desc(columnWithCollation)
+            : sql`${columnWithCollation} desc`
         );
       } else if (sort.field === 'identifiantReferentiel') {
-        definitionsQuery.orderBy(
+        orderByExpressions.push(
           sort.direction === 'asc'
-            ? indicateurDefinitionTable.identifiantReferentiel
-            : desc(indicateurDefinitionTable.identifiantReferentiel)
+            ? sql`${indicateurDefinitionTable.identifiantReferentiel}`
+            : sql`${indicateurDefinitionTable.identifiantReferentiel} desc`
         );
       }
     });
 
+    // Stable tiebreaker to ensure consistent pagination across pages.
+    orderByExpressions.push(sql`${indicateurDefinitionTable.id} asc`);
+
     definitionsQuery
+      .orderBy(...orderByExpressions)
       .limit(queryOptions.limit)
       .offset((queryOptions.page - 1) * queryOptions.limit);
 

--- a/apps/backend/src/indicateurs/indicateurs/list-indicateurs/list-indicateurs.service.ts
+++ b/apps/backend/src/indicateurs/indicateurs/list-indicateurs/list-indicateurs.service.ts
@@ -697,8 +697,16 @@ export class ListIndicateursService {
     }
 
     if (filters.estConfidentiel !== undefined) {
+      // Pour estConfidentiel=false, on inclut les lignes NULL (indicateurs sans
+      // entrée dans indicateur_collectivite via LEFT JOIN) car SQL `NULL = false`
+      // évalue à NULL et exclut ces lignes à tort.
       whereConditions.push(
-        eq(indicateurCollectiviteTable.confidentiel, filters.estConfidentiel)
+        filters.estConfidentiel
+          ? eq(indicateurCollectiviteTable.confidentiel, true)
+          : or(
+              eq(indicateurCollectiviteTable.confidentiel, false),
+              isNull(indicateurCollectiviteTable.confidentiel)
+            )
       );
     }
 
@@ -766,7 +774,7 @@ export class ListIndicateursService {
 
         // Columns from indicateurCollectiviteTable
         commentaire: indicateurCollectiviteTable.commentaire,
-        estConfidentiel: indicateurCollectiviteTable.confidentiel,
+        estConfidentiel: sql<boolean>`${indicateurCollectiviteTable.confidentiel} is true`,
         estFavori: indicateurCollectiviteTable.favoris,
         modifiedAt: sqlToDateTimeISO(
           sql`COALESCE(${indicateurCollectiviteTable.modifiedAt}, ${indicateurDefinitionTable.modifiedAt})`

--- a/e2e/tests/indicateurs/export-indicateurs/export-indicateurs.pom.ts
+++ b/e2e/tests/indicateurs/export-indicateurs/export-indicateurs.pom.ts
@@ -1,0 +1,67 @@
+import { Download, expect, Page } from '@playwright/test';
+import { Workbook } from 'exceljs';
+
+export class ExportIndicateursPom {
+  constructor(readonly page: Page) {}
+
+  async gotoPersoList(collectiviteId: number) {
+    await this.page.goto(
+      `/collectivite/${collectiviteId}/indicateurs/liste/perso`
+    );
+    await expect(
+      this.page.locator('[data-test="indicateurs.liste.exporter-excel"]')
+    ).toBeVisible();
+  }
+
+  /**
+   * Applique un filtre texte via le champ de recherche de la liste puis attend
+   * que la liste reflète le nombre de résultats attendu (le champ déclenche la
+   * recherche avec un `debounce`), garantissant que `filters.text` est bien
+   * transmis au bouton d'export avant l'appel à `exportAll`.
+   */
+  async filterByText(text: string, expectedCount: number) {
+    await this.page
+      .getByPlaceholder('Rechercher par nom ou description')
+      .fill(text);
+    await expect(
+      this.page.getByText(`${expectedCount} indicateurs`)
+    ).toBeVisible();
+  }
+
+  async exportAll(): Promise<Workbook> {
+    const downloadPromise = this.page.waitForEvent('download');
+    await this.page
+      .locator('[data-test="indicateurs.liste.exporter-excel"]')
+      .click();
+    const download = await downloadPromise;
+    return this.parseXlsx(download);
+  }
+
+  async gotoDetail(collectiviteId: number, indicateurId: number) {
+    await this.page.goto(
+      `/collectivite/${collectiviteId}/indicateurs/perso/${indicateurId}`
+    );
+    await expect(
+      this.page.locator('[data-test="indicateurs.detail.exporter-excel"]')
+    ).toBeVisible();
+  }
+
+  async exportSingle(): Promise<Workbook> {
+    const downloadPromise = this.page.waitForEvent('download');
+    await this.page
+      .locator('[data-test="indicateurs.detail.exporter-excel"]')
+      .click();
+    const download = await downloadPromise;
+    return this.parseXlsx(download);
+  }
+
+  private async parseXlsx(download: Download): Promise<Workbook> {
+    const path = await download.path();
+    if (!path) {
+      throw new Error('Download path is not available');
+    }
+    const wb = new Workbook();
+    await wb.xlsx.readFile(path);
+    return wb;
+  }
+}

--- a/e2e/tests/indicateurs/export-indicateurs/export-indicateurs.spec.ts
+++ b/e2e/tests/indicateurs/export-indicateurs/export-indicateurs.spec.ts
@@ -1,0 +1,66 @@
+import { expect } from '@playwright/test';
+import { UserFixture } from 'tests/users/users.fixture';
+import { testWithIndicateurs as test } from '../indicateurs.fixture';
+import { ExportIndicateursPom } from './export-indicateurs.pom';
+
+/** Strictement supérieur à une page de liste (9 par défaut) */
+const NB_INDICATEURS = 12;
+
+/** Terme présent dans les titres des indicateurs à exporter, mais absent du
+ * titre de l'indicateur hors périmètre (voir `HORS_PERIMETRE_TITRE`). */
+const FILTRE_TEXTE = 'export e2e';
+const HORS_PERIMETRE_TITRE = 'Indicateur hors périmètre';
+
+test.describe('Export indicateurs en Excel', () => {
+  let collectiviteId: number;
+  let indicateurIds: number[];
+  let user: UserFixture;
+  let pom: ExportIndicateursPom;
+
+  test.beforeEach(async ({ page, collectivites, indicateurs }) => {
+    const created = await collectivites.addCollectiviteAndUser({
+      userArgs: { autoLogin: true },
+    });
+    collectiviteId = created.collectivite.data.id;
+    user = created.user;
+    pom = new ExportIndicateursPom(page);
+
+    // Indicateurs sans parent : un onglet par indicateur dans l'export
+    indicateurIds = [];
+    for (let i = 0; i < NB_INDICATEURS; i++) {
+      indicateurIds.push(
+        await indicateurs.create(user, {
+          collectiviteId,
+          titre: `Indicateur ${FILTRE_TEXTE} ${i}`,
+          unite: 'unité',
+        })
+      );
+    }
+  });
+
+  test("exporte tous les indicateurs filtrés (mode all, au-delà d'une page)", async ({
+    indicateurs,
+  }) => {
+    // Indicateur volontairement hors du périmètre du filtre appliqué ensuite :
+    // il ne doit pas figurer dans l'export si `filters` est bien pris en compte.
+    await indicateurs.create(user, {
+      collectiviteId,
+      titre: HORS_PERIMETRE_TITRE,
+      unite: 'unité',
+    });
+
+    await pom.gotoPersoList(collectiviteId);
+    await pom.filterByText(FILTRE_TEXTE, NB_INDICATEURS);
+    const wb = await pom.exportAll();
+
+    // Un onglet par indicateur (indicateurs perso sans parent)
+    expect(wb.worksheets.length).toBe(NB_INDICATEURS);
+  });
+
+  test('exporte un indicateur unique depuis le détail (mode selection)', async () => {
+    await pom.gotoDetail(collectiviteId, indicateurIds[0]);
+    const wb = await pom.exportSingle();
+
+    expect(wb.worksheets.length).toBe(1);
+  });
+});

--- a/e2e/tests/indicateurs/export-indicateurs/export-indicateurs.spec.ts
+++ b/e2e/tests/indicateurs/export-indicateurs/export-indicateurs.spec.ts
@@ -25,7 +25,6 @@ test.describe('Export indicateurs en Excel', () => {
     user = created.user;
     pom = new ExportIndicateursPom(page);
 
-    // Indicateurs sans parent : un onglet par indicateur dans l'export
     indicateurIds = [];
     for (let i = 0; i < NB_INDICATEURS; i++) {
       indicateurIds.push(
@@ -53,14 +52,19 @@ test.describe('Export indicateurs en Excel', () => {
     await pom.filterByText(FILTRE_TEXTE, NB_INDICATEURS);
     const wb = await pom.exportAll();
 
-    // Un onglet par indicateur (indicateurs perso sans parent)
-    expect(wb.worksheets.length).toBe(NB_INDICATEURS);
+    // Format consolidé : 1 onglet unique, 1 ligne d'en-tête + 1 ligne par
+    // indicateur filtré. L'indicateur hors périmètre est exclu (sinon
+    // NB_INDICATEURS + 2), ce qui prouve que `filters` est transmis à l'export.
+    expect(wb.worksheets.length).toBe(1);
+    expect(wb.getWorksheet(1)?.rowCount).toBe(NB_INDICATEURS + 1);
   });
 
   test('exporte un indicateur unique depuis le détail (mode selection)', async () => {
     await pom.gotoDetail(collectiviteId, indicateurIds[0]);
     const wb = await pom.exportSingle();
 
+    // Format consolidé : 1 onglet, 1 ligne d'en-tête + 1 ligne de données
     expect(wb.worksheets.length).toBe(1);
+    expect(wb.getWorksheet(1)?.rowCount).toBe(2);
   });
 });


### PR DESCRIPTION
Remplace le format multi-onglets (1 onglet par indicateur parent) par une
feuille unique consolidée : 1 ligne par indicateur (parent puis enfants
indentés), colonnes fixes Identifiant / Nom / Indicateur parent / Unité /
Pilotes / Services / Commentaire, puis colonnes dynamiques Résultat <année>
et Objectif <année> sur l'union des années avec valeurs saisies.

- Supprime la dépendance à ListCollectiviteDefinitionsRepository dans le service
  (listResult.data contient déjà pilotes, services, commentaire, enfants)
- Le builder charge les valeurs de tous les indicateurs (parents + enfants)
  en une seule passe et exclut les données open-data (indicateur_source_metadonnee)
- Freeze pane sur la ligne d'en-tête
- Mise à jour des tests e2e backend (format attendu : wb.worksheets.length=1)
  et des tests e2e UI Playwright (rowCount = header + nb indicateurs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * L’export Excel des indicateurs propose désormais 2 modes : export de la sélection, ou export de la liste complète avec filtres et tri.
  * Le fichier exporté est consolidé dans un seul onglet, avec colonnes dynamiques par année et une présentation incluant les informations principales.
* **Correctifs**
  * Meilleure gestion de la confidentialité lors de l’export et de l’affichage, y compris pour les valeurs non définies.
  * Pagination et tri plus fiables (pas de doublons/manquants).
* **Tests**
  * E2E et vérifications d’export Excel renforcées, dont le cas parent/enfant et le format consolidé.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->