### PR TITLE
feat(indicateurs): procédure upsertValeursField (collage résultat/objectif)

### DIFF
--- a/apps/backend/src/indicateurs/indicateurs.module.ts
+++ b/apps/backend/src/indicateurs/indicateurs.module.ts
@@ -11,7 +11,9 @@ import { PersonnalisationsModule } from '../collectivites/personnalisations/pers
 import { ReferentielsCoreModule } from '../referentiels/referentiels-core.module';
 import { UsersModule } from '../users/users.module';
 import { SheetModule } from '../utils/google-sheets/sheet.module';
+import { TransactionModule } from '../utils/transaction/transaction.module';
 import { IndicateurChartService } from './charts/indicateur-chart.service';
+import { BatchUpsertValeursFieldRepository } from './valeurs/batch-upsert-valeurs-field.repository';
 import { ListCollectiviteDefinitionsRepository } from './definitions/list-collectivite-definitions/list-collectivite-definitions.repository';
 import { ListPlatformDefinitionsController } from './definitions/list-platform-definitions/list-platform-definitions.controller';
 import { ListPlatformDefinitionsRepository } from './definitions/list-platform-definitions/list-platform-definitions.repository';
@@ -68,8 +70,10 @@ const DEFINITIONS_PROVIDERS = [
     SheetModule,
     PersonnalisationsModule,
     ReferentielsCoreModule,
+    TransactionModule,
   ],
   providers: [
+    BatchUpsertValeursFieldRepository,
     ExportIndicateursService,
     IndicateurSourcesService,
     IndicateurSourcesService,

--- a/apps/backend/src/indicateurs/valeurs/batch-upsert-valeurs-field.repository.ts
+++ b/apps/backend/src/indicateurs/valeurs/batch-upsert-valeurs-field.repository.ts
@@ -1,0 +1,62 @@
+import { Injectable } from '@nestjs/common';
+import { buildConflictUpdateColumns } from '@tet/backend/utils/database/conflict.utils';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import {
+  IndicateurValeur,
+  IndicateurValeurWithoutReferenceType,
+} from '@tet/domain/indicateurs';
+import { isNull } from 'drizzle-orm';
+import { indicateurValeurTable } from './indicateur-valeur.table';
+
+export type BatchValeurFieldRow = {
+  collectiviteId: number;
+  indicateurId: number;
+  dateValeur: string;
+  valeur: number;
+  createdBy: string | null;
+  createdAt: string;
+  modifiedBy: string | null;
+  modifiedAt: string;
+};
+
+@Injectable()
+export class BatchUpsertValeursFieldRepository {
+  constructor(private readonly databaseService: DatabaseService) {}
+
+  async upsertMany(
+    rows: BatchValeurFieldRow[],
+    field: IndicateurValeurWithoutReferenceType,
+    tx?: Transaction
+  ): Promise<IndicateurValeur[]> {
+    return (tx ?? this.databaseService.db)
+      .insert(indicateurValeurTable)
+      .values(
+        rows.map((row) => ({
+          collectiviteId: row.collectiviteId,
+          indicateurId: row.indicateurId,
+          dateValeur: row.dateValeur,
+          [field]: row.valeur,
+          createdBy: row.createdBy,
+          createdAt: row.createdAt,
+          modifiedBy: row.modifiedBy,
+          modifiedAt: row.modifiedAt,
+          metadonneeId: null,
+        }))
+      )
+      .onConflictDoUpdate({
+        target: [
+          indicateurValeurTable.indicateurId,
+          indicateurValeurTable.collectiviteId,
+          indicateurValeurTable.dateValeur,
+        ],
+        targetWhere: isNull(indicateurValeurTable.metadonneeId),
+        set: buildConflictUpdateColumns(indicateurValeurTable, [
+          field,
+          'modifiedBy',
+          'modifiedAt',
+        ]),
+      })
+      .returning();
+  }
+}

--- a/apps/backend/src/indicateurs/valeurs/crud-valeurs.router.e2e-spec.ts
+++ b/apps/backend/src/indicateurs/valeurs/crud-valeurs.router.e2e-spec.ts
@@ -32,6 +32,10 @@ type InputUpsert = inferProcedureInput<
   AppRouter['indicateurs']['valeurs']['upsert']
 >;
 
+type InputUpsertValeurField = inferProcedureInput<
+  AppRouter['indicateurs']['valeurs']['upsertValeurField']
+>;
+
 // Platform indicateur (shared across all collectivites)
 const indicateurId = 1;
 
@@ -370,6 +374,97 @@ describe("Route de lecture/écriture des valeurs d'indicateurs", () => {
     expect(
       after.indicateurs[0].sources.collectivite.valeurs[0].objectif
     ).toBe(5);
+  });
+
+  test('upsertValeurField écrit un résultat pour une année passée', async () => {
+    const caller = router.createCaller({ user: authenticatedUser });
+
+    const inserted = await caller.indicateurs.valeurs.upsertValeurField({
+      collectiviteId,
+      indicateurId,
+      dateValeur: '2021-01-01',
+      field: 'resultat',
+      valeur: 12,
+    } satisfies InputUpsertValeurField);
+    expect(inserted?.resultat).toBe(12);
+
+    const updated = await caller.indicateurs.valeurs.upsertValeurField({
+      collectiviteId,
+      indicateurId,
+      dateValeur: '2021-01-01',
+      field: 'resultat',
+      valeur: 34,
+    } satisfies InputUpsertValeurField);
+    expect(updated?.resultat).toBe(34);
+
+    const after = await caller.indicateurs.valeurs.list({
+      collectiviteId,
+      indicateurIds: [indicateurId],
+    });
+    if (Array.isArray(after.indicateurs) === false) {
+      throw new Error('after.indicateurs is not an array');
+    }
+    expect(after.indicateurs[0].sources.collectivite.valeurs.length).toBe(1);
+    expect(
+      after.indicateurs[0].sources.collectivite.valeurs[0].resultat
+    ).toBe(34);
+  });
+
+  test('upsertValeurField écrit un objectif pour une année future sans toucher le résultat', async () => {
+    const caller = router.createCaller({ user: authenticatedUser });
+
+    const inserted = await caller.indicateurs.valeurs.upsertValeurField({
+      collectiviteId,
+      indicateurId,
+      dateValeur: '2030-01-01',
+      field: 'objectif',
+      valeur: 80,
+    } satisfies InputUpsertValeurField);
+    expect(inserted).toMatchObject({ objectif: 80, resultat: null });
+  });
+
+  test('upsertValeurField refuse un résultat pour une année future', async () => {
+    const caller = router.createCaller({ user: authenticatedUser });
+
+    await expect(
+      caller.indicateurs.valeurs.upsertValeurField({
+        collectiviteId,
+        indicateurId,
+        dateValeur: '2030-01-01',
+        field: 'resultat',
+        valeur: 5,
+      } satisfies InputUpsertValeurField)
+    ).rejects.toThrow();
+
+    const after = await caller.indicateurs.valeurs.list({
+      collectiviteId,
+      indicateurIds: [indicateurId],
+    });
+    if (Array.isArray(after.indicateurs) === false) {
+      throw new Error('after.indicateurs is not an array');
+    }
+    expect(after.indicateurs[0].sources.collectivite).toBeUndefined();
+  });
+
+  test("upsertValeurField écrivant un résultat ne réinitialise pas l'objectif existant", async () => {
+    const caller = router.createCaller({ user: authenticatedUser });
+
+    await caller.indicateurs.valeurs.upsert({
+      collectiviteId,
+      indicateurId,
+      dateValeur: '2021-01-01',
+      resultat: 10,
+      objectif: 5,
+    });
+
+    const updated = await caller.indicateurs.valeurs.upsertValeurField({
+      collectiviteId,
+      indicateurId,
+      dateValeur: '2021-01-01',
+      field: 'resultat',
+      valeur: 20,
+    } satisfies InputUpsertValeurField);
+    expect(updated).toMatchObject({ resultat: 20, objectif: 5 });
   });
 
   test("Valeurs calculées lors de l'insertion d'une valeur", async () => {

--- a/apps/backend/src/indicateurs/valeurs/crud-valeurs.router.e2e-spec.ts
+++ b/apps/backend/src/indicateurs/valeurs/crud-valeurs.router.e2e-spec.ts
@@ -36,6 +36,10 @@ type InputUpsertValeurField = inferProcedureInput<
   AppRouter['indicateurs']['valeurs']['upsertValeurField']
 >;
 
+type InputUpsertValeursField = inferProcedureInput<
+  AppRouter['indicateurs']['valeurs']['upsertValeursField']
+>;
+
 // Platform indicateur (shared across all collectivites)
 const indicateurId = 1;
 
@@ -465,6 +469,151 @@ describe("Route de lecture/écriture des valeurs d'indicateurs", () => {
       valeur: 20,
     } satisfies InputUpsertValeurField);
     expect(updated).toMatchObject({ resultat: 20, objectif: 5 });
+  });
+
+  test('upsertValeursField écrit un lot mixte résultat passé + objectif futur', async () => {
+    const caller = router.createCaller({ user: authenticatedUser });
+
+    const result = await caller.indicateurs.valeurs.upsertValeursField({
+      collectiviteId,
+      valeurs: [
+        { indicateurId, dateValeur: '2021-01-01', field: 'resultat', valeur: 10 },
+        { indicateurId, dateValeur: '2030-01-01', field: 'objectif', valeur: 80 },
+        { indicateurId, dateValeur: '2050-01-01', field: 'objectif', valeur: 60 },
+      ],
+    } satisfies InputUpsertValeursField);
+    expect(result.length).toBe(3);
+
+    const after = await caller.indicateurs.valeurs.list({
+      collectiviteId,
+      indicateurIds: [indicateurId],
+    });
+    if (Array.isArray(after.indicateurs) === false) {
+      throw new Error('after.indicateurs is not an array');
+    }
+    expect(after.indicateurs[0].sources.collectivite.valeurs.length).toBe(3);
+  });
+
+  test('upsertValeursField refuse tout le lot si un résultat vise une année future', async () => {
+    const caller = router.createCaller({ user: authenticatedUser });
+
+    await expect(
+      caller.indicateurs.valeurs.upsertValeursField({
+        collectiviteId,
+        valeurs: [
+          { indicateurId, dateValeur: '2021-01-01', field: 'resultat', valeur: 10 },
+          { indicateurId, dateValeur: '2030-01-01', field: 'resultat', valeur: 5 },
+        ],
+      } satisfies InputUpsertValeursField)
+    ).rejects.toThrow();
+
+    const after = await caller.indicateurs.valeurs.list({
+      collectiviteId,
+      indicateurIds: [indicateurId],
+    });
+    if (Array.isArray(after.indicateurs) === false) {
+      throw new Error('after.indicateurs is not an array');
+    }
+    expect(after.indicateurs[0].sources.collectivite).toBeUndefined();
+  });
+
+  test('upsertValeursField dédoublonne un même champ/indicateur/date (la dernière gagne)', async () => {
+    const caller = router.createCaller({ user: authenticatedUser });
+
+    const result = await caller.indicateurs.valeurs.upsertValeursField({
+      collectiviteId,
+      valeurs: [
+        { indicateurId, dateValeur: '2030-01-01', field: 'objectif', valeur: 1 },
+        { indicateurId, dateValeur: '2030-01-01', field: 'objectif', valeur: 9 },
+      ],
+    } satisfies InputUpsertValeursField);
+    expect(result.length).toBe(1);
+    expect(result[0].objectif).toBe(9);
+  });
+
+  test('upsertValeursField rejette un lot vide', async () => {
+    const caller = router.createCaller({ user: authenticatedUser });
+
+    await expect(
+      caller.indicateurs.valeurs.upsertValeursField({
+        collectiviteId,
+        valeurs: [],
+      } satisfies InputUpsertValeursField)
+    ).rejects.toThrow();
+  });
+
+  test('upsertValeursField déclenche le recompute des indicateurs calculés', async () => {
+    const caller = router.createCaller({ user: authenticatedUser });
+
+    const cae1eIndicateurId = await getIndicateurIdByIdentifiant(
+      databaseService,
+      'cae_1.e'
+    );
+    const cae1fIndicateurId = await getIndicateurIdByIdentifiant(
+      databaseService,
+      'cae_1.f'
+    );
+    const indicateurCalculeId = await getIndicateurIdByIdentifiant(
+      databaseService,
+      'cae_1.k'
+    );
+
+    await deleteIndicateurValeursForCollectivite(
+      databaseService,
+      paysDuLaonCollectiviteId,
+      [indicateurCalculeId, cae1fIndicateurId, cae1eIndicateurId]
+    );
+
+    await caller.indicateurs.valeurs.upsertValeursField({
+      collectiviteId: paysDuLaonCollectiviteId,
+      valeurs: [
+        {
+          indicateurId: cae1eIndicateurId,
+          dateValeur: '2015-01-01',
+          field: 'resultat',
+          valeur: 102.04,
+        },
+      ],
+    } satisfies InputUpsertValeursField);
+
+    const after = await caller.indicateurs.valeurs.list({
+      collectiviteId: paysDuLaonCollectiviteId,
+      indicateurIds: [indicateurCalculeId],
+    });
+    if (Array.isArray(after.indicateurs) === false) {
+      throw new Error('after.indicateurs is not an array');
+    }
+    expect(after.indicateurs[0].sources.collectivite.valeurs.length).toBe(1);
+    expect(
+      after.indicateurs[0].sources.collectivite.valeurs[0]
+    ).toMatchObject({ resultat: 102.04, calculAuto: true });
+  });
+
+  test('upsertValeursField fusionne résultat et objectif de la même cellule en une ligne', async () => {
+    const caller = router.createCaller({ user: authenticatedUser });
+
+    const result = await caller.indicateurs.valeurs.upsertValeursField({
+      collectiviteId,
+      valeurs: [
+        { indicateurId, dateValeur: '2021-01-01', field: 'resultat', valeur: 10 },
+        { indicateurId, dateValeur: '2021-01-01', field: 'objectif', valeur: 12 },
+      ],
+    } satisfies InputUpsertValeursField);
+    expect(result.length).toBe(1);
+    expect(result[0]).toMatchObject({ resultat: 10, objectif: 12 });
+  });
+
+  test("upsertValeursField refuse si l'utilisateur n'a pas les droits sur la collectivité", async () => {
+    const caller = router.createCaller({ user: authenticatedUser });
+
+    await expect(
+      caller.indicateurs.valeurs.upsertValeursField({
+        collectiviteId: 100,
+        valeurs: [
+          { indicateurId, dateValeur: '2021-01-01', field: 'resultat', valeur: 1 },
+        ],
+      } satisfies InputUpsertValeursField)
+    ).rejects.toThrow();
   });
 
   test("Valeurs calculées lors de l'insertion d'une valeur", async () => {

--- a/apps/backend/src/indicateurs/valeurs/crud-valeurs.router.ts
+++ b/apps/backend/src/indicateurs/valeurs/crud-valeurs.router.ts
@@ -9,6 +9,7 @@ import { getMoyenneCollectivitesRequestSchema } from './get-moyenne-collectivite
 import { getValeursReferenceRequestSchema } from './get-valeurs-reference.request';
 import { listIndicateurValeursInputSchema } from './list-indicateur-valeurs.input';
 import { upsertValeurFieldSchema } from './upsert-valeur-field.request';
+import { upsertValeursFieldSchema } from './upsert-valeurs-field.request';
 import { upsertValeurIndicateurSchema } from './upsert-valeur-indicateur.request';
 import ValeursMoyenneService from './valeurs-moyenne.service';
 import ValeursReferenceService from './valeurs-reference.service';
@@ -38,6 +39,11 @@ export class IndicateurValeursRouter {
       .input(upsertValeurFieldSchema)
       .mutation(({ input, ctx }) => {
         return this.service.upsertValeurField(input, ctx.user);
+      }),
+    upsertValeursField: this.trpc.authedProcedure
+      .input(upsertValeursFieldSchema)
+      .mutation(({ input, ctx }) => {
+        return this.service.upsertValeursField(input, ctx.user);
       }),
     delete: this.trpc.authedProcedure
       .input(deleteValeurIndicateurSchema)

--- a/apps/backend/src/indicateurs/valeurs/crud-valeurs.router.ts
+++ b/apps/backend/src/indicateurs/valeurs/crud-valeurs.router.ts
@@ -8,6 +8,7 @@ import { deleteValeurIndicateurSchema } from './delete-valeur-indicateur.request
 import { getMoyenneCollectivitesRequestSchema } from './get-moyenne-collectivites.request';
 import { getValeursReferenceRequestSchema } from './get-valeurs-reference.request';
 import { listIndicateurValeursInputSchema } from './list-indicateur-valeurs.input';
+import { upsertValeurFieldSchema } from './upsert-valeur-field.request';
 import { upsertValeurIndicateurSchema } from './upsert-valeur-indicateur.request';
 import ValeursMoyenneService from './valeurs-moyenne.service';
 import ValeursReferenceService from './valeurs-reference.service';
@@ -32,6 +33,11 @@ export class IndicateurValeursRouter {
       .input(upsertValeurIndicateurSchema)
       .mutation(({ input, ctx }) => {
         return this.service.upsertValeur(input, ctx.user);
+      }),
+    upsertValeurField: this.trpc.authedProcedure
+      .input(upsertValeurFieldSchema)
+      .mutation(({ input, ctx }) => {
+        return this.service.upsertValeurField(input, ctx.user);
       }),
     delete: this.trpc.authedProcedure
       .input(deleteValeurIndicateurSchema)

--- a/apps/backend/src/indicateurs/valeurs/crud-valeurs.service.ts
+++ b/apps/backend/src/indicateurs/valeurs/crud-valeurs.service.ts
@@ -24,6 +24,7 @@ import {
   IndicateurValeurGroupee,
   IndicateurValeursGroupeeParSource,
   IndicateurValeurWithIdentifiant,
+  IndicateurValeurWithoutReferenceType,
 } from '@tet/domain/indicateurs';
 import {
   hasPermission,
@@ -54,6 +55,7 @@ import {
   omit,
   omitBy,
   partition,
+  uniq,
 } from 'es-toolkit';
 import { GetUserRolesAndPermissionsService } from '../../users/authorizations/get-user-roles-and-permissions/get-user-roles-and-permissions.service';
 import {
@@ -79,9 +81,60 @@ import {
 import { ListIndicateurValeursInput } from './list-indicateur-valeurs.input';
 import { UpsertValeurIndicateur } from './upsert-valeur-indicateur.request';
 import { UpsertValeurField } from './upsert-valeur-field.request';
+import { UpsertValeursField } from './upsert-valeurs-field.request';
+import {
+  BatchValeurFieldRow,
+  BatchUpsertValeursFieldRepository,
+} from './batch-upsert-valeurs-field.repository';
 import { isFieldAllowedForYear, yearOf } from './valeur-field.rules';
+import { TransactionManager } from '@tet/backend/utils/transaction/transaction-manager.service';
+import { success } from '@tet/backend/utils/result.type';
 
 type IndicateurValeurInsert = IndicateurValeurCreate;
+
+const toBatchRowsByField = ({
+  valeurs,
+  collectiviteId,
+  precisionByIndicateurId,
+  userId,
+  now,
+}: {
+  valeurs: UpsertValeursField['valeurs'];
+  collectiviteId: number;
+  precisionByIndicateurId: Record<number, number>;
+  userId: string;
+  now: string;
+}): Record<IndicateurValeurWithoutReferenceType, BatchValeurFieldRow[]> => {
+  const latestValueByKey = new Map<
+    string,
+    UpsertValeursField['valeurs'][number]
+  >();
+  valeurs.forEach((valeur) =>
+    latestValueByKey.set(
+      `${valeur.field}:${valeur.indicateurId}:${valeur.dateValeur}`,
+      valeur
+    )
+  );
+
+  const toRow = (
+    valeur: UpsertValeursField['valeurs'][number]
+  ): BatchValeurFieldRow => ({
+    collectiviteId,
+    indicateurId: valeur.indicateurId,
+    dateValeur: valeur.dateValeur,
+    valeur: roundTo(valeur.valeur, precisionByIndicateurId[valeur.indicateurId]),
+    createdBy: userId,
+    createdAt: now,
+    modifiedBy: userId,
+    modifiedAt: now,
+  });
+
+  const byField = groupBy([...latestValueByKey.values()], (v) => v.field);
+  return {
+    resultat: (byField.resultat ?? []).map(toRow),
+    objectif: (byField.objectif ?? []).map(toRow),
+  };
+};
 
 @Injectable()
 export default class CrudValeursService {
@@ -105,7 +158,9 @@ export default class CrudValeursService {
     private readonly listPlatformDefinitionsRepository: ListPlatformDefinitionsRepository,
     private readonly listIndicateursService: ListIndicateursService,
     private readonly updateIndicateurService: UpdateDefinitionService,
-    private readonly computeValeursService: ComputeValeursService
+    private readonly computeValeursService: ComputeValeursService,
+    private readonly transactionManager: TransactionManager,
+    private readonly batchUpsertValeursFieldRepository: BatchUpsertValeursFieldRepository
   ) {}
 
   private getIndicateurValeursSqlConditions(
@@ -640,6 +695,151 @@ export default class CrudValeursService {
       { collectiviteId, indicateurId, dateValeur, ...valeurField },
       user
     );
+  }
+
+  async upsertValeursField(
+    data: UpsertValeursField,
+    user: AuthenticatedUser
+  ): Promise<IndicateurValeur[]> {
+    const { collectiviteId, valeurs } = data;
+
+    const currentYear = new Date().getFullYear();
+    const hasDisallowedField = valeurs.some(
+      (valeur) =>
+        !isFieldAllowedForYear({
+          field: valeur.field,
+          year: yearOf(valeur.dateValeur),
+          currentYear,
+        })
+    );
+    if (hasDisallowedField) {
+      throw new BadRequestException(
+        `Un résultat ne peut pas être saisi pour une année future ; utiliser un objectif.`
+      );
+    }
+
+    const indicateurIds = uniq(valeurs.map((v) => v.indicateurId));
+    const indicateurs = await Promise.all(
+      indicateurIds.map((indicateurId) =>
+        this.listIndicateursService.getIndicateur({
+          collectiviteId,
+          indicateurId,
+        })
+      )
+    );
+
+    await this.authorizeValeursMutation(user, collectiviteId, indicateurs);
+
+    const precisionByIndicateurId = Object.fromEntries(
+      indicateurs.map((indicateur) => [indicateur.id, indicateur.precision])
+    );
+    const rowsByField = toBatchRowsByField({
+      valeurs,
+      collectiviteId,
+      precisionByIndicateurId,
+      userId: user.id,
+      now: new Date().toISOString(),
+    });
+
+    const upsertedValeurs = await this.writeValeursFieldBatches(rowsByField);
+
+    await Promise.all(
+      indicateurIds.map((indicateurId) =>
+        this.updateIndicateurService.updateDefinitionModifiedFields({
+          indicateurId,
+          collectiviteId,
+          user,
+        })
+      )
+    );
+
+    const calculatedValeursToUpsert =
+      await this.computeValeursService.updateCalculatedIndicateurValeurs(
+        upsertedValeurs,
+        indicateurs
+      );
+    if (calculatedValeursToUpsert.length) {
+      await this.upsertIndicateurValeurs(calculatedValeursToUpsert, undefined);
+    }
+
+    return upsertedValeurs;
+  }
+
+  private async writeValeursFieldBatches(
+    rowsByField: Record<IndicateurValeurWithoutReferenceType, BatchValeurFieldRow[]>
+  ): Promise<IndicateurValeur[]> {
+    const upsertResult = await this.transactionManager.executeSingle<
+      IndicateurValeur[]
+    >(async (tx) => {
+      const resultatsWritten = rowsByField.resultat.length
+        ? await this.batchUpsertValeursFieldRepository.upsertMany(
+            rowsByField.resultat,
+            'resultat',
+            tx
+          )
+        : [];
+      const objectifsWritten = rowsByField.objectif.length
+        ? await this.batchUpsertValeursFieldRepository.upsertMany(
+            rowsByField.objectif,
+            'objectif',
+            tx
+          )
+        : [];
+
+      const valeurById = new Map<number, IndicateurValeur>();
+      [...resultatsWritten, ...objectifsWritten].forEach((valeur) =>
+        valeurById.set(valeur.id, valeur)
+      );
+      return success([...valeurById.values()]);
+    });
+    if (!upsertResult.success) {
+      throw new Error(getErrorMessage(upsertResult.error));
+    }
+    return upsertResult.data;
+  }
+
+  private async authorizeValeursMutation(
+    user: AuthenticatedUser,
+    collectiviteId: number,
+    indicateurs: IndicateurListItem[]
+  ): Promise<void> {
+    const userPermissionsResult =
+      await this.getUserPermissionsService.getUserRolesAndPermissions({
+        userId: user.id,
+      });
+    if (!userPermissionsResult.success) {
+      throw new ForbiddenException(
+        `Droits insuffisants, l'utilisateur ${user.id} n'a pas les droits pour muter les valeurs de la collectivité ${collectiviteId}`
+      );
+    }
+    const userPermissions = userPermissionsResult.data;
+
+    if (
+      hasPermission(userPermissions, 'indicateurs.valeurs.mutate', {
+        collectiviteId,
+      })
+    ) {
+      return;
+    }
+
+    const canMutatePiloted = hasPermission(
+      userPermissions,
+      'indicateurs.valeurs.mutate_piloted_by_me',
+      { collectiviteId }
+    );
+    const canMutateAllIndicateurs = indicateurs.every(
+      (indicateur) =>
+        canMutatePiloted &&
+        indicateur.pilotes?.some((pilote) => pilote.userId === user.id)
+    );
+    if (!canMutateAllIndicateurs) {
+      this.permissionService.throwForbiddenException(
+        user,
+        'indicateurs.valeurs.mutate',
+        ResourceType.COLLECTIVITE,
+        collectiviteId
+      );
+    }
   }
 
   async deleteValeurIndicateur(

--- a/apps/backend/src/indicateurs/valeurs/crud-valeurs.service.ts
+++ b/apps/backend/src/indicateurs/valeurs/crud-valeurs.service.ts
@@ -78,6 +78,8 @@ import {
 } from './indicateur-valeur.table';
 import { ListIndicateurValeursInput } from './list-indicateur-valeurs.input';
 import { UpsertValeurIndicateur } from './upsert-valeur-indicateur.request';
+import { UpsertValeurField } from './upsert-valeur-field.request';
+import { isFieldAllowedForYear, yearOf } from './valeur-field.rules';
 
 type IndicateurValeurInsert = IndicateurValeurCreate;
 
@@ -613,6 +615,31 @@ export default class CrudValeursService {
 
       return upsertedIndicateurValeur;
     }
+  }
+
+  async upsertValeurField(data: UpsertValeurField, user: AuthenticatedUser) {
+    const { collectiviteId, indicateurId, dateValeur, field, valeur } = data;
+    const year = yearOf(dateValeur);
+
+    if (
+      !isFieldAllowedForYear({
+        field,
+        year,
+        currentYear: new Date().getFullYear(),
+      })
+    ) {
+      throw new BadRequestException(
+        `Un résultat ne peut pas être saisi pour l'année future ${year} ; utiliser un objectif.`
+      );
+    }
+
+    const valeurField =
+      field === 'resultat' ? { resultat: valeur } : { objectif: valeur };
+
+    return this.upsertValeur(
+      { collectiviteId, indicateurId, dateValeur, ...valeurField },
+      user
+    );
   }
 
   async deleteValeurIndicateur(

--- a/apps/backend/src/indicateurs/valeurs/upsert-valeur-field.request.ts
+++ b/apps/backend/src/indicateurs/valeurs/upsert-valeur-field.request.ts
@@ -1,0 +1,18 @@
+import {
+  IndicateurValeurWithoutReferenceTypes,
+  indicateurValeurSchemaCreate,
+} from '@tet/domain/indicateurs';
+import * as z from 'zod/mini';
+
+export const upsertValeurFieldSchema = z.object({
+  ...z.pick(indicateurValeurSchemaCreate, {
+    collectiviteId: true,
+    indicateurId: true,
+  }).shape,
+
+  dateValeur: z.string().check(z.regex(/^\d{4}-\d{2}-\d{2}$/)),
+  field: z.enum(IndicateurValeurWithoutReferenceTypes),
+  valeur: z.number(),
+});
+
+export type UpsertValeurField = z.infer<typeof upsertValeurFieldSchema>;

--- a/apps/backend/src/indicateurs/valeurs/upsert-valeurs-field.request.ts
+++ b/apps/backend/src/indicateurs/valeurs/upsert-valeurs-field.request.ts
@@ -1,0 +1,27 @@
+import {
+  IndicateurValeurWithoutReferenceTypes,
+  indicateurValeurSchemaCreate,
+} from '@tet/domain/indicateurs';
+import * as z from 'zod/mini';
+
+export const upsertValeursFieldSchema = z.object({
+  ...z.pick(indicateurValeurSchemaCreate, {
+    collectiviteId: true,
+  }).shape,
+
+  valeurs: z
+    .array(
+      z.object({
+        ...z.pick(indicateurValeurSchemaCreate, {
+          indicateurId: true,
+        }).shape,
+
+        dateValeur: z.string().check(z.regex(/^\d{4}-\d{2}-\d{2}$/)),
+        field: z.enum(IndicateurValeurWithoutReferenceTypes),
+        valeur: z.number(),
+      })
+    )
+    .check(z.minLength(1)),
+});
+
+export type UpsertValeursField = z.infer<typeof upsertValeursFieldSchema>;

--- a/apps/backend/src/indicateurs/valeurs/valeur-field.rules.spec.ts
+++ b/apps/backend/src/indicateurs/valeurs/valeur-field.rules.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'vitest';
+import { isFieldAllowedForYear, yearOf } from './valeur-field.rules';
+
+describe('yearOf', () => {
+  test('extrait l année du champ dateValeur', () => {
+    expect(yearOf('2030-01-01')).toBe(2030);
+  });
+});
+
+describe('isFieldAllowedForYear', () => {
+  const currentYear = 2026;
+
+  test('un objectif est autorisé quelle que soit l année', () => {
+    expect(
+      isFieldAllowedForYear({ field: 'objectif', year: 2050, currentYear })
+    ).toBe(true);
+    expect(
+      isFieldAllowedForYear({ field: 'objectif', year: 2019, currentYear })
+    ).toBe(true);
+  });
+
+  test('un résultat est autorisé pour une année passée ou courante', () => {
+    expect(
+      isFieldAllowedForYear({ field: 'resultat', year: 2019, currentYear })
+    ).toBe(true);
+    expect(
+      isFieldAllowedForYear({
+        field: 'resultat',
+        year: currentYear,
+        currentYear,
+      })
+    ).toBe(true);
+  });
+
+  test('un résultat est refusé pour une année future', () => {
+    expect(
+      isFieldAllowedForYear({ field: 'resultat', year: 2030, currentYear })
+    ).toBe(false);
+  });
+});

--- a/apps/backend/src/indicateurs/valeurs/valeur-field.rules.ts
+++ b/apps/backend/src/indicateurs/valeurs/valeur-field.rules.ts
@@ -1,0 +1,14 @@
+import { IndicateurValeurWithoutReferenceType } from '@tet/domain/indicateurs';
+
+export const yearOf = (dateValeur: string): number =>
+  Number(dateValeur.slice(0, 4));
+
+export const isFieldAllowedForYear = ({
+  field,
+  year,
+  currentYear,
+}: {
+  field: IndicateurValeurWithoutReferenceType;
+  year: number;
+  currentYear: number;
+}): boolean => field === 'objectif' || year <= currentYear;


### PR DESCRIPTION
## Contexte

**Stacke sur #4670** (dont il réutilise la règle `valeur-field.rules` + l'enum domaine). Pendant « lot » de `upsertValeurField` : collage / pré-remplissage de la grille, où chaque cellule choisit son champ (`resultat` ou `objectif`).

Révisé après la découverte métier (vérifiée en DB) : années futures = objectifs, jamais de résultat.

## Changement

- **`upsert-valeurs-field.request.ts`** — `{collectiviteId, valeurs: [{indicateurId, dateValeur, field: 'resultat'|'objectif', valeur: number}]}` (min 1). Enum domaine, `dateValeur` validé `YYYY-MM-DD`, `valeur` non-null.
- **`batch-upsert-valeurs-field.repository.ts`** — batch `INSERT ... onConflictDoUpdate` **paramétré par `field`** (clé naturelle `metadonnee_id IS NULL`, `set` field-only via `buildConflictUpdateColumns`), `tx?` en dernier param.
- **`crud-valeurs.service.ts` `upsertValeursField`** :
  - applique la règle année-future **sur chaque item** (rejet global `BAD_REQUEST` si un résultat vise le futur) ;
  - **dédoublonne** par `(field, indicateur, date)` (dernière gagne) → évite `ON CONFLICT cannot affect row a second time` ;
  - **partitionne par `field`**, un batch par colonne, **les deux dans une transaction** (2 statements → tout-ou-rien) ;
  - recompute des parents calculés **1×** hors tx (comme `upsertValeur`) ;
  - refresh `indicateur_collectivite` par indicateur ;
  - auth pilote-aware avec **un seul fetch** de permissions.

## Tests e2e

lot mixte résultat passé + objectif futur, refus global si un résultat vise le futur, dédoublonnage (dernière gagne), lot vide rejeté, recompute déclenché. 28/28. Typecheck + lint OK.

## Note

La transaction est justifiée ici (2 statements via la partition par field), contrairement au cas mono-statement.
