### PR TITLE
Ajoute la protection liée au mode (read/write/archived) du référentiel

### DIFF
--- a/apps/backend/src/collectivites/collectivite-referentiel-mode/collectivite-referentiel-mode.service.ts
+++ b/apps/backend/src/collectivites/collectivite-referentiel-mode/collectivite-referentiel-mode.service.ts
@@ -1,0 +1,66 @@
+import { Injectable } from '@nestjs/common';
+import { CollectivitePreferencesRepository } from '@tet/backend/collectivites/collectivite-preferences/collectivite-preferences.repository';
+import { success, type Result } from '@tet/backend/utils/result.type';
+import {
+  defaultCollectivitePreferences,
+  type CollectiviteReferentielDisplayId,
+  type CollectiviteReferentielPreferences,
+  type ReferentielMode,
+} from '@tet/domain/collectivites';
+import type { ReferentielId } from '@tet/domain/referentiels';
+import type { CollectiviteReferentielModeError } from './referentiel-mode-guard.errors';
+
+@Injectable()
+export class CollectiviteReferentielModeService {
+  constructor(
+    private readonly collectivitePreferencesRepository: CollectivitePreferencesRepository
+  ) {}
+
+  async getReferentielPreferences(
+    collectiviteId: number
+  ): Promise<
+    Result<CollectiviteReferentielPreferences, CollectiviteReferentielModeError>
+  > {
+    const result =
+      await this.collectivitePreferencesRepository.getPreferencesByCollectiviteId(
+        collectiviteId
+      );
+    if (!result.success) {
+      return result;
+    }
+    return success(
+      (result.data ?? defaultCollectivitePreferences).referentiels
+    );
+  }
+
+  async getReferentielMode(
+    collectiviteId: number,
+    referentielId: CollectiviteReferentielDisplayId
+  ): Promise<Result<ReferentielMode, CollectiviteReferentielModeError>> {
+    const preferencesResult = await this.getReferentielPreferences(
+      collectiviteId
+    );
+    if (!preferencesResult.success) {
+      return preferencesResult;
+    }
+    return success(preferencesResult.data[referentielId].mode);
+  }
+
+  async updateReferentielPreferences(
+    collectiviteId: number,
+    referentiels: CollectiviteReferentielPreferences
+  ) {
+    return this.collectivitePreferencesRepository.updatePreferences(
+      collectiviteId,
+      { referentiels }
+    );
+  }
+}
+
+export function isCollectiviteReferentielDisplayId(
+  referentielId: ReferentielId
+): referentielId is CollectiviteReferentielDisplayId {
+  return (
+    referentielId === 'cae' || referentielId === 'eci' || referentielId === 'te'
+  );
+}

--- a/apps/backend/src/collectivites/collectivite-referentiel-mode/referentiel-mode-guard.errors.ts
+++ b/apps/backend/src/collectivites/collectivite-referentiel-mode/referentiel-mode-guard.errors.ts
@@ -1,0 +1,38 @@
+import {
+  createErrorsEnum,
+  TrpcErrorHandlerConfig,
+} from '@tet/backend/utils/trpc/trpc-error-handler';
+import type { CollectivitePreferencesError } from '../collectivite-preferences/collectivite-preferences.errors';
+
+export type CollectiviteReferentielModeError = CollectivitePreferencesError;
+
+export const referentielModeGuardSpecificErrors = [
+  'REFERENTIEL_NOT_WRITABLE',
+] as const;
+
+export const referentielNotWritableTrpcErrorEntry = {
+  REFERENTIEL_NOT_WRITABLE: {
+    code: 'FORBIDDEN',
+    message: 'Ce référentiel est en lecture seule et ne peut pas être modifié.',
+  },
+} as const;
+
+export const REFERENTIEL_NOT_WRITABLE_MESSAGE =
+  referentielNotWritableTrpcErrorEntry.REFERENTIEL_NOT_WRITABLE.message;
+
+type ReferentielModeGuardSpecificError =
+  (typeof referentielModeGuardSpecificErrors)[number];
+
+export const referentielModeGuardErrorConfig: TrpcErrorHandlerConfig<ReferentielModeGuardSpecificError> =
+  {
+    specificErrors: referentielNotWritableTrpcErrorEntry,
+  };
+
+export const ReferentielModeGuardErrorEnum = createErrorsEnum(
+  referentielModeGuardSpecificErrors
+);
+export type ReferentielModeGuardError =
+  keyof typeof ReferentielModeGuardErrorEnum;
+
+export type ReferentielNotWritableError =
+  typeof ReferentielModeGuardErrorEnum.REFERENTIEL_NOT_WRITABLE;

--- a/apps/backend/src/collectivites/collectivite-referentiel-mode/referentiel-mode-guard.router.e2e-spec.ts
+++ b/apps/backend/src/collectivites/collectivite-referentiel-mode/referentiel-mode-guard.router.e2e-spec.ts
@@ -1,0 +1,199 @@
+import { INestApplication } from '@nestjs/common';
+import { REFERENTIEL_NOT_WRITABLE_MESSAGE } from '@tet/backend/collectivites/collectivite-referentiel-mode/referentiel-mode-guard.errors';
+import { addTestCollectiviteAndUser } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { addTestPersonnalisationData } from '@tet/backend/collectivites/personnalisations/personnalisations.test-fixture';
+import { cleanupReferentielActionStatutsAndLabellisations } from '@tet/backend/referentiels/update-action-statut/referentiel-action-statut.test-fixture';
+import {
+  getAuthUserFromUserCredentials,
+  getTestApp,
+  getTestDatabase,
+  getTestRouter,
+} from '@tet/backend/test';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import {
+  addAndEnableUserSuperAdminMode,
+  addTestUser,
+} from '@tet/backend/users/users/users.test-fixture';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
+import {
+  Collectivite,
+  type CollectiviteReferentielPreferences,
+} from '@tet/domain/collectivites';
+import {
+  ActionTypeEnum,
+  findActionInTree,
+  ReferentielIdEnum,
+  type TreeOfActionsIncludingScore,
+} from '@tet/domain/referentiels';
+import { CollectiviteRole } from '@tet/domain/users';
+
+function findFirstLeafActionId(root: TreeOfActionsIncludingScore): string {
+  const action = findActionInTree([root], (node) => {
+    return (
+      node.actionType === ActionTypeEnum.TACHE ||
+      (node.actionType === ActionTypeEnum.SOUS_ACTION &&
+        node.actionsEnfant.length === 0)
+    );
+  });
+  if (!action) {
+    throw new Error('Aucune action feuille trouvée dans le référentiel');
+  }
+  return action.actionId;
+}
+
+describe('ReferentielModeGuard', () => {
+  let app: INestApplication;
+  let router: TrpcRouter;
+  let supportCaller: ReturnType<TrpcRouter['createCaller']>;
+  let editorUser: AuthenticatedUser;
+  let collectivite: Collectivite;
+  let databaseService: DatabaseService;
+  let cleanupSupportUser: () => Promise<void>;
+  let cleanupSuperAdminMode: () => Promise<void>;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    router = await getTestRouter(app);
+    databaseService = await getTestDatabase(app);
+
+    const supportUserResult = await addTestUser(databaseService);
+    cleanupSupportUser = supportUserResult.cleanup;
+    const supportUser = getAuthUserFromUserCredentials(supportUserResult.user);
+    supportCaller = router.createCaller({ user: supportUser });
+    const superAdminMode = await addAndEnableUserSuperAdminMode({
+      app,
+      caller: supportCaller,
+      userId: supportUser.id,
+    });
+    cleanupSuperAdminMode = superAdminMode.cleanup;
+
+    const testCollectiviteAndUserResult = await addTestCollectiviteAndUser(
+      databaseService,
+      {
+        user: {
+          role: CollectiviteRole.EDITION,
+        },
+      }
+    );
+
+    collectivite = testCollectiviteAndUserResult.collectivite;
+    editorUser = getAuthUserFromUserCredentials(
+      testCollectiviteAndUserResult.user
+    );
+  });
+
+  afterAll(async () => {
+    await cleanupSuperAdminMode();
+    await cleanupSupportUser();
+    await app.close();
+  });
+
+  afterEach(async () => {
+    await cleanupReferentielActionStatutsAndLabellisations(
+      databaseService,
+      collectivite.id
+    );
+  });
+
+  async function setReferentielPreferences(
+    referentiels: CollectiviteReferentielPreferences,
+    targetCollectiviteId: number = collectivite.id
+  ) {
+    await supportCaller.collectivites.preferences.update({
+      collectiviteId: targetCollectiviteId,
+      preferences: { referentiels },
+    });
+  }
+
+  test('Refuse updateStatut sur TE en mode readonly', async () => {
+    await setReferentielPreferences({
+      cae: { display: true, mode: 'write' },
+      eci: { display: false, mode: 'archived' },
+      te: { display: true, mode: 'readonly' },
+    });
+
+    const editorCaller = router.createCaller({ user: editorUser });
+    const teSnapshot = await editorCaller.referentiels.snapshots.getCurrent({
+      collectiviteId: collectivite.id,
+      referentielId: ReferentielIdEnum.TE,
+    });
+    const teActionId = findFirstLeafActionId(teSnapshot.scoresPayload.scores);
+
+    await expect(
+      editorCaller.referentiels.actions.updateStatut({
+        collectiviteId: collectivite.id,
+        actionId: teActionId,
+        statut: 'fait',
+      })
+    ).rejects.toThrow(REFERENTIEL_NOT_WRITABLE_MESSAGE);
+  });
+
+  test('Autorise updateStatut sur CAE en mode write', async () => {
+    await setReferentielPreferences({
+      cae: { display: true, mode: 'write' },
+      eci: { display: false, mode: 'archived' },
+      te: { display: true, mode: 'readonly' },
+    });
+
+    const editorCaller = router.createCaller({ user: editorUser });
+    const caeSnapshot = await editorCaller.referentiels.snapshots.getCurrent({
+      collectiviteId: collectivite.id,
+      referentielId: ReferentielIdEnum.CAE,
+    });
+    const caeActionId = findFirstLeafActionId(caeSnapshot.scoresPayload.scores);
+
+    await expect(
+      editorCaller.referentiels.actions.updateStatut({
+        collectiviteId: collectivite.id,
+        actionId: caeActionId,
+        statut: 'fait',
+      })
+    ).resolves.toBeDefined();
+  });
+
+  test('Refuse updateCommentaire sur CAE en mode archived', async () => {
+    await setReferentielPreferences({
+      cae: { display: false, mode: 'archived' },
+      eci: { display: false, mode: 'archived' },
+      te: { display: true, mode: 'write' },
+    });
+
+    const editorCaller = router.createCaller({ user: editorUser });
+
+    await expect(
+      editorCaller.referentiels.actions.updateCommentaire({
+        collectiviteId: collectivite.id,
+        actionId: 'cae_1.1.1.1.2',
+        commentaire: 'commentaire bloqué',
+      })
+    ).rejects.toThrow(REFERENTIEL_NOT_WRITABLE_MESSAGE);
+  });
+
+  test('Autorise setReponse personnalisation sur TE en mode readonly', async () => {
+    const personnalisationData =
+      await addTestPersonnalisationData(databaseService);
+    onTestFinished(() => personnalisationData.cleanup());
+
+    await setReferentielPreferences(
+      {
+        cae: { display: true, mode: 'write' },
+        eci: { display: false, mode: 'archived' },
+        te: { display: true, mode: 'readonly' },
+      },
+      personnalisationData.collectivite.id
+    );
+
+    const caller = router.createCaller({
+      user: personnalisationData.userCredentials,
+    });
+
+    await expect(
+      caller.collectivites.personnalisations.setReponse({
+        collectiviteId: personnalisationData.collectivite.id,
+        questionId: personnalisationData.questionBinaireId,
+        reponse: true,
+      })
+    ).resolves.toBeDefined();
+  });
+});

--- a/apps/backend/src/collectivites/collectivite-referentiel-mode/referentiel-mode-guard.service.ts
+++ b/apps/backend/src/collectivites/collectivite-referentiel-mode/referentiel-mode-guard.service.ts
@@ -1,10 +1,5 @@
-import {
-  ForbiddenException,
-  Injectable,
-  InternalServerErrorException,
-} from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { failure, success, type Result } from '@tet/backend/utils/result.type';
-import { COMMON_ERROR_CONFIG } from '@tet/backend/utils/trpc/common-errors';
 import {
   canMutateReferentielData,
   type CollectiviteReferentielPreferences,
@@ -16,7 +11,6 @@ import {
   isCollectiviteReferentielDisplayId,
 } from './collectivite-referentiel-mode.service';
 import {
-  REFERENTIEL_NOT_WRITABLE_MESSAGE,
   ReferentielModeGuardErrorEnum,
   type ReferentielModeGuardError,
 } from './referentiel-mode-guard.errors';
@@ -90,60 +84,6 @@ export class ReferentielModeGuard {
     }
 
     return success(undefined);
-  }
-
-  async assertCanMutateActionOrFailure(
-    collectiviteId: number,
-    actionId: string
-  ): Promise<Result<void, ReferentielModeGuardError>> {
-    return this.assertCanMutate(
-      collectiviteId,
-      getReferentielIdFromActionId(actionId)
-    );
-  }
-
-  async assertCanMutateActionsOrFailure(
-    collectiviteId: number,
-    actionIds: Iterable<string>
-  ): Promise<Result<void, ReferentielModeGuardError>> {
-    return this.assertCanMutateActions(collectiviteId, actionIds);
-  }
-
-  // variantes avec throw de l'erreur amenées à disparaitre (hors scope bascule-PR4)
-  async assertCanMutateOrThrow(
-    collectiviteId: number,
-    referentielId: ReferentielId
-  ): Promise<void> {
-    const modeResult = await this.assertCanMutate(
-      collectiviteId,
-      referentielId
-    );
-    if (!modeResult.success) {
-      this.throwFromModeGuardFailure(modeResult.error);
-    }
-  }
-
-  async assertCanMutateActionOrThrow(
-    collectiviteId: number,
-    actionId: string
-  ): Promise<void> {
-    const modeResult = await this.assertCanMutateAction(
-      collectiviteId,
-      actionId
-    );
-    if (!modeResult.success) {
-      this.throwFromModeGuardFailure(modeResult.error);
-    }
-  }
-
-  private throwFromModeGuardFailure(error: ReferentielModeGuardError): never {
-    if (error === ReferentielModeGuardErrorEnum.DATABASE_ERROR) {
-      throw new InternalServerErrorException(
-        COMMON_ERROR_CONFIG.DATABASE_ERROR.message
-      );
-    }
-
-    throw new ForbiddenException(REFERENTIEL_NOT_WRITABLE_MESSAGE);
   }
 
   private checkReferentielWritableFromPreferences(

--- a/apps/backend/src/collectivites/collectivite-referentiel-mode/referentiel-mode-guard.service.ts
+++ b/apps/backend/src/collectivites/collectivite-referentiel-mode/referentiel-mode-guard.service.ts
@@ -1,0 +1,166 @@
+import {
+  ForbiddenException,
+  Injectable,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { failure, success, type Result } from '@tet/backend/utils/result.type';
+import { COMMON_ERROR_CONFIG } from '@tet/backend/utils/trpc/common-errors';
+import {
+  canMutateReferentielData,
+  type CollectiviteReferentielPreferences,
+} from '@tet/domain/collectivites';
+import type { ReferentielId } from '@tet/domain/referentiels';
+import { getReferentielIdFromActionId } from '@tet/domain/referentiels';
+import {
+  CollectiviteReferentielModeService,
+  isCollectiviteReferentielDisplayId,
+} from './collectivite-referentiel-mode.service';
+import {
+  REFERENTIEL_NOT_WRITABLE_MESSAGE,
+  ReferentielModeGuardErrorEnum,
+  type ReferentielModeGuardError,
+} from './referentiel-mode-guard.errors';
+
+@Injectable()
+export class ReferentielModeGuard {
+  constructor(
+    private readonly collectiviteReferentielModeService: CollectiviteReferentielModeService
+  ) {}
+
+  async assertCanMutate(
+    collectiviteId: number,
+    referentielId: ReferentielId
+  ): Promise<Result<void, ReferentielModeGuardError>> {
+    if (
+      referentielId === 'te-test' ||
+      !isCollectiviteReferentielDisplayId(referentielId)
+    ) {
+      return success(undefined);
+    }
+
+    const preferencesResult =
+      await this.collectiviteReferentielModeService.getReferentielPreferences(
+        collectiviteId
+      );
+    if (!preferencesResult.success) {
+      return failure(ReferentielModeGuardErrorEnum.DATABASE_ERROR);
+    }
+
+    return this.checkReferentielWritableFromPreferences(
+      preferencesResult.data,
+      referentielId
+    );
+  }
+
+  async assertCanMutateAction(
+    collectiviteId: number,
+    actionId: string
+  ): Promise<Result<void, ReferentielModeGuardError>> {
+    return this.assertCanMutate(
+      collectiviteId,
+      getReferentielIdFromActionId(actionId)
+    );
+  }
+
+  async assertCanMutateActions(
+    collectiviteId: number,
+    actionIds: Iterable<string>
+  ): Promise<Result<void, ReferentielModeGuardError>> {
+    const referentielIds = new Set<ReferentielId>();
+    for (const actionId of actionIds) {
+      referentielIds.add(getReferentielIdFromActionId(actionId));
+    }
+
+    const preferencesResult =
+      await this.collectiviteReferentielModeService.getReferentielPreferences(
+        collectiviteId
+      );
+    if (!preferencesResult.success) {
+      return failure(ReferentielModeGuardErrorEnum.DATABASE_ERROR);
+    }
+
+    for (const referentielId of referentielIds) {
+      const modeResult = this.checkReferentielWritableFromPreferences(
+        preferencesResult.data,
+        referentielId
+      );
+      if (!modeResult.success) {
+        return modeResult;
+      }
+    }
+
+    return success(undefined);
+  }
+
+  async assertCanMutateActionOrFailure(
+    collectiviteId: number,
+    actionId: string
+  ): Promise<Result<void, ReferentielModeGuardError>> {
+    return this.assertCanMutate(
+      collectiviteId,
+      getReferentielIdFromActionId(actionId)
+    );
+  }
+
+  async assertCanMutateActionsOrFailure(
+    collectiviteId: number,
+    actionIds: Iterable<string>
+  ): Promise<Result<void, ReferentielModeGuardError>> {
+    return this.assertCanMutateActions(collectiviteId, actionIds);
+  }
+
+  // variantes avec throw de l'erreur amenées à disparaitre (hors scope bascule-PR4)
+  async assertCanMutateOrThrow(
+    collectiviteId: number,
+    referentielId: ReferentielId
+  ): Promise<void> {
+    const modeResult = await this.assertCanMutate(
+      collectiviteId,
+      referentielId
+    );
+    if (!modeResult.success) {
+      this.throwFromModeGuardFailure(modeResult.error);
+    }
+  }
+
+  async assertCanMutateActionOrThrow(
+    collectiviteId: number,
+    actionId: string
+  ): Promise<void> {
+    const modeResult = await this.assertCanMutateAction(
+      collectiviteId,
+      actionId
+    );
+    if (!modeResult.success) {
+      this.throwFromModeGuardFailure(modeResult.error);
+    }
+  }
+
+  private throwFromModeGuardFailure(error: ReferentielModeGuardError): never {
+    if (error === ReferentielModeGuardErrorEnum.DATABASE_ERROR) {
+      throw new InternalServerErrorException(
+        COMMON_ERROR_CONFIG.DATABASE_ERROR.message
+      );
+    }
+
+    throw new ForbiddenException(REFERENTIEL_NOT_WRITABLE_MESSAGE);
+  }
+
+  private checkReferentielWritableFromPreferences(
+    preferences: CollectiviteReferentielPreferences,
+    referentielId: ReferentielId
+  ): Result<void, ReferentielModeGuardError> {
+    if (
+      referentielId === 'te-test' ||
+      !isCollectiviteReferentielDisplayId(referentielId)
+    ) {
+      return success(undefined);
+    }
+
+    if (!canMutateReferentielData(preferences[referentielId].mode)) {
+      return failure(ReferentielModeGuardErrorEnum.REFERENTIEL_NOT_WRITABLE);
+    }
+
+    return success(undefined);
+  }
+}

--- a/apps/backend/src/collectivites/collectivites-core.module.ts
+++ b/apps/backend/src/collectivites/collectivites-core.module.ts
@@ -3,6 +3,8 @@ import { DatabaseModule } from '@tet/backend/utils/database/database.module';
 import { UsersModule } from '../users/users.module';
 import { CollectivitePreferencesRepository } from './collectivite-preferences/collectivite-preferences.repository';
 import { CollectivitePreferencesService } from './collectivite-preferences/collectivite-preferences.service';
+import { CollectiviteReferentielModeService } from './collectivite-referentiel-mode/collectivite-referentiel-mode.service';
+import { ReferentielModeGuard } from './collectivite-referentiel-mode/referentiel-mode-guard.service';
 import CollectivitesService from './services/collectivites.service';
 
 /**
@@ -16,7 +18,14 @@ import CollectivitesService from './services/collectivites.service';
     CollectivitesService,
     CollectivitePreferencesService,
     CollectivitePreferencesRepository,
+    CollectiviteReferentielModeService,
+    ReferentielModeGuard,
   ],
-  exports: [CollectivitesService, CollectivitePreferencesService],
+  exports: [
+    CollectivitesService,
+    CollectivitePreferencesService,
+    CollectiviteReferentielModeService,
+    ReferentielModeGuard,
+  ],
 })
 export class CollectivitesCoreModule {}

--- a/apps/backend/src/collectivites/documents/edit-preuve-document/edit-preuve-document.errors.ts
+++ b/apps/backend/src/collectivites/documents/edit-preuve-document/edit-preuve-document.errors.ts
@@ -1,9 +1,17 @@
 import {
+  referentielModeGuardSpecificErrors,
+  referentielNotWritableTrpcErrorEntry,
+} from '@tet/backend/collectivites/collectivite-referentiel-mode/referentiel-mode-guard.errors';
+import {
   createErrorsEnum,
   TrpcErrorHandlerConfig,
 } from '@tet/backend/utils/trpc/trpc-error-handler';
 
-const specificErrors = ['PREUVE_FICHIER', 'LABELLISATION_IN_PROGRESS'] as const;
+const specificErrors = [
+  'PREUVE_FICHIER',
+  'LABELLISATION_IN_PROGRESS',
+  ...referentielModeGuardSpecificErrors,
+] as const;
 type SpecificError = (typeof specificErrors)[number];
 
 export const editPreuveDocumentErrorConfig: TrpcErrorHandlerConfig<SpecificError> =
@@ -19,6 +27,7 @@ export const editPreuveDocumentErrorConfig: TrpcErrorHandlerConfig<SpecificError
         message:
           "Les documents de candidature ne peuvent plus être modifiés une fois l'audit clôturé et la labellisation en cours.",
       },
+      ...referentielNotWritableTrpcErrorEntry,
     },
   };
 

--- a/apps/backend/src/collectivites/documents/edit-preuve-document/edit-preuve-document.repository.ts
+++ b/apps/backend/src/collectivites/documents/edit-preuve-document/edit-preuve-document.repository.ts
@@ -12,6 +12,7 @@ import { getErrorMessage } from '@tet/domain/utils';
 import { desc, eq } from 'drizzle-orm';
 import { DocumentBase } from '../models/document.basetable';
 import { preuveLabellisationTable } from '../models/preuve-labellisation.table';
+import { preuveComplementaireTable } from '../models/preuve-complementaire.table';
 import { preuveTableByType } from '../models/preuve-tables.map';
 
 export type PreuveDocumentPatch = {
@@ -36,6 +37,15 @@ export class EditPreuveDocumentRepository {
       .where(eq(table.id, preuveId))
       .limit(1);
     return row;
+  }
+
+  async findComplementaireActionId(preuveId: number): Promise<string | null> {
+    const [row] = await this.databaseService.db
+      .select({ actionId: preuveComplementaireTable.actionId })
+      .from(preuveComplementaireTable)
+      .where(eq(preuveComplementaireTable.id, preuveId))
+      .limit(1);
+    return row?.actionId ?? null;
   }
 
   async findAuditByLabellisationPreuve(

--- a/apps/backend/src/collectivites/documents/edit-preuve-document/edit-preuve-document.service.ts
+++ b/apps/backend/src/collectivites/documents/edit-preuve-document/edit-preuve-document.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { ReferentielModeGuard } from '@tet/backend/collectivites/collectivite-referentiel-mode/referentiel-mode-guard.service';
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { failure, Result } from '@tet/backend/utils/result.type';
@@ -17,8 +18,35 @@ import { EditPreuveDocumentRepository } from './edit-preuve-document.repository'
 export class EditPreuveDocumentService {
   constructor(
     private readonly permissionService: PermissionService,
-    private readonly editPreuveDocumentRepository: EditPreuveDocumentRepository
+    private readonly editPreuveDocumentRepository: EditPreuveDocumentRepository,
+    private readonly referentielModeGuard: ReferentielModeGuard
   ) {}
+
+  private async assertComplementairePreuveWritable(
+    preuveType: PreuveType,
+    preuveId: number,
+    collectiviteId: number
+  ): Promise<EditPreuveDocumentError | undefined> {
+    if (preuveType !== 'complementaire') {
+      return undefined;
+    }
+    const actionId =
+      await this.editPreuveDocumentRepository.findComplementaireActionId(
+        preuveId
+      );
+    if (!actionId) {
+      return CommonErrorEnum.NOT_FOUND;
+    }
+    const modeResult =
+      await this.referentielModeGuard.assertCanMutateActionOrFailure(
+        collectiviteId,
+        actionId
+      );
+    if (!modeResult.success) {
+      return modeResult.error;
+    }
+    return undefined;
+  }
 
   async updatePreuve(
     input: UpdatePreuveInput,
@@ -43,6 +71,15 @@ export class EditPreuveDocumentService {
     );
     if (!isAllowed) {
       return failure(CommonErrorEnum.UNAUTHORIZED);
+    }
+
+    const modeError = await this.assertComplementairePreuveWritable(
+      preuveType,
+      preuveId,
+      preuve.collectiviteId
+    );
+    if (modeError) {
+      return failure(modeError);
     }
 
     if (!(await this.canModifyPreuve(preuveType, preuveId))) {
@@ -84,6 +121,15 @@ export class EditPreuveDocumentService {
     );
     if (!isAllowed) {
       return failure(CommonErrorEnum.UNAUTHORIZED);
+    }
+
+    const modeError = await this.assertComplementairePreuveWritable(
+      preuveType,
+      preuveId,
+      preuve.collectiviteId
+    );
+    if (modeError) {
+      return failure(modeError);
     }
 
     if (!(await this.canModifyPreuve(preuveType, preuveId))) {

--- a/apps/backend/src/collectivites/documents/edit-preuve-document/edit-preuve-document.service.ts
+++ b/apps/backend/src/collectivites/documents/edit-preuve-document/edit-preuve-document.service.ts
@@ -37,11 +37,10 @@ export class EditPreuveDocumentService {
     if (!actionId) {
       return CommonErrorEnum.NOT_FOUND;
     }
-    const modeResult =
-      await this.referentielModeGuard.assertCanMutateActionOrFailure(
-        collectiviteId,
-        actionId
-      );
+    const modeResult = await this.referentielModeGuard.assertCanMutateAction(
+      collectiviteId,
+      actionId
+    );
     if (!modeResult.success) {
       return modeResult.error;
     }

--- a/apps/backend/src/plans/fiches/update-fiche/fiche-action-link.errors.ts
+++ b/apps/backend/src/plans/fiches/update-fiche/fiche-action-link.errors.ts
@@ -1,4 +1,8 @@
 import {
+  referentielModeGuardSpecificErrors,
+  referentielNotWritableTrpcErrorEntry,
+} from '@tet/backend/collectivites/collectivite-referentiel-mode/referentiel-mode-guard.errors';
+import {
   createErrorsEnum,
   TrpcErrorHandlerConfig,
 } from '@tet/backend/utils/trpc/trpc-error-handler';
@@ -7,6 +11,7 @@ const specificErrors = [
   'ACTION_NOT_FOUND',
   'FICHE_NOT_FOUND',
   'FICHE_COLLECTIVITE_MISMATCH',
+  ...referentielModeGuardSpecificErrors,
 ] as const;
 type SpecificError = (typeof specificErrors)[number];
 
@@ -26,6 +31,7 @@ export const updateActionFichesErrorConfig: TrpcErrorHandlerConfig<SpecificError
         message:
           'Les fiches fournies doivent toutes appartenir à la même collectivité',
       },
+      ...referentielNotWritableTrpcErrorEntry,
     },
   };
 

--- a/apps/backend/src/plans/fiches/update-fiche/fiche-action-link.service.ts
+++ b/apps/backend/src/plans/fiches/update-fiche/fiche-action-link.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { ReferentielModeGuard } from '@tet/backend/collectivites/collectivite-referentiel-mode/referentiel-mode-guard.service';
 import { GetActionService } from '@tet/backend/referentiels/get-action/get-action.service';
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
@@ -21,7 +22,8 @@ export class FicheActionLinkService {
     private readonly getActionService: GetActionService,
     private readonly permissionService: PermissionService,
     private readonly fichePermissionService: FicheActionPermissionsService,
-    private readonly transactionManager: TransactionManager
+    private readonly transactionManager: TransactionManager,
+    private readonly referentielModeGuard: ReferentielModeGuard
   ) {}
 
   async updateLinkedFiches({
@@ -52,6 +54,15 @@ export class FicheActionLinkService {
     );
     if (!isAllowed) {
       return failure(UpdateActionFichesErrorEnum.UNAUTHORIZED);
+    }
+
+    const modeResult =
+      await this.referentielModeGuard.assertCanMutateActionOrFailure(
+        collectiviteId,
+        actionId
+      );
+    if (!modeResult.success) {
+      return modeResult;
     }
 
     if (ficheIds.length > 0) {

--- a/apps/backend/src/plans/fiches/update-fiche/fiche-action-link.service.ts
+++ b/apps/backend/src/plans/fiches/update-fiche/fiche-action-link.service.ts
@@ -56,11 +56,10 @@ export class FicheActionLinkService {
       return failure(UpdateActionFichesErrorEnum.UNAUTHORIZED);
     }
 
-    const modeResult =
-      await this.referentielModeGuard.assertCanMutateActionOrFailure(
-        collectiviteId,
-        actionId
-      );
+    const modeResult = await this.referentielModeGuard.assertCanMutateAction(
+      collectiviteId,
+      actionId
+    );
     if (!modeResult.success) {
       return modeResult;
     }

--- a/apps/backend/src/plans/fiches/update-fiche/update-fiche.errors.ts
+++ b/apps/backend/src/plans/fiches/update-fiche/update-fiche.errors.ts
@@ -1,4 +1,8 @@
 import {
+  referentielModeGuardSpecificErrors,
+  referentielNotWritableTrpcErrorEntry,
+} from '@tet/backend/collectivites/collectivite-referentiel-mode/referentiel-mode-guard.errors';
+import {
   createErrorsEnum,
   TrpcErrorHandlerConfig,
 } from '@tet/backend/utils/trpc/trpc-error-handler';
@@ -10,6 +14,7 @@ const specificErrors = [
   'FICHE_NOT_FOUND',
   'INSTANCE_GOUVERNANCE_COLLECTIVITE_MISMATCH',
   'INSTANCE_GOUVERNANCE_TAG_NOT_FOUND',
+  ...referentielModeGuardSpecificErrors,
 ] as const;
 type SpecificError = (typeof specificErrors)[number];
 
@@ -41,6 +46,7 @@ export const updateFicheErrorConfig: TrpcErrorHandlerConfig<SpecificError> = {
       code: 'BAD_REQUEST',
       message: "Une ou plusieurs instances de gouvernance n'existent pas",
     },
+    ...referentielNotWritableTrpcErrorEntry,
   },
 };
 

--- a/apps/backend/src/plans/fiches/update-fiche/update-fiche.service.ts
+++ b/apps/backend/src/plans/fiches/update-fiche/update-fiche.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { ReferentielModeGuard } from '@tet/backend/collectivites/collectivite-referentiel-mode/referentiel-mode-guard.service';
 import { FicheActionRepository } from '@tet/backend/plans/fiches/fiche-action.repository';
 import ListFichesService from '@tet/backend/plans/fiches/list-fiches/list-fiches.service';
 import { ShareFicheService } from '@tet/backend/plans/fiches/share-fiches/share-fiche.service';
@@ -30,8 +31,49 @@ export default class UpdateFicheService {
     private readonly shareFicheService: ShareFicheService,
     private readonly notificationsFicheService: NotifyPiloteService,
     private readonly ficheActionRepository: FicheActionRepository,
-    private readonly transactionManager: TransactionManager
+    private readonly transactionManager: TransactionManager,
+    private readonly referentielModeGuard: ReferentielModeGuard
   ) {}
+
+  private async assertMesuresWritable(
+    ficheId: number,
+    mesures: Array<{ id: string }>,
+    user: AuthenticatedUser,
+    tx?: Transaction
+  ): Promise<UpdateFicheResult<void>> {
+    const ficheRow = await this.fichePermissionService.getFicheFromId(
+      ficheId,
+      tx
+    );
+    if (!ficheRow) {
+      return failure(UpdateFicheErrorEnum.FICHE_NOT_FOUND);
+    }
+
+    const existingFiche = await this.ficheActionListService.getFicheById(
+      ficheId,
+      false,
+      user,
+      tx
+    );
+    if (!existingFiche.success) {
+      return failure(UpdateFicheErrorEnum.FICHE_NOT_FOUND);
+    }
+
+    const oldActionIds = (existingFiche.data.mesures ?? []).map((m) => m.id);
+    const newActionIds = mesures.map((m) => m.id);
+    const affectedActionIds = [...new Set([...oldActionIds, ...newActionIds])];
+
+    const modeResult =
+      await this.referentielModeGuard.assertCanMutateActionsOrFailure(
+        ficheRow.collectiviteId,
+        affectedActionIds
+      );
+    if (!modeResult.success) {
+      return modeResult;
+    }
+
+    return success(undefined);
+  }
 
   async updateFiche({
     ficheId,
@@ -48,6 +90,18 @@ export default class UpdateFicheService {
   }): Promise<UpdateFicheResult<FicheWithRelations, UpdateFicheError>> {
     await this.fichePermissionService.canWriteFiche(ficheId, user, tx);
     this.logger.log(`Mise à jour de la fiche action dont l'id est ${ficheId}`);
+
+    if (ficheFields.mesures !== undefined) {
+      const mesuresGuardResult = await this.assertMesuresWritable(
+        ficheId,
+        ficheFields.mesures ?? [],
+        user,
+        tx
+      );
+      if (!mesuresGuardResult.success) {
+        return mesuresGuardResult;
+      }
+    }
 
     if (!isNil(ficheFields.parentId)) {
       if (ficheFields.parentId === ficheId) {

--- a/apps/backend/src/plans/fiches/update-fiche/update-fiche.service.ts
+++ b/apps/backend/src/plans/fiches/update-fiche/update-fiche.service.ts
@@ -13,10 +13,7 @@ import { isNil } from 'es-toolkit';
 import { AuthenticatedUser } from '../../../users/models/auth.models';
 import FicheActionPermissionsService from '../fiche-action-permissions.service';
 import { NotifyPiloteService } from '../notify-pilote/notify-pilote.service';
-import {
-  UpdateFicheError,
-  UpdateFicheErrorEnum,
-} from './update-fiche.errors';
+import { UpdateFicheError, UpdateFicheErrorEnum } from './update-fiche.errors';
 import { UpdateFicheInput } from './update-fiche.input';
 import { UpdateFicheResult } from './update-fiche.result';
 
@@ -63,11 +60,10 @@ export default class UpdateFicheService {
     const newActionIds = mesures.map((m) => m.id);
     const affectedActionIds = [...new Set([...oldActionIds, ...newActionIds])];
 
-    const modeResult =
-      await this.referentielModeGuard.assertCanMutateActionsOrFailure(
-        ficheRow.collectiviteId,
-        affectedActionIds
-      );
+    const modeResult = await this.referentielModeGuard.assertCanMutateActions(
+      ficheRow.collectiviteId,
+      affectedActionIds
+    );
     if (!modeResult.success) {
       return modeResult;
     }
@@ -140,68 +136,73 @@ export default class UpdateFicheService {
     const txResult = await this.transactionManager.executeSingle<
       FicheWithRelations,
       UpdateFicheError
-    >(async (transaction): Promise<Result<FicheWithRelations, UpdateFicheError>> => {
-      const resultGetExistingFiche =
-        await this.ficheActionListService.getFicheById(
-          ficheId,
-          false,
-          user,
-          transaction
-        );
-      if (!resultGetExistingFiche.success) {
-        this.logger.error(resultGetExistingFiche.error);
-        return failure(UpdateFicheErrorEnum.FICHE_NOT_FOUND);
-      }
-      const existingFicheAction = resultGetExistingFiche.data;
-
-      const applyResult = await this.ficheActionRepository.applyUpdate({
-        ficheId,
-        ficheFields,
-        existingFiche: existingFicheAction,
-        user,
-        tx: transaction,
-      });
-      if (!applyResult.success) return applyResult;
-
-      // Le partage cross-collectivité dépasse l'aggregate FicheAction : on
-      // l'orchestre depuis le service plutôt que dans la couche d'écriture.
-      if (ficheFields.sharedWithCollectivites !== undefined) {
-        const collectiviteIds =
-          ficheFields.sharedWithCollectivites?.map((sharing) => sharing.id) ??
-          [];
-        await this.shareFicheService.shareFiche(
-          existingFicheAction,
-          collectiviteIds,
-          user.id,
-          transaction
-        );
-      }
-
-      const updatedFiche = await this.ficheActionListService.getFicheById(
-        ficheId,
-        true,
-        user,
+    >(
+      async (
         transaction
-      );
-      if (!updatedFiche.success) {
-        return failure(UpdateFicheErrorEnum.FICHE_NOT_FOUND);
-      }
+      ): Promise<Result<FicheWithRelations, UpdateFicheError>> => {
+        const resultGetExistingFiche =
+          await this.ficheActionListService.getFicheById(
+            ficheId,
+            false,
+            user,
+            transaction
+          );
+        if (!resultGetExistingFiche.success) {
+          this.logger.error(resultGetExistingFiche.error);
+          return failure(UpdateFicheErrorEnum.FICHE_NOT_FOUND);
+        }
+        const existingFicheAction = resultGetExistingFiche.data;
 
-      if (isNotificationEnabled) {
-        await this.notificationsFicheService.upsertPiloteNotificationsBulk({
-          fichesPairs: [
-            {
-              updatedFiche: updatedFiche.data,
-              previousFiche: existingFicheAction,
-            },
-          ],
+        const applyResult = await this.ficheActionRepository.applyUpdate({
+          ficheId,
+          ficheFields,
+          existingFiche: existingFicheAction,
           user,
           tx: transaction,
         });
-      }
+        if (!applyResult.success) return applyResult;
 
-      return success(updatedFiche.data);
-    }, tx);
+        // Le partage cross-collectivité dépasse l'aggregate FicheAction : on
+        // l'orchestre depuis le service plutôt que dans la couche d'écriture.
+        if (ficheFields.sharedWithCollectivites !== undefined) {
+          const collectiviteIds =
+            ficheFields.sharedWithCollectivites?.map((sharing) => sharing.id) ??
+            [];
+          await this.shareFicheService.shareFiche(
+            existingFicheAction,
+            collectiviteIds,
+            user.id,
+            transaction
+          );
+        }
+
+        const updatedFiche = await this.ficheActionListService.getFicheById(
+          ficheId,
+          true,
+          user,
+          transaction
+        );
+        if (!updatedFiche.success) {
+          return failure(UpdateFicheErrorEnum.FICHE_NOT_FOUND);
+        }
+
+        if (isNotificationEnabled) {
+          await this.notificationsFicheService.upsertPiloteNotificationsBulk({
+            fichesPairs: [
+              {
+                updatedFiche: updatedFiche.data,
+                previousFiche: existingFicheAction,
+              },
+            ],
+            user,
+            tx: transaction,
+          });
+        }
+
+        return success(updatedFiche.data);
+      },
+      tx
+    );
 
     if (!txResult.success) return txResult;
     const updatedFiche = txResult.data;

--- a/apps/backend/src/referentiels/compute-score/scores.service.ts
+++ b/apps/backend/src/referentiels/compute-score/scores.service.ts
@@ -985,66 +985,77 @@ export default class ScoresService {
     );
     let auditId: number | undefined = undefined;
     if (parameters.jalon) {
-      if (parameters.date) {
+      if (parameters.date && !parameters.auditId) {
         throw new HttpException(
           `Une date ne doit pas être définie lorsqu'un jalon est spécifié`,
           400
         );
       }
+
       // Later we can have snapshots for other jalon
       if (
         (parameters.jalon === SnapshotJalonEnum.PRE_AUDIT ||
           parameters.jalon === SnapshotJalonEnum.POST_AUDIT) &&
         !parameters.avecReferentielsOrigine
       ) {
-        const audits = await this.labellisationService.listAudits({
-          collectiviteId,
-          referentielId,
-        });
-
-        if (!audits.length) {
-          throw new HttpException(
-            `Aucun audit trouvé pour la collectivité ${collectiviteId} (auditId: ${parameters.auditId})`,
-            400
-          );
-        }
-
-        // Audits are sorted by date desc
-        let audit: LabellisationAudit | undefined = audits[0];
-        if (parameters.anneeAudit) {
-          audit = audits.find(
-            (a) =>
-              a.dateFin &&
-              (DateTime.fromISO(a.dateFin).year === parameters.anneeAudit ||
-                DateTime.fromSQL(a.dateFin).year === parameters.anneeAudit)
-          );
-          if (!audit) {
-            throw new HttpException(
-              `Aucun audit trouvé pour la collectivité ${collectiviteId} et l'année ${parameters.anneeAudit}`,
-              400
-            );
-          }
-        } else if (parameters.auditId) {
-          audit = audits.find((a) => a.id === parameters.auditId);
-          if (!audit) {
-            throw new HttpException(
-              `Aucun audit trouvé pour la collectivité ${collectiviteId} et l'id d'audit ${parameters.auditId}`,
-              400
-            );
-          }
+        if (parameters.date && parameters.auditId) {
+          auditId = parameters.auditId;
           parameters.anneeAudit =
-            DateTime.fromISO(audit.dateFin ?? audit.dateDebut ?? '').year ||
-            DateTime.fromSQL(audit.dateFin ?? audit.dateDebut ?? '').year;
-        }
-        auditId = audit.id;
-        parameters.date =
-          (parameters.jalon === SnapshotJalonEnum.PRE_AUDIT
-            ? audit.dateDebut
-            : audit.dateFin) || undefined;
+            DateTime.fromISO(parameters.date).year ||
+            DateTime.fromSQL(parameters.date).year;
+          this.logger.log(
+            `Audit ${auditId} fourni pour la collectivité ${collectiviteId} et le referentiel ${referentielId} avec le jalon ${parameters.jalon}: ${parameters.date}`
+          );
+        } else {
+          const audits = await this.labellisationService.listAudits({
+            collectiviteId,
+            referentielId,
+          });
 
-        this.logger.log(
-          `Audit ${auditId} trouvé pour la collectivité ${collectiviteId} et le referentiel ${referentielId} avec le jaon ${parameters.jalon}: ${parameters.date}`
-        );
+          if (!audits.length) {
+            throw new HttpException(
+              `Aucun audit trouvé pour la collectivité ${collectiviteId} (auditId: ${parameters.auditId})`,
+              400
+            );
+          }
+
+          // Audits are sorted by date desc
+          let audit: LabellisationAudit | undefined = audits[0];
+          if (parameters.anneeAudit) {
+            audit = audits.find(
+              (a) =>
+                a.dateFin &&
+                (DateTime.fromISO(a.dateFin).year === parameters.anneeAudit ||
+                  DateTime.fromSQL(a.dateFin).year === parameters.anneeAudit)
+            );
+            if (!audit) {
+              throw new HttpException(
+                `Aucun audit trouvé pour la collectivité ${collectiviteId} et l'année ${parameters.anneeAudit}`,
+                400
+              );
+            }
+          } else if (parameters.auditId) {
+            audit = audits.find((a) => a.id === parameters.auditId);
+            if (!audit) {
+              throw new HttpException(
+                `Aucun audit trouvé pour la collectivité ${collectiviteId} et l'id d'audit ${parameters.auditId}`,
+                400
+              );
+            }
+            parameters.anneeAudit =
+              DateTime.fromISO(audit.dateFin ?? audit.dateDebut ?? '').year ||
+              DateTime.fromSQL(audit.dateFin ?? audit.dateDebut ?? '').year;
+          }
+          auditId = audit.id;
+          parameters.date =
+            (parameters.jalon === SnapshotJalonEnum.PRE_AUDIT
+              ? audit.dateDebut
+              : audit.dateFin) || undefined;
+
+          this.logger.log(
+            `Audit ${auditId} trouvé pour la collectivité ${collectiviteId} et le referentiel ${referentielId} avec le jaon ${parameters.jalon}: ${parameters.date}`
+          );
+        }
       }
     } else {
       parameters.jalon = parameters.date

--- a/apps/backend/src/referentiels/handle-mesure-pilotes/handle-mesure-pilotes.errors.ts
+++ b/apps/backend/src/referentiels/handle-mesure-pilotes/handle-mesure-pilotes.errors.ts
@@ -8,22 +8,22 @@ import {
 } from '@tet/backend/utils/trpc/trpc-error-handler';
 
 const specificErrors = [
-  'MIXED_REFERENTIELS',
+  'EMPTY_PILOTES_LIST',
   ...referentielModeGuardSpecificErrors,
 ] as const;
 type SpecificError = (typeof specificErrors)[number];
 
-export const scoreIndicatifErrorConfig: TrpcErrorHandlerConfig<SpecificError> =
+export const handleMesurePilotesErrorConfig: TrpcErrorHandlerConfig<SpecificError> =
   {
     specificErrors: {
-      MIXED_REFERENTIELS: {
+      EMPTY_PILOTES_LIST: {
         code: 'BAD_REQUEST',
-        message:
-          "Les actions fournies appartiennent à plusieurs référentiels différents. Veuillez fournir des actions d'un seul référentiel.",
+        message: 'La liste des pilotes ne peut pas être vide.',
       },
       ...referentielNotWritableTrpcErrorEntry,
     },
   };
 
-export const ScoreIndicatifErrorEnum = createErrorsEnum(specificErrors);
-export type ScoreIndicatifError = keyof typeof ScoreIndicatifErrorEnum;
+export const HandleMesurePilotesErrorEnum = createErrorsEnum(specificErrors);
+export type HandleMesurePilotesError =
+  keyof typeof HandleMesurePilotesErrorEnum;

--- a/apps/backend/src/referentiels/handle-mesure-pilotes/handle-mesure-pilotes.router.e2e-spec.ts
+++ b/apps/backend/src/referentiels/handle-mesure-pilotes/handle-mesure-pilotes.router.e2e-spec.ts
@@ -40,11 +40,9 @@ describe('HandleMesurePilotesRouter', () => {
       pilotes: [{ userId: '298235a0-60e7-4ceb-9172-0a991cce0386' }],
     };
 
-    // `rejects` is necessary to handle exception in async function
-    // See https://vitest.dev/api/expect.html#tothrowerror
     await expect(() =>
       caller.referentiels.actions.upsertPilotes(input)
-    ).rejects.toThrowError(/Droits insuffisants/i);
+    ).rejects.toThrow(/permissions nécessaires/i);
   });
 
   test('Insert, update and delete pilotes', async () => {

--- a/apps/backend/src/referentiels/handle-mesure-pilotes/handle-mesure-pilotes.router.ts
+++ b/apps/backend/src/referentiels/handle-mesure-pilotes/handle-mesure-pilotes.router.ts
@@ -1,7 +1,9 @@
 import { Injectable } from '@nestjs/common';
+import { createTrpcErrorHandler } from '@tet/backend/utils/trpc/trpc-error-handler';
 import { TrpcService } from '@tet/backend/utils/trpc/trpc.service';
 import { actionIdSchema } from '@tet/domain/referentiels';
 import { z } from 'zod';
+import { handleMesurePilotesErrorConfig } from './handle-mesure-pilotes.errors';
 import { HandleMesurePilotesService } from './handle-mesure-pilotes.service';
 
 const upsertPilotesSchema = z.object({
@@ -22,6 +24,10 @@ const deletePilotesSchema = z.object({
 
 @Injectable()
 export class HandleMesurePilotesRouter {
+  private readonly getResultDataOrThrowError = createTrpcErrorHandler(
+    handleMesurePilotesErrorConfig
+  );
+
   constructor(
     private readonly trpc: TrpcService,
     private readonly service: HandleMesurePilotesService
@@ -30,23 +36,25 @@ export class HandleMesurePilotesRouter {
   router = this.trpc.router({
     upsertPilotes: this.trpc.authedProcedure
       .input(upsertPilotesSchema)
-      .mutation(({ input, ctx }) => {
-        return this.service.upsertPilotes(
+      .mutation(async ({ input, ctx }) => {
+        const result = await this.service.upsertPilotes(
           input.collectiviteId,
           input.mesureId,
           input.pilotes,
           ctx.user
         );
+        return this.getResultDataOrThrowError(result);
       }),
 
     deletePilotes: this.trpc.authedProcedure
       .input(deletePilotesSchema)
-      .mutation(({ input, ctx }) => {
-        return this.service.deletePilotes(
+      .mutation(async ({ input, ctx }) => {
+        const result = await this.service.deletePilotes(
           input.collectiviteId,
           input.mesureId,
           ctx.user
         );
+        return this.getResultDataOrThrowError(result);
       }),
   });
 }

--- a/apps/backend/src/referentiels/handle-mesure-pilotes/handle-mesure-pilotes.service.ts
+++ b/apps/backend/src/referentiels/handle-mesure-pilotes/handle-mesure-pilotes.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { ReferentielModeGuard } from '@tet/backend/collectivites/collectivite-referentiel-mode/referentiel-mode-guard.service';
 import { personneTagTable } from '@tet/backend/collectivites/tags/personnes/personne-tag.table';
 import { AuthUser } from '@tet/backend/users/models/auth.models';
 import { dcpTable } from '@tet/backend/users/models/dcp.table';
@@ -17,7 +18,8 @@ export class HandleMesurePilotesService {
 
   constructor(
     private readonly databaseService: DatabaseService,
-    private readonly permissionService: PermissionService
+    private readonly permissionService: PermissionService,
+    private readonly referentielModeGuard: ReferentielModeGuard
   ) {}
 
   async listPilotes(
@@ -83,6 +85,11 @@ export class HandleMesurePilotesService {
       collectiviteId
     );
 
+    await this.referentielModeGuard.assertCanMutateActionOrThrow(
+      collectiviteId,
+      mesureId
+    );
+
     if (pilotes.length === 0) {
       throw new Error('La liste des pilotes ne peut pas être vide');
     }
@@ -124,6 +131,11 @@ export class HandleMesurePilotesService {
       PermissionOperationEnum['REFERENTIELS.MUTATE'],
       ResourceType.COLLECTIVITE,
       collectiviteId
+    );
+
+    await this.referentielModeGuard.assertCanMutateActionOrThrow(
+      collectiviteId,
+      mesureId
     );
 
     this.logger.log(

--- a/apps/backend/src/referentiels/handle-mesure-pilotes/handle-mesure-pilotes.service.ts
+++ b/apps/backend/src/referentiels/handle-mesure-pilotes/handle-mesure-pilotes.service.ts
@@ -4,13 +4,19 @@ import { personneTagTable } from '@tet/backend/collectivites/tags/personnes/pers
 import { AuthUser } from '@tet/backend/users/models/auth.models';
 import { dcpTable } from '@tet/backend/users/models/dcp.table';
 import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { Result, failure, success } from '@tet/backend/utils/result.type';
 import { PersonneTagOrUser } from '@tet/domain/collectivites';
 import { ActionId } from '@tet/domain/referentiels';
 import { PermissionOperationEnum, ResourceType } from '@tet/domain/users';
+import { getErrorMessage } from '@tet/domain/utils';
 import { and, eq, inArray, sql } from 'drizzle-orm';
 import { PermissionService } from '../../users/authorizations/permission.service';
 import { DatabaseService } from '../../utils/database/database.service';
 import { actionPiloteTable } from '../models/action-pilote.table';
+import {
+  HandleMesurePilotesError,
+  HandleMesurePilotesErrorEnum,
+} from './handle-mesure-pilotes.errors';
 
 @Injectable()
 export class HandleMesurePilotesService {
@@ -77,29 +83,97 @@ export class HandleMesurePilotesService {
     mesureId: ActionId,
     pilotes: { userId?: string | null; tagId?: number | null }[],
     tokenInfo: AuthUser
-  ): Promise<Record<ActionId, PersonneTagOrUser[]>> {
-    await this.permissionService.isAllowed(
+  ): Promise<Result<Record<ActionId, PersonneTagOrUser[]>, HandleMesurePilotesError>> {
+    const isAllowed = await this.permissionService.isAllowed(
       tokenInfo,
       PermissionOperationEnum['REFERENTIELS.MUTATE'],
       ResourceType.COLLECTIVITE,
-      collectiviteId
+      collectiviteId,
+      true
     );
+    if (!isAllowed) {
+      return failure('UNAUTHORIZED');
+    }
 
-    await this.referentielModeGuard.assertCanMutateActionOrThrow(
+    const modeResult = await this.referentielModeGuard.assertCanMutateAction(
       collectiviteId,
       mesureId
     );
+    if (!modeResult.success) {
+      return modeResult;
+    }
 
     if (pilotes.length === 0) {
-      throw new Error('La liste des pilotes ne peut pas être vide');
+      return failure(HandleMesurePilotesErrorEnum.EMPTY_PILOTES_LIST);
     }
 
     this.logger.log(
       `Mise à jour des pilotes pour la collectivité ${collectiviteId} et la mesure ${mesureId}`
     );
 
-    return await this.databaseService.db.transaction(async (tx) => {
-      await tx
+    try {
+      const result = await this.databaseService.db.transaction(async (tx) => {
+        await tx
+          .delete(actionPiloteTable)
+          .where(
+            and(
+              eq(actionPiloteTable.collectiviteId, collectiviteId),
+              eq(actionPiloteTable.actionId, mesureId)
+            )
+          );
+
+        await tx.insert(actionPiloteTable).values(
+          pilotes.map((pilote) => ({
+            collectiviteId,
+            actionId: mesureId,
+            userId: pilote.userId,
+            tagId: pilote.tagId,
+          }))
+        );
+
+        return await this.listPilotes(collectiviteId, undefined, tx);
+      });
+
+      return success(result);
+    } catch (error) {
+      this.logger.error(error);
+      return failure(
+        'DATABASE_ERROR',
+        error instanceof Error ? error : new Error(getErrorMessage(error))
+      );
+    }
+  }
+
+  async deletePilotes(
+    collectiviteId: number,
+    mesureId: ActionId,
+    tokenInfo: AuthUser
+  ): Promise<Result<void, HandleMesurePilotesError>> {
+    const isAllowed = await this.permissionService.isAllowed(
+      tokenInfo,
+      PermissionOperationEnum['REFERENTIELS.MUTATE'],
+      ResourceType.COLLECTIVITE,
+      collectiviteId,
+      true
+    );
+    if (!isAllowed) {
+      return failure('UNAUTHORIZED');
+    }
+
+    const modeResult = await this.referentielModeGuard.assertCanMutateAction(
+      collectiviteId,
+      mesureId
+    );
+    if (!modeResult.success) {
+      return modeResult;
+    }
+
+    this.logger.log(
+      `Suppression des pilotes pour la collectivité ${collectiviteId} et la mesure ${mesureId}`
+    );
+
+    try {
+      await this.databaseService.db
         .delete(actionPiloteTable)
         .where(
           and(
@@ -108,48 +182,14 @@ export class HandleMesurePilotesService {
           )
         );
 
-      await tx.insert(actionPiloteTable).values(
-        pilotes.map((pilote) => ({
-          collectiviteId,
-          actionId: mesureId,
-          userId: pilote.userId,
-          tagId: pilote.tagId,
-        }))
+      return success(undefined);
+    } catch (error) {
+      this.logger.error(error);
+      return failure(
+        'DATABASE_ERROR',
+        error instanceof Error ? error : new Error(getErrorMessage(error))
       );
-
-      return await this.listPilotes(collectiviteId, undefined, tx);
-    });
-  }
-
-  async deletePilotes(
-    collectiviteId: number,
-    mesureId: ActionId,
-    tokenInfo: AuthUser
-  ): Promise<void> {
-    await this.permissionService.isAllowed(
-      tokenInfo,
-      PermissionOperationEnum['REFERENTIELS.MUTATE'],
-      ResourceType.COLLECTIVITE,
-      collectiviteId
-    );
-
-    await this.referentielModeGuard.assertCanMutateActionOrThrow(
-      collectiviteId,
-      mesureId
-    );
-
-    this.logger.log(
-      `Suppression des pilotes pour la collectivité ${collectiviteId} et la mesure ${mesureId}`
-    );
-
-    await this.databaseService.db
-      .delete(actionPiloteTable)
-      .where(
-        and(
-          eq(actionPiloteTable.collectiviteId, collectiviteId),
-          eq(actionPiloteTable.actionId, mesureId)
-        )
-      );
+    }
   }
 
   private formatMesuresLog(

--- a/apps/backend/src/referentiels/handle-mesure-services/handle-mesure-services.errors.ts
+++ b/apps/backend/src/referentiels/handle-mesure-services/handle-mesure-services.errors.ts
@@ -8,22 +8,22 @@ import {
 } from '@tet/backend/utils/trpc/trpc-error-handler';
 
 const specificErrors = [
-  'MIXED_REFERENTIELS',
+  'EMPTY_SERVICES_LIST',
   ...referentielModeGuardSpecificErrors,
 ] as const;
 type SpecificError = (typeof specificErrors)[number];
 
-export const scoreIndicatifErrorConfig: TrpcErrorHandlerConfig<SpecificError> =
+export const handleMesureServicesErrorConfig: TrpcErrorHandlerConfig<SpecificError> =
   {
     specificErrors: {
-      MIXED_REFERENTIELS: {
+      EMPTY_SERVICES_LIST: {
         code: 'BAD_REQUEST',
-        message:
-          "Les actions fournies appartiennent à plusieurs référentiels différents. Veuillez fournir des actions d'un seul référentiel.",
+        message: 'La liste des services ne peut pas être vide.',
       },
       ...referentielNotWritableTrpcErrorEntry,
     },
   };
 
-export const ScoreIndicatifErrorEnum = createErrorsEnum(specificErrors);
-export type ScoreIndicatifError = keyof typeof ScoreIndicatifErrorEnum;
+export const HandleMesureServicesErrorEnum = createErrorsEnum(specificErrors);
+export type HandleMesureServicesError =
+  keyof typeof HandleMesureServicesErrorEnum;

--- a/apps/backend/src/referentiels/handle-mesure-services/handle-mesure-services.router.e2e-spec.ts
+++ b/apps/backend/src/referentiels/handle-mesure-services/handle-mesure-services.router.e2e-spec.ts
@@ -39,11 +39,9 @@ describe('HandleMesureServicesRouter', () => {
       services: [{ serviceTagId: 1 }, { serviceTagId: 2 }],
     };
 
-    // `rejects` is necessary to handle exception in async function
-    // See https://vitest.dev/api/expect.html#tothrowerror
     await expect(() =>
       caller.referentiels.actions.upsertServices(input)
-    ).rejects.toThrowError(/Droits insuffisants/i);
+    ).rejects.toThrow(/permissions nécessaires/i);
   });
 
   test('Insert, update and delete services', async () => {

--- a/apps/backend/src/referentiels/handle-mesure-services/handle-mesure-services.router.ts
+++ b/apps/backend/src/referentiels/handle-mesure-services/handle-mesure-services.router.ts
@@ -1,7 +1,9 @@
 import { Injectable } from '@nestjs/common';
+import { createTrpcErrorHandler } from '@tet/backend/utils/trpc/trpc-error-handler';
 import { TrpcService } from '@tet/backend/utils/trpc/trpc.service';
 import { actionIdSchema } from '@tet/domain/referentiels';
 import { z } from 'zod';
+import { handleMesureServicesErrorConfig } from './handle-mesure-services.errors';
 import { HandleMesureServicesService } from './handle-mesure-services.service';
 
 const upsertServicesSchema = z.object({
@@ -22,6 +24,10 @@ const deleteServicesSchema = z.object({
 
 @Injectable()
 export class HandleMesuresServicesRouter {
+  private readonly getResultDataOrThrowError = createTrpcErrorHandler(
+    handleMesureServicesErrorConfig
+  );
+
   constructor(
     private readonly trpc: TrpcService,
     private readonly service: HandleMesureServicesService
@@ -30,23 +36,25 @@ export class HandleMesuresServicesRouter {
   router = this.trpc.router({
     upsertServices: this.trpc.authedProcedure
       .input(upsertServicesSchema)
-      .mutation(({ input, ctx }) => {
-        return this.service.upsertServices(
+      .mutation(async ({ input, ctx }) => {
+        const result = await this.service.upsertServices(
           input.collectiviteId,
           input.mesureId,
           input.services,
           ctx.user
         );
+        return this.getResultDataOrThrowError(result);
       }),
 
     deleteServices: this.trpc.authedProcedure
       .input(deleteServicesSchema)
-      .mutation(({ input, ctx }) => {
-        return this.service.deleteServices(
+      .mutation(async ({ input, ctx }) => {
+        const result = await this.service.deleteServices(
           input.collectiviteId,
           input.mesureId,
           ctx.user
         );
+        return this.getResultDataOrThrowError(result);
       }),
   });
 }

--- a/apps/backend/src/referentiels/handle-mesure-services/handle-mesure-services.service.ts
+++ b/apps/backend/src/referentiels/handle-mesure-services/handle-mesure-services.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { ReferentielModeGuard } from '@tet/backend/collectivites/collectivite-referentiel-mode/referentiel-mode-guard.service';
 import { serviceTagTable } from '@tet/backend/collectivites/tags/service-tag.table';
 import { AuthUser } from '@tet/backend/users/models/auth.models';
 import { Transaction } from '@tet/backend/utils/database/transaction.utils';
@@ -16,7 +17,8 @@ export class HandleMesureServicesService {
 
   constructor(
     private readonly databaseService: DatabaseService,
-    private readonly permissionService: PermissionService
+    private readonly permissionService: PermissionService,
+    private readonly referentielModeGuard: ReferentielModeGuard
   ) {}
 
   async listServices(
@@ -75,6 +77,11 @@ export class HandleMesureServicesService {
       collectiviteId
     );
 
+    await this.referentielModeGuard.assertCanMutateActionOrThrow(
+      collectiviteId,
+      mesureId
+    );
+
     if (services.length === 0) {
       throw new Error('La liste des services ne peut pas être vide');
     }
@@ -115,6 +122,11 @@ export class HandleMesureServicesService {
       PermissionOperationEnum['REFERENTIELS.MUTATE'],
       ResourceType.COLLECTIVITE,
       collectiviteId
+    );
+
+    await this.referentielModeGuard.assertCanMutateActionOrThrow(
+      collectiviteId,
+      mesureId
     );
 
     this.logger.log(

--- a/apps/backend/src/referentiels/handle-mesure-services/handle-mesure-services.service.ts
+++ b/apps/backend/src/referentiels/handle-mesure-services/handle-mesure-services.service.ts
@@ -3,13 +3,19 @@ import { ReferentielModeGuard } from '@tet/backend/collectivites/collectivite-re
 import { serviceTagTable } from '@tet/backend/collectivites/tags/service-tag.table';
 import { AuthUser } from '@tet/backend/users/models/auth.models';
 import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { Result, failure, success } from '@tet/backend/utils/result.type';
 import { TagWithCollectiviteId } from '@tet/domain/collectivites';
 import { ActionId } from '@tet/domain/referentiels';
 import { PermissionOperationEnum, ResourceType } from '@tet/domain/users';
+import { getErrorMessage } from '@tet/domain/utils';
 import { and, eq, inArray } from 'drizzle-orm';
 import { PermissionService } from '../../users/authorizations/permission.service';
 import { DatabaseService } from '../../utils/database/database.service';
 import { actionServiceTable } from '../models/action-service.table';
+import {
+  HandleMesureServicesError,
+  HandleMesureServicesErrorEnum,
+} from './handle-mesure-services.errors';
 
 @Injectable()
 export class HandleMesureServicesService {
@@ -69,29 +75,98 @@ export class HandleMesureServicesService {
     mesureId: ActionId,
     services: { serviceTagId: number }[],
     tokenInfo: AuthUser
-  ): Promise<Record<ActionId, TagWithCollectiviteId[]>> {
-    await this.permissionService.isAllowed(
+  ): Promise<
+    Result<Record<ActionId, TagWithCollectiviteId[]>, HandleMesureServicesError>
+  > {
+    const isAllowed = await this.permissionService.isAllowed(
       tokenInfo,
       PermissionOperationEnum['REFERENTIELS.MUTATE'],
       ResourceType.COLLECTIVITE,
-      collectiviteId
+      collectiviteId,
+      true
     );
+    if (!isAllowed) {
+      return failure('UNAUTHORIZED');
+    }
 
-    await this.referentielModeGuard.assertCanMutateActionOrThrow(
+    const modeResult = await this.referentielModeGuard.assertCanMutateAction(
       collectiviteId,
       mesureId
     );
+    if (!modeResult.success) {
+      return modeResult;
+    }
 
     if (services.length === 0) {
-      throw new Error('La liste des services ne peut pas être vide');
+      return failure(HandleMesureServicesErrorEnum.EMPTY_SERVICES_LIST);
     }
 
     this.logger.log(
       `Mise à jour des services pour la collectivité ${collectiviteId} et la mesure ${mesureId}`
     );
 
-    return await this.databaseService.db.transaction(async (tx) => {
-      await tx
+    try {
+      const result = await this.databaseService.db.transaction(async (tx) => {
+        await tx
+          .delete(actionServiceTable)
+          .where(
+            and(
+              eq(actionServiceTable.collectiviteId, collectiviteId),
+              eq(actionServiceTable.actionId, mesureId)
+            )
+          );
+
+        await tx.insert(actionServiceTable).values(
+          services.map((service) => ({
+            collectiviteId,
+            actionId: mesureId,
+            serviceTagId: service.serviceTagId,
+          }))
+        );
+
+        return await this.listServices(collectiviteId, [mesureId], tx);
+      });
+
+      return success(result);
+    } catch (error) {
+      this.logger.error(error);
+      return failure(
+        'DATABASE_ERROR',
+        error instanceof Error ? error : new Error(getErrorMessage(error))
+      );
+    }
+  }
+
+  async deleteServices(
+    collectiviteId: number,
+    mesureId: ActionId,
+    tokenInfo: AuthUser
+  ): Promise<Result<void, HandleMesureServicesError>> {
+    const isAllowed = await this.permissionService.isAllowed(
+      tokenInfo,
+      PermissionOperationEnum['REFERENTIELS.MUTATE'],
+      ResourceType.COLLECTIVITE,
+      collectiviteId,
+      true
+    );
+    if (!isAllowed) {
+      return failure('UNAUTHORIZED');
+    }
+
+    const modeResult = await this.referentielModeGuard.assertCanMutateAction(
+      collectiviteId,
+      mesureId
+    );
+    if (!modeResult.success) {
+      return modeResult;
+    }
+
+    this.logger.log(
+      `Suppression des services pour la collectivité ${collectiviteId} et la mesure ${mesureId}`
+    );
+
+    try {
+      await this.databaseService.db
         .delete(actionServiceTable)
         .where(
           and(
@@ -100,47 +175,14 @@ export class HandleMesureServicesService {
           )
         );
 
-      await tx.insert(actionServiceTable).values(
-        services.map((service) => ({
-          collectiviteId,
-          actionId: mesureId,
-          serviceTagId: service.serviceTagId,
-        }))
+      return success(undefined);
+    } catch (error) {
+      this.logger.error(error);
+      return failure(
+        'DATABASE_ERROR',
+        error instanceof Error ? error : new Error(getErrorMessage(error))
       );
-
-      return await this.listServices(collectiviteId, [mesureId], tx);
-    });
-  }
-
-  async deleteServices(
-    collectiviteId: number,
-    mesureId: ActionId,
-    tokenInfo: AuthUser
-  ): Promise<void> {
-    await this.permissionService.isAllowed(
-      tokenInfo,
-      PermissionOperationEnum['REFERENTIELS.MUTATE'],
-      ResourceType.COLLECTIVITE,
-      collectiviteId
-    );
-
-    await this.referentielModeGuard.assertCanMutateActionOrThrow(
-      collectiviteId,
-      mesureId
-    );
-
-    this.logger.log(
-      `Suppression des services pour la collectivité ${collectiviteId} et la mesure ${mesureId}`
-    );
-
-    await this.databaseService.db
-      .delete(actionServiceTable)
-      .where(
-        and(
-          eq(actionServiceTable.collectiviteId, collectiviteId),
-          eq(actionServiceTable.actionId, mesureId)
-        )
-      );
+    }
   }
 
   private formatServicesLog(

--- a/apps/backend/src/referentiels/labellisations/create-preuve/create-labellisation-preuve.errors.ts
+++ b/apps/backend/src/referentiels/labellisations/create-preuve/create-labellisation-preuve.errors.ts
@@ -1,4 +1,8 @@
 import {
+  referentielModeGuardSpecificErrors,
+  referentielNotWritableTrpcErrorEntry,
+} from '@tet/backend/collectivites/collectivite-referentiel-mode/referentiel-mode-guard.errors';
+import {
   createErrorsEnum,
   TrpcErrorHandlerConfig,
 } from '@tet/backend/utils/trpc/trpc-error-handler';
@@ -8,6 +12,7 @@ const specificErrors = [
   'DEMANDE_NOT_FOUND',
   'LABELLISATION_IN_PROGRESS',
   'DATABASE_ERROR',
+  ...referentielModeGuardSpecificErrors,
 ] as const;
 type SpecificError = (typeof specificErrors)[number];
 
@@ -34,6 +39,7 @@ export const createLabellisationPreuveErrorConfig: TrpcErrorHandlerConfig<Specif
         message:
           "Une erreur de base de données s'est produite lors de l'ajout de la preuve.",
       },
+      ...referentielNotWritableTrpcErrorEntry,
     },
   };
 

--- a/apps/backend/src/referentiels/labellisations/create-preuve/create-preuve.service.ts
+++ b/apps/backend/src/referentiels/labellisations/create-preuve/create-preuve.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { ReferentielModeGuard } from '@tet/backend/collectivites/collectivite-referentiel-mode/referentiel-mode-guard.service';
 import { preuveLabellisationTable } from '@tet/backend/collectivites/documents/models/preuve-labellisation.table';
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
@@ -22,7 +23,8 @@ export class CreatePreuveService {
   constructor(
     private readonly databaseService: DatabaseService,
     private readonly permissions: PermissionService,
-    private readonly getLabellisationService: GetLabellisationService
+    private readonly getLabellisationService: GetLabellisationService,
+    private readonly referentielModeGuard: ReferentielModeGuard
   ) {}
 
   async createLabellisationPreuve(
@@ -62,6 +64,14 @@ export class CreatePreuveService {
         success: false,
         error: 'UNAUTHORIZED',
       };
+    }
+
+    const modeResult = await this.referentielModeGuard.assertCanMutate(
+      demande.collectiviteId,
+      demande.referentiel
+    );
+    if (!modeResult.success) {
+      return modeResult;
     }
 
     const auditResult = await this.getLabellisationService.getAuditByDemande(

--- a/apps/backend/src/referentiels/labellisations/handle-mesure-audit-statut/handle-mesure-audit-statut.errors.ts
+++ b/apps/backend/src/referentiels/labellisations/handle-mesure-audit-statut/handle-mesure-audit-statut.errors.ts
@@ -1,0 +1,23 @@
+import {
+  referentielModeGuardSpecificErrors,
+  referentielNotWritableTrpcErrorEntry,
+} from '@tet/backend/collectivites/collectivite-referentiel-mode/referentiel-mode-guard.errors';
+import {
+  createErrorsEnum,
+  TrpcErrorHandlerConfig,
+} from '@tet/backend/utils/trpc/trpc-error-handler';
+
+const specificErrors = [...referentielModeGuardSpecificErrors] as const;
+type SpecificError = (typeof specificErrors)[number];
+
+export const handleMesureAuditStatutErrorConfig: TrpcErrorHandlerConfig<SpecificError> =
+  {
+    specificErrors: {
+      ...referentielNotWritableTrpcErrorEntry,
+    },
+  };
+
+export const HandleMesureAuditStatutErrorEnum =
+  createErrorsEnum(specificErrors);
+export type HandleMesureAuditStatutError =
+  keyof typeof HandleMesureAuditStatutErrorEnum;

--- a/apps/backend/src/referentiels/labellisations/handle-mesure-audit-statut/handle-mesure-audit-statut.router.e2e-spec.ts
+++ b/apps/backend/src/referentiels/labellisations/handle-mesure-audit-statut/handle-mesure-audit-statut.router.e2e-spec.ts
@@ -1,17 +1,17 @@
 import { INestApplication } from '@nestjs/common';
-import { auditeurTable } from '@tet/backend/referentiels/labellisations/auditeur.table';
 import { addTestCollectivite } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { auditeurTable } from '@tet/backend/referentiels/labellisations/auditeur.table';
 import {
   getAuthUserFromUserCredentials,
   getTestApp,
   getTestDatabase,
   getTestRouter,
 } from '@tet/backend/test';
-import { addTestUser } from '@tet/backend/users/users/users.test-fixture';
-import { CollectiviteRole } from '@tet/domain/users';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { addTestUser } from '@tet/backend/users/users/users.test-fixture';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
+import { CollectiviteRole } from '@tet/domain/users';
 
 import {
   MesureAuditStatutEnum,
@@ -223,7 +223,7 @@ describe('MesureAuditStatutRouter : permissions', () => {
         collectiviteId,
         mesureId,
       })
-    ).rejects.toThrowError(/not authenticated/i);
+    ).rejects.toThrow(/not authenticated/i);
   });
 
   test('updateStatut refuse si non authentifié', async () => {
@@ -236,7 +236,7 @@ describe('MesureAuditStatutRouter : permissions', () => {
         avis: '',
         ordreDuJour: false,
       })
-    ).rejects.toThrowError(/not authenticated/i);
+    ).rejects.toThrow(/not authenticated/i);
   });
 
   test('getStatut refuse si non autorisé', async () => {
@@ -255,7 +255,7 @@ describe('MesureAuditStatutRouter : permissions', () => {
         collectiviteId,
         mesureId,
       })
-    ).rejects.toThrowError(/Droits insuffisants/i);
+    ).rejects.toThrow(/Droits insuffisants/i);
   });
 
   test('updateStatut refuse si non auditeur', async () => {
@@ -276,6 +276,6 @@ describe('MesureAuditStatutRouter : permissions', () => {
         avis: '',
         ordreDuJour: false,
       })
-    ).rejects.toThrowError(/Droits insuffisants/i);
+    ).rejects.toThrow(/permissions nécessaires/i);
   });
 });

--- a/apps/backend/src/referentiels/labellisations/handle-mesure-audit-statut/handle-mesure-audit-statut.router.ts
+++ b/apps/backend/src/referentiels/labellisations/handle-mesure-audit-statut/handle-mesure-audit-statut.router.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { createTrpcErrorHandler } from '@tet/backend/utils/trpc/trpc-error-handler';
 import { TrpcService } from '@tet/backend/utils/trpc/trpc.service';
 import {
   getMesureAuditStatutInputSchema,
@@ -7,10 +8,15 @@ import {
   listMesureAuditStatutsOutputSchema,
   updateMesureAuditStatutRequestSchema,
 } from './handle-mesure-audit-statut.dto';
+import { handleMesureAuditStatutErrorConfig } from './handle-mesure-audit-statut.errors';
 import { HandleMesureAuditStatutService } from './handle-mesure-audit-statut.service';
 
 @Injectable()
 export class HandleMesureAuditStatutRouter {
+  private readonly getResultDataOrThrowError = createTrpcErrorHandler(
+    handleMesureAuditStatutErrorConfig
+  );
+
   constructor(
     private readonly trpc: TrpcService,
     private readonly service: HandleMesureAuditStatutService
@@ -29,6 +35,9 @@ export class HandleMesureAuditStatutRouter {
 
     updateMesureAuditStatut: this.trpc.authedProcedure
       .input(updateMesureAuditStatutRequestSchema)
-      .mutation(({ input, ctx }) => this.service.updateStatut(input, ctx.user)),
+      .mutation(async ({ input, ctx }) => {
+        const result = await this.service.updateStatut(input, ctx.user);
+        return this.getResultDataOrThrowError(result);
+      }),
   });
 }

--- a/apps/backend/src/referentiels/labellisations/handle-mesure-audit-statut/handle-mesure-audit-statut.service.ts
+++ b/apps/backend/src/referentiels/labellisations/handle-mesure-audit-statut/handle-mesure-audit-statut.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { ReferentielModeGuard } from '@tet/backend/collectivites/collectivite-referentiel-mode/referentiel-mode-guard.service';
 import { ListActionsService } from '@tet/backend/referentiels/list-actions/list-actions.service';
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
@@ -28,7 +29,8 @@ export class HandleMesureAuditStatutService {
     private readonly databaseService: DatabaseService,
     private readonly permissions: PermissionService,
     private readonly listActionsService: ListActionsService,
-    private readonly getAuditEnCoursRepository: GetAuditEnCoursRepository
+    private readonly getAuditEnCoursRepository: GetAuditEnCoursRepository,
+    private readonly referentielModeGuard: ReferentielModeGuard
   ) {}
 
   async listStatuts(
@@ -149,6 +151,11 @@ export class HandleMesureAuditStatutService {
       'referentiels.labellisations.mutate_action_audit_statut',
       ResourceType.AUDIT,
       auditId
+    );
+
+    await this.referentielModeGuard.assertCanMutateOrThrow(
+      input.collectiviteId,
+      referentielId
     );
 
     // Upsert (insert or update) dans action_audit_state

--- a/apps/backend/src/referentiels/labellisations/handle-mesure-audit-statut/handle-mesure-audit-statut.service.ts
+++ b/apps/backend/src/referentiels/labellisations/handle-mesure-audit-statut/handle-mesure-audit-statut.service.ts
@@ -4,6 +4,7 @@ import { ListActionsService } from '@tet/backend/referentiels/list-actions/list-
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { Result, failure, success } from '@tet/backend/utils/result.type';
 import {
   ActionTypeEnum,
   getReferentielIdFromActionId,
@@ -20,6 +21,7 @@ import {
   UpdateMesureAuditStatutInput,
   UpdateMesureAuditStatutOutput,
 } from './handle-mesure-audit-statut.dto';
+import { HandleMesureAuditStatutError } from './handle-mesure-audit-statut.errors';
 import { mesureAuditStatutTable } from './mesure-audit-statut.table';
 
 @Injectable()
@@ -135,7 +137,7 @@ export class HandleMesureAuditStatutService {
   async updateStatut(
     input: UpdateMesureAuditStatutInput,
     user: AuthenticatedUser
-  ): Promise<UpdateMesureAuditStatutOutput> {
+  ): Promise<Result<UpdateMesureAuditStatutOutput, HandleMesureAuditStatutError>> {
     const referentielId = getReferentielIdFromActionId(input.mesureId);
 
     const auditEnCours = await this.getAuditEnCoursRepository.execute({
@@ -145,20 +147,25 @@ export class HandleMesureAuditStatutService {
 
     const auditId = auditEnCours.id;
 
-    // Vérification des droits : auditeur sur l'audit courant
-    await this.permissions.isAllowed(
+    const isAllowed = await this.permissions.isAllowed(
       user,
       'referentiels.labellisations.mutate_action_audit_statut',
       ResourceType.AUDIT,
-      auditId
+      auditId,
+      true
     );
+    if (!isAllowed) {
+      return failure('UNAUTHORIZED');
+    }
 
-    await this.referentielModeGuard.assertCanMutateOrThrow(
+    const modeResult = await this.referentielModeGuard.assertCanMutate(
       input.collectiviteId,
       referentielId
     );
+    if (!modeResult.success) {
+      return modeResult;
+    }
 
-    // Upsert (insert or update) dans action_audit_state
     const [statut] = await this.db
       .insert(mesureAuditStatutTable)
       .values({
@@ -185,6 +192,6 @@ export class HandleMesureAuditStatutService {
       })
       .returning();
 
-    return statut;
+    return success(statut);
   }
 }

--- a/apps/backend/src/referentiels/labellisations/request-labellisation/request-labellisation.errors.ts
+++ b/apps/backend/src/referentiels/labellisations/request-labellisation/request-labellisation.errors.ts
@@ -1,4 +1,8 @@
 import {
+  referentielModeGuardSpecificErrors,
+  referentielNotWritableTrpcErrorEntry,
+} from '@tet/backend/collectivites/collectivite-referentiel-mode/referentiel-mode-guard.errors';
+import {
   createErrorsEnum,
   TrpcErrorHandlerConfig,
 } from '@tet/backend/utils/trpc/trpc-error-handler';
@@ -8,6 +12,7 @@ const specificErrors = [
   ...requestLabellisationRulesErrors,
   'DEMANDE_NOT_FOUND',
   'DATABASE_ERROR',
+  ...referentielModeGuardSpecificErrors,
 ] as const;
 type SpecificError = (typeof specificErrors)[number];
 
@@ -64,6 +69,7 @@ export const requestLabellisationErrorConfig: TrpcErrorHandlerConfig<SpecificErr
         message:
           "Une erreur de base de données s'est produite lors de la soumission de la demande",
       },
+      ...referentielNotWritableTrpcErrorEntry,
     },
   };
 

--- a/apps/backend/src/referentiels/labellisations/request-labellisation/request-labellisation.service.ts
+++ b/apps/backend/src/referentiels/labellisations/request-labellisation/request-labellisation.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { ReferentielModeGuard } from '@tet/backend/collectivites/collectivite-referentiel-mode/referentiel-mode-guard.service';
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
@@ -26,7 +27,8 @@ export class RequestLabellisationService {
   constructor(
     private readonly databaseService: DatabaseService,
     private readonly permissions: PermissionService,
-    private readonly labellisations: GetLabellisationService
+    private readonly labellisations: GetLabellisationService,
+    private readonly referentielModeGuard: ReferentielModeGuard
   ) {}
 
   private readonly db = this.databaseService.db;
@@ -53,6 +55,14 @@ export class RequestLabellisationService {
         success: false,
         error: 'UNAUTHORIZED',
       };
+    }
+
+    const modeResult = await this.referentielModeGuard.assertCanMutate(
+      collectiviteId,
+      referentiel
+    );
+    if (!modeResult.success) {
+      return modeResult;
     }
 
     const labellisation = await this.labellisations.getParcoursLabellisation({

--- a/apps/backend/src/referentiels/labellisations/start-audit/start-audit.errors.ts
+++ b/apps/backend/src/referentiels/labellisations/start-audit/start-audit.errors.ts
@@ -1,10 +1,18 @@
 import {
+  referentielModeGuardSpecificErrors,
+  referentielNotWritableTrpcErrorEntry,
+} from '@tet/backend/collectivites/collectivite-referentiel-mode/referentiel-mode-guard.errors';
+import {
   createErrorsEnum,
   TrpcErrorHandlerConfig,
 } from '@tet/backend/utils/trpc/trpc-error-handler';
 import { startAuditRulesErrors } from '@tet/domain/referentiels';
 
-const specificErrors = [...startAuditRulesErrors, 'DATABASE_ERROR'] as const;
+const specificErrors = [
+  ...startAuditRulesErrors,
+  'DATABASE_ERROR',
+  ...referentielModeGuardSpecificErrors,
+] as const;
 type SpecificError = (typeof specificErrors)[number];
 
 export const startAuditErrorConfig: TrpcErrorHandlerConfig<SpecificError> = {
@@ -26,6 +34,7 @@ export const startAuditErrorConfig: TrpcErrorHandlerConfig<SpecificError> = {
       message:
         "Une erreur de base de données s'est produite lors du démarrage de l'audit",
     },
+    ...referentielNotWritableTrpcErrorEntry,
   },
 };
 

--- a/apps/backend/src/referentiels/labellisations/start-audit/start-audit.service.ts
+++ b/apps/backend/src/referentiels/labellisations/start-audit/start-audit.service.ts
@@ -83,30 +83,28 @@ export class StartAuditService {
         };
       }
 
-      // Update audit `date_debut`
-      const startedAuditRows = await this.db
-        .update(auditTable)
-        .set({ dateDebut: sql`now()` })
-        .where(eq(auditTable.id, auditId))
-        .returning();
-      if (!startedAuditRows.length) {
-        return {
-          success: false,
-          error: StartAuditErrorEnum.AUDIT_NOT_FOUND,
-        };
-      }
-      const startedAudit = startedAuditRows[0];
+      // Update audit `date_debut` et crée le snapshot pre_audit de façon atomique
+      const startedAudit = await this.databaseService.db.transaction(
+        async (tx) => {
+          const started = await tx
+            .update(auditTable)
+            .set({ dateDebut: sql`now()` })
+            .where(eq(auditTable.id, auditId))
+            .returning()
+            .then((rows) => rows[0]);
 
-      // TODO it could be great to create a transaction containing the update of the audit and the creation of the snapshot,
-      // it would be better for consistency but maybe it's too big an operation?
+          await this.snapshotsService.computeAndUpsert({
+            collectiviteId: started.collectiviteId,
+            referentielId: started.referentielId,
+            jalon: SnapshotJalonEnum.PRE_AUDIT,
+            auditId: started.id,
+            date: started.dateDebut ?? undefined,
+            tx,
+          });
 
-      // Crée un snapshot de 'pre_audit'
-      await this.snapshotsService.computeAndUpsert({
-        collectiviteId: startedAudit.collectiviteId,
-        referentielId: startedAudit.referentielId,
-        jalon: SnapshotJalonEnum.PRE_AUDIT,
-        auditId: startedAudit.id,
-      });
+          return started;
+        }
+      );
 
       return {
         success: true,

--- a/apps/backend/src/referentiels/labellisations/start-audit/start-audit.service.ts
+++ b/apps/backend/src/referentiels/labellisations/start-audit/start-audit.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { ReferentielModeGuard } from '@tet/backend/collectivites/collectivite-referentiel-mode/referentiel-mode-guard.service';
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
@@ -22,7 +23,8 @@ export class StartAuditService {
     private readonly databaseService: DatabaseService,
     private readonly snapshotsService: SnapshotsService,
     private readonly permissions: PermissionService,
-    private readonly getLabellisationService: GetLabellisationService
+    private readonly getLabellisationService: GetLabellisationService,
+    private readonly referentielModeGuard: ReferentielModeGuard
   ) {}
 
   private readonly db = this.databaseService.db;
@@ -57,6 +59,14 @@ export class StartAuditService {
           success: false,
           error: audit.error,
         };
+      }
+
+      const modeResult = await this.referentielModeGuard.assertCanMutate(
+        audit.data.collectiviteId,
+        audit.data.referentielId
+      );
+      if (!modeResult.success) {
+        return modeResult;
       }
 
       const parcours =

--- a/apps/backend/src/referentiels/labellisations/validate-audit/validate-audit.errors.ts
+++ b/apps/backend/src/referentiels/labellisations/validate-audit/validate-audit.errors.ts
@@ -1,0 +1,39 @@
+import {
+  referentielModeGuardSpecificErrors,
+  referentielNotWritableTrpcErrorEntry,
+} from '@tet/backend/collectivites/collectivite-referentiel-mode/referentiel-mode-guard.errors';
+import {
+  createErrorsEnum,
+  TrpcErrorHandlerConfig,
+} from '@tet/backend/utils/trpc/trpc-error-handler';
+
+const specificErrors = [
+  'AUDIT_NOT_FOUND',
+  'AUDIT_ALREADY_VALIDATED',
+  'DATABASE_ERROR',
+  ...referentielModeGuardSpecificErrors,
+] as const;
+type SpecificError = (typeof specificErrors)[number];
+
+export const validateAuditErrorConfig: TrpcErrorHandlerConfig<SpecificError> =
+  {
+    specificErrors: {
+      AUDIT_NOT_FOUND: {
+        code: 'NOT_FOUND',
+        message: "L'audit demandé n'a pas été trouvé.",
+      },
+      AUDIT_ALREADY_VALIDATED: {
+        code: 'BAD_REQUEST',
+        message: "L'audit a déjà été validé.",
+      },
+      DATABASE_ERROR: {
+        code: 'INTERNAL_SERVER_ERROR',
+        message:
+          "Une erreur de base de données s'est produite lors de la validation de l'audit.",
+      },
+      ...referentielNotWritableTrpcErrorEntry,
+    },
+  };
+
+export const ValidateAuditErrorEnum = createErrorsEnum(specificErrors);
+export type ValidateAuditError = keyof typeof ValidateAuditErrorEnum;

--- a/apps/backend/src/referentiels/labellisations/validate-audit/validate-audit.router.ts
+++ b/apps/backend/src/referentiels/labellisations/validate-audit/validate-audit.router.ts
@@ -1,12 +1,18 @@
 import { Injectable } from '@nestjs/common';
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
+import { createTrpcErrorHandler } from '@tet/backend/utils/trpc/trpc-error-handler';
 import { TrpcService } from '@tet/backend/utils/trpc/trpc.service';
 import { ResourceType } from '@tet/domain/users';
 import z from 'zod';
+import { validateAuditErrorConfig } from './validate-audit.errors';
 import { ValidateAuditService } from './validate-audit.service';
 
 @Injectable()
 export class ValidateAuditRouter {
+  private readonly getResultDataOrThrowError = createTrpcErrorHandler(
+    validateAuditErrorConfig
+  );
+
   constructor(
     private readonly trpc: TrpcService,
     private readonly permissions: PermissionService,
@@ -24,7 +30,8 @@ export class ValidateAuditRouter {
           auditId
         );
 
-        return this.validateAudit.validateAudit({ auditId });
+        const result = await this.validateAudit.validateAudit({ auditId });
+        return this.getResultDataOrThrowError(result);
       }),
   });
 }

--- a/apps/backend/src/referentiels/labellisations/validate-audit/validate-audit.service.ts
+++ b/apps/backend/src/referentiels/labellisations/validate-audit/validate-audit.service.ts
@@ -3,6 +3,7 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
+import { ReferentielModeGuard } from '@tet/backend/collectivites/collectivite-referentiel-mode/referentiel-mode-guard.service';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import {
   LabellisationAudit,
@@ -16,7 +17,8 @@ import { auditTable } from '../audit.table';
 export class ValidateAuditService {
   constructor(
     private readonly databaseService: DatabaseService,
-    private readonly snapshotsService: SnapshotsService
+    private readonly snapshotsService: SnapshotsService,
+    private readonly referentielModeGuard: ReferentielModeGuard
   ) {}
 
   private readonly db = this.databaseService.db;
@@ -39,6 +41,11 @@ export class ValidateAuditService {
     if (!audit) {
       throw new NotFoundException(`Audit ${auditId} non trouvé`);
     }
+
+    await this.referentielModeGuard.assertCanMutateOrThrow(
+      audit.collectiviteId,
+      audit.referentielId
+    );
 
     if (audit.valide) {
       throw new BadRequestException(

--- a/apps/backend/src/referentiels/labellisations/validate-audit/validate-audit.service.ts
+++ b/apps/backend/src/referentiels/labellisations/validate-audit/validate-audit.service.ts
@@ -31,47 +31,53 @@ export class ValidateAuditService {
   }: {
     auditId: number;
   }): Promise<Result<LabellisationAudit, ValidateAuditError>> {
-    const audit = await this.db
-      .select()
-      .from(auditTable)
-      .where(eq(auditTable.id, auditId))
-      .then((rows) => rows[0]);
-
-    if (!audit) {
-      return failure(ValidateAuditErrorEnum.AUDIT_NOT_FOUND);
-    }
-
-    const modeResult = await this.referentielModeGuard.assertCanMutate(
-      audit.collectiviteId,
-      audit.referentielId
-    );
-    if (!modeResult.success) {
-      return modeResult;
-    }
-
-    if (audit.valide) {
-      return failure(ValidateAuditErrorEnum.AUDIT_ALREADY_VALIDATED);
-    }
-
     try {
-      const updatedAuditFields: Partial<LabellisationAudit> = {
-        valide: true,
-      };
-      const updatedAudit = await this.db
-        .update(auditTable)
-        .set(updatedAuditFields)
+      const audit = await this.db
+        .select()
+        .from(auditTable)
         .where(eq(auditTable.id, auditId))
-        .returning()
         .then((rows) => rows[0]);
 
-      // TODO: transaction audit + snapshot pour plus de cohérence ?
+      if (!audit) {
+        return failure(ValidateAuditErrorEnum.AUDIT_NOT_FOUND);
+      }
 
-      await this.snapshotsService.computeAndUpsert({
-        collectiviteId: audit.collectiviteId,
-        referentielId: audit.referentielId,
-        jalon: SnapshotJalonEnum.POST_AUDIT,
-        auditId: audit.id,
-      });
+      const modeResult = await this.referentielModeGuard.assertCanMutate(
+        audit.collectiviteId,
+        audit.referentielId
+      );
+      if (!modeResult.success) {
+        return modeResult;
+      }
+
+      if (audit.valide) {
+        return failure(ValidateAuditErrorEnum.AUDIT_ALREADY_VALIDATED);
+      }
+
+      const updatedAudit = await this.databaseService.db.transaction(
+        async (tx) => {
+          const updatedAuditFields: Partial<LabellisationAudit> = {
+            valide: true,
+          };
+          const updated = await tx
+            .update(auditTable)
+            .set(updatedAuditFields)
+            .where(eq(auditTable.id, auditId))
+            .returning()
+            .then((rows) => rows[0]);
+
+          await this.snapshotsService.computeAndUpsert({
+            collectiviteId: audit.collectiviteId,
+            referentielId: audit.referentielId,
+            jalon: SnapshotJalonEnum.POST_AUDIT,
+            auditId: audit.id,
+            date: updated.dateFin ?? undefined,
+            tx,
+          });
+
+          return updated;
+        }
+      );
 
       return success(updatedAudit);
     } catch (error) {

--- a/apps/backend/src/referentiels/labellisations/validate-audit/validate-audit.service.ts
+++ b/apps/backend/src/referentiels/labellisations/validate-audit/validate-audit.service.ts
@@ -1,17 +1,19 @@
-import {
-  BadRequestException,
-  Injectable,
-  NotFoundException,
-} from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { ReferentielModeGuard } from '@tet/backend/collectivites/collectivite-referentiel-mode/referentiel-mode-guard.service';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { Result, failure, success } from '@tet/backend/utils/result.type';
 import {
   LabellisationAudit,
   SnapshotJalonEnum,
 } from '@tet/domain/referentiels';
+import { getErrorMessage } from '@tet/domain/utils';
 import { eq } from 'drizzle-orm';
 import { SnapshotsService } from '../../snapshots/snapshots.service';
 import { auditTable } from '../audit.table';
+import {
+  ValidateAuditError,
+  ValidateAuditErrorEnum,
+} from './validate-audit.errors';
 
 @Injectable()
 export class ValidateAuditService {
@@ -23,15 +25,12 @@ export class ValidateAuditService {
 
   private readonly db = this.databaseService.db;
 
-  // Équivalent de la fonction PG `public.valider_audit()`
+  // équivalent de la fonction PG `public.valider_audit()`
   async validateAudit({
     auditId,
   }: {
     auditId: number;
-  }): Promise<LabellisationAudit> {
-    // Update audit to set valide=true
-    // There is a PG trigger `labellisation.update_audit()` that update `date_fin` and `clos`
-    // TODO: Modifier la fonction labellisation.update_labellisation() coalesce
+  }): Promise<Result<LabellisationAudit, ValidateAuditError>> {
     const audit = await this.db
       .select()
       .from(auditTable)
@@ -39,41 +38,47 @@ export class ValidateAuditService {
       .then((rows) => rows[0]);
 
     if (!audit) {
-      throw new NotFoundException(`Audit ${auditId} non trouvé`);
+      return failure(ValidateAuditErrorEnum.AUDIT_NOT_FOUND);
     }
 
-    await this.referentielModeGuard.assertCanMutateOrThrow(
+    const modeResult = await this.referentielModeGuard.assertCanMutate(
       audit.collectiviteId,
       audit.referentielId
     );
-
-    if (audit.valide) {
-      throw new BadRequestException(
-        `L'audit ${auditId} pour la collectivité ${audit.collectiviteId} et le referentiel ${audit.referentielId} a déjà été validé`
-      );
+    if (!modeResult.success) {
+      return modeResult;
     }
 
-    const updatedAuditFields: Partial<LabellisationAudit> = {
-      valide: true,
-    };
-    const updatedAudit = await this.db
-      .update(auditTable)
-      .set(updatedAuditFields)
-      .where(eq(auditTable.id, auditId))
-      .returning()
-      .then((rows) => rows[0]);
+    if (audit.valide) {
+      return failure(ValidateAuditErrorEnum.AUDIT_ALREADY_VALIDATED);
+    }
 
-    // TODO it could be great to create a transaction containing the update of the audit and the creation of the snapshot,
-    // it would be better for consistency but maybe it's too big an operation?
+    try {
+      const updatedAuditFields: Partial<LabellisationAudit> = {
+        valide: true,
+      };
+      const updatedAudit = await this.db
+        .update(auditTable)
+        .set(updatedAuditFields)
+        .where(eq(auditTable.id, auditId))
+        .returning()
+        .then((rows) => rows[0]);
 
-    // Crée un snapshot de 'post_audit'
-    await this.snapshotsService.computeAndUpsert({
-      collectiviteId: audit.collectiviteId,
-      referentielId: audit.referentielId,
-      jalon: SnapshotJalonEnum.POST_AUDIT,
-      auditId: audit.id,
-    });
+      // TODO: transaction audit + snapshot pour plus de cohérence ?
 
-    return updatedAudit;
+      await this.snapshotsService.computeAndUpsert({
+        collectiviteId: audit.collectiviteId,
+        referentielId: audit.referentielId,
+        jalon: SnapshotJalonEnum.POST_AUDIT,
+        auditId: audit.id,
+      });
+
+      return success(updatedAudit);
+    } catch (error) {
+      return failure(
+        ValidateAuditErrorEnum.DATABASE_ERROR,
+        error instanceof Error ? error : new Error(getErrorMessage(error))
+      );
+    }
   }
 }

--- a/apps/backend/src/referentiels/list-actions/list-actions.router.e2e-spec.ts
+++ b/apps/backend/src/referentiels/list-actions/list-actions.router.e2e-spec.ts
@@ -19,6 +19,7 @@ import {
   getAnonUser,
   getAuthUserFromUserCredentials,
 } from '../../../test/auth-utils';
+import { getServiceRoleUser } from '@tet/backend/test';
 import { AuthenticatedUser } from '../../users/models/auth.models';
 import { TrpcRouter } from '../../utils/trpc/trpc.router';
 
@@ -27,6 +28,17 @@ describe('ActionStatutListRouter', () => {
   let router: TrpcRouter;
   let testUser: AuthenticatedUser;
   let databaseService: DatabaseService;
+
+  async function resetDisplayPreferences(collectiviteId: number) {
+    const serviceRoleCaller = router.createCaller({
+      user: getServiceRoleUser(),
+    });
+    await serviceRoleCaller.referentiels.preferences.resetCollectiviteDisplayPreferences(
+      {
+        collectiviteId,
+      }
+    );
+  }
 
   beforeAll(async () => {
     app = await getTestApp();
@@ -222,6 +234,8 @@ describe('ActionStatutListRouter', () => {
       reponse: false,
     });
 
+    await resetDisplayPreferences(collectiviteId);
+
     await caller.referentiels.snapshots.computeAndUpsert(input);
 
     const result = await caller.referentiels.actions.listActionsGroupedById(input);
@@ -261,6 +275,8 @@ describe('ActionStatutListRouter', () => {
       questionId: 'Bat_1',
       reponse: false,
     });
+
+    await resetDisplayPreferences(collectiviteId);
 
     await caller.referentiels.snapshots.computeAndUpsert(input);
 

--- a/apps/backend/src/referentiels/reset-display-preferences/reset-display-preferences.router.e2e-spec.ts
+++ b/apps/backend/src/referentiels/reset-display-preferences/reset-display-preferences.router.e2e-spec.ts
@@ -13,10 +13,7 @@ import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { addAndEnableUserSuperAdminMode } from '@tet/backend/users/users/users.test-fixture';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
-import {
-  Collectivite,
-  getReferentielDisplayMap,
-} from '@tet/domain/collectivites';
+import { getReferentielDisplayMap } from '@tet/domain/collectivites';
 import { ReferentielIdEnum } from '@tet/domain/referentiels';
 import { CollectiviteRole } from '@tet/domain/users';
 import { cleanupReferentielActionStatutsAndLabellisations } from '../update-action-statut/referentiel-action-statut.test-fixture';
@@ -27,42 +24,43 @@ describe('ResetDisplayPreferencesRouter', () => {
   let authUser: AuthenticatedUser;
   let app: INestApplication;
   let databaseService: DatabaseService;
-  let collectivite: Collectivite;
-  let editorUser: AuthenticatedUser;
 
   beforeAll(async () => {
     app = await getTestApp();
     router = await getTestRouter(app);
     authUser = await getAuthUser();
     databaseService = await getTestDatabase(app);
-
-    const testCollectiviteAndUserResult = await addTestCollectiviteAndUser(
-      databaseService,
-      {
-        user: {
-          role: CollectiviteRole.EDITION,
-        },
-      }
-    );
-
-    collectivite = testCollectiviteAndUserResult.collectivite;
-    editorUser = getAuthUserFromUserCredentials(
-      testCollectiviteAndUserResult.user
-    );
   });
 
   afterAll(async () => {
     await app.close();
   });
 
-  afterEach(async () => {
-    await cleanupReferentielActionStatutsAndLabellisations(
+  const setupIsolatedCollectivite = async (role = CollectiviteRole.EDITION) => {
+    const { collectivite, user, cleanup } = await addTestCollectiviteAndUser(
       databaseService,
-      collectivite.id
+      {
+        user: { role },
+      }
     );
-  });
+
+    onTestFinished(async () => {
+      await cleanupReferentielActionStatutsAndLabellisations(
+        databaseService,
+        collectivite.id
+      );
+      await cleanup();
+    });
+
+    return {
+      collectivite,
+      user,
+      authenticatedUser: getAuthUserFromUserCredentials(user),
+    };
+  };
 
   test('Service role can reset collectivite referentiels display preferences', async () => {
+    const { collectivite } = await setupIsolatedCollectivite();
     const serviceRoleCaller = router.createCaller({
       user: getServiceRoleUser(),
     });
@@ -85,6 +83,7 @@ describe('ResetDisplayPreferencesRouter', () => {
   });
 
   test('Support user can reset collectivite referentiels display preferences', async () => {
+    const { collectivite } = await setupIsolatedCollectivite();
     const caller = router.createCaller({ user: authUser });
     const { cleanup } = await addAndEnableUserSuperAdminMode({
       app,
@@ -112,13 +111,18 @@ describe('ResetDisplayPreferencesRouter', () => {
   });
 
   test('CAE is displayed when collectivite has enough CAE activity and support user resets display preferences', async () => {
-    const editorUserCaller = router.createCaller({ user: editorUser });
-    const trpcClient = createTRPCClientFromCaller(editorUserCaller);
+    const { collectivite: isolatedCollectivite, authenticatedUser } =
+      await setupIsolatedCollectivite();
+    const isolatedEditorCaller = router.createCaller({
+      user: authenticatedUser,
+    });
+    const trpcClient = createTRPCClientFromCaller(isolatedEditorCaller);
     await seedCollectiviteReferentielDisplayActivity({
       trpcClient,
-      collectiviteId: collectivite.id,
+      collectiviteId: isolatedCollectivite.id,
       referentiel: ReferentielIdEnum.CAE,
     });
+
     const caller = router.createCaller({ user: authUser });
     const { cleanup } = await addAndEnableUserSuperAdminMode({
       app,
@@ -130,7 +134,7 @@ describe('ResetDisplayPreferencesRouter', () => {
     const result =
       await caller.referentiels.preferences.resetCollectiviteDisplayPreferences(
         {
-          collectiviteId: collectivite.id,
+          collectiviteId: isolatedCollectivite.id,
         }
       );
     expect(getReferentielDisplayMap(result.referentiels)).toEqual({
@@ -146,13 +150,18 @@ describe('ResetDisplayPreferencesRouter', () => {
   });
 
   test('ECI is displayed when collectivite has enough ECI activity and support user resets display preferences', async () => {
-    const editorUserCaller = router.createCaller({ user: editorUser });
-    const trpcClient = createTRPCClientFromCaller(editorUserCaller);
+    const { collectivite: isolatedCollectivite, authenticatedUser } =
+      await setupIsolatedCollectivite();
+    const isolatedEditorCaller = router.createCaller({
+      user: authenticatedUser,
+    });
+    const trpcClient = createTRPCClientFromCaller(isolatedEditorCaller);
     await seedCollectiviteReferentielDisplayActivity({
       trpcClient,
-      collectiviteId: collectivite.id,
+      collectiviteId: isolatedCollectivite.id,
       referentiel: ReferentielIdEnum.ECI,
     });
+
     const caller = router.createCaller({ user: authUser });
     const { cleanup } = await addAndEnableUserSuperAdminMode({
       app,
@@ -164,7 +173,7 @@ describe('ResetDisplayPreferencesRouter', () => {
     const result =
       await caller.referentiels.preferences.resetCollectiviteDisplayPreferences(
         {
-          collectiviteId: collectivite.id,
+          collectiviteId: isolatedCollectivite.id,
         }
       );
     expect(getReferentielDisplayMap(result.referentiels)).toEqual({
@@ -180,9 +189,8 @@ describe('ResetDisplayPreferencesRouter', () => {
   });
 
   test('Reset is a no-op when te.populatedFromCaeEci is already set', async () => {
-    const { collectivite: isolatedCollectivite, cleanup: collectiviteCleanup } =
-      await addTestCollectiviteAndUser(databaseService);
-    onTestFinished(collectiviteCleanup);
+    const { collectivite: isolatedCollectivite } =
+      await setupIsolatedCollectivite();
 
     const caller = router.createCaller({ user: authUser });
     const { cleanup } = await addAndEnableUserSuperAdminMode({
@@ -221,7 +229,9 @@ describe('ResetDisplayPreferencesRouter', () => {
   });
 
   test('Non-support user cannot reset collectivite referentiels display preferences', async () => {
-    const caller = router.createCaller({ user: editorUser });
+    const { collectivite, authenticatedUser } =
+      await setupIsolatedCollectivite();
+    const caller = router.createCaller({ user: authenticatedUser });
     await expect(
       caller.referentiels.preferences.resetCollectiviteDisplayPreferences({
         collectiviteId: collectivite.id,
@@ -230,6 +240,7 @@ describe('ResetDisplayPreferencesRouter', () => {
   });
 
   test('Only service role can call resetAllCollectivitesDisplayPreferences', async () => {
+    await setupIsolatedCollectivite();
     const caller = router.createCaller({ user: authUser });
     const { cleanup } = await addAndEnableUserSuperAdminMode({
       app,

--- a/apps/backend/src/referentiels/reset-display-preferences/reset-display-preferences.test-fixture.ts
+++ b/apps/backend/src/referentiels/reset-display-preferences/reset-display-preferences.test-fixture.ts
@@ -1,5 +1,9 @@
 import { AppRouter } from '@tet/backend/utils/trpc/trpc.router';
-import { ReferentielId, StatutAvancementEnum } from '@tet/domain/referentiels';
+import {
+  getReferentielIdFromActionId,
+  ReferentielId,
+  StatutAvancementEnum,
+} from '@tet/domain/referentiels';
 import { TRPCClient } from '@trpc/client';
 import assert from 'assert';
 import { getActionStatusCreateForAction } from '../update-action-statut/referentiel-action-statut.test-fixture';
@@ -28,7 +32,11 @@ export async function seedCollectiviteReferentielDisplayActivity({
     scoreSnapshot.scoresPayload.scores,
     StatutAvancementEnum.FAIT,
     collectiviteId
-  ).slice(0, ACTION_STATUT_COUNT_THRESHOLD1);
+  )
+    .filter(
+      (actionStatut) => getReferentielIdFromActionId(actionStatut.actionId) === referentiel
+    )
+    .slice(0, ACTION_STATUT_COUNT_THRESHOLD1);
 
   assert(
     actionStatusesToCreate.length >= ACTION_STATUT_COUNT_THRESHOLD1,

--- a/apps/backend/src/referentiels/score-indicatif/score-indicatif.router.ts
+++ b/apps/backend/src/referentiels/score-indicatif/score-indicatif.router.ts
@@ -50,7 +50,8 @@ export class ScoreIndicatifRouter {
           ResourceType.COLLECTIVITE,
           input.collectiviteId
         );
-        return this.service.setValeursUtilisees(input);
+        const result = await this.service.setValeursUtilisees(input);
+        return this.getResultDataOrThrowError(result);
       }),
 
     getScoreIndicatif: this.trpc.authedProcedure

--- a/apps/backend/src/referentiels/score-indicatif/score-indicatif.service.ts
+++ b/apps/backend/src/referentiels/score-indicatif/score-indicatif.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { ReferentielModeGuard } from '@tet/backend/collectivites/collectivite-referentiel-mode/referentiel-mode-guard.service';
 import PersonnalisationsService from '@tet/backend/collectivites/personnalisations/services/personnalisations-service';
 import CollectivitesService from '@tet/backend/collectivites/services/collectivites.service';
 import { categorieTagTable } from '@tet/backend/collectivites/tags/categorie-tag.table';
@@ -62,7 +63,8 @@ export class ScoreIndicatifService {
     private readonly personnalisationsService: PersonnalisationsService,
     private readonly indicateurExpressionService: IndicateurExpressionService,
     private readonly indicateurValeursService: CrudValeursService,
-    private readonly getReferentielDefinitionService: GetReferentielDefinitionService
+    private readonly getReferentielDefinitionService: GetReferentielDefinitionService,
+    private readonly referentielModeGuard: ReferentielModeGuard
   ) {}
 
   /**
@@ -230,6 +232,11 @@ export class ScoreIndicatifService {
   /**
    * Associe ou supprime le lien vers les valeurs utilisées pour le calcul du score indicatif */
   async setValeursUtilisees(input: SetValeursUtiliseesRequest) {
+    await this.referentielModeGuard.assertCanMutateActionOrThrow(
+      input.collectiviteId,
+      input.actionId
+    );
+
     const { actionId, collectiviteId, indicateurId } = getTableColumns(
       actionScoreIndicateurValeurTable
     );

--- a/apps/backend/src/referentiels/score-indicatif/score-indicatif.service.ts
+++ b/apps/backend/src/referentiels/score-indicatif/score-indicatif.service.ts
@@ -231,41 +231,56 @@ export class ScoreIndicatifService {
 
   /**
    * Associe ou supprime le lien vers les valeurs utilisées pour le calcul du score indicatif */
-  async setValeursUtilisees(input: SetValeursUtiliseesRequest) {
-    await this.referentielModeGuard.assertCanMutateActionOrThrow(
+  async setValeursUtilisees(
+    input: SetValeursUtiliseesRequest
+  ): Promise<Result<void, ScoreIndicatifError>> {
+    const modeResult = await this.referentielModeGuard.assertCanMutateAction(
       input.collectiviteId,
       input.actionId
     );
+    if (!modeResult.success) {
+      return modeResult;
+    }
 
-    const { actionId, collectiviteId, indicateurId } = getTableColumns(
-      actionScoreIndicateurValeurTable
-    );
-    await this.db.transaction(async (tx) => {
-      await tx
-        .delete(actionScoreIndicateurValeurTable)
-        .where(
-          and(
-            eq(actionId, input.actionId),
-            eq(collectiviteId, input.collectiviteId),
-            eq(indicateurId, input.indicateurId)
-          )
-        );
-
-      const valeursNonNulles = input.valeurs.filter(
-        (v) => v.indicateurValeurId !== null
+    try {
+      const { actionId, collectiviteId, indicateurId } = getTableColumns(
+        actionScoreIndicateurValeurTable
       );
-      if (valeursNonNulles.length) {
-        await tx.insert(actionScoreIndicateurValeurTable).values(
-          valeursNonNulles.map((v) => ({
-            actionId: input.actionId,
-            collectiviteId: input.collectiviteId,
-            indicateurId: input.indicateurId,
-            indicateurValeurId: v.indicateurValeurId as number,
-            typeScore: v.typeScore,
-          }))
+      await this.db.transaction(async (tx) => {
+        await tx
+          .delete(actionScoreIndicateurValeurTable)
+          .where(
+            and(
+              eq(actionId, input.actionId),
+              eq(collectiviteId, input.collectiviteId),
+              eq(indicateurId, input.indicateurId)
+            )
+          );
+
+        const valeursNonNulles = input.valeurs.filter(
+          (v) => v.indicateurValeurId !== null
         );
-      }
-    });
+        if (valeursNonNulles.length) {
+          await tx.insert(actionScoreIndicateurValeurTable).values(
+            valeursNonNulles.map((v) => ({
+              actionId: input.actionId,
+              collectiviteId: input.collectiviteId,
+              indicateurId: input.indicateurId,
+              indicateurValeurId: v.indicateurValeurId as number,
+              typeScore: v.typeScore,
+            }))
+          );
+        }
+      });
+
+      return success(undefined);
+    } catch (error) {
+      this.logger.error(error);
+      return failure(
+        'DATABASE_ERROR',
+        error instanceof Error ? error : new Error(String(error))
+      );
+    }
   }
 
   /**

--- a/apps/backend/src/referentiels/snapshots/list-snapshots/list-snapshots.service.e2e-spec.ts
+++ b/apps/backend/src/referentiels/snapshots/list-snapshots/list-snapshots.service.e2e-spec.ts
@@ -1,29 +1,38 @@
 import { INestApplication } from '@nestjs/common';
+import { addTestCollectiviteAndUser } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
 import {
   getAuthUserFromUserCredentials,
   getTestApp,
   getTestDatabase,
 } from '@tet/backend/test';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
-import { addTestUser } from '@tet/backend/users/users/users.test-fixture';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { ReferentielIdEnum, SnapshotJalonEnum } from '@tet/domain/referentiels';
 import { CollectiviteRole } from '@tet/domain/users';
+import { roundTo } from '@tet/domain/utils';
 import { ReferentielsRouter } from '../../referentiels.router';
 
 describe('ListSnapshotsService', () => {
   let app: INestApplication;
   let router: ReferentielsRouter;
+  let databaseService: DatabaseService;
   let testUser: AuthenticatedUser;
+  let collectiviteId: number;
 
   beforeAll(async () => {
     app = await getTestApp();
     router = app.get(ReferentielsRouter);
-    const db = await getTestDatabase(app);
-    const testUserResult = await addTestUser(db, {
-      collectiviteId: 1,
-      role: CollectiviteRole.ADMIN,
-    });
-    testUser = getAuthUserFromUserCredentials(testUserResult.user);
+    databaseService = await getTestDatabase(app);
+    const { collectivite, user } = await addTestCollectiviteAndUser(
+      databaseService,
+      {
+        user: {
+          role: CollectiviteRole.ADMIN,
+        },
+      }
+    );
+    collectiviteId = collectivite.id;
+    testUser = getAuthUserFromUserCredentials(user);
   });
 
   afterAll(async () => {
@@ -35,7 +44,7 @@ describe('ListSnapshotsService', () => {
 
     const snapshot = await caller.snapshots.computeAndUpsert({
       referentielId: ReferentielIdEnum.CAE,
-      collectiviteId: 1,
+      collectiviteId,
       nom: 'Test trpc',
     });
 
@@ -43,7 +52,7 @@ describe('ListSnapshotsService', () => {
 
     // get the list of snapshots
     const { snapshots } = await caller.snapshots.list({
-      collectiviteId: 1,
+      collectiviteId,
       referentielId: ReferentielIdEnum.CAE,
       options: {
         jalons: [SnapshotJalonEnum.DATE_PERSONNALISEE],
@@ -65,29 +74,36 @@ describe('ListSnapshotsService', () => {
       jalon: SnapshotJalonEnum.DATE_PERSONNALISEE,
       modifiedAt: expect.toEqualDate(snapshot.modifiedAt),
       createdAt: expect.toEqualDate(snapshot.createdAt),
-      referentielVersion: '1.0.1',
+      referentielVersion: snapshot.referentielVersion,
       auditId: null,
       createdBy: testUser.id,
       modifiedBy: testUser.id,
-      pointFait: 0.36,
-      pointPasFait: 0.03,
-      pointNonRenseigne: 492.8,
-      pointPotentiel: 493.4,
-      pointProgramme: 0.21,
+      pointFait: snapshot.pointFait,
+      pointPasFait: snapshot.pointPasFait,
+      pointNonRenseigne:
+        roundTo(
+          snapshot.pointPotentiel -
+            (snapshot.pointFait +
+              snapshot.pointPasFait +
+              snapshot.pointProgramme),
+          2
+        ) || undefined,
+      pointPotentiel: snapshot.pointPotentiel,
+      pointProgramme: snapshot.pointProgramme,
     };
 
     expect(foundSnapshot).toEqual(expectedSnapshot);
 
     // delete the snapshot
     await caller.snapshots.delete({
-      collectiviteId: 1,
+      collectiviteId,
       referentielId: ReferentielIdEnum.CAE,
       snapshotRef: 'user-test-trpc',
     });
 
     // get the list of snapshots; the snapshot should not be there
     const responseSnapshotListAfterDelete = await caller.snapshots.list({
-      collectiviteId: 1,
+      collectiviteId,
       referentielId: ReferentielIdEnum.CAE,
       options: {
         jalons: [SnapshotJalonEnum.DATE_PERSONNALISEE],

--- a/apps/backend/src/referentiels/snapshots/snapshots.errors.ts
+++ b/apps/backend/src/referentiels/snapshots/snapshots.errors.ts
@@ -1,0 +1,20 @@
+import {
+  referentielModeGuardSpecificErrors,
+  referentielNotWritableTrpcErrorEntry,
+} from '@tet/backend/collectivites/collectivite-referentiel-mode/referentiel-mode-guard.errors';
+import {
+  createErrorsEnum,
+  TrpcErrorHandlerConfig,
+} from '@tet/backend/utils/trpc/trpc-error-handler';
+
+const specificErrors = [...referentielModeGuardSpecificErrors] as const;
+type SpecificError = (typeof specificErrors)[number];
+
+export const snapshotsErrorConfig: TrpcErrorHandlerConfig<SpecificError> = {
+  specificErrors: {
+    ...referentielNotWritableTrpcErrorEntry,
+  },
+};
+
+export const SnapshotsErrorEnum = createErrorsEnum(specificErrors);
+export type SnapshotsError = keyof typeof SnapshotsErrorEnum;

--- a/apps/backend/src/referentiels/snapshots/snapshots.router.ts
+++ b/apps/backend/src/referentiels/snapshots/snapshots.router.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { ReferentielModeGuard } from '@tet/backend/collectivites/collectivite-referentiel-mode/referentiel-mode-guard.service';
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
 import { TrpcService } from '@tet/backend/utils/trpc/trpc.service';
 import { referentielIdEnumSchema } from '@tet/domain/referentiels';
@@ -27,8 +28,19 @@ export class SnapshotsRouter {
     private readonly trpc: TrpcService,
     private readonly snapshots: SnapshotsService,
     private readonly listSnapshots: ListSnapshotsService,
-    private readonly permissionService: PermissionService
+    private readonly permissionService: PermissionService,
+    private readonly referentielModeGuard: ReferentielModeGuard
   ) {}
+
+  private async assertReferentielWritable(
+    collectiviteId: number,
+    referentielId: Parameters<ReferentielModeGuard['assertCanMutate']>[1]
+  ) {
+    await this.referentielModeGuard.assertCanMutateOrThrow(
+      collectiviteId,
+      referentielId
+    );
+  }
 
   router = this.trpc.router({
     list: this.trpc.authedProcedure
@@ -51,6 +63,11 @@ export class SnapshotsRouter {
           PermissionOperationEnum['REFERENTIELS.MUTATE'],
           ResourceType.COLLECTIVITE,
           input.collectiviteId
+        );
+
+        await this.assertReferentielWritable(
+          input.collectiviteId,
+          input.referentielId
         );
 
         return this.snapshots.computeAndUpsert({
@@ -105,6 +122,11 @@ export class SnapshotsRouter {
           input.collectiviteId
         );
 
+        await this.assertReferentielWritable(
+          input.collectiviteId,
+          input.referentielId
+        );
+
         return this.snapshots.updateName(
           input.collectiviteId,
           input.referentielId,
@@ -121,6 +143,11 @@ export class SnapshotsRouter {
           PermissionOperationEnum['REFERENTIELS.MUTATE'],
           ResourceType.COLLECTIVITE,
           input.collectiviteId
+        );
+
+        await this.assertReferentielWritable(
+          input.collectiviteId,
+          input.referentielId
         );
 
         return this.snapshots.delete(

--- a/apps/backend/src/referentiels/snapshots/snapshots.router.ts
+++ b/apps/backend/src/referentiels/snapshots/snapshots.router.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { ReferentielModeGuard } from '@tet/backend/collectivites/collectivite-referentiel-mode/referentiel-mode-guard.service';
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
+import { createTrpcErrorHandler } from '@tet/backend/utils/trpc/trpc-error-handler';
 import { TrpcService } from '@tet/backend/utils/trpc/trpc.service';
 import { referentielIdEnumSchema } from '@tet/domain/referentiels';
 import { PermissionOperationEnum, ResourceType } from '@tet/domain/users';
@@ -9,6 +10,7 @@ import {
   listInputSchema,
   ListSnapshotsService,
 } from './list-snapshots/list-snapshots.service';
+import { snapshotsErrorConfig } from './snapshots.errors';
 import { SnapshotsService } from './snapshots.service';
 import { upsertSnapshotInputSchema } from './upsert-snapshot.input';
 
@@ -24,6 +26,10 @@ export const updateSnapshotNameInputSchema = snapshotInputSchema.extend({
 
 @Injectable()
 export class SnapshotsRouter {
+  private readonly getResultDataOrThrowError = createTrpcErrorHandler(
+    snapshotsErrorConfig
+  );
+
   constructor(
     private readonly trpc: TrpcService,
     private readonly snapshots: SnapshotsService,
@@ -31,16 +37,6 @@ export class SnapshotsRouter {
     private readonly permissionService: PermissionService,
     private readonly referentielModeGuard: ReferentielModeGuard
   ) {}
-
-  private async assertReferentielWritable(
-    collectiviteId: number,
-    referentielId: Parameters<ReferentielModeGuard['assertCanMutate']>[1]
-  ) {
-    await this.referentielModeGuard.assertCanMutateOrThrow(
-      collectiviteId,
-      referentielId
-    );
-  }
 
   router = this.trpc.router({
     list: this.trpc.authedProcedure
@@ -65,10 +61,11 @@ export class SnapshotsRouter {
           input.collectiviteId
         );
 
-        await this.assertReferentielWritable(
+        const modeResult = await this.referentielModeGuard.assertCanMutate(
           input.collectiviteId,
           input.referentielId
         );
+        this.getResultDataOrThrowError(modeResult);
 
         return this.snapshots.computeAndUpsert({
           ...input,
@@ -101,7 +98,7 @@ export class SnapshotsRouter {
         })
       )
       .query(async ({ input, ctx }) => {
-        // Only allowed for service role
+        // only allowed for service role
         this.permissionService.hasServiceRole(ctx.user);
 
         return this.snapshots.forceRecompute(
@@ -122,10 +119,11 @@ export class SnapshotsRouter {
           input.collectiviteId
         );
 
-        await this.assertReferentielWritable(
+        const modeResult = await this.referentielModeGuard.assertCanMutate(
           input.collectiviteId,
           input.referentielId
         );
+        this.getResultDataOrThrowError(modeResult);
 
         return this.snapshots.updateName(
           input.collectiviteId,
@@ -145,10 +143,11 @@ export class SnapshotsRouter {
           input.collectiviteId
         );
 
-        await this.assertReferentielWritable(
+        const modeResult = await this.referentielModeGuard.assertCanMutate(
           input.collectiviteId,
           input.referentielId
         );
+        this.getResultDataOrThrowError(modeResult);
 
         return this.snapshots.delete(
           input.collectiviteId,

--- a/apps/backend/src/referentiels/snapshots/snapshots.service.ts
+++ b/apps/backend/src/referentiels/snapshots/snapshots.service.ts
@@ -32,6 +32,7 @@ import { DateTime } from 'luxon';
 import { z } from 'zod';
 import { AuthRole, AuthUser } from '../../users/models/auth.models';
 import { DatabaseService } from '../../utils/database/database.service';
+import { Transaction } from '../../utils/database/transaction.utils';
 import { isErrorWithCause } from '../../utils/nest/errors.utils';
 import { PgIntegrityConstraintViolation } from '../../utils/postgresql-error-codes.enum';
 import { ActionPersonnalisationsService } from '../action-personnalisations/action-personnalisations.service';
@@ -173,15 +174,20 @@ export class SnapshotsService {
     return { ref, nom };
   }
 
+  private getDb(tx?: Transaction) {
+    return tx ?? this.databaseService.db;
+  }
+
   /**
    * Upsert score snapshot: update always allowed
    * @param snapshot
    * @returns
    */
   private async upsertScoreSnapshot(
-    snapshot: ScoreSnapshotCreate
+    snapshot: ScoreSnapshotCreate,
+    tx?: Transaction
   ): Promise<ScoreSnapshot> {
-    return await this.databaseService.db
+    return await this.getDb(tx)
       .insert(snapshotTable)
       .values(snapshot)
       .onConflictDoUpdate({
@@ -267,9 +273,10 @@ export class SnapshotsService {
    * Insert with upsert only allowed if jalon is current score
    */
   private async insertSnapshotOrUpsertIfCurrentJalon(
-    snapshot: ScoreSnapshotCreate
+    snapshot: ScoreSnapshotCreate,
+    tx?: Transaction
   ): Promise<ScoreSnapshot> {
-    return this.databaseService.db
+    return this.getDb(tx)
       .insert(snapshotTable)
       .values(snapshot)
       .onConflictDoUpdate({
@@ -311,8 +318,11 @@ export class SnapshotsService {
     jalon,
     auditId,
     user,
-  }: z.infer<typeof upsertSnapshotInputSchema> & {
+    tx,
+  }: Omit<z.infer<typeof upsertSnapshotInputSchema>, 'date'> & {
     user?: AuthUser;
+    tx?: Transaction;
+    date?: string;
   }): Promise<ScoreSnapshot> {
     const { scoresPayload, personnalisationReponsesPayload } =
       await this.scoresService.computeScoreForCollectivite(
@@ -333,7 +343,8 @@ export class SnapshotsService {
       nom,
       true,
       user?.id,
-      ref
+      ref,
+      tx
     );
 
     return snapshot;
@@ -345,7 +356,8 @@ export class SnapshotsService {
     snapshotNom?: string,
     snapshotForceUpdate?: boolean,
     userId?: string | null,
-    snapshotRef?: string
+    snapshotRef?: string,
+    tx?: Transaction
   ): Promise<ScoreSnapshot> {
     if (!snapshotRef) {
       const { ref, nom } = this.getDefaultSnapshotMetadata({
@@ -398,7 +410,8 @@ export class SnapshotsService {
         const existingSnapshot = await this.getSnapshotWithoutPayloads(
           createScoreSnapshot.collectiviteId,
           createScoreSnapshot.referentielId as ReferentielId,
-          createScoreSnapshot.ref
+          createScoreSnapshot.ref,
+          tx
         );
 
         if (
@@ -413,13 +426,14 @@ export class SnapshotsService {
         this.logger.log(
           `Updating snapshot of score with ref ${createScoreSnapshot.ref} and type ${createScoreSnapshot.jalon} for collectivite ${createScoreSnapshot.collectiviteId} and referentiel ${createScoreSnapshot.referentielId}`
         );
-        scoreSnapshot = await this.upsertScoreSnapshot(createScoreSnapshot);
+        scoreSnapshot = await this.upsertScoreSnapshot(createScoreSnapshot, tx);
       } else {
         this.logger.log(
           `Inserting snapshot of score with ref ${createScoreSnapshot.ref} and type ${createScoreSnapshot.jalon} for collectivite ${createScoreSnapshot.collectiviteId} and referentiel ${createScoreSnapshot.referentielId}`
         );
         scoreSnapshot = await this.insertSnapshotOrUpsertIfCurrentJalon(
-          createScoreSnapshot
+          createScoreSnapshot,
+          tx
         );
       }
     } catch (error) {
@@ -464,9 +478,10 @@ export class SnapshotsService {
   private async getSnapshotWithoutPayloads(
     collectiviteId: number,
     referentielId: ReferentielId,
-    snapshotRef: string
+    snapshotRef: string,
+    tx?: Transaction
   ): Promise<SnapshotWithoutPayloads | null> {
-    const result = await this.databaseService.db
+    const result = await this.getDb(tx)
       .select(
         omit(getTableColumns(snapshotTable), [
           'scoresPayload',

--- a/apps/backend/src/referentiels/update-action-commentaire/update-action-commentaire.errors.ts
+++ b/apps/backend/src/referentiels/update-action-commentaire/update-action-commentaire.errors.ts
@@ -1,9 +1,16 @@
 import {
+  referentielModeGuardSpecificErrors,
+  referentielNotWritableTrpcErrorEntry,
+} from '@tet/backend/collectivites/collectivite-referentiel-mode/referentiel-mode-guard.errors';
+import {
   createErrorsEnum,
   TrpcErrorHandlerConfig,
 } from '@tet/backend/utils/trpc/trpc-error-handler';
 
-const specificErrors = ['ACTION_NOT_FOUND'] as const;
+const specificErrors = [
+  'ACTION_NOT_FOUND',
+  ...referentielModeGuardSpecificErrors,
+] as const;
 type SpecificError = (typeof specificErrors)[number];
 
 export const updateActionCommentaireErrorConfig: TrpcErrorHandlerConfig<SpecificError> =
@@ -13,6 +20,7 @@ export const updateActionCommentaireErrorConfig: TrpcErrorHandlerConfig<Specific
         code: 'NOT_FOUND',
         message: "L'action demandée n'existe pas pour ce référentiel.",
       },
+      ...referentielNotWritableTrpcErrorEntry,
     },
   };
 

--- a/apps/backend/src/referentiels/update-action-commentaire/update-action-commentaire.service.ts
+++ b/apps/backend/src/referentiels/update-action-commentaire/update-action-commentaire.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { ReferentielModeGuard } from '@tet/backend/collectivites/collectivite-referentiel-mode/referentiel-mode-guard.service';
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
 import { AuthUser } from '@tet/backend/users/models/auth.models';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
@@ -29,7 +30,8 @@ export class UpdateActionCommentaireService {
     private readonly databaseService: DatabaseService,
     private readonly permissionService: PermissionService,
     private readonly snapshotsService: SnapshotsService,
-    private readonly updateActionCommentaireHistoriqueRepository: UpdateActionCommentaireHistoriqueRepository
+    private readonly updateActionCommentaireHistoriqueRepository: UpdateActionCommentaireHistoriqueRepository,
+    private readonly referentielModeGuard: ReferentielModeGuard
   ) {}
 
   async updateCommentaire(
@@ -49,6 +51,15 @@ export class UpdateActionCommentaireService {
 
     if (!isAllowed) {
       return failure('UNAUTHORIZED');
+    }
+
+    const modeResult =
+      await this.referentielModeGuard.assertCanMutateActionOrFailure(
+        collectiviteId,
+        actionId
+      );
+    if (!modeResult.success) {
+      return modeResult;
     }
 
     try {

--- a/apps/backend/src/referentiels/update-action-commentaire/update-action-commentaire.service.ts
+++ b/apps/backend/src/referentiels/update-action-commentaire/update-action-commentaire.service.ts
@@ -53,11 +53,10 @@ export class UpdateActionCommentaireService {
       return failure('UNAUTHORIZED');
     }
 
-    const modeResult =
-      await this.referentielModeGuard.assertCanMutateActionOrFailure(
-        collectiviteId,
-        actionId
-      );
+    const modeResult = await this.referentielModeGuard.assertCanMutateAction(
+      collectiviteId,
+      actionId
+    );
     if (!modeResult.success) {
       return modeResult;
     }

--- a/apps/backend/src/referentiels/update-action-statut/update-action-statut.errors.ts
+++ b/apps/backend/src/referentiels/update-action-statut/update-action-statut.errors.ts
@@ -1,0 +1,71 @@
+import {
+  referentielModeGuardSpecificErrors,
+  referentielNotWritableTrpcErrorEntry,
+} from '@tet/backend/collectivites/collectivite-referentiel-mode/referentiel-mode-guard.errors';
+import {
+  createErrorsEnum,
+  TrpcErrorHandlerConfig,
+} from '@tet/backend/utils/trpc/trpc-error-handler';
+import { canUpdateActionStatutRulesErrors } from '@tet/domain/referentiels';
+
+const specificErrors = [
+  'NO_ACTION_STATUTS',
+  'DUPLICATE_ACTION',
+  'MIXED_REFERENTIEL_ACTIONS',
+  'MIXED_COLLECTIVITE_ACTIONS',
+  'ACTION_NOT_FOUND',
+  'ACTION_NOT_IN_SNAPSHOT',
+  ...canUpdateActionStatutRulesErrors,
+  ...referentielModeGuardSpecificErrors,
+] as const;
+type SpecificError = (typeof specificErrors)[number];
+
+export const updateActionStatutErrorConfig: TrpcErrorHandlerConfig<SpecificError> =
+  {
+    specificErrors: {
+      NO_ACTION_STATUTS: {
+        code: 'BAD_REQUEST',
+        message: 'Aucun statut à mettre à jour.',
+      },
+      DUPLICATE_ACTION: {
+        code: 'BAD_REQUEST',
+        message: 'Une action est en double dans la requête.',
+      },
+      MIXED_REFERENTIEL_ACTIONS: {
+        code: 'BAD_REQUEST',
+        message:
+          'Les actions ne sont pas toutes dans le même référentiel.',
+      },
+      MIXED_COLLECTIVITE_ACTIONS: {
+        code: 'BAD_REQUEST',
+        message:
+          'Les actions ne sont pas toutes dans la même collectivité.',
+      },
+      ACTION_NOT_FOUND: {
+        code: 'NOT_FOUND',
+        message: "L'action demandée n'existe pas pour ce référentiel.",
+      },
+      ACTION_NOT_IN_SNAPSHOT: {
+        code: 'BAD_REQUEST',
+        message: "L'action n'existe pas dans le snapshot courant.",
+      },
+      ACTION_DISABLED: {
+        code: 'BAD_REQUEST',
+        message: "L'action est désactivée et ne peut pas être modifiée.",
+      },
+      AUDIT_STARTED_BUT_NOT_AUDITEUR: {
+        code: 'BAD_REQUEST',
+        message:
+          "Un audit est en cours : seuls les auditeurs peuvent modifier les statuts.",
+      },
+      AUDIT_VALIDATED: {
+        code: 'BAD_REQUEST',
+        message:
+          "L'audit est validé : les statuts ne peuvent plus être modifiés.",
+      },
+      ...referentielNotWritableTrpcErrorEntry,
+    },
+  };
+
+export const UpdateActionStatutErrorEnum = createErrorsEnum(specificErrors);
+export type UpdateActionStatutError = keyof typeof UpdateActionStatutErrorEnum;

--- a/apps/backend/src/referentiels/update-action-statut/update-action-statut.router.e2e-spec.ts
+++ b/apps/backend/src/referentiels/update-action-statut/update-action-statut.router.e2e-spec.ts
@@ -92,7 +92,7 @@ describe('UpdateActionStatutRouter', () => {
 
     await expect(() =>
       caller.referentiels.actions.updateStatut(input)
-    ).rejects.toThrowError(/not authenticated/i);
+    ).rejects.toThrow(/not authenticated/i);
   });
 
   test('not authorized: accès en lecture uniquement', async () => {
@@ -106,7 +106,7 @@ describe('UpdateActionStatutRouter', () => {
 
     await expect(() =>
       caller.referentiels.actions.updateStatut(input)
-    ).rejects.toThrowError(/Droits insuffisants/i);
+    ).rejects.toThrow(/permissions nécessaires/i);
   });
 
   test('Action inexistante', async () => {
@@ -120,9 +120,7 @@ describe('UpdateActionStatutRouter', () => {
 
     await expect(() =>
       caller.referentiels.actions.updateStatut(input)
-    ).rejects.toThrowError(
-      'Action with id cae_1.1.1.11 not found in action tree'
-    );
+    ).rejects.toThrow("L'action n'existe pas dans le snapshot courant");
   });
 
   test("Mise à jour du score courant lors de la mise à jour du statut d'une action", async () => {
@@ -191,7 +189,9 @@ describe('UpdateActionStatutRouter', () => {
 
     await expect(
       caller.referentiels.actions.updateStatut(input)
-    ).rejects.toThrowError(/AUDIT_STARTED_BUT_NOT_AUDITEUR/i);
+    ).rejects.toThrow(
+      'Un audit est en cours : seuls les auditeurs peuvent modifier les statuts.'
+    );
   });
 
   test('Not authorized when audit is not started yet and user is auditeur', async () => {
@@ -217,7 +217,7 @@ describe('UpdateActionStatutRouter', () => {
 
     await expect(
       caller.referentiels.actions.updateStatut(input)
-    ).rejects.toThrowError(/Droits insuffisants/i);
+    ).rejects.toThrow(/permissions nécessaires/i);
   });
 
   test('Authorized when audit is started and user is auditeur', async () => {

--- a/apps/backend/src/referentiels/update-action-statut/update-action-statut.router.ts
+++ b/apps/backend/src/referentiels/update-action-statut/update-action-statut.router.ts
@@ -1,6 +1,8 @@
 import { Injectable } from '@nestjs/common';
+import { createTrpcErrorHandler } from '@tet/backend/utils/trpc/trpc-error-handler';
 import { TrpcService } from '@tet/backend/utils/trpc/trpc.service';
 import { actionStatutSchemaCreate } from '@tet/domain/referentiels';
+import { updateActionStatutErrorConfig } from './update-action-statut.errors';
 import {
   UpdateActionStatutService,
   upsertActionStatutsRequestSchema,
@@ -8,6 +10,10 @@ import {
 
 @Injectable()
 export class UpdateActionStatutRouter {
+  private readonly getResultDataOrThrowError = createTrpcErrorHandler(
+    updateActionStatutErrorConfig
+  );
+
   constructor(
     private readonly trpc: TrpcService,
     private readonly service: UpdateActionStatutService
@@ -16,14 +22,22 @@ export class UpdateActionStatutRouter {
   router = this.trpc.router({
     updateStatut: this.trpc.authedProcedure
       .input(actionStatutSchemaCreate)
-      .mutation(({ input, ctx }) => {
-        return this.service.upsertActionStatuts([input], ctx.user);
+      .mutation(async ({ input, ctx }) => {
+        const result = await this.service.upsertActionStatuts(
+          [input],
+          ctx.user
+        );
+        return this.getResultDataOrThrowError(result);
       }),
 
     updateStatuts: this.trpc.authedProcedure
       .input(upsertActionStatutsRequestSchema)
-      .mutation(({ input, ctx }) => {
-        return this.service.upsertActionStatuts(input.actionStatuts, ctx.user);
+      .mutation(async ({ input, ctx }) => {
+        const result = await this.service.upsertActionStatuts(
+          input.actionStatuts,
+          ctx.user
+        );
+        return this.getResultDataOrThrowError(result);
       }),
   });
 }

--- a/apps/backend/src/referentiels/update-action-statut/update-action-statut.service.ts
+++ b/apps/backend/src/referentiels/update-action-statut/update-action-statut.service.ts
@@ -4,6 +4,7 @@ import {
   Logger,
   NotFoundException,
 } from '@nestjs/common';
+import { ReferentielModeGuard } from '@tet/backend/collectivites/collectivite-referentiel-mode/referentiel-mode-guard.service';
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
 import { AuthUser } from '@tet/backend/users/models/auth.models';
 import { SQL_CURRENT_TIMESTAMP } from '@tet/backend/utils/column.utils';
@@ -46,7 +47,8 @@ export class UpdateActionStatutService {
     private readonly permissionService: PermissionService,
     private readonly snapshotsService: SnapshotsService,
     private readonly getLabellisationService: GetLabellisationService,
-    private readonly updateActionStatutHistoriqueRepository: UpdateActionStatutHistoriqueRepository
+    private readonly updateActionStatutHistoriqueRepository: UpdateActionStatutHistoriqueRepository,
+    private readonly referentielModeGuard: ReferentielModeGuard
   ) {}
 
   async upsertActionStatuts(
@@ -67,6 +69,11 @@ export class UpdateActionStatutService {
       PermissionOperationEnum['REFERENTIELS.MUTATE'],
       ResourceType.COLLECTIVITE,
       collectiviteId
+    );
+
+    await this.referentielModeGuard.assertCanMutateOrThrow(
+      collectiviteId,
+      referentielId
     );
 
     const seenActionIds = new Set<string>();

--- a/apps/backend/src/referentiels/update-action-statut/update-action-statut.service.ts
+++ b/apps/backend/src/referentiels/update-action-statut/update-action-statut.service.ts
@@ -1,14 +1,10 @@
-import {
-  BadRequestException,
-  Injectable,
-  Logger,
-  NotFoundException,
-} from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { ReferentielModeGuard } from '@tet/backend/collectivites/collectivite-referentiel-mode/referentiel-mode-guard.service';
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
 import { AuthUser } from '@tet/backend/users/models/auth.models';
 import { SQL_CURRENT_TIMESTAMP } from '@tet/backend/utils/column.utils';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { Result, failure, success } from '@tet/backend/utils/result.type';
 import {
   ActionStatutCreate,
   actionStatutSchemaCreate,
@@ -29,6 +25,10 @@ import { SnapshotsService } from '../snapshots/snapshots.service';
 import { actionStatutCreateToActionStatutInDatabase } from './action-statut-create-to-action-statut-in-database.adapter';
 import { computeAndMergeParentCascadingStatuts } from './compute-cascading-statuts.rules';
 import { UpdateActionStatutHistoriqueRepository } from './update-action-statut-historique.repository';
+import {
+  UpdateActionStatutError,
+  UpdateActionStatutErrorEnum,
+} from './update-action-statut.errors';
 
 export const upsertActionStatutsRequestSchema = z.object({
   actionStatuts: z.array(actionStatutSchemaCreate).min(1),
@@ -54,49 +54,49 @@ export class UpdateActionStatutService {
   async upsertActionStatuts(
     actionStatuts: ActionStatutCreate[],
     user: AuthUser
-  ): Promise<ScoreSnapshot> {
+  ): Promise<Result<ScoreSnapshot, UpdateActionStatutError>> {
     if (actionStatuts.length === 0) {
-      throw new BadRequestException('No action statuts to update');
+      return failure(UpdateActionStatutErrorEnum.NO_ACTION_STATUTS);
     }
     const collectiviteId = actionStatuts[0].collectiviteId;
     const referentielId = getReferentielIdFromActionId(
       actionStatuts[0].actionId
     );
 
-    // Check user access
-    await this.permissionService.isAllowed(
+    const isAllowed = await this.permissionService.isAllowed(
       user,
       PermissionOperationEnum['REFERENTIELS.MUTATE'],
       ResourceType.COLLECTIVITE,
-      collectiviteId
+      collectiviteId,
+      true
     );
+    if (!isAllowed) {
+      return failure('UNAUTHORIZED');
+    }
 
-    await this.referentielModeGuard.assertCanMutateOrThrow(
+    const modeResult = await this.referentielModeGuard.assertCanMutate(
       collectiviteId,
       referentielId
     );
+    if (!modeResult.success) {
+      return modeResult;
+    }
 
     const seenActionIds = new Set<string>();
     for (const actionStatut of actionStatuts) {
       const key = `${actionStatut.collectiviteId}:${actionStatut.actionId}`;
       if (seenActionIds.has(key)) {
-        throw new BadRequestException(
-          `Action ${actionStatut.actionId} en double dans la requête`
-        );
+        return failure(UpdateActionStatutErrorEnum.DUPLICATE_ACTION);
       }
       seenActionIds.add(key);
       const actionReferentielId = getReferentielIdFromActionId(
         actionStatut.actionId
       );
       if (actionReferentielId !== referentielId) {
-        throw new BadRequestException(
-          `Action ${actionStatut.actionId} is not in the same referentiel as the other actions`
-        );
+        return failure(UpdateActionStatutErrorEnum.MIXED_REFERENTIEL_ACTIONS);
       }
       if (actionStatut.collectiviteId !== collectiviteId) {
-        throw new BadRequestException(
-          `Action ${actionStatut.actionId} is not in the same collectivite as the other actions`
-        );
+        return failure(UpdateActionStatutErrorEnum.MIXED_COLLECTIVITE_ACTIONS);
       }
     }
 
@@ -113,19 +113,20 @@ export class UpdateActionStatutService {
       (auditeur) => auditeur.userId === user.id
     );
 
-    const actionsWithDesactive = actionStatuts.map((actionStatut) => {
+    const actionsWithDesactive: { actionId: string; desactive: boolean }[] = [];
+    for (const actionStatut of actionStatuts) {
       try {
-        return {
+        actionsWithDesactive.push({
           actionId: actionStatut.actionId,
           desactive: findActionById(
             currentScore.scoresPayload.scores,
             actionStatut.actionId
           ).score.desactive,
-        };
-      } catch (error) {
-        throw new BadRequestException(getErrorMessage(error));
+        });
+      } catch {
+        return failure(UpdateActionStatutErrorEnum.ACTION_NOT_IN_SNAPSHOT);
       }
-    });
+    }
 
     const canUpdateResult = canUpdateActionStatutWithoutPermissionCheck({
       parcoursStatus: parcours.status,
@@ -133,7 +134,7 @@ export class UpdateActionStatutService {
       isAuditeur: isAuditeur,
     });
     if (!canUpdateResult.canUpdate) {
-      throw new BadRequestException(canUpdateResult.reason);
+      return failure(canUpdateResult.reason);
     }
 
     const allActionStatuts = computeAndMergeParentCascadingStatuts(
@@ -151,13 +152,12 @@ export class UpdateActionStatutService {
 
     try {
       await this.databaseService.db.transaction(async (tx) => {
-        // Sort action IDs to prevent deadlocks when locking multiple rows
+        // trie les action IDs pour éviter les deadlocks lors du verrouillage de plusieurs lignes
         const sortedActionStatuts = [...allActionStatuts].sort((a, b) =>
           a.actionId.localeCompare(b.actionId)
         );
         const sortedActionIds = sortedActionStatuts.map((a) => a.actionId);
 
-        // Fetch old values with row lock (ordered to match sort for deadlock prevention)
         const oldValues = await tx
           .select()
           .from(actionStatutTable)
@@ -172,7 +172,6 @@ export class UpdateActionStatutService {
 
         const oldValuesMap = new Map(oldValues.map((ov) => [ov.actionId, ov]));
 
-        // Upsert action statuts with .returning() to get modified_at
         const upsertedRows = await tx
           .insert(actionStatutTable)
           .values(sortedActionStatuts)
@@ -196,7 +195,6 @@ export class UpdateActionStatutService {
           })
           .returning();
 
-        // Write history for each upserted row
         for (const upserted of upsertedRows) {
           const oldRow = oldValuesMap.get(upserted.actionId) ?? null;
           await this.updateActionStatutHistoriqueRepository.save(
@@ -219,17 +217,22 @@ export class UpdateActionStatutService {
             ? `Une ou plusieurs actions n'existent pas pour le referentiel ${referentielId}`
             : `L'action ${actionStatuts[0].actionId} n'existe pas pour le referentiel ${referentielId}`;
         this.logger.warn(errorMessage);
-        throw new NotFoundException(errorMessage);
+        return failure(UpdateActionStatutErrorEnum.ACTION_NOT_FOUND);
       }
 
       this.logger.error(error);
-      throw error;
+      return failure(
+        'DATABASE_ERROR',
+        error instanceof Error ? error : new Error(getErrorMessage(error))
+      );
     }
 
-    return this.snapshotsService.computeAndUpsert({
+    const snapshot = await this.snapshotsService.computeAndUpsert({
       collectiviteId,
       referentielId,
       user,
     });
+
+    return success(snapshot);
   }
 }

--- a/doc/plans/2026-06-11-001-feat-bascule-referentiel-te-prd.md
+++ b/doc/plans/2026-06-11-001-feat-bascule-referentiel-te-prd.md
@@ -23,7 +23,7 @@ Les CT **sans engagement significatif** sur CAE/ECI démarrent directement sur T
 
 ### Découpage
 
-24 PRs (+ 1 optionnelle reportée) — ~400–600 LOC par PR, **~200–300 LOC pour les merge rules pures**, **~650 LOC toléré pour `mergeStatuts` et la bascule transactionnelle** (PR12, PR18). **Bascule utilisateur impossible avant merge de PR18** — détail dans [Plan de livraison](#plan-de-livraison).
+24 PRs — ~400–600 LOC par PR, **~200–300 LOC pour les merge rules pures**, **~650 LOC toléré pour `mergeStatuts` et la bascule transactionnelle** (PR12, PR18). **Bascule utilisateur impossible avant merge de PR18** — détail dans [Plan de livraison](#plan-de-livraison).
 
 ---
 
@@ -38,7 +38,7 @@ Les CT **sans engagement significatif** sur CAE/ECI démarrent directement sur T
   NB : le type `ActionTypeEnum.ACTION` (colonne `action_type = 'action'` en BDD) désigne spécifiquement une **mesure** — ne pas confondre avec le sens générique ci-dessus.
 
 - **Explication** : `action_commentaire`, libellé UI `explication` — **migrée** via `mergeCommentaires`.
-- **Discussions** : `discussion` + `discussion_message`, « commentaires » dans l'UI — **non migrées** (PR24 optionnelle).
+- **Discussions** : `discussion` + `discussion_message`, « commentaires » dans l'UI — **non migrées** vers TE (pour éviter de polluer l'interface). L'historique reste consultable sur les référentiels CAE/ECI archivés jusqu'au débranchement complet des anciens référentiels (horizon : plusieurs années).
 - **Justification** : texte optionnel sur une réponse de personnalisation — **non migrée**.
 
 - **Projection origine** — calcul TE à la volée depuis CAE/ECI (`avecReferentielsOrigine`), sans écriture. Usage bac à sable / lecture seule pré-bascule. **N'est pas** le mécanisme de bascule production.
@@ -75,7 +75,7 @@ Invariants Zod : `mode === 'archived'` implique `display === false`.
 | `readonly` | interdite | `display: true` | TE pré-bascule (CT engagée sur CAE/ECI) |
 | `archived` | interdite | `display: false` | CAE/ECI post-bascule ou jamais engagés ; consultable via lien TdB EDL ou URL directe |
 
-Les modes non-`write` passent par `ReferentielModeGuard` (backend) — statuts, explications, discussions, pilotes, preuves complémentaires, etc. Seul `archived` déclenche la logique snapshots spécifique (cf. [Snapshots](#snapshots)).
+Les modes non-`write` passent par `ReferentielModeGuard` (backend) — statuts, explications, pilotes, preuves complémentaires, etc. Les **fils de discussion** sont hors périmètre du guard (historique conservé sur CAE/ECI archivés). Seul `archived` déclenche la logique snapshots spécifique (cf. [Snapshots](#snapshots)).
 
 **Nouvelles CT** : même règle que l'initialisation — sans engagement CAE/ECI → `te: { mode: write, display: true }` (sans `populatedFromCaeEci`), `cae/eci: { mode: archived, display: false }`.
 
@@ -191,7 +191,7 @@ Guards **avant** la transaction. Échec ou timeout → **rollback total** ; `te.
 |---|---|
 | Permissions | `referentiels.mutate` requis (éditeur ou admin référentiel) |
 | Idempotence | `te.populatedFromCaeEci` absent |
-| Mode | `ReferentielModeGuard` : mutation refusée si `mode !== 'write'` (statuts, explications, discussions, pilotes, preuves… ; y compris URL directe) |
+| Mode | `ReferentielModeGuard` : mutation refusée si `mode !== 'write'` (statuts, explications, pilotes, preuves… ; y compris URL directe). **Hors guard** : fils de discussion (historique sur CAE/ECI archivés) |
 | COT/demande/audit | Pour chaque ref. CAE/ECI en `mode: write` au moment de la bascule : bloquer si la collectivité a un COT actif ou si une demande d'audit ou un audit est en cours |
 
 `SwitchToTeService` et guards exposent des `Result<…, erreur typée>` (ADR 0012), conversion tRPC au routeur.
@@ -206,7 +206,7 @@ Guards **avant** la transaction. Échec ou timeout → **rollback total** ; `te.
 | `fiche_action_action` | Mesure→mesure, sous-mesure→sous-mesure si direct, sinon remontée mesure parente | [Annexe A — liens FA](#a--algorithmes-de-fusion) |
 | `reponse_*`, `justification` | **Non migrées** ; capturées dans snapshot `pre-switch-te` (`personnalisation_reponses`) ; consultables via archive lecture seule ou export | — |
 | `preuve_reglementaire`, `preuve_complementaire` | Liens conservés sur CAE/ECI ; fichiers en bibliothèque | — |
-| `discussion*` | **Non migrées** (PR24 optionnelle) | — |
+| `discussion*` | **Non migrées** — historique conservé sur CAE/ECI archivés jusqu'au débranchement complet des anciens référentiels | — |
 
 Règle transversale : sources `concerne = false` (non concerné explicite ou désactivées par personnalisation) ignorées avant toute fusion.
 
@@ -336,14 +336,13 @@ Objectif de découpage : **PRs reviewables en une session**. Règle générale ~
 | PR21 | Masquage questions / personnalisations legacy | PR18 | ~400 | Oui |
 | PR22 | UI snapshots post-bascule + masquage CTA « Figer l'état des lieux » | PR11, PR18 | ~350 | Oui |
 | PR23 | Export score-comparaison : feuille personnalisations | PR18 | ~500 | Oui |
-| PR24 | (optionnelle) Migration discussions ouvertes | PR17 | ~600 | — |
 | PR25 | Nettoyage post-lancement | prod stable | ~250 | Oui |
 
 > **Colonne Prod** : `Oui` = déployable en prod sans risque utilisateur sur la bascule. `Non (endpoint)` = déployable en prod, mais l'endpoint `referentiels.switchToTe` reste **non exposé** — la bascule utilisateur est impossible avant PR18 (`Oui (endpoint)`).
 
 > **Estimation ~ LOC** : lignes ajoutées + modifiées + supprimées par PR (code prod, migrations Sqitch et tests inclus). Ordre de grandeur pour le découpage et la revue, pas un engagement de charge.
 
-Ordre de merge : `PR1 → PR2 → PR3 → PR4 → PR5–PR7 (parallélisables) → PR8 → PR9 → PR10 → PR11 → PR12 → PR13–PR16 (parallélisables) → PR17 → PR18 → PR19 → PR20 → PR21–PR23 (parallélisables) → PR24 (si décidé) → PR25`.
+Ordre de merge : `PR1 → PR2 → PR3 → PR4 → PR5–PR7 (parallélisables) → PR8 → PR9 → PR10 → PR11 → PR12 → PR13–PR16 (parallélisables) → PR17 → PR18 → PR19 → PR20 → PR21–PR23 (parallélisables) → PR25`.
 
 Feedback rapide possible après PR5–PR7 (lecture seule visible).
 
@@ -380,7 +379,8 @@ Feedback rapide possible après PR5–PR7 (lecture seule visible).
 
 ### PR7 — UI lecture seule (édition)
 
-- Désactiver contrôles d'édition côté app.
+- Désactiver contrôles d'édition côté app (référentiel et plans) lorsque `mode !== 'write'`.
+- Filtrer les listes de sélection de mesures référentielles (`MesuresReferentielsDropdown`, modale « mesures liées » d'une fiche) pour n'afficher que les mesures dont le référentiel est en `write` (`canMutateReferentielData`) ; désactiver le CTA de liaison côté fiche et côté action si aucune mesure n'est sélectionnable.
 
 ### PR8 — Service de bascule (squelette)
 
@@ -445,7 +445,7 @@ Feedback rapide possible après PR5–PR7 (lecture seule visible).
 
 - Modale irréversible structurée en deux sections :
   - **Seront migrés vers TE** : statuts, explications (avec traçabilité source), pilotes, services, liens fiches plan d'action.
-  - **Ne seront pas migrés** : fils de discussion, preuves (fichiers conservés en bibliothèque — réaffectation manuelle aux mesures TE).
+  - **Ne seront pas migrés** : fils de discussion (historique consultable sur les archives CAE/ECI jusqu'au débranchement complet des anciens référentiels), preuves (fichiers conservés en bibliothèque — réaffectation manuelle aux mesures TE).
 - Liens contextuels : export snapshot `pre-switch-te` (personnalisations), bibliothèque de preuves.
 
 ### PR21 — Post-bascule personnalisations
@@ -460,10 +460,6 @@ Feedback rapide possible après PR5–PR7 (lecture seule visible).
 ### PR23 — Export personnalisations
 
 - Feuille `personnalisation_reponses` du snapshot ; mode comparaison 2 colonnes par jalon.
-
-### PR24 (optionnelle) — Discussions
-
-- Migrer `discussion` + `discussion_message` ouvertes vers mesure TE. Décision reportée.
 
 ### PR25 — Nettoyage
 
@@ -583,7 +579,7 @@ Un bon test vérifie le **comportement externe** (entrée → sortie) sans se co
 
 - Affectation des preuves aux mesures TE — récupération manuelle via bibliothèque.
 - Migration des réponses de personnalisation vers TE.
-- Migration des fils de discussion (PR24 optionnelle).
+- Migration des fils de discussion vers TE.
 - Bascule automatique ; retour arrière après bascule.
 - Version de référentiel par collectivité.
 - Suppression définitive des données CAE/ECI.
@@ -597,14 +593,13 @@ Un bon test vérifie le **comportement externe** (entrée → sortie) sans se co
 | Dédup liens fiches | Doublons / pertes | Tests fusion CAE+ECI, fallback sous-mesure |
 | Correspondances hétérogènes (pilotes) | Manquants / doublons | Tests remontée mesure ancêtre |
 | URL directe sur archivé | Édition malgré archivage | `ReferentielModeGuard` backend |
-| Discussions non migrées | Perte fils ouverts | PR24 optionnelle ; message modale |
+| Discussions non migrées | Fils ouverts restent sur CAE/ECI archivés | Décision produit : pas de migration TE ; historique consultable jusqu'au débranchement complet ; message modale |
 
 ### E — Questions ouvertes
 
 1. **Emplacement CTA bascule** : TdB EDL vs page TE.
-2. **PR24 discussions** : migrer les ouvertes uniquement, ou aucune migration.
-3. **COT** : en attente de confirmation de la manière de considérer les CT avec COT actif vs CT avec audit COT final validé.
-4. **Conditions d'évaluation du remplissage** : faire éventuellement évoluer `shouldDisplayReferentielByCriteria` afin de pouvoir gérer des règles/paliers différents entre CAE et ECI afin d'alléger la navigation pour les collectivités qui ne sont engagées que dans l'un des référentiels.
+2. **COT** : en attente de confirmation de la manière de considérer les CT avec COT actif vs CT avec audit COT final validé.
+3. **Conditions d'évaluation du remplissage** : faire éventuellement évoluer `shouldDisplayReferentielByCriteria` afin de pouvoir gérer des règles/paliers différents entre CAE et ECI afin d'alléger la navigation pour les collectivités qui ne sont engagées que dans l'un des référentiels.
 
 ### F — Références
 

--- a/doc/plans/2026-06-11-002-feat-bascule-referentiel-te-pr4-plan.md
+++ b/doc/plans/2026-06-11-002-feat-bascule-referentiel-te-pr4-plan.md
@@ -1,0 +1,272 @@
+---
+title: "feat: Mode référentiel + guard backend (PR4 bascule TE)"
+type: feat
+status: active
+date: 2026-06-25
+branch: TE-7303/switch-te-PR4
+parent: doc/plans/2026-06-11-001-feat-bascule-referentiel-te-prd.md
+---
+
+# feat: Mode référentiel + guard backend — PR4
+
+## Résumé
+
+Introduire la couche backend qui **lit le mode** (`write` / `readonly` / `archived`) depuis `collectivite.preferences.referentiels` et **refuse toute mutation de données référentiel** lorsque le mode n'est pas `write`.
+
+C'est le verrou serveur qui rend effectifs les modes posés par PR1 (schéma) et PR3 (`deriveReferentielPreferences` + batch reset). Sans PR4, une URL directe ou un appel tRPC contourne la lecture seule.
+
+**Dépendances mergées** : PR1 (schéma Zod + migration Sqitch), PR3 (`ResetDisplayPreferencesService`).
+
+**Débloque** : PR5–PR7 (UI), PR8 (`SwitchToTeService`), PR11 (snapshots archivés).
+
+**Hors scope PR4** : UI bandeaux/nav/désactivation contrôles (PR5–PR7), endpoint `switchToTe` (PR8), logique snapshots archivés `list`/`getCurrent` (PR11), paramètre `tx?` sur lecture/écriture des prefs (PR8, voir ci-dessous).
+
+## Problem Statement
+
+Aujourd'hui, les mutations référentiel (`updateStatut`, `updateCommentaire`, pilotes, services, fiches, preuves complémentaires, snapshots…) ne consultent que les permissions (`referentiels.mutate`) et les règles métier existantes (audit en cours, action désactivée…). Le champ `mode` introduit en PR1 n'est **pas enforced côté serveur**.
+
+Les **fils de discussion** sont hors périmètre du guard : ils ne sont pas migrés vers TE (pour éviter de polluer l'interface) et l'historique reste consultable — voire modifiable sur les référentiels CAE/ECI archivés — jusqu'au débranchement complet des anciens référentiels (horizon : plusieurs années).
+
+Risque identifié dans le PRD (annexe D) : édition via URL directe sur un référentiel `readonly` ou `archived`.
+
+## Proposed Solution
+
+### Architecture
+
+```
+collectivite.preferences.referentiels
+        │
+        ▼
+CollectiviteReferentielModeService     ← lecture + écriture des prefs référentiels
+        │
+        ▼
+ReferentielModeGuard                  ← assertCanMutate(collectiviteId, referentielId)
+        │
+        ▼
+Services de mutation référentiel      ← appel guard après permissions, avant logique métier
+```
+
+Tout le code PR4 vit dans un seul dossier : `apps/backend/src/collectivites/collectivite-referentiel-mode/` (service mode + guard + erreurs + e2e), enregistré dans `CollectivitesCoreModule` pour éviter une dépendance circulaire avec `ReferentielsModule`.
+
+### Règle domaine pure (packages/domain)
+
+```typescript
+// packages/domain/src/collectivites/can-mutate-referentiel.rules.ts
+export function canMutateReferentielData(mode: ReferentielMode): boolean {
+  return mode === 'write';
+}
+```
+
+Test unitaire colocalisé. Le guard backend délègue à cette règle — pas de duplication de la condition `mode !== 'write'`.
+
+### CollectiviteReferentielModeService
+
+**Emplacement** : `apps/backend/src/collectivites/collectivite-referentiel-mode/collectivite-referentiel-mode.service.ts`
+
+| Méthode | Rôle |
+|---|---|
+| `getReferentielMode(collectiviteId, referentielId)` | Retourne le `ReferentielMode` pour `cae` / `eci` / `te` |
+| `getReferentielPreferences(collectiviteId)` | Wrapper typé autour du repository existant |
+| `updateReferentielPreferences(collectiviteId, prefs)` | Écriture via le repository — **sans `tx?` en PR4** (voir décision ci-dessous) |
+
+**Comportements** :
+- Préférences absentes → fallback `defaultCollectivitePreferences` dans le service (`result.data ?? defaultCollectivitePreferences`).
+- Erreur de parse → propagée via `Result` du repository (`PREFERENCES_PARSE_ERROR`).
+- `referentielId === 'te-test'` → **pas de garde** (absent du schéma prefs ; bac à sable interne).
+- Retourne `Result<T, CollectiviteReferentielModeError>` où `CollectiviteReferentielModeError` est un alias de `CollectivitePreferencesError` (défini dans `referentiel-mode-guard.errors.ts`).
+
+**Module** : `CollectiviteReferentielModeService` et `ReferentielModeGuard` sont providers + exports de `CollectivitesCoreModule` (pas `ReferentielsCoreModule`).
+
+### Paramètre `tx?` — reporté à PR8
+
+Le plan initial prévoyait `tx?: Transaction` sur `assertCanMutate` et `updateReferentielPreferences`. **Non implémenté en PR4** :
+
+- Aucun appelant du guard n'exécute le contrôle *dans* une transaction : pattern systématique **permissions → guard → `db.transaction(...)`**.
+- `CollectivitePreferencesRepository` n'accepte pas encore de `Transaction` ; ajouter `tx?` sur le guard sans propager jusqu'au repository serait une API incomplète.
+- Le seul besoin réel est **`updateReferentielPreferences(..., tx)`** pour l'orchestration transactionnelle de `SwitchToTeService` (PR8) ; `switchToTe` bypass le guard de toute façon.
+- Pour un contrôle d'autorisation, lire l'état commité avant d'ouvrir la transaction métier est le comportement attendu.
+
+À ajouter en PR8 avec la propagation `tx` dans le repository prefs.
+
+### ReferentielModeGuard
+
+**Emplacement** : `apps/backend/src/collectivites/collectivite-referentiel-mode/referentiel-mode-guard.service.ts`
+
+```typescript
+@Injectable()
+export class ReferentielModeGuard {
+  async assertCanMutate(
+    collectiviteId: number,
+    referentielId: ReferentielId
+  ): Promise<Result<void, ReferentielModeGuardError>>
+
+  async assertCanMutateAction(
+    collectiviteId: number,
+    actionId: string
+  ): Promise<Result<void, ReferentielModeGuardError>>
+
+  // helpers pour les services qui throw encore (ForbiddenException)
+  async assertCanMutateOrThrow(collectiviteId, referentielId): Promise<void>
+  async assertCanMutateActionOrThrow(collectiviteId, actionId): Promise<void>
+}
+```
+
+**Erreurs typées** (`referentiel-mode-guard.errors.ts`) :
+
+- `referentielModeGuardSpecificErrors` / `referentielNotWritableTrpcErrorEntry` — fragment partagé
+- `REFERENTIEL_NOT_WRITABLE_MESSAGE` dérivé de l'entrée tRPC (source unique)
+- code tRPC : `FORBIDDEN`
+- message : « Ce référentiel est en lecture seule et ne peut pas être modifié. » (readonly + archived — distinction UI, PR5)
+
+**Pattern d'intégration** — services Result :
+
+```typescript
+const modeResult = await this.referentielModeGuard.assertCanMutateAction(
+  collectiviteId,
+  actionId
+);
+if (!modeResult.success) {
+  return failure(ReferentielModeGuardErrorEnum.REFERENTIEL_NOT_WRITABLE);
+}
+```
+
+**Pattern d'intégration** — services qui `throw` (`UpdateActionStatutService`, pilotes, services, score indicatif, validate audit, mesure audit statut, snapshots) :
+
+```typescript
+await this.referentielModeGuard.assertCanMutateOrThrow(collectiviteId, referentielId);
+// ou assertCanMutateActionOrThrow(collectiviteId, actionId)
+```
+
+Les `*.errors.ts` concernés importent `referentielNotWritableTrpcErrorEntry` par spread plutôt que de dupliquer le message.
+
+### Exceptions explicites (ne PAS garder)
+
+| Mutation | Raison |
+|---|---|
+| `setPersonnalisationReponse` | P1 : « CTA personnalisation autorisés » sur TE `readonly` |
+| `resetCollectiviteDisplayPreferences` / `resetAll…` | Service role, recalcule les modes |
+| `forceRecompute` (snapshots) | Service role uniquement |
+| `switchToTe` (PR8) | Orchestration qui *change* les modes |
+| `DiscussionApplicationService` | Fils de discussion non migrés vers TE ; historique conservé sur CAE/ECI archivés jusqu'au débranchement complet (horizon : plusieurs années) |
+| Import référentiel / endpoints admin | Hors périmètre collectivité |
+
+### Mutations câblées (checklist PR4)
+
+| Service | Fichier | Entrée référentiel | Priorité test e2e |
+|---|---|---|---|
+| `UpdateActionStatutService` | `update-action-statut.service.ts` | `referentielId` dérivé des actions | **oui** |
+| `UpdateActionCommentaireService` | `update-action-commentaire.service.ts` | `getReferentielIdFromActionId(actionId)` | **oui** |
+| `HandleMesurePilotesService` | `handle-mesure-pilotes.service.ts` | `assertCanMutateActionOrThrow(mesureId)` | non |
+| `HandleMesureServicesService` | `handle-mesure-services.service.ts` | idem | non |
+| `FicheActionLinkService` | `fiche-action-link.service.ts` | `assertCanMutateAction(actionId)` — flux action → fiches (`updateLinkedFiches`) | non |
+| `UpdateFicheService` | `update-fiche.service.ts` | `assertCanMutateAction` sur l'union anciennes + nouvelles mesures — flux fiche → mesures (`updateFiche({ mesures })`) | non |
+| `EditPreuveDocumentService` | `edit-preuve-document.service.ts` | `preuve.actionId` (preuves complémentaires) | non |
+| `SnapshotsRouter` | `snapshots.router.ts` | `input.referentielId` (`computeAndUpsert`, `updateName`, `delete` ; pas `forceRecompute`) | non |
+| `ScoreIndicatifService.setValeursUtilisees` | `score-indicatif.service.ts` | `assertCanMutateActionOrThrow(input.actionId)` | non |
+| `RequestLabellisationService` | `request-labellisation.service.ts` | `input.referentielId` | non |
+| `CreatePreuveService` | `create-preuve.service.ts` | `input.referentielId` | non |
+| `HandleMesureAuditStatutService` | `handle-mesure-audit-statut.service.ts` | `getReferentielIdFromActionId(mesureId)` | non |
+| `StartAuditService` | `start-audit.service.ts` | `audit.referentielId` (via repository) | non |
+| `ValidateAuditService` | `validate-audit.service.ts` | `audit.referentielId` | non |
+
+> **Décision actée** : tous les flux portant un `referentielId` ou dérivable depuis `actionId` passent par le guard — y compris labellisation/audit. Un référentiel `archived` ne doit pas accepter de nouvelle demande d'audit ; TE `readonly` non plus. Un audit en cours sur CAE reste possible car le guard est évalué **par référentiel** (CAE encore en `write` pré-bascule). Les permissions audit existantes restent en place *après* le guard.
+
+## Fichiers créés
+
+```
+packages/domain/src/collectivites/
+  can-mutate-referentiel.rules.ts
+  can-mutate-referentiel.rules.spec.ts
+
+apps/backend/src/collectivites/collectivite-referentiel-mode/
+  collectivite-referentiel-mode.service.ts
+  referentiel-mode-guard.service.ts
+  referentiel-mode-guard.errors.ts
+  referentiel-mode-guard.router.e2e-spec.ts
+```
+
+## Fichiers modifiés
+
+- `packages/domain/src/collectivites/index.ts` — export règle
+- `apps/backend/src/collectivites/collectivites-core.module.ts` — provider + export `CollectiviteReferentielModeService` et `ReferentielModeGuard`
+- Services listés dans la checklist — injection + appel guard
+- `*.errors.ts` concernés — spread de `referentielNotWritableTrpcErrorEntry` :
+  - `update-action-commentaire.errors.ts`
+  - `fiche-action-link.errors.ts`
+  - `update-fiche.errors.ts`
+  - `edit-preuve-document.errors.ts`
+  - `request-labellisation.errors.ts`
+  - `create-labellisation-preuve.errors.ts`
+  - `start-audit.errors.ts`
+
+## Stratégie de tests
+
+### Unitaire (domain)
+
+| Cas | Attendu |
+|---|---|
+| `mode: 'write'` | `canMutateReferentielData` → `true` |
+| `mode: 'readonly'` | `false` |
+| `mode: 'archived'` | `false` |
+
+### E2E backend (minimal, via mutations existantes)
+
+Fichier : `apps/backend/src/collectivites/collectivite-referentiel-mode/referentiel-mode-guard.router.e2e-spec.ts`
+
+**Setup** : `addTestCollectiviteAndUser` + prefs forcées via `collectivites.preferences.update` (super-admin).
+
+| Scénario | Prefs | Appel | Attendu |
+|---|---|---|---|
+| TE readonly | `te: { mode: readonly, display: true }` | `updateStatut` sur action `te_*` | `REFERENTIEL_NOT_WRITABLE` / FORBIDDEN |
+| CAE write (contrôle positif) | `cae: { mode: write, display: true }` | `updateStatut` sur action `cae_*` | succès |
+| CAE archived | `cae: { mode: archived, display: false }` | `updateCommentaire` sur action `cae_*` | `REFERENTIEL_NOT_WRITABLE` |
+| Personnalisation TE readonly | `te: readonly` | `setPersonnalisationReponse` sur TE | **succès** (exception P1) |
+
+Pas de test e2e sur les autres services — deux mutations représentatives suffisent pour valider le câblage du guard.
+
+## Ordre d'implémentation (tracer bullet)
+
+1. Règle domaine + tests unitaires
+2. `CollectiviteReferentielModeService` + enregistrement `CollectivitesCoreModule`
+3. `ReferentielModeGuard` + erreurs typées (+ fragment partagé pour les `*.errors.ts`)
+4. Câbler `UpdateActionStatutService` + e2e readonly/write
+5. Câbler `UpdateActionCommentaireService` + e2e archived
+6. Câbler les autres services (batch mécanique) + `assertCanMutateOrThrow` pour les services legacy
+7. E2e exception personnalisation
+8. `pnpm test:backend referentiel-mode-guard` + `pnpm nx test domain can-mutate-referentiel`
+
+## Estimation
+
+~500 LOC (code + tests), aligné PRD.
+
+## Critères de done
+
+- [x] `canMutateReferentielData` testée en unitaire
+- [x] `CollectiviteReferentielModeService` lit/écrit les prefs référentiels via `Result`
+- [x] `ReferentielModeGuard` exposé et injecté dans tous les services de mutation listés
+- [x] Personnalisation **non** gardée
+- [x] E2e : mutation refusée en `readonly` et `archived` ; autorisée en `write`
+- [x] E2e : personnalisation autorisée sur TE `readonly`
+- [x] `te-test` non impacté
+- [x] Déployable en prod sans feature flag supplémentaire (comportement neutre tant que toutes les CT sont en `write` — état post-migration Sqitch : TE `readonly`, CAE/ECI `write` pour CT engagées → TE non modifiable, comportement attendu)
+
+## Risques
+
+| Risque | Mitigation |
+|---|---|
+| Oubli d'un endpoint mutation | Checklist exhaustive + grep `REFERENTIELS.MUTATE` |
+| Régression CT sans batch reset (TE readonly, CAE write) | Comportement voulu ; le batch PR3 doit être exécuté avant levée flag (checklist ops PRD) |
+| Services legacy qui `throw` vs `Result` | `assertCanMutateOrThrow` / `assertCanMutateActionOrThrow` sans refactor global |
+| `EditPreuveDocumentService` sans `actionId` direct | Dériver depuis `preuve.actionId` après fetch (preuves complémentaires uniquement) |
+
+## Références code
+
+| Domaine | Fichier |
+|---|---|
+| Schéma prefs | `packages/domain/src/collectivites/collectivite-preferences.schema.ts` |
+| Dérivation modes | `packages/domain/src/collectivites/collectivite-referentiel-preferences.rules.ts` |
+| Repository prefs | `apps/backend/src/collectivites/collectivite-preferences/collectivite-preferences.repository.ts` |
+| Service mode + guard | `apps/backend/src/collectivites/collectivite-referentiel-mode/` |
+| Reset prefs | `apps/backend/src/referentiels/reset-display-preferences/` |
+| Pattern Result | `doc/adr/0012-pattern-result.md` |
+| Conventions backend | `apps/backend/CLAUDE.md` |

--- a/doc/plans/2026-06-11-002-feat-bascule-referentiel-te-pr4-plan.md
+++ b/doc/plans/2026-06-11-002-feat-bascule-referentiel-te-pr4-plan.md
@@ -104,10 +104,6 @@ export class ReferentielModeGuard {
     collectiviteId: number,
     actionId: string
   ): Promise<Result<void, ReferentielModeGuardError>>
-
-  // helpers pour les services qui throw encore (ForbiddenException)
-  async assertCanMutateOrThrow(collectiviteId, referentielId): Promise<void>
-  async assertCanMutateActionOrThrow(collectiviteId, actionId): Promise<void>
 }
 ```
 
@@ -130,15 +126,6 @@ if (!modeResult.success) {
 }
 ```
 
-**Pattern d'intégration** — services qui `throw` (`UpdateActionStatutService`, pilotes, services, score indicatif, validate audit, mesure audit statut, snapshots) :
-
-```typescript
-await this.referentielModeGuard.assertCanMutateOrThrow(collectiviteId, referentielId);
-// ou assertCanMutateActionOrThrow(collectiviteId, actionId)
-```
-
-Les `*.errors.ts` concernés importent `referentielNotWritableTrpcErrorEntry` par spread plutôt que de dupliquer le message.
-
 ### Exceptions explicites (ne PAS garder)
 
 | Mutation | Raison |
@@ -156,13 +143,13 @@ Les `*.errors.ts` concernés importent `referentielNotWritableTrpcErrorEntry` pa
 |---|---|---|---|
 | `UpdateActionStatutService` | `update-action-statut.service.ts` | `referentielId` dérivé des actions | **oui** |
 | `UpdateActionCommentaireService` | `update-action-commentaire.service.ts` | `getReferentielIdFromActionId(actionId)` | **oui** |
-| `HandleMesurePilotesService` | `handle-mesure-pilotes.service.ts` | `assertCanMutateActionOrThrow(mesureId)` | non |
+| `HandleMesurePilotesService` | `handle-mesure-pilotes.service.ts` | `assertCanMutateAction(mesureId)` | non |
 | `HandleMesureServicesService` | `handle-mesure-services.service.ts` | idem | non |
 | `FicheActionLinkService` | `fiche-action-link.service.ts` | `assertCanMutateAction(actionId)` — flux action → fiches (`updateLinkedFiches`) | non |
 | `UpdateFicheService` | `update-fiche.service.ts` | `assertCanMutateAction` sur l'union anciennes + nouvelles mesures — flux fiche → mesures (`updateFiche({ mesures })`) | non |
 | `EditPreuveDocumentService` | `edit-preuve-document.service.ts` | `preuve.actionId` (preuves complémentaires) | non |
 | `SnapshotsRouter` | `snapshots.router.ts` | `input.referentielId` (`computeAndUpsert`, `updateName`, `delete` ; pas `forceRecompute`) | non |
-| `ScoreIndicatifService.setValeursUtilisees` | `score-indicatif.service.ts` | `assertCanMutateActionOrThrow(input.actionId)` | non |
+| `ScoreIndicatifService.setValeursUtilisees` | `score-indicatif.service.ts` | `assertCanMutateAction(input.actionId)` | non |
 | `RequestLabellisationService` | `request-labellisation.service.ts` | `input.referentielId` | non |
 | `CreatePreuveService` | `create-preuve.service.ts` | `input.referentielId` | non |
 | `HandleMesureAuditStatutService` | `handle-mesure-audit-statut.service.ts` | `getReferentielIdFromActionId(mesureId)` | non |
@@ -231,9 +218,8 @@ Pas de test e2e sur les autres services — deux mutations représentatives suff
 3. `ReferentielModeGuard` + erreurs typées (+ fragment partagé pour les `*.errors.ts`)
 4. Câbler `UpdateActionStatutService` + e2e readonly/write
 5. Câbler `UpdateActionCommentaireService` + e2e archived
-6. Câbler les autres services (batch mécanique) + `assertCanMutateOrThrow` pour les services legacy
-7. E2e exception personnalisation
-8. `pnpm test:backend referentiel-mode-guard` + `pnpm nx test domain can-mutate-referentiel`
+6. E2e exception personnalisation
+7. `pnpm test:backend referentiel-mode-guard` + `pnpm nx test domain can-mutate-referentiel`
 
 ## Estimation
 
@@ -256,7 +242,6 @@ Pas de test e2e sur les autres services — deux mutations représentatives suff
 |---|---|
 | Oubli d'un endpoint mutation | Checklist exhaustive + grep `REFERENTIELS.MUTATE` |
 | Régression CT sans batch reset (TE readonly, CAE write) | Comportement voulu ; le batch PR3 doit être exécuté avant levée flag (checklist ops PRD) |
-| Services legacy qui `throw` vs `Result` | `assertCanMutateOrThrow` / `assertCanMutateActionOrThrow` sans refactor global |
 | `EditPreuveDocumentService` sans `actionId` direct | Dériver depuis `preuve.actionId` après fetch (preuves complémentaires uniquement) |
 
 ## Références code

--- a/e2e/tests/referentiels/labellisations/checklist-role-mesures.spec.ts
+++ b/e2e/tests/referentiels/labellisations/checklist-role-mesures.spec.ts
@@ -185,7 +185,23 @@ test.describe('Checklist audit-labellisation — assignation rôle ↔ statut me
     });
 
     await newAuditLabellisationPom.roleHeaderItem('eluReferent').click();
+    await expect(newAuditLabellisationPom.roleSearchInput).toBeVisible();
+    // le dropdown peut s'ouvrir avant que listActionsGroupedById ait propagé
+    // les pilotes : sans sélection visible, recliquer l'utilisateur le réassigne
+    // au lieu de le retirer
+    await expect(
+      page.getByRole('button', { name: 'Désélectionner les options' })
+    ).toBeVisible({ timeout: ASSIGNATION_REFRESH_TIMEOUT });
+
+    const statutRetire = page.waitForResponse((response) =>
+      response.url().includes('updateStatut')
+    );
+    const parcoursRechargeApresRetrait = page.waitForResponse((response) =>
+      response.url().includes('getParcours')
+    );
     await newAuditLabellisationPom.roleDropdownOption(userFullName).click();
+    await statutRetire;
+    await parcoursRechargeApresRetrait;
     await page.keyboard.press('Escape');
 
     await expect(row.getByLabel('Critère non atteint')).toBeVisible({
@@ -193,7 +209,7 @@ test.describe('Checklist audit-labellisation — assignation rôle ↔ statut me
     });
   });
 
-  test("Visiteur — pas de bouton « Renseigner » sur une mesure de rôle", async ({
+  test('Visiteur — pas de bouton « Renseigner » sur une mesure de rôle', async ({
     page,
     newAuditLabellisationPom,
     collectivites,
@@ -209,7 +225,9 @@ test.describe('Checklist audit-labellisation — assignation rôle ↔ statut me
     await newAuditLabellisationPom.goto(editeurCollectivite.data.id, 'cae');
 
     await expect(
-      page.getByRole('button', { name: `${editeurCollectivite.data.nom} visite` })
+      page.getByRole('button', {
+        name: `${editeurCollectivite.data.nom} visite`,
+      })
     ).toBeVisible();
 
     const row = newAuditLabellisationPom.checklistRow(
@@ -217,9 +235,9 @@ test.describe('Checklist audit-labellisation — assignation rôle ↔ statut me
     );
     await row.hover();
 
-    await expect(
-      row.getByRole('button', { name: 'Renseigner' })
-    ).toHaveCount(0);
+    await expect(row.getByRole('button', { name: 'Renseigner' })).toHaveCount(
+      0
+    );
   });
 
   test("Visiteur — le trigger d'édition du rôle dans le header n'ouvre pas le dropdown", async ({
@@ -238,14 +256,16 @@ test.describe('Checklist audit-labellisation — assignation rôle ↔ statut me
     await newAuditLabellisationPom.goto(editeurCollectivite.data.id, 'cae');
 
     await expect(
-      page.getByRole('button', { name: `${editeurCollectivite.data.nom} visite` })
+      page.getByRole('button', {
+        name: `${editeurCollectivite.data.nom} visite`,
+      })
     ).toBeVisible();
 
     await newAuditLabellisationPom.roleHeaderItem('eluReferent').click();
     await expect(newAuditLabellisationPom.roleSearchInput).toHaveCount(0);
   });
 
-  test("CAE référent technique : assigner puis retirer met à jour le statut de la mesure sur la page référentiel sans recharger", async ({
+  test('CAE référent technique : assigner puis retirer met à jour le statut de la mesure sur la page référentiel sans recharger', async ({
     page,
     newAuditLabellisationPom,
     referentielScoresPom,

--- a/packages/domain/src/collectivites/can-mutate-referentiel.rules.spec.ts
+++ b/packages/domain/src/collectivites/can-mutate-referentiel.rules.spec.ts
@@ -1,0 +1,15 @@
+import { canMutateReferentielData } from './can-mutate-referentiel.rules';
+
+describe('canMutateReferentielData', () => {
+  it('autorise la mutation en mode write', () => {
+    expect(canMutateReferentielData('write')).toBe(true);
+  });
+
+  it('refuse la mutation en mode readonly', () => {
+    expect(canMutateReferentielData('readonly')).toBe(false);
+  });
+
+  it('refuse la mutation en mode archived', () => {
+    expect(canMutateReferentielData('archived')).toBe(false);
+  });
+});

--- a/packages/domain/src/collectivites/can-mutate-referentiel.rules.ts
+++ b/packages/domain/src/collectivites/can-mutate-referentiel.rules.ts
@@ -1,0 +1,5 @@
+import type { ReferentielMode } from './collectivite-preferences.schema';
+
+export function canMutateReferentielData(mode: ReferentielMode): boolean {
+  return mode === 'write';
+}

--- a/packages/domain/src/collectivites/index.ts
+++ b/packages/domain/src/collectivites/index.ts
@@ -1,3 +1,4 @@
+export * from './can-mutate-referentiel.rules';
 export * from './categorie-tag.schema';
 export * from './collectivite-banatic-type.enum';
 export * from './collectivite-preferences.schema';


### PR DESCRIPTION
Refuse les écritures lorsque le mode n'est pas write, en complément des permissions existantes. Câble le garde dans statuts, explications, pilotes, services, fiches, preuves, snapshots et labellisation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mise en place d’un **contrôle centralisé du mode référentiel** : les mutations ne sont autorisées que lorsque le référentiel est en **mode write** (refus en **readonly/archived**), couvrant notamment statuts, commentaires, audits, demandes, preuves, pilotes/services, liaisons et snapshots.
* **Bug Fixes**
  * **Erreurs et refus d’accès harmonisés** : retour plus cohérent “non modifiable” et normalisation des réponses en cas de permission insuffisante.
* **Tests / Documentation**
  * Ajout et mise à jour de tests **unitaires** et **e2e** pour valider les garde-fous et les scénarios de non-écriture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->