### PR TITLE
feat(indicateurs): collage tableur dans la grille de saisie

### DIFF
--- a/apps/app/src/indicateurs/valeurs/grid/__tests__/indicateur-values-grid.stories.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/__tests__/indicateur-values-grid.stories.tsx
@@ -8,7 +8,13 @@ import {
   fakeYears,
 } from './grid-fixtures';
 import { IndicateurValuesGrid } from '../indicateur-values-grid';
-import { generateCellKey, CellKey, GridCell, IndicateurValuesGridActions } from '../types';
+import {
+  generateCellKey,
+  CellKey,
+  CellValueInput,
+  GridCell,
+  IndicateurValuesGridActions,
+} from '../types';
 
 const meta: Meta<typeof IndicateurValuesGrid> = {
   title: 'Indicateurs/Grille de saisie',
@@ -19,27 +25,50 @@ export default meta;
 
 type Story = StoryObj<typeof IndicateurValuesGrid>;
 
+const withValues = (
+  previous: Map<CellKey, GridCell>,
+  inputs: CellValueInput[]
+): Map<CellKey, GridCell> => {
+  const next = new Map(previous);
+  inputs.forEach(({ indicateurId, valueId, year, resultat }) => {
+    const key = generateCellKey(indicateurId, year);
+    const current = next.get(key);
+    const coveringSources =
+      current?.kind === 'user-data' ? current.coveringSources : [];
+    const nextValueId = valueId ?? indicateurId * 1000 + year;
+    next.set(
+      key,
+      resultat === null
+        ? { kind: 'user-data', value: null, valueId: nextValueId, coveringSources }
+        : {
+            kind: 'user-data',
+            value: resultat,
+            valueId: nextValueId,
+            coveringSources,
+          }
+    );
+  });
+  return next;
+};
+
 const InteractiveGrid = (): JSX.Element => {
   const [cells, setCells] = useState<Map<CellKey, GridCell>>(() => fakeCells());
   const actions = useMemo<IndicateurValuesGridActions>(
     () => ({
       ...fakeGridActions,
-      saveCellValue: async ({ indicateurId, valueId, year, resultat }) => {
-        setCells((previous) => {
-          const key = generateCellKey(indicateurId, year);
-          const current = previous.get(key);
-          const coveringSources =
-            current?.kind === 'user-data' ? current.coveringSources : [];
-          const nextValueId = valueId ?? indicateurId * 1000 + year;
-          const updatedCell: GridCell =
-            resultat === null
-              ? { kind: 'user-data', value: null, valueId: nextValueId, coveringSources }
-              : { kind: 'user-data', value: resultat, valueId: nextValueId, coveringSources };
-          const next = new Map(previous);
-          next.set(key, updatedCell);
-          return next;
-        });
+      saveCellValue: async (input) => {
+        setCells((previous) => withValues(previous, [input]));
         return { ok: true, value: undefined };
+      },
+      saveCellValues: async (inputs) => {
+        window.alert(
+          `Collage : ${inputs.length} valeur(s) ecrite(s)\n` +
+            inputs
+              .map((input) => `${input.indicateurId} / ${input.year} = ${input.resultat}`)
+              .join('\n')
+        );
+        setCells((previous) => withValues(previous, inputs));
+        return { ok: true, value: { written: inputs.length, failed: [] } };
       },
     }),
     []
@@ -52,6 +81,7 @@ const InteractiveGrid = (): JSX.Element => {
       unit="t/an"
       cells={cells}
       actions={actions}
+      notify={(message) => window.alert(message)}
     />
   );
 };

--- a/apps/app/src/indicateurs/valeurs/grid/__tests__/parse-cell-key.spec.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/__tests__/parse-cell-key.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import {
+  generateCellKey,
+  isCellKey,
+  parseCellKey,
+  toIndicateurId,
+  toYear,
+} from '../types';
+
+describe('parseCellKey', () => {
+  it('fait le round-trip inverse de generateCellKey', () => {
+    const key = generateCellKey(toIndicateurId(12), toYear(2030));
+    expect(parseCellKey(key)).toEqual({ indicateurId: 12, year: 2030 });
+  });
+});
+
+describe('isCellKey', () => {
+  it('accepte une clé bien formée', () => {
+    expect(isCellKey('12:2030')).toBe(true);
+  });
+
+  it('rejette null, un séparateur manquant, une partie vide ou non numérique', () => {
+    expect(isCellKey(null)).toBe(false);
+    expect(isCellKey('12')).toBe(false);
+    expect(isCellKey(':2030')).toBe(false);
+    expect(isCellKey('12:')).toBe(false);
+    expect(isCellKey('a:2030')).toBe(false);
+    expect(isCellKey('12:2030:x')).toBe(false);
+  });
+});

--- a/apps/app/src/indicateurs/valeurs/grid/grid-context.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/grid-context.tsx
@@ -17,6 +17,7 @@ export type GridContextValue = {
   cells: Map<CellKey, GridCell>;
   isLoading: boolean;
   actions: IndicateurValuesGridActions;
+  notify?: (message: string) => void;
 };
 
 const GridContext = createContext<GridContextValue | null>(null);
@@ -30,10 +31,11 @@ export const GridProvider = ({
   cells,
   isLoading,
   actions,
+  notify,
 }: GridContextValue & { children: ReactNode }): JSX.Element => {
   const value = useMemo<GridContextValue>(
-    () => ({ groups, years, referenceYear, unit, cells, isLoading, actions }),
-    [groups, years, referenceYear, unit, cells, isLoading, actions]
+    () => ({ groups, years, referenceYear, unit, cells, isLoading, actions, notify }),
+    [groups, years, referenceYear, unit, cells, isLoading, actions, notify]
   );
   return <GridContext.Provider value={value}>{children}</GridContext.Provider>;
 };

--- a/apps/app/src/indicateurs/valeurs/grid/grid-frame.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/grid-frame.tsx
@@ -6,17 +6,26 @@ import { appLabels } from '@/app/labels/catalog';
 import { useGridContext } from './grid-context';
 import { useGetTable } from './use-get-table';
 import { useGridKeyboardNav } from './keyboard-navigation/use-grid-keyboard-nav';
+import { useGridCopyPaste } from './paste/use-grid-copy-paste';
 import { GroupRowHeader } from './group-row-header';
 import { RowHeader } from './row-header';
 import { YearColumnHeader } from './year-column-header';
 
 export const GridFrame = (): JSX.Element => {
-  const { groups, years, referenceYear, unit } = useGridContext();
+  const { groups, years, referenceYear, unit, cells, actions, notify } =
+    useGridContext();
   const { table, tableRef } = useGetTable({ groups, years });
   const { onKeyDown, onFocus } = useGridKeyboardNav({
     containerRef: tableRef,
     groups,
     years,
+  });
+  const { onPaste } = useGridCopyPaste({
+    groups,
+    years,
+    cells,
+    saveCellValues: actions.saveCellValues,
+    notify,
   });
 
   return (
@@ -25,6 +34,7 @@ export const GridFrame = (): JSX.Element => {
         ref={tableRef}
         onKeyDown={onKeyDown}
         onFocus={onFocus}
+        onPasteCapture={onPaste}
         aria-label={appLabels.indicateurValeursGrille}
         className="w-full border-collapse text-sm"
         role="grid"

--- a/apps/app/src/indicateurs/valeurs/grid/indicateur-values-grid.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/indicateur-values-grid.tsx
@@ -19,6 +19,7 @@ export type IndicateurValuesGridProps = {
   cells: Map<CellKey, GridCell>;
   isLoading?: boolean;
   actions: IndicateurValuesGridActions;
+  notify?: (message: string) => void;
 };
 
 export const IndicateurValuesGrid = ({
@@ -29,6 +30,7 @@ export const IndicateurValuesGrid = ({
   cells,
   isLoading = false,
   actions,
+  notify,
 }: IndicateurValuesGridProps): JSX.Element => (
   <GridProvider
     groups={groups}
@@ -38,6 +40,7 @@ export const IndicateurValuesGrid = ({
     cells={cells}
     isLoading={isLoading}
     actions={actions}
+    notify={notify}
   >
     <div className="rounded-xl border border-grey-3 bg-white p-4">
       <GridFrame />

--- a/apps/app/src/indicateurs/valeurs/grid/keyboard-navigation/use-grid-keyboard-nav.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/keyboard-navigation/use-grid-keyboard-nav.ts
@@ -11,9 +11,7 @@ import {
   getNextNavKey,
   NavDirection,
 } from './grid-navigation';
-import { GridRowGroup, isCellKey, Year } from '../types';
-
-const CELL_ATTRIBUTE = 'data-cell-id';
+import { CELL_ID_ATTRIBUTE, GridRowGroup, isCellKey, Year } from '../types';
 
 const getNavDirection = (event: KeyboardEvent): NavDirection | null => {
   if (event.key === 'ArrowDown') return 'down';
@@ -24,7 +22,7 @@ const getNavDirection = (event: KeyboardEvent): NavDirection | null => {
 };
 
 const getFocusableCells = (container: HTMLElement): HTMLElement[] =>
-  Array.from(container.querySelectorAll<HTMLElement>(`[${CELL_ATTRIBUTE}]`));
+  Array.from(container.querySelectorAll<HTMLElement>(`[${CELL_ID_ATTRIBUTE}]`));
 
 export const useGridKeyboardNav = ({
   containerRef,
@@ -67,7 +65,7 @@ export const useGridKeyboardNav = ({
       if (container === null || !(target instanceof HTMLElement)) {
         return;
       }
-      const fromKey = target.getAttribute(CELL_ATTRIBUTE);
+      const fromKey = target.getAttribute(CELL_ID_ATTRIBUTE);
       const direction = getNavDirection(event);
       if (!isCellKey(fromKey) || direction === null) {
         return;
@@ -77,7 +75,7 @@ export const useGridKeyboardNav = ({
         return;
       }
       const toCell = container.querySelector<HTMLElement>(
-        `[${CELL_ATTRIBUTE}="${toKey}"]`
+        `[${CELL_ID_ATTRIBUTE}="${toKey}"]`
       );
       if (toCell === null) {
         return;
@@ -95,7 +93,7 @@ export const useGridKeyboardNav = ({
       if (container === null || !(focused instanceof HTMLElement)) {
         return;
       }
-      if (focused.getAttribute(CELL_ATTRIBUTE) === null) {
+      if (focused.getAttribute(CELL_ID_ATTRIBUTE) === null) {
         return;
       }
       getFocusableCells(container).forEach((cell) =>

--- a/apps/app/src/indicateurs/valeurs/grid/paste/grid-paste.spec.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/paste/grid-paste.spec.tsx
@@ -1,0 +1,108 @@
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { appLabels } from '../../../../labels/catalog';
+import { IndicateurValuesGrid } from '../indicateur-values-grid';
+import { fakeGridActions } from '../__tests__/grid-fixtures';
+import {
+  generateCellKey,
+  CellKey,
+  GridCell,
+  GridRowGroup,
+  IndicateurValuesGridActions,
+  toIndicateurId,
+  toYear,
+} from '../types';
+
+afterEach(cleanup);
+
+const years = [2030, 2036].map(toYear);
+
+const groups: GridRowGroup[] = [
+  {
+    id: 'g',
+    label: 'G',
+    rows: [
+      { indicateurId: toIndicateurId(1), label: 'A' },
+      { indicateurId: toIndicateurId(2), label: 'B' },
+    ],
+  },
+];
+
+const userData: GridCell = { kind: 'user-data', value: null, coveringSources: [] };
+const openData: GridCell = {
+  kind: 'open-data',
+  value: 5,
+  adoptedSourceId: 's',
+  source: { sourceId: 's', libelle: 'S', methodologie: null, dateVersion: '2026-01-01' },
+};
+
+const cells = new Map<CellKey, GridCell>([
+  [generateCellKey(toIndicateurId(1), toYear(2030)), userData],
+  [generateCellKey(toIndicateurId(1), toYear(2036)), userData],
+  [generateCellKey(toIndicateurId(2), toYear(2030)), openData],
+  [generateCellKey(toIndicateurId(2), toYear(2036)), userData],
+]);
+
+const renderGrid = (
+  actions: IndicateurValuesGridActions,
+  notify: (message: string) => void
+): HTMLElement =>
+  render(
+    <IndicateurValuesGrid
+      groups={groups}
+      years={years}
+      cells={cells}
+      actions={actions}
+      notify={notify}
+    />
+  ).container;
+
+const cellInput = (container: HTMLElement, key: string): HTMLElement => {
+  const input = container.querySelector<HTMLElement>(`[data-cell-id="${key}"]`);
+  if (input === null) {
+    throw new Error(`no cell input for ${key}`);
+  }
+  return input;
+};
+
+describe('IndicateurValuesGrid paste', () => {
+  it('colle un bloc via saveCellValues et signale les cellules ignorees par un toast', async () => {
+    const saveCellValues = vi
+      .fn()
+      .mockResolvedValue({ ok: true, value: { written: 4, failed: [] } });
+    const notify = vi.fn();
+    const container = renderGrid({ ...fakeGridActions, saveCellValues }, notify);
+    const anchor = cellInput(container, '1:2030');
+    anchor.focus();
+
+    fireEvent.paste(anchor, {
+      clipboardData: { getData: () => '10\t20\n30\t40\n50\t60' },
+    });
+
+    await waitFor(() => expect(saveCellValues).toHaveBeenCalledTimes(1));
+    expect(saveCellValues.mock.calls[0][0]).toEqual([
+      { indicateurId: toIndicateurId(1), valueId: undefined, year: toYear(2030), resultat: 10 },
+      { indicateurId: toIndicateurId(1), valueId: undefined, year: toYear(2036), resultat: 20 },
+      { indicateurId: toIndicateurId(2), valueId: undefined, year: toYear(2030), resultat: 30 },
+      { indicateurId: toIndicateurId(2), valueId: undefined, year: toYear(2036), resultat: 40 },
+    ]);
+    expect(notify).toHaveBeenCalledWith(
+      appLabels.indicateurCollageIgnore({ count: 2 })
+    );
+  });
+
+  it("n'appelle pas le toast quand tout le collage aboutit", async () => {
+    const saveCellValues = vi
+      .fn()
+      .mockResolvedValue({ ok: true, value: { written: 1, failed: [] } });
+    const notify = vi.fn();
+    const container = renderGrid({ ...fakeGridActions, saveCellValues }, notify);
+    const anchor = cellInput(container, '1:2036');
+    anchor.focus();
+
+    fireEvent.paste(anchor, { clipboardData: { getData: () => '7' } });
+
+    await waitFor(() => expect(saveCellValues).toHaveBeenCalledTimes(1));
+    expect(notify).not.toHaveBeenCalled();
+  });
+});

--- a/apps/app/src/indicateurs/valeurs/grid/paste/paste-values.spec.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/paste/paste-values.spec.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+import { pasteValues } from './paste-values';
+import {
+  generateCellKey,
+  CellKey,
+  GridCell,
+  GridRowGroup,
+  toIndicateurId,
+  toYear,
+} from '../types';
+
+const years = [2030, 2036].map(toYear);
+
+const groups: GridRowGroup[] = [
+  {
+    id: 'g',
+    label: 'G',
+    rows: [
+      { indicateurId: toIndicateurId(1), label: 'A' },
+      { indicateurId: toIndicateurId(2), label: 'B' },
+      { indicateurId: toIndicateurId(3), label: 'C' },
+    ],
+  },
+];
+
+const userData: GridCell = { kind: 'user-data', value: null, coveringSources: [] };
+const openData: GridCell = {
+  kind: 'open-data',
+  value: 5,
+  adoptedSourceId: 's',
+  source: { sourceId: 's', libelle: 'S', methodologie: null, dateVersion: '2026-01-01' },
+};
+
+const cells = new Map<CellKey, GridCell>([
+  [generateCellKey(toIndicateurId(1), toYear(2030)), userData],
+  [generateCellKey(toIndicateurId(1), toYear(2036)), userData],
+  [generateCellKey(toIndicateurId(2), toYear(2030)), openData],
+  [generateCellKey(toIndicateurId(2), toYear(2036)), userData],
+  [generateCellKey(toIndicateurId(3), toYear(2030)), userData],
+  [generateCellKey(toIndicateurId(3), toYear(2036)), userData],
+]);
+
+const paste = (text: string, anchorId: number, anchorYear: number) =>
+  pasteValues({
+    text,
+    anchorIndicateurId: toIndicateurId(anchorId),
+    anchorYear: toYear(anchorYear),
+    groups,
+    years,
+    cells,
+  });
+
+describe('pasteValues', () => {
+  it('mappe un bloc TSV positionnellement depuis la cellule ancre', () => {
+    const { cellsToWrite, skipped } = paste('10\t20\n30\t40', 1, 2030);
+
+    expect(cellsToWrite).toEqual([
+      { indicateurId: 1, valueId: undefined, year: 2030, resultat: 10 },
+      { indicateurId: 1, valueId: undefined, year: 2036, resultat: 20 },
+      { indicateurId: 2, valueId: undefined, year: 2030, resultat: 30 },
+      { indicateurId: 2, valueId: undefined, year: 2036, resultat: 40 },
+    ]);
+    expect(skipped).toBe(0);
+  });
+
+  it('reecrit une cellule open-data (retour en saisie utilisateur)', () => {
+    const { cellsToWrite, skipped } = paste('7', 2, 2030);
+
+    expect(cellsToWrite).toEqual([
+      { indicateurId: 2, valueId: undefined, year: 2030, resultat: 7 },
+    ]);
+    expect(skipped).toBe(0);
+  });
+
+  it('decoupe un bloc Excel (TSV) et lit les decimales a la virgule', () => {
+    const { cellsToWrite, skipped } = paste('12,5\t8\n3\t4,2', 1, 2030);
+
+    expect(cellsToWrite).toEqual([
+      { indicateurId: 1, valueId: undefined, year: 2030, resultat: 12.5 },
+      { indicateurId: 1, valueId: undefined, year: 2036, resultat: 8 },
+      { indicateurId: 2, valueId: undefined, year: 2030, resultat: 3 },
+      { indicateurId: 2, valueId: undefined, year: 2036, resultat: 4.2 },
+    ]);
+    expect(skipped).toBe(0);
+  });
+
+  it('ne compte pas une cellule vide de padding Excel comme ignoree', () => {
+    const { cellsToWrite, skipped } = paste('5\t', 3, 2030);
+
+    expect(cellsToWrite).toEqual([
+      { indicateurId: 3, valueId: undefined, year: 2030, resultat: 5 },
+    ]);
+    expect(skipped).toBe(0);
+  });
+
+  it('ne decoupe pas un CSV a points-virgules en colonnes', () => {
+    const { cellsToWrite, skipped } = paste('12;8', 1, 2030);
+
+    expect(cellsToWrite).toEqual([]);
+    expect(skipped).toBe(1);
+  });
+
+  it('tolere les espaces irreguliers autour des valeurs', () => {
+    const { cellsToWrite, skipped } = paste('  12,5  \t  8  \n 3 \t 4,2 ', 1, 2030);
+
+    expect(cellsToWrite).toEqual([
+      { indicateurId: 1, valueId: undefined, year: 2030, resultat: 12.5 },
+      { indicateurId: 1, valueId: undefined, year: 2036, resultat: 8 },
+      { indicateurId: 2, valueId: undefined, year: 2030, resultat: 3 },
+      { indicateurId: 2, valueId: undefined, year: 2036, resultat: 4.2 },
+    ]);
+    expect(skipped).toBe(0);
+  });
+
+  it('ignore les cellules hors de la grille', () => {
+    const { cellsToWrite, skipped } = paste('1\t2\n3', 3, 2036);
+
+    expect(cellsToWrite).toEqual([
+      { indicateurId: 3, valueId: undefined, year: 2036, resultat: 1 },
+    ]);
+    expect(skipped).toBe(2);
+  });
+
+  it('ignore une saisie non numerique sans ecraser la cible', () => {
+    const { cellsToWrite, skipped } = paste('abc', 1, 2030);
+
+    expect(cellsToWrite).toEqual([]);
+    expect(skipped).toBe(1);
+  });
+
+  it('rend un resultat vide pour un collage vide', () => {
+    expect(paste('', 1, 2030)).toEqual({ cellsToWrite: [], skipped: 0 });
+  });
+
+  it('rend un resultat vide pour une ancre inconnue', () => {
+    expect(paste('10', 99, 2030)).toEqual({ cellsToWrite: [], skipped: 0 });
+  });
+});

--- a/apps/app/src/indicateurs/valeurs/grid/paste/paste-values.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/paste/paste-values.ts
@@ -1,0 +1,70 @@
+import { findCell, toDisplayRows } from '../grid-model';
+import { parseCellNumber } from '../parse-cell-number';
+import {
+  CellKey,
+  GridCell,
+  GridRowGroup,
+  IndicateurId,
+  CellValueInput,
+  Year,
+} from '../types';
+
+export type PasteOutcome = { cellsToWrite: CellValueInput[]; skipped: number };
+
+const parseClipboard = (text: string): string[][] =>
+  text
+    .replace(/\r\n?/g, '\n')
+    .replace(/\n+$/, '')
+    .split('\n')
+    .map((line) => line.split('\t'));
+
+export const pasteValues = ({
+  text,
+  anchorIndicateurId,
+  anchorYear,
+  groups,
+  years,
+  cells,
+}: {
+  text: string;
+  anchorIndicateurId: IndicateurId;
+  anchorYear: Year;
+  groups: GridRowGroup[];
+  years: Year[];
+  cells: Map<CellKey, GridCell>;
+}): PasteOutcome => {
+  if (text.trim() === '') {
+    return { cellsToWrite: [], skipped: 0 };
+  }
+  const rows = toDisplayRows(groups);
+  const anchorRow = rows.findIndex((row) => row.indicateurId === anchorIndicateurId);
+  const anchorColumn = years.findIndex((year) => year === anchorYear);
+  if (anchorRow === -1 || anchorColumn === -1) {
+    return { cellsToWrite: [], skipped: 0 };
+  }
+  const pasted = parseClipboard(text);
+  const pastedValueCount = pasted.reduce(
+    (total, line) => total + line.filter((raw) => raw.trim() !== '').length,
+    0
+  );
+  const cellsToWrite = pasted.flatMap((line, rowOffset) =>
+    line.flatMap((raw, columnOffset) => {
+      const row = rows[anchorRow + rowOffset];
+      const year = years[anchorColumn + columnOffset];
+      if (row === undefined || year === undefined) {
+        return [];
+      }
+      const cell = findCell({ cells, indicateurId: row.indicateurId, year });
+      if (cell === null) {
+        return [];
+      }
+      const resultat = parseCellNumber(raw);
+      if (resultat === null) {
+        return [];
+      }
+      const valueId = cell.kind === 'user-data' ? cell.valueId : undefined;
+      return [{ indicateurId: row.indicateurId, valueId, year, resultat }];
+    })
+  );
+  return { cellsToWrite, skipped: pastedValueCount - cellsToWrite.length };
+};

--- a/apps/app/src/indicateurs/valeurs/grid/paste/use-grid-copy-paste.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/paste/use-grid-copy-paste.ts
@@ -1,0 +1,65 @@
+import { ClipboardEvent, useCallback } from 'react';
+import { appLabels } from '@/app/labels/catalog';
+import { pasteValues } from './paste-values';
+import {
+  CELL_ID_ATTRIBUTE,
+  CellKey,
+  GridCell,
+  GridRowGroup,
+  IndicateurValuesGridActions,
+  isCellKey,
+  parseCellKey,
+  Year,
+} from '../types';
+
+export const useGridCopyPaste = ({
+  groups,
+  years,
+  cells,
+  saveCellValues,
+  notify,
+}: {
+  groups: GridRowGroup[];
+  years: Year[];
+  cells: Map<CellKey, GridCell>;
+  saveCellValues: IndicateurValuesGridActions['saveCellValues'];
+  notify?: (message: string) => void;
+}): {
+  onPaste: (event: ClipboardEvent<HTMLElement>) => void;
+} => {
+  const onPaste = useCallback(
+    (event: ClipboardEvent<HTMLElement>) => {
+      const target = event.target;
+      if (!(target instanceof HTMLElement)) {
+        return;
+      }
+      const key = target.getAttribute(CELL_ID_ATTRIBUTE);
+      if (!isCellKey(key)) {
+        return;
+      }
+      const anchor = parseCellKey(key);
+      const { cellsToWrite, skipped } = pasteValues({
+        text: event.clipboardData.getData('text/plain'),
+        anchorIndicateurId: anchor.indicateurId,
+        anchorYear: anchor.year,
+        groups,
+        years,
+        cells,
+      });
+      const nothingToPaste = cellsToWrite.length === 0 && skipped === 0;
+      if (nothingToPaste) {
+        return;
+      }
+      event.preventDefault();
+      if (cellsToWrite.length > 0) {
+        void saveCellValues(cellsToWrite);
+      }
+      if (skipped > 0) {
+        notify?.(appLabels.indicateurCollageIgnore({ count: skipped }));
+      }
+    },
+    [groups, years, cells, saveCellValues, notify]
+  );
+
+  return { onPaste };
+};

--- a/apps/app/src/indicateurs/valeurs/grid/types.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/types.ts
@@ -9,11 +9,23 @@ export const toYear = (value: number): Year => value as Year;
 
 export type CellKey = `${number}:${number}`;
 
+export const CELL_ID_ATTRIBUTE = 'data-cell-id';
+
 export const generateCellKey = (indicateurId: IndicateurId, year: Year): CellKey =>
   `${indicateurId}:${year}` as CellKey;
 
 export const isCellKey = (value: string | null): value is CellKey =>
   value !== null && /^\d+:\d+$/.test(value);
+
+export const parseCellKey = (
+  key: CellKey
+): { indicateurId: IndicateurId; year: Year } => {
+  const [indicateurId, year] = key.split(':');
+  return {
+    indicateurId: toIndicateurId(Number(indicateurId)),
+    year: toYear(Number(year)),
+  };
+};
 
 export type SourceInfo = {
   sourceId: string;

--- a/apps/app/src/labels/catalog.ts
+++ b/apps/app/src/labels/catalog.ts
@@ -1741,6 +1741,10 @@ export const appLabels = {
     value: number;
     source: string;
   }): string => `${rowLabel}, ${year} : ${value} (open data, source ${source})`,
+  indicateurCollageIgnore: countedPlural({
+    one: 'valeur ignorée au collage (hors grille ou non numérique)',
+    other: 'valeurs ignorées au collage (hors grille ou non numérique)',
+  }),
 
   acteEngagementDocUrl: '/Acte_engagement.docx',
   reglementLabelUrl: ({


### PR DESCRIPTION
## Collage tableur dans la grille de saisie

Stacked sur #4660. Ajoute le collage type tableur (TSV) positionnel dans la grille de saisie.

### Comportement
- Colle un bloc TSV depuis la cellule ancre : parse le presse-papier et écrit les valeurs via `saveCellValues`.
- Décimales à la virgule (`12,5` → 12.5), espaces autour des valeurs tolérés.
- Une cellule vide du bloc collé (padding Excel des lignes irrégulières) ne compte **pas** comme ignorée.
- Une cellule **open-data impactée par un collage repasse en saisie utilisateur**.
- Les valeurs hors grille ou non numériques sont ignorées et signalées par un **toast** (via `notify` injecté par le `GridProvider`).
- Un CSV (`;` / `,`) n'est **pas** découpé en colonnes : seul le TSV (format du presse-papier tableur) l'est, la virgule étant le séparateur décimal.

### Implémentation
- `paste-values.ts` (parsing + mapping positionnel), `use-grid-copy-paste.ts` (hook, `onPasteCapture`) — regroupés dans `paste/`.
- `notify` ajouté au contexte / props de la grille (`GridProvider`).

### Tests
- `paste-values.spec.ts` : TSV, décimales, padding Excel, CSV, espaces irréguliers, réécriture open-data, hors grille.
- `grid-paste.spec.tsx` : intégration + toast des cellules ignorées.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Le collage de valeurs dans la grille est désormais pris en charge, avec application automatique des données sur plusieurs cellules.
  * Un message d’information peut s’afficher lorsqu’une partie des valeurs collées ne peut pas être appliquée.

* **Améliorations**
  * La navigation au clavier et la gestion du focus ont été harmonisées pour rendre l’utilisation de la grille plus fiable.

* **Tests**
  * De nouveaux tests couvrent le parsing des clés de cellule et les comportements de collage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->