### PR TITLE
feat(indicateurs): pastille de couverture + sélecteur open data (sélection unité et lot) — P8+P9

### DIFF
--- a/apps/app/src/indicateurs/valeurs/grid/__tests__/grid-fixtures.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/__tests__/grid-fixtures.ts
@@ -4,6 +4,7 @@ import {
   GridCell,
   GridRowGroup,
   IndicateurValuesGridActions,
+  OpenDataSource,
   toIndicateurId,
   toYear,
   Year,
@@ -24,34 +25,63 @@ export const fakeGroups: GridRowGroup[] = sectors.map((sector, sectorIndex) => (
   })),
 }));
 
-const citepa = {
-  sourceId: 'citepa',
-  libelle: 'CITEPA',
-  methodologie: 'Inventaire national spatialisé',
-  dateVersion: '2026-01-01',
-};
+const sourceDefs = [
+  {
+    sourceId: 'citepa',
+    libelle: 'CITEPA',
+    methodologie: 'Inventaire national spatialisé',
+    dateVersion: '2026-01-01',
+  },
+  {
+    sourceId: 'insee',
+    libelle: 'INSEE',
+    methodologie: null,
+    dateVersion: '2024-01-01',
+  },
+  {
+    sourceId: 'ademe',
+    libelle: 'ADEME',
+    methodologie: 'Base Carbone',
+    dateVersion: '2025-01-01',
+  },
+];
 
 const pseudoValue = (indicateurId: number, year: number): number =>
   ((indicateurId * 7 + year) % 900) + 100;
 
+const coveringSourcesFor = (
+  indicateurId: number,
+  year: number
+): OpenDataSource[] =>
+  sourceDefs
+    .slice(0, 2 + ((indicateurId + year) % 2))
+    .map((def, index) => ({
+      ...def,
+      value: pseudoValue(indicateurId, year) + index * 15,
+    }));
+
 const buildCell = (indicateurId: number, year: number): GridCell => {
   const seed = (indicateurId + year) % 6;
+  const coveringSources = coveringSourcesFor(indicateurId, year);
   if (seed === 0) {
+    const [chosen] = coveringSources;
     return {
       kind: 'open-data',
-      value: pseudoValue(indicateurId, year),
-      adoptedSourceId: citepa.sourceId,
-      source: citepa,
+      value: chosen.value,
+      selectedSourceId: chosen.sourceId,
+      source: {
+        sourceId: chosen.sourceId,
+        libelle: chosen.libelle,
+        methodologie: chosen.methodologie,
+        dateVersion: chosen.dateVersion,
+      },
+      coveringSources,
     };
   }
-  if (seed === 1) {
-    return {
-      kind: 'user-data',
-      value: null,
-      coveringSources: [{ ...citepa, value: pseudoValue(indicateurId, year) }],
-    };
+  if (seed === 1 || seed === 2 || seed === 3) {
+    return { kind: 'user-data', value: null, coveringSources };
   }
-  if (seed === 2) {
+  if (seed === 4) {
     return { kind: 'user-data', value: null, coveringSources: [] };
   }
   return {
@@ -77,6 +107,6 @@ export const fakeCells = (): Map<CellKey, GridCell> =>
 export const fakeGridActions: IndicateurValuesGridActions = {
   saveCellValue: async () => ({ ok: true, value: undefined }),
   saveCellValues: async (inputs) => ({ ok: true, value: { written: inputs.length, failed: [] } }),
-  adopt: async () => ({ ok: true, value: undefined }),
+  selectOpenData: async () => ({ ok: true, value: undefined }),
   clearCell: async () => ({ ok: true, value: undefined }),
 };

--- a/apps/app/src/indicateurs/valeurs/grid/__tests__/indicateur-values-grid.stories.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/__tests__/indicateur-values-grid.stories.tsx
@@ -14,6 +14,7 @@ import { rowDragId } from '../use-grid-reorder';
 import {
   generateCellKey,
   parseCellKey,
+  SelectOpenDataInput,
   CellKey,
   CellValueInput,
   GridCell,
@@ -30,12 +31,6 @@ const meta: Meta<typeof IndicateurValuesGrid> = {
 export default meta;
 
 type Story = StoryObj<typeof IndicateurValuesGrid>;
-
-type GridState = {
-  years: Year[];
-  referenceYear: Year;
-  cells: Map<CellKey, GridCell>;
-};
 
 const withValues = (
   previous: Map<CellKey, GridCell>,
@@ -63,6 +58,37 @@ const withValues = (
   return next;
 };
 
+const selectOpenDataInCells = (
+  cells: Map<CellKey, GridCell>,
+  { indicateurId, year, sourceId }: SelectOpenDataInput
+): Map<CellKey, GridCell> => {
+  const key = generateCellKey(indicateurId, year);
+  const current = cells.get(key);
+  if (current === undefined) {
+    return cells;
+  }
+  const chosen = current.coveringSources.find(
+    (source) => source.sourceId === sourceId
+  );
+  if (chosen === undefined) {
+    return cells;
+  }
+  const next = new Map(cells);
+  next.set(key, {
+    kind: 'open-data',
+    value: chosen.value,
+    selectedSourceId: chosen.sourceId,
+    source: {
+      sourceId: chosen.sourceId,
+      libelle: chosen.libelle,
+      methodologie: chosen.methodologie,
+      dateVersion: chosen.dateVersion,
+    },
+    coveringSources: current.coveringSources,
+  });
+  return next;
+};
+
 const rekeyReferenceColumn = ({
   cells,
   referenceYear,
@@ -83,6 +109,12 @@ const rekeyReferenceColumn = ({
       return [nextKey, cell] as const;
     })
   );
+
+type GridState = {
+  years: Year[];
+  referenceYear: Year;
+  cells: Map<CellKey, GridCell>;
+};
 
 const InteractiveGrid = (): JSX.Element => {
   const [state, setState] = useState<GridState>(() => ({
@@ -114,6 +146,13 @@ const InteractiveGrid = (): JSX.Element => {
           cells: withValues(previous.cells, inputs),
         }));
         return { ok: true, value: { written: inputs.length, failed: [] } };
+      },
+      selectOpenData: async (input) => {
+        setState((previous) => ({
+          ...previous,
+          cells: selectOpenDataInCells(previous.cells, input),
+        }));
+        return { ok: true, value: undefined };
       },
     }),
     []

--- a/apps/app/src/indicateurs/valeurs/grid/__tests__/open-data-coverage.spec.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/__tests__/open-data-coverage.spec.ts
@@ -18,8 +18,9 @@ describe('isCovered', () => {
       isCovered({
         kind: 'open-data',
         value: 5,
-        adoptedSourceId: 'citepa',
+        selectedSourceId: 'citepa',
         source: { sourceId: 'citepa', libelle: 'CITEPA', methodologie: null, dateVersion: '2026-01-01' },
+        coveringSources: [],
       })
     ).toBe(false);
     expect(isCovered(null)).toBe(false);

--- a/apps/app/src/indicateurs/valeurs/grid/__tests__/user-data-cell.spec.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/__tests__/user-data-cell.spec.tsx
@@ -1,7 +1,8 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
+import { GridCellServicesProvider } from '../grid-context';
 import { UserDataCell } from '../user-data-cell';
-import { toIndicateurId, toYear } from '../types';
+import { GridCell, toIndicateurId, toYear } from '../types';
 
 const typeAndCommit = (input: HTMLElement, raw: string): void => {
   fireEvent.focus(input);
@@ -9,20 +10,42 @@ const typeAndCommit = (input: HTMLElement, raw: string): void => {
   fireEvent.keyDown(input, { key: 'Enter' });
 };
 
-const renderEmptyCell = (
+const emptyUserCell: Extract<GridCell, { kind: 'user-data' }> = {
+  kind: 'user-data',
+  value: null,
+  coveringSources: [],
+};
+
+const filledUserCell: Extract<GridCell, { kind: 'user-data' }> = {
+  kind: 'user-data',
+  value: 12,
+  valueId: 100,
+  coveringSources: [],
+};
+
+const renderCell = (
+  cell: Extract<GridCell, { kind: 'user-data' }>,
   saveCellValue: ReturnType<typeof vi.fn>
 ): HTMLInputElement => {
   render(
-    <UserDataCell
-      cell={{ kind: 'user-data', value: null, coveringSources: [] }}
-      ariaLabel="NOx 2030"
-      indicateurId={toIndicateurId(12)}
-      year={toYear(2030)}
-      saveCellValue={saveCellValue}
-    />
+    <GridCellServicesProvider
+      services={{ saveCellValue, selectOpenData: vi.fn(), unit: 't' }}
+    >
+      <UserDataCell
+        cell={cell}
+        secteur="Résidentiel"
+        polluant="NOx"
+        indicateurId={toIndicateurId(12)}
+        year={toYear(2030)}
+      />
+    </GridCellServicesProvider>
   );
   return screen.getByRole('textbox') as HTMLInputElement;
 };
+
+const renderEmptyCell = (
+  saveCellValue: ReturnType<typeof vi.fn>
+): HTMLInputElement => renderCell(emptyUserCell, saveCellValue);
 
 describe('UserDataCell edition', () => {
   it('commit la valeur saisie via saveCellValue a la validation', async () => {
@@ -76,16 +99,7 @@ describe('UserDataCell edition', () => {
 
   it('signale une erreur sans ecrire quand la saisie est invalide', async () => {
     const saveCellValue = vi.fn().mockResolvedValue({ ok: true, value: undefined });
-    render(
-      <UserDataCell
-        cell={{ kind: 'user-data', value: 12, valueId: 100, coveringSources: [] }}
-        ariaLabel="NOx 2030"
-        indicateurId={toIndicateurId(12)}
-        year={toYear(2030)}
-        saveCellValue={saveCellValue}
-      />
-    );
-    const input = screen.getByRole('textbox') as HTMLInputElement;
+    const input = renderCell(filledUserCell, saveCellValue);
 
     typeAndCommit(input, '1..2');
 
@@ -95,16 +109,7 @@ describe('UserDataCell edition', () => {
 
   it("ne commit pas quand la valeur n'a pas change", () => {
     const saveCellValue = vi.fn();
-    render(
-      <UserDataCell
-        cell={{ kind: 'user-data', value: 12, valueId: 100, coveringSources: [] }}
-        ariaLabel="NOx 2030"
-        indicateurId={toIndicateurId(12)}
-        year={toYear(2030)}
-        saveCellValue={saveCellValue}
-      />
-    );
-    const input = screen.getByRole('textbox');
+    const input = renderCell(filledUserCell, saveCellValue);
 
     fireEvent.focus(input);
     fireEvent.keyDown(input, { key: 'Enter' });

--- a/apps/app/src/indicateurs/valeurs/grid/coverage-dot.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/coverage-dot.tsx
@@ -1,8 +1,0 @@
-import { JSX } from 'react';
-
-export const CoverageDot = (): JSX.Element => (
-  <span
-    aria-hidden
-    className="absolute right-1 top-1 h-2 w-2 rounded-full bg-success-1 ring-2 ring-success-2"
-  />
-);

--- a/apps/app/src/indicateurs/valeurs/grid/grid-context.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/grid-context.tsx
@@ -24,6 +24,37 @@ export type GridContextValue = {
 
 const GridContext = createContext<GridContextValue | null>(null);
 
+export type GridCellServices = {
+  saveCellValue: IndicateurValuesGridActions['saveCellValue'];
+  selectOpenData: IndicateurValuesGridActions['selectOpenData'];
+  unit: string | null;
+  notify?: (message: string) => void;
+};
+
+const GridCellServicesContext = createContext<GridCellServices | null>(null);
+
+export const GridCellServicesProvider = ({
+  services,
+  children,
+}: {
+  services: GridCellServices;
+  children: ReactNode;
+}): JSX.Element => (
+  <GridCellServicesContext.Provider value={services}>
+    {children}
+  </GridCellServicesContext.Provider>
+);
+
+export const useGridCellServices = (): GridCellServices => {
+  const services = use(GridCellServicesContext);
+  if (services === null) {
+    throw new Error(
+      'useGridCellServices must be used within a <GridProvider>'
+    );
+  }
+  return services;
+};
+
 export const GridProvider = ({
   children,
   groups,
@@ -63,7 +94,22 @@ export const GridProvider = ({
       onReferenceYearChange,
     ]
   );
-  return <GridContext.Provider value={value}>{children}</GridContext.Provider>;
+  const cellServices = useMemo<GridCellServices>(
+    () => ({
+      saveCellValue: actions.saveCellValue,
+      selectOpenData: actions.selectOpenData,
+      unit,
+      notify,
+    }),
+    [actions.saveCellValue, actions.selectOpenData, unit, notify]
+  );
+  return (
+    <GridContext.Provider value={value}>
+      <GridCellServicesProvider services={cellServices}>
+        {children}
+      </GridCellServicesProvider>
+    </GridContext.Provider>
+  );
 };
 
 export const useGridContext = (): GridContextValue => {

--- a/apps/app/src/indicateurs/valeurs/grid/keyboard-navigation/keyboard-nav.spec.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/keyboard-navigation/keyboard-nav.spec.tsx
@@ -37,8 +37,9 @@ const userData: GridCell = { kind: 'user-data', value: null, coveringSources: []
 const openData: GridCell = {
   kind: 'open-data',
   value: 5,
-  adoptedSourceId: 's',
+  selectedSourceId: 's',
   source: { sourceId: 's', libelle: 'S', methodologie: null, dateVersion: '2026-01-01' },
+  coveringSources: [],
 };
 
 const cells = new Map<CellKey, GridCell>([

--- a/apps/app/src/indicateurs/valeurs/grid/open-data-cell.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/open-data-cell.tsx
@@ -1,47 +1,54 @@
-import { JSX, memo, ReactNode } from 'react';
-import { ProvenanceBadge } from './provenance-badge';
-import { generateCellKey, CellKey, IndicateurId, SourceInfo, Year } from './types';
+'use client';
 
-type FocusableCellProps = {
-  cellId: CellKey;
-  ariaLabel: string;
-  children: ReactNode;
-};
-
-const FocusableCell = ({
-  cellId,
-  ariaLabel,
-  children,
-}: FocusableCellProps): JSX.Element => (
-  <div
-    data-cell-id={cellId}
-    aria-label={ariaLabel}
-    className="flex h-full items-center justify-between gap-1 bg-success-2 px-3 text-sm outline-none focus:ring-2 focus:ring-inset focus:ring-primary-5"
-  >
-    {children}
-  </div>
-);
+import { JSX, memo } from 'react';
+import { appLabels } from '@/app/labels/catalog';
+import { ColumnSelection } from './open-data-picker/open-data-picker';
+import { OpenDataSelector } from './open-data-picker/open-data-selector';
+import { SourceBadge } from './source-badge';
+import { generateCellKey, GridCell, IndicateurId, Year } from './types';
 
 type OpenDataCellProps = {
-  value: number;
-  source: SourceInfo;
-  ariaLabel: string;
+  cell: Extract<GridCell, { kind: 'open-data' }>;
+  secteur: string;
+  polluant: string;
   indicateurId: IndicateurId;
   year: Year;
+  columnSelection?: ColumnSelection;
 };
 
 export const OpenDataCell = memo(
   ({
-    value,
-    source,
-    ariaLabel,
+    cell,
+    secteur,
+    polluant,
     indicateurId,
     year,
+    columnSelection,
   }: OpenDataCellProps): JSX.Element => (
-    <FocusableCell cellId={generateCellKey(indicateurId, year)} ariaLabel={ariaLabel}>
-      <ProvenanceBadge source={source} />
-      <span className="text-success-1">{value}</span>
-    </FocusableCell>
+    <OpenDataSelector
+      secteur={secteur}
+      polluant={polluant}
+      indicateurId={indicateurId}
+      year={year}
+      sources={cell.coveringSources}
+      selectedSourceId={cell.selectedSourceId}
+      columnSelection={columnSelection}
+    >
+      <button
+        type="button"
+        data-cell-id={generateCellKey(indicateurId, year)}
+        aria-label={appLabels.indicateurCelluleOpenData({
+          rowLabel: polluant,
+          year,
+          value: cell.value,
+          source: cell.source.libelle,
+        })}
+        className="flex h-full w-full items-center justify-between gap-1 bg-success-2 px-3 text-sm outline-none focus:ring-2 focus:ring-inset focus:ring-primary-5"
+      >
+        <SourceBadge source={cell.source} />
+        <span className="text-success-1">{cell.value}</span>
+      </button>
+    </OpenDataSelector>
   )
 );
 

--- a/apps/app/src/indicateurs/valeurs/grid/open-data-coverage.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/open-data-coverage.ts
@@ -1,6 +1,6 @@
-import { CoveringSource, GridCell } from './types';
+import { OpenDataSource, GridCell } from './types';
 
-export const openDataSourcesFor = (cell: GridCell | null): CoveringSource[] =>
+export const openDataSourcesFor = (cell: GridCell | null): OpenDataSource[] =>
   cell !== null && cell.kind === 'user-data' ? cell.coveringSources : [];
 
 export const isCovered = (cell: GridCell | null): boolean =>

--- a/apps/app/src/indicateurs/valeurs/grid/open-data-picker/build-column-selection.spec.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/open-data-picker/build-column-selection.spec.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildColumnSelection } from './build-column-selection';
+import {
+  generateCellKey,
+  CellKey,
+  GridCell,
+  GridRowGroup,
+  OpenDataSource,
+  toIndicateurId,
+  toYear,
+} from '../types';
+
+const citepa: OpenDataSource = {
+  sourceId: 'citepa',
+  libelle: 'CITEPA',
+  value: 100,
+  methodologie: null,
+  dateVersion: '2026-01-01',
+};
+
+const insee: OpenDataSource = {
+  sourceId: 'insee',
+  libelle: 'INSEE',
+  value: 200,
+  methodologie: null,
+  dateVersion: '2024-01-01',
+};
+
+const year = toYear(2030);
+
+const coveredEmpty = (): GridCell => ({
+  kind: 'user-data',
+  value: null,
+  coveringSources: [citepa],
+});
+
+const coveredByBoth = (): GridCell => ({
+  kind: 'user-data',
+  value: null,
+  coveringSources: [citepa, insee],
+});
+
+const filled = (): GridCell => ({
+  kind: 'user-data',
+  value: 5,
+  valueId: 1,
+  coveringSources: [],
+});
+
+const group: GridRowGroup = {
+  id: 'secteur',
+  label: 'Résidentiel',
+  rows: [1, 2, 3, 4].map((id) => ({
+    indicateurId: toIndicateurId(id),
+    label: `p${id}`,
+  })),
+};
+
+const cellsWith = (
+  entries: [number, GridCell][]
+): Map<CellKey, GridCell> =>
+  new Map(
+    entries.map(([id, cell]) => [generateCellKey(toIndicateurId(id), year), cell])
+  );
+
+describe('buildColumnSelection', () => {
+  it('compte les cellules vides couvertes par la même source dans le secteur × année', () => {
+    const selection = buildColumnSelection({
+      cell: coveredEmpty(),
+      group,
+      year,
+      cells: cellsWith([
+        [1, coveredEmpty()],
+        [2, coveredEmpty()],
+        [3, coveredEmpty()],
+        [4, filled()],
+      ]),
+      selectOpenData: vi.fn(),
+    });
+    expect(selection?.count).toBe(3);
+  });
+
+  it('sélectionne la source pour chaque cellule vide couverte', async () => {
+    const selectOpenData = vi.fn().mockResolvedValue({ ok: true, value: undefined });
+    const selection = buildColumnSelection({
+      cell: coveredEmpty(),
+      group,
+      year,
+      cells: cellsWith([
+        [1, coveredEmpty()],
+        [2, coveredEmpty()],
+        [3, coveredEmpty()],
+      ]),
+      selectOpenData,
+    });
+
+    await selection?.onSelect();
+
+    expect(selectOpenData).toHaveBeenCalledTimes(3);
+    expect(selectOpenData).toHaveBeenCalledWith({
+      indicateurId: 2,
+      year: 2030,
+      sourceId: 'citepa',
+    });
+  });
+
+  it('remonte false quand une sélection de la colonne échoue', async () => {
+    const selectOpenData = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, value: undefined })
+      .mockResolvedValueOnce({ ok: false, error: 'boom' });
+    const selection = buildColumnSelection({
+      cell: coveredEmpty(),
+      group,
+      year,
+      cells: cellsWith([
+        [1, coveredEmpty()],
+        [2, coveredEmpty()],
+      ]),
+      selectOpenData,
+    });
+
+    expect(await selection?.onSelect()).toBe(false);
+  });
+
+  it('propose le lot depuis une cellule open data, via sa source sélectionnée', () => {
+    const openDataCell: GridCell = {
+      kind: 'open-data',
+      value: 358,
+      selectedSourceId: 'insee',
+      source: {
+        sourceId: 'insee',
+        libelle: 'INSEE',
+        methodologie: null,
+        dateVersion: '2024-01-01',
+      },
+      coveringSources: [citepa, insee],
+    };
+    const selection = buildColumnSelection({
+      cell: openDataCell,
+      group,
+      year,
+      cells: cellsWith([
+        [1, coveredByBoth()],
+        [2, coveredByBoth()],
+      ]),
+      selectOpenData: vi.fn(),
+    });
+    expect(selection).toEqual(
+      expect.objectContaining({
+        count: 2,
+        source: expect.objectContaining({ libelle: 'INSEE' }),
+      })
+    );
+  });
+
+  it("rend undefined quand une seule cellule vide est couverte", () => {
+    const selection = buildColumnSelection({
+      cell: coveredEmpty(),
+      group,
+      year,
+      cells: cellsWith([
+        [1, coveredEmpty()],
+        [2, filled()],
+      ]),
+      selectOpenData: vi.fn(),
+    });
+    expect(selection).toBeUndefined();
+  });
+
+  it('rend undefined quand la cellule courante est déjà renseignée', () => {
+    const selection = buildColumnSelection({
+      cell: filled(),
+      group,
+      year,
+      cells: cellsWith([
+        [1, coveredEmpty()],
+        [2, coveredEmpty()],
+      ]),
+      selectOpenData: vi.fn(),
+    });
+    expect(selection).toBeUndefined();
+  });
+});

--- a/apps/app/src/indicateurs/valeurs/grid/open-data-picker/build-column-selection.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/open-data-picker/build-column-selection.ts
@@ -1,0 +1,68 @@
+import { findCell } from '../grid-model';
+import {
+  CellKey,
+  GridCell,
+  GridRowGroup,
+  IndicateurValuesGridActions,
+  OpenDataSource,
+  Year,
+} from '../types';
+import { ColumnSelection } from './open-data-picker';
+
+const sourceToPropagate = (
+  cell: GridCell | null
+): OpenDataSource | undefined => {
+  if (cell === null) {
+    return undefined;
+  }
+  if (cell.kind === 'user-data') {
+    return cell.value === null ? cell.coveringSources[0] : undefined;
+  }
+  return cell.coveringSources.find((s) => s.sourceId === cell.selectedSourceId);
+};
+
+export const buildColumnSelection = ({
+  cell,
+  group,
+  year,
+  cells,
+  selectOpenData,
+}: {
+  cell: GridCell | null;
+  group: GridRowGroup;
+  year: Year;
+  cells: Map<CellKey, GridCell>;
+  selectOpenData: IndicateurValuesGridActions['selectOpenData'];
+}): ColumnSelection | undefined => {
+  const source = sourceToPropagate(cell);
+  if (source === undefined) {
+    return undefined;
+  }
+  const targets = group.rows.filter((row) => {
+    const rowCell = findCell({ cells, indicateurId: row.indicateurId, year });
+    return (
+      rowCell?.kind === 'user-data' &&
+      rowCell.value === null &&
+      rowCell.coveringSources.some((s) => s.sourceId === source.sourceId)
+    );
+  });
+  if (targets.length <= 1) {
+    return undefined;
+  }
+  return {
+    source,
+    count: targets.length,
+    onSelect: async () => {
+      const outcomes = await Promise.all(
+        targets.map((row) =>
+          selectOpenData({
+            indicateurId: row.indicateurId,
+            year,
+            sourceId: source.sourceId,
+          })
+        )
+      );
+      return outcomes.every((outcome) => outcome.ok);
+    },
+  };
+};

--- a/apps/app/src/indicateurs/valeurs/grid/open-data-picker/coverage-dot.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/open-data-picker/coverage-dot.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { Button } from '@tet/ui';
+import { JSX } from 'react';
+import { appLabels } from '@/app/labels/catalog';
+import { IndicateurId, OpenDataSource, Year } from '../types';
+import { ColumnSelection } from './open-data-picker';
+import { OpenDataSelector } from './open-data-selector';
+
+type CoverageDotProps = {
+  coveringSources: OpenDataSource[];
+  secteur: string;
+  polluant: string;
+  indicateurId: IndicateurId;
+  year: Year;
+  columnSelection?: ColumnSelection;
+};
+
+export const CoverageDot = ({
+  coveringSources,
+  secteur,
+  polluant,
+  indicateurId,
+  year,
+  columnSelection,
+}: CoverageDotProps): JSX.Element => (
+  <OpenDataSelector
+    secteur={secteur}
+    polluant={polluant}
+    indicateurId={indicateurId}
+    year={year}
+    sources={coveringSources}
+    columnSelection={columnSelection}
+  >
+    <Button
+      variant="unstyled"
+      aria-label={appLabels.indicateurValeurOpenDataDisponible}
+      className="absolute right-0.5 top-0.5 flex items-center justify-center p-1"
+    >
+      <span className="h-2 w-2 rounded-full bg-success-1 ring-2 ring-success-2" />
+    </Button>
+  </OpenDataSelector>
+);

--- a/apps/app/src/indicateurs/valeurs/grid/open-data-picker/open-data-picker.spec.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/open-data-picker/open-data-picker.spec.tsx
@@ -1,0 +1,88 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { OpenDataPicker } from './open-data-picker';
+import { OpenDataSource, toYear } from '../types';
+
+const sources: OpenDataSource[] = [
+  {
+    sourceId: 'ame',
+    libelle: 'AME',
+    value: 640,
+    methodologie: 'Projection « avec mesures existantes »',
+    dateVersion: '2024-01-01',
+  },
+  {
+    sourceId: 'ams',
+    libelle: 'AMS',
+    value: 560,
+    methodologie: null,
+    dateVersion: '2024-01-01',
+  },
+];
+
+const renderPicker = (
+  overrides: Partial<Parameters<typeof OpenDataPicker>[0]> = {}
+): void => {
+  render(
+    <OpenDataPicker
+      secteur="Résidentiel"
+      polluant="NOx"
+      year={toYear(2030)}
+      unit="t"
+      sources={sources}
+      onSelect={vi.fn()}
+      onClose={vi.fn()}
+      {...overrides}
+    />
+  );
+};
+
+describe('OpenDataPicker', () => {
+  it('affiche le titre, le contexte de la cellule et chaque source avec sa valeur', () => {
+    renderPicker();
+    expect(screen.getByText("Compléter avec de l'open data")).not.toBeNull();
+    expect(screen.getByText('Résidentiel · NOx · 2030')).not.toBeNull();
+    expect(screen.getByText('AME')).not.toBeNull();
+    expect(screen.getByText('640 t')).not.toBeNull();
+    expect(screen.getByText('AMS')).not.toBeNull();
+    expect(screen.getByText('560 t')).not.toBeNull();
+  });
+
+  it('remonte le sourceId au clic sur une source', () => {
+    const onSelect = vi.fn();
+    renderPicker({ onSelect });
+    fireEvent.click(screen.getByText('AMS'));
+    expect(onSelect).toHaveBeenCalledWith('ams');
+  });
+
+  it('ferme au clic sur le bouton de fermeture', () => {
+    const onClose = vi.fn();
+    renderPicker({ onClose });
+    fireEvent.click(screen.getByRole('button', { name: 'Fermer' }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("propose la sélection en lot quand columnSelection est fourni", () => {
+    const onSelectLot = vi.fn();
+    renderPicker({
+      columnSelection: { source: sources[0], count: 9, onSelect: onSelectLot },
+    });
+    fireEvent.click(
+      screen.getByText(
+        'Sélectionner la donnée AME pour les 9 cellules vides du secteur Résidentiel'
+      )
+    );
+    expect(onSelectLot).toHaveBeenCalled();
+  });
+
+  it('marque la source sélectionnée', () => {
+    renderPicker({ selectedSourceId: 'ame' });
+    const selected = screen.getByRole('button', { pressed: true });
+    expect(selected.textContent).toContain('AME');
+  });
+
+  it("n'affiche pas la sélection en lot sans columnSelection", () => {
+    renderPicker();
+    expect(screen.queryByText(/Sélectionner .* pour les/)).toBeNull();
+  });
+});

--- a/apps/app/src/indicateurs/valeurs/grid/open-data-picker/open-data-picker.stories.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/open-data-picker/open-data-picker.stories.tsx
@@ -1,0 +1,61 @@
+import { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { OpenDataSource, toYear } from '../types';
+import { OpenDataPicker } from './open-data-picker';
+
+const meta: Meta<typeof OpenDataPicker> = {
+  title: 'Indicateurs/Grille de saisie/Picker open data',
+  component: OpenDataPicker,
+  decorators: [
+    (Story) => (
+      <div className="w-fit rounded-xl border border-grey-3 bg-white shadow-lg">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof OpenDataPicker>;
+
+const sources: OpenDataSource[] = [
+  {
+    sourceId: 'ame',
+    libelle: 'AME',
+    value: 640,
+    methodologie: 'Projection « avec mesures existantes »',
+    dateVersion: '2024-01-01',
+  },
+  {
+    sourceId: 'ams',
+    libelle: 'AMS',
+    value: 560,
+    methodologie: null,
+    dateVersion: '2024-01-01',
+  },
+];
+
+const baseArgs = {
+  secteur: 'Résidentiel',
+  polluant: 'NOx',
+  year: toYear(2030),
+  unit: 't',
+  sources,
+  onSelect: (sourceId: string) => window.alert(`Sélection : ${sourceId}`),
+  onClose: () => window.alert('Fermeture'),
+};
+
+export const Selecteur: Story = {
+  args: {
+    ...baseArgs,
+    selectedSourceId: 'ame',
+    columnSelection: {
+      source: sources[0],
+      count: 9,
+      onSelect: async () => {
+        window.alert('Sélection en lot');
+        return true;
+      },
+    },
+  },
+};

--- a/apps/app/src/indicateurs/valeurs/grid/open-data-picker/open-data-picker.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/open-data-picker/open-data-picker.tsx
@@ -1,0 +1,201 @@
+import { appLabels } from '@/app/labels/catalog';
+import { Button, cn, Icon } from '@tet/ui';
+import { JSX } from 'react';
+import { OpenDataSource, Year } from '../types';
+
+const publicationYear = (dateVersion: string): number =>
+  new Date(dateVersion).getFullYear();
+
+const PickerHeader = ({
+  secteur,
+  polluant,
+  year,
+  onClose,
+}: {
+  secteur: string;
+  polluant: string;
+  year: Year;
+  onClose: () => void;
+}): JSX.Element => (
+  <header className="flex items-start justify-between gap-2">
+    <div className="flex flex-col">
+      <p className="mb-0 text-base font-bold text-primary-9">
+        {appLabels.indicateurCompleterOpenData}
+      </p>
+      <p className="text-xs text-grey-6">
+        {appLabels.indicateurContexteCellule(secteur, polluant, year)}
+      </p>
+    </div>
+    <Button
+      variant="unstyled"
+      icon="close-line"
+      onClick={onClose}
+      title={appLabels.fermer}
+    />
+  </header>
+);
+
+const SourceValue = ({
+  value,
+  unit,
+  isSelected,
+}: {
+  value: number;
+  unit: string | null;
+  isSelected: boolean;
+}): JSX.Element => (
+  <span className="flex items-center gap-1 whitespace-nowrap text-sm font-bold text-success-1">
+    {isSelected ? <Icon icon="checkbox-circle-fill" size="sm" /> : null}
+    {unit !== null ? `${value} ${unit}` : value}
+  </span>
+);
+
+const SourceCard = ({
+  source,
+  year,
+  unit,
+  isSelected,
+  onSelect,
+}: {
+  source: OpenDataSource;
+  year: Year;
+  unit: string | null;
+  isSelected: boolean;
+  onSelect: () => void;
+}): JSX.Element => (
+  <button
+    type="button"
+    onClick={onSelect}
+    aria-pressed={isSelected}
+    className={cn(
+      'flex w-full items-start justify-between gap-3 rounded-lg border p-3 text-left transition-colors',
+      isSelected
+        ? 'border-success-1 bg-success-1/5'
+        : 'border-grey-3 hover:border-primary-4 hover:bg-primary-0'
+    )}
+  >
+    <span className="flex flex-col gap-0.5">
+      <span className="text-sm font-bold text-primary-9">{source.libelle}</span>
+      <span className="text-xs text-grey-6">
+        {appLabels.indicateurSourceDonnee(source.libelle, year)}
+      </span>
+      {source.methodologie !== null ? (
+        <span className="text-xs text-grey-6">
+          {appLabels.indicateurSourceMethodologie(
+            source.methodologie,
+            publicationYear(source.dateVersion)
+          )}
+        </span>
+      ) : null}
+    </span>
+    <SourceValue value={source.value} unit={unit} isSelected={isSelected} />
+  </button>
+);
+
+const SourceList = ({
+  sources,
+  year,
+  unit,
+  selectedSourceId,
+  onSelect,
+}: {
+  sources: OpenDataSource[];
+  year: Year;
+  unit: string | null;
+  selectedSourceId?: string;
+  onSelect: (sourceId: string) => void;
+}): JSX.Element => (
+  <ul
+    aria-label={appLabels.indicateurSelectionnerValeurOpenData}
+    className="flex flex-col gap-2"
+  >
+    {sources.map((source) => (
+      <li key={source.sourceId}>
+        <SourceCard
+          source={source}
+          year={year}
+          unit={unit}
+          isSelected={source.sourceId === selectedSourceId}
+          onSelect={() => onSelect(source.sourceId)}
+        />
+      </li>
+    ))}
+  </ul>
+);
+
+const ColumnSelectionButton = ({
+  libelle,
+  count,
+  secteur,
+  onSelect,
+}: {
+  libelle: string;
+  count: number;
+  secteur: string;
+  onSelect: () => void;
+}): JSX.Element => (
+  <button
+    type="button"
+    onClick={onSelect}
+    className="rounded-lg border border-dashed border-success-1 bg-success-1/10 p-3 text-left text-sm text-success-1 transition-colors hover:bg-success-1/20"
+  >
+    {appLabels.indicateurSelectionnerPourColonne(libelle, count, secteur)}
+  </button>
+);
+
+export type ColumnSelection = {
+  source: OpenDataSource;
+  count: number;
+  onSelect: () => Promise<boolean>;
+};
+
+type OpenDataPickerProps = {
+  secteur: string;
+  polluant: string;
+  year: Year;
+  unit: string | null;
+  sources: OpenDataSource[];
+  selectedSourceId?: string;
+  onSelect: (sourceId: string) => void;
+  onClose: () => void;
+  columnSelection?: ColumnSelection;
+};
+
+export const OpenDataPicker = ({
+  secteur,
+  polluant,
+  year,
+  unit,
+  sources,
+  selectedSourceId,
+  onSelect,
+  onClose,
+  columnSelection,
+}: OpenDataPickerProps): JSX.Element => (
+  <section
+    aria-label={appLabels.indicateurCompleterOpenData}
+    className="flex w-80 flex-col p-3"
+  >
+    <PickerHeader
+      secteur={secteur}
+      polluant={polluant}
+      year={year}
+      onClose={onClose}
+    />
+    <SourceList
+      sources={sources}
+      year={year}
+      unit={unit}
+      selectedSourceId={selectedSourceId}
+      onSelect={onSelect}
+    />
+    {columnSelection !== undefined ? (
+      <ColumnSelectionButton
+        libelle={columnSelection.source.libelle}
+        count={columnSelection.count}
+        secteur={secteur}
+        onSelect={columnSelection.onSelect}
+      />
+    ) : null}
+  </section>
+);

--- a/apps/app/src/indicateurs/valeurs/grid/open-data-picker/open-data-selector.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/open-data-picker/open-data-selector.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { JSX } from 'react';
+import { appLabels } from '@/app/labels/catalog';
+import DropdownFloater from '@/app/ui/shared/floating-ui/DropdownFloater';
+import { useGridCellServices } from '../grid-context';
+import { OpenDataSource, IndicateurId, Year } from '../types';
+import { ColumnSelection, OpenDataPicker } from './open-data-picker';
+
+type OpenDataSelectorProps = {
+  secteur: string;
+  polluant: string;
+  indicateurId: IndicateurId;
+  year: Year;
+  sources: OpenDataSource[];
+  selectedSourceId?: string;
+  columnSelection?: ColumnSelection;
+  children: JSX.Element;
+};
+
+export const OpenDataSelector = ({
+  secteur,
+  polluant,
+  indicateurId,
+  year,
+  sources,
+  selectedSourceId,
+  columnSelection,
+  children,
+}: OpenDataSelectorProps): JSX.Element => {
+  const { selectOpenData, unit, notify } = useGridCellServices();
+  return (
+    <DropdownFloater
+      placement="bottom-end"
+      offsetValue={2}
+      render={({ close }) => (
+        <OpenDataPicker
+          secteur={secteur}
+          polluant={polluant}
+          year={year}
+          unit={unit}
+          sources={sources}
+          selectedSourceId={selectedSourceId}
+          onSelect={async (sourceId) => {
+            const selectionResult = await selectOpenData({
+              indicateurId,
+              year,
+              sourceId,
+            });
+            if (selectionResult.ok) {
+              close();
+            } else {
+              notify?.(appLabels.indicateurSelectionnerValeurEchec);
+            }
+          }}
+          onClose={close}
+          columnSelection={
+            columnSelection === undefined
+              ? undefined
+              : {
+                  ...columnSelection,
+                  onSelect: async () => {
+                    const allSelected = await columnSelection.onSelect();
+                    if (allSelected) {
+                      close();
+                    } else {
+                      notify?.(appLabels.indicateurSelectionnerValeurEchec);
+                    }
+                    return allSelected;
+                  },
+                }
+          }
+        />
+      )}
+    >
+      {children}
+    </DropdownFloater>
+  );
+};

--- a/apps/app/src/indicateurs/valeurs/grid/paste/grid-paste.spec.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/paste/grid-paste.spec.tsx
@@ -32,8 +32,9 @@ const userData: GridCell = { kind: 'user-data', value: null, coveringSources: []
 const openData: GridCell = {
   kind: 'open-data',
   value: 5,
-  adoptedSourceId: 's',
+  selectedSourceId: 's',
   source: { sourceId: 's', libelle: 'S', methodologie: null, dateVersion: '2026-01-01' },
+  coveringSources: [],
 };
 
 const cells = new Map<CellKey, GridCell>([

--- a/apps/app/src/indicateurs/valeurs/grid/paste/paste-values.spec.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/paste/paste-values.spec.ts
@@ -27,8 +27,9 @@ const userData: GridCell = { kind: 'user-data', value: null, coveringSources: []
 const openData: GridCell = {
   kind: 'open-data',
   value: 5,
-  adoptedSourceId: 's',
+  selectedSourceId: 's',
   source: { sourceId: 's', libelle: 'S', methodologie: null, dateVersion: '2026-01-01' },
+  coveringSources: [],
 };
 
 const cells = new Map<CellKey, GridCell>([

--- a/apps/app/src/indicateurs/valeurs/grid/source-badge.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/source-badge.tsx
@@ -5,7 +5,7 @@ import { SourceInfo } from './types';
 const shortYear = (dateVersion: string): string =>
   `'${dateVersion.slice(2, 4)}`;
 
-export const ProvenanceBadge = memo(
+export const SourceBadge = memo(
   ({ source }: { source: SourceInfo }): JSX.Element => (
     <Badge
       size="xs"
@@ -14,4 +14,4 @@ export const ProvenanceBadge = memo(
   )
 );
 
-ProvenanceBadge.displayName = 'ProvenanceBadge';
+SourceBadge.displayName = 'SourceBadge';

--- a/apps/app/src/indicateurs/valeurs/grid/types.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/types.ts
@@ -34,7 +34,7 @@ export type SourceInfo = {
   dateVersion: string;
 };
 
-export type CoveringSource = {
+export type OpenDataSource = {
   sourceId: string;
   libelle: string;
   value: number;
@@ -47,19 +47,20 @@ export type GridCell =
       kind: 'user-data';
       value: number;
       valueId: number;
-      coveringSources: CoveringSource[];
+      coveringSources: OpenDataSource[];
     }
   | {
       kind: 'user-data';
       value: null;
       valueId?: number;
-      coveringSources: CoveringSource[];
+      coveringSources: OpenDataSource[];
     }
   | {
       kind: 'open-data';
       value: number;
-      adoptedSourceId: string;
+      selectedSourceId: string;
       source: SourceInfo;
+      coveringSources: OpenDataSource[];
     };
 
 export type GridRow = {
@@ -84,7 +85,7 @@ export type CellValueInput = {
   resultat: number | null;
 };
 
-export type AdoptInput = {
+export type SelectOpenDataInput = {
   indicateurId: IndicateurId;
   year: Year;
   sourceId: string;
@@ -103,6 +104,6 @@ export type BulkOutcome = {
 export type IndicateurValuesGridActions = {
   saveCellValue: (input: CellValueInput) => Promise<Result>;
   saveCellValues: (inputs: CellValueInput[]) => Promise<Result<BulkOutcome>>;
-  adopt: (input: AdoptInput) => Promise<Result>;
+  selectOpenData: (input: SelectOpenDataInput) => Promise<Result>;
   clearCell: (input: ClearCellInput) => Promise<Result>;
 };

--- a/apps/app/src/indicateurs/valeurs/grid/use-get-table.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/use-get-table.tsx
@@ -7,18 +7,13 @@ import {
   useReactTable,
 } from '@tanstack/react-table';
 import { JSX, RefObject, useMemo, useRef } from 'react';
-import { appLabels } from '@/app/labels/catalog';
 import { useGridContext } from './grid-context';
 import { findCell, GridDisplayRow, toDisplayRows } from './grid-model';
 import { OpenDataCell } from './open-data-cell';
+import { buildColumnSelection } from './open-data-picker/build-column-selection';
+import { ColumnSelection } from './open-data-picker/open-data-picker';
 import { UserDataCell } from './user-data-cell';
-import {
-  GridCell,
-  GridRowGroup,
-  IndicateurId,
-  IndicateurValuesGridActions,
-  Year,
-} from './types';
+import { GridCell, GridRowGroup, IndicateurId, Year } from './types';
 
 const columnHelper = createColumnHelper<GridDisplayRow>();
 
@@ -29,13 +24,15 @@ const renderCell = ({
   indicateurId,
   year,
   rowLabel,
-  saveCellValue,
+  groupLabel,
+  columnSelection,
 }: {
   cell: GridCell | null;
   indicateurId: IndicateurId;
   year: Year;
   rowLabel: string;
-  saveCellValue: IndicateurValuesGridActions['saveCellValue'];
+  groupLabel: string;
+  columnSelection?: ColumnSelection;
 }): JSX.Element => {
   if (cell === null) {
     return <EmptyCell />;
@@ -43,26 +40,23 @@ const renderCell = ({
   if (cell.kind === 'open-data') {
     return (
       <OpenDataCell
-        value={cell.value}
-        source={cell.source}
-        ariaLabel={appLabels.indicateurCelluleOpenData({
-          rowLabel,
-          year,
-          value: cell.value,
-          source: cell.source.libelle,
-        })}
+        cell={cell}
+        secteur={groupLabel}
+        polluant={rowLabel}
         indicateurId={indicateurId}
         year={year}
+        columnSelection={columnSelection}
       />
     );
   }
   return (
     <UserDataCell
       cell={cell}
-      ariaLabel={appLabels.indicateurCellule(rowLabel, year)}
+      secteur={groupLabel}
+      polluant={rowLabel}
       indicateurId={indicateurId}
       year={year}
-      saveCellValue={saveCellValue}
+      columnSelection={columnSelection}
     />
   );
 };
@@ -89,21 +83,36 @@ export const useGetTable = ({
       years.map((year) =>
         columnHelper.display({
           id: `year-${year}`,
-          cell: ({ row }) =>
-            renderCell({
-              cell: findCell({
-                cells,
-                indicateurId: row.original.indicateurId,
-                year,
-              }),
+          cell: ({ row }) => {
+            const cell = findCell({
+              cells,
+              indicateurId: row.original.indicateurId,
+              year,
+            });
+            const group = groups.find(
+              (candidate) => candidate.id === row.original.groupId
+            );
+            return renderCell({
+              cell,
               indicateurId: row.original.indicateurId,
               year,
               rowLabel: row.original.rowLabel,
-              saveCellValue: actions.saveCellValue,
-            }),
+              groupLabel: row.original.groupLabel,
+              columnSelection:
+                group === undefined
+                  ? undefined
+                  : buildColumnSelection({
+                      cell,
+                      group,
+                      year,
+                      cells,
+                      selectOpenData: actions.selectOpenData,
+                    }),
+            });
+          },
         })
       ),
-    [years, cells, actions.saveCellValue]
+    [years, cells, groups, actions.selectOpenData]
   );
 
   const table = useReactTable({

--- a/apps/app/src/indicateurs/valeurs/grid/user-data-cell.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/user-data-cell.tsx
@@ -1,32 +1,32 @@
 import { JSX, memo, useCallback } from 'react';
+import { appLabels } from '@/app/labels/catalog';
 import { CellInput } from './cell-input';
-import { CoverageDot } from './coverage-dot';
+import { useGridCellServices } from './grid-context';
+import { ColumnSelection } from './open-data-picker/open-data-picker';
+import { CoverageDot } from './open-data-picker/coverage-dot';
 import { SaveAck } from './save-ack';
 import { useCellEdit } from './use-cell-edit';
-import {
-  generateCellKey,
-  GridCell,
-  IndicateurId,
-  IndicateurValuesGridActions,
-  Year,
-} from './types';
+import { generateCellKey, GridCell, IndicateurId, Year } from './types';
 
 type UserDataCellProps = {
   cell: Extract<GridCell, { kind: 'user-data' }>;
-  ariaLabel: string;
+  secteur: string;
+  polluant: string;
   indicateurId: IndicateurId;
   year: Year;
-  saveCellValue: IndicateurValuesGridActions['saveCellValue'];
+  columnSelection?: ColumnSelection;
 };
 
 export const UserDataCell = memo(
   ({
     cell,
-    ariaLabel,
+    secteur,
+    polluant,
     indicateurId,
     year,
-    saveCellValue,
+    columnSelection,
   }: UserDataCellProps): JSX.Element => {
+    const { saveCellValue } = useGridCellServices();
     const { value, valueId, coveringSources } = cell;
     const onSave = useCallback(
       (resultat: number | null) =>
@@ -45,13 +45,22 @@ export const UserDataCell = memo(
         <CellInput
           cellId={generateCellKey(indicateurId, year)}
           value={text}
-          ariaLabel={ariaLabel}
+          ariaLabel={appLabels.indicateurCellule(polluant, year)}
           hasError={status === 'error'}
           onChange={onChange}
           onSave={save}
           onCancel={cancel}
         />
-        {showCoverageDot && <CoverageDot />}
+        {showCoverageDot && (
+          <CoverageDot
+            coveringSources={coveringSources}
+            secteur={secteur}
+            polluant={polluant}
+            indicateurId={indicateurId}
+            year={year}
+            columnSelection={columnSelection}
+          />
+        )}
         {status === 'saved' && <SaveAck />}
       </div>
     );

--- a/apps/app/src/labels/catalog.ts
+++ b/apps/app/src/labels/catalog.ts
@@ -1766,6 +1766,28 @@ export const appLabels = {
     one: 'valeur ignorée au collage (hors grille ou non numérique)',
     other: 'valeurs ignorées au collage (hors grille ou non numérique)',
   }),
+  indicateurSelectionnerValeurOpenData: 'Sélectionner une valeur open data',
+  indicateurValeurOpenDataDisponible: 'Valeur open data disponible',
+  indicateurSelectionnerValeurEchec:
+    'La sélection de la valeur open data a échoué',
+  indicateurCompleterOpenData: "Compléter avec de l'open data",
+  indicateurContexteCellule: (
+    secteur: string,
+    polluant: string,
+    year: number
+  ): string => `${secteur} · ${polluant} · ${year}`,
+  indicateurSourceDonnee: (libelle: string, year: number): string =>
+    `Scénario ${libelle} · donnée ${year}`,
+  indicateurSourceMethodologie: (
+    methodologie: string,
+    anneePublication: number
+  ): string => `${methodologie} · publié ${anneePublication}`,
+  indicateurSelectionnerPourColonne: (
+    libelle: string,
+    count: number,
+    secteur: string
+  ): string =>
+    `Sélectionner la donnée ${libelle} pour les ${count} cellules vides du secteur ${secteur}`,
 
   acteEngagementDocUrl: '/Acte_engagement.docx',
   reglementLabelUrl: ({


### PR DESCRIPTION
Base = `main`. **Fusion P8 (sélecteur open data par cellule) + P9 (sélection en lot / pré-remplir les vides)** : le design place l'action « en lot » **dans** le popover par cellule, donc les deux ne forment qu'une seule surface.

## Contenu

**Pastille de couverture** (`open-data-picker/coverage-dot.tsx`) : sur une cellule utilisateur **vide** couverte par de l'open data, un point vert (`CoverageDot`) ouvre le sélecteur. `aria-label` = « Valeur open data disponible ».

**Sélecteur open data** (`open-data-picker/open-data-picker.tsx`) — popover monté dans `@/app/ui/shared/floating-ui/DropdownFloater` (voir note DS) :
- En-tête **« Compléter avec de l'open data »** (`text-base`) + bouton de fermeture (`Button icon="close-line"`), fil d'ariane `secteur · polluant · année`.
- **Cartes source** cliquables (`SourceCard`) : libellé, `Scénario … · donnée AAAA`, méthodo `… · publié AAAA`, **valeur + unité** en vert. La source **sélectionnée** est mise en valeur (bordure verte + `checkbox-circle-fill` à côté de la valeur, `aria-pressed`).
- **Sélection en lot** (encart pointillé, vert discret) : « Sélectionner la donnée AME pour les N cellules vides du secteur … ». Le nombre de vides couverts est calculé par colonne × secteur (`buildColumnSelection` dans `use-get-table`), et le libellé **suit la source sélectionnée de la cellule courante** : `ColumnSelection` porte la `source` propagée (pas un `libelle` détaché), donc l'étiquette affichée et l'action déclenchée ne peuvent pas diverger.
- Tailles de texte limitées à `sm`/`xs` (titre `base`).

**Réouverture pour changer de source** : une cellule **open data** (`open-data-cell.tsx`) est désormais un déclencheur du même sélecteur — cliquer rouvre le popover avec la source courante marquée, pour **switcher**. La cellule open data porte donc `coveringSources` (les alternatives) en plus de `source`/`selectedSourceId` (`types.ts`).

**Action injectée** `selectOpenData(input)` (grille agnostique) ; le résultat `Result` est **attendu** dans les deux chemins :
- cellule unique : fermeture au succès, `notify` à l'échec ;
- **en lot** : `buildColumnSelection.onSelect` agrège les N écritures (`Promise.all`) et renvoie « toutes réussies ? » ; le sélecteur **ferme seulement si tout a réussi**, sinon `notify` (plus d'échec silencieux).

Modélisation : la sélection produit une `GridCell` open data (union existante).

**Vocabulaire** : entièrement « sélection » (plus aucune trace d'« adoption » — action `selectOpenData`, `SelectOpenDataInput`, `columnSelection`, `selectedSourceId`).

## Stories
- `Picker open data` (`open-data-picker.stories.tsx`) : **le sélecteur seul** (une story `Selecteur` montrant source sélectionnée + lot).
- `Grille de saisie / Polluants` : la grille stateful de bout en bout (la story dédiée « SelectionOpenData » a été retirée, redondante).

## Vérifs
- specs grille **66/66** ; typecheck `apps/app` exit 0 ; `nx run app:lint` 0 erreur.

## Notes / hors scope
- **`DropdownFloater`** : on utilise la primitive **app-level**, pas celle de `@tet/ui` — cette dernière est un interne privé de `Select` (non exporté, `placement` hardcodé). La promouvoir = PR `@tet/ui` séparée (export + généralisation `placement`).
- **Sélection en lot** : le front agrège/awaite désormais les N `selectOpenData` et remonte l'échec. Un use case applicatif **atomique** (`selectOpenDataForColumn`) côté back-end reste préférable (pan 2).
- **Mémoïsation cellule** (suivi séparé) : `columnSelection` est un objet recréé à chaque render, ce qui neutralise le `memo` de `OpenDataCell`/`UserDataCell`. Le vrai correctif (extraction d'un composant `YearCell` + lecture par sélecteur) est une PR de refacto dédiée, hors de ce diff ciblé.
- **Durcissement de types** (suivi séparé) : `sourceId` reste un `string` nu (pas de `SourceId` brandé), `SourceInfo`/`OpenDataSource` ne sont pas dérivés l'un de l'autre, et le variant `user-data` n'est pas discriminé `filled`/`empty` — passe de typage à part.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Les cellules de valeurs open data permettent désormais de choisir une source directement depuis la grille.
  * Un sélecteur dédié affiche le contexte, les sources disponibles et une sélection groupée pour compléter plusieurs cellules.
  * De nouveaux libellés améliorent les messages et l’accessibilité autour de cette sélection.

* **Corrections de bugs**
  * La grille, le collage et la navigation clavier utilisent maintenant le bon état de source sélectionnée.
  * Les affichages et tests associés ont été mis à jour pour refléter ces nouveaux comportements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
