### PR TITLE
fix(preuves): autorise le super-admin (mode support) à déposer des preuves

### DIFF
--- a/data_layer/sqitch/deploy/collectivite/bucket_rls_super_admin_write.sql
+++ b/data_layer/sqitch/deploy/collectivite/bucket_rls_super_admin_write.sql
@@ -1,0 +1,79 @@
+-- Deploy tet:collectivite/bucket_rls_super_admin_write to pg
+-- requires: collectivite/bucket
+-- requires: utilisateur/droits_v2
+-- requires: labellisation/preuve_v2
+-- requires: utilisateur/add-is-active-column-to-utilisateur-support
+
+BEGIN;
+
+create or replace function est_super_admin()
+    returns boolean
+    security definer
+begin
+    atomic
+    select is_support_mode_enabled
+    from utilisateur_support
+    where user_id = auth.uid()
+      and is_authenticated();
+end;
+comment on function est_super_admin is
+    'Vrai si l''utilisateur courant a le mode support (super-admin) activé.';
+
+create or replace function
+    is_bucket_writer(id text)
+    returns boolean
+as
+$$
+select count(*) > 0
+from collectivite_bucket cb
+where (is_any_role_on(cb.collectivite_id)
+    or private.est_auditeur(cb.collectivite_id)
+    or est_super_admin())
+  and cb.bucket_id = is_bucket_writer.id
+$$ language sql;
+comment on function is_bucket_writer is
+    'Returns true if current user can write on a bucket id';
+
+drop policy if exists allow_insert on preuve_complementaire;
+create policy allow_insert
+    on preuve_complementaire for insert
+    with check (have_edition_acces(collectivite_id)
+        or est_auditeur_action(collectivite_id, action_id)
+        or est_super_admin());
+
+drop policy if exists allow_update on preuve_complementaire;
+create policy allow_update
+    on preuve_complementaire for update
+    using (have_edition_acces(collectivite_id)
+        or est_auditeur_action(collectivite_id, action_id)
+        or est_super_admin());
+
+drop policy if exists allow_delete on preuve_complementaire;
+create policy allow_delete
+    on preuve_complementaire for delete
+    using (have_edition_acces(collectivite_id)
+        or est_auditeur_action(collectivite_id, action_id)
+        or est_super_admin());
+
+drop policy if exists allow_insert on preuve_reglementaire;
+create policy allow_insert
+    on preuve_reglementaire for insert
+    with check (have_edition_acces(collectivite_id)
+        or private.est_auditeur(collectivite_id)
+        or est_super_admin());
+
+drop policy if exists allow_update on preuve_reglementaire;
+create policy allow_update
+    on preuve_reglementaire for update
+    using (have_edition_acces(collectivite_id)
+        or private.est_auditeur(collectivite_id)
+        or est_super_admin());
+
+drop policy if exists allow_delete on preuve_reglementaire;
+create policy allow_delete
+    on preuve_reglementaire for delete
+    using (have_edition_acces(collectivite_id)
+        or private.est_auditeur(collectivite_id)
+        or est_super_admin());
+
+COMMIT;

--- a/data_layer/sqitch/revert/collectivite/bucket_rls_super_admin_write.sql
+++ b/data_layer/sqitch/revert/collectivite/bucket_rls_super_admin_write.sql
@@ -1,0 +1,57 @@
+-- Revert tet:collectivite/bucket_rls_super_admin_write from pg
+
+BEGIN;
+
+drop policy if exists allow_insert on preuve_complementaire;
+create policy allow_insert
+    on preuve_complementaire for insert
+    with check (have_edition_acces(collectivite_id)
+        or est_auditeur_action(collectivite_id, action_id));
+
+drop policy if exists allow_update on preuve_complementaire;
+create policy allow_update
+    on preuve_complementaire for update
+    using (have_edition_acces(collectivite_id)
+        or est_auditeur_action(collectivite_id, action_id));
+
+drop policy if exists allow_delete on preuve_complementaire;
+create policy allow_delete
+    on preuve_complementaire for delete
+    using (have_edition_acces(collectivite_id)
+        or est_auditeur_action(collectivite_id, action_id));
+
+drop policy if exists allow_insert on preuve_reglementaire;
+create policy allow_insert
+    on preuve_reglementaire for insert
+    with check (have_edition_acces(collectivite_id)
+        or private.est_auditeur(collectivite_id));
+
+drop policy if exists allow_update on preuve_reglementaire;
+create policy allow_update
+    on preuve_reglementaire for update
+    using (have_edition_acces(collectivite_id)
+        or private.est_auditeur(collectivite_id));
+
+drop policy if exists allow_delete on preuve_reglementaire;
+create policy allow_delete
+    on preuve_reglementaire for delete
+    using (have_edition_acces(collectivite_id)
+        or private.est_auditeur(collectivite_id));
+
+create or replace function
+    is_bucket_writer(id text)
+    returns boolean
+as
+$$
+select count(*) > 0
+from collectivite_bucket cb
+where (is_any_role_on(cb.collectivite_id)
+    or private.est_auditeur(cb.collectivite_id))
+  and cb.bucket_id = is_bucket_writer.id
+$$ language sql;
+comment on function is_bucket_writer is
+    'Returns true if current user can write on a bucket id';
+
+drop function if exists est_super_admin();
+
+COMMIT;

--- a/data_layer/sqitch/sqitch.plan
+++ b/data_layer/sqitch/sqitch.plan
@@ -1000,3 +1000,4 @@ plan_action/ai_plan_import_job_created_plan [plan_action/ai_plan_import_job] 202
 collectivite/bucket_rls_ademe_read [collectivite/bucket_rls_strict_read] 2026-06-16T12:00:00Z Frederic Arnoux <frederic.arnoux@beta.gouv.fr> # Autorise les utilisateurs ADEME (@ademe.fr) a lire storage.objects malgre la policy stricte Pentest V5
 
 collectivite/preferences_referentiel_mode [collectivite/preferences] 2026-06-24T10:00:00Z Marc Rutkowski <marc@attractive-media.fr> # Etend preferences.referentiels avec display+mode (migre les données existantes)
+collectivite/bucket_rls_super_admin_write [collectivite/bucket utilisateur/droits_v2 labellisation/preuve_v2 utilisateur/add-is-active-column-to-utilisateur-support] 2026-07-01T14:01:47Z Gaël Servaud <gaelservaud@Host-003.lan> # Autorise le super-admin (mode support) a ecrire preuves/storage : ajoute est_super_admin() a is_bucket_writer et aux policies preuve_complementaire/reglementaire

--- a/data_layer/sqitch/verify/collectivite/bucket_rls_super_admin_write.sql
+++ b/data_layer/sqitch/verify/collectivite/bucket_rls_super_admin_write.sql
@@ -1,0 +1,8 @@
+-- Verify tet:collectivite/bucket_rls_super_admin_write on pg
+
+BEGIN;
+
+select has_function_privilege('est_super_admin()', 'execute');
+select has_function_privilege('is_bucket_writer(text)', 'execute');
+
+ROLLBACK;

--- a/data_layer/tests/collectivite/bucket_rls_super_admin.sql
+++ b/data_layer/tests/collectivite/bucket_rls_super_admin.sql
@@ -1,0 +1,47 @@
+begin;
+select plan(2);
+
+-- Un super-admin : mode support activé, aucun droit sur la collectivité 1.
+do $$
+declare
+    super_admin_id uuid := '11111111-1111-1111-1111-111111111111';
+begin
+    perform test_create_user(super_admin_id, 'Sudo', 'Admin', 'sudo.admin@example.com');
+    update utilisateur_support
+        set is_support_mode_enabled = true
+        where user_id = super_admin_id;
+end
+$$;
+
+-- Un utilisateur vérifié lambda, sans droit ni mode support (contrôle négatif).
+do $$
+declare
+    outsider_id uuid := '22222222-2222-2222-2222-222222222222';
+begin
+    perform test_create_user(outsider_id, 'Lambda', 'Verifie', 'lambda.verifie@example.com');
+end
+$$;
+
+
+-- En tant que super-admin (mode support activé)
+select test.identify_as('sudo.admin@example.com');
+
+select ok(
+       is_bucket_writer((select cb.bucket_id
+                         from collectivite_bucket cb
+                         where cb.collectivite_id = 1)),
+       'Un super-admin peut écrire dans le bucket d''une collectivité où il n''a aucun droit (1)'
+   );
+
+
+-- En tant qu'utilisateur vérifié sans droit ni mode support
+select test.identify_as('lambda.verifie@example.com');
+
+select ok(
+       not is_bucket_writer((select cb.bucket_id
+                             from collectivite_bucket cb
+                             where cb.collectivite_id = 1)),
+       'Un utilisateur vérifié sans droit ni mode support ne peut PAS écrire dans le bucket (1)'
+   );
+
+rollback;


### PR DESCRIPTION
## Contexte

En prod, un super-admin (mode support activé) recevait un **400** à l'upload d'un document depuis l'état des lieux :

```
POST /storage/v1/object/<bucket>/<hash> → 400
{"...":"new row violates row-level security policy"}
```

Le front montre le bouton « ajouter un document » via la permission applicative `referentiels.mutate` (accordée au rôle `SUPER_ADMIN`, qui correspond au toggle `utilisateur_support.is_support_mode_enabled`). Mais les RLS d'écriture ne reconnaissaient que les membres de la collectivité et les auditeurs. Un super-admin plateforme n'a ni droit collectivité ni statut auditeur → refus RLS.

## Le flux réel (post-`preuve_v2`)

Le write-path d'une preuve depuis l'état des lieux touche **deux surfaces RLS client** :

1. **Upload** — `uploadFileToBucket` → `storage.objects`, gate `is_bucket_writer` (= `is_any_role_on OR est_auditeur`).
2. **Association** — `supabase.from('preuve_complementaire'|'preuve_reglementaire').insert(...)`, gate `have_edition_acces OR est_auditeur_*`.

(L'étape intermédiaire « ajout à la bibliothèque » passe déjà par le backend service-role — `trpc.collectivites.documents.create` — donc pas de souci RLS là.)

Aucune de ces deux gates ne connaissait le mode support. La table `preuve_lien` visée dans une première version est **morte** (`DROP TABLE` dans `preuve_v2`) — remplacée par `preuve_complementaire`/`preuve_reglementaire`.

## Changement

- Nouveau helper `est_super_admin()` (`security definer`, teste `is_support_mode_enabled`). `security definer` requis car `utilisateur_support` a la RLS activée sans policy SELECT.
- `is_bucket_writer` ← `... OR est_super_admin()` → couvre l'upload storage.
- Policies `preuve_complementaire` et `preuve_reglementaire` (insert/update/delete) ← `... OR est_super_admin()` → couvre l'association.

Gate sur `is_support_mode_enabled` (le toggle), conformément à l'intention : « quand le mode support est activé, on autorise l'écriture de doc ».

## Validation locale (faite)

- `sqitch deploy` : **OK** (SQL valide).
- Objets créés : `est_super_admin` (secdef) + `is_bucket_writer` dans `public`.
- `pg_policies` : les 3 policies `preuve_complementaire` (+ `preuve_reglementaire`) contiennent bien `OR est_super_admin()`.
- Validation *fonctionnelle* (A/B mode support on/off) non faite en local : base de dev non seedée (`utilisateur_support`/`collectivite_bucket` vides) → laissée à la CI + test manuel.

## Test (test-first)

- Commit 1 (`test`) : régression pgTAP `bucket_rls_super_admin.sql`, **rouge sur main** (`is_bucket_writer` renvoie faux pour un super-admin sans droit), verte après. Basé sur `is_bucket_writer()` (déterministe, indépendant de l'enforcement RLS du harness). Exécuté par la CI `test-db-deploy` + pgTAP.
- L'association `preuve_complementaire` n'a pas de test d'insert dédié (l'enforcement RLS-insert n'est pas fiable dans le harness pgTAP local) → couverte par la revue du diff + test manuel super-admin.

## Surface de review

- **Attention humaine** : `deploy/collectivite/bucket_rls_super_admin_write.sql` (logique RLS) + `revert` (restaure fidèlement les prédicats d'origine, drop du helper en dernier).
- **Mécanique** : `verify`, ligne `sqitch.plan`, test pgTAP.

## Hors scope (candidat plan-stack)

Les surfaces 1 et 2 restent client-direct → Supabase (RLS décorrélée de `permission.models.ts`). Une migration backend (service-role + `permissionService.isAllowed`) du write-path preuve supprimerait ce couplage. Non traité ici (bugfix ciblé).