### PR TITLE
feat(ui): rend InlineEditWrapper utilisable en menu non-modal

### DIFF
--- a/packages/ui/src/design-system/inline-edit/inline-edit.wrapper.stories.tsx
+++ b/packages/ui/src/design-system/inline-edit/inline-edit.wrapper.stories.tsx
@@ -45,3 +45,49 @@ const RenderDefault = () => {
 export const Default: Story = {
   render: () => <RenderDefault />,
 };
+
+const RenderNonModalMenu = () => {
+  const sources = ['CITEPA 2026', 'INSEE 2024', 'Saisie manuelle'];
+
+  const [selected, setSelected] = useState(sources[0]);
+
+  return (
+    <InlineEditWrapper
+      role="menu"
+      modal={false}
+      lockScroll={false}
+      flip
+      offset={4}
+      floatingMatchReferenceHeight={false}
+      renderOnEdit={({ openState }) => (
+        <ul className="m-0 list-none p-1">
+          {sources.map((source) => (
+            <li key={source}>
+              <button
+                type="button"
+                className="w-full rounded px-3 py-1.5 text-left text-sm text-grey-8 hover:bg-grey-2"
+                onClick={() => {
+                  setSelected(source);
+                  openState.setIsOpen(false);
+                }}
+              >
+                {source}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    >
+      <button
+        type="button"
+        className="inline-flex items-center gap-2 rounded-lg border border-primary-3 px-2 py-3 text-primary-8 font-medium"
+      >
+        {selected}
+      </button>
+    </InlineEditWrapper>
+  );
+};
+
+export const NonModalMenu: Story = {
+  render: () => <RenderNonModalMenu />,
+};

--- a/packages/ui/src/design-system/inline-edit/inline-edit.wrapper.tsx
+++ b/packages/ui/src/design-system/inline-edit/inline-edit.wrapper.tsx
@@ -1,10 +1,11 @@
 import {
   autoUpdate,
+  flip as flipMiddleware,
   FloatingFocusManager,
   FloatingNode,
   FloatingOverlay,
   FloatingPortal,
-  offset,
+  offset as offsetMiddleware,
   shift,
   size,
   useClick,
@@ -12,6 +13,7 @@ import {
   useFloating,
   useFloatingNodeId,
   useInteractions,
+  useRole,
 } from '@floating-ui/react';
 import { cloneElement, HTMLAttributes, useState } from 'react';
 
@@ -19,6 +21,8 @@ import { useOpenState } from '../../hooks/use-open-state';
 import { preset } from '../../tailwind-preset';
 import { cn } from '../../utils/cn';
 import { OpenState } from '../../utils/types';
+
+export type InlineEditFloatingRole = 'dialog' | 'menu' | 'listbox';
 
 export type InlineEditWrapperProps = {
   children:
@@ -29,6 +33,11 @@ export type InlineEditWrapperProps = {
   onClose?: () => void;
   disabled?: boolean;
   floatingMatchReferenceHeight?: boolean;
+  role?: InlineEditFloatingRole;
+  modal?: boolean;
+  lockScroll?: boolean;
+  flip?: boolean;
+  offset?: number;
 };
 
 /**
@@ -42,6 +51,11 @@ export const InlineEditWrapper = ({
   disabled,
   openState,
   floatingMatchReferenceHeight = true,
+  role,
+  modal = true,
+  lockScroll = true,
+  flip = false,
+  offset,
 }: InlineEditWrapperProps) => {
   const { isOpen, setIsOpen } = useOpenState(openState);
 
@@ -65,7 +79,10 @@ export const InlineEditWrapper = ({
     whileElementsMounted: autoUpdate,
     placement: 'bottom-start',
     middleware: [
-      offset(({ rects }) => -rects.reference.height),
+      offsetMiddleware(
+        offset !== undefined ? offset : ({ rects }) => -rects.reference.height
+      ),
+      ...(flip ? [flipMiddleware()] : []),
       shift({
         crossAxis: true,
       }),
@@ -80,6 +97,7 @@ export const InlineEditWrapper = ({
   const { getReferenceProps, getFloatingProps } = useInteractions([
     useClick(context),
     useDismiss(context),
+    useRole(context, { role: role ?? 'dialog', enabled: role !== undefined }),
   ]);
 
   const isChildrenFunction = typeof children === 'function';
@@ -110,8 +128,8 @@ export const InlineEditWrapper = ({
       {renderOnEdit && isOpen && (
         <FloatingNode id={nodeId}>
           <FloatingPortal>
-            <FloatingOverlay lockScroll />
-            <FloatingFocusManager context={context}>
+            {lockScroll && <FloatingOverlay lockScroll />}
+            <FloatingFocusManager context={context} modal={modal}>
               <div
                 className="flex flex-col border border-grey-3 rounded-md bg-white shadow-md z-10"
                 {...getFloatingProps({


### PR DESCRIPTION
## Contexte

DS0 du plan `feat-indicateur-values-grid` : étendre le primitif `@tet/ui` `InlineEditWrapper` pour qu'il serve aussi de **menu/listbox non-modal** (pickers open-data F5/F8, PrefillMenu), sans fork. À lander avant P7/P8.

## Changement

`InlineEditWrapper` était figé en éditeur **modal** : overlay `lockScroll` toujours monté, focus-trap, offset négatif recouvrant la référence, pas de `flip` ni de `role`. On ajoute 5 props **opt-in**, chacune par défaut au comportement actuel — **strictement non-breaking** :

| Prop | Défaut | Effet |
|------|--------|-------|
| `role` | `undefined` | `useRole` (activé seulement si fourni : `menu`/`listbox`/`dialog`) |
| `modal` | `true` | `FloatingFocusManager modal` (piège focus) |
| `lockScroll` | `true` | monte l'overlay `FloatingOverlay lockScroll` |
| `flip` | `false` | middleware `flip()` |
| `offset` | recouvrement (`-hauteur réf.`) | décalage principal en px |

Un picker non-modal se configure ainsi : `role="menu" modal={false} lockScroll={false} flip offset={4}`.

Défauts vérifiés iso-comportement : `useRole` désactivé sans `role`, `FloatingFocusManager` sans prop `modal` valait déjà `modal={true}`, l'overlay et l'offset de recouvrement sont inchangés.

## Hors scope (différé)

`list-nav` (navigation clavier flèches via `useListNavigation`) est **différé à son consommateur (P8)** : il impose un contrat d'enregistrement de refs d'items qu'on ne peut pas concevoir correctement sans le picker réel. L'ajouter à l'aveugle serait de l'API spéculative.

## Démo / vérif

- Story `NonModalMenu` ajoutée (menu de sources non-modal).
- `nx run ui:typecheck` (sans cache) OK, eslint OK.
- Aucun consommateur existant (`EditableTitle`, `table.cell`, `infos`, `plan.header`, `planning`…) ne passe les nouvelles props → comportement inchangé.
