### PR TITLE
fix(referentiels): liste les archives de preuves les plus récentes en bas

### DIFF
--- a/apps/backend/src/referentiels/preuves-archive/preuves-archive.repository.ts
+++ b/apps/backend/src/referentiels/preuves-archive/preuves-archive.repository.ts
@@ -3,7 +3,7 @@ import { auditeurTable } from '@tet/backend/referentiels/labellisations/auditeur
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { failure, success, type Result } from '@tet/backend/utils/result.type';
 import { getErrorMessage } from '@tet/domain/utils';
-import { and, desc, eq, gt, inArray } from 'drizzle-orm';
+import { and, asc, eq, gt, inArray } from 'drizzle-orm';
 import {
   AuditPreuvesArchive,
   auditPreuvesArchiveStatusSchema,
@@ -168,7 +168,7 @@ export class PreuvesArchiveRepository {
             gt(auditPreuvesArchiveTable.expiresAt, new Date().toISOString())
           )
         )
-        .orderBy(desc(auditPreuvesArchiveTable.createdAt));
+        .orderBy(asc(auditPreuvesArchiveTable.createdAt));
 
       const parsed = rows.map((row) => this.parseRow(row));
       const failed = parsed.find((result) => !result.success);


### PR DESCRIPTION
## Quoi

La liste des archives de preuves (`preuvesArchive.list`) était triée **descendant** par date de création (plus récente en premier). On passe en **ascendant** → les archives les plus récentes apparaissent **en bas**.

## Comment

`preuves-archive.repository.ts` : `orderBy(desc(createdAt))` → `orderBy(asc(createdAt))`. Le front rend la liste dans l'ordre reçu (aucun tri client à changer).

## Tests

- `preuves-archive.router.e2e-spec` 13/13 (les tests `list` n'assertent pas l'ordre → inchangés), typecheck + lint OK.