### PR TITLE
refactor(labels): retire les libellés CNL d'audit inutilisés

### DIFF
--- a/apps/app/src/labels/catalog.ts
+++ b/apps/app/src/labels/catalog.ts
@@ -413,7 +413,7 @@ export const appLabels = {
     etoileLabel: string;
   }): string => `${etoileLabel} étoile`,
   demarrerAuditCotAvecLabellisationMessage:
-    'Pour passer en CNL, penser à joindre les documents de labellisation.',
+    'Penser à joindre les documents de labellisation.',
   demarrerAuditSelectionIncomplete:
     "Sélectionnez un type d'audit et une étoile.",
   demarrerAuditTypeCotAvecLabellisation: 'Audit COT avec labellisation',
@@ -1485,7 +1485,7 @@ export const appLabels = {
 
   referentAssocierReferents: 'Associer des référents',
   referentStatutDescription:
-    "\"Référent\" est un statut lié au programme Territoire Engagé Transition Écologique de l'ADEME. Les personnes désignées ci-après sont les contacts privilégiés de la collectivité pour l'ADEME et toutes les personnes intervenants dans ce cadre (Bureau d'Appui, auditeur, membre de la CNL) ainsi que pour leurs homologues dans d'autres collectivités.",
+    "\"Référent\" est un statut lié au programme Territoire Engagé Transition Écologique de l'ADEME. Les personnes désignées ci-après sont les contacts privilégiés de la collectivité pour l'ADEME et toutes les personnes intervenants dans ce cadre (Bureau d'Appui, auditeur) ainsi que pour leurs homologues dans d'autres collectivités.",
   referentPersonneNonIdentifiee: ({ fonction }: { fonction: string }): string =>
     `Personne n'est identifié comme "${fonction}" dans la `,
   referentInscritIntraAdemeAvant: "Inscrit sur l'espace collaboratif",

--- a/apps/app/src/labels/catalog.ts
+++ b/apps/app/src/labels/catalog.ts
@@ -420,9 +420,6 @@ export const appLabels = {
   demarrerAuditTypeLabellisation: 'Audit de labellisation',
   auditSansLabellisationMessage:
     "Suite à cette validation, et après vérification par l'équipe Territoires en Transitions, un nouveau cycle va démarrer avec le score validé par l'audit.",
-  auditLabellisationMessage:
-    "Suite à cette validation, plus aucune modification ne sera possible dans le cadre de l'audit et le secrétariat de la Commission nationale du label (CNL) sera notifié pour réceptionner le dossier de candidature complet et le transmettre aux membres de la CNL.",
-
   notesAuditeur: "Notes de l'auditeur, auditrice",
   notesAuditeurHint:
     "Remarques sur la mesure, questions pour la séance d'audit",
@@ -1341,8 +1338,6 @@ export const appLabels = {
   vousRecevrezEmailA: 'Vous recevrez un email à ',
   avecLienTelechargerRapport:
     " avec un lien pour télécharger votre rapport dès qu'il sera prêt.",
-  joindreDocumentsLabellisationCNL:
-    '* Pour passer en CNL penser à joindre les documents de labellisation.',
   quelTypeAuditSouhaitezVousDemander:
     "Quel type d'audit souhaitez-vous demander ?",
   envoyerMaDemande: 'Envoyer ma demande',

--- a/apps/app/src/referentiels/audits/old/valider-audit.button.tsx
+++ b/apps/app/src/referentiels/audits/old/valider-audit.button.tsx
@@ -54,11 +54,9 @@ export const ValiderAuditModal = ({
           ))}
         </div>
       ) : null}
-      <p className="mt-4">
-        {demandeId
-          ? appLabels.auditLabellisationMessage
-          : appLabels.auditSansLabellisationMessage}
-      </p>
+      {!demandeId && (
+        <p className="mt-4">{appLabels.auditSansLabellisationMessage}</p>
+      )}
       <div className="flex gap-4">
         <Button
           dataTest="validate"


### PR DESCRIPTION
## Contexte

Suppression de **toutes les mentions de la CNL (Commission nationale du label) dans la copy utilisateur**, repérées en auditant le catalogue de labels.

Périmètre volontairement limité à la copy visible : le champ métier `dateCnl` / colonne `date_cnl` (date de validation par la commission) n'est **pas** touché — c'est un concept fonctionnel, pas un libellé, et sa suppression relèverait d'une migration séparée.

## Changements

**Libellés inutilisés supprimés :**
- `joindreDocumentsLabellisationCNL` — clé morte (son consommateur avait été retiré par un refactor antérieur).
- `auditLabellisationMessage` — message retiré de `old/valider-audit.button.tsx`, puis clé supprimée (plus aucun consommateur).

**Mentions CNL retirées de la copy encore utilisée :**
- `demarrerAuditCotAvecLabellisationMessage` — reformulé : « Pour passer en CNL, penser à joindre les documents de labellisation. » → « Penser à joindre les documents de labellisation. »
- `referentStatutDescription` — retrait de « , membre de la CNL » dans l'énumération des intervenants.

## Résultat

Plus aucune occurrence « CNL » / « Commission nationale du label » dans `catalog.ts`.

## Hors périmètre (non touché)

Champ `dateCnl` / `date_cnl` : domaine, table backend, service, tests, types générés. À traiter séparément si le concept doit disparaître du modèle.