### PR TITLE
feat(audit-labellisation): l'auditeur devient visiteur à la validation (rôle AUDITEUR_AUDIT_VALIDE)

### DIFF
--- a/apps/app/src/referentiels/audits/cloture/data/use-validate-audit.ts
+++ b/apps/app/src/referentiels/audits/cloture/data/use-validate-audit.ts
@@ -1,9 +1,11 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTRPC } from '@tet/api';
+import { useRouter } from 'next/navigation';
 
 export const useValidateAudit = () => {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
+  const router = useRouter();
 
   return useMutation(
     trpc.referentiels.labellisations.validateAudit.mutationOptions({
@@ -25,6 +27,8 @@ export const useValidateAudit = () => {
         queryClient.invalidateQueries({
           queryKey: trpc.referentiels.labellisations.getParcours.queryKey(),
         });
+
+        router.refresh();
       },
     })
   );

--- a/apps/app/src/referentiels/labellisations/useCycleLabellisation.ts
+++ b/apps/app/src/referentiels/labellisations/useCycleLabellisation.ts
@@ -13,7 +13,7 @@ import {
   ReferentielId,
   SujetDemandeEnum,
 } from '@tet/domain/referentiels';
-import { useIsAuditeur } from '../audits/useAudit';
+import { isUserAuditeurForAudit } from '@tet/domain/users';
 import { useLabellisationParcours } from './useLabellisationParcours';
 
 export type TCycleLabellisation = {
@@ -38,7 +38,6 @@ export const useCycleLabellisation = (
 ): TCycleLabellisation => {
   const { collectiviteId, hasCollectivitePermission } =
     useCurrentCollectivite();
-  const isAuditeur = useIsAuditeur();
   const user = useUser();
   const { data: identite } = useGetCollectivite(collectiviteId);
 
@@ -47,6 +46,9 @@ export const useCycleLabellisation = (
     referentielId,
   });
 
+  const isAuditeur = parcours?.audit
+    ? isUserAuditeurForAudit(user, parcours.audit.id)
+    : false;
   const status = parcours?.status || 'non_demandee';
   const isConductingAudit = isAuditeur && status === 'audit_en_cours';
   const isCOT = Boolean(identite?.activeCOT);

--- a/apps/backend/src/referentiels/labellisations/update-audit-report/update-audit-report.router.e2e-spec.ts
+++ b/apps/backend/src/referentiels/labellisations/update-audit-report/update-audit-report.router.e2e-spec.ts
@@ -215,7 +215,7 @@ describe('UpdateAuditReportRouter', () => {
     ).rejects.toThrow();
   });
 
-  test("refuse l'auditeur des que l'audit est clos, meme dans les 15 jours", async () => {
+  test("autorise l'auditeur dans les 15 jours même si l'audit est clos", async () => {
     const { auditeurUser, preuve, newFichier, cleanup } = await seedReport({
       clos: true,
       valide: true,
@@ -224,13 +224,12 @@ describe('UpdateAuditReportRouter', () => {
     onTestFinished(cleanup);
 
     const caller = router.createCaller({ user: await getAuthUser(auditeurUser) });
+    await caller.referentiels.labellisations.updateAuditReport({
+      preuveId: preuve.id,
+      fichierId: newFichier.id,
+    });
 
-    await expect(
-      caller.referentiels.labellisations.updateAuditReport({
-        preuveId: preuve.id,
-        fichierId: newFichier.id,
-      })
-    ).rejects.toThrow();
+    expect(await getPreuveFichierId(preuve.id)).toBe(newFichier.id);
   });
 
   test("refuse un fichier appartenant à une autre collectivité", async () => {

--- a/apps/backend/src/users/authorizations/get-user-roles-and-permissions/get-user-roles-and-permissions.adapter.ts
+++ b/apps/backend/src/users/authorizations/get-user-roles-and-permissions/get-user-roles-and-permissions.adapter.ts
@@ -29,11 +29,12 @@ function buildUniquePermissionsSet(
 function toAuditRolesAndPermissions(
   audit: AuditRolesRow
 ): AuditRolesAndPermissions {
-  if (audit.clos) {
+  const auditTermine = audit.valide || audit.clos;
+  if (auditTermine) {
     return {
       auditId: audit.auditId,
-      role: null,
-      permissions: buildUniquePermissionsSet([CollectiviteRole.LECTURE]),
+      role: AuditRole.AUDITEUR_AUDIT_VALIDE,
+      permissions: buildUniquePermissionsSet([AuditRole.AUDITEUR_AUDIT_VALIDE]),
     };
   }
   const role = audit.auditDateDebut

--- a/apps/backend/src/users/authorizations/get-user-roles-and-permissions/get-user-roles-and-permissions.repository.ts
+++ b/apps/backend/src/users/authorizations/get-user-roles-and-permissions/get-user-roles-and-permissions.repository.ts
@@ -32,6 +32,7 @@ export type AuditRolesRow = {
   auditId: number;
   auditDateDebut: string | null;
   clos: boolean;
+  valide: boolean;
   collectiviteId: number;
   collectiviteNom: string;
   collectiviteAccesRestreint: boolean;
@@ -116,6 +117,7 @@ export class GetUserRolesAndPermissionsRepository {
         collectivitePreferences: collectiviteTable.preferences,
         auditDateDebut: auditTable.dateDebut,
         clos: auditTable.clos,
+        valide: auditTable.valide,
       })
       .from(auditeurTable)
       .innerJoin(auditTable, eq(auditTable.id, auditeurTable.auditId))

--- a/apps/backend/src/users/authorizations/get-user-roles-and-permissions/get-user-roles-and-permissions.router.e2e-spec.ts
+++ b/apps/backend/src/users/authorizations/get-user-roles-and-permissions/get-user-roles-and-permissions.router.e2e-spec.ts
@@ -145,7 +145,7 @@ describe('GetUserPermissions', () => {
     ]);
   });
 
-  test("Passe l'auditeur en lecture seule pendant 15 jours après la clôture de l'audit", async () => {
+  test("Garde l'auditeur en AUDITEUR_AUDIT_VALIDE pendant 15 jours après la clôture de l'audit", async () => {
     const { collectivite, user, cleanup } = await addTestCollectiviteAndUser(
       databaseService,
       {
@@ -179,8 +179,49 @@ describe('GetUserPermissions', () => {
     expect(auditeeCollectivite?.audits).toEqual([
       {
         auditId: audit.id,
-        role: null,
-        permissions: permissionsByRole[CollectiviteRole.LECTURE],
+        role: AuditRole.AUDITEUR_AUDIT_VALIDE,
+        permissions: permissionsByRole[AuditRole.AUDITEUR_AUDIT_VALIDE],
+      },
+    ]);
+  });
+
+  test("Passe l'auditeur en AUDITEUR_AUDIT_VALIDE dès la validation, même si l'audit n'est pas encore clos", async () => {
+    const { collectivite, user, cleanup } = await addTestCollectiviteAndUser(
+      databaseService,
+      {
+        user: {
+          role: CollectiviteRole.EDITION,
+        },
+      }
+    );
+    onTestFinished(cleanup);
+
+    const { audit } = await createAuditWithOnTestFinished({
+      databaseService,
+      collectiviteId: collectivite.id,
+      referentielId: ReferentielIdEnum.CAE,
+      valide: true,
+      clos: false,
+    });
+
+    await addAuditeurPermission({
+      databaseService,
+      auditId: audit.id,
+      userId: user.id,
+    });
+
+    const caller = router.createCaller({ user: await getAuthUser(user) });
+
+    const result = await caller.users.users.get();
+
+    const auditeeCollectivite = result.collectivites.find(
+      (c) => c.collectiviteId === collectivite.id
+    );
+    expect(auditeeCollectivite?.audits).toEqual([
+      {
+        auditId: audit.id,
+        role: AuditRole.AUDITEUR_AUDIT_VALIDE,
+        permissions: permissionsByRole[AuditRole.AUDITEUR_AUDIT_VALIDE],
       },
     ]);
   });

--- a/packages/domain/src/referentiels/labellisations/can-update-audit-report/can-update-audit-report.rule.spec.ts
+++ b/packages/domain/src/referentiels/labellisations/can-update-audit-report/can-update-audit-report.rule.spec.ts
@@ -52,11 +52,21 @@ describe('canUpdateAuditReport', () => {
     ).toBe(false);
   });
 
-  it("refuse des que l'audit est clos, meme dans les 15 jours (verrou definitif)", () => {
+  it('autorise dans les 15 jours même si l’audit est clos', () => {
     expect(
       canUpdateAuditReport({
         isAuditeur: true,
         audit: { clos: true, valide: true, dateFin: daysAgo(14) },
+        now,
+      })
+    ).toBe(true);
+  });
+
+  it("refuse plus de 15 jours après la clôture, même si l'audit est clos", () => {
+    expect(
+      canUpdateAuditReport({
+        isAuditeur: true,
+        audit: { clos: true, valide: true, dateFin: daysAgo(16) },
         now,
       })
     ).toBe(false);

--- a/packages/domain/src/referentiels/labellisations/can-update-audit-report/can-update-audit-report.rule.ts
+++ b/packages/domain/src/referentiels/labellisations/can-update-audit-report/can-update-audit-report.rule.ts
@@ -14,10 +14,7 @@ export function canUpdateAuditReport({
   if (audit === null || !isAuditeur) {
     return false;
   }
-  if (audit.clos) {
-    return false;
-  }
-  if (!audit.valide) {
+  if (!audit.valide && !audit.clos) {
     return true;
   }
   if (audit.dateFin === null) {

--- a/packages/domain/src/users/authorizations/permission.models.ts
+++ b/packages/domain/src/users/authorizations/permission.models.ts
@@ -110,4 +110,9 @@ export const permissionsByRole: Record<UserRole, PermissionOperation[]> = {
     'indicateurs.indicateurs.delete',
     'indicateurs.valeurs.mutate',
   ],
+  [AuditRole.AUDITEUR_AUDIT_VALIDE]: [
+    ...collectiviteLecturePermissions,
+
+    'collectivites.documents.mutate',
+  ],
 };

--- a/packages/domain/src/users/authorizations/user-role.enum.schema.ts
+++ b/packages/domain/src/users/authorizations/user-role.enum.schema.ts
@@ -49,6 +49,7 @@ export function isCollectiviteRole(role: UserRole): role is CollectiviteRole {
 export const AuditRole = {
   AUDITEUR_AUDIT_NON_DEMARRE: 'auditeur_audit_non_demarre',
   AUDITEUR: 'auditeur',
+  AUDITEUR_AUDIT_VALIDE: 'auditeur_audit_valide',
 } as const;
 
 export const auditRoleSchema = z.enum(AuditRole);
@@ -58,6 +59,7 @@ export type AuditRole = (typeof AuditRole)[keyof typeof AuditRole];
 export const auditRoleEnumValues = [
   AuditRole.AUDITEUR_AUDIT_NON_DEMARRE,
   AuditRole.AUDITEUR,
+  AuditRole.AUDITEUR_AUDIT_VALIDE,
 ] as const;
 
 export function isAuditRole(role: UserRole): role is AuditRole {


### PR DESCRIPTION
## Intention

À la **validation** d'un audit (`valide=true`), l'auditeur gardait le rôle `AUDITEUR` (badge « audit » dans le sélecteur de collectivités + édition d'audit) jusqu'à la clôture — pour une demande de labellisation, `clos` ne passe `true` qu'à la décision CNL, souvent lointaine.

Désormais, dès qu'un audit est **terminé** (validé ou clos), l'auditeur **devient visiteur** (badge « visite », édition d'audit révoquée), et la seule action conservée est **remplacer le rapport pendant 15 jours**.

## Approche : un rôle granulaire

On s'appuie sur le pattern existant (`AUDITEUR_AUDIT_NON_DEMARRE`) :

- Nouveau rôle **`AUDITEUR_AUDIT_VALIDE`** = `LECTURE` + `collectivites.documents.mutate`.
- L'adapter `get-user-roles` l'attribue à **tout audit terminé** (validé **ou** clos) encore dans la fenêtre — `getAuditRoles` ne renvoie déjà que `clos=false OR date_fin > now()-15j`.
- Ce rôle **n'est pas** un auditeur actif (`isUserAuditeur` ne le liste pas) → le badge du **sélecteur de collectivités** passe « visite ».
- Le remplacement passe par le **flux d'upload générique existant** (`documents.mutate`) — aucun composant front ni endpoint dédié ; l'attache reste gatée par `canUpdateAuditReport`.

## Fenêtre 15 jours « quoi qu'il arrive »

`canUpdateAuditReport` : le **verrou définitif sur `clos` est levé**. Un audit en cours est librement éditable ; tout audit **terminé** (validé ou clos) est remplaçable tant que `date_fin < 15 jours`. Ça débloque les audits **COT**, que le trigger `labellisation.update_audit()` clôt (`clos=true`) dès la validation.

## Surface de review

- `user-role.enum.schema.ts` / `permission.models.ts` — rôle `AUDITEUR_AUDIT_VALIDE` + permissions.
- `get-user-roles-and-permissions.adapter.ts` (+ `repository.ts` expose `valide`) — mapping du rôle (audit terminé dans la fenêtre).
- `can-update-audit-report.rule.ts` — suppression du verrou `clos`, fenêtre 15j sur `date_fin`.
- `useCycleLabellisation.ts` — statut auditeur du cycle basé sur l'**appartenance** (`isUserAuditeurForAudit`) : sur la page labellisation, l'auditeur validé garde la perspective « auditeur » alors que le sélecteur le voit visiteur.
- `use-validate-audit.ts` — `router.refresh` (badge sans rechargement).

## Point sécurité

`documents.mutate` accordé à `AUDITEUR_AUDIT_VALIDE` couvre tous les documents de la collectivité — tradeoff assumé : l'action qui compte (attacher le rapport) reste gatée par `canUpdateAuditReport` (auditeur de cet audit + fenêtre 15j). Pas d'escalade vers l'édition d'audit (rôle sans `referentiels.mutate` ni `mutate_action_audit_statut`).

## Tests

- `can-update-audit-report.rule` (8/8) : le verrou clos devient « autorise dans les 15j même si clos » + « refuse au-delà de 15j même si clos ».
- e2e `get-user-roles` (5/5) : audit terminé dans la fenêtre (validé ou clos) → `AUDITEUR_AUDIT_VALIDE`.
- e2e `update-audit-report` (7/7) : remplacement autorisé dans les 15j, clos compris ; refusé hors fenêtre / non-auditeur ; IDOR cross-collectivité.
- typecheck domain+back+front, lint OK.

## Notes / hors PR

- Choix produit : à validation, l'auditeur perd l'édition d'audit (pas seulement le badge) ; le remplacement du rapport reste ouvert 15j quoi qu'il arrive.
- Edge préexistant : un auditeur-visiteur sur une collectivité `acces_restreint` pourrait être gaté avant d'atteindre le rapport — non traité ici.

_Pas de plan markdown lié (issu d'une session d'investigation)._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Les audits validés disposent désormais d’un statut et de droits dédiés, avec des permissions adaptées pour continuer à travailler sur les documents.

* **Bug Fixes**
  * La mise à jour d’un rapport d’audit est désormais autorisée pendant une courte fenêtre après la clôture/validation.
  * L’interface se rafraîchit automatiquement après validation pour afficher les dernières données.
  * Les rôles et accès liés aux audits validés sont mieux pris en compte dans l’application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->