### PR TITLE
feat(indicateurs): grille de saisie tabulaire réutilisable (R0)

### DIFF
--- a/apps/app/src/indicateurs/valeurs/grid/__tests__/grid-fixtures.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/__tests__/grid-fixtures.ts
@@ -1,0 +1,82 @@
+import {
+  cellKey,
+  CellKey,
+  GridCell,
+  GridRowGroup,
+  IndicateurValuesGridActions,
+  toIndicateurId,
+  toYear,
+  Year,
+} from '../types';
+
+export const fakeYears: Year[] = [2026, 2030, 2036, 2050].map(toYear);
+export const fakeReferenceYear: Year = toYear(2026);
+
+const sectors = ['Résidentiel', 'Tertiaire', 'Transport routier', 'Agriculture', 'Industrie'];
+const pollutants = ['NOx', 'PM10', 'PM2,5', 'COVNM', 'SO2', 'NH3'];
+
+export const fakeGroups: GridRowGroup[] = sectors.map((sector, sectorIndex) => ({
+  id: `secteur-${sectorIndex}`,
+  label: sector,
+  rows: pollutants.map((pollutant, pollutantIndex) => ({
+    indicateurId: toIndicateurId(sectorIndex * 10 + pollutantIndex),
+    label: pollutant,
+  })),
+}));
+
+const citepa = {
+  sourceId: 'citepa',
+  libelle: 'CITEPA',
+  methodologie: 'Inventaire national spatialisé',
+  dateVersion: '2026-01-01',
+};
+
+const pseudoValue = (indicateurId: number, year: number): number =>
+  ((indicateurId * 7 + year) % 900) + 100;
+
+const buildCell = (indicateurId: number, year: number): GridCell => {
+  const seed = (indicateurId + year) % 6;
+  if (seed === 0) {
+    return {
+      kind: 'open-data',
+      value: pseudoValue(indicateurId, year),
+      adoptedSourceId: citepa.sourceId,
+      source: citepa,
+    };
+  }
+  if (seed === 1) {
+    return {
+      kind: 'user-data',
+      value: null,
+      coveringSources: [{ ...citepa, value: pseudoValue(indicateurId, year) }],
+    };
+  }
+  if (seed === 2) {
+    return { kind: 'user-data', value: null, coveringSources: [] };
+  }
+  return {
+    kind: 'user-data',
+    value: pseudoValue(indicateurId, year),
+    valueId: indicateurId * 1000 + year,
+    coveringSources: [],
+  };
+};
+
+export const fakeCells = (): Map<CellKey, GridCell> =>
+  new Map(
+    fakeGroups.flatMap((group) =>
+      group.rows.flatMap((row) =>
+        fakeYears.map(
+          (year) =>
+            [cellKey(row.indicateurId, year), buildCell(row.indicateurId, year)] as const
+        )
+      )
+    )
+  );
+
+export const fakeGridActions: IndicateurValuesGridActions = {
+  writeCell: async () => ({ ok: true, value: undefined }),
+  writeBulk: async (inputs) => ({ ok: true, value: { written: inputs.length, failed: [] } }),
+  adopt: async () => ({ ok: true, value: undefined }),
+  clearCell: async () => ({ ok: true, value: undefined }),
+};

--- a/apps/app/src/indicateurs/valeurs/grid/__tests__/grid-model.spec.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/__tests__/grid-model.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { findCell, toDisplayRows } from '../grid-model';
+import {
+  cellKey,
+  GridCell,
+  GridRowGroup,
+  toIndicateurId,
+  toYear,
+} from '../types';
+
+const groups: GridRowGroup[] = [
+  {
+    id: 'residentiel',
+    label: 'Résidentiel',
+    rows: [
+      { indicateurId: toIndicateurId(1), label: 'NOx' },
+      { indicateurId: toIndicateurId(2), label: 'PM10' },
+    ],
+  },
+  {
+    id: 'tertiaire',
+    label: 'Tertiaire',
+    rows: [{ indicateurId: toIndicateurId(3), label: 'NOx' }],
+  },
+];
+
+describe('toDisplayRows', () => {
+  it('aplatit les groupes en lignes en portant le contexte de groupe', () => {
+    const rows = toDisplayRows(groups);
+    expect(rows).toHaveLength(3);
+    expect(rows[0]).toMatchObject({
+      indicateurId: toIndicateurId(1),
+      groupId: 'residentiel',
+      isGroupStart: true,
+      groupSize: 2,
+    });
+    expect(rows[1]).toMatchObject({
+      indicateurId: toIndicateurId(2),
+      isGroupStart: false,
+      groupSize: 2,
+    });
+    expect(rows[2]).toMatchObject({
+      indicateurId: toIndicateurId(3),
+      groupId: 'tertiaire',
+      isGroupStart: true,
+      groupSize: 1,
+    });
+  });
+});
+
+describe('findCell', () => {
+  it('retrouve une cellule par indicateur et année, sinon null', () => {
+    const cell: GridCell = {
+      kind: 'user-data',
+      value: 42,
+      valueId: 100,
+      coveringSources: [],
+    };
+    const cells = new Map([[cellKey(toIndicateurId(1), toYear(2030)), cell]]);
+    expect(
+      findCell({ cells, indicateurId: toIndicateurId(1), year: toYear(2030) })
+    ).toBe(cell);
+    expect(
+      findCell({ cells, indicateurId: toIndicateurId(9), year: toYear(2030) })
+    ).toBeNull();
+  });
+});

--- a/apps/app/src/indicateurs/valeurs/grid/__tests__/indicateur-values-grid.stories.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/__tests__/indicateur-values-grid.stories.tsx
@@ -1,0 +1,40 @@
+import { Meta, StoryObj } from '@storybook/nextjs-vite';
+import {
+  fakeCells,
+  fakeGridActions,
+  fakeGroups,
+  fakeReferenceYear,
+  fakeYears,
+} from './grid-fixtures';
+import { IndicateurValuesGrid } from '../indicateur-values-grid';
+
+const meta: Meta<typeof IndicateurValuesGrid> = {
+  title: 'Indicateurs/Grille de saisie',
+  component: IndicateurValuesGrid,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof IndicateurValuesGrid>;
+
+export const Polluants: Story = {
+  args: {
+    groups: fakeGroups,
+    years: fakeYears,
+    referenceYear: fakeReferenceYear,
+    unit: 't/an',
+    cells: fakeCells(),
+    actions: fakeGridActions,
+  },
+};
+
+export const Vide: Story = {
+  args: {
+    groups: fakeGroups,
+    years: fakeYears,
+    referenceYear: fakeReferenceYear,
+    unit: 't/an',
+    cells: new Map(),
+    actions: fakeGridActions,
+  },
+};

--- a/apps/app/src/indicateurs/valeurs/grid/__tests__/open-data-coverage.spec.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/__tests__/open-data-coverage.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { countOpenDataProposals, isCovered } from '../open-data-coverage';
+import { GridCell } from '../types';
+
+const covering = {
+  sourceId: 'citepa',
+  libelle: 'CITEPA',
+  value: 10,
+  methodologie: null,
+  dateVersion: '2026-01-01',
+};
+
+describe('isCovered', () => {
+  it('est vrai seulement si une cellule user-data a une source couvrante', () => {
+    expect(isCovered({ kind: 'user-data', value: null, coveringSources: [covering] })).toBe(true);
+    expect(isCovered({ kind: 'user-data', value: null, coveringSources: [] })).toBe(false);
+    expect(
+      isCovered({
+        kind: 'open-data',
+        value: 5,
+        adoptedSourceId: 'citepa',
+        source: { sourceId: 'citepa', libelle: 'CITEPA', methodologie: null, dateVersion: '2026-01-01' },
+      })
+    ).toBe(false);
+    expect(isCovered(null)).toBe(false);
+  });
+});
+
+describe('countOpenDataProposals', () => {
+  it('compte les cellules vides couvertes par au moins une source', () => {
+    const cells: GridCell[] = [
+      { kind: 'user-data', value: null, coveringSources: [covering] },
+      { kind: 'user-data', value: 3, valueId: 30, coveringSources: [covering] },
+      { kind: 'user-data', value: null, coveringSources: [] },
+    ];
+    expect(countOpenDataProposals(cells)).toBe(1);
+  });
+});

--- a/apps/app/src/indicateurs/valeurs/grid/__tests__/render-smoke.spec.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/__tests__/render-smoke.spec.tsx
@@ -1,0 +1,24 @@
+import { render } from '@testing-library/react';
+import { describe, it } from 'vitest';
+import {
+  fakeCells,
+  fakeGridActions,
+  fakeGroups,
+  fakeReferenceYear,
+  fakeYears,
+} from './grid-fixtures';
+import { IndicateurValuesGrid } from '../indicateur-values-grid';
+
+describe('IndicateurValuesGrid smoke', () => {
+  it('rend sans lever', () => {
+    render(
+      <IndicateurValuesGrid
+        groups={fakeGroups}
+        years={fakeYears}
+        referenceYear={fakeReferenceYear}
+        cells={fakeCells()}
+        actions={fakeGridActions}
+      />
+    );
+  });
+});

--- a/apps/app/src/indicateurs/valeurs/grid/drag-handle.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/drag-handle.tsx
@@ -1,0 +1,6 @@
+import { cn, Icon } from '@tet/ui';
+import { JSX } from 'react';
+
+export const DragHandle = ({ className }: { className?: string }): JSX.Element => (
+  <Icon icon="draggable" size="xs" className={cn('text-grey-5', className)} />
+);

--- a/apps/app/src/indicateurs/valeurs/grid/grid-context.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/grid-context.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { createContext, JSX, ReactNode, use, useMemo } from 'react';
+import {
+  CellKey,
+  GridCell,
+  GridRowGroup,
+  IndicateurValuesGridActions,
+  Year,
+} from './types';
+
+export type GridContextValue = {
+  groups: GridRowGroup[];
+  years: Year[];
+  referenceYear: Year | null;
+  unit: string | null;
+  cells: Map<CellKey, GridCell>;
+  isLoading: boolean;
+  actions: IndicateurValuesGridActions;
+};
+
+const GridContext = createContext<GridContextValue | null>(null);
+
+export const GridProvider = ({
+  children,
+  groups,
+  years,
+  referenceYear,
+  unit,
+  cells,
+  isLoading,
+  actions,
+}: GridContextValue & { children: ReactNode }): JSX.Element => {
+  const value = useMemo<GridContextValue>(
+    () => ({ groups, years, referenceYear, unit, cells, isLoading, actions }),
+    [groups, years, referenceYear, unit, cells, isLoading, actions]
+  );
+  return <GridContext.Provider value={value}>{children}</GridContext.Provider>;
+};
+
+export const useGridContext = (): GridContextValue => {
+  const context = use(GridContext);
+  if (context === null) {
+    throw new Error('useGridContext must be used within a <GridProvider>');
+  }
+  return context;
+};

--- a/apps/app/src/indicateurs/valeurs/grid/grid-frame.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/grid-frame.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import {
+  createColumnHelper,
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from '@tanstack/react-table';
+import { JSX, useMemo } from 'react';
+import { useGridContext } from './grid-context';
+import { findCell, GridDisplayRow, toDisplayRows } from './grid-model';
+import { GroupRowHeader } from './group-row-header';
+import { RowHeader } from './row-header';
+import { OpenDataCell } from './open-data-cell';
+import { GridCell } from './types';
+import { UserDataCell } from './user-data-cell';
+import { YearColumnHeader } from './year-column-header';
+
+const columnHelper = createColumnHelper<GridDisplayRow>();
+
+const EmptyCell = (): JSX.Element => <div className="h-full bg-grey-1" />;
+
+const renderCell = (cell: GridCell | null): JSX.Element => {
+  if (cell === null) {
+    return <EmptyCell />;
+  }
+  if (cell.kind === 'open-data') {
+    return <OpenDataCell value={cell.value} source={cell.source} />;
+  }
+  return <UserDataCell value={cell.value} coveringSources={cell.coveringSources} />;
+};
+
+export const GridFrame = (): JSX.Element => {
+  const { groups, years, referenceYear, unit, cells } = useGridContext();
+
+  const displayRows = useMemo<GridDisplayRow[]>(
+    () => toDisplayRows(groups),
+    [groups]
+  );
+
+  const columns = useMemo(
+    () =>
+      years.map((year) =>
+        columnHelper.display({
+          id: `year-${year}`,
+          cell: ({ row }) =>
+            renderCell(findCell({ cells, indicateurId: row.original.indicateurId, year })),
+        })
+      ),
+    [years, cells]
+  );
+
+  const table = useReactTable({
+    data: displayRows,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  });
+
+  return (
+    <div className="max-h-[70vh] overflow-auto">
+      <table className="w-full border-collapse text-sm" role="grid">
+        <thead>
+          <tr>
+            <th
+              scope="col"
+              className="sticky left-0 top-0 z-30 border border-grey-3 bg-grey-1 p-2"
+            />
+            <th scope="col" className="sticky top-0 z-20 border border-grey-3 bg-grey-1 p-2" />
+            {years.map((year) => (
+              <YearColumnHeader
+                key={year}
+                year={year}
+                unit={unit}
+                isReference={year === referenceYear}
+              />
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {table.getRowModel().rows.map((row) => (
+            <tr key={row.id}>
+              {row.original.isGroupStart && (
+                <GroupRowHeader
+                  label={row.original.groupLabel}
+                  rowSpan={row.original.groupSize}
+                />
+              )}
+              <RowHeader label={row.original.rowLabel} />
+              {row.getVisibleCells().map((cell) => (
+                <td key={cell.id} className="h-10 border border-grey-3 p-0">
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};

--- a/apps/app/src/indicateurs/valeurs/grid/grid-model.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/grid-model.ts
@@ -1,0 +1,39 @@
+import {
+  cellKey,
+  CellKey,
+  GridCell,
+  GridRowGroup,
+  IndicateurId,
+  Year,
+} from './types';
+
+export type GridDisplayRow = {
+  indicateurId: IndicateurId;
+  rowLabel: string;
+  groupId: string;
+  groupLabel: string;
+  isGroupStart: boolean;
+  groupSize: number;
+};
+
+export const toDisplayRows = (groups: GridRowGroup[]): GridDisplayRow[] =>
+  groups.flatMap((group) =>
+    group.rows.map((row, index) => ({
+      indicateurId: row.indicateurId,
+      rowLabel: row.label,
+      groupId: group.id,
+      groupLabel: group.label,
+      isGroupStart: index === 0,
+      groupSize: group.rows.length,
+    }))
+  );
+
+export const findCell = ({
+  cells,
+  indicateurId,
+  year,
+}: {
+  cells: Map<CellKey, GridCell>;
+  indicateurId: IndicateurId;
+  year: Year;
+}): GridCell | null => cells.get(cellKey(indicateurId, year)) ?? null;

--- a/apps/app/src/indicateurs/valeurs/grid/group-row-header.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/group-row-header.tsx
@@ -1,0 +1,19 @@
+import { JSX, memo } from 'react';
+import { DragHandle } from './drag-handle';
+
+export const GroupRowHeader = memo(
+  ({ label, rowSpan }: { label: string; rowSpan: number }): JSX.Element => (
+    <th
+      scope="rowgroup"
+      rowSpan={rowSpan}
+      className="sticky left-0 z-10 border border-grey-3 bg-grey-1 p-2 align-top text-left font-bold text-primary-9"
+    >
+      <div className="flex items-center gap-1">
+        <DragHandle />
+        {label}
+      </div>
+    </th>
+  )
+);
+
+GroupRowHeader.displayName = 'GroupRowHeader';

--- a/apps/app/src/indicateurs/valeurs/grid/index.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/index.ts
@@ -1,0 +1,9 @@
+export * from './types';
+export * from './indicateur-values-grid';
+export { toDisplayRows, findCell } from './grid-model';
+export type { GridDisplayRow } from './grid-model';
+export {
+  openDataSourcesFor,
+  countOpenDataProposals,
+  isCovered,
+} from './open-data-coverage';

--- a/apps/app/src/indicateurs/valeurs/grid/indicateur-values-grid.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/indicateur-values-grid.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { JSX } from 'react';
+import { GridProvider } from './grid-context';
+import { GridFrame } from './grid-frame';
+import {
+  CellKey,
+  GridCell,
+  GridRowGroup,
+  IndicateurValuesGridActions,
+  Year,
+} from './types';
+
+export type IndicateurValuesGridProps = {
+  groups: GridRowGroup[];
+  years: Year[];
+  referenceYear?: Year;
+  unit?: string;
+  cells: Map<CellKey, GridCell>;
+  isLoading?: boolean;
+  actions: IndicateurValuesGridActions;
+};
+
+export const IndicateurValuesGrid = ({
+  groups,
+  years,
+  referenceYear,
+  unit,
+  cells,
+  isLoading = false,
+  actions,
+}: IndicateurValuesGridProps): JSX.Element => (
+  <GridProvider
+    groups={groups}
+    years={years}
+    referenceYear={referenceYear ?? null}
+    unit={unit ?? null}
+    cells={cells}
+    isLoading={isLoading}
+    actions={actions}
+  >
+    <div className="rounded-xl border border-grey-3 bg-white p-4">
+      <GridFrame />
+    </div>
+  </GridProvider>
+);

--- a/apps/app/src/indicateurs/valeurs/grid/open-data-cell.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/open-data-cell.tsx
@@ -1,0 +1,14 @@
+import { JSX, memo } from 'react';
+import { ProvenanceBadge } from './provenance-badge';
+import { SourceInfo } from './types';
+
+export const OpenDataCell = memo(
+  ({ value, source }: { value: number; source: SourceInfo }): JSX.Element => (
+    <div className="flex h-full items-center justify-between gap-1 bg-success-2 px-3 text-sm">
+      <ProvenanceBadge source={source} />
+      <span className="text-success-1">{value}</span>
+    </div>
+  )
+);
+
+OpenDataCell.displayName = 'OpenDataCell';

--- a/apps/app/src/indicateurs/valeurs/grid/open-data-coverage.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/open-data-coverage.ts
@@ -1,0 +1,15 @@
+import { CoveringSource, GridCell } from './types';
+
+export const openDataSourcesFor = (cell: GridCell | null): CoveringSource[] =>
+  cell !== null && cell.kind === 'user-data' ? cell.coveringSources : [];
+
+export const isCovered = (cell: GridCell | null): boolean =>
+  openDataSourcesFor(cell).length > 0;
+
+export const countOpenDataProposals = (cells: GridCell[]): number =>
+  cells.filter(
+    (cell) =>
+      cell.kind === 'user-data' &&
+      cell.value === null &&
+      cell.coveringSources.length > 0
+  ).length;

--- a/apps/app/src/indicateurs/valeurs/grid/provenance-badge.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/provenance-badge.tsx
@@ -1,0 +1,17 @@
+import { Badge } from '@tet/ui';
+import { JSX, memo } from 'react';
+import { SourceInfo } from './types';
+
+const shortYear = (dateVersion: string): string =>
+  `'${dateVersion.slice(2, 4)}`;
+
+export const ProvenanceBadge = memo(
+  ({ source }: { source: SourceInfo }): JSX.Element => (
+    <Badge
+      size="xs"
+      title={`${source.libelle} ${shortYear(source.dateVersion)}`}
+    />
+  )
+);
+
+ProvenanceBadge.displayName = 'ProvenanceBadge';

--- a/apps/app/src/indicateurs/valeurs/grid/row-header.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/row-header.tsx
@@ -1,0 +1,18 @@
+import { JSX, memo } from 'react';
+import { DragHandle } from './drag-handle';
+
+export const RowHeader = memo(
+  ({ label }: { label: string }): JSX.Element => (
+    <th
+      scope="row"
+      className="border border-grey-3 bg-white p-2 text-left font-medium text-primary-9"
+    >
+      <div className="flex items-center gap-1">
+        <DragHandle />
+        {label}
+      </div>
+    </th>
+  )
+);
+
+RowHeader.displayName = 'RowHeader';

--- a/apps/app/src/indicateurs/valeurs/grid/types.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/types.ts
@@ -1,0 +1,93 @@
+declare const indicateurIdBrand: unique symbol;
+export type IndicateurId = number & { readonly [indicateurIdBrand]: true };
+export const toIndicateurId = (value: number): IndicateurId =>
+  value as IndicateurId;
+
+declare const yearBrand: unique symbol;
+export type Year = number & { readonly [yearBrand]: true };
+export const toYear = (value: number): Year => value as Year;
+
+export type CellKey = string;
+
+export const cellKey = (indicateurId: IndicateurId, year: Year): CellKey =>
+  `${indicateurId}:${year}`;
+
+export type SourceInfo = {
+  sourceId: string;
+  libelle: string;
+  methodologie: string | null;
+  dateVersion: string;
+};
+
+export type CoveringSource = {
+  sourceId: string;
+  libelle: string;
+  value: number;
+  methodologie: string | null;
+  dateVersion: string;
+};
+
+export type GridCell =
+  | {
+      kind: 'user-data';
+      value: number;
+      valueId: number;
+      coveringSources: CoveringSource[];
+    }
+  | {
+      kind: 'user-data';
+      value: null;
+      valueId?: number;
+      coveringSources: CoveringSource[];
+    }
+  | {
+      kind: 'open-data';
+      value: number;
+      adoptedSourceId: string;
+      source: SourceInfo;
+    };
+
+export type GridRow = {
+  indicateurId: IndicateurId;
+  label: string;
+};
+
+export type GridRowGroup = {
+  id: string;
+  label: string;
+  rows: GridRow[];
+};
+
+export type Result<T = void> =
+  | { ok: true; value: T }
+  | { ok: false; error: string };
+
+export type WriteCellInput = {
+  indicateurId: IndicateurId;
+  valueId?: number;
+  year: Year;
+  resultat: number | null;
+};
+
+export type AdoptInput = {
+  indicateurId: IndicateurId;
+  year: Year;
+  sourceId: string;
+};
+
+export type ClearCellInput = {
+  indicateurId: IndicateurId;
+  valueId: number;
+};
+
+export type BulkOutcome = {
+  written: number;
+  failed: WriteCellInput[];
+};
+
+export type IndicateurValuesGridActions = {
+  writeCell: (input: WriteCellInput) => Promise<Result>;
+  writeBulk: (inputs: WriteCellInput[]) => Promise<Result<BulkOutcome>>;
+  adopt: (input: AdoptInput) => Promise<Result>;
+  clearCell: (input: ClearCellInput) => Promise<Result>;
+};

--- a/apps/app/src/indicateurs/valeurs/grid/user-data-cell.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/user-data-cell.tsx
@@ -1,0 +1,28 @@
+import { JSX, memo } from 'react';
+import { CoveringSource } from './types';
+
+export const UserDataCell = memo(
+  ({
+    value,
+    coveringSources,
+  }: {
+    value: number | null;
+    coveringSources: CoveringSource[];
+  }): JSX.Element => {
+    const isEmpty = value === null;
+    const showCoverageDot = isEmpty && coveringSources.length > 0;
+    return (
+      <div className="relative flex h-full items-center justify-end px-3 text-sm">
+        {!isEmpty && <span className="text-primary-9">{value}</span>}
+        {showCoverageDot && (
+          <span
+            aria-hidden
+            className="absolute right-1 top-1 h-2 w-2 rounded-full bg-success-1 ring-2 ring-success-2"
+          />
+        )}
+      </div>
+    );
+  }
+);
+
+UserDataCell.displayName = 'UserDataCell';

--- a/apps/app/src/indicateurs/valeurs/grid/year-column-header.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/year-column-header.tsx
@@ -1,0 +1,30 @@
+import { JSX, memo } from 'react';
+import { DragHandle } from './drag-handle';
+import { Year } from './types';
+
+type YearColumnHeaderProps = {
+  year: Year;
+  unit: string | null;
+  isReference: boolean;
+};
+
+export const YearColumnHeader = memo(
+  ({ year, unit, isReference }: YearColumnHeaderProps): JSX.Element => (
+    <th
+      scope="col"
+      className="sticky top-0 z-20 min-w-[140px] border border-grey-3 bg-grey-1 p-2 text-right font-bold text-primary-9"
+    >
+      <div className="flex flex-col items-end">
+        <div className="flex items-center gap-1">
+          <DragHandle />
+          <span>{isReference ? `réf. ${year}` : year}</span>
+        </div>
+        {unit ? (
+          <span className="text-xs font-normal text-grey-5">{unit}</span>
+        ) : null}
+      </div>
+    </th>
+  )
+);
+
+YearColumnHeader.displayName = 'YearColumnHeader';


### PR DESCRIPTION
## R0 — fondation de la grille de saisie tabulaire des indicateurs

Composant `IndicateurValuesGrid` **agnostique des appels API**, sur `@tanstack/react-table`, développé en isolation (Storybook + fake adapter). Premier PR du pan frontend ; les interactions (édition/autosave, clavier, drag, picker open-data) suivront (P3+).

### Contrat public (props)
- `groups: GridRowGroup[]` — `{ id, label, rows: GridRow[] }` (groupe → lignes, ids stables).
- `years`, `referenceYear?`, `unit?` (l'unité vient du consommateur), `cells: Map<CellKey, GridCell>`, `isLoading?`.
- `actions: IndicateurValuesGridActions` — `writeCell/writeBulk/adopt/clearCell` (injecté par le caller ; non câblé en R0).
- `GridCell` = union `user-data` (éditable) | `open-data` (lecture seule + provenance).

### Contenu
- Modèle react-table (`toDisplayRows`) + util `open-data-coverage` (`openDataSourcesFor`), avec specs.
- Fake adapter in-memory + fixtures déterministes (Storybook / tests).
- Cellules `user-data`/`open-data`, headers groupe/ligne/année, atomes badge de provenance / poignée de drag.
- `GridProvider` (`use()`, fail-fast) + `GridFrame` + composant tout-en-un ; composants mémoïsés.
- Tokens DS uniquement ; pastille de couverture **orange** ; cellule vide = rien affiché.
- `__tests__/` regroupe specs + stories + fixtures.

### Vérifié
- 4 specs unitaires + smoke test de render (jsdom) — 5/5.
- Story `Indicateurs → Grille de saisie` (Polluants / Vide) rendue en Storybook.
- Revues `te-en-t-style-enforcer` + skills React appliquées (naming, mémoïsation, tokens DS).

### Différé (phases suivantes)
- Câblage `actions` (autosave), nav clavier, drag+reset, picker/prefill open-data.
- Regroupe contexte `{state, actions, meta}` + API compound `.Provider`/`.Frame`.
- `réf.` label → `appLabels` à l'intégration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ajout d’une grille d’affichage des valeurs d’indicateurs avec en-têtes par année, repère de l’année de référence et affichage des groupes.
  * Affichage différencié des valeurs importées et saisies, avec badges de provenance pour les sources.
  * Ajout de poignées de déplacement dans les en-têtes et libellés de lignes, avec une meilleure présentation des cellules vides et des couvertures.
* **Tests**
  * Ajout de tests de rendu et de logique d’affichage, ainsi que de tests sur la couverture des données ouvertes.
  * Ajout de fixtures de données et de stories pour faciliter la vérification visuelle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->