### PR TITLE
Affiche un bandeau pour indiquer qu'un référentiel est archivé ou en lecture seule

### DIFF
--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/(overview)/@tabs/header.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/(overview)/@tabs/header.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { referentielToName } from '@/app/app/labels';
-import { appLabels } from '@/app/labels/catalog';
 import DownloadScoreButton from '@/app/app/pages/collectivite/Referentiels/DownloadScore/download-score.button';
 import SaveScoreButton from '@/app/app/pages/collectivite/Referentiels/SaveScore/save-score.button';
+import { appLabels } from '@/app/labels/catalog';
 import { useGetAction } from '@/app/referentiels/actions/use-get-action';
+import { ReferentielModeBanner } from '@/app/referentiels/referentiel-mode/referentiel-mode.banner';
 import { ScoreProgressBar } from '@/app/referentiels/scores/score.progress-bar';
 import { ScoreRatioBadge } from '@/app/referentiels/scores/score.ratio-badge';
 import { useCurrentCollectivite } from '@tet/api/collectivites';
@@ -45,6 +46,7 @@ export const Header = ({ referentielId }: { referentielId: ReferentielId }) => {
           <ScoreProgressBar className="grow" action={action} />
           <ScoreRatioBadge action={action} className="sm:ml-auto" />
         </div>
+        <ReferentielModeBanner />
       </PageHeader.Metadata>
     </PageHeader>
   );

--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/(overview)/@tabs/header.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/(overview)/@tabs/header.tsx
@@ -5,7 +5,6 @@ import DownloadScoreButton from '@/app/app/pages/collectivite/Referentiels/Downl
 import SaveScoreButton from '@/app/app/pages/collectivite/Referentiels/SaveScore/save-score.button';
 import { appLabels } from '@/app/labels/catalog';
 import { useGetAction } from '@/app/referentiels/actions/use-get-action';
-import { ReferentielModeBanner } from '@/app/referentiels/referentiel-mode/referentiel-mode.banner';
 import { ScoreProgressBar } from '@/app/referentiels/scores/score.progress-bar';
 import { ScoreRatioBadge } from '@/app/referentiels/scores/score.ratio-badge';
 import { useCurrentCollectivite } from '@tet/api/collectivites';
@@ -46,7 +45,6 @@ export const Header = ({ referentielId }: { referentielId: ReferentielId }) => {
           <ScoreProgressBar className="grow" action={action} />
           <ScoreRatioBadge action={action} className="sm:ml-auto" />
         </div>
-        <ReferentielModeBanner />
       </PageHeader.Metadata>
     </PageHeader>
   );

--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/layout.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/layout.tsx
@@ -1,4 +1,5 @@
 import { ReferentielProvider } from '@/app/referentiels/referentiel-context';
+import { ReferentielModeBanner } from '@/app/referentiels/referentiel-mode/referentiel-mode.banner';
 import { referentielIdEnumSchema } from '@tet/domain/referentiels';
 import { ReactNode } from 'react';
 
@@ -14,6 +15,7 @@ export default async function Layout({
 
   return (
     <ReferentielProvider referentielId={referentielId}>
+      <ReferentielModeBanner />
       {children}
     </ReferentielProvider>
   );

--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/new/[referentielId]/(overview)/@tabs/layout.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/new/[referentielId]/(overview)/@tabs/layout.tsx
@@ -1,6 +1,5 @@
-import { ChecklistProvider } from '@/app/referentiels/audit-labellisation/checklist.context';
 import { ChecklistPageHeader } from '@/app/referentiels/audit-labellisation/checklist-page-header/checklist-page-header';
-import { ReferentielModeBanner } from '@/app/referentiels/referentiel-mode/referentiel-mode.banner';
+import { ChecklistProvider } from '@/app/referentiels/audit-labellisation/checklist.context';
 import { ReferentielViewModeProvider } from '@/app/referentiels/referentiel.table/use-referentiel-view-mode';
 import {
   isAuditLabellisationReferentiel,
@@ -34,7 +33,6 @@ export default async function Layout({
       <ReferentielViewModeProvider>
         <ChecklistPageHeader referentielId={referentielId} />
         <Spacer height={1} />
-        <ReferentielModeBanner />
         <TabsWrapper>{children}</TabsWrapper>
       </ReferentielViewModeProvider>
     </ChecklistProvider>

--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/new/[referentielId]/(overview)/@tabs/layout.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/new/[referentielId]/(overview)/@tabs/layout.tsx
@@ -1,5 +1,6 @@
 import { ChecklistProvider } from '@/app/referentiels/audit-labellisation/checklist.context';
 import { ChecklistPageHeader } from '@/app/referentiels/audit-labellisation/checklist-page-header/checklist-page-header';
+import { ReferentielModeBanner } from '@/app/referentiels/referentiel-mode/referentiel-mode.banner';
 import { ReferentielViewModeProvider } from '@/app/referentiels/referentiel.table/use-referentiel-view-mode';
 import {
   isAuditLabellisationReferentiel,
@@ -33,6 +34,7 @@ export default async function Layout({
       <ReferentielViewModeProvider>
         <ChecklistPageHeader referentielId={referentielId} />
         <Spacer height={1} />
+        <ReferentielModeBanner />
         <TabsWrapper>{children}</TabsWrapper>
       </ReferentielViewModeProvider>
     </ChecklistProvider>

--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/new/[referentielId]/layout.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/new/[referentielId]/layout.tsx
@@ -1,5 +1,6 @@
 import { ArchivesPanelProvider } from '@/app/referentiels/archives-panel/archives-panel.provider';
 import { ReferentielProvider } from '@/app/referentiels/referentiel-context';
+import { ReferentielModeBanner } from '@/app/referentiels/referentiel-mode/referentiel-mode.banner';
 import { referentielIdEnumSchema } from '@tet/domain/referentiels';
 import { ReactNode } from 'react';
 
@@ -15,7 +16,10 @@ export default async function Layout({
 
   return (
     <ReferentielProvider referentielId={referentielId}>
-      <ArchivesPanelProvider>{children}</ArchivesPanelProvider>
+      <ArchivesPanelProvider>
+        <ReferentielModeBanner />
+        {children}
+      </ArchivesPanelProvider>
     </ReferentielProvider>
   );
 }

--- a/apps/app/src/labels/catalog.ts
+++ b/apps/app/src/labels/catalog.ts
@@ -8,8 +8,8 @@ export const appLabels = {
   referentielCae: 'Climat Air Énergie',
   referentielEci: 'Économie Circulaire',
   referentielCrte: 'Contrat Relance Transition Écologique',
-  referentielTe: 'Transition Écologique',
-  referentielTeTest: 'Transition Écologique (test)',
+  referentielTe: 'Climat Ressources',
+  referentielTeTest: 'Climat Ressources (test)',
 
   nonRenseigne: 'Non renseigné',
   nonRenseignable: 'Non renseignable',
@@ -673,7 +673,7 @@ export const appLabels = {
   labellisationClimatAirEnergie: 'Labellisation Climat-Air-Énergie',
   referentielEconomieCirculaire: 'Référentiel Économie Circulaire',
   labellisationEconomieCirculaire: 'Labellisation Économie Circulaire',
-  referentielTransitionEcologique: 'Référentiel Transition Écologique',
+  referentielTransitionEcologique: 'Référentiel Climat Ressources',
   parametres: 'Paramètres',
   maCollectivite: 'Ma collectivité',
   gestionDesUtilisateurs: 'Gestion des utilisateurs',
@@ -1593,6 +1593,20 @@ export const appLabels = {
   premiereEtoileSansAudit:
     "Obtenir la première étoile (1er niveau de labellisation) ne nécessite pas d'audit et sera validé rapidement et directement par l'ADEME ! Les étoiles supérieures sont conditionnées à un audit réalisé par une personne experte mandatée par l'ADEME.",
 
+  nouvelleVueChecklistTitre: 'Nouvelle vue de la checklist disponible',
+  nouvelleVueChecklistDescription:
+    "Une nouvelle vue tabulaire est disponible pour explorer la checklist d'audit et de labellisation. Vous pouvez la tester en avant-première.",
+  nouvelleVueChecklistCta: 'Tester la nouvelle vue',
+
+  referentielModeReadonlyTitle: 'Référentiel en lecture seule',
+  referentielModeReadonlydDescription:
+    "Consultation seule — ce référentiel n'est pas modifiable.",
+  referentielTeModeReadonlyDescription:
+    'Explorez la structure du référentiel Climat Ressources',
+  referentielModeArchivedTitle: 'Référentiel archivé',
+  referentielModeArchivedDescription:
+    "Consultation seule — ce référentiel n'est plus modifiable.",
+
   monCompte: 'Mon compte',
   nombreDePointsInitial: 'Nombre de points initial',
   ouvrirLaMesure: 'Ouvrir la mesure',
@@ -1751,7 +1765,7 @@ export const appLabels = {
     `Saisissez une année entre ${min} et ${max}.`,
   indicateurChangerAnneeReferenceTitre: "Changer l'année de référence ?",
   indicateurChangerAnneeReferenceDescription:
-    "Les valeurs de la colonne de référence seront récupérées depuis les indicateurs si elles sont disponibles, sinon réinitialisées.",
+    'Les valeurs de la colonne de référence seront récupérées depuis les indicateurs si elles sont disponibles, sinon réinitialisées.',
   indicateurColonneAnnee: 'colonne année',
   indicateurLigne: 'ligne',
   indicateurGroupe: 'groupe',
@@ -1774,12 +1788,12 @@ export const appLabels = {
   }),
   indicateurSelectionnerValeurOpenData: 'Sélectionner une valeur open data',
   indicateurValeurOpenDataDisponible: 'Valeur open data disponible',
-  indicateurCelluleOpenDataDisponible: 'Open data disponible pour cette cellule',
+  indicateurCelluleOpenDataDisponible:
+    'Open data disponible pour cette cellule',
   indicateurSelectionnerValeurEchec:
     'La sélection de la valeur open data a échoué',
   indicateurRepasserSaisieManuelle: 'Repasser en saisie manuelle',
-  indicateurRepasserSaisieEchec:
-    'Le retour en saisie manuelle a échoué',
+  indicateurRepasserSaisieEchec: 'Le retour en saisie manuelle a échoué',
   indicateurCompleterOpenData: "Compléter avec de l'open data",
   indicateurContexteCellule: (
     secteur: string,

--- a/apps/app/src/referentiels/referentiel-mode/get-referentiel-mode-banner-props.ts
+++ b/apps/app/src/referentiels/referentiel-mode/get-referentiel-mode-banner-props.ts
@@ -1,0 +1,49 @@
+import { appLabels } from '@/app/labels/catalog';
+import {
+  canMutateReferentielData,
+  type ReferentielMode,
+} from '@tet/domain/collectivites';
+import type { ReferentielId } from '@tet/domain/referentiels';
+
+export type ReferentielModeBannerProps = {
+  title: string;
+  description: string;
+  state: 'info' | 'warning';
+};
+
+export function getReferentielModeBannerProps({
+  referentielId,
+  mode,
+}: {
+  referentielId: ReferentielId;
+  mode: ReferentielMode;
+}): ReferentielModeBannerProps | null {
+  if (canMutateReferentielData(mode)) {
+    return null;
+  }
+
+  if (mode === 'readonly') {
+    if (referentielId === 'te') {
+      return {
+        title: appLabels.referentielModeReadonlyTitle,
+        description: appLabels.referentielTeModeReadonlyDescription,
+        state: 'info',
+      };
+    }
+    return {
+      title: appLabels.referentielModeReadonlyTitle,
+      description: appLabels.referentielModeReadonlydDescription,
+      state: 'info',
+    };
+  }
+
+  if (mode === 'archived') {
+    return {
+      title: appLabels.referentielModeArchivedTitle,
+      description: appLabels.referentielModeArchivedDescription,
+      state: 'warning',
+    };
+  }
+
+  return null;
+}

--- a/apps/app/src/referentiels/referentiel-mode/referentiel-mode.banner.tsx
+++ b/apps/app/src/referentiels/referentiel-mode/referentiel-mode.banner.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useReferentielId } from '@/app/referentiels/referentiel-context';
+import { useReferentielTeEnabled } from '@/app/referentiels/use-referentiel-te-enabled';
+import { Alert } from '@tet/ui';
+import { getReferentielModeBannerProps } from './get-referentiel-mode-banner-props';
+import { useReferentielMode } from './use-referentiel-mode';
+
+export const ReferentielModeBanner = () => {
+  const isReferentielTeEnabled = useReferentielTeEnabled();
+  const referentielId = useReferentielId();
+  const mode = useReferentielMode();
+
+  if (!isReferentielTeEnabled || !mode) {
+    return null;
+  }
+
+  const bannerProps = getReferentielModeBannerProps({
+    referentielId,
+    mode,
+  });
+
+  if (!bannerProps) {
+    return null;
+  }
+
+  return (
+    <div
+      role="status"
+      data-test="referentiels.mode-banner"
+      data-referentiel-mode={mode}
+    >
+      <Alert
+        className="mb-8"
+        title={bannerProps.title}
+        description={bannerProps.description}
+        state={bannerProps.state}
+      />
+    </div>
+  );
+};

--- a/apps/app/src/referentiels/referentiel-mode/use-referentiel-mode.ts
+++ b/apps/app/src/referentiels/referentiel-mode/use-referentiel-mode.ts
@@ -1,0 +1,40 @@
+import { useReferentielId } from '@/app/referentiels/referentiel-context';
+import { useCurrentCollectivite } from '@tet/api/collectivites';
+import type {
+  CollectiviteReferentielDisplayId,
+  ReferentielMode,
+} from '@tet/domain/collectivites';
+
+const referentielIdsWithMode: CollectiviteReferentielDisplayId[] = [
+  'cae',
+  'eci',
+  'te',
+];
+
+export function useReferentielMode(): ReferentielMode | null {
+  const referentielId = useReferentielId();
+  const { collectivitePreferences } = useCurrentCollectivite();
+
+  if (referentielId === 'te-test') {
+    return null;
+  }
+
+  if (
+    !referentielIdsWithMode.includes(
+      referentielId as CollectiviteReferentielDisplayId
+    )
+  ) {
+    return null;
+  }
+
+  const referentielPrefs =
+    collectivitePreferences?.referentiels?.[
+      referentielId as CollectiviteReferentielDisplayId
+    ];
+
+  if (!referentielPrefs) {
+    return null;
+  }
+
+  return referentielPrefs.mode;
+}

--- a/data_layer/sqitch/deploy/referentiel/rename_te.sql
+++ b/data_layer/sqitch/deploy/referentiel/rename_te.sql
@@ -1,0 +1,13 @@
+-- Deploy tet:referentiel/rename_te to pg
+
+BEGIN;
+
+update referentiel_definition
+set nom='Climat Ressources'
+where id in ('te', 'te-test');
+
+update action_definition
+set nom='Climat Ressources'
+where action_id in ('te', 'te-test');
+
+COMMIT;

--- a/data_layer/sqitch/revert/referentiel/rename_te.sql
+++ b/data_layer/sqitch/revert/referentiel/rename_te.sql
@@ -1,0 +1,13 @@
+-- Revert tet:referentiel/rename_te from pg
+
+BEGIN;
+
+update referentiel_definition
+set nom='Transition Écologique'
+where id in ('te', 'te-test');
+
+update action_definition
+set nom='Transition Écologique'
+where action_id in ('te', 'te-test');
+
+COMMIT;

--- a/data_layer/sqitch/sqitch.plan
+++ b/data_layer/sqitch/sqitch.plan
@@ -1005,3 +1005,4 @@ collectivite/bucket_rls_super_admin_write [collectivite/bucket utilisateur/droit
 collectivite/bucket_rls_visiteur_read [collectivite/bucket_rls_ademe_read] 2026-06-30T12:00:00Z Frederic Arnoux <frederic.arnoux@beta.gouv.fr> # Retablit la lecture de storage.objects pour les membres en mode visite (niveau_acces lecture, auditeur actif)
 
 referentiel/add_thematique_sgpe [referentiel/add_adaptation_niveau] 2026-07-01T10:00:00Z Marc Rutkowski <marc@attractive-media.fr> # Ajoute la colonne thematique_sgpe sur action_definition
+referentiel/rename_te 2026-07-02T07:57:03Z Marc Rutkowski <marc@attractive-media.fr> # Renomme le référentiel "te"

--- a/data_layer/sqitch/verify/referentiel/rename_te.sql
+++ b/data_layer/sqitch/verify/referentiel/rename_te.sql
@@ -1,0 +1,21 @@
+-- Verify tet:referentiel/rename_te on pg
+
+BEGIN;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM referentiel_definition
+    WHERE id IN ('te', 'te-test') AND nom <> 'Climat Ressources'
+  ) THEN
+    RAISE EXCEPTION 'referentiel_definition.nom non mis à jour pour te/te-test';
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM action_definition
+    WHERE action_id IN ('te', 'te-test') AND nom <> 'Climat Ressources'
+  ) THEN
+    RAISE EXCEPTION 'action_definition.nom non mis à jour pour te/te-test';
+  END IF;
+END $$;
+
+ROLLBACK;

--- a/e2e/tests/collectivite/preferences-referentiels/preferences-referentiels.spec.ts
+++ b/e2e/tests/collectivite/preferences-referentiels/preferences-referentiels.spec.ts
@@ -34,7 +34,7 @@ test.describe('Préférences référentiels (support)', () => {
       page.getByRole('checkbox', { name: 'Économie Circulaire' })
     ).toBeVisible();
     await expect(
-      page.getByRole('checkbox', { name: 'Transition Écologique' })
+      page.getByRole('checkbox', { name: 'Climat Ressources' })
     ).toBeVisible();
     await expect(
       page.getByRole('button', { name: 'Réinitialiser selon le remplissage' })
@@ -48,7 +48,7 @@ test.describe('Préférences référentiels (support)', () => {
       page.getByRole('link', { name: 'Référentiel Économie Circulaire' })
     ).toBeVisible();
     await expect(
-      page.getByRole('link', { name: 'Référentiel Transition Écologique' })
+      page.getByRole('link', { name: 'Référentiel Climat Ressources' })
     ).toBeVisible();
 
     await page.getByRole('checkbox', { name: 'Climat Air Énergie' }).click();
@@ -64,7 +64,7 @@ test.describe('Préférences référentiels (support)', () => {
       page.getByRole('link', { name: 'Référentiel Économie Circulaire' })
     ).toBeVisible();
     await expect(
-      page.getByRole('link', { name: 'Référentiel Transition Écologique' })
+      page.getByRole('link', { name: 'Référentiel Climat Ressources' })
     ).toBeVisible();
 
     await page
@@ -80,7 +80,7 @@ test.describe('Préférences référentiels (support)', () => {
       page.getByRole('checkbox', { name: 'Économie Circulaire' })
     ).not.toBeChecked();
     await expect(
-      page.getByRole('checkbox', { name: 'Transition Écologique' })
+      page.getByRole('checkbox', { name: 'Climat Ressources' })
     ).toBeChecked();
 
     await page.getByRole('checkbox', { name: 'Climat Air Énergie' }).click();
@@ -92,7 +92,7 @@ test.describe('Préférences référentiels (support)', () => {
       page.getByRole('link', { name: 'Référentiel Économie Circulaire' })
     ).toHaveCount(0);
     await expect(
-      page.getByRole('link', { name: 'Référentiel Transition Écologique' })
+      page.getByRole('link', { name: 'Référentiel Climat Ressources' })
     ).toBeVisible();
   });
 });

--- a/e2e/tests/referentiels/labellisations/labellisation.pom.ts
+++ b/e2e/tests/referentiels/labellisations/labellisation.pom.ts
@@ -118,16 +118,22 @@ export class LabellisationPom {
       'button',
       { name: 'Annuler' }
     );
-    this.cloturerAuditCloseButton = this.cloturerAuditModal.getByRole('button', {
-      name: 'Fermer',
-    });
+    this.cloturerAuditCloseButton = this.cloturerAuditModal.getByRole(
+      'button',
+      {
+        name: 'Fermer',
+      }
+    );
     this.cloturerAuditEngagementCheckbox = this.cloturerAuditModal.getByRole(
       'checkbox',
       { name: /Je m'engage/ }
     );
-    this.cloturerAuditObjetField = this.cloturerAuditModal.getByRole('textbox', {
-      name: /Objet de l'email/,
-    });
+    this.cloturerAuditObjetField = this.cloturerAuditModal.getByRole(
+      'textbox',
+      {
+        name: /Objet de l'email/,
+      }
+    );
     this.cloturerAuditContenuField = this.cloturerAuditModal.getByRole(
       'textbox',
       { name: /Contenu de l'email/ }
@@ -140,12 +146,10 @@ export class LabellisationPom {
       'button',
       { name: 'Copier le contenu du mail' }
     );
-    this.cloturerAuditFileInput = this.cloturerAuditModal.locator(
-      'input[type="file"]'
-    );
-    this.cloturerAuditUploadingCard = this.cloturerAuditModal.locator(
-      '[aria-busy="true"]'
-    );
+    this.cloturerAuditFileInput =
+      this.cloturerAuditModal.locator('input[type="file"]');
+    this.cloturerAuditUploadingCard =
+      this.cloturerAuditModal.locator('[aria-busy="true"]');
 
     this.validateAuditSuccessMessage = page.getByText(
       'Labellisation en cours - audité par'
@@ -194,9 +198,7 @@ export class LabellisationPom {
   }
 
   async goto(referentielId: ReferentielId) {
-    await this.page
-      .getByRole('button', { name: 'État des lieux' })
-      .click();
+    await this.page.getByRole('button', { name: 'État des lieux' }).click();
     await this.page
       .getByRole('link', {
         name: navLabellisationLabelByReferentiel[referentielId],
@@ -211,6 +213,6 @@ export class LabellisationPom {
 const navLabellisationLabelByReferentiel: Record<ReferentielId, string> = {
   cae: 'Labellisation Climat-Air-Énergie',
   eci: 'Labellisation Économie Circulaire',
-  te: 'Labellisation Transition Écologique',
-  'te-test': 'Labellisation Transition Écologique (test)',
+  te: 'Labellisation Climat Ressources',
+  'te-test': 'Labellisation Climat Ressources (test)',
 };

--- a/e2e/tests/referentiels/referentiel-mode/referentiel-mode-banner.pom.ts
+++ b/e2e/tests/referentiels/referentiel-mode/referentiel-mode-banner.pom.ts
@@ -1,0 +1,18 @@
+import { expect, Locator, Page } from '@playwright/test';
+
+export class ReferentielModeBannerPom {
+  readonly banner: Locator;
+
+  constructor(readonly page: Page) {
+    this.banner = page.getByTestId('referentiels.mode-banner');
+  }
+
+  async expectVisibleWithMode(mode: 'readonly' | 'archived') {
+    await expect(this.banner).toBeVisible();
+    await expect(this.banner).toHaveAttribute('data-referentiel-mode', mode);
+  }
+
+  async expectHidden() {
+    await expect(this.banner).toHaveCount(0);
+  }
+}

--- a/e2e/tests/referentiels/referentiel-mode/referentiel-mode-banner.spec.ts
+++ b/e2e/tests/referentiels/referentiel-mode/referentiel-mode-banner.spec.ts
@@ -1,0 +1,52 @@
+import { expect } from '@playwright/test';
+import { test } from 'tests/main.fixture';
+import { ReferentielModeBannerPom } from './referentiel-mode-banner.pom';
+
+test.describe('Bandeau mode référentiel', () => {
+  test('affiche le bandeau readonly sur TE et pas sur CAE en write', async ({
+    collectivites,
+    page,
+    referentiels,
+  }) => {
+    const { collectivite, user } = await collectivites.addCollectiviteAndUser({
+      userArgs: { autoLogin: true },
+    });
+
+    const supportUser = await collectivite.addUser({
+      isSupport: true,
+      isSuperAdminRoleEnabled: true,
+    });
+
+    await referentiels.setReferentielPreferences(
+      supportUser,
+      collectivite.data.id,
+      {
+        cae: { display: true, mode: 'write' },
+        eci: { display: false, mode: 'archived' },
+        te: { display: true, mode: 'readonly' },
+      }
+    );
+
+    await user.precomputeReferentielSnapshot(collectivite.data.id, 'te');
+
+    const bannerPom = new ReferentielModeBannerPom(page);
+
+    await page.goto(
+      `/collectivite/${collectivite.data.id}/referentiel/te/progression`
+    );
+    await expect(
+      page.getByRole('heading', { name: 'Référentiel' })
+    ).toBeVisible();
+    await bannerPom.expectVisibleWithMode('readonly');
+
+    await user.precomputeReferentielSnapshot(collectivite.data.id, 'cae');
+
+    await page.goto(
+      `/collectivite/${collectivite.data.id}/referentiel/cae/progression`
+    );
+    await expect(
+      page.getByRole('heading', { name: 'Référentiel' })
+    ).toBeVisible();
+    await bannerPom.expectHidden();
+  });
+});

--- a/e2e/tests/referentiels/referentiels.fixture.ts
+++ b/e2e/tests/referentiels/referentiels.fixture.ts
@@ -10,13 +10,13 @@ import {
   startAudit,
   validateAudit,
 } from '@tet/backend/referentiels/labellisations/labellisations.test-fixture';
-import { and, desc, eq } from 'drizzle-orm';
 import {
   cleanupReferentielActionStatutsAndLabellisations,
   updateAllNeedReferentielStatutsToCompleteReferentiel,
   updateAllNeedReferentielStatutsToMatchReferentielScoreCriteria,
   updateAllReferentielStatutsToFait,
 } from '@tet/backend/referentiels/update-action-statut/referentiel-action-statut.test-fixture';
+import type { CollectiviteReferentielPreferences } from '@tet/domain/collectivites';
 import {
   ActionStatutCreate,
   AUDIT_REPORT_UPDATE_WINDOW_DAYS,
@@ -26,9 +26,11 @@ import {
   ROLE_IDENTIFIANTS,
   ScoreSnapshot,
 } from '@tet/domain/referentiels';
+import { and, desc, eq } from 'drizzle-orm';
 import { testWithCollectivites } from 'tests/collectivite/collectivites.fixture';
 import { databaseService } from 'tests/shared/database.service';
 import { FixtureFactory } from 'tests/shared/fixture-factory.interface';
+import { setupTrpcClient } from 'tests/shared/trpc.utils';
 import { UserFixture } from 'tests/users/users.fixture';
 import { LabellisationPom } from './labellisations/labellisation.pom';
 import { NewAuditLabellisationPom } from './labellisations/new-audit-labellisation.pom';
@@ -234,6 +236,33 @@ class ReferentielsFixtureFactory extends FixtureFactory {
       actionStatut
     );
     return response;
+  }
+
+  async setReferentielPreferences(
+    supportUser: UserFixture,
+    collectiviteId: number,
+    referentiels: CollectiviteReferentielPreferences
+  ): Promise<void> {
+    const { accessToken } = await supportUser.supabaseClient.authenticateUser(
+      supportUser.data.email,
+      supportUser.data.password
+    );
+    const trpcClient = setupTrpcClient(accessToken);
+
+    await trpcClient.users.authorizations.toggleSuperAdminRole.mutate({
+      isEnabled: true,
+    });
+
+    try {
+      await trpcClient.collectivites.preferences.update.mutate({
+        collectiviteId,
+        preferences: { referentiels },
+      });
+    } finally {
+      await trpcClient.users.authorizations.toggleSuperAdminRole.mutate({
+        isEnabled: false,
+      });
+    }
   }
 
   async cleanupByCollectiviteId(collectiviteId: number): Promise<void> {

--- a/packages/pdf-components/src/fiche-action/external-types.ts
+++ b/packages/pdf-components/src/fiche-action/external-types.ts
@@ -46,8 +46,8 @@ export const referentielToName = {
   cae: 'Climat Air Énergie',
   eci: 'Économie Circulaire',
   crte: 'Contrat Relance Transition Écologique',
-  te: 'Transition Écologique',
-  'te-test': 'Transition Écologique (test)',
+  te: 'Climat Ressources',
+  'te-test': 'Climat Ressources (test)',
 } as const satisfies Record<ReferentielLabelKey, string>;
 
 export const avancementToLabel: Record<StatutAvancement, string> = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Un bandeau d’information s’affiche désormais pour certains référentiels en mode **lecture seule** ou **archivé** (avec un statut adapté).
  * Les pages de référentiel l’intègrent automatiquement au-dessus du contenu lorsque c’est pertinent.
* **Améliorations**
  * Le référentiel **Transition Écologique** est renommé en **Climat Ressources** dans l’interface et les libellés associés (navigation, labellisations, exports).
* **Bug Fixes**
  * Les parcours et vérifications automatisées reflètent correctement les nouveaux intitulés et modes d’affichage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->