### PR TITLE
fix(indicateurs): rend idempotente la branche INSERT de upsertValeur

### DIFF
--- a/apps/backend/src/indicateurs/valeurs/crud-valeurs.router.e2e-spec.ts
+++ b/apps/backend/src/indicateurs/valeurs/crud-valeurs.router.e2e-spec.ts
@@ -307,6 +307,71 @@ describe("Route de lecture/écriture des valeurs d'indicateurs", () => {
     expect(row.resultat).toBe(5);
   });
 
+  test('Un second upsert sur la même date met à jour au lieu de dupliquer', async () => {
+    const caller = router.createCaller({ user: authenticatedUser });
+
+    await caller.indicateurs.valeurs.upsert({
+      collectiviteId,
+      indicateurId,
+      dateValeur: '2021-01-01',
+      resultat: 10,
+    });
+
+    const second = await caller.indicateurs.valeurs.upsert({
+      collectiviteId,
+      indicateurId,
+      dateValeur: '2021-01-01',
+      resultat: 20,
+    });
+    expect(second?.resultat).toBe(20);
+
+    const after = await caller.indicateurs.valeurs.list({
+      collectiviteId,
+      indicateurIds: [indicateurId],
+    });
+    if (Array.isArray(after.indicateurs) === false) {
+      throw new Error('after.indicateurs is not an array');
+    }
+    expect(after.indicateurs[0].sources.collectivite.valeurs.length).toBe(1);
+    expect(
+      after.indicateurs[0].sources.collectivite.valeurs[0].resultat
+    ).toBe(20);
+  });
+
+  test("Un second upsert sans id ne réinitialise pas l'objectif existant", async () => {
+    const caller = router.createCaller({ user: authenticatedUser });
+
+    await caller.indicateurs.valeurs.upsert({
+      collectiviteId,
+      indicateurId,
+      dateValeur: '2021-01-01',
+      resultat: 10,
+      objectif: 5,
+    });
+
+    await caller.indicateurs.valeurs.upsert({
+      collectiviteId,
+      indicateurId,
+      dateValeur: '2021-01-01',
+      resultat: 20,
+    });
+
+    const after = await caller.indicateurs.valeurs.list({
+      collectiviteId,
+      indicateurIds: [indicateurId],
+    });
+    if (Array.isArray(after.indicateurs) === false) {
+      throw new Error('after.indicateurs is not an array');
+    }
+    expect(after.indicateurs[0].sources.collectivite.valeurs.length).toBe(1);
+    expect(
+      after.indicateurs[0].sources.collectivite.valeurs[0].resultat
+    ).toBe(20);
+    expect(
+      after.indicateurs[0].sources.collectivite.valeurs[0].objectif
+    ).toBe(5);
+  });
+
   test("Valeurs calculées lors de l'insertion d'une valeur", async () => {
     const caller = router.createCaller({ user: authenticatedUser });
 

--- a/apps/backend/src/indicateurs/valeurs/crud-valeurs.service.ts
+++ b/apps/backend/src/indicateurs/valeurs/crud-valeurs.service.ts
@@ -559,6 +559,22 @@ export default class CrudValeursService {
               modifiedAt: now,
               metadonneeId: null,
             })
+            .onConflictDoUpdate({
+              target: [
+                indicateurValeurTable.indicateurId,
+                indicateurValeurTable.collectiviteId,
+                indicateurValeurTable.dateValeur,
+              ],
+              targetWhere: isNull(indicateurValeurTable.metadonneeId),
+              set: {
+                resultat: data.resultat,
+                resultatCommentaire: data.resultatCommentaire,
+                objectif: data.objectif,
+                objectifCommentaire: data.objectifCommentaire,
+                modifiedBy: user.id,
+                modifiedAt: now,
+              },
+            })
             .returning();
 
           upsertedIndicateurValeur = inserted[0];


### PR DESCRIPTION
## Contexte

Bug adjacent réel repéré dans le plan `feat-indicateur-values-grid` (FIX-2, tête de stack backend).

## Problème

La branche INSERT de `upsertValeur` (payload sans `id`, avec `dateValeur`) faisait un INSERT aveugle. En cas de saisie concurrente, de double soumission ou de collage sur la même date (`indicateurId, collectiviteId, dateValeur`), le second insert violait la contrainte unique partielle `unique_indicateur_valeur_utilisateur` (`WHERE metadonnee_id IS NULL`) et levait une erreur.

## Correctif

Ajout d'un `onConflictDoUpdate` en miroir du batch `upsertIndicateurValeurs` :
- `target` = `(indicateurId, collectiviteId, dateValeur)`, `targetWhere` = `metadonnee_id IS NULL` (aligné sur l'index unique partiel existant) ;
- `set` = uniquement les champs fournis par le payload (les `undefined` sont omis par Drizzle), pour ne pas réinitialiser l'objectif existant lors d'un ré-upsert résultat-seul.

L'index unique partiel existe déjà en base (`fusion@v4.0.0.sql`) : aucune migration.

## Tests

Deux tests e2e rouges-puis-verts dans `crud-valeurs.router.e2e-spec.ts` :
- un second upsert sur la même date met à jour au lieu de dupliquer ;
- un second upsert sans id ne réinitialise pas l'objectif existant.

`nx test backend crud-valeurs.router.e2e-spec` : 13/13. Typecheck + lint OK.
