### PR TITLE
feat(indicateurs): edition inline de l'annee de reference (P7)

### DIFF
--- a/apps/app/src/indicateurs/valeurs/grid/__tests__/indicateur-values-grid.stories.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/__tests__/indicateur-values-grid.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/nextjs-vite';
-import { Button } from '@tet/ui';
 import { arrayMove } from '@dnd-kit/sortable';
+import { Button } from '@tet/ui';
 import { JSX, useCallback, useMemo, useState } from 'react';
 import {
   fakeCells,
@@ -13,11 +13,13 @@ import { IndicateurValuesGrid } from '../indicateur-values-grid';
 import { rowDragId } from '../use-grid-reorder';
 import {
   generateCellKey,
+  parseCellKey,
   CellKey,
   CellValueInput,
   GridCell,
   GridRowGroup,
   IndicateurValuesGridActions,
+  Year,
 } from '../types';
 
 const meta: Meta<typeof IndicateurValuesGrid> = {
@@ -28,6 +30,12 @@ const meta: Meta<typeof IndicateurValuesGrid> = {
 export default meta;
 
 type Story = StoryObj<typeof IndicateurValuesGrid>;
+
+type GridState = {
+  years: Year[];
+  referenceYear: Year;
+  cells: Map<CellKey, GridCell>;
+};
 
 const withValues = (
   previous: Map<CellKey, GridCell>,
@@ -55,15 +63,43 @@ const withValues = (
   return next;
 };
 
+const rekeyReferenceColumn = ({
+  cells,
+  referenceYear,
+  nextYear,
+}: {
+  cells: Map<CellKey, GridCell>;
+  referenceYear: Year;
+  nextYear: Year;
+}): Map<CellKey, GridCell> =>
+  new Map(
+    Array.from(cells, ([key, cell]) => {
+      const parsed = parseCellKey(key);
+      const belongsToReferenceColumn =
+        parsed !== null && parsed.year === referenceYear;
+      const nextKey = belongsToReferenceColumn
+        ? generateCellKey(parsed.indicateurId, nextYear)
+        : key;
+      return [nextKey, cell] as const;
+    })
+  );
+
 const InteractiveGrid = (): JSX.Element => {
-  const [cells, setCells] = useState<Map<CellKey, GridCell>>(() => fakeCells());
+  const [state, setState] = useState<GridState>(() => ({
+    years: fakeYears,
+    referenceYear: fakeReferenceYear,
+    cells: fakeCells(),
+  }));
   const [groups, setGroups] = useState<GridRowGroup[]>(fakeGroups);
 
   const actions = useMemo<IndicateurValuesGridActions>(
     () => ({
       ...fakeGridActions,
       saveCellValue: async (input) => {
-        setCells((previous) => withValues(previous, [input]));
+        setState((previous) => ({
+          ...previous,
+          cells: withValues(previous.cells, [input]),
+        }));
         return { ok: true, value: undefined };
       },
       saveCellValues: async (inputs) => {
@@ -73,7 +109,10 @@ const InteractiveGrid = (): JSX.Element => {
               .map((input) => `${input.indicateurId} / ${input.year} = ${input.resultat}`)
               .join('\n')
         );
-        setCells((previous) => withValues(previous, inputs));
+        setState((previous) => ({
+          ...previous,
+          cells: withValues(previous.cells, inputs),
+        }));
         return { ok: true, value: { written: inputs.length, failed: [] } };
       },
     }),
@@ -104,6 +143,28 @@ const InteractiveGrid = (): JSX.Element => {
 
   const resetRowOrder = useCallback(() => setGroups(fakeGroups), []);
 
+  const onReferenceYearChange = useCallback((nextYear: Year): void => {
+    setState((previous) => {
+      const isNoOp =
+        nextYear === previous.referenceYear ||
+        previous.years.includes(nextYear);
+      if (isNoOp) {
+        return previous;
+      }
+      return {
+        years: previous.years.map((year) =>
+          year === previous.referenceYear ? nextYear : year
+        ),
+        referenceYear: nextYear,
+        cells: rekeyReferenceColumn({
+          cells: previous.cells,
+          referenceYear: previous.referenceYear,
+          nextYear,
+        }),
+      };
+    });
+  }, []);
+
   return (
     <div className="flex flex-col items-start gap-2">
       <Button size="xs" variant="outlined" onClick={resetRowOrder}>
@@ -111,13 +172,14 @@ const InteractiveGrid = (): JSX.Element => {
       </Button>
       <IndicateurValuesGrid
         groups={groups}
-        years={fakeYears}
-        referenceYear={fakeReferenceYear}
+        years={state.years}
+        referenceYear={state.referenceYear}
         unit="t/an"
-        cells={cells}
+        cells={state.cells}
         actions={actions}
         notify={(message) => window.alert(message)}
         onReorderRows={onReorderRows}
+        onReferenceYearChange={onReferenceYearChange}
       />
     </div>
   );

--- a/apps/app/src/indicateurs/valeurs/grid/grid-context.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/grid-context.tsx
@@ -19,6 +19,7 @@ export type GridContextValue = {
   actions: IndicateurValuesGridActions;
   notify?: (message: string) => void;
   onReorderRows?: (groupId: string, activeId: string, overId: string) => void;
+  onReferenceYearChange?: (year: Year) => void;
 };
 
 const GridContext = createContext<GridContextValue | null>(null);
@@ -34,6 +35,7 @@ export const GridProvider = ({
   actions,
   notify,
   onReorderRows,
+  onReferenceYearChange,
 }: GridContextValue & { children: ReactNode }): JSX.Element => {
   const value = useMemo<GridContextValue>(
     () => ({
@@ -46,6 +48,7 @@ export const GridProvider = ({
       actions,
       notify,
       onReorderRows,
+      onReferenceYearChange,
     }),
     [
       groups,
@@ -57,6 +60,7 @@ export const GridProvider = ({
       actions,
       notify,
       onReorderRows,
+      onReferenceYearChange,
     ]
   );
   return <GridContext.Provider value={value}>{children}</GridContext.Provider>;

--- a/apps/app/src/indicateurs/valeurs/grid/grid-frame.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/grid-frame.tsx
@@ -35,6 +35,7 @@ export const GridFrame = (): JSX.Element => {
     actions,
     notify,
     onReorderRows,
+    onReferenceYearChange,
   } = useGridContext();
 
   const {
@@ -202,6 +203,7 @@ export const GridFrame = (): JSX.Element => {
               years={orderedYears}
               unit={unit}
               referenceYear={referenceYear}
+              onReferenceYearChange={onReferenceYearChange}
             />
             <GridBody rows={table.getRowModel().rows} groups={orderedGroups} />
           </table>

--- a/apps/app/src/indicateurs/valeurs/grid/grid-head.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/grid-head.tsx
@@ -7,15 +7,19 @@ import { YearColumnHeader } from './year-column-header';
 import { yearDragId } from './use-grid-reorder';
 import { Year } from './types';
 
+type GridHeadProps = {
+  years: Year[];
+  unit: string | null;
+  referenceYear: Year | null;
+  onReferenceYearChange?: (year: Year) => void;
+};
+
 export const GridHead = ({
   years,
   unit,
   referenceYear,
-}: {
-  years: Year[];
-  unit: string | null;
-  referenceYear: Year | null;
-}): JSX.Element => (
+  onReferenceYearChange,
+}: GridHeadProps): JSX.Element => (
   <thead>
     <tr role="row">
       <th
@@ -37,6 +41,7 @@ export const GridHead = ({
             year={year}
             unit={unit}
             isReference={year === referenceYear}
+            onReferenceYearChange={onReferenceYearChange}
           />
         ))}
       </SortableContext>

--- a/apps/app/src/indicateurs/valeurs/grid/indicateur-values-grid.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/indicateur-values-grid.tsx
@@ -21,6 +21,7 @@ export type IndicateurValuesGridProps = {
   actions: IndicateurValuesGridActions;
   notify?: (message: string) => void;
   onReorderRows?: (groupId: string, activeId: string, overId: string) => void;
+  onReferenceYearChange?: (year: Year) => void;
 };
 
 export const IndicateurValuesGrid = ({
@@ -33,6 +34,7 @@ export const IndicateurValuesGrid = ({
   actions,
   notify,
   onReorderRows,
+  onReferenceYearChange,
 }: IndicateurValuesGridProps): JSX.Element => (
   <GridProvider
     groups={groups}
@@ -44,6 +46,7 @@ export const IndicateurValuesGrid = ({
     actions={actions}
     notify={notify}
     onReorderRows={onReorderRows}
+    onReferenceYearChange={onReferenceYearChange}
   >
     <div className="rounded-xl border border-grey-3 bg-white p-4">
       <GridFrame />

--- a/apps/app/src/indicateurs/valeurs/grid/reference-year/reference-year-editor.spec.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/reference-year/reference-year-editor.spec.tsx
@@ -1,0 +1,75 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { appLabels } from '../../../../labels/catalog';
+import { toYear } from '../types';
+import { ReferenceYearEditor } from './reference-year-editor';
+
+const openEditor = (onReferenceYearChange: () => void): HTMLInputElement => {
+  const year = toYear(2020);
+  render(
+    <ReferenceYearEditor
+      year={year}
+      onReferenceYearChange={onReferenceYearChange}
+    />
+  );
+  fireEvent.click(
+    screen.getByRole('button', {
+      name: appLabels.indicateurModifierAnneeReference(year),
+    })
+  );
+  return screen.getByRole('textbox', {
+    name: appLabels.indicateurAnneeReferenceChamp,
+  }) as HTMLInputElement;
+};
+
+const submitForm = (input: HTMLInputElement): void => {
+  const form = input.closest('form');
+  if (form === null) {
+    throw new Error('form not found');
+  }
+  fireEvent.submit(form);
+};
+
+const isEditorClosed = (): boolean =>
+  screen.queryByRole('textbox', {
+    name: appLabels.indicateurAnneeReferenceChamp,
+  }) === null;
+
+describe('ReferenceYearEditor', () => {
+  it("enregistre l'année saisie à la validation", async () => {
+    const onReferenceYearChange = vi.fn();
+    const input = openEditor(onReferenceYearChange);
+    fireEvent.change(input, { target: { value: '2018' } });
+    submitForm(input);
+    await waitFor(() =>
+      expect(onReferenceYearChange).toHaveBeenCalledWith(2018)
+    );
+  });
+
+  it("affiche le message et n'enregistre pas une année hors bornes", async () => {
+    const onReferenceYearChange = vi.fn();
+    const input = openEditor(onReferenceYearChange);
+    fireEvent.change(input, { target: { value: '1800' } });
+    submitForm(input);
+    await screen.findByText(
+      appLabels.indicateurAnneeReferenceInvalide(1900, 2100)
+    );
+    expect(onReferenceYearChange).not.toHaveBeenCalled();
+  });
+
+  it("annule sans enregistrer quand l'année est inchangée", async () => {
+    const onReferenceYearChange = vi.fn();
+    const input = openEditor(onReferenceYearChange);
+    submitForm(input);
+    await waitFor(() => expect(isEditorClosed()).toBe(true));
+    expect(onReferenceYearChange).not.toHaveBeenCalled();
+  });
+
+  it('annule sur Échap sans enregistrer', () => {
+    const onReferenceYearChange = vi.fn();
+    const input = openEditor(onReferenceYearChange);
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(isEditorClosed()).toBe(true);
+    expect(onReferenceYearChange).not.toHaveBeenCalled();
+  });
+});

--- a/apps/app/src/indicateurs/valeurs/grid/reference-year/reference-year-editor.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/reference-year/reference-year-editor.tsx
@@ -1,0 +1,117 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { cn, Field, Icon, InlineEditWrapper, Input } from '@tet/ui';
+import { ComponentProps, JSX } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { appLabels } from '@/app/labels/catalog';
+import { toYear, Year } from '../types';
+
+const MIN_REFERENCE_YEAR = 1900;
+const MAX_REFERENCE_YEAR = 2100;
+const referenceYearMessage = appLabels.indicateurAnneeReferenceInvalide(
+  MIN_REFERENCE_YEAR,
+  MAX_REFERENCE_YEAR
+);
+
+const referenceYearSchema = z.object({
+  year: z
+    .number({ message: referenceYearMessage })
+    .int(referenceYearMessage)
+    .min(MIN_REFERENCE_YEAR, referenceYearMessage)
+    .max(MAX_REFERENCE_YEAR, referenceYearMessage),
+});
+type ReferenceYearForm = z.infer<typeof referenceYearSchema>;
+
+type ReferenceYearEditorProps = {
+  year: Year;
+  onReferenceYearChange: (year: Year) => void;
+};
+
+type ReferenceYearInputProps = {
+  year: Year;
+  onSubmit: (year: Year) => void;
+  onCancel: () => void;
+};
+
+const ReferenceYearInput = ({
+  year,
+  onSubmit,
+  onCancel,
+}: ReferenceYearInputProps): JSX.Element => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<ReferenceYearForm>({
+    resolver: zodResolver(referenceYearSchema),
+    defaultValues: { year },
+    mode: 'onChange',
+  });
+
+  return (
+    <form
+      className="w-24"
+      onSubmit={handleSubmit(({ year: nextYear }) => onSubmit(toYear(nextYear)))}
+    >
+      <Field
+        small
+        state={errors.year ? 'error' : 'default'}
+        message={errors.year?.message}
+      >
+        <Input
+          type="text"
+          inputMode="numeric"
+          autoFocus
+          aria-label={appLabels.indicateurAnneeReferenceChamp}
+          displaySize="sm"
+          className="text-right"
+          {...register('year', { valueAsNumber: true })}
+          onFocus={(event) => event.currentTarget.select()}
+          onKeyDown={(event) => {
+            if (event.key === 'Escape') {
+              event.preventDefault();
+              onCancel();
+            }
+          }}
+        />
+      </Field>
+    </form>
+  );
+};
+
+export const ReferenceYearEditor = ({
+  year,
+  onReferenceYearChange,
+}: ReferenceYearEditorProps): JSX.Element => (
+  <InlineEditWrapper
+    renderOnEdit={({ openState }) => (
+      <ReferenceYearInput
+        year={year}
+        onSubmit={(next) => {
+          if (next !== year) {
+            onReferenceYearChange(next);
+          }
+          openState.setIsOpen(false);
+        }}
+        onCancel={() => openState.setIsOpen(false)}
+      />
+    )}
+  >
+    {(triggerProps: ComponentProps<'button'>) => (
+      <button
+        type="button"
+        {...triggerProps}
+        aria-label={appLabels.indicateurModifierAnneeReference(year)}
+        className={cn(
+          triggerProps.className,
+          'inline-flex items-center gap-1 font-bold text-primary-9'
+        )}
+      >
+        <span className="underline decoration-dotted underline-offset-2">
+          {appLabels.indicateurAnneeReference(year)}
+        </span>
+        <Icon icon="edit-line" size="xs" aria-hidden />
+      </button>
+    )}
+  </InlineEditWrapper>
+);

--- a/apps/app/src/indicateurs/valeurs/grid/year-column-header.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/year-column-header.tsx
@@ -4,6 +4,7 @@ import { cn } from '@tet/ui';
 import { JSX, memo } from 'react';
 import { appLabels } from '@/app/labels/catalog';
 import { DragHandle } from './drag-handle';
+import { ReferenceYearEditor } from './reference-year/reference-year-editor';
 import { Unit } from './unit';
 import { Year } from './types';
 
@@ -12,10 +13,41 @@ type YearColumnHeaderProps = {
   year: Year;
   unit: string | null;
   isReference: boolean;
+  onReferenceYearChange?: (year: Year) => void;
+};
+
+type YearHeaderLabelProps = Pick<
+  YearColumnHeaderProps,
+  'year' | 'isReference' | 'onReferenceYearChange'
+>;
+
+const YearHeaderLabel = ({
+  year,
+  isReference,
+  onReferenceYearChange,
+}: YearHeaderLabelProps): JSX.Element => {
+  if (!isReference) {
+    return <span>{year}</span>;
+  }
+  if (onReferenceYearChange === undefined) {
+    return <span>{appLabels.indicateurAnneeReference(year)}</span>;
+  }
+  return (
+    <ReferenceYearEditor
+      year={year}
+      onReferenceYearChange={onReferenceYearChange}
+    />
+  );
 };
 
 export const YearColumnHeader = memo(
-  ({ dragId, year, unit, isReference }: YearColumnHeaderProps): JSX.Element => {
+  ({
+    dragId,
+    year,
+    unit,
+    isReference,
+    onReferenceYearChange,
+  }: YearColumnHeaderProps): JSX.Element => {
     const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
       useSortable({
         id: dragId,
@@ -37,9 +69,15 @@ export const YearColumnHeader = memo(
             <DragHandle
               attributes={attributes}
               listeners={listeners}
-              targetLabel={String(year)}
+              targetLabel={
+                isReference ? appLabels.indicateurAnneeReference(year) : String(year)
+              }
             />
-            <span>{isReference ? appLabels.indicateurAnneeReference(year) : year}</span>
+            <YearHeaderLabel
+              year={year}
+              isReference={isReference}
+              onReferenceYearChange={onReferenceYearChange}
+            />
           </div>
           {unit ? <Unit>{unit}</Unit> : null}
         </div>

--- a/apps/app/src/labels/catalog.ts
+++ b/apps/app/src/labels/catalog.ts
@@ -1745,6 +1745,11 @@ export const appLabels = {
   indicateurReinitialiserOrdre: "Réinitialiser l'ordre",
   indicateurOrdreReinitialise: 'Ordre réinitialisé',
   indicateurAnneeReference: (year: number): string => `réf. ${year}`,
+  indicateurAnneeReferenceChamp: 'Année de référence',
+  indicateurModifierAnneeReference: (year: number): string =>
+    `réf. ${year}, modifier l'année de référence`,
+  indicateurAnneeReferenceInvalide: (min: number, max: number): string =>
+    `Saisissez une année entre ${min} et ${max}.`,
   indicateurColonneAnnee: 'colonne année',
   indicateurLigne: 'ligne',
   indicateurGroupe: 'groupe',


### PR DESCRIPTION
P6 (#4662) mergée. **Base = `main`.**

## Contenu (P7 du plan)
Année de référence **éditable inline** dans l'en-tête de sa colonne, via `InlineEditWrapper` (primitif DS utilisé tel quel, aucune extension).

- **`reference-year/reference-year-editor.tsx`** (+ spec de rendu, 4 tests) : formulaire **React Hook Form + Zod** (schéma `referenceYearSchema` inline : entier dans `[1900, 2100]`, message via `appLabels`). `Input` numérique (autofocus + select-on-focus, `Escape` annule, submit sur Enter). Aucune écriture sur saisie invalide ; le parent (propriétaire de `onReferenceYearChange`) décide de ne pas propager quand l'année est inchangée.
- **Affordance d'édition** : le déclencheur affiche l'année avec un **soulignement pointillé** + une **icône crayon** (`edit-line`, `aria-hidden`) pour signaler que c'est éditable.
- **`YearHeaderLabel`** (early returns, ni ternaire imbriqué ni condition composée) : éditeur si colonne de référence **et** callback fourni, sinon libellé statique `réf. YYYY` → **rétrocompatible**.
- **`onReferenceYearChange`** : callback **injecté** (grille agnostique, comme `notify` de P6), câblé de `IndicateurValuesGrid` jusqu'à `YearColumnHeader` ; `memo` préservé.
- **Sémantique** : `referenceYear` = l'année sous laquelle sont enregistrées les valeurs de la colonne. Éditer re-keye la colonne ; le caller persiste. La story `Polluants` (stateful) démontre le re-key des cellules vers la nouvelle année.

## Vérifs
- specs grille **54/54** (4 de rendu `ReferenceYearEditor` : enregistrement, hors-bornes, inchangé, Échap — le comportement de validation est couvert par le rendu, pas par un test isolé du schéma zod)
- `nx run app:typecheck` **exit 0** ; `nx run app:lint` **0 erreur**
- Revue `te-en-t-style-enforcer` : BLOQUANT (message de validation inline → `appLabels.indicateurAnneeReferenceInvalide`) et À CORRIGER (condition composée → early returns) **traités**.
- Revue `/ce:review` (5 agents : TS, JSX qualité/état/structure, simplicité) : **0 P1**, verdict ship-ready. Corrigés : test de comportement du champ (spec de rendu), garde no-op déplacée chez le parent, libellé de la poignée cohérent sur la colonne de référence.

## Notes / hors scope
- Le comportement (ouvrir / saisir / valider / annuler) est **couvert en jsdom** par `reference-year-editor.spec.tsx` (`InlineEditWrapper` s'ouvre bien en jsdom). Storybook reste pour la vérif visuelle du positionnement Floating UI.
- Si la nouvelle année de référence existe **déjà** comme colonne, la story fake **ignore** le changement (no-op) pour éviter deux colonnes identiques. Le vrai wiring (pan 2) devra trancher (fusion / refus / toast).
- Ordre / édition **éphémères côté story** ; la persistance est un concern caller / pan-2.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Possibilité de modifier l’année de référence directement dans l’en-tête du tableau.
  * Nouveau champ d’édition inline avec validation des valeurs autorisées.

* **Bug Fixes**
  * Les changements d’année de référence mettent correctement à jour l’affichage des colonnes.
  * L’édition se ferme sans action si la valeur n’a pas changé ou en cas d’annulation.

* **Tests**
  * Ajout de tests couvrant la validation, la sauvegarde et l’annulation de l’édition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->