### PR TITLE
feat(indicateurs): navigation clavier type tableur dans la grille de saisie

### DIFF
--- a/apps/app/src/indicateurs/valeurs/grid/__tests__/grid-fixtures.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/__tests__/grid-fixtures.ts
@@ -1,5 +1,5 @@
 import {
-  cellKey,
+  generateCellKey,
   CellKey,
   GridCell,
   GridRowGroup,
@@ -68,7 +68,7 @@ export const fakeCells = (): Map<CellKey, GridCell> =>
       group.rows.flatMap((row) =>
         fakeYears.map(
           (year) =>
-            [cellKey(row.indicateurId, year), buildCell(row.indicateurId, year)] as const
+            [generateCellKey(row.indicateurId, year), buildCell(row.indicateurId, year)] as const
         )
       )
     )

--- a/apps/app/src/indicateurs/valeurs/grid/__tests__/grid-model.spec.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/__tests__/grid-model.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { findCell, toDisplayRows } from '../grid-model';
 import {
-  cellKey,
+  generateCellKey,
   GridCell,
   GridRowGroup,
   toIndicateurId,
@@ -56,7 +56,7 @@ describe('findCell', () => {
       valueId: 100,
       coveringSources: [],
     };
-    const cells = new Map([[cellKey(toIndicateurId(1), toYear(2030)), cell]]);
+    const cells = new Map([[generateCellKey(toIndicateurId(1), toYear(2030)), cell]]);
     expect(
       findCell({ cells, indicateurId: toIndicateurId(1), year: toYear(2030) })
     ).toBe(cell);

--- a/apps/app/src/indicateurs/valeurs/grid/__tests__/indicateur-values-grid.stories.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/__tests__/indicateur-values-grid.stories.tsx
@@ -8,7 +8,7 @@ import {
   fakeYears,
 } from './grid-fixtures';
 import { IndicateurValuesGrid } from '../indicateur-values-grid';
-import { cellKey, CellKey, GridCell, IndicateurValuesGridActions } from '../types';
+import { generateCellKey, CellKey, GridCell, IndicateurValuesGridActions } from '../types';
 
 const meta: Meta<typeof IndicateurValuesGrid> = {
   title: 'Indicateurs/Grille de saisie',
@@ -26,7 +26,7 @@ const InteractiveGrid = (): JSX.Element => {
       ...fakeGridActions,
       saveCellValue: async ({ indicateurId, valueId, year, resultat }) => {
         setCells((previous) => {
-          const key = cellKey(indicateurId, year);
+          const key = generateCellKey(indicateurId, year);
           const current = previous.get(key);
           const coveringSources =
             current?.kind === 'user-data' ? current.coveringSources : [];

--- a/apps/app/src/indicateurs/valeurs/grid/cell-input.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/cell-input.tsx
@@ -1,7 +1,9 @@
 import { Input } from '@tet/ui';
 import { JSX } from 'react';
+import { CellKey } from './types';
 
 type CellInputProps = {
+  cellId: CellKey;
   value: string;
   ariaLabel: string;
   hasError: boolean;
@@ -11,6 +13,7 @@ type CellInputProps = {
 };
 
 export const CellInput = ({
+  cellId,
   value,
   ariaLabel,
   hasError,
@@ -21,6 +24,7 @@ export const CellInput = ({
   <Input
     type="text"
     inputMode="decimal"
+    data-cell-id={cellId}
     aria-label={ariaLabel}
     aria-invalid={hasError}
     displaySize="sm"

--- a/apps/app/src/indicateurs/valeurs/grid/grid-frame.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/grid-frame.tsx
@@ -1,102 +1,36 @@
 'use client';
 
-import {
-  createColumnHelper,
-  flexRender,
-  getCoreRowModel,
-  useReactTable,
-} from '@tanstack/react-table';
-import { JSX, useMemo } from 'react';
+import { flexRender } from '@tanstack/react-table';
+import { JSX } from 'react';
+import { appLabels } from '@/app/labels/catalog';
 import { useGridContext } from './grid-context';
-import { findCell, GridDisplayRow, toDisplayRows } from './grid-model';
+import { useGetTable } from './use-get-table';
+import { useGridKeyboardNav } from './keyboard-navigation/use-grid-keyboard-nav';
 import { GroupRowHeader } from './group-row-header';
 import { RowHeader } from './row-header';
-import { OpenDataCell } from './open-data-cell';
-import {
-  GridCell,
-  IndicateurId,
-  IndicateurValuesGridActions,
-  Year,
-} from './types';
-import { UserDataCell } from './user-data-cell';
 import { YearColumnHeader } from './year-column-header';
 
-const columnHelper = createColumnHelper<GridDisplayRow>();
-
-const EmptyCell = (): JSX.Element => <div className="h-full bg-grey-1" />;
-
-const renderCell = ({
-  cell,
-  indicateurId,
-  year,
-  rowLabel,
-  saveCellValue,
-}: {
-  cell: GridCell | null;
-  indicateurId: IndicateurId;
-  year: Year;
-  rowLabel: string;
-  saveCellValue: IndicateurValuesGridActions['saveCellValue'];
-}): JSX.Element => {
-  if (cell === null) {
-    return <EmptyCell />;
-  }
-  if (cell.kind === 'open-data') {
-    return <OpenDataCell value={cell.value} source={cell.source} />;
-  }
-  return (
-    <UserDataCell
-      cell={cell}
-      ariaLabel={`${rowLabel} ${year}`}
-      indicateurId={indicateurId}
-      year={year}
-      saveCellValue={saveCellValue}
-    />
-  );
-};
-
 export const GridFrame = (): JSX.Element => {
-  const { groups, years, referenceYear, unit, cells, actions } =
-    useGridContext();
-
-  const displayRows = useMemo<GridDisplayRow[]>(
-    () => toDisplayRows(groups),
-    [groups]
-  );
-
-  const columns = useMemo(
-    () =>
-      years.map((year) =>
-        columnHelper.display({
-          id: `year-${year}`,
-          cell: ({ row }) =>
-            renderCell({
-              cell: findCell({
-                cells,
-                indicateurId: row.original.indicateurId,
-                year,
-              }),
-              indicateurId: row.original.indicateurId,
-              year,
-              rowLabel: row.original.rowLabel,
-              saveCellValue: actions.saveCellValue,
-            }),
-        })
-      ),
-    [years, cells, actions.saveCellValue]
-  );
-
-  const table = useReactTable({
-    data: displayRows,
-    columns,
-    getCoreRowModel: getCoreRowModel(),
+  const { groups, years, referenceYear, unit } = useGridContext();
+  const { table, tableRef } = useGetTable({ groups, years });
+  const { onKeyDown, onFocus } = useGridKeyboardNav({
+    containerRef: tableRef,
+    groups,
+    years,
   });
 
   return (
     <div className="max-h-[70vh] overflow-auto">
-      <table className="w-full border-collapse text-sm" role="grid">
+      <table
+        ref={tableRef}
+        onKeyDown={onKeyDown}
+        onFocus={onFocus}
+        aria-label={appLabels.indicateurValeursGrille}
+        className="w-full border-collapse text-sm"
+        role="grid"
+      >
         <thead>
-          <tr>
+          <tr role="row">
             <th
               scope="col"
               className="sticky left-0 top-0 z-30 border border-grey-3 bg-grey-1 p-2"
@@ -114,7 +48,7 @@ export const GridFrame = (): JSX.Element => {
         </thead>
         <tbody>
           {table.getRowModel().rows.map((row) => (
-            <tr key={row.id}>
+            <tr key={row.id} role="row">
               {row.original.isGroupStart && (
                 <GroupRowHeader
                   label={row.original.groupLabel}
@@ -123,7 +57,11 @@ export const GridFrame = (): JSX.Element => {
               )}
               <RowHeader label={row.original.rowLabel} />
               {row.getVisibleCells().map((cell) => (
-                <td key={cell.id} className="h-10 border border-grey-3 p-0">
+                <td
+                  key={cell.id}
+                  role="gridcell"
+                  className="h-10 border border-grey-3 p-0"
+                >
                   {flexRender(cell.column.columnDef.cell, cell.getContext())}
                 </td>
               ))}

--- a/apps/app/src/indicateurs/valeurs/grid/grid-model.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/grid-model.ts
@@ -1,5 +1,5 @@
 import {
-  cellKey,
+  generateCellKey,
   CellKey,
   GridCell,
   GridRowGroup,
@@ -36,4 +36,4 @@ export const findCell = ({
   cells: Map<CellKey, GridCell>;
   indicateurId: IndicateurId;
   year: Year;
-}): GridCell | null => cells.get(cellKey(indicateurId, year)) ?? null;
+}): GridCell | null => cells.get(generateCellKey(indicateurId, year)) ?? null;

--- a/apps/app/src/indicateurs/valeurs/grid/keyboard-navigation/grid-navigation.spec.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/keyboard-navigation/grid-navigation.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { buildNavigableKeys, getNextNavKey } from './grid-navigation';
+import { GridRowGroup, toIndicateurId, toYear } from '../types';
+
+const years = [2030, 2036].map(toYear);
+
+const groups: GridRowGroup[] = [
+  {
+    id: 'g',
+    label: 'G',
+    rows: [
+      { indicateurId: toIndicateurId(1), label: 'A' },
+      { indicateurId: toIndicateurId(2), label: 'B' },
+      { indicateurId: toIndicateurId(3), label: 'C' },
+    ],
+  },
+];
+
+const navigableKeys = buildNavigableKeys({ groups, years });
+
+describe('buildNavigableKeys', () => {
+  it('range les cellules de la matrice par ligne puis par colonne', () => {
+    expect(navigableKeys).toEqual([
+      ['1:2030', '1:2036'],
+      ['2:2030', '2:2036'],
+      ['3:2030', '3:2036'],
+    ]);
+  });
+});
+
+describe('getNextNavKey', () => {
+  it('descend d\'une ligne dans la même colonne', () => {
+    expect(getNextNavKey(navigableKeys, '1:2030', 'down')).toBe('2:2030');
+  });
+
+  it('monte d\'une ligne dans la même colonne', () => {
+    expect(getNextNavKey(navigableKeys, '3:2036', 'up')).toBe('2:2036');
+  });
+
+  it('avance et recule en ordre ligne-major (Tab)', () => {
+    expect(getNextNavKey(navigableKeys, '1:2036', 'next')).toBe('2:2030');
+    expect(getNextNavKey(navigableKeys, '2:2030', 'previous')).toBe('1:2036');
+  });
+
+  it('rend null au bord de la grille', () => {
+    expect(getNextNavKey(navigableKeys, '3:2036', 'down')).toBe(null);
+    expect(getNextNavKey(navigableKeys, '1:2030', 'up')).toBe(null);
+  });
+
+  it('rend null pour une cellule inconnue', () => {
+    expect(getNextNavKey(navigableKeys, '9:2030', 'down')).toBe(null);
+  });
+});

--- a/apps/app/src/indicateurs/valeurs/grid/keyboard-navigation/grid-navigation.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/keyboard-navigation/grid-navigation.ts
@@ -1,0 +1,79 @@
+import { match } from 'ts-pattern';
+import { toDisplayRows } from '../grid-model';
+import { generateCellKey, CellKey, GridRowGroup, Year } from '../types';
+
+export type NavDirection = 'up' | 'down' | 'next' | 'previous';
+
+export const buildNavigableKeys = ({
+  groups,
+  years,
+}: {
+  groups: GridRowGroup[];
+  years: Year[];
+}): CellKey[][] =>
+  toDisplayRows(groups).map((displayRow) =>
+    years.map((year) => generateCellKey(displayRow.indicateurId, year))
+  );
+
+type CellPosition = { row: number; col: number };
+
+const findCellPosition = (
+  navigableKeys: CellKey[][],
+  key: CellKey
+): CellPosition | null => {
+  const row = navigableKeys.findIndex((rowKeys) => rowKeys.includes(key));
+  if (row === -1) {
+    return null;
+  }
+  return { row, col: navigableKeys[row].indexOf(key) };
+};
+
+const goUp = (
+  navigableKeys: CellKey[][],
+  { row, col }: CellPosition
+): CellKey | null => navigableKeys[row - 1]?.[col] ?? null;
+
+const goDown = (
+  navigableKeys: CellKey[][],
+  { row, col }: CellPosition
+): CellKey | null => navigableKeys[row + 1]?.[col] ?? null;
+
+const goNext = (
+  navigableKeys: CellKey[][],
+  { row, col }: CellPosition
+): CellKey | null => {
+  const nextInRow = navigableKeys[row][col + 1];
+  if (nextInRow !== undefined) {
+    return nextInRow;
+  }
+  return navigableKeys[row + 1]?.[0] ?? null;
+};
+
+const goPrevious = (
+  navigableKeys: CellKey[][],
+  { row, col }: CellPosition
+): CellKey | null => {
+  const previousInRow = navigableKeys[row][col - 1];
+  if (previousInRow !== undefined) {
+    return previousInRow;
+  }
+  const previousRow = navigableKeys[row - 1];
+  return previousRow?.[previousRow.length - 1] ?? null;
+};
+
+export const getNextNavKey = (
+  navigableKeys: CellKey[][],
+  fromKey: CellKey,
+  direction: NavDirection
+): CellKey | null => {
+  const position = findCellPosition(navigableKeys, fromKey);
+  if (position === null) {
+    return null;
+  }
+  return match(direction)
+    .with('up', () => goUp(navigableKeys, position))
+    .with('down', () => goDown(navigableKeys, position))
+    .with('next', () => goNext(navigableKeys, position))
+    .with('previous', () => goPrevious(navigableKeys, position))
+    .exhaustive();
+};

--- a/apps/app/src/indicateurs/valeurs/grid/keyboard-navigation/keyboard-nav.spec.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/keyboard-navigation/keyboard-nav.spec.tsx
@@ -1,0 +1,204 @@
+import {
+  cleanup,
+  createEvent,
+  fireEvent,
+  render,
+} from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { IndicateurValuesGrid } from '../indicateur-values-grid';
+import { fakeGridActions } from '../__tests__/grid-fixtures';
+import {
+  generateCellKey,
+  CellKey,
+  GridCell,
+  GridRowGroup,
+  IndicateurValuesGridActions,
+  toIndicateurId,
+  toYear,
+} from '../types';
+
+afterEach(cleanup);
+
+const years = [2030, 2036].map(toYear);
+
+const groups: GridRowGroup[] = [
+  {
+    id: 'g',
+    label: 'G',
+    rows: [
+      { indicateurId: toIndicateurId(1), label: 'A' },
+      { indicateurId: toIndicateurId(2), label: 'B' },
+      { indicateurId: toIndicateurId(3), label: 'C' },
+    ],
+  },
+];
+
+const userData: GridCell = { kind: 'user-data', value: null, coveringSources: [] };
+const openData: GridCell = {
+  kind: 'open-data',
+  value: 5,
+  adoptedSourceId: 's',
+  source: { sourceId: 's', libelle: 'S', methodologie: null, dateVersion: '2026-01-01' },
+};
+
+const cells = new Map<CellKey, GridCell>([
+  [generateCellKey(toIndicateurId(1), toYear(2030)), userData],
+  [generateCellKey(toIndicateurId(1), toYear(2036)), userData],
+  [generateCellKey(toIndicateurId(2), toYear(2030)), openData],
+  [generateCellKey(toIndicateurId(2), toYear(2036)), userData],
+  [generateCellKey(toIndicateurId(3), toYear(2030)), userData],
+  [generateCellKey(toIndicateurId(3), toYear(2036)), userData],
+]);
+
+const renderGrid = (
+  actions: IndicateurValuesGridActions = fakeGridActions
+): HTMLElement =>
+  render(
+    <IndicateurValuesGrid
+      groups={groups}
+      years={years}
+      cells={cells}
+      actions={actions}
+    />
+  ).container;
+
+const cellInput = (container: HTMLElement, key: string): HTMLElement => {
+  const input = container.querySelector<HTMLElement>(`[data-cell-id="${key}"]`);
+  if (input === null) {
+    throw new Error(`no cell input for ${key}`);
+  }
+  return input;
+};
+
+const focusedCellId = (): string | null =>
+  document.activeElement?.getAttribute('data-cell-id') ?? null;
+
+describe('IndicateurValuesGrid keyboard navigation', () => {
+  it('ArrowDown déplace le focus vers la cellule dessous, open-data comprise', () => {
+    const container = renderGrid();
+    const first = cellInput(container, '1:2030');
+    first.focus();
+
+    fireEvent.keyDown(first, { key: 'ArrowDown' });
+
+    expect(focusedCellId()).toBe('2:2030');
+  });
+
+  it('Tab déplace vers la cellule navigable suivante', () => {
+    const container = renderGrid();
+    const cell = cellInput(container, '1:2036');
+    cell.focus();
+
+    fireEvent.keyDown(cell, { key: 'Tab' });
+
+    expect(focusedCellId()).toBe('2:2030');
+  });
+
+  it('Enter enregistre la valeur puis descend', () => {
+    const saveCellValue = vi.fn().mockResolvedValue({ ok: true, value: undefined });
+    const container = renderGrid({ ...fakeGridActions, saveCellValue });
+    const first = cellInput(container, '1:2030');
+    first.focus();
+
+    fireEvent.change(first, { target: { value: '5' } });
+    fireEvent.keyDown(first, { key: 'Enter' });
+
+    expect(saveCellValue).toHaveBeenCalledWith(
+      expect.objectContaining({ resultat: 5 })
+    );
+    expect(focusedCellId()).toBe('2:2030');
+  });
+
+  it('Tab sur la dernière cellule ne piège pas le focus', () => {
+    const container = renderGrid();
+    const last = cellInput(container, '3:2036');
+    last.focus();
+
+    const event = createEvent.keyDown(last, { key: 'Tab' });
+    fireEvent(last, event);
+
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('établit un roving tabindex : une seule cellule tabbable', () => {
+    const container = renderGrid();
+    const tabbable = Array.from(
+      container.querySelectorAll('[data-cell-id]')
+    ).filter((input) => input.getAttribute('tabindex') === '0');
+
+    expect(tabbable).toHaveLength(1);
+  });
+
+  it('préserve le roving tabindex quand la map cells est reconstruite', () => {
+    const { container, rerender } = render(
+      <IndicateurValuesGrid
+        groups={groups}
+        years={years}
+        cells={cells}
+        actions={fakeGridActions}
+      />
+    );
+    const target = cellInput(container, '3:2036');
+    target.focus();
+
+    rerender(
+      <IndicateurValuesGrid
+        groups={groups}
+        years={years}
+        cells={new Map(cells)}
+        actions={fakeGridActions}
+      />
+    );
+
+    expect(target.getAttribute('tabindex')).toBe('0');
+  });
+
+  it('rétablit une cellule tabbable après remplacement du nœud tabbable', () => {
+    const { container, rerender } = render(
+      <IndicateurValuesGrid
+        groups={groups}
+        years={years}
+        cells={cells}
+        actions={fakeGridActions}
+      />
+    );
+    cellInput(container, '1:2030').focus();
+
+    const swapped = new Map(cells);
+    swapped.set(generateCellKey(toIndicateurId(1), toYear(2030)), openData);
+    rerender(
+      <IndicateurValuesGrid
+        groups={groups}
+        years={years}
+        cells={swapped}
+        actions={fakeGridActions}
+      />
+    );
+
+    const tabbable = Array.from(
+      container.querySelectorAll('[data-cell-id]')
+    ).filter((cell) => cell.getAttribute('tabindex') === '0');
+    expect(tabbable).toHaveLength(1);
+  });
+
+  it('ne piège pas le focus quand la cellule cible est absente de la grille', () => {
+    const sparseCells = new Map(cells);
+    sparseCells.delete(generateCellKey(toIndicateurId(2), toYear(2030)));
+    const container = render(
+      <IndicateurValuesGrid
+        groups={groups}
+        years={years}
+        cells={sparseCells}
+        actions={fakeGridActions}
+      />
+    ).container;
+    const first = cellInput(container, '1:2030');
+    first.focus();
+
+    const event = createEvent.keyDown(first, { key: 'ArrowDown' });
+    fireEvent(first, event);
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(focusedCellId()).toBe('1:2030');
+  });
+});

--- a/apps/app/src/indicateurs/valeurs/grid/keyboard-navigation/use-grid-keyboard-nav.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/keyboard-navigation/use-grid-keyboard-nav.ts
@@ -1,0 +1,109 @@
+import {
+  FocusEvent,
+  KeyboardEvent,
+  RefObject,
+  useCallback,
+  useEffect,
+  useMemo,
+} from 'react';
+import {
+  buildNavigableKeys,
+  getNextNavKey,
+  NavDirection,
+} from './grid-navigation';
+import { GridRowGroup, isCellKey, Year } from '../types';
+
+const CELL_ATTRIBUTE = 'data-cell-id';
+
+const getNavDirection = (event: KeyboardEvent): NavDirection | null => {
+  if (event.key === 'ArrowDown') return 'down';
+  if (event.key === 'ArrowUp') return 'up';
+  if (event.key === 'Enter') return event.shiftKey ? 'up' : 'down';
+  if (event.key === 'Tab') return event.shiftKey ? 'previous' : 'next';
+  return null;
+};
+
+const getFocusableCells = (container: HTMLElement): HTMLElement[] =>
+  Array.from(container.querySelectorAll<HTMLElement>(`[${CELL_ATTRIBUTE}]`));
+
+export const useGridKeyboardNav = ({
+  containerRef,
+  groups,
+  years,
+}: {
+  containerRef: RefObject<HTMLElement | null>;
+  groups: GridRowGroup[];
+  years: Year[];
+}): {
+  onKeyDown: (event: KeyboardEvent) => void;
+  onFocus: (event: FocusEvent<HTMLElement>) => void;
+} => {
+  const navigableKeys = useMemo(
+    () => buildNavigableKeys({ groups, years }),
+    [groups, years]
+  );
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (container === null) {
+      return;
+    }
+    const cells = getFocusableCells(container);
+    const hasTabbableCell = cells.some(
+      (cell) => cell.getAttribute('tabindex') === '0'
+    );
+    if (cells.length === 0 || hasTabbableCell) {
+      return;
+    }
+    cells.forEach((cell, index) =>
+      cell.setAttribute('tabindex', index === 0 ? '0' : '-1')
+    );
+  });
+
+  const onKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      const container = containerRef.current;
+      const target = event.target;
+      if (container === null || !(target instanceof HTMLElement)) {
+        return;
+      }
+      const fromKey = target.getAttribute(CELL_ATTRIBUTE);
+      const direction = getNavDirection(event);
+      if (!isCellKey(fromKey) || direction === null) {
+        return;
+      }
+      const toKey = getNextNavKey(navigableKeys, fromKey, direction);
+      if (toKey === null) {
+        return;
+      }
+      const toCell = container.querySelector<HTMLElement>(
+        `[${CELL_ATTRIBUTE}="${toKey}"]`
+      );
+      if (toCell === null) {
+        return;
+      }
+      event.preventDefault();
+      toCell.focus();
+    },
+    [containerRef, navigableKeys]
+  );
+
+  const onFocus = useCallback(
+    (event: FocusEvent<HTMLElement>) => {
+      const container = containerRef.current;
+      const focused = event.target;
+      if (container === null || !(focused instanceof HTMLElement)) {
+        return;
+      }
+      if (focused.getAttribute(CELL_ATTRIBUTE) === null) {
+        return;
+      }
+      getFocusableCells(container).forEach((cell) =>
+        cell.setAttribute('tabindex', cell === focused ? '0' : '-1')
+      );
+    },
+    [containerRef]
+  );
+
+  return { onKeyDown, onFocus };
+};

--- a/apps/app/src/indicateurs/valeurs/grid/open-data-cell.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/open-data-cell.tsx
@@ -1,13 +1,47 @@
-import { JSX, memo } from 'react';
+import { JSX, memo, ReactNode } from 'react';
 import { ProvenanceBadge } from './provenance-badge';
-import { SourceInfo } from './types';
+import { generateCellKey, CellKey, IndicateurId, SourceInfo, Year } from './types';
+
+type FocusableCellProps = {
+  cellId: CellKey;
+  ariaLabel: string;
+  children: ReactNode;
+};
+
+const FocusableCell = ({
+  cellId,
+  ariaLabel,
+  children,
+}: FocusableCellProps): JSX.Element => (
+  <div
+    data-cell-id={cellId}
+    aria-label={ariaLabel}
+    className="flex h-full items-center justify-between gap-1 bg-success-2 px-3 text-sm outline-none focus:ring-2 focus:ring-inset focus:ring-primary-5"
+  >
+    {children}
+  </div>
+);
+
+type OpenDataCellProps = {
+  value: number;
+  source: SourceInfo;
+  ariaLabel: string;
+  indicateurId: IndicateurId;
+  year: Year;
+};
 
 export const OpenDataCell = memo(
-  ({ value, source }: { value: number; source: SourceInfo }): JSX.Element => (
-    <div className="flex h-full items-center justify-between gap-1 bg-success-2 px-3 text-sm">
+  ({
+    value,
+    source,
+    ariaLabel,
+    indicateurId,
+    year,
+  }: OpenDataCellProps): JSX.Element => (
+    <FocusableCell cellId={generateCellKey(indicateurId, year)} ariaLabel={ariaLabel}>
       <ProvenanceBadge source={source} />
       <span className="text-success-1">{value}</span>
-    </div>
+    </FocusableCell>
   )
 );
 

--- a/apps/app/src/indicateurs/valeurs/grid/row-header.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/row-header.tsx
@@ -5,6 +5,7 @@ export const RowHeader = memo(
   ({ label }: { label: string }): JSX.Element => (
     <th
       scope="row"
+      role="rowheader"
       className="border border-grey-3 bg-white p-2 text-left font-medium text-primary-9"
     >
       <div className="flex items-center gap-1">

--- a/apps/app/src/indicateurs/valeurs/grid/types.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/types.ts
@@ -7,10 +7,13 @@ declare const yearBrand: unique symbol;
 export type Year = number & { readonly [yearBrand]: true };
 export const toYear = (value: number): Year => value as Year;
 
-export type CellKey = string;
+export type CellKey = `${number}:${number}`;
 
-export const cellKey = (indicateurId: IndicateurId, year: Year): CellKey =>
-  `${indicateurId}:${year}`;
+export const generateCellKey = (indicateurId: IndicateurId, year: Year): CellKey =>
+  `${indicateurId}:${year}` as CellKey;
+
+export const isCellKey = (value: string | null): value is CellKey =>
+  value !== null && /^\d+:\d+$/.test(value);
 
 export type SourceInfo = {
   sourceId: string;

--- a/apps/app/src/indicateurs/valeurs/grid/use-get-table.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/use-get-table.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import {
+  createColumnHelper,
+  getCoreRowModel,
+  Table,
+  useReactTable,
+} from '@tanstack/react-table';
+import { JSX, RefObject, useMemo, useRef } from 'react';
+import { appLabels } from '@/app/labels/catalog';
+import { useGridContext } from './grid-context';
+import { findCell, GridDisplayRow, toDisplayRows } from './grid-model';
+import { OpenDataCell } from './open-data-cell';
+import { UserDataCell } from './user-data-cell';
+import {
+  GridCell,
+  GridRowGroup,
+  IndicateurId,
+  IndicateurValuesGridActions,
+  Year,
+} from './types';
+
+const columnHelper = createColumnHelper<GridDisplayRow>();
+
+const EmptyCell = (): JSX.Element => <div className="h-full bg-grey-1" />;
+
+const renderCell = ({
+  cell,
+  indicateurId,
+  year,
+  rowLabel,
+  saveCellValue,
+}: {
+  cell: GridCell | null;
+  indicateurId: IndicateurId;
+  year: Year;
+  rowLabel: string;
+  saveCellValue: IndicateurValuesGridActions['saveCellValue'];
+}): JSX.Element => {
+  if (cell === null) {
+    return <EmptyCell />;
+  }
+  if (cell.kind === 'open-data') {
+    return (
+      <OpenDataCell
+        value={cell.value}
+        source={cell.source}
+        ariaLabel={appLabels.indicateurCelluleOpenData({
+          rowLabel,
+          year,
+          value: cell.value,
+          source: cell.source.libelle,
+        })}
+        indicateurId={indicateurId}
+        year={year}
+      />
+    );
+  }
+  return (
+    <UserDataCell
+      cell={cell}
+      ariaLabel={appLabels.indicateurCellule(rowLabel, year)}
+      indicateurId={indicateurId}
+      year={year}
+      saveCellValue={saveCellValue}
+    />
+  );
+};
+
+export const useGetTable = ({
+  groups,
+  years,
+}: {
+  groups: GridRowGroup[];
+  years: Year[];
+}): {
+  table: Table<GridDisplayRow>;
+  tableRef: RefObject<HTMLTableElement | null>;
+} => {
+  const { cells, actions } = useGridContext();
+
+  const displayRows = useMemo<GridDisplayRow[]>(
+    () => toDisplayRows(groups),
+    [groups]
+  );
+
+  const columns = useMemo(
+    () =>
+      years.map((year) =>
+        columnHelper.display({
+          id: `year-${year}`,
+          cell: ({ row }) =>
+            renderCell({
+              cell: findCell({
+                cells,
+                indicateurId: row.original.indicateurId,
+                year,
+              }),
+              indicateurId: row.original.indicateurId,
+              year,
+              rowLabel: row.original.rowLabel,
+              saveCellValue: actions.saveCellValue,
+            }),
+        })
+      ),
+    [years, cells, actions.saveCellValue]
+  );
+
+  const table = useReactTable({
+    data: displayRows,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  });
+
+  const tableRef = useRef<HTMLTableElement>(null);
+
+  return { table, tableRef };
+};

--- a/apps/app/src/indicateurs/valeurs/grid/user-data-cell.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/user-data-cell.tsx
@@ -4,6 +4,7 @@ import { CoverageDot } from './coverage-dot';
 import { SaveAck } from './save-ack';
 import { useCellEdit } from './use-cell-edit';
 import {
+  generateCellKey,
   GridCell,
   IndicateurId,
   IndicateurValuesGridActions,
@@ -42,6 +43,7 @@ export const UserDataCell = memo(
     return (
       <div className="relative h-full">
         <CellInput
+          cellId={generateCellKey(indicateurId, year)}
           value={text}
           ariaLabel={ariaLabel}
           hasError={status === 'error'}

--- a/apps/app/src/indicateurs/valeurs/grid/year-column-header.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/year-column-header.tsx
@@ -12,6 +12,7 @@ export const YearColumnHeader = memo(
   ({ year, unit, isReference }: YearColumnHeaderProps): JSX.Element => (
     <th
       scope="col"
+      role="columnheader"
       className="sticky top-0 z-20 min-w-[140px] border border-grey-3 bg-grey-1 p-2 text-right font-bold text-primary-9"
     >
       <div className="flex flex-col items-end">

--- a/apps/app/src/labels/catalog.ts
+++ b/apps/app/src/labels/catalog.ts
@@ -1727,6 +1727,20 @@ export const appLabels = {
   collectiviteIdInvalide: 'Identifiant de collectivité invalide',
   uneErreurEstSurvenue: 'Une erreur est survenue',
   indicateurValeurEnregistree: 'Enregistré',
+  indicateurValeursGrille: 'Valeurs des indicateurs',
+  indicateurCellule: (rowLabel: string, year: number): string =>
+    `${rowLabel}, ${year}`,
+  indicateurCelluleOpenData: ({
+    rowLabel,
+    year,
+    value,
+    source,
+  }: {
+    rowLabel: string;
+    year: number;
+    value: number;
+    source: string;
+  }): string => `${rowLabel}, ${year} : ${value} (open data, source ${source})`,
 
   acteEngagementDocUrl: '/Acte_engagement.docx',
   reglementLabelUrl: ({


### PR DESCRIPTION
## Navigation clavier tableur de la grille de saisie

Ajoute la navigation clavier type tableur à la grille de saisie des indicateurs (PAN 1 — frontend agnostique, `apps/app/src/indicateurs/valeurs/grid/`).

### Comportement
- Flèches ↑↓ : même colonne, ligne ±1. Tab / Shift+Tab : ordre de lecture avec passage de ligne. Enter / Shift+Enter : descend / monte.
- La grille étant toujours pleine, **toutes les cellules sont navigables**, y compris open-data (lecture seule) — focusables, focus visible, `aria-label` valeur + provenance.
- Roving tabindex : exactement une cellule tabbable, ré-établie en invariant après chaque rendu ; guard anti-piège si la cible est absente du DOM.

### Implémentation
- `buildNavigableKeys` → `CellKey[][]` (matrice 2D ligne × colonne) ; `getNextNavKey` résout la position `[ligne][colonne]` et se déplace via un `match` ts-pattern (`goUp` / `goDown` / `goNext` / `goPrevious`).
- Construction react-table isolée dans le hook `useGetTable`.
- `cellKey` renommé `generateCellKey`.
- Fichiers de navigation regroupés dans `keyboard-navigation/`.

### Tests
- `grid-navigation.spec.ts` : mouvements, bords, matrice.
- `keyboard-nav.spec.tsx` : roving tabindex, non-piège du focus, cellule tabbable ré-établie après remontage.
