### PR TITLE
fix(indicateurs): restreint l'UPDATE de upsertValeur à la ligne collectivité ciblée

### DIFF
--- a/apps/backend/src/indicateurs/valeurs/crud-valeurs.router.e2e-spec.ts
+++ b/apps/backend/src/indicateurs/valeurs/crud-valeurs.router.e2e-spec.ts
@@ -20,6 +20,7 @@ import { and, eq } from 'drizzle-orm';
 import { AuthenticatedUser } from '../../users/models/auth.models';
 import { DatabaseService } from '../../utils/database/database.service';
 import { AppRouter, TrpcRouter } from '../../utils/trpc/trpc.router';
+import { indicateurSourceMetadonneeTable } from '../shared/models/indicateur-source-metadonnee.table';
 import { getIndicateursValeursResponseSchema } from './get-indicateur-valeurs.response';
 import { indicateurValeurTable } from './indicateur-valeur.table';
 
@@ -230,6 +231,80 @@ describe("Route de lecture/écriture des valeurs d'indicateurs", () => {
       resultAfterObjectif.indicateurs[0].sources.collectivite.valeurs[0]
         .objectif
     ).toBe(44);
+  });
+
+  test("Mettre à jour par id ne peut pas muter la valeur d'un autre indicateur", async () => {
+    const caller = router.createCaller({ user: authenticatedUser });
+
+    const created = await caller.indicateurs.valeurs.upsert({
+      collectiviteId,
+      indicateurId,
+      dateValeur: '2021-01-01',
+      resultat: 10,
+    });
+    if (!created) {
+      expect.fail('created is undefined');
+    }
+
+    const autreIndicateurId = await getIndicateurIdByIdentifiant(
+      databaseService,
+      'cae_1.e'
+    );
+
+    const result = await caller.indicateurs.valeurs.upsert({
+      collectiviteId,
+      indicateurId: autreIndicateurId,
+      id: created.id,
+      resultat: 999,
+    });
+
+    expect(result).toBeUndefined();
+
+    const after = await caller.indicateurs.valeurs.list({
+      collectiviteId,
+      indicateurIds: [indicateurId],
+    });
+    if (Array.isArray(after.indicateurs) === false) {
+      throw new Error('after.indicateurs is not an array');
+    }
+    expect(
+      after.indicateurs[0].sources.collectivite.valeurs[0].resultat
+    ).toBe(10);
+  });
+
+  test('Mettre à jour par id ne peut pas écraser une valeur open-data', async () => {
+    const caller = router.createCaller({ user: authenticatedUser });
+
+    const [metadonnee] = await databaseService.db
+      .select()
+      .from(indicateurSourceMetadonneeTable)
+      .limit(1);
+
+    const [openDataValeur] = await databaseService.db
+      .insert(indicateurValeurTable)
+      .values({
+        collectiviteId,
+        indicateurId,
+        dateValeur: '2019-01-01',
+        resultat: 5,
+        metadonneeId: metadonnee.id,
+      })
+      .returning();
+
+    const result = await caller.indicateurs.valeurs.upsert({
+      collectiviteId,
+      indicateurId,
+      id: openDataValeur.id,
+      resultat: 999,
+    });
+
+    expect(result).toBeUndefined();
+
+    const [row] = await databaseService.db
+      .select()
+      .from(indicateurValeurTable)
+      .where(eq(indicateurValeurTable.id, openDataValeur.id));
+    expect(row.resultat).toBe(5);
   });
 
   test("Valeurs calculées lors de l'insertion d'une valeur", async () => {

--- a/apps/backend/src/indicateurs/valeurs/crud-valeurs.service.ts
+++ b/apps/backend/src/indicateurs/valeurs/crud-valeurs.service.ts
@@ -530,7 +530,9 @@ export default class CrudValeursService {
           .where(
             and(
               eq(indicateurValeurTable.collectiviteId, collectiviteId),
-              eq(indicateurValeurTable.id, data.id)
+              eq(indicateurValeurTable.indicateurId, indicateurId),
+              eq(indicateurValeurTable.id, data.id),
+              isNull(indicateurValeurTable.metadonneeId)
             )
           )
           .returning();


### PR DESCRIPTION
## Contexte

Bug adjacent réel repéré dans le plan `feat-indicateur-values-grid` (FIX-1, tête de stack backend, sécurité).

## Problème

La branche UPDATE de `upsertValeur` (`crud-valeurs.service.ts`) filtrait le `where` sur `(collectiviteId, id)` seulement :

- **Bypass des droits pilote (IDOR)** : l'autorisation est vérifiée sur `indicateurId` du payload, mais l'UPDATE cible n'importe quelle valeur de la collectivité portant cet `id`. Un utilisateur pilote de l'indicateur A pouvait donc muter une valeur de l'indicateur B (qu'il ne pilote pas) en passant `indicateurId: A` + `id` d'une valeur de B.
- **Écrasement open-data** : aucune garde `metadonnee_id IS NULL`, donc l'`id` d'une ligne open-data (importée) pouvait être écrasé par une saisie collectivité.

## Correctif

Ajout de `eq(indicateurId)` + `isNull(metadonneeId)` au `where` de l'UPDATE. Aucune ligne ne matche si l'`id` n'appartient pas à l'indicateur ciblé, ou s'il s'agit d'une ligne open-data.

## Tests

Deux tests e2e rouges-puis-verts dans `crud-valeurs.router.e2e-spec.ts` :
- update par `id` ne peut pas muter la valeur d'un autre indicateur ;
- update par `id` ne peut pas écraser une valeur open-data.

`nx test backend crud-valeurs.router.e2e-spec` : 13/13. Typecheck + lint OK.
