### PR TITLE
revert(referentiels): ne scope plus les preuves de mesures à la fenêtre de l'audit

### DIFF
--- a/apps/backend/src/referentiels/preuves-archive/generate-preuves-archive/generate-preuves-archive.service.ts
+++ b/apps/backend/src/referentiels/preuves-archive/generate-preuves-archive/generate-preuves-archive.service.ts
@@ -14,7 +14,6 @@ import { ResourceType } from '@tet/domain/users';
 import { getErrorMessage } from '@tet/domain/utils';
 import { GetReferentielService } from '../../get-referentiel/get-referentiel.service';
 import { BuildArchiveService } from '../build-archive/build-archive.service';
-import { type AuditPreuvesWindow } from '../list-audit-preuves/collect-preuves.repository';
 import { ListAuditPreuvesService } from '../list-audit-preuves/list-audit-preuves.service';
 import {
   AuditPreuvesArchiveStatusEnum,
@@ -31,7 +30,6 @@ interface JobContext {
   user: AuthenticatedUser;
   demandeId: number;
   referentielId: ReferentielId;
-  auditWindow: AuditPreuvesWindow;
 }
 
 /**
@@ -168,9 +166,9 @@ export class GeneratePreuvesArchiveService {
       );
     }
 
-    const auditContextResult = await this.resolveAuditContext(archive.auditId);
-    if (!auditContextResult.success) {
-      return auditContextResult;
+    const demandeIdResult = await this.resolveDemandeId(archive.auditId);
+    if (!demandeIdResult.success) {
+      return demandeIdResult;
     }
 
     const referentielIdResult = parseReferentielId(archive.referentielId);
@@ -180,36 +178,30 @@ export class GeneratePreuvesArchiveService {
 
     return success({
       user,
-      demandeId: auditContextResult.data.demandeId,
-      auditWindow: auditContextResult.data.auditWindow,
+      demandeId: demandeIdResult.data,
       referentielId: referentielIdResult.data,
     });
   }
 
-  private async resolveAuditContext(
+  private async resolveDemandeId(
     auditId: number
-  ): Promise<
-    Result<
-      { demandeId: number; auditWindow: AuditPreuvesWindow },
-      GenerateArchiveFailure
-    >
-  > {
+  ): Promise<Result<number, GenerateArchiveFailure>> {
     try {
       const auditDetails = await this.getLabellisationService.getAudit(auditId);
       if (!auditDetails.success) {
         return nonRetryableFailure(`Audit ${auditId} introuvable`);
       }
-      const { demandeId, dateDebut, dateFin } = auditDetails.data;
+      const demandeId = auditDetails.data.demandeId;
       if (demandeId == null) {
         return nonRetryableFailure(
           `Aucune demande de labellisation rattachée à l'audit ${auditId}`
         );
       }
-      return success({ demandeId, auditWindow: { dateDebut, dateFin } });
+      return success(demandeId);
     } catch (error) {
       // L'accès DB peut tomber transitoirement : laisser BullMQ relancer.
       return retryableFailure(
-        `Résolution de l'audit échouée: ${getErrorMessage(error)}`
+        `Résolution de la demande échouée: ${getErrorMessage(error)}`
       );
     }
   }
@@ -223,7 +215,6 @@ export class GeneratePreuvesArchiveService {
       referentielId: context.referentielId,
       auditId: archive.auditId,
       demandeId: context.demandeId,
-      auditWindow: context.auditWindow,
       user: context.user,
     });
     if (!preuvesResult.success) {

--- a/apps/backend/src/referentiels/preuves-archive/list-audit-preuves/collect-preuves.repository.e2e-spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/list-audit-preuves/collect-preuves.repository.e2e-spec.ts
@@ -12,7 +12,7 @@ import {
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { Collectivite } from '@tet/domain/collectivites';
 import { CollectiviteRole } from '@tet/domain/users';
-import { and, eq, like, sql } from 'drizzle-orm';
+import { and, eq, like } from 'drizzle-orm';
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import { PREUVES_ARCHIVES_BUCKET } from '../preuves-archive.constants';
 import { CollectPreuvesRepository } from './collect-preuves.repository';
@@ -115,7 +115,6 @@ describe('CollectPreuvesRepository - filtre confidentiel (SQL réel)', () => {
     const result = await repository.getComplementairePreuves({
       collectiviteId: collectivite.id,
       referentielId: 'cae',
-      auditWindow: { dateDebut: null, dateFin: null },
       canReadConfidentiel: true,
     });
 
@@ -130,7 +129,6 @@ describe('CollectPreuvesRepository - filtre confidentiel (SQL réel)', () => {
     const result = await repository.getComplementairePreuves({
       collectiviteId: collectivite.id,
       referentielId: 'cae',
-      auditWindow: { dateDebut: null, dateFin: null },
       canReadConfidentiel: false,
     });
 
@@ -143,7 +141,6 @@ describe('CollectPreuvesRepository - filtre confidentiel (SQL réel)', () => {
     const result = await repository.getComplementairePreuves({
       collectiviteId: collectivite.id,
       referentielId: 'cae',
-      auditWindow: { dateDebut: null, dateFin: null },
       canReadConfidentiel: false,
     });
 
@@ -251,7 +248,6 @@ describe('CollectPreuvesRepository - scope par référentiel (SQL réel)', () =>
     const result = await repository.getComplementairePreuves({
       collectiviteId: collectivite.id,
       referentielId: 'cae',
-      auditWindow: { dateDebut: null, dateFin: null },
       canReadConfidentiel: true,
     });
 
@@ -264,148 +260,11 @@ describe('CollectPreuvesRepository - scope par référentiel (SQL réel)', () =>
     const result = await repository.getComplementairePreuves({
       collectiviteId: collectivite.id,
       referentielId: 'eci',
-      auditWindow: { dateDebut: null, dateFin: null },
       canReadConfidentiel: true,
     });
 
     expect(result.success).toBe(true);
     if (!result.success) return;
     expect(result.data.files.map((file) => file.hash)).toEqual([eciHash]);
-  });
-});
-
-describe("CollectPreuvesRepository - scope par fenetre d'audit (SQL réel)", () => {
-  let app: INestApplication;
-  let db: DatabaseService;
-  let repository: CollectPreuvesRepository;
-  let collectivite: Collectivite;
-  let adminUserId: string;
-  let cleanupCollectivite: () => Promise<void>;
-
-  const dateDebut = '2024-01-01T00:00:00Z';
-  const dateFin = '2024-12-31T23:59:59Z';
-
-  let avantHash: string;
-  let dansHash: string;
-  let apresHash: string;
-  let futurHash: string;
-
-  beforeAll(async () => {
-    app = await getTestApp();
-    db = await getTestDatabase(app);
-    repository = app.get(CollectPreuvesRepository);
-
-    const fixture = await addTestCollectiviteAndUser(db, {
-      user: { role: CollectiviteRole.ADMIN },
-    });
-    collectivite = fixture.collectivite;
-    adminUserId = getAuthUserFromUserCredentials(fixture.user).id;
-    cleanupCollectivite = fixture.cleanup;
-
-    avantHash = `hash-avant-${collectivite.id}`;
-    dansHash = `hash-dans-${collectivite.id}`;
-    apresHash = `hash-apres-${collectivite.id}`;
-    futurHash = `hash-futur-${collectivite.id}`;
-
-    await db.db
-      .insert(collectiviteBucketTable)
-      .values({ bucketId: PREUVES_ARCHIVES_BUCKET, collectiviteId: collectivite.id });
-
-    const preuvesFixtures = [
-      { hash: avantHash, modifiedAt: '2023-06-01T00:00:00Z' },
-      { hash: dansHash, modifiedAt: '2024-06-15T00:00:00Z' },
-      { hash: apresHash, modifiedAt: '2025-06-01T00:00:00Z' },
-      { hash: futurHash, modifiedAt: '2099-01-01T00:00:00Z' },
-    ];
-
-    const fichiers = await db.db
-      .insert(bibliothequeFichierTable)
-      .values(
-        preuvesFixtures.map(({ hash }) => ({
-          collectiviteId: collectivite.id,
-          hash,
-          filename: `${hash}.pdf`,
-          confidentiel: false,
-        }))
-      )
-      .returning();
-
-    await db.db.insert(storageObjectTable).values(
-      fichiers.map((fichier) => ({
-        bucketId: PREUVES_ARCHIVES_BUCKET,
-        name: fichier.hash,
-        metadata: { size: 1024 },
-      }))
-    );
-
-    const preuves = await db.db
-      .insert(preuveComplementaireTable)
-      .values(
-        fichiers.map((fichier) => ({
-          collectiviteId: collectivite.id,
-          actionId: 'cae_1.1.3',
-          fichierId: fichier.id,
-          modifiedBy: adminUserId,
-        }))
-      )
-      .returning({ id: preuveComplementaireTable.id });
-
-    await db.db.transaction(async (tx) => {
-      await tx.execute(sql`set local session_replication_role = replica`);
-      await preuves.reduce(async (previous, preuve, index) => {
-        await previous;
-        await tx
-          .update(preuveComplementaireTable)
-          .set({ modifiedAt: preuvesFixtures[index].modifiedAt })
-          .where(eq(preuveComplementaireTable.id, preuve.id));
-      }, Promise.resolve());
-    });
-  });
-
-  afterAll(async () => {
-    await db.db
-      .delete(preuveComplementaireTable)
-      .where(eq(preuveComplementaireTable.collectiviteId, collectivite.id));
-    await db.db
-      .delete(storageObjectTable)
-      .where(
-        and(
-          eq(storageObjectTable.bucketId, PREUVES_ARCHIVES_BUCKET),
-          like(storageObjectTable.name, `%${collectivite.id}`)
-        )
-      );
-    await db.db
-      .delete(bibliothequeFichierTable)
-      .where(eq(bibliothequeFichierTable.collectiviteId, collectivite.id));
-    await cleanupCollectivite();
-    await app.close();
-  });
-
-  test('fenetre [date_debut, date_fin] : ne renvoie que la preuve modifiée dans la fenetre', async () => {
-    const result = await repository.getComplementairePreuves({
-      collectiviteId: collectivite.id,
-      referentielId: 'cae',
-      auditWindow: { dateDebut, dateFin },
-      canReadConfidentiel: true,
-    });
-
-    expect(result.success).toBe(true);
-    if (!result.success) return;
-    expect(result.data.files.map((file) => file.hash)).toEqual([dansHash]);
-  });
-
-  test('date_fin null : borne haute = now(), exclut une preuve future', async () => {
-    const result = await repository.getComplementairePreuves({
-      collectiviteId: collectivite.id,
-      referentielId: 'cae',
-      auditWindow: { dateDebut, dateFin: null },
-      canReadConfidentiel: true,
-    });
-
-    expect(result.success).toBe(true);
-    if (!result.success) return;
-    expect(result.data.files.map((file) => file.hash).sort()).toEqual(
-      [dansHash, apresHash].sort()
-    );
   });
 });

--- a/apps/backend/src/referentiels/preuves-archive/list-audit-preuves/collect-preuves.repository.ts
+++ b/apps/backend/src/referentiels/preuves-archive/list-audit-preuves/collect-preuves.repository.ts
@@ -12,18 +12,7 @@ import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { failure, success, type Result } from '@tet/backend/utils/result.type';
 import { ReferentielId } from '@tet/domain/referentiels';
 import { getErrorMessage } from '@tet/domain/utils';
-import {
-  and,
-  eq,
-  gte,
-  inArray,
-  isNull,
-  lte,
-  or,
-  sql,
-  type Column,
-  type SQL,
-} from 'drizzle-orm';
+import { and, eq, inArray, isNull, or, sql, type Column, type SQL } from 'drizzle-orm';
 import { z } from 'zod';
 import {
   PreuvesArchiveErrorEnum,
@@ -54,11 +43,6 @@ type CollectedPreuves = {
   links: CollectedLinkPreuve[];
 };
 
-export interface AuditPreuvesWindow {
-  dateDebut: string | null;
-  dateFin: string | null;
-}
-
 @Injectable()
 export class CollectPreuvesRepository {
   private readonly db = this.database.db;
@@ -69,11 +53,9 @@ export class CollectPreuvesRepository {
   async getComplementairePreuves(input: {
     collectiviteId: number;
     referentielId: ReferentielId;
-    auditWindow: AuditPreuvesWindow;
     canReadConfidentiel: boolean;
   }): Promise<Result<CollectedPreuves, PreuvesArchiveError>> {
-    const { collectiviteId, referentielId, auditWindow, canReadConfidentiel } =
-      input;
+    const { collectiviteId, referentielId, canReadConfidentiel } = input;
     try {
       const rows = await this.db
         .select({
@@ -112,10 +94,6 @@ export class CollectPreuvesRepository {
         .where(
           and(
             eq(preuveComplementaireTable.collectiviteId, collectiviteId),
-            this.auditWindowFilter(
-              preuveComplementaireTable.modifiedAt,
-              auditWindow
-            ),
             this.hideConfidentielFilter(
               preuveComplementaireTable.fichierId,
               canReadConfidentiel
@@ -138,11 +116,9 @@ export class CollectPreuvesRepository {
   async getReglementairePreuves(input: {
     collectiviteId: number;
     referentielId: ReferentielId;
-    auditWindow: AuditPreuvesWindow;
     canReadConfidentiel: boolean;
   }): Promise<Result<CollectedPreuves, PreuvesArchiveError>> {
-    const { collectiviteId, referentielId, auditWindow, canReadConfidentiel } =
-      input;
+    const { collectiviteId, referentielId, canReadConfidentiel } = input;
     try {
       const rows = await this.db
         .select({
@@ -185,10 +161,6 @@ export class CollectPreuvesRepository {
         .where(
           and(
             eq(preuveReglementaireTable.collectiviteId, collectiviteId),
-            this.auditWindowFilter(
-              preuveReglementaireTable.modifiedAt,
-              auditWindow
-            ),
             this.hideConfidentielFilter(
               preuveReglementaireTable.fichierId,
               canReadConfidentiel
@@ -320,17 +292,6 @@ export class CollectPreuvesRepository {
         error instanceof Error ? error : new Error(getErrorMessage(error))
       );
     }
-  }
-
-  private auditWindowFilter(
-    modifiedAtColumn: Column,
-    auditWindow: AuditPreuvesWindow
-  ): SQL | undefined {
-    const apresDebut = auditWindow.dateDebut
-      ? gte(modifiedAtColumn, auditWindow.dateDebut)
-      : undefined;
-    const avantFin = lte(modifiedAtColumn, auditWindow.dateFin ?? sql`now()`);
-    return and(apresDebut, avantFin);
   }
 
   private storageObjectInCollectiviteBuckets(collectiviteId: number): SQL {

--- a/apps/backend/src/referentiels/preuves-archive/list-audit-preuves/list-audit-preuves.service.spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/list-audit-preuves/list-audit-preuves.service.spec.ts
@@ -12,17 +12,11 @@ const user = { id: 'user-id' } as AuthenticatedUser;
 
 const referentielId: ReferentielId = 'cae';
 
-const auditWindow = {
-  dateDebut: '2024-01-01T00:00:00Z',
-  dateFin: '2024-12-31T23:59:59Z',
-};
-
 const baseInput = {
   collectiviteId: 1,
   referentielId,
   auditId: 10,
   demandeId: 20,
-  auditWindow,
   user,
 };
 
@@ -121,20 +115,6 @@ describe('ListAuditPreuvesService', () => {
     );
     expect(getReglementairePreuves).toHaveBeenCalledWith(
       expect.objectContaining({ referentielId })
-    );
-  });
-
-  it("transmet la fenetre de l'audit aux collectes mesure (complémentaire et réglementaire)", async () => {
-    const { service, getComplementairePreuves, getReglementairePreuves } =
-      buildService();
-
-    await service.list(baseInput);
-
-    expect(getComplementairePreuves).toHaveBeenCalledWith(
-      expect.objectContaining({ auditWindow })
-    );
-    expect(getReglementairePreuves).toHaveBeenCalledWith(
-      expect.objectContaining({ auditWindow })
     );
   });
 

--- a/apps/backend/src/referentiels/preuves-archive/list-audit-preuves/list-audit-preuves.service.ts
+++ b/apps/backend/src/referentiels/preuves-archive/list-audit-preuves/list-audit-preuves.service.ts
@@ -11,7 +11,6 @@ import {
 } from '../preuves-archive.errors';
 import {
   CollectPreuvesRepository,
-  type AuditPreuvesWindow,
   type CollectedFilePreuve,
   type CollectedLinkPreuve,
 } from './collect-preuves.repository';
@@ -32,7 +31,6 @@ export interface ListPreuvesForAuditInput {
   referentielId: ReferentielId;
   demandeId: number;
   auditId: number;
-  auditWindow: AuditPreuvesWindow;
   user: AuthenticatedUser;
 }
 
@@ -48,14 +46,7 @@ export class ListAuditPreuvesService {
   async list(
     input: ListPreuvesForAuditInput
   ): Promise<Result<PreuvesByOrigin, PreuvesArchiveError>> {
-    const {
-      collectiviteId,
-      referentielId,
-      demandeId,
-      auditId,
-      auditWindow,
-      user,
-    } = input;
+    const { collectiviteId, referentielId, demandeId, auditId, user } = input;
 
     try {
       const canReadConfidentiel = await this.permissions.isAllowed(
@@ -71,13 +62,11 @@ export class ListAuditPreuvesService {
           this.repository.getComplementairePreuves({
             collectiviteId,
             referentielId,
-            auditWindow,
             canReadConfidentiel,
           }),
           this.repository.getReglementairePreuves({
             collectiviteId,
             referentielId,
-            auditWindow,
             canReadConfidentiel,
           }),
           this.repository.getLabellisationPreuves({


### PR DESCRIPTION
## Quoi

Revert ciblé du commit `e39f286e3` (« feat(referentiels): scope les preuves de mesures a la fenetre de l'audit »).

## Pourquoi

Le scoping introduisait un filtre `auditWindowFilter` sur `modifiedAt` pour les preuves **complémentaires** et **réglementaires** (origine `mesure`) lors de la génération de l'archive d'audit : seules celles modifiées dans `[date_debut, date_fin]` de l'audit étaient incluses. Conséquence : des documents complémentaires/réglementaires modifiés **hors fenêtre** disparaissaient de l'archive.

On rétablit le comportement antérieur : l'archive collecte **toutes** les preuves complémentaires et réglementaires de la collectivité/référentiel, sans filtre temporel. Les preuves d'**audit** (par `auditId`) et de **labellisation** (par `demandeId`) n'étaient déjà pas concernées par ce filtre.

## Comment

`git revert e39f286e3` — le commit ne touchait que 5 fichiers (`collect-preuves.repository` + son e2e, `list-audit-preuves.service` + son spec, `generate-preuves-archive.service`) et aucun commit postérieur ne les avait modifiés → revert propre. Les tests spécifiques à la fenêtre, ajoutés par ce commit, sont retirés par le revert.

## Tests

- `collect-preuves` e2e 5/5, `list-audit-preuves.service` 4/4, typecheck backend OK.

_Filtre confidentialité (`hideConfidentielFilter`) inchangé : les preuves confidentielles restent masquées pour qui n'a pas `read_confidentiel`._