### PR TITLE
refactor(ui): FloatingPanel slots Content/Footer + sous-titre validité archives

### DIFF
--- a/apps/app/src/labels/catalog.ts
+++ b/apps/app/src/labels/catalog.ts
@@ -284,6 +284,8 @@ export const appLabels = {
   preuvesArchiveGenerer: 'Générer une archive',
   preuvesArchiveAucune: 'Aucune archive générée pour le moment.',
   preuvesArchivePanelTitre: 'Les archives',
+  preuvesArchiveValiditeInfo:
+    'Les archives restent valides 7 jours, puis sont supprimées.',
   preuvesArchiveFermerPanel: 'Fermer le panneau des archives',
   preuvesArchiveLigneTitre: ({
     referentiel,

--- a/apps/app/src/referentiels/archives-panel/archives-panel-layout.tsx
+++ b/apps/app/src/referentiels/archives-panel/archives-panel-layout.tsx
@@ -19,8 +19,14 @@ export function ArchivesPanelLayout({
       onClose={onClose}
       closeLabel={appLabels.preuvesArchiveFermerPanel}
     >
-      <ul className="m-0 flex list-none flex-col gap-6 p-0">{children}</ul>
-      {action && <div className="mt-4 flex justify-end">{action}</div>}
+      <FloatingPanel.Content>
+        <ul className="m-0 flex list-none flex-col gap-6 p-0">{children}</ul>
+      </FloatingPanel.Content>
+      {action && (
+        <FloatingPanel.Footer>
+          <div className="flex justify-end">{action}</div>
+        </FloatingPanel.Footer>
+      )}
     </FloatingPanel>
   );
 }

--- a/apps/app/src/referentiels/archives-panel/archives-panel-layout.tsx
+++ b/apps/app/src/referentiels/archives-panel/archives-panel-layout.tsx
@@ -16,6 +16,7 @@ export function ArchivesPanelLayout({
   return (
     <FloatingPanel
       title={appLabels.preuvesArchivePanelTitre}
+      subtitle={appLabels.preuvesArchiveValiditeInfo}
       onClose={onClose}
       closeLabel={appLabels.preuvesArchiveFermerPanel}
     >

--- a/packages/ui/src/design-system/FloatingPanel/FloatingPanel.behavior.test.tsx
+++ b/packages/ui/src/design-system/FloatingPanel/FloatingPanel.behavior.test.tsx
@@ -1,0 +1,31 @@
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { FloatingPanel } from './FloatingPanel';
+
+describe('FloatingPanel', () => {
+  it('garde le footer hors de la zone scrollable quand le contenu deborde', () => {
+    render(
+      <FloatingPanel title="Mes telechargements" onClose={() => undefined}>
+        <FloatingPanel.Content>
+          <p>Premier element de la liste</p>
+        </FloatingPanel.Content>
+        <FloatingPanel.Footer>
+          <button type="button">Generer une archive</button>
+        </FloatingPanel.Footer>
+      </FloatingPanel>
+    );
+
+    const scrollRegion = screen
+      .getByText('Premier element de la liste')
+      .closest('.overflow-y-auto');
+    const footerButton = screen.getByRole('button', {
+      name: 'Generer une archive',
+    });
+
+    expect(scrollRegion).not.toBeNull();
+    expect(scrollRegion?.contains(footerButton)).toBe(false);
+  });
+});

--- a/packages/ui/src/design-system/FloatingPanel/FloatingPanel.behavior.test.tsx
+++ b/packages/ui/src/design-system/FloatingPanel/FloatingPanel.behavior.test.tsx
@@ -28,4 +28,20 @@ describe('FloatingPanel', () => {
     expect(scrollRegion).not.toBeNull();
     expect(scrollRegion?.contains(footerButton)).toBe(false);
   });
+
+  it('affiche le sous-titre sous le titre quand il est fourni', () => {
+    render(
+      <FloatingPanel
+        title="Mes telechargements"
+        subtitle="12 elements en attente"
+        onClose={() => undefined}
+      >
+        <FloatingPanel.Content>
+          <p>Premier element de la liste</p>
+        </FloatingPanel.Content>
+      </FloatingPanel>
+    );
+
+    expect(screen.getByText('12 elements en attente')).toBeInTheDocument();
+  });
 });

--- a/packages/ui/src/design-system/FloatingPanel/FloatingPanel.stories.tsx
+++ b/packages/ui/src/design-system/FloatingPanel/FloatingPanel.stories.tsx
@@ -29,7 +29,7 @@ export const Default: Story = {
 
 export const ContenuLong: Story = {
   render: (args) => (
-    <FloatingPanel {...args}>
+    <FloatingPanel {...args} subtitle="12 éléments en attente">
       <FloatingPanel.Content>
         <ul className="m-0 flex list-none flex-col gap-4 p-0">
           {Array.from({ length: 12 }, (_, index) => (

--- a/packages/ui/src/design-system/FloatingPanel/FloatingPanel.stories.tsx
+++ b/packages/ui/src/design-system/FloatingPanel/FloatingPanel.stories.tsx
@@ -1,5 +1,6 @@
 import { Meta, StoryObj } from '@storybook/nextjs-vite';
 
+import { Button } from '../Button';
 import { FloatingPanel } from '.';
 
 const meta: Meta<typeof FloatingPanel> = {
@@ -17,9 +18,11 @@ type Story = StoryObj<typeof FloatingPanel>;
 export const Default: Story = {
   render: (args) => (
     <FloatingPanel {...args}>
-      <p className="m-0 text-sm text-grey-8">
-        {"Contenu du panel — typiquement une liste d'éléments en attente."}
-      </p>
+      <FloatingPanel.Content>
+        <p className="m-0 text-sm text-grey-8">
+          {"Contenu du panel — typiquement une liste d'éléments en attente."}
+        </p>
+      </FloatingPanel.Content>
     </FloatingPanel>
   ),
 };
@@ -27,18 +30,25 @@ export const Default: Story = {
 export const ContenuLong: Story = {
   render: (args) => (
     <FloatingPanel {...args}>
-      <ul className="m-0 flex list-none flex-col gap-4 p-0">
-        {Array.from({ length: 12 }, (_, index) => (
-          <li key={index} className="flex flex-col gap-1">
-            <span className="text-sm font-semibold text-primary-9">
-              Élément #{index + 1}
-            </span>
-            <span className="text-xs text-grey-7">
-              {"Description courte de l'élément."}
-            </span>
-          </li>
-        ))}
-      </ul>
+      <FloatingPanel.Content>
+        <ul className="m-0 flex list-none flex-col gap-4 p-0">
+          {Array.from({ length: 12 }, (_, index) => (
+            <li key={index} className="flex flex-col gap-1">
+              <span className="text-sm font-semibold text-primary-9">
+                Élément #{index + 1}
+              </span>
+              <span className="text-xs text-grey-7">
+                {"Description courte de l'élément."}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </FloatingPanel.Content>
+      <FloatingPanel.Footer>
+        <div className="flex justify-end">
+          <Button size="sm">Tout télécharger</Button>
+        </div>
+      </FloatingPanel.Footer>
     </FloatingPanel>
   ),
 };

--- a/packages/ui/src/design-system/FloatingPanel/FloatingPanel.tsx
+++ b/packages/ui/src/design-system/FloatingPanel/FloatingPanel.tsx
@@ -10,31 +10,47 @@ export type FloatingPanelProps = {
   children: ReactNode;
 };
 
-export const FloatingPanel = ({
+const Content = ({ children }: { children: ReactNode }): JSX.Element => (
+  <div className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto">
+    {children}
+  </div>
+);
+
+const Footer = ({ children }: { children: ReactNode }): JSX.Element => (
+  <div className="flex shrink-0 flex-col gap-3">
+    <Divider />
+    {children}
+  </div>
+);
+
+export function FloatingPanel({
   title,
   onClose,
   closeLabel,
   children,
-}: FloatingPanelProps): JSX.Element => (
-  <aside
-    aria-label={title}
-    className="fixed bottom-6 right-6 z-modal flex max-w-modal-xs flex-col gap-3 rounded-md border border-grey-4 bg-white p-6 shadow-[0_4px_30px_0px_rgba(0,0,0,0.02)]"
-  >
-    <div className="flex shrink-0 items-start justify-between gap-3">
-      <h3 className="mb-0 text-base font-semibold leading-6 text-primary-9">
-        {title}
-      </h3>
-      <Button
-        title={closeLabel ?? uiLabels.fermer}
-        onClick={onClose}
-        icon="close-line"
-        variant="unstyled"
-        size="xs"
-      />
-    </div>
-    <Divider />
-    <div className="flex max-h-[70vh] flex-col gap-6 overflow-y-auto">
+}: FloatingPanelProps): JSX.Element {
+  return (
+    <aside
+      aria-label={title}
+      className="fixed bottom-6 right-6 z-modal flex max-h-[80vh] max-w-modal-xs flex-col gap-3 rounded-md border border-grey-4 bg-white p-6 shadow-[0_4px_30px_0px_rgba(0,0,0,0.02)]"
+    >
+      <div className="flex shrink-0 items-start justify-between gap-3">
+        <h3 className="mb-0 text-base font-semibold leading-6 text-primary-9">
+          {title}
+        </h3>
+        <Button
+          title={closeLabel ?? uiLabels.fermer}
+          onClick={onClose}
+          icon="close-line"
+          variant="unstyled"
+          size="xs"
+        />
+      </div>
+      <Divider />
       {children}
-    </div>
-  </aside>
-);
+    </aside>
+  );
+}
+
+FloatingPanel.Content = Content;
+FloatingPanel.Footer = Footer;

--- a/packages/ui/src/design-system/FloatingPanel/FloatingPanel.tsx
+++ b/packages/ui/src/design-system/FloatingPanel/FloatingPanel.tsx
@@ -5,6 +5,7 @@ import { Divider } from '../Divider';
 
 export type FloatingPanelProps = {
   title: string;
+  subtitle?: string;
   onClose: () => void;
   closeLabel?: string;
   children: ReactNode;
@@ -25,6 +26,7 @@ const Footer = ({ children }: { children: ReactNode }): JSX.Element => (
 
 export function FloatingPanel({
   title,
+  subtitle,
   onClose,
   closeLabel,
   children,
@@ -35,9 +37,12 @@ export function FloatingPanel({
       className="fixed bottom-6 right-6 z-modal flex max-h-[80vh] max-w-modal-xs flex-col gap-3 rounded-md border border-grey-4 bg-white p-6 shadow-[0_4px_30px_0px_rgba(0,0,0,0.02)]"
     >
       <div className="flex shrink-0 items-start justify-between gap-3">
-        <h3 className="mb-0 text-base font-semibold leading-6 text-primary-9">
-          {title}
-        </h3>
+        <div className="flex flex-col gap-1">
+          <h3 className="mb-0 text-base font-semibold leading-6 text-primary-9">
+            {title}
+          </h3>
+          {subtitle && <p className="m-0 text-sm text-grey-7">{subtitle}</p>}
+        </div>
         <Button
           title={closeLabel ?? uiLabels.fermer}
           onClick={onClose}


### PR DESCRIPTION
## Contexte

Le footer du `FloatingPanel` (DS) disparaissait quand le contenu débordait : il était passé via `children`, donc rendu **à l'intérieur** de la zone plafonnée à `max-height` et scrollable. Dès que la liste dépassait, le footer partait avec le scroll. Le header, lui, est `shrink-0` et reste fixe — le footer méritait le même traitement.

## Nature

Petit correctif DS à l'origine, étendu en accord avec le demandeur. La PR porte **deux natures assumées** :
- `refactor(ui)` — `FloatingPanel` reçoit des slots compound `Content`/`Footer`, ce qui corrige le footer ;
- `feat(referentiels)` — sous-titre de validité 7 jours sur le panneau d'archives.

## API (hybride)

```tsx
<FloatingPanel title="…" subtitle="…" onClose={…} closeLabel="…">
  <FloatingPanel.Content>…liste scrollable…</FloatingPanel.Content>
  <FloatingPanel.Footer>…action épinglée…</FloatingPanel.Footer>
</FloatingPanel>
```

Le **header reste piloté par props sur le root** (frame fixe), les **régions variables** (`Content`/`Footer`) sont des slots compound.

## Décision de design : hybride plutôt que `Header` compound

Un `Header` compound a été essayé puis écarté. Le header d'un `FloatingPanel` est invariant (toujours titre + fermeture), `onClose` est obligatoire (panneau non-modal) et `title` nomme le landmark `<aside>` via `aria-label`. Garder le header en props **encode ces invariants gratuitement** ; un slot `Header` libre permettait un panneau sans bouton de fermeture et un `aria-labelledby` pendant (nom accessible cassé), pour une flexibilité qu'un seul consommateur n'exerce pas. `Content`/`Footer` en compound restent justifiés : leur contenu varie réellement.

## Surface de review

**Attention humaine :**
- `packages/ui/.../FloatingPanel/FloatingPanel.tsx` — `Content` est le seul à scroller (`flex-1 min-h-0 overflow-y-auto`), `Footer` est épinglé (`shrink-0`), le plafond de hauteur est sur l'`aside`. Membres statiques typés via le pattern fonction + assignation (identique à `ChecklistTable`).
- `apps/app/src/referentiels/archives-panel/archives-panel-layout.tsx` — migration vers `.Content`/`.Footer` + sous-titre.

**Mécanique / faible enjeu :**
- `FloatingPanel.stories.tsx`, `FloatingPanel.behavior.test.tsx`, libellé `preuvesArchiveValiditeInfo`.

## Zone à confiance limitée

- **Couplage copie / constante** : « 7 jours » est en dur dans le libellé. La source de vérité est `ARCHIVE_TTL_MS = 7 * 24 * 60 * 60 * 1000` côté backend, non importable depuis le front. Cohérent aujourd'hui ; dérive possible si la TTL change.

## Test de régression

`FloatingPanel.behavior.test.tsx` vérifie que le footer n'est **pas** descendant de la zone `overflow-y-auto` (rouge démontré sur la structure buguée où le footer vivait dans le scroll), et que le sous-titre s'affiche quand fourni.

## Anti-duplication

`FloatingPanel` est l'unique primitive de panneau flottant, avec un seul consommateur (le panneau d'archives). Le libellé suit `appLabels.*` ; le sous-titre est une chaîne statique.

## DISCOVERED

Aucun item ajouté à `DISCOVERED.md`.
