### PR TITLE
fix(storybook): débloque storybook:app bloqué sur un spinner infini

### DIFF
--- a/apps/app/.storybook/README.md
+++ b/apps/app/.storybook/README.md
@@ -1,0 +1,22 @@
+# Storybook (apps/app)
+
+Lancement : `pnpm storybook:app`.
+
+## Contraintes de config (non-évidentes)
+
+- **`optimizeDeps.include` des sous-chemins `@tet/domain/*`** (`main.ts`).
+  `@tet/domain` est distribué en CJS ; `@tet/api` (consommé depuis `src`)
+  l'importe en ESM. Sans pré-bundle Vite, les imports nommés échouent
+  (`does not provide an export named ...`) et bloquent toutes les stories.
+  → En ajoutant une story qui importe un nouveau sous-chemin `@tet/domain/*`,
+  l'ajouter à cette liste.
+
+- **`.env` chargé via `dotenv`** (`main.ts`). `nx storybook app` s'exécute au
+  cwd racine du monorepo, donc `apps/app/.env` n'est pas chargé
+  automatiquement ; sans lui, `createBrowserClient('')` lève une exception.
+
+- **Providers réels dans `preview.tsx`.** Chaque story est enveloppée dans
+  Supabase / tRPC / Collectivité avec un `user` mocké. Le mock doit suivre le
+  schéma `UserWithRolesAndPermissions`. Une story dont le composant appelle
+  tRPC/supabase renverra `401` (pas de session) : préférer la variante
+  présentationnelle `*Base` ou mocker la donnée.

--- a/apps/app/.storybook/main.ts
+++ b/apps/app/.storybook/main.ts
@@ -1,4 +1,19 @@
 import type { StorybookConfig } from '@storybook/nextjs-vite';
+import { config as loadEnv } from 'dotenv';
+import { join } from 'node:path';
+
+loadEnv({ path: join(process.cwd(), 'apps/app/.env') });
+
+const domainSubpaths = [
+  '@tet/domain/collectivites',
+  '@tet/domain/collectivites/tableau-de-bord',
+  '@tet/domain/indicateurs',
+  '@tet/domain/plans',
+  '@tet/domain/referentiels',
+  '@tet/domain/shared',
+  '@tet/domain/users',
+  '@tet/domain/utils',
+];
 
 const config: StorybookConfig = {
   framework: '@storybook/nextjs-vite',
@@ -17,6 +32,15 @@ const config: StorybookConfig = {
     NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL || '',
     NEXT_PUBLIC_SUPABASE_ANON_KEY:
       process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '',
+  },
+
+  async viteFinal(viteConfig) {
+    const { mergeConfig } = await import('vite');
+    return mergeConfig(viteConfig, {
+      optimizeDeps: {
+        include: domainSubpaths,
+      },
+    });
   },
 };
 

--- a/apps/app/.storybook/preview.tsx
+++ b/apps/app/.storybook/preview.tsx
@@ -8,36 +8,33 @@ import './preview.css';
 import { SupabaseProvider, TrpcWithReactQueryProvider } from '@tet/api';
 import { CollectiviteProvider } from '@tet/api/collectivites';
 import { UserProvider } from '@tet/api/users';
-import { CollectiviteRole, permissionsByRole } from '@tet/domain/users';
+import { defaultCollectivitePreferences } from '@tet/domain/collectivites';
+import {
+  CollectiviteRole,
+  permissionsByRole,
+  UserWithRolesAndPermissions,
+} from '@tet/domain/users';
 
-const user = {
+const user: UserWithRolesAndPermissions = {
+  id: '',
+  nom: '',
+  prenom: '',
+  email: '',
+  telephone: null,
+  cguAccepteesLe: null,
+  roles: [],
+  permissions: [],
   collectivites: [
     {
       collectiviteId: 1,
-      nom: 'Amberieu-en-Bugey',
+      collectiviteNom: 'Amberieu-en-Bugey',
+      collectiviteAccesRestreint: false,
+      collectivitePreferences: defaultCollectivitePreferences,
       role: CollectiviteRole.EDITION,
-      accesRestreint: false,
-      isRoleAuditeur: false,
-      isSimplifiedView: false,
       permissions: permissionsByRole[CollectiviteRole.EDITION],
+      audits: [],
     },
   ],
-  id: '',
-  isSupport: false,
-  isVerified: false,
-  app_metadata: {},
-  user_metadata: {},
-  email: '',
-  email_verified: false,
-  aud: '',
-  created_at: '',
-  nom: '',
-  prenom: '',
-  nomComplet: '',
-  role: '',
-  roleId: '',
-  telephone: '',
-  cgu_acceptees_le: null,
 };
 
 const preview: Preview = {


### PR DESCRIPTION
## Problème

`pnpm storybook:app` restait bloqué sur un spinner « Preparing story » infini sur **toutes** les stories (canvas « No Preview »). Le graphe de modules de la preview plantait avant tout rendu.

## Diagnostic (pilotage headless de l'iframe)

Trois blocages successifs, tous corrigés ici :

1. **Interop CJS→ESM `@tet/domain`.** `@tet/api` est consommé depuis `src` (compilé ESM par Vite) mais `@tet/domain` est un dist CJS (barrel SWC `_export_star`) illisible en import ESM nommé → `does not provide an export named 'getErrorMessage'` → tout le graphe preview casse.
2. **`apps/app/.env` non chargé.** `nx storybook app` tourne au cwd racine du monorepo ; `main.ts` retombait sur `NEXT_PUBLIC_SUPABASE_URL = ''` → `createBrowserClient('')` throw synchrone.
3. **Mock `user` de `preview.tsx` périmé.** Champs renommés + `audits` manquant vs le schéma domaine actuel → `hasCollectiviteRole` plantait sur `collectivite.audits`.

## Fixes (`apps/app/.storybook/`)

- `main.ts` — `viteFinal` + `optimizeDeps.include` des sous-chemins `@tet/domain/*` (esbuild aplatit le CJS) ; chargement de `apps/app/.env` via `dotenv`.
- `preview.tsx` — mock reconstruit selon `UserWithRolesAndPermissions` (`collectiviteNom`/`collectiviteAccesRestreint`/`collectivitePreferences: defaultCollectivitePreferences`/`audits: []`, `roles`/`permissions`).

## Surface de review

- **Attention humaine** : les 2 fichiers (config Storybook uniquement, hors périmètre app/backend). `preview.tsx` : vérifier que la forme du mock colle au schéma.
- Aucun fichier applicatif ni backend touché.

## Vérification

Rendu vérifié via navigateur headless (`@playwright/test`) sur l'iframe Storybook :
- story pur-UI (`ui/charts/Donut`) : rend, **zéro erreur** ;
- story couplée API (`invite-membre.form`) : le formulaire rend ; seule reste une `401 Not authenticated` sur la query tRPC (attendu, pas de session Storybook).

## Zones de confiance faible / hypothèses

- **Pas de test de régression automatisé** : les `*.stories.tsx` sont exclus du CI (cf. `apps/app/CLAUDE.md`). Un fix de config/mock Storybook n'a pas de harnais de test unitaire ; vérification manuelle headless à la place.
- `optimizeDeps.include` liste explicitement les 8 sous-chemins `@tet/domain/*` présents dans le graphe. Si une nouvelle story importe un sous-chemin domaine non listé, il faudra l'ajouter (sinon même erreur d'interop).
- Le mock est un **bug préexistant** (jamais mis à jour après le refacto rôles/permissions), indépendant de l'origine de l'investigation.

## DISCOVERED

- Les 12 stories dont le composant monte un hook tRPC/supabase (groupe A) rendent mais renvoient `401` faute de session. Piste séparée : basculer sur les variantes présentationnelles `*Base` ou mocker tRPC dans `preview.tsx`.