### PR TITLE
feat(indicateurs): procédure upsertValeurField (résultat ou objectif par cellule)

### DIFF
--- a/DISCOVERED.md
+++ b/DISCOVERED.md
@@ -16,3 +16,27 @@
 - **Découvert pendant** : audit-checklist-view-update (stabilisation des e2e labellisation)
 - **Découvert le** : 2026-05-21
 
+## [refactor] Le backend n'implémente pas l'ADR « pas de throw en service → Result<T,E> »
+- **Symptôme** : la convention `.claude/CLAUDE.md` impose `Result<T,E>` (neverthrow) pour les erreurs métier des services ; en réalité tout `apps/backend` signale les erreurs métier via `throw new *Exception` NestJS. 34 fichiers throw une exception HTTP, 0 fichier importe `neverthrow`.
+- **Localisation** : ensemble de `apps/backend/src/**/*.service.ts` (ex. `indicateurs/valeurs/crud-valeurs.service.ts:306,322,454,631,730`).
+- **Diagnostic suspecté** : l'ADR décrit une cible hexagonale non appliquée côté backend. Une migration cohérente suppose un mapper `Result → TRPCError` centralisé + reprise service par service ; la faire à la maille d'une seule méthode créerait le seul `Result` du backend et casserait la surface d'erreur tRPC (le routeur renverrait l'objet Result en success).
+- **Impact** : archi — écart durable entre convention documentée et code ; dev — ambiguïté sur la règle à suivre pour tout nouveau service.
+- **Découvert pendant** : feat/indicateur-upsert-resultat (revue /ce:review)
+- **Découvert le** : 2026-07-03
+
+## [refactor] Le format ISO de `dateValeur` n'est contraint que sur un seul chemin d'appel
+- **Symptôme** : `upsert-valeur-field.request.ts:13` durcit à la main `z.string().check(z.regex(/^\d{4}-\d{2}-\d{2}$/))`, alors que le schéma domaine `indicateurValeurSchemaCreate.shape.dateValeur` reste un `z.string()` nu. La règle pure `yearOf` (`valeur-field.rules.ts:3`, `dateValeur.slice(0,4)`) dépend de ce format ISO, mais seul ce chemin l'impose ; `upsert` (sibling) ne le garantit pas.
+- **Localisation** : `apps/backend/src/indicateurs/valeurs/upsert-valeur-field.request.ts:13` ; `packages/domain/src/indicateurs/valeurs/indicateur-valeur.schema.ts:13`.
+- **Diagnostic suspecté** : le contrat de format devrait vivre dans le schéma domaine (ou un `DateValeur` brandé) et être consommé par les deux requests, plutôt que dupliqué/partiel. Hors-scope ici car cela touche `packages/domain` et le request sibling.
+- **Impact** : dev — anti-duplication ; correction pure couplée à une invariant enforçée à un seul endroit.
+- **Découvert pendant** : feat/indicateur-upsert-resultat (revue /ce:review)
+- **Découvert le** : 2026-07-03
+
+## [improvement] Validation métier avant autorisation dans upsertValeurField
+- **Symptôme** : `upsertValeurField` lève `BadRequestException` (règle année future) avant de déléguer à `upsertValeur` où vit le contrôle d'autorisation (`canMutateValeur`). Un utilisateur sans droit `mutate` sur la collectivité qui soumet un résultat futur reçoit 400 au lieu de 403.
+- **Localisation** : `apps/backend/src/indicateurs/valeurs/crud-valeurs.service.ts:631` (validation) vs `:504` (autorisation dans `upsertValeur`).
+- **Diagnostic suspecté** : ordre conventionnel = autoriser puis valider. Divulgation triviale (n'expose que la règle temporelle, aucune donnée ressource), d'où priorité basse.
+- **Impact** : utilisateur — code d'erreur incohérent sur un cas non autorisé ; sécurité — divulgation négligeable.
+- **Découvert pendant** : feat/indicateur-upsert-resultat (revue /ce:review)
+- **Découvert le** : 2026-07-03
+

--- a/apps/backend/src/indicateurs/valeurs/crud-valeurs.router.e2e-spec.ts
+++ b/apps/backend/src/indicateurs/valeurs/crud-valeurs.router.e2e-spec.ts
@@ -28,6 +28,10 @@ type InputUpsert = inferProcedureInput<
   AppRouter['indicateurs']['valeurs']['upsert']
 >;
 
+type InputUpsertValeurField = inferProcedureInput<
+  AppRouter['indicateurs']['valeurs']['upsertValeurField']
+>;
+
 // Platform indicateur (shared across all collectivites)
 const indicateurId = 1;
 
@@ -354,6 +358,97 @@ describe("Route de lecture/écriture des valeurs d'indicateurs", () => {
     expect(
       after.indicateurs[0].sources.collectivite.valeurs[0].objectif
     ).toBe(5);
+  });
+
+  test('upsertValeurField écrit un résultat pour une année passée', async () => {
+    const caller = router.createCaller({ user: authenticatedUser });
+
+    const inserted = await caller.indicateurs.valeurs.upsertValeurField({
+      collectiviteId,
+      indicateurId,
+      dateValeur: '2021-01-01',
+      field: 'resultat',
+      valeur: 12,
+    } satisfies InputUpsertValeurField);
+    expect(inserted?.resultat).toBe(12);
+
+    const updated = await caller.indicateurs.valeurs.upsertValeurField({
+      collectiviteId,
+      indicateurId,
+      dateValeur: '2021-01-01',
+      field: 'resultat',
+      valeur: 34,
+    } satisfies InputUpsertValeurField);
+    expect(updated?.resultat).toBe(34);
+
+    const after = await caller.indicateurs.valeurs.list({
+      collectiviteId,
+      indicateurIds: [indicateurId],
+    });
+    if (Array.isArray(after.indicateurs) === false) {
+      throw new Error('after.indicateurs is not an array');
+    }
+    expect(after.indicateurs[0].sources.collectivite.valeurs.length).toBe(1);
+    expect(
+      after.indicateurs[0].sources.collectivite.valeurs[0].resultat
+    ).toBe(34);
+  });
+
+  test('upsertValeurField écrit un objectif pour une année future sans toucher le résultat', async () => {
+    const caller = router.createCaller({ user: authenticatedUser });
+
+    const inserted = await caller.indicateurs.valeurs.upsertValeurField({
+      collectiviteId,
+      indicateurId,
+      dateValeur: '2030-01-01',
+      field: 'objectif',
+      valeur: 80,
+    } satisfies InputUpsertValeurField);
+    expect(inserted).toMatchObject({ objectif: 80, resultat: null });
+  });
+
+  test('upsertValeurField refuse un résultat pour une année future', async () => {
+    const caller = router.createCaller({ user: authenticatedUser });
+
+    await expect(
+      caller.indicateurs.valeurs.upsertValeurField({
+        collectiviteId,
+        indicateurId,
+        dateValeur: '2030-01-01',
+        field: 'resultat',
+        valeur: 5,
+      } satisfies InputUpsertValeurField)
+    ).rejects.toThrow();
+
+    const after = await caller.indicateurs.valeurs.list({
+      collectiviteId,
+      indicateurIds: [indicateurId],
+    });
+    if (Array.isArray(after.indicateurs) === false) {
+      throw new Error('after.indicateurs is not an array');
+    }
+    expect(after.indicateurs[0].sources.collectivite).toBeUndefined();
+  });
+
+  test("upsertValeurField écrivant un résultat ne réinitialise pas l'objectif existant", async () => {
+    const caller = router.createCaller({ user: authenticatedUser });
+
+    await caller.indicateurs.valeurs.upsert({
+      collectiviteId,
+      indicateurId,
+      dateValeur: '2021-01-01',
+      resultat: 10,
+      objectif: 5,
+    });
+
+    const updated = await caller.indicateurs.valeurs.upsertValeurField({
+      collectiviteId,
+      indicateurId,
+      dateValeur: '2021-01-01',
+      field: 'resultat',
+      valeur: 20,
+    } satisfies InputUpsertValeurField);
+    expect(updated).toMatchObject({ resultat: 20, objectif: 5 });
   });
 
   test("Valeurs calculées lors de l'insertion d'une valeur", async () => {

--- a/apps/backend/src/indicateurs/valeurs/crud-valeurs.router.ts
+++ b/apps/backend/src/indicateurs/valeurs/crud-valeurs.router.ts
@@ -8,6 +8,7 @@ import { deleteValeurIndicateurSchema } from './delete-valeur-indicateur.request
 import { getMoyenneCollectivitesRequestSchema } from './get-moyenne-collectivites.request';
 import { getValeursReferenceRequestSchema } from './get-valeurs-reference.request';
 import { listIndicateurValeursInputSchema } from './list-indicateur-valeurs.input';
+import { upsertValeurFieldSchema } from './upsert-valeur-field.request';
 import { upsertValeurIndicateurSchema } from './upsert-valeur-indicateur.request';
 import ValeursMoyenneService from './valeurs-moyenne.service';
 import ValeursReferenceService from './valeurs-reference.service';
@@ -32,6 +33,11 @@ export class IndicateurValeursRouter {
       .input(upsertValeurIndicateurSchema)
       .mutation(({ input, ctx }) => {
         return this.service.upsertValeur(input, ctx.user);
+      }),
+    upsertValeurField: this.trpc.authedProcedure
+      .input(upsertValeurFieldSchema)
+      .mutation(({ input, ctx }) => {
+        return this.service.upsertValeurField(input, ctx.user);
       }),
     delete: this.trpc.authedProcedure
       .input(deleteValeurIndicateurSchema)

--- a/apps/backend/src/indicateurs/valeurs/crud-valeurs.service.ts
+++ b/apps/backend/src/indicateurs/valeurs/crud-valeurs.service.ts
@@ -78,6 +78,8 @@ import {
 } from './indicateur-valeur.table';
 import { ListIndicateurValeursInput } from './list-indicateur-valeurs.input';
 import { UpsertValeurIndicateur } from './upsert-valeur-indicateur.request';
+import { UpsertValeurField } from './upsert-valeur-field.request';
+import { isFieldAllowedForYear, yearOf } from './valeur-field.rules';
 
 type IndicateurValeurInsert = IndicateurValeurCreate;
 
@@ -613,6 +615,31 @@ export default class CrudValeursService {
 
       return upsertedIndicateurValeur;
     }
+  }
+
+  async upsertValeurField(data: UpsertValeurField, user: AuthenticatedUser) {
+    const { collectiviteId, indicateurId, dateValeur, field, valeur } = data;
+    const year = yearOf(dateValeur);
+
+    if (
+      !isFieldAllowedForYear({
+        field,
+        year,
+        currentYear: new Date().getFullYear(),
+      })
+    ) {
+      throw new BadRequestException(
+        `Un résultat ne peut pas être saisi pour l'année future ${year} ; utiliser un objectif.`
+      );
+    }
+
+    const valeurField =
+      field === 'resultat' ? { resultat: valeur } : { objectif: valeur };
+
+    return this.upsertValeur(
+      { collectiviteId, indicateurId, dateValeur, ...valeurField },
+      user
+    );
   }
 
   async deleteValeurIndicateur(

--- a/apps/backend/src/indicateurs/valeurs/upsert-valeur-field.request.ts
+++ b/apps/backend/src/indicateurs/valeurs/upsert-valeur-field.request.ts
@@ -1,0 +1,18 @@
+import {
+  IndicateurValeurWithoutReferenceTypes,
+  indicateurValeurSchemaCreate,
+} from '@tet/domain/indicateurs';
+import * as z from 'zod/mini';
+
+export const upsertValeurFieldSchema = z.object({
+  ...z.pick(indicateurValeurSchemaCreate, {
+    collectiviteId: true,
+    indicateurId: true,
+  }).shape,
+
+  dateValeur: z.string().check(z.regex(/^\d{4}-\d{2}-\d{2}$/)),
+  field: z.enum(IndicateurValeurWithoutReferenceTypes),
+  valeur: z.number(),
+});
+
+export type UpsertValeurField = z.infer<typeof upsertValeurFieldSchema>;

--- a/apps/backend/src/indicateurs/valeurs/valeur-field.rules.spec.ts
+++ b/apps/backend/src/indicateurs/valeurs/valeur-field.rules.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'vitest';
+import { isFieldAllowedForYear, yearOf } from './valeur-field.rules';
+
+describe('yearOf', () => {
+  test('extrait l année du champ dateValeur', () => {
+    expect(yearOf('2030-01-01')).toBe(2030);
+  });
+});
+
+describe('isFieldAllowedForYear', () => {
+  const currentYear = 2026;
+
+  test('un objectif est autorisé quelle que soit l année', () => {
+    expect(
+      isFieldAllowedForYear({ field: 'objectif', year: 2050, currentYear })
+    ).toBe(true);
+    expect(
+      isFieldAllowedForYear({ field: 'objectif', year: 2019, currentYear })
+    ).toBe(true);
+  });
+
+  test('un résultat est autorisé pour une année passée ou courante', () => {
+    expect(
+      isFieldAllowedForYear({ field: 'resultat', year: 2019, currentYear })
+    ).toBe(true);
+    expect(
+      isFieldAllowedForYear({
+        field: 'resultat',
+        year: currentYear,
+        currentYear,
+      })
+    ).toBe(true);
+  });
+
+  test('un résultat est refusé pour une année future', () => {
+    expect(
+      isFieldAllowedForYear({ field: 'resultat', year: 2030, currentYear })
+    ).toBe(false);
+  });
+});

--- a/apps/backend/src/indicateurs/valeurs/valeur-field.rules.ts
+++ b/apps/backend/src/indicateurs/valeurs/valeur-field.rules.ts
@@ -1,0 +1,14 @@
+import { IndicateurValeurWithoutReferenceType } from '@tet/domain/indicateurs';
+
+export const yearOf = (dateValeur: string): number =>
+  Number(dateValeur.slice(0, 4));
+
+export const isFieldAllowedForYear = ({
+  field,
+  year,
+  currentYear,
+}: {
+  field: IndicateurValeurWithoutReferenceType;
+  year: number;
+  currentYear: number;
+}): boolean => field === 'objectif' || year <= currentYear;


### PR DESCRIPTION
## Contexte

Sujet backend du plan `feat-indicateur-values-grid`, **révisé** après une découverte métier (vérifiée en DB locale) : les **années futures ne portent que des objectifs**, jamais de résultat (2150 valeurs futures = 100% objectif, 0 résultat). La grille écrit donc soit un `resultat`, soit un `objectif` selon la colonne — pas uniquement du résultat comme le plan le supposait.

## Changement

Procédure `upsertValeurField` qui écrit **un seul champ** d'une valeur d'indicateur, choisi par l'appelant :

- **`upsert-valeur-field.request.ts`** — `{collectiviteId, indicateurId, dateValeur, field: 'resultat'|'objectif', valeur: number}`. `field` réutilise l'enum domaine `IndicateurValeurWithoutReferenceTypes`. `dateValeur` validé au format `YYYY-MM-DD`. `valeur` non-nullable (l'effacement d'une cellule = `clearCell`, pas cette procédure → pas de ligne fantôme tout-null).
- **`valeur-field.rules.ts`** *(règle pure + spec)* — `isFieldAllowedForYear` : un `resultat` est **interdit pour une année future** ; un `objectif` est autorisé partout. `yearOf` extrait l'année.
- **`crud-valeurs.service.ts`** — `upsertValeurField` applique la règle (rejet `BAD_REQUEST` sinon), mappe `{[field]: valeur}` et délègue à `upsertValeur` (gardes IDOR/idempotence de FIX-1/FIX-2). Seule la colonne `field` est écrite → l'autre préservée (**objectif-safe ET resultat-safe**).

## Tests

`valeur-field.rules.spec` (objectif/passé/courant/futur) + e2e : résultat passé (insert+update), objectif futur sans toucher le résultat, résultat futur refusé, résultat ne réinitialise pas l'objectif. 23/23. Typecheck + lint OK.

## Revue

`/code-review` (high) + `te-en-t-style-enforcer`. Intégré : réutilisation de l'enum domaine (au lieu de re-déclarer `['resultat','objectif']`), `valeur` non-nullable (ligne fantôme null), validation format `dateValeur` (NaN→500), `year` hoisté, nommage technique anglais. **Assumé/documenté** : throw (service legacy throw-based, router sans handler Result) ; l'invariant « pas de résultat futur » garde l'entrée grille — l'imposer sur le `upsert` partagé est une décision produit plus large (hors scope).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Ajout d’une saisie simplifiée des valeurs d’indicateurs, avec prise en charge distincte des résultats et des objectifs.
  * Les résultats peuvent être renseignés pour les dates passées ou courantes, tandis que les objectifs restent acceptés quelle que soit la date.

* **Correctifs**
  * Empêche la saisie d’un résultat pour une année future.
  * La mise à jour d’un résultat ne réinitialise plus un objectif déjà enregistré pour la même date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->