### PR TITLE
perf(ci): tests e2e à 3 workers Playwright

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -127,7 +127,7 @@ jobs:
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
         run: |
-          pnpm exec playwright test --config ./e2e/playwright.config.ts --grep-invert @serial --workers=2
+          pnpm exec playwright test --config ./e2e/playwright.config.ts --grep-invert @serial --workers=3
 
       - name: Run serial tests (non isolés)
         id: test-serial


### PR DESCRIPTION
Passe les tests e2e isolés de 2 à 3 workers Playwright.

Extrait de #4667 pour scoper cette dernière au backend.

Mesuré sur #4667 : le step `Run isolated tests (parallel)` passe de ~448s (2 workers) à ~355-367s (3 workers), soit ~1m20 de gain sur le job test-e2e.

Point de vigilance : à surveiller sur quelques runs, la contention CPU (app + auth + backend + supabase sur 4 cœurs) peut augmenter le taux de flaky ; `retries: 2` amortit.