### PR TITLE
feat(indicateurs): edition + autosave par cellule dans la grille de saisie

### DIFF
--- a/apps/app/src/indicateurs/valeurs/grid/__tests__/grid-fixtures.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/__tests__/grid-fixtures.ts
@@ -75,8 +75,8 @@ export const fakeCells = (): Map<CellKey, GridCell> =>
   );
 
 export const fakeGridActions: IndicateurValuesGridActions = {
-  writeCell: async () => ({ ok: true, value: undefined }),
-  writeBulk: async (inputs) => ({ ok: true, value: { written: inputs.length, failed: [] } }),
+  saveCellValue: async () => ({ ok: true, value: undefined }),
+  saveCellValues: async (inputs) => ({ ok: true, value: { written: inputs.length, failed: [] } }),
   adopt: async () => ({ ok: true, value: undefined }),
   clearCell: async () => ({ ok: true, value: undefined }),
 };

--- a/apps/app/src/indicateurs/valeurs/grid/__tests__/indicateur-values-grid.stories.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/__tests__/indicateur-values-grid.stories.tsx
@@ -1,4 +1,5 @@
 import { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { JSX, useMemo, useState } from 'react';
 import {
   fakeCells,
   fakeGridActions,
@@ -7,6 +8,7 @@ import {
   fakeYears,
 } from './grid-fixtures';
 import { IndicateurValuesGrid } from '../indicateur-values-grid';
+import { cellKey, CellKey, GridCell, IndicateurValuesGridActions } from '../types';
 
 const meta: Meta<typeof IndicateurValuesGrid> = {
   title: 'Indicateurs/Grille de saisie',
@@ -17,15 +19,45 @@ export default meta;
 
 type Story = StoryObj<typeof IndicateurValuesGrid>;
 
+const InteractiveGrid = (): JSX.Element => {
+  const [cells, setCells] = useState<Map<CellKey, GridCell>>(() => fakeCells());
+  const actions = useMemo<IndicateurValuesGridActions>(
+    () => ({
+      ...fakeGridActions,
+      saveCellValue: async ({ indicateurId, valueId, year, resultat }) => {
+        setCells((previous) => {
+          const key = cellKey(indicateurId, year);
+          const current = previous.get(key);
+          const coveringSources =
+            current?.kind === 'user-data' ? current.coveringSources : [];
+          const nextValueId = valueId ?? indicateurId * 1000 + year;
+          const updatedCell: GridCell =
+            resultat === null
+              ? { kind: 'user-data', value: null, valueId: nextValueId, coveringSources }
+              : { kind: 'user-data', value: resultat, valueId: nextValueId, coveringSources };
+          const next = new Map(previous);
+          next.set(key, updatedCell);
+          return next;
+        });
+        return { ok: true, value: undefined };
+      },
+    }),
+    []
+  );
+  return (
+    <IndicateurValuesGrid
+      groups={fakeGroups}
+      years={fakeYears}
+      referenceYear={fakeReferenceYear}
+      unit="t/an"
+      cells={cells}
+      actions={actions}
+    />
+  );
+};
+
 export const Polluants: Story = {
-  args: {
-    groups: fakeGroups,
-    years: fakeYears,
-    referenceYear: fakeReferenceYear,
-    unit: 't/an',
-    cells: fakeCells(),
-    actions: fakeGridActions,
-  },
+  render: () => <InteractiveGrid />,
 };
 
 export const Vide: Story = {

--- a/apps/app/src/indicateurs/valeurs/grid/__tests__/parse-cell-number.spec.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/__tests__/parse-cell-number.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { parseCellNumber } from '../parse-cell-number';
+
+describe('parseCellNumber', () => {
+  it('rend null pour une saisie vide', () => {
+    expect(parseCellNumber('')).toBe(null);
+    expect(parseCellNumber('   ')).toBe(null);
+  });
+
+  it('lit un entier et un decimal', () => {
+    expect(parseCellNumber('42')).toBe(42);
+    expect(parseCellNumber('-3')).toBe(-3);
+  });
+
+  it('accepte la virgule francaise et tout separateur d espace', () => {
+    expect(parseCellNumber('12,5')).toBe(12.5);
+    expect(parseCellNumber('1 000')).toBe(1000);
+    expect(parseCellNumber('1 000')).toBe(1000);
+    expect(parseCellNumber('1 000')).toBe(1000);
+  });
+
+  it('rend null pour une saisie non numerique', () => {
+    expect(parseCellNumber('abc')).toBe(null);
+    expect(parseCellNumber('1.2.3')).toBe(null);
+  });
+});

--- a/apps/app/src/indicateurs/valeurs/grid/__tests__/user-data-cell.spec.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/__tests__/user-data-cell.spec.tsx
@@ -1,0 +1,114 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { UserDataCell } from '../user-data-cell';
+import { toIndicateurId, toYear } from '../types';
+
+const typeAndCommit = (input: HTMLElement, raw: string): void => {
+  fireEvent.focus(input);
+  fireEvent.change(input, { target: { value: raw } });
+  fireEvent.keyDown(input, { key: 'Enter' });
+};
+
+const renderEmptyCell = (
+  saveCellValue: ReturnType<typeof vi.fn>
+): HTMLInputElement => {
+  render(
+    <UserDataCell
+      cell={{ kind: 'user-data', value: null, coveringSources: [] }}
+      ariaLabel="NOx 2030"
+      indicateurId={toIndicateurId(12)}
+      year={toYear(2030)}
+      saveCellValue={saveCellValue}
+    />
+  );
+  return screen.getByRole('textbox') as HTMLInputElement;
+};
+
+describe('UserDataCell edition', () => {
+  it('commit la valeur saisie via saveCellValue a la validation', async () => {
+    const saveCellValue = vi.fn().mockResolvedValue({ ok: true, value: undefined });
+    const input = renderEmptyCell(saveCellValue);
+
+    typeAndCommit(input, '42');
+
+    await waitFor(() =>
+      expect(saveCellValue).toHaveBeenCalledWith({
+        indicateurId: 12,
+        valueId: undefined,
+        year: 2030,
+        resultat: 42,
+      })
+    );
+    await screen.findByText('Enregistré');
+  });
+
+  it('filtre les caracteres non numeriques a la saisie', () => {
+    const input = renderEmptyCell(
+      vi.fn().mockResolvedValue({ ok: true, value: undefined })
+    );
+
+    fireEvent.change(input, { target: { value: '1a2b' } });
+
+    expect(input.value).toBe('12');
+  });
+
+  it('conserve la saisie et signale une erreur quand le write echoue', async () => {
+    const saveCellValue = vi.fn().mockResolvedValue({ ok: false, error: 'boom' });
+    const input = renderEmptyCell(saveCellValue);
+
+    typeAndCommit(input, '7');
+
+    await waitFor(() => expect(input.getAttribute('aria-invalid')).toBe('true'));
+    expect(input.value).toBe('7');
+    expect(screen.queryByText('Enregistré')).toBe(null);
+  });
+
+  it('reste editable et signale une erreur si le write rejette', async () => {
+    const saveCellValue = vi.fn().mockRejectedValue(new Error('network'));
+    const input = renderEmptyCell(saveCellValue);
+
+    typeAndCommit(input, '42');
+    await waitFor(() => expect(input.getAttribute('aria-invalid')).toBe('true'));
+
+    typeAndCommit(input, '43');
+    await waitFor(() => expect(saveCellValue).toHaveBeenCalledTimes(2));
+  });
+
+  it('signale une erreur sans ecrire quand la saisie est invalide', async () => {
+    const saveCellValue = vi.fn().mockResolvedValue({ ok: true, value: undefined });
+    render(
+      <UserDataCell
+        cell={{ kind: 'user-data', value: 12, valueId: 100, coveringSources: [] }}
+        ariaLabel="NOx 2030"
+        indicateurId={toIndicateurId(12)}
+        year={toYear(2030)}
+        saveCellValue={saveCellValue}
+      />
+    );
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+
+    typeAndCommit(input, '1..2');
+
+    await waitFor(() => expect(input.getAttribute('aria-invalid')).toBe('true'));
+    expect(saveCellValue).not.toHaveBeenCalled();
+  });
+
+  it("ne commit pas quand la valeur n'a pas change", () => {
+    const saveCellValue = vi.fn();
+    render(
+      <UserDataCell
+        cell={{ kind: 'user-data', value: 12, valueId: 100, coveringSources: [] }}
+        ariaLabel="NOx 2030"
+        indicateurId={toIndicateurId(12)}
+        year={toYear(2030)}
+        saveCellValue={saveCellValue}
+      />
+    );
+    const input = screen.getByRole('textbox');
+
+    fireEvent.focus(input);
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(saveCellValue).not.toHaveBeenCalled();
+  });
+});

--- a/apps/app/src/indicateurs/valeurs/grid/cell-input.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/cell-input.tsx
@@ -1,0 +1,44 @@
+import { Input } from '@tet/ui';
+import { JSX } from 'react';
+
+type CellInputProps = {
+  value: string;
+  ariaLabel: string;
+  hasError: boolean;
+  onChange: (raw: string) => void;
+  onSave: () => void;
+  onCancel: () => void;
+};
+
+export const CellInput = ({
+  value,
+  ariaLabel,
+  hasError,
+  onChange,
+  onSave,
+  onCancel,
+}: CellInputProps): JSX.Element => (
+  <Input
+    type="text"
+    inputMode="decimal"
+    aria-label={ariaLabel}
+    aria-invalid={hasError}
+    displaySize="sm"
+    state={hasError ? 'error' : undefined}
+    value={value}
+    onFocus={(event) => event.currentTarget.select()}
+    onChange={(event) => onChange(event.currentTarget.value)}
+    onBlur={onSave}
+    onKeyDown={(event) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        onSave();
+      } else if (event.key === 'Escape') {
+        event.preventDefault();
+        onCancel();
+      }
+    }}
+    containerClassname="w-full h-full"
+    className="text-right"
+  />
+);

--- a/apps/app/src/indicateurs/valeurs/grid/coverage-dot.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/coverage-dot.tsx
@@ -1,0 +1,8 @@
+import { JSX } from 'react';
+
+export const CoverageDot = (): JSX.Element => (
+  <span
+    aria-hidden
+    className="absolute right-1 top-1 h-2 w-2 rounded-full bg-success-1 ring-2 ring-success-2"
+  />
+);

--- a/apps/app/src/indicateurs/valeurs/grid/grid-frame.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/grid-frame.tsx
@@ -12,7 +12,12 @@ import { findCell, GridDisplayRow, toDisplayRows } from './grid-model';
 import { GroupRowHeader } from './group-row-header';
 import { RowHeader } from './row-header';
 import { OpenDataCell } from './open-data-cell';
-import { GridCell } from './types';
+import {
+  GridCell,
+  IndicateurId,
+  IndicateurValuesGridActions,
+  Year,
+} from './types';
 import { UserDataCell } from './user-data-cell';
 import { YearColumnHeader } from './year-column-header';
 
@@ -20,18 +25,39 @@ const columnHelper = createColumnHelper<GridDisplayRow>();
 
 const EmptyCell = (): JSX.Element => <div className="h-full bg-grey-1" />;
 
-const renderCell = (cell: GridCell | null): JSX.Element => {
+const renderCell = ({
+  cell,
+  indicateurId,
+  year,
+  rowLabel,
+  saveCellValue,
+}: {
+  cell: GridCell | null;
+  indicateurId: IndicateurId;
+  year: Year;
+  rowLabel: string;
+  saveCellValue: IndicateurValuesGridActions['saveCellValue'];
+}): JSX.Element => {
   if (cell === null) {
     return <EmptyCell />;
   }
   if (cell.kind === 'open-data') {
     return <OpenDataCell value={cell.value} source={cell.source} />;
   }
-  return <UserDataCell value={cell.value} coveringSources={cell.coveringSources} />;
+  return (
+    <UserDataCell
+      cell={cell}
+      ariaLabel={`${rowLabel} ${year}`}
+      indicateurId={indicateurId}
+      year={year}
+      saveCellValue={saveCellValue}
+    />
+  );
 };
 
 export const GridFrame = (): JSX.Element => {
-  const { groups, years, referenceYear, unit, cells } = useGridContext();
+  const { groups, years, referenceYear, unit, cells, actions } =
+    useGridContext();
 
   const displayRows = useMemo<GridDisplayRow[]>(
     () => toDisplayRows(groups),
@@ -44,10 +70,20 @@ export const GridFrame = (): JSX.Element => {
         columnHelper.display({
           id: `year-${year}`,
           cell: ({ row }) =>
-            renderCell(findCell({ cells, indicateurId: row.original.indicateurId, year })),
+            renderCell({
+              cell: findCell({
+                cells,
+                indicateurId: row.original.indicateurId,
+                year,
+              }),
+              indicateurId: row.original.indicateurId,
+              year,
+              rowLabel: row.original.rowLabel,
+              saveCellValue: actions.saveCellValue,
+            }),
         })
       ),
-    [years, cells]
+    [years, cells, actions.saveCellValue]
   );
 
   const table = useReactTable({

--- a/apps/app/src/indicateurs/valeurs/grid/parse-cell-number.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/parse-cell-number.ts
@@ -1,0 +1,8 @@
+export const parseCellNumber = (raw: string): number | null => {
+  const normalized = raw.replace(/\s/g, '').replaceAll(',', '.');
+  if (normalized === '') {
+    return null;
+  }
+  const parsed = Number(normalized);
+  return Number.isNaN(parsed) ? null : parsed;
+};

--- a/apps/app/src/indicateurs/valeurs/grid/save-ack.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/save-ack.tsx
@@ -1,0 +1,15 @@
+import { Icon } from '@tet/ui';
+import { JSX } from 'react';
+import { appLabels } from '@/app/labels/catalog';
+
+export const SaveAck = (): JSX.Element => (
+  <span
+    role="status"
+    className="pointer-events-none absolute right-1 top-1 text-success-1"
+  >
+    <span aria-hidden>
+      <Icon icon="check-line" size="xs" />
+    </span>
+    <span className="sr-only">{appLabels.indicateurValeurEnregistree}</span>
+  </span>
+);

--- a/apps/app/src/indicateurs/valeurs/grid/types.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/types.ts
@@ -62,7 +62,7 @@ export type Result<T = void> =
   | { ok: true; value: T }
   | { ok: false; error: string };
 
-export type WriteCellInput = {
+export type CellValueInput = {
   indicateurId: IndicateurId;
   valueId?: number;
   year: Year;
@@ -82,12 +82,12 @@ export type ClearCellInput = {
 
 export type BulkOutcome = {
   written: number;
-  failed: WriteCellInput[];
+  failed: CellValueInput[];
 };
 
 export type IndicateurValuesGridActions = {
-  writeCell: (input: WriteCellInput) => Promise<Result>;
-  writeBulk: (inputs: WriteCellInput[]) => Promise<Result<BulkOutcome>>;
+  saveCellValue: (input: CellValueInput) => Promise<Result>;
+  saveCellValues: (inputs: CellValueInput[]) => Promise<Result<BulkOutcome>>;
   adopt: (input: AdoptInput) => Promise<Result>;
   clearCell: (input: ClearCellInput) => Promise<Result>;
 };

--- a/apps/app/src/indicateurs/valeurs/grid/use-cell-edit.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/use-cell-edit.ts
@@ -1,0 +1,86 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { parseCellNumber } from './parse-cell-number';
+import { Result } from './types';
+
+export type CellEditStatus = 'idle' | 'saving' | 'saved' | 'error';
+
+export type CellEdit = {
+  text: string;
+  status: CellEditStatus;
+  onChange: (raw: string) => void;
+  save: () => Promise<void>;
+  cancel: () => void;
+};
+
+const DISALLOWED_CHARS = /[^0-9.,\s-]/g;
+const SAVED_ACKNOWLEDGEMENT_MS = 2000;
+
+export const useCellEdit = ({
+  currentValue,
+  onSave,
+}: {
+  currentValue: number | null;
+  onSave: (resultat: number | null) => Promise<Result>;
+}): CellEdit => {
+  const [draftValue, setDraftValue] = useState<string | null>(null);
+  const [status, setStatus] = useState<CellEditStatus>('idle');
+  const isSaving = useRef(false);
+
+  const currentText = currentValue === null ? '' : String(currentValue);
+  const text = draftValue ?? currentText;
+
+  useEffect(() => {
+    if (status !== 'saved') {
+      return;
+    }
+    const timer = setTimeout(() => setStatus('idle'), SAVED_ACKNOWLEDGEMENT_MS);
+    return () => clearTimeout(timer);
+  }, [status]);
+
+  const onChange = useCallback((raw: string) => {
+    setDraftValue(raw.replace(DISALLOWED_CHARS, ''));
+    setStatus('idle');
+  }, []);
+
+  const cancel = useCallback(() => {
+    setDraftValue(null);
+    setStatus('idle');
+  }, []);
+
+  const save = useCallback(async () => {
+    const nothingToSave = draftValue === null;
+    if (isSaving.current || nothingToSave) {
+      return;
+    }
+    const savedRaw = draftValue;
+    const parsedValue = parseCellNumber(savedRaw);
+    const isUnparseable = savedRaw.trim() !== '' && parsedValue === null;
+    if (isUnparseable) {
+      setStatus('error');
+      return;
+    }
+    const isUnchanged = parsedValue === currentValue;
+    if (isUnchanged) {
+      setDraftValue(null);
+      setStatus('idle');
+      return;
+    }
+    isSaving.current = true;
+    setStatus('saving');
+    try {
+      const writeResult = await onSave(parsedValue);
+      if (writeResult.ok) {
+        setDraftValue((current) => (current === savedRaw ? null : current));
+        setStatus((current) => (current === 'saving' ? 'saved' : current));
+      } else {
+        setStatus('error');
+      }
+    } catch {
+      setStatus('error');
+    } finally {
+      isSaving.current = false;
+    }
+  }, [draftValue, currentValue, onSave]);
+
+  return { text, status, onChange, save, cancel };
+};

--- a/apps/app/src/indicateurs/valeurs/grid/user-data-cell.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/user-data-cell.tsx
@@ -1,25 +1,56 @@
-import { JSX, memo } from 'react';
-import { CoveringSource } from './types';
+import { JSX, memo, useCallback } from 'react';
+import { CellInput } from './cell-input';
+import { CoverageDot } from './coverage-dot';
+import { SaveAck } from './save-ack';
+import { useCellEdit } from './use-cell-edit';
+import {
+  GridCell,
+  IndicateurId,
+  IndicateurValuesGridActions,
+  Year,
+} from './types';
+
+type UserDataCellProps = {
+  cell: Extract<GridCell, { kind: 'user-data' }>;
+  ariaLabel: string;
+  indicateurId: IndicateurId;
+  year: Year;
+  saveCellValue: IndicateurValuesGridActions['saveCellValue'];
+};
 
 export const UserDataCell = memo(
   ({
-    value,
-    coveringSources,
-  }: {
-    value: number | null;
-    coveringSources: CoveringSource[];
-  }): JSX.Element => {
-    const isEmpty = value === null;
-    const showCoverageDot = isEmpty && coveringSources.length > 0;
+    cell,
+    ariaLabel,
+    indicateurId,
+    year,
+    saveCellValue,
+  }: UserDataCellProps): JSX.Element => {
+    const { value, valueId, coveringSources } = cell;
+    const onSave = useCallback(
+      (resultat: number | null) =>
+        saveCellValue({ indicateurId, valueId, year, resultat }),
+      [saveCellValue, indicateurId, valueId, year]
+    );
+    const { text, status, onChange, save, cancel } = useCellEdit({
+      currentValue: value,
+      onSave,
+    });
+    const isEmpty = text === '';
+    const showCoverageDot =
+      isEmpty && status === 'idle' && coveringSources.length > 0;
     return (
-      <div className="relative flex h-full items-center justify-end px-3 text-sm">
-        {!isEmpty && <span className="text-primary-9">{value}</span>}
-        {showCoverageDot && (
-          <span
-            aria-hidden
-            className="absolute right-1 top-1 h-2 w-2 rounded-full bg-success-1 ring-2 ring-success-2"
-          />
-        )}
+      <div className="relative h-full">
+        <CellInput
+          value={text}
+          ariaLabel={ariaLabel}
+          hasError={status === 'error'}
+          onChange={onChange}
+          onSave={save}
+          onCancel={cancel}
+        />
+        {showCoverageDot && <CoverageDot />}
+        {status === 'saved' && <SaveAck />}
       </div>
     );
   }

--- a/apps/app/src/labels/catalog.ts
+++ b/apps/app/src/labels/catalog.ts
@@ -1726,6 +1726,7 @@ export const appLabels = {
     "Cette collectivité n'est pas accessible en mode visite.",
   collectiviteIdInvalide: 'Identifiant de collectivité invalide',
   uneErreurEstSurvenue: 'Une erreur est survenue',
+  indicateurValeurEnregistree: 'Enregistré',
 
   acteEngagementDocUrl: '/Acte_engagement.docx',
   reglementLabelUrl: ({


### PR DESCRIPTION
Empilee sur #4658 (R0). **Base = `feat/indicateur-values-grid`**, pas `main`.

## Contenu (P3 du plan)
Rend la cellule `user-data` editable avec **autosave par cellule** via l'action injectee `writeCell` — la grille reste agnostique de tRPC (le caller possede optimistic/invalidation/toasts ; ici la story fournit un fake stateful).

- `CellInput` sur le **DS `Input`** (type text, `inputMode=decimal`, `state=error`) — filtre `onChange`, select-on-focus, commit Enter/blur, `Escape` annule.
- `useCellEdit` : machine `idle | saving | saved | error`, buffer derive `buffer ?? serverValue` (pas de `useEffect` de sync), **serialisation des commits** (`isSaving`) pour ne pas ecraser une saisie faite pendant un save en vol.
- `SaveAck` (`role="status"` + `appLabels`) et `CoverageDot` extraits ; `parseCellNumber` (util pure + spec).
- Story `Polluants` interactive (le fake `writeCell` reconcilie la `Map` de `cells`).
- a11y : `aria-label` (indicateur + annee), `aria-invalid`.

## Hors scope (PR suivantes du plan)
Navigation clavier tableur (P4), collage (P5), drag/reset (P6), picker open-data (P8).

## Verifs
- specs grille **13/13** (5 R0 + 4 `parseCellNumber` + 4 edition)
- `nx run app:lint` **0 erreur**
- typecheck : aucune erreur introduite (le seul echec `app:typecheck` est un artefact `.next/types` perime, identique sur R0)

## Reviewers (te-en-t-style-enforcer + 4 JSX) passes et corriges
Race (perte de saisie en vol) + memo casse par `onCommit` inline + a11y (nom accessible, `aria-invalid`, `role=status`) + i18n (`appLabels`). Deferres car hors scope P3 (touchent le contrat R0 fige) : brand `IndicateurId`/`Year`, invariant `value⇒valueId`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Nouvelle grille de valeurs d’indicateurs plus interactive, avec en-têtes de groupes, colonnes par année et indication de l’année de référence.
  * Les cellules éditables affichent désormais un statut de sauvegarde et une meilleure indication visuelle des données issues de sources ouvertes.

* **Correctifs**
  * La saisie numérique est mieux normalisée et bloque les entrées invalides.
  * L’édition évite les enregistrements inutiles, conserve la saisie en cas d’erreur et améliore le comportement du clavier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->