### PR TITLE
feat(referentiels): suppression des archives de preuves (TTL + limite 10 par audit)

### DIFF
--- a/apps/backend/src/referentiels/preuves-archive/delete-preuves-archive/delete-preuves-archive.service.spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/delete-preuves-archive/delete-preuves-archive.service.spec.ts
@@ -1,0 +1,186 @@
+import { failure, success, type Result } from '@tet/backend/utils/result.type';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  AuditPreuvesArchiveStatusEnum,
+  type AuditPreuvesArchive,
+} from '../models/audit-preuves-archive.table';
+import {
+  PreuvesArchiveErrorEnum,
+  type PreuvesArchiveError,
+} from '../preuves-archive.errors';
+import { DeletePreuvesArchiveService } from './delete-preuves-archive.service';
+
+const input = { auditId: 10, requestedBy: 'owner-id' };
+
+const EXPIRED = '2020-01-01T00:00:00.000Z';
+
+function makeArchive(
+  overrides: Partial<AuditPreuvesArchive> & { id: string }
+): AuditPreuvesArchive {
+  return {
+    collectiviteId: 1,
+    referentielId: 'cae',
+    auditId: 10,
+    requestedBy: 'owner-id',
+    status: AuditPreuvesArchiveStatusEnum.COMPLETED,
+    totalFiles: 0,
+    processedFiles: 0,
+    storagePath: `${overrides.id}.zip`,
+    errorMessage: null,
+    createdAt: '2026-06-01T00:00:00.000Z',
+    modifiedAt: '2026-06-01T00:00:00.000Z',
+    expiresAt: '2999-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function buildService({
+  expired = success([]),
+  candidates = success([]),
+  removeDocument = success(undefined),
+  deleteByIds = success([]),
+}: {
+  expired?: Result<AuditPreuvesArchive[], PreuvesArchiveError>;
+  candidates?: Result<AuditPreuvesArchive[], PreuvesArchiveError>;
+  removeDocument?: Result<undefined, PreuvesArchiveError>;
+  deleteByIds?: Result<AuditPreuvesArchive[], PreuvesArchiveError>;
+} = {}) {
+  const repository = {
+    deleteExpired: vi.fn().mockResolvedValue(expired),
+    listForDeletion: vi.fn().mockResolvedValue(candidates),
+    deleteByIds: vi.fn().mockResolvedValue(deleteByIds),
+  };
+
+  const documentStorage = {
+    removeDocument: vi.fn().mockResolvedValue(removeDocument),
+  };
+
+  const service = new DeletePreuvesArchiveService(
+    repository as never,
+    documentStorage as never
+  );
+
+  return { service, repository, documentStorage };
+}
+
+describe('DeletePreuvesArchiveService', () => {
+  it("supprime globalement les archives expirées, même d'un autre user ou collectivité", async () => {
+    const { service, repository, documentStorage } = buildService({
+      expired: success([
+        makeArchive({
+          id: 'autre',
+          requestedBy: 'autre-user',
+          collectiviteId: 99,
+        }),
+      ]),
+    });
+
+    const result = await service.delete(input);
+
+    expect(result).toEqual(success(1));
+    expect(documentStorage.removeDocument).toHaveBeenCalledWith({
+      bucketId: 'preuves-archives',
+      key: 'autre.zip',
+    });
+    expect(repository.deleteByIds).not.toHaveBeenCalled();
+  });
+
+  it('supprime la ligne avant le blob pour la passe scopée', async () => {
+    const { service, repository, documentStorage } = buildService({
+      candidates: success([
+        makeArchive({ id: 'expiree', expiresAt: EXPIRED }),
+        makeArchive({ id: 'fraiche' }),
+      ]),
+      deleteByIds: success([makeArchive({ id: 'expiree', expiresAt: EXPIRED })]),
+    });
+
+    const result = await service.delete(input);
+
+    expect(result).toEqual(success(1));
+    expect(repository.deleteByIds).toHaveBeenCalledWith(['expiree']);
+    expect(documentStorage.removeDocument).toHaveBeenCalledWith({
+      bucketId: 'preuves-archives',
+      key: 'expiree.zip',
+    });
+    expect(repository.deleteByIds.mock.invocationCallOrder[0]).toBeLessThan(
+      documentStorage.removeDocument.mock.invocationCallOrder[0]
+    );
+  });
+
+  it('additionne les expirées globales et les archives au-delà de la limite', async () => {
+    const { service } = buildService({
+      expired: success([makeArchive({ id: 'globale', requestedBy: 'x' })]),
+      candidates: success([
+        makeArchive({ id: 'scopee', expiresAt: EXPIRED }),
+        makeArchive({ id: 'fraiche' }),
+      ]),
+      deleteByIds: success([makeArchive({ id: 'scopee', expiresAt: EXPIRED })]),
+    });
+
+    const result = await service.delete(input);
+
+    expect(result).toEqual(success(2));
+  });
+
+  it("ne touche à rien quand aucune archive n'est à supprimer", async () => {
+    const { service, repository, documentStorage } = buildService({
+      candidates: success([makeArchive({ id: 'fraiche' })]),
+    });
+
+    const result = await service.delete(input);
+
+    expect(result).toEqual(success(0));
+    expect(documentStorage.removeDocument).not.toHaveBeenCalled();
+    expect(repository.deleteByIds).not.toHaveBeenCalled();
+  });
+
+  it('supprime quand même la ligne si la suppression du blob échoue', async () => {
+    const { service, repository } = buildService({
+      candidates: success([makeArchive({ id: 'expiree', expiresAt: EXPIRED })]),
+      deleteByIds: success([makeArchive({ id: 'expiree', expiresAt: EXPIRED })]),
+      removeDocument: failure(PreuvesArchiveErrorEnum.GET_ARCHIVE_ERROR),
+    });
+
+    const result = await service.delete(input);
+
+    expect(result).toEqual(success(1));
+    expect(repository.deleteByIds).toHaveBeenCalledWith(['expiree']);
+  });
+
+  it("propage l'échec de deleteExpired sans rien lister", async () => {
+    const { service, repository } = buildService({
+      expired: failure(PreuvesArchiveErrorEnum.UPDATE_ARCHIVE_ERROR),
+    });
+
+    const result = await service.delete(input);
+
+    expect(result).toEqual(
+      failure(PreuvesArchiveErrorEnum.UPDATE_ARCHIVE_ERROR)
+    );
+    expect(repository.listForDeletion).not.toHaveBeenCalled();
+  });
+
+  it("propage l'échec de listForDeletion", async () => {
+    const { service, documentStorage } = buildService({
+      candidates: failure(PreuvesArchiveErrorEnum.GET_ARCHIVE_ERROR),
+    });
+
+    const result = await service.delete(input);
+
+    expect(result).toEqual(failure(PreuvesArchiveErrorEnum.GET_ARCHIVE_ERROR));
+    expect(documentStorage.removeDocument).not.toHaveBeenCalled();
+  });
+
+  it("propage l'échec de deleteByIds", async () => {
+    const { service } = buildService({
+      candidates: success([makeArchive({ id: 'expiree', expiresAt: EXPIRED })]),
+      deleteByIds: failure(PreuvesArchiveErrorEnum.UPDATE_ARCHIVE_ERROR),
+    });
+
+    const result = await service.delete(input);
+
+    expect(result).toEqual(
+      failure(PreuvesArchiveErrorEnum.UPDATE_ARCHIVE_ERROR)
+    );
+  });
+});

--- a/apps/backend/src/referentiels/preuves-archive/delete-preuves-archive/delete-preuves-archive.service.ts
+++ b/apps/backend/src/referentiels/preuves-archive/delete-preuves-archive/delete-preuves-archive.service.ts
@@ -1,0 +1,92 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { DocumentStorageService } from '@tet/backend/utils/supabase/document-storage.service';
+import { success, type Result } from '@tet/backend/utils/result.type';
+import { PREUVES_ARCHIVES_BUCKET } from '../preuves-archive.constants';
+import { type PreuvesArchiveError } from '../preuves-archive.errors';
+import { PreuvesArchiveRepository } from '../preuves-archive.repository';
+import {
+  MAX_ARCHIVES_PER_AUDIT_USER,
+  selectArchivesToDelete,
+  type DeletableArchive,
+} from './select-archives-to-delete';
+
+export interface DeletePreuvesArchiveInput {
+  auditId: number;
+  requestedBy: string;
+}
+
+@Injectable()
+export class DeletePreuvesArchiveService {
+  private readonly logger = new Logger(DeletePreuvesArchiveService.name);
+
+  constructor(
+    private readonly repository: PreuvesArchiveRepository,
+    private readonly documentStorage: DocumentStorageService
+  ) {}
+
+  async delete(
+    input: DeletePreuvesArchiveInput
+  ): Promise<Result<number, PreuvesArchiveError>> {
+    const expired = await this.repository.deleteExpired();
+    if (!expired.success) {
+      return expired;
+    }
+    await this.removeStoredArchives(expired.data);
+
+    const overLimit = await this.deleteArchivesOverLimit(input);
+    if (!overLimit.success) {
+      return overLimit;
+    }
+
+    return success(expired.data.length + overLimit.data);
+  }
+
+  private async deleteArchivesOverLimit(
+    input: DeletePreuvesArchiveInput
+  ): Promise<Result<number, PreuvesArchiveError>> {
+    const candidates = await this.repository.listForDeletion(input);
+    if (!candidates.success) {
+      return candidates;
+    }
+
+    const toDelete = selectArchivesToDelete(candidates.data, {
+      now: new Date(),
+      keepMostRecent: MAX_ARCHIVES_PER_AUDIT_USER,
+    });
+    if (toDelete.length === 0) {
+      return success(0);
+    }
+
+    const deleted = await this.repository.deleteByIds(
+      toDelete.map((archive) => archive.id)
+    );
+    if (!deleted.success) {
+      return deleted;
+    }
+    await this.removeStoredArchives(deleted.data);
+
+    return success(deleted.data.length);
+  }
+
+  private async removeStoredArchives(
+    archives: DeletableArchive[]
+  ): Promise<void> {
+    const storedKeys = archives.flatMap((archive) =>
+      archive.storagePath !== null ? [archive.storagePath] : []
+    );
+
+    await Promise.all(
+      storedKeys.map(async (key) => {
+        const removed = await this.documentStorage.removeDocument({
+          bucketId: PREUVES_ARCHIVES_BUCKET,
+          key,
+        });
+        if (!removed.success) {
+          this.logger.error(
+            `Suppression du blob d'archive ${key} échouée: ${removed.error}`
+          );
+        }
+      })
+    );
+  }
+}

--- a/apps/backend/src/referentiels/preuves-archive/delete-preuves-archive/select-archives-to-delete.spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/delete-preuves-archive/select-archives-to-delete.spec.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+import { AuditPreuvesArchiveStatusEnum } from '../models/audit-preuves-archive.table';
+import {
+  MAX_ARCHIVES_PER_AUDIT_USER,
+  selectArchivesToDelete,
+  type DeletableArchive,
+} from './select-archives-to-delete';
+
+const now = new Date('2026-06-30T00:00:00.000Z');
+
+function toArchive(
+  overrides: Partial<DeletableArchive> & { id: string }
+): DeletableArchive {
+  return {
+    status: AuditPreuvesArchiveStatusEnum.COMPLETED,
+    storagePath: `${overrides.id}.zip`,
+    expiresAt: '2026-07-07T00:00:00.000Z',
+    createdAt: '2026-06-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+const dayOf = (day: number) =>
+  `2026-06-${String(day).padStart(2, '0')}T00:00:00.000Z`;
+
+describe('selectArchivesToDelete', () => {
+  it("ne supprime rien tant qu'il y a 10 archives fraîches ou moins", () => {
+    const archives = Array.from(
+      { length: MAX_ARCHIVES_PER_AUDIT_USER },
+      (_, i) => toArchive({ id: `a-${i}`, createdAt: dayOf(10 + i) })
+    );
+
+    expect(
+      selectArchivesToDelete(archives, {
+        now,
+        keepMostRecent: MAX_ARCHIVES_PER_AUDIT_USER,
+      })
+    ).toEqual([]);
+  });
+
+  it('supprime les plus vieilles au-delà de la 10e', () => {
+    const archives = Array.from({ length: 12 }, (_, i) =>
+      toArchive({ id: `a-${i}`, createdAt: dayOf(i + 1) })
+    );
+
+    const deleted = selectArchivesToDelete(archives, {
+      now,
+      keepMostRecent: MAX_ARCHIVES_PER_AUDIT_USER,
+    });
+
+    expect(deleted.map((archive) => archive.id)).toEqual(['a-1', 'a-0']);
+  });
+
+  it('supprime une archive expirée même dans les 10 plus récentes', () => {
+    const archives = [
+      toArchive({
+        id: 'expiree',
+        createdAt: dayOf(20),
+        expiresAt: '2026-06-25T00:00:00.000Z',
+      }),
+      toArchive({ id: 'fraiche', createdAt: dayOf(28) }),
+    ];
+
+    const deleted = selectArchivesToDelete(archives, {
+      now,
+      keepMostRecent: MAX_ARCHIVES_PER_AUDIT_USER,
+    });
+
+    expect(deleted.map((archive) => archive.id)).toEqual(['expiree']);
+  });
+
+  it('ne supprime jamais une archive in-flight, même vieille et expirée', () => {
+    const archives = [
+      toArchive({
+        id: 'pending-vieille',
+        status: AuditPreuvesArchiveStatusEnum.PENDING,
+        createdAt: dayOf(1),
+        expiresAt: '2026-06-08T00:00:00.000Z',
+      }),
+      ...Array.from({ length: MAX_ARCHIVES_PER_AUDIT_USER }, (_, i) =>
+        toArchive({ id: `a-${i}`, createdAt: dayOf(15 + i) })
+      ),
+    ];
+
+    expect(
+      selectArchivesToDelete(archives, {
+        now,
+        keepMostRecent: MAX_ARCHIVES_PER_AUDIT_USER,
+      })
+    ).toEqual([]);
+  });
+
+  it('compte les in-flight dans la limite de 10', () => {
+    const inFlight = [
+      toArchive({
+        id: 'proc-1',
+        status: AuditPreuvesArchiveStatusEnum.PROCESSING,
+        createdAt: dayOf(29),
+      }),
+      toArchive({
+        id: 'proc-2',
+        status: AuditPreuvesArchiveStatusEnum.PROCESSING,
+        createdAt: dayOf(28),
+      }),
+    ];
+    const completed = Array.from({ length: 9 }, (_, i) =>
+      toArchive({ id: `c-${i}`, createdAt: dayOf(i + 1) })
+    );
+
+    const deleted = selectArchivesToDelete([...inFlight, ...completed], {
+      now,
+      keepMostRecent: MAX_ARCHIVES_PER_AUDIT_USER,
+    });
+
+    expect(deleted.map((archive) => archive.id)).toEqual(['c-0']);
+  });
+});

--- a/apps/backend/src/referentiels/preuves-archive/delete-preuves-archive/select-archives-to-delete.ts
+++ b/apps/backend/src/referentiels/preuves-archive/delete-preuves-archive/select-archives-to-delete.ts
@@ -1,0 +1,39 @@
+import {
+  auditPreuvesArchiveInFlightStatuses,
+  type AuditPreuvesArchive,
+} from '../models/audit-preuves-archive.table';
+
+export const MAX_ARCHIVES_PER_AUDIT_USER = 10;
+
+export type DeletableArchive = Pick<
+  AuditPreuvesArchive,
+  'id' | 'status' | 'storagePath' | 'expiresAt' | 'createdAt'
+>;
+
+export interface SelectArchivesToDeleteOptions {
+  now: Date;
+  keepMostRecent: number;
+}
+
+export function selectArchivesToDelete(
+  archives: DeletableArchive[],
+  { now, keepMostRecent }: SelectArchivesToDeleteOptions
+): DeletableArchive[] {
+  const fromMostRecent = [...archives].sort(
+    (a, b) =>
+      Number(a.createdAt < b.createdAt) - Number(a.createdAt > b.createdAt)
+  );
+  const nowMs = now.getTime();
+
+  return fromMostRecent.filter((archive, rank) => {
+    const isInFlight = auditPreuvesArchiveInFlightStatuses.includes(
+      archive.status
+    );
+    if (isInFlight) {
+      return false;
+    }
+    const isExpired = new Date(archive.expiresAt).getTime() <= nowMs;
+    const isBeyondLimit = rank >= keepMostRecent;
+    return isExpired || isBeyondLimit;
+  });
+}

--- a/apps/backend/src/referentiels/preuves-archive/models/audit-preuves-archive.table.ts
+++ b/apps/backend/src/referentiels/preuves-archive/models/audit-preuves-archive.table.ts
@@ -42,6 +42,11 @@ export type AuditPreuvesArchiveStatus = z.infer<
 export const auditPreuvesArchiveInFlightStatuses: readonly AuditPreuvesArchiveStatus[] =
   [AuditPreuvesArchiveStatusEnum.PENDING, AuditPreuvesArchiveStatusEnum.PROCESSING];
 
+export const auditPreuvesArchiveDeletableStatuses: AuditPreuvesArchiveStatus[] = [
+  AuditPreuvesArchiveStatusEnum.COMPLETED,
+  AuditPreuvesArchiveStatusEnum.FAILED,
+];
+
 export const auditPreuvesArchiveTable = pgTable(
   'audit_preuves_archive',
   {

--- a/apps/backend/src/referentiels/preuves-archive/preuves-archive.delete.e2e-spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/preuves-archive.delete.e2e-spec.ts
@@ -1,0 +1,173 @@
+import { INestApplication } from '@nestjs/common';
+import { addTestCollectiviteAndUser } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { auditTable } from '@tet/backend/referentiels/labellisations/audit.table';
+import { addAuditeurPermission } from '@tet/backend/referentiels/labellisations/labellisations.test-fixture';
+import {
+  getAuthUserFromUserCredentials,
+  getTestApp,
+  getTestDatabase,
+} from '@tet/backend/test';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { addTestUser } from '@tet/backend/users/users/users.test-fixture';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { DocumentStorageService } from '@tet/backend/utils/supabase/document-storage.service';
+import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
+import { Collectivite } from '@tet/domain/collectivites';
+import { CollectiviteRole } from '@tet/domain/users';
+import { randomUUID } from 'crypto';
+import { eq } from 'drizzle-orm';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { GeneratePreuvesArchiveWorker } from './generate-preuves-archive/generate-preuves-archive.worker';
+import {
+  auditPreuvesArchiveTable,
+  AuditPreuvesArchiveStatusEnum,
+} from './models/audit-preuves-archive.table';
+import { PREUVES_ARCHIVES_BUCKET } from './preuves-archive.constants';
+
+const daysAgo = (days: number) =>
+  new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+
+describe('Archive de preuves - suppression (storage réel, sans mock)', () => {
+  let app: INestApplication;
+  let db: DatabaseService;
+  let router: TrpcRouter;
+  let storage: DocumentStorageService;
+
+  let collectivite: Collectivite;
+  let auditeur: AuthenticatedUser;
+  let otherUser: AuthenticatedUser;
+  let cleanupCollectivite: () => Promise<void>;
+  let auditeurCleanup: () => Promise<void>;
+  let auditId: number;
+
+  beforeAll(async () => {
+    app = await getTestApp({
+      overrides: (moduleBuilder) => {
+        moduleBuilder
+          .overrideProvider(GeneratePreuvesArchiveWorker)
+          .useValue({ onModuleInit: () => undefined });
+      },
+    });
+    db = await getTestDatabase(app);
+    router = await app.get(TrpcRouter);
+    storage = app.get(DocumentStorageService);
+
+    const fixture = await addTestCollectiviteAndUser(db, {
+      user: { role: CollectiviteRole.ADMIN },
+    });
+    collectivite = fixture.collectivite;
+    auditeur = getAuthUserFromUserCredentials(fixture.user);
+    cleanupCollectivite = fixture.cleanup;
+
+    const otherUserResult = await addTestUser(db, { verified: false });
+    otherUser = getAuthUserFromUserCredentials(otherUserResult.user);
+
+    const [audit] = await db.db
+      .insert(auditTable)
+      .values({ collectiviteId: collectivite.id, referentielId: 'cae' })
+      .returning();
+    auditId = audit.id;
+
+    ({ cleanup: auditeurCleanup } = await addAuditeurPermission({
+      databaseService: db,
+      auditId: audit.id,
+      userId: auditeur.id,
+    }));
+  });
+
+  afterAll(async () => {
+    await db.db
+      .delete(auditPreuvesArchiveTable)
+      .where(eq(auditPreuvesArchiveTable.collectiviteId, collectivite.id));
+    await auditeurCleanup();
+    await db.db
+      .delete(auditTable)
+      .where(eq(auditTable.collectiviteId, collectivite.id));
+    await cleanupCollectivite();
+    await app.close();
+  });
+
+  test('une demande supprime réellement le blob et la ligne au-delà des 10 plus récentes', async () => {
+    const storagePath = `e2e-delete/${randomUUID()}.zip`;
+    const notExpired = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+
+    const stored = await storage.storeDocument({
+      bucketId: PREUVES_ARCHIVES_BUCKET,
+      key: storagePath,
+      contentType: 'application/zip',
+      content: Buffer.from('archive-bytes'),
+    });
+    expect(stored.success).toBe(true);
+
+    const [oldest] = await db.db
+      .insert(auditPreuvesArchiveTable)
+      .values({
+        collectiviteId: collectivite.id,
+        referentielId: 'cae',
+        auditId,
+        requestedBy: auditeur.id,
+        status: AuditPreuvesArchiveStatusEnum.COMPLETED,
+        storagePath,
+        createdAt: '2020-01-01T00:00:00.000Z',
+        expiresAt: notExpired,
+      })
+      .returning();
+
+    await db.db.insert(auditPreuvesArchiveTable).values(
+      Array.from({ length: 10 }, (_, i) => ({
+        collectiviteId: collectivite.id,
+        referentielId: 'cae',
+        auditId,
+        requestedBy: auditeur.id,
+        status: AuditPreuvesArchiveStatusEnum.COMPLETED,
+        createdAt: `2026-06-${String(i + 1).padStart(2, '0')}T00:00:00.000Z`,
+        expiresAt: notExpired,
+      }))
+    );
+
+    const caller = router.createCaller({ user: auditeur });
+    await caller.referentiels.preuvesArchive.request({
+      collectiviteId: collectivite.id,
+      referentielId: 'cae',
+    });
+
+    const remaining = await db.db
+      .select()
+      .from(auditPreuvesArchiveTable)
+      .where(eq(auditPreuvesArchiveTable.id, oldest.id));
+    expect(remaining).toHaveLength(0);
+
+    const afterDelete = await storage.downloadDocument({
+      bucketId: PREUVES_ARCHIVES_BUCKET,
+      key: storagePath,
+    });
+    expect(afterDelete.success).toBe(false);
+  });
+
+  test("une demande purge aussi les archives expirées d'un autre utilisateur", async () => {
+    const [otherExpired] = await db.db
+      .insert(auditPreuvesArchiveTable)
+      .values({
+        collectiviteId: collectivite.id,
+        referentielId: 'cae',
+        auditId,
+        requestedBy: otherUser.id,
+        status: AuditPreuvesArchiveStatusEnum.COMPLETED,
+        storagePath: null,
+        expiresAt: daysAgo(8),
+      })
+      .returning();
+
+    const caller = router.createCaller({ user: auditeur });
+    await caller.referentiels.preuvesArchive.request({
+      collectiviteId: collectivite.id,
+      referentielId: 'cae',
+    });
+
+    const remaining = await db.db
+      .select()
+      .from(auditPreuvesArchiveTable)
+      .where(eq(auditPreuvesArchiveTable.id, otherExpired.id));
+    expect(remaining).toHaveLength(0);
+  });
+});

--- a/apps/backend/src/referentiels/preuves-archive/preuves-archive.full-pipeline.e2e-spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/preuves-archive.full-pipeline.e2e-spec.ts
@@ -90,6 +90,7 @@ describe('Archive de preuves - pipeline complet (ZIP réel)', () => {
             success: true,
             data: { signedUrl: 'https://fake.test/archive.zip' },
           }),
+          removeDocument: async () => ({ success: true }),
         });
       },
     });

--- a/apps/backend/src/referentiels/preuves-archive/preuves-archive.repository.ts
+++ b/apps/backend/src/referentiels/preuves-archive/preuves-archive.repository.ts
@@ -3,9 +3,10 @@ import { auditeurTable } from '@tet/backend/referentiels/labellisations/auditeur
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { failure, success, type Result } from '@tet/backend/utils/result.type';
 import { getErrorMessage } from '@tet/domain/utils';
-import { and, asc, eq, gt, inArray } from 'drizzle-orm';
+import { and, asc, eq, gt, inArray, lte } from 'drizzle-orm';
 import {
   AuditPreuvesArchive,
+  auditPreuvesArchiveDeletableStatuses,
   auditPreuvesArchiveStatusSchema,
   AuditPreuvesArchiveStatus,
   AuditPreuvesArchiveStatusEnum,
@@ -170,17 +171,39 @@ export class PreuvesArchiveRepository {
         )
         .orderBy(asc(auditPreuvesArchiveTable.createdAt));
 
-      const parsed = rows.map((row) => this.parseRow(row));
-      const failed = parsed.find((result) => !result.success);
-      if (failed && !failed.success) {
-        return failed;
-      }
-      return success(
-        parsed.flatMap((result) => (result.success ? [result.data] : []))
-      );
+      return this.parseRows(rows);
     } catch (error) {
       this.logger.error(
         `Liste des archives (collectivité ${input.collectiviteId}, référentiel ${input.referentielId}, user ${input.requestedBy}): ${getErrorMessage(
+          error
+        )}`
+      );
+      return failure(
+        PreuvesArchiveErrorEnum.GET_ARCHIVE_ERROR,
+        error instanceof Error ? error : new Error(getErrorMessage(error))
+      );
+    }
+  }
+
+  async listForDeletion(input: {
+    auditId: number;
+    requestedBy: string;
+  }): Promise<Result<AuditPreuvesArchive[], PreuvesArchiveError>> {
+    try {
+      const rows = await this.db
+        .select()
+        .from(auditPreuvesArchiveTable)
+        .where(
+          and(
+            eq(auditPreuvesArchiveTable.auditId, input.auditId),
+            eq(auditPreuvesArchiveTable.requestedBy, input.requestedBy)
+          )
+        );
+
+      return this.parseRows(rows);
+    } catch (error) {
+      this.logger.error(
+        `Liste des archives à supprimer (audit ${input.auditId}, user ${input.requestedBy}): ${getErrorMessage(
           error
         )}`
       );
@@ -240,6 +263,65 @@ export class PreuvesArchiveRepository {
     } catch (error) {
       this.logger.error(
         `Suppression de la ligne pending ${id}: ${getErrorMessage(error)}`
+      );
+      return failure(
+        PreuvesArchiveErrorEnum.UPDATE_ARCHIVE_ERROR,
+        error instanceof Error ? error : new Error(getErrorMessage(error))
+      );
+    }
+  }
+
+  async deleteByIds(
+    ids: string[]
+  ): Promise<Result<AuditPreuvesArchive[], PreuvesArchiveError>> {
+    if (ids.length === 0) {
+      return success([]);
+    }
+    try {
+      const rows = await this.db
+        .delete(auditPreuvesArchiveTable)
+        .where(
+          and(
+            inArray(auditPreuvesArchiveTable.id, ids),
+            inArray(
+              auditPreuvesArchiveTable.status,
+              auditPreuvesArchiveDeletableStatuses
+            )
+          )
+        )
+        .returning();
+      return this.parseRows(rows);
+    } catch (error) {
+      this.logger.error(
+        `Suppression des archives ${ids.join(', ')}: ${getErrorMessage(error)}`
+      );
+      return failure(
+        PreuvesArchiveErrorEnum.UPDATE_ARCHIVE_ERROR,
+        error instanceof Error ? error : new Error(getErrorMessage(error))
+      );
+    }
+  }
+
+  async deleteExpired(): Promise<
+    Result<AuditPreuvesArchive[], PreuvesArchiveError>
+  > {
+    try {
+      const rows = await this.db
+        .delete(auditPreuvesArchiveTable)
+        .where(
+          and(
+            lte(auditPreuvesArchiveTable.expiresAt, new Date().toISOString()),
+            inArray(
+              auditPreuvesArchiveTable.status,
+              auditPreuvesArchiveDeletableStatuses
+            )
+          )
+        )
+        .returning();
+      return this.parseRows(rows);
+    } catch (error) {
+      this.logger.error(
+        `Suppression des archives expirées: ${getErrorMessage(error)}`
       );
       return failure(
         PreuvesArchiveErrorEnum.UPDATE_ARCHIVE_ERROR,
@@ -366,5 +448,18 @@ export class PreuvesArchiveRepository {
       );
     }
     return success({ ...row, status: parsedStatus.data });
+  }
+
+  private parseRows(
+    rows: AuditPreuvesArchive[]
+  ): Result<AuditPreuvesArchive[], PreuvesArchiveError> {
+    const parsed = rows.map((row) => this.parseRow(row));
+    const failed = parsed.find((result) => !result.success);
+    if (failed && !failed.success) {
+      return failed;
+    }
+    return success(
+      parsed.flatMap((result) => (result.success ? [result.data] : []))
+    );
   }
 }

--- a/apps/backend/src/referentiels/preuves-archive/preuves-archive.router.e2e-spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/preuves-archive.router.e2e-spec.ts
@@ -48,6 +48,7 @@ describe('Archive de preuves - tRPC', () => {
             success: true,
             data: { signedUrl: FAKE_SIGNED_URL },
           }),
+          removeDocument: async () => ({ success: true }),
         });
       },
     });

--- a/apps/backend/src/referentiels/preuves-archive/request-preuves-archive/request-preuves-archive.service.spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/request-preuves-archive/request-preuves-archive.service.spec.ts
@@ -50,7 +50,7 @@ function buildService({
   isAllowed?: boolean;
   currentAudit?: CurrentAuditResult;
   isAuditeur?: boolean;
-} = {}): RequestPreuvesArchiveService {
+} = {}) {
   const permissions = {
     isAllowed: vi.fn().mockResolvedValue(isAllowed),
   } as unknown;
@@ -64,23 +64,52 @@ function buildService({
     createOrGetInFlight: vi.fn().mockResolvedValue(success(makeArchive())),
   } as unknown;
 
+  const deleteService = {
+    delete: vi.fn().mockResolvedValue(success(0)),
+  };
+
   const queue = {
     add: vi.fn().mockResolvedValue(undefined),
   } as unknown;
 
-  return new RequestPreuvesArchiveService(
+  const service = new RequestPreuvesArchiveService(
     permissions as never,
     getLabellisationService as never,
     repository as never,
+    deleteService as never,
     queue as never
   );
+
+  return { service, deleteObsoleteArchives: deleteService.delete };
 }
 
 describe('RequestPreuvesArchiveService', () => {
   // unauthorized et le happy-path sont prouvés en réel par le router e2e ; ce
   // spec ne garde que le mapping d'erreur propre au service.
+  it('supprime les archives obsolètes à chaque demande aboutie', async () => {
+    const { service, deleteObsoleteArchives } = buildService();
+
+    await service.request(requestInput);
+
+    expect(deleteObsoleteArchives).toHaveBeenCalledWith({
+      auditId: 10,
+      requestedBy: owner.id,
+    });
+  });
+
+  it('la demande aboutit même quand la purge best-effort des archives obsolètes échoue', async () => {
+    const { service, deleteObsoleteArchives } = buildService();
+    deleteObsoleteArchives.mockResolvedValueOnce(
+      failure(PreuvesArchiveErrorEnum.UPDATE_ARCHIVE_ERROR)
+    );
+
+    const result = await service.request(requestInput);
+
+    expect(result.success).toBe(true);
+  });
+
   it("échoue avec AUDIT_NOT_FOUND quand aucun audit n'est en cours", async () => {
-    const service = buildService({
+    const { service } = buildService({
       currentAudit: { success: false, error: 'NOT_FOUND' },
     });
 
@@ -97,7 +126,7 @@ describe('RequestPreuvesArchiveService', () => {
   });
 
   it("échoue avec UNAUTHORIZED quand l'utilisateur n'est pas auditeur de l'audit en cours", async () => {
-    const service = buildService({ isAuditeur: false });
+    const { service } = buildService({ isAuditeur: false });
 
     const result = await service.request(requestInput);
 

--- a/apps/backend/src/referentiels/preuves-archive/request-preuves-archive/request-preuves-archive.service.ts
+++ b/apps/backend/src/referentiels/preuves-archive/request-preuves-archive/request-preuves-archive.service.ts
@@ -21,6 +21,7 @@ import {
   type PreuvesArchiveJobData,
 } from '../preuves-archive.queue';
 import { PreuvesArchiveRepository } from '../preuves-archive.repository';
+import { DeletePreuvesArchiveService } from '../delete-preuves-archive/delete-preuves-archive.service';
 
 const ARCHIVE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
@@ -45,6 +46,7 @@ export class RequestPreuvesArchiveService {
     private readonly permissions: PermissionService,
     private readonly getLabellisationService: GetLabellisationService,
     private readonly repository: PreuvesArchiveRepository,
+    private readonly deleteService: DeletePreuvesArchiveService,
     @InjectQueue(PREUVES_ARCHIVE_QUEUE_NAME)
     private readonly queue: Queue<PreuvesArchiveJobData>
   ) {}
@@ -108,6 +110,16 @@ export class RequestPreuvesArchiveService {
     }
 
     const archive = createResult.data;
+
+    const deleted = await this.deleteService.delete({
+      auditId,
+      requestedBy: user.id,
+    });
+    if (!deleted.success) {
+      this.logger.error(
+        `Suppression des archives obsolètes (audit ${auditId}, user ${user.id}) échouée: ${deleted.error}`
+      );
+    }
 
     if (auditPreuvesArchiveInFlightStatuses.includes(archive.status)) {
       try {

--- a/apps/backend/src/referentiels/referentiels.module.ts
+++ b/apps/backend/src/referentiels/referentiels.module.ts
@@ -68,6 +68,7 @@ import { ListAuditPreuvesService } from './preuves-archive/list-audit-preuves/li
 import { ListPreuvesArchiveRouter } from './preuves-archive/list-preuves-archive/list-preuves-archive.router';
 import { ListPreuvesArchiveService } from './preuves-archive/list-preuves-archive/list-preuves-archive.service';
 import { PreuvesArchiveRepository } from './preuves-archive/preuves-archive.repository';
+import { DeletePreuvesArchiveService } from './preuves-archive/delete-preuves-archive/delete-preuves-archive.service';
 import {
   PREUVES_ARCHIVE_JOB_OPTIONS,
   PREUVES_ARCHIVE_QUEUE_NAME,
@@ -121,6 +122,7 @@ import { UpdateActionStatutService } from './update-action-statut/update-action-
     CollectPreuvesRepository,
     ListAuditPreuvesService,
     BuildArchiveService,
+    DeletePreuvesArchiveService,
     RequestPreuvesArchiveService,
     RequestPreuvesArchiveRouter,
     GetPreuvesArchiveService,


### PR DESCRIPTION
## Contexte
La génération d'archives de preuves d'audit n'avait aucun nettoyage : le TTL de 7 jours (`expiresAt`) ne faisait que **masquer** les archives de `list`/`get`, sans jamais supprimer ni les lignes DB ni les zip du bucket Supabase. Aucune borne non plus sur le nombre d'archives accumulées par un auditeur.

## Changements
À chaque `request()`, deux nettoyages **best-effort** :
- **Purge TTL globale** — supprime toutes les archives expirées, **toutes collectivités et tous utilisateurs** (pas seulement le demandeur), pour réclamer le storage même des auditeurs qui ne refont jamais de demande.
- **Limite par (audit, auditeur)** — supprime les archives au-delà des **10 plus récentes** pour le couple (audit, utilisateur) courant.

Pour chaque suppression, la **ligne DB est supprimée d'abord** (`.returning()`) **puis le blob** du bucket (`removeDocument`) : le pire cas devient un blob orphelin (invisible, récupérable) plutôt qu'une ligne fantôme pointant un blob disparu ; seules les suppressions réelles sont comptées. Les archives **en cours** (`pending`/`processing`) sont **préservées** et **comptées** dans la limite de 10. Un échec de nettoyage est loggé mais **n'interrompt pas** la demande.

### Découpage
- `delete-preuves-archive/select-archives-to-delete.ts` — logique pure (sélection des archives à supprimer) + constante `MAX_ARCHIVES_PER_AUDIT_USER = 10`.
- `delete-preuves-archive/delete-preuves-archive.service.ts` — orchestre purge globale + limite scopée ; compose repo + façade storage.
- `preuves-archive.repository.ts` — `deleteExpired` (global), `listForDeletion` + `deleteByIds` (par ids), suppressions renvoyant les lignes effacées.
- `models/audit-preuves-archive.table.ts` — constante `auditPreuvesArchiveDeletableStatuses` (source unique des statuts supprimables).
- `request-preuves-archive.service.ts` — appel du nettoyage à chaque demande.

## Tests
- Spec unitaire de la sélection pure (limite 10, TTL, protection in-flight, in-flight comptés).
- Spec du service (purge globale, ordre ligne→blob, best-effort, propagation d'erreur, compte cumulé).
- Assertions unitaires : `request` déclenche le nettoyage ; la demande aboutit même si le nettoyage échoue.
- **e2e sans mock du storage** : suppression réelle (ligne + blob) au-delà de la limite, et purge globale de l'archive expirée **d'un autre utilisateur**.
- Suite `preuves-archive` complète verte (104 tests), typecheck + lint OK.

## Hors scope
- Pas de cron/sweep de fond : la purge des expirées est globale mais **déclenchée par les demandes** (réclamation paresseuse) — sans aucune demande, rien ne tourne.
- Les blobs réellement orphelins (échec storage résiduel) relèveraient d'une lifecycle policy de bucket, non traitée ici.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Lors d’une demande d’archives “preuves”, déclenche désormais un nettoyage : suppression des archives expirées et des archives dépassant la limite de conservation, tout en conservant les archives en cours (et en tenant compte des archives en traitement pour la limite).
* **Bug Fixes**
  * La purge s’effectue en base et dans le stockage, avec poursuite du nettoyage même en cas d’échec de suppression d’un fichier.
  * Si le nettoyage échoue, le flux de demande continue sans impacter le résultat de la demande.
* **Tests**
  * Ajout/extension de tests unitaires et e2e couvrant la sélection, l’ordre des opérations, et le comportement inter-utilisateurs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
