### PR TITLE
fix(personnalisations): restaure le repli type vers soustype pour la valeur legacy syndicat

### DIFF
--- a/apps/backend/src/collectivites/personnalisations/services/personnalisations-expression.service.spec.ts
+++ b/apps/backend/src/collectivites/personnalisations/services/personnalisations-expression.service.spec.ts
@@ -706,6 +706,92 @@ sinon si identite(type, EPCI) et reponse(dechets_2, NON) alors min(score(cae_1.2
         )
       ).toBe(true);
     });
+
+    it('identite(type, syndicat) retourne true pour un syndicat (compatibilite des referentiels historiques cae/eci)', () => {
+      expect(
+        expressionService.parseAndEvaluateExpression(
+          'identite(type, syndicat)',
+          {
+            identiteCollectivite: {
+              type: CollectiviteTypeEnum.EPCI,
+              soustype: CollectiviteSousTypeEnum.SYNDICAT,
+              populationTags: [],
+              drom: false,
+            },
+          }
+        )
+      ).toBe(true);
+    });
+
+    it('identite(type, syndicat) retourne false pour un EPCI FP', () => {
+      expect(
+        expressionService.parseAndEvaluateExpression(
+          'identite(type, syndicat)',
+          {
+            identiteCollectivite: {
+              type: CollectiviteTypeEnum.EPCI,
+              soustype: CollectiviteSousTypeEnum.EPCI_FP,
+              populationTags: [],
+              drom: false,
+            },
+          }
+        )
+      ).toBe(false);
+    });
+
+    it('identite(type, epci_a_fiscalite_propre) retourne false pour un EPCI FP (le repli ne concerne que la valeur legacy syndicat)', () => {
+      expect(
+        expressionService.parseAndEvaluateExpression(
+          'identite(type, epci_a_fiscalite_propre)',
+          {
+            identiteCollectivite: {
+              type: CollectiviteTypeEnum.EPCI,
+              soustype: CollectiviteSousTypeEnum.EPCI_FP,
+              populationTags: [],
+              drom: false,
+            },
+          }
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe('formules historiques eci stockees avec identite(type, syndicat)', () => {
+    const syndicat = {
+      type: CollectiviteTypeEnum.EPCI,
+      soustype: CollectiviteSousTypeEnum.SYNDICAT,
+      populationTags: [],
+      drom: false,
+    };
+    const desactivation425 =
+      'si identite(type, syndicat) et reponse(dechets_2, oui) alors faux sinon vrai';
+    const desactivation124 = 'si identite(type, syndicat) alors faux sinon vrai';
+
+    it('eci_4.2.5 reste active pour un syndicat de traitement ayant declare dechets_2', () => {
+      expect(
+        expressionService.parseAndEvaluateExpression(desactivation425, {
+          reponses: { dechets_2: true },
+          identiteCollectivite: syndicat,
+        })
+      ).toBe(false);
+    });
+
+    it('eci_4.2.5 reste desactivee pour un syndicat sans la competence dechets_2', () => {
+      expect(
+        expressionService.parseAndEvaluateExpression(desactivation425, {
+          reponses: { dechets_2: false },
+          identiteCollectivite: syndicat,
+        })
+      ).toBe(true);
+    });
+
+    it('eci_1.2.4 reste active pour un syndicat', () => {
+      expect(
+        expressionService.parseAndEvaluateExpression(desactivation124, {
+          identiteCollectivite: syndicat,
+        })
+      ).toBe(false);
+    });
   });
 
   it('identite(dans_aire_urbaine, oui) retourne vrai quand dansAireUrbaine est true', async () => {

--- a/apps/backend/src/utils/expression-parser/evaluate-identite.ts
+++ b/apps/backend/src/utils/expression-parser/evaluate-identite.ts
@@ -1,5 +1,6 @@
 import {
   CollectivitePopulationTypeEnum,
+  CollectiviteSousTypeEnum,
   IdentiteCollectivite,
 } from '@tet/domain/collectivites';
 
@@ -19,9 +20,36 @@ function isIdentiteField(value: string): value is IdentiteField {
   return value in IDENTITE_EVALUATORS;
 }
 
+const LEGACY_TYPE_SYNDICAT_VALUE =
+  CollectiviteSousTypeEnum.SYNDICAT.toLowerCase();
+
+/**
+ * Compatibilité ascendante des référentiels historiques (cae, eci).
+ *
+ * "syndicat" était à l'origine une valeur du champ `type` (l'enum SQL
+ * type_collectivite valait 'EPCI' | 'commune' | 'syndicat'). Le modèle a depuis
+ * séparé `type` (EPCI | commune) et `soustype` (epci_a_fiscalite_propre |
+ * syndicat | pole), et les expressions nouvellement importées sont normalisées
+ * en `identite(soustype, syndicat)`. Mais les règles déjà stockées en base et
+ * jamais ré-importées gardent `identite(type, syndicat)`. Sans ce repli du champ
+ * `type` vers le `soustype` pour cette valeur legacy, elles s'évalueraient
+ * toujours à false pour un syndicat, car `type` ne vaut jamais 'syndicat'.
+ */
+function matchesLegacyTypeSyndicat(
+  identite: IdentiteCollectivite,
+  primary: string
+): boolean {
+  const value = primary.toLowerCase();
+  return (
+    value === LEGACY_TYPE_SYNDICAT_VALUE &&
+    identite.soustype?.toLowerCase() === LEGACY_TYPE_SYNDICAT_VALUE
+  );
+}
+
 const IDENTITE_EVALUATORS: Record<IdentiteField, IdentiteEvaluator> = {
   type: (identite, primary) =>
-    identite.type.toLowerCase() === primary.toLowerCase(),
+    identite.type.toLowerCase() === primary.toLowerCase() ||
+    matchesLegacyTypeSyndicat(identite, primary),
   soustype: (identite, primary) =>
     identite.soustype?.toLowerCase() === primary.toLowerCase(),
   population: (identite, primary) =>


### PR DESCRIPTION
## Contexte / diagnostic

\`identite(type, syndicat)\` s'evaluait toujours a \`false\` pour un syndicat depuis le commit \`d46de8956\` (\"Gestion fine des sous-types\"), qui a retire le repli \`type -> soustype\` a l'evaluation au profit d'une normalisation a l'import. Les regles **cae/eci deja en base et jamais re-importees** gardent \`identite(type, syndicat)\` : leurs desactivations/reductions specifiques aux syndicats etaient silencieusement inactives sur le chemin TS.

Confirme en **prod** sur deux syndicats de traitement des dechets :
- **4870 SYMEVAD** (\`SMF\`, \`dechets_2=OUI\`) : \`eci_4.2.5\` desactivee a tort (devrait etre active).
- **4891 SBA** (\`SMF\`) : \`eci_1.2.4\` qui basculerait au prochain recalcul.

## Le correctif

Le champ \`type\` retombe a nouveau sur le \`soustype\` **uniquement** pour la valeur legacy \`syndicat\`, isole dans \`matchesLegacyTypeSyndicat\` (avec commentaire d'explication). Le repli est volontairement plus permissif que la verification a l'import (qui, elle, reste stricte \"contenu neuf = soustype\") : on repare la donnee legacy au runtime sans permettre d'en creer de la nouvelle.

## Surface de review

- \`apps/backend/src/utils/expression-parser/evaluate-identite.ts\` — la logique (attention humaine).
- \`...personnalisations-expression.service.spec.ts\` — tests (regression + 2 gardes + 3 scenarios reproduisant les formules prod).

## Test-first

- Commit du test rouge : \`5aa8b43e5\` (rouge sans le fix, vert avec). Preuve red->green re-jouee en remisant le seul \`evaluate-identite.ts\` : 3 tests rouges, dont \`eci_4.2.5 reste active\` (SYMEVAD).

## Anti-duplication

Reutilise le concept/constante \`LEGACY_TYPE_SYNDICAT_VALUE\` (deja defini dans \`verify-referentiel-expressions.ts\` cote import). Aucun nouveau mecanisme cree. La normalisation a l'import et la verification ne sont **pas** modifiees.

## Zones de moindre confiance / suite

- **Non resolu ici** : lequel du moteur TS (snapshots) ou SQL (\`client_scores\`, deja correct pour les syndicats) est autoritaire pour le score affiche. Ce fix corrige le chemin TS ; le chemin SQL etait deja correct.
- **Complement optionnel post-merge** : un recalcul cible pour rafraichir les snapshots de syndicats deja figes a tort pendant la fenetre buggee. Le fix seul corrige tout recalcul futur, mais ne rafraichit pas retroactivement un snapshot existant.