### PR TITLE
refactor(audit-labellisation): uniformise le libellé "vue tabulaire" et supprime le CTA dupliqué

### DIFF
--- a/apps/app/src/labels/catalog.ts
+++ b/apps/app/src/labels/catalog.ts
@@ -430,10 +430,9 @@ export const appLabels = {
   auditColonneOrdreDuJour: 'À discuter en séance',
   auditColonneNotes: "Notes de l'auditeur·ice",
   decouvrirInfosAuditTableauTitre:
-    "Retrouvez le suivi de l'audit dans la vue tableau",
+    "Retrouvez le suivi de l'audit dans la vue tabulaire",
   decouvrirInfosAuditTableauDescription:
-    "Le statut d'audit, les points à discuter en séance et les notes de l'auditeur·ice sont désormais disponibles directement dans la vue tableau des mesures.",
-  decouvrirInfosAuditTableauCta: 'Découvrir la vue tableau',
+    "Le statut d'audit, les points à discuter en séance et les notes de l'auditeur·ice sont désormais disponibles directement dans la vue tabulaire des mesures.",
   detaillerAvancementTache: "Détailler l'avancement à la tâche",
   detaillerAvancement: "Détailler l'avancement",
   detaillerAvancementPourcentage: "Détailler l'avancement au pourcentage",

--- a/apps/app/src/referentiels/audit-labellisation/checklist/audit-table-hint.banner.tsx
+++ b/apps/app/src/referentiels/audit-labellisation/checklist/audit-table-hint.banner.tsx
@@ -22,7 +22,7 @@ export const AuditTableHintBanner = ({
         variant="primary"
         href={makeReferentielNewUrl({ collectiviteId, referentielId })}
       >
-        {appLabels.decouvrirInfosAuditTableauCta}
+        {appLabels.decouvrirVueTabulaire}
       </Button>
     }
   />


### PR DESCRIPTION
## Nature

Refactor de libellés (une seule nature).

## Contexte

Extrait de la branche `fix/badge-auditeur-apres-validation` : ces modifications de catalogue sont indépendantes du fix du badge auditeur et méritent leur propre PR.

## Surface de review

- `apps/app/src/labels/catalog.ts` — attention humaine (libellés)
- `apps/app/src/referentiels/audit-labellisation/checklist/audit-table-hint.banner.tsx` — attention humaine (consommation de la clé)

## Changements

- Le bandeau de découverte de la vue tabulaire pointait sur `decouvrirInfosAuditTableauCta`, doublon de `decouvrirVueTabulaire`. Le CTA dupliqué est supprimé du catalogue et le bandeau consomme la clé existante.
- Les libellés titre et description adoptent "vue tabulaire" au lieu de "vue tableau", pour cohérence avec le reste du catalogue.

## Anti-duplication

Recherche `decouvrirVueTabulaire` / `decouvrirInfosAuditTableauCta` dans `apps/app/src` : `decouvrirVueTabulaire` existait déjà (catalog.ts), le bandeau était le seul consommateur du CTA dupliqué. Aucune autre référence.

## Couplage

`banner.tsx` accompagne `catalog.ts` : c'est le seul consommateur de la clé supprimée. Séparer les deux casserait le typecheck.

## Zones low-confidence

Aucune.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mise à jour de libellés liés au suivi de l’audit pour utiliser « vue tabulaire » à la place de « vue tableau ».
  * Clarification du texte d’aide pour indiquer que le statut d’audit, les points à discuter et les notes de l’auditeur·ice sont accessibles directement dans la vue tabulaire des mesures.
  * Le bouton d’accès affiche désormais un intitulé plus explicite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->