### PR TITLE
feat(indicateurs): impact en % de l'objectif dans la grille de valeurs

### DIFF
--- a/apps/app/src/indicateurs/valeurs/grid/__tests__/grid-fixtures.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/__tests__/grid-fixtures.ts
@@ -10,8 +10,15 @@ import {
   Year,
 } from '../types';
 
-export const fakeYears: Year[] = [2026, 2030, 2036, 2050].map(toYear);
-export const fakeReferenceYear: Year = toYear(2026);
+const currentYear = new Date().getFullYear();
+
+export const fakeReferenceYear: Year = toYear(currentYear);
+export const fakeYears: Year[] = [
+  currentYear,
+  currentYear + 4,
+  currentYear + 10,
+  currentYear + 24,
+].map(toYear);
 
 const sectors = ['Résidentiel', 'Tertiaire', 'Transport routier', 'Agriculture', 'Industrie'];
 const pollutants = ['NOx', 'PM10', 'PM2,5', 'COVNM', 'SO2', 'NH3'];
@@ -46,8 +53,25 @@ const sourceDefs = [
   },
 ];
 
-const pseudoValue = (indicateurId: number, year: number): number =>
-  ((indicateurId * 7 + year) % 900) + 100;
+const referenceValueOf = (indicateurId: number): number =>
+  200 + (indicateurId % 6) * 60;
+
+const yearFactor = (year: number): number => {
+  const horizon = year - currentYear;
+  if (horizon <= 0) {
+    return 1;
+  }
+  if (horizon <= 4) {
+    return 0.82;
+  }
+  if (horizon <= 10) {
+    return 0.58;
+  }
+  return 0.31;
+};
+
+const trajectoryValue = (indicateurId: number, year: number): number =>
+  Math.round(referenceValueOf(indicateurId) * yearFactor(year));
 
 const coveringSourcesFor = (
   indicateurId: number,
@@ -57,13 +81,13 @@ const coveringSourcesFor = (
     .slice(0, 2 + ((indicateurId + year) % 2))
     .map((def, index) => ({
       ...def,
-      value: pseudoValue(indicateurId, year) + index * 15,
+      value: trajectoryValue(indicateurId, year) + index * 12,
     }));
 
 const buildCell = (indicateurId: number, year: number): GridCell => {
-  const seed = (indicateurId + year) % 6;
   const coveringSources = coveringSourcesFor(indicateurId, year);
-  if (seed === 0) {
+  const variant = (indicateurId + year) % 4;
+  if (variant === 0) {
     const [chosen] = coveringSources;
     return {
       kind: 'open-data',
@@ -78,17 +102,14 @@ const buildCell = (indicateurId: number, year: number): GridCell => {
       coveringSources,
     };
   }
-  if (seed === 1 || seed === 2 || seed === 3) {
+  if (variant === 1 && year !== fakeReferenceYear) {
     return { kind: 'user-data', value: null, coveringSources };
-  }
-  if (seed === 4) {
-    return { kind: 'user-data', value: null, coveringSources: [] };
   }
   return {
     kind: 'user-data',
-    value: pseudoValue(indicateurId, year),
+    value: trajectoryValue(indicateurId, year),
     valueId: indicateurId * 1000 + year,
-    coveringSources: [],
+    coveringSources: variant === 3 ? coveringSources : [],
   };
 };
 

--- a/apps/app/src/indicateurs/valeurs/grid/__tests__/open-data-cell.spec.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/__tests__/open-data-cell.spec.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { GridCellServicesProvider } from '../grid-context';
+import { OpenDataCell } from '../open-data-cell';
+import { GridCell, toIndicateurId, toYear } from '../types';
+
+const snbcCell: Extract<GridCell, { kind: 'open-data' }> = {
+  kind: 'open-data',
+  value: 0.3,
+  selectedSourceId: 'snbc',
+  source: {
+    sourceId: 'snbc',
+    libelle: 'SNBC',
+    methodologie: null,
+    dateVersion: '2024-01-01',
+  },
+  coveringSources: [],
+};
+
+const renderOpenDataCell = (variationToReferenceYear: number | null): void => {
+  render(
+    <GridCellServicesProvider
+      services={{ saveCellValue: vi.fn(), selectOpenData: vi.fn(), unit: 't' }}
+    >
+      <OpenDataCell
+        cell={snbcCell}
+        secteur="Résidentiel"
+        polluant="NOx"
+        indicateurId={toIndicateurId(25)}
+        year={toYear(2050)}
+        variationToReferenceYear={variationToReferenceYear}
+      />
+    </GridCellServicesProvider>
+  );
+};
+
+describe('OpenDataCell', () => {
+  it('affiche la valeur reprise de la source', () => {
+    renderOpenDataCell(null);
+
+    expect(screen.getByText('0.3')).toBeDefined();
+  });
+
+  it('associe la variation signee comme description accessible de la cellule', () => {
+    renderOpenDataCell(-0.897);
+
+    const description = screen.getByText(
+      /-89,7\s*% par rapport à l'année de référence/
+    );
+    expect(
+      document.querySelector(`[aria-describedby="${description.id}"]`)
+    ).not.toBe(null);
+  });
+});

--- a/apps/app/src/indicateurs/valeurs/grid/__tests__/render-smoke.spec.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/__tests__/render-smoke.spec.tsx
@@ -1,5 +1,5 @@
-import { render } from '@testing-library/react';
-import { describe, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
 import {
   fakeCells,
   fakeGridActions,
@@ -9,16 +9,28 @@ import {
 } from './grid-fixtures';
 import { IndicateurValuesGrid } from '../indicateur-values-grid';
 
+const renderGrid = (): void => {
+  render(
+    <IndicateurValuesGrid
+      groups={fakeGroups}
+      years={fakeYears}
+      referenceYear={fakeReferenceYear}
+      cells={fakeCells()}
+      actions={fakeGridActions}
+    />
+  );
+};
+
 describe('IndicateurValuesGrid smoke', () => {
   it('rend sans lever', () => {
-    render(
-      <IndicateurValuesGrid
-        groups={fakeGroups}
-        years={fakeYears}
-        referenceYear={fakeReferenceYear}
-        cells={fakeCells()}
-        actions={fakeGridActions}
-      />
-    );
+    renderGrid();
+  });
+
+  it('affiche des variations d objectif sur les colonnes futures', () => {
+    renderGrid();
+
+    expect(
+      screen.getAllByText(/par rapport à l'année de référence/).length
+    ).toBeGreaterThan(0);
   });
 });

--- a/apps/app/src/indicateurs/valeurs/grid/__tests__/user-data-cell.spec.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/__tests__/user-data-cell.spec.tsx
@@ -37,6 +37,7 @@ const renderCell = (
         polluant="NOx"
         indicateurId={toIndicateurId(12)}
         year={toYear(2030)}
+        variationToReferenceYear={null}
       />
     </GridCellServicesProvider>
   );
@@ -105,6 +106,30 @@ describe('UserDataCell edition', () => {
 
     await waitFor(() => expect(input.getAttribute('aria-invalid')).toBe('true'));
     expect(saveCellValue).not.toHaveBeenCalled();
+  });
+
+  it('associe la variation signee comme description accessible de la cellule editable', () => {
+    render(
+      <GridCellServicesProvider
+        services={{ saveCellValue: vi.fn(), selectOpenData: vi.fn(), unit: 't' }}
+      >
+        <UserDataCell
+          cell={filledUserCell}
+          secteur="Résidentiel"
+          polluant="NOx"
+          indicateurId={toIndicateurId(12)}
+          year={toYear(2050)}
+          variationToReferenceYear={-0.6}
+        />
+      </GridCellServicesProvider>
+    );
+
+    const description = screen.getByText(
+      /-60\s*% par rapport à l'année de référence/
+    );
+    expect(screen.getByRole('textbox').getAttribute('aria-describedby')).toBe(
+      description.id
+    );
   });
 
   it("ne commit pas quand la valeur n'a pas change", () => {

--- a/apps/app/src/indicateurs/valeurs/grid/cell-input.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/cell-input.tsx
@@ -1,4 +1,4 @@
-import { Input } from '@tet/ui';
+import { cn } from '@tet/ui';
 import { JSX } from 'react';
 import { CellKey } from './types';
 
@@ -6,6 +6,7 @@ type CellInputProps = {
   cellId: CellKey;
   value: string;
   ariaLabel: string;
+  describedById?: string;
   hasError: boolean;
   onChange: (raw: string) => void;
   onSave: () => void;
@@ -16,20 +17,21 @@ export const CellInput = ({
   cellId,
   value,
   ariaLabel,
+  describedById,
   hasError,
   onChange,
   onSave,
   onCancel,
 }: CellInputProps): JSX.Element => (
-  <Input
+  <input
     type="text"
     inputMode="decimal"
     data-cell-id={cellId}
     aria-label={ariaLabel}
+    aria-describedby={describedById}
     aria-invalid={hasError}
-    displaySize="sm"
-    state={hasError ? 'error' : undefined}
     value={value}
+    size={Math.max(value.length, 2)}
     onFocus={(event) => event.currentTarget.select()}
     onChange={(event) => onChange(event.currentTarget.value)}
     onBlur={onSave}
@@ -42,7 +44,9 @@ export const CellInput = ({
         onCancel();
       }
     }}
-    containerClassname="w-full h-full"
-    className="text-right"
+    className={cn(
+      'min-w-[3ch] rounded bg-transparent px-0.5 py-1 text-right text-sm text-grey-8 outline-none [field-sizing:content] focus:ring-2 focus:ring-inset focus:ring-primary-5',
+      hasError && 'text-error-1 ring-2 ring-inset ring-error-1'
+    )}
   />
 );

--- a/apps/app/src/indicateurs/valeurs/grid/cell-props.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/cell-props.ts
@@ -1,0 +1,11 @@
+import { ColumnSelection } from './open-data-picker/open-data-picker';
+import { IndicateurId, Year } from './types';
+
+export type GridCellProps = {
+  secteur: string;
+  polluant: string;
+  indicateurId: IndicateurId;
+  year: Year;
+  columnSelection?: ColumnSelection;
+  variationToReferenceYear: number | null;
+};

--- a/apps/app/src/indicateurs/valeurs/grid/open-data-cell.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/open-data-cell.tsx
@@ -2,18 +2,17 @@
 
 import { JSX, memo } from 'react';
 import { appLabels } from '@/app/labels/catalog';
-import { ColumnSelection } from './open-data-picker/open-data-picker';
+import { GridCellProps } from './cell-props';
+import {
+  ValueWithVariation,
+  variationHintId,
+} from './variation/variation-hint';
 import { OpenDataSelector } from './open-data-picker/open-data-selector';
 import { SourceBadge } from './source-badge';
-import { generateCellKey, GridCell, IndicateurId, Year } from './types';
+import { generateCellKey, GridCell } from './types';
 
-type OpenDataCellProps = {
+type OpenDataCellProps = GridCellProps & {
   cell: Extract<GridCell, { kind: 'open-data' }>;
-  secteur: string;
-  polluant: string;
-  indicateurId: IndicateurId;
-  year: Year;
-  columnSelection?: ColumnSelection;
 };
 
 export const OpenDataCell = memo(
@@ -24,32 +23,46 @@ export const OpenDataCell = memo(
     indicateurId,
     year,
     columnSelection,
-  }: OpenDataCellProps): JSX.Element => (
-    <OpenDataSelector
-      secteur={secteur}
-      polluant={polluant}
-      indicateurId={indicateurId}
-      year={year}
-      sources={cell.coveringSources}
-      selectedSourceId={cell.selectedSourceId}
-      columnSelection={columnSelection}
-    >
-      <button
-        type="button"
-        data-cell-id={generateCellKey(indicateurId, year)}
-        aria-label={appLabels.indicateurCelluleOpenData({
-          rowLabel: polluant,
-          year,
-          value: cell.value,
-          source: cell.source.libelle,
-        })}
-        className="flex h-full w-full items-center justify-between gap-1 bg-success-2 px-3 text-sm outline-none focus:ring-2 focus:ring-inset focus:ring-primary-5"
+    variationToReferenceYear,
+  }: OpenDataCellProps): JSX.Element => {
+    const cellId = generateCellKey(indicateurId, year);
+    const impactId = variationHintId(cellId, variationToReferenceYear);
+    return (
+      <OpenDataSelector
+        secteur={secteur}
+        polluant={polluant}
+        indicateurId={indicateurId}
+        year={year}
+        sources={cell.coveringSources}
+        selectedSourceId={cell.selectedSourceId}
+        columnSelection={columnSelection}
       >
-        <SourceBadge source={cell.source} />
-        <span className="text-success-1">{cell.value}</span>
-      </button>
-    </OpenDataSelector>
-  )
+        <button
+          type="button"
+          data-cell-id={cellId}
+          aria-label={appLabels.indicateurCelluleOpenData({
+            rowLabel: polluant,
+            year,
+            value: cell.value,
+            source: cell.source.libelle,
+          })}
+          aria-describedby={impactId}
+          className="flex h-full w-full items-center gap-2 bg-success-2 px-3 text-sm outline-none focus:ring-2 focus:ring-inset focus:ring-primary-5"
+        >
+          <span className="shrink-0">
+            <SourceBadge source={cell.source} />
+          </span>
+          <ValueWithVariation
+            variationToReferenceYear={variationToReferenceYear}
+            hintId={impactId}
+            className="ml-auto"
+          >
+            <span className="text-success-1">{cell.value}</span>
+          </ValueWithVariation>
+        </button>
+      </OpenDataSelector>
+    );
+  }
 );
 
 OpenDataCell.displayName = 'OpenDataCell';

--- a/apps/app/src/indicateurs/valeurs/grid/use-get-table.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/use-get-table.tsx
@@ -7,6 +7,7 @@ import {
   useReactTable,
 } from '@tanstack/react-table';
 import { JSX, RefObject, useMemo, useRef } from 'react';
+import { resolveVariationToReferenceYear } from './variation/variation';
 import { useGridContext } from './grid-context';
 import { findCell, GridDisplayRow, toDisplayRows } from './grid-model';
 import { OpenDataCell } from './open-data-cell';
@@ -26,6 +27,7 @@ const renderCell = ({
   rowLabel,
   groupLabel,
   columnSelection,
+  variationToReferenceYear,
 }: {
   cell: GridCell | null;
   indicateurId: IndicateurId;
@@ -33,32 +35,23 @@ const renderCell = ({
   rowLabel: string;
   groupLabel: string;
   columnSelection?: ColumnSelection;
+  variationToReferenceYear: number | null;
 }): JSX.Element => {
   if (cell === null) {
     return <EmptyCell />;
   }
+  const commonProps = {
+    secteur: groupLabel,
+    polluant: rowLabel,
+    indicateurId,
+    year,
+    columnSelection,
+    variationToReferenceYear,
+  };
   if (cell.kind === 'open-data') {
-    return (
-      <OpenDataCell
-        cell={cell}
-        secteur={groupLabel}
-        polluant={rowLabel}
-        indicateurId={indicateurId}
-        year={year}
-        columnSelection={columnSelection}
-      />
-    );
+    return <OpenDataCell cell={cell} {...commonProps} />;
   }
-  return (
-    <UserDataCell
-      cell={cell}
-      secteur={groupLabel}
-      polluant={rowLabel}
-      indicateurId={indicateurId}
-      year={year}
-      columnSelection={columnSelection}
-    />
-  );
+  return <UserDataCell cell={cell} {...commonProps} />;
 };
 
 export const useGetTable = ({
@@ -71,7 +64,7 @@ export const useGetTable = ({
   table: Table<GridDisplayRow>;
   tableRef: RefObject<HTMLTableElement | null>;
 } => {
-  const { cells, actions } = useGridContext();
+  const { cells, actions, referenceYear } = useGridContext();
 
   const displayRows = useMemo<GridDisplayRow[]>(
     () => toDisplayRows(groups),
@@ -108,11 +101,18 @@ export const useGetTable = ({
                       cells,
                       selectOpenData: actions.selectOpenData,
                     }),
+              variationToReferenceYear: resolveVariationToReferenceYear({
+                cell,
+                cells,
+                indicateurId: row.original.indicateurId,
+                year,
+                referenceYear,
+              }),
             });
           },
         })
       ),
-    [years, cells, groups, actions.selectOpenData]
+    [years, cells, groups, actions.selectOpenData, referenceYear]
   );
 
   const table = useReactTable({

--- a/apps/app/src/indicateurs/valeurs/grid/user-data-cell.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/user-data-cell.tsx
@@ -1,20 +1,19 @@
 import { JSX, memo, useCallback } from 'react';
 import { appLabels } from '@/app/labels/catalog';
 import { CellInput } from './cell-input';
+import { GridCellProps } from './cell-props';
 import { useGridCellServices } from './grid-context';
-import { ColumnSelection } from './open-data-picker/open-data-picker';
+import {
+  ValueWithVariation,
+  variationHintId,
+} from './variation/variation-hint';
 import { CoverageDot } from './open-data-picker/coverage-dot';
 import { SaveAck } from './save-ack';
 import { useCellEdit } from './use-cell-edit';
-import { generateCellKey, GridCell, IndicateurId, Year } from './types';
+import { generateCellKey, GridCell } from './types';
 
-type UserDataCellProps = {
+type UserDataCellProps = GridCellProps & {
   cell: Extract<GridCell, { kind: 'user-data' }>;
-  secteur: string;
-  polluant: string;
-  indicateurId: IndicateurId;
-  year: Year;
-  columnSelection?: ColumnSelection;
 };
 
 export const UserDataCell = memo(
@@ -25,9 +24,12 @@ export const UserDataCell = memo(
     indicateurId,
     year,
     columnSelection,
+    variationToReferenceYear,
   }: UserDataCellProps): JSX.Element => {
     const { saveCellValue } = useGridCellServices();
     const { value, valueId, coveringSources } = cell;
+    const cellId = generateCellKey(indicateurId, year);
+    const impactId = variationHintId(cellId, variationToReferenceYear);
     const onSave = useCallback(
       (resultat: number | null) =>
         saveCellValue({ indicateurId, valueId, year, resultat }),
@@ -42,15 +44,23 @@ export const UserDataCell = memo(
       isEmpty && status === 'idle' && coveringSources.length > 0;
     return (
       <div className="relative h-full">
-        <CellInput
-          cellId={generateCellKey(indicateurId, year)}
-          value={text}
-          ariaLabel={appLabels.indicateurCellule(polluant, year)}
-          hasError={status === 'error'}
-          onChange={onChange}
-          onSave={save}
-          onCancel={cancel}
-        />
+        <label className="flex h-full cursor-text items-center justify-end pr-3">
+          <ValueWithVariation
+            variationToReferenceYear={variationToReferenceYear}
+            hintId={impactId}
+          >
+            <CellInput
+              cellId={cellId}
+              value={text}
+              ariaLabel={appLabels.indicateurCellule(polluant, year)}
+              describedById={impactId}
+              hasError={status === 'error'}
+              onChange={onChange}
+              onSave={save}
+              onCancel={cancel}
+            />
+          </ValueWithVariation>
+        </label>
         {showCoverageDot && (
           <CoverageDot
             coveringSources={coveringSources}

--- a/apps/app/src/indicateurs/valeurs/grid/variation/variation-hint.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/variation/variation-hint.tsx
@@ -1,0 +1,48 @@
+import { cn } from '@tet/ui';
+import { JSX, ReactNode } from 'react';
+import { appLabels } from '@/app/labels/catalog';
+import { formatVariation } from './variation';
+import { CellKey } from '../types';
+
+export const variationHintId = (
+  cellId: CellKey,
+  variationToReferenceYear: number | null
+): string | undefined =>
+  variationToReferenceYear === null ? undefined : `${cellId}-variation`;
+
+const VariationHint = ({
+  id,
+  ratio,
+}: {
+  id?: string;
+  ratio: number;
+}): JSX.Element => {
+  const label = formatVariation(ratio);
+  return (
+    <span className="pointer-events-none shrink-0 text-[0.625rem] font-normal text-grey-5">
+      <span aria-hidden>{`(${label})`}</span>
+      <span id={id} className="sr-only">
+        {appLabels.indicateurVariationReference(label)}
+      </span>
+    </span>
+  );
+};
+
+export const ValueWithVariation = ({
+  variationToReferenceYear,
+  hintId,
+  className,
+  children,
+}: {
+  variationToReferenceYear: number | null;
+  hintId?: string;
+  className?: string;
+  children: ReactNode;
+}): JSX.Element => (
+  <span className={cn('flex items-baseline gap-1', className)}>
+    {variationToReferenceYear !== null && (
+      <VariationHint id={hintId} ratio={variationToReferenceYear} />
+    )}
+    {children}
+  </span>
+);

--- a/apps/app/src/indicateurs/valeurs/grid/variation/variation.spec.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/variation/variation.spec.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+import {
+  computeVariation,
+  formatVariation,
+  resolveVariationToReferenceYear,
+} from './variation';
+import {
+  generateCellKey,
+  CellKey,
+  GridCell,
+  toIndicateurId,
+  toYear,
+} from '../types';
+
+describe('computeVariation', () => {
+  it('rend la variation signee vs la valeur de reference', () => {
+    expect(computeVariation({ value: 40, referenceValue: 100 })).toBe(
+      -0.6
+    );
+    expect(computeVariation({ value: 140, referenceValue: 100 })).toBe(
+      0.4
+    );
+  });
+
+  it('rend null quand la valeur de reference est absente', () => {
+    expect(
+      computeVariation({ value: 40, referenceValue: null })
+    ).toBe(null);
+  });
+
+  it('rend null quand la valeur de reference est nulle', () => {
+    expect(computeVariation({ value: 40, referenceValue: 0 })).toBe(
+      null
+    );
+  });
+});
+
+const NARROW_NO_BREAK_SPACE = 0x202f;
+
+describe('formatVariation', () => {
+  it('prefixe le signe et suffixe le pourcentage', () => {
+    expect(formatVariation(-0.6)).toMatch(/^-60\s%$/);
+    expect(formatVariation(0.4)).toMatch(/^\+40\s%$/);
+    expect(formatVariation(0)).toMatch(/^0\s%$/);
+  });
+
+  it('rend au plus une decimale avec la virgule francaise', () => {
+    expect(formatVariation(0.333)).toMatch(/^\+33,3\s%$/);
+  });
+
+  it('separe le nombre du pourcentage par une espace fine insecable', () => {
+    const formatted = formatVariation(0.4);
+    expect(formatted.charCodeAt(formatted.length - 2)).toBe(
+      NARROW_NO_BREAK_SPACE
+    );
+  });
+});
+
+describe('resolveVariationToReferenceYear', () => {
+  const indicateurId = toIndicateurId(1);
+  const valued = (value: number): GridCell => ({
+    kind: 'user-data',
+    value,
+    valueId: value,
+    coveringSources: [],
+  });
+  const cellsWith = (byYear: Record<number, GridCell>): Map<CellKey, GridCell> =>
+    new Map(
+      Object.entries(byYear).map(([year, cell]) => [
+        generateCellKey(indicateurId, toYear(Number(year))),
+        cell,
+      ])
+    );
+
+  it('rend la variation d une colonne future vs la valeur de reference', () => {
+    expect(
+      resolveVariationToReferenceYear({
+        cell: valued(40),
+        cells: cellsWith({ 2026: valued(100), 2050: valued(40) }),
+        indicateurId,
+        year: toYear(2050),
+        referenceYear: toYear(2026),
+      })
+    ).toBe(-0.6);
+  });
+
+  it('rend null pour l annee de reference et les annees passees', () => {
+    expect(
+      resolveVariationToReferenceYear({
+        cell: valued(120),
+        cells: cellsWith({ 2026: valued(100), 2020: valued(120) }),
+        indicateurId,
+        year: toYear(2020),
+        referenceYear: toYear(2026),
+      })
+    ).toBe(null);
+  });
+
+  it('rend null sans annee de reference', () => {
+    expect(
+      resolveVariationToReferenceYear({
+        cell: valued(40),
+        cells: cellsWith({ 2050: valued(40) }),
+        indicateurId,
+        year: toYear(2050),
+        referenceYear: null,
+      })
+    ).toBe(null);
+  });
+
+  it('rend null quand la cellule de reference est absente', () => {
+    expect(
+      resolveVariationToReferenceYear({
+        cell: valued(40),
+        cells: cellsWith({ 2050: valued(40) }),
+        indicateurId,
+        year: toYear(2050),
+        referenceYear: toYear(2026),
+      })
+    ).toBe(null);
+  });
+});

--- a/apps/app/src/indicateurs/valeurs/grid/variation/variation.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/variation/variation.ts
@@ -1,0 +1,63 @@
+import { findCell } from '../grid-model';
+import { CellKey, GridCell, IndicateurId, Year } from '../types';
+
+export const computeVariation = ({
+  value,
+  referenceValue,
+}: {
+  value: number;
+  referenceValue: number | null;
+}): number | null => {
+  if (referenceValue === null || referenceValue === 0) {
+    return null;
+  }
+  return (value - referenceValue) / referenceValue;
+};
+
+export const resolveVariationToReferenceYear = ({
+  cell,
+  cells,
+  indicateurId,
+  year,
+  referenceYear,
+}: {
+  cell: GridCell | null;
+  cells: Map<CellKey, GridCell>;
+  indicateurId: IndicateurId;
+  year: Year;
+  referenceYear: Year | null;
+}): number | null => {
+  if (referenceYear === null) {
+    return null;
+  }
+  const isObjective = year > referenceYear;
+  if (!isObjective) {
+    return null;
+  }
+  if (cell === null || cell.value === null) {
+    return null;
+  }
+  const referenceCell = findCell({ cells, indicateurId, year: referenceYear });
+  return computeVariation({
+    value: cell.value,
+    referenceValue: referenceCell?.value ?? null,
+  });
+};
+
+const signPrefix = (percent: number): string => {
+  if (percent > 0) {
+    return '+';
+  }
+  if (percent < 0) {
+    return '-';
+  }
+  return '';
+};
+
+const NARROW_NO_BREAK_SPACE = String.fromCharCode(0x202f);
+
+export const formatVariation = (ratio: number): string => {
+  const percent = Math.round(ratio * 1000) / 10;
+  const magnitude = Math.abs(percent).toString().replace('.', ',');
+  return `${signPrefix(percent)}${magnitude}${NARROW_NO_BREAK_SPACE}%`;
+};

--- a/apps/app/src/indicateurs/valeurs/grid/year-column-header.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/year-column-header.tsx
@@ -60,7 +60,7 @@ export const YearColumnHeader = memo(
         role="columnheader"
         style={{ transform: CSS.Transform.toString(transform), transition }}
         className={cn(
-          'sticky top-0 z-20 min-w-[140px] border border-grey-3 bg-grey-1 p-2 text-right font-bold text-primary-9',
+          'sticky top-0 z-20 min-w-[220px] border border-grey-3 bg-grey-1 p-2 text-right font-bold text-primary-9',
           isDragging && 'opacity-50'
         )}
       >

--- a/apps/app/src/labels/catalog.ts
+++ b/apps/app/src/labels/catalog.ts
@@ -1741,6 +1741,8 @@ export const appLabels = {
     value: number;
     source: string;
   }): string => `${rowLabel}, ${year} : ${value} (open data, source ${source})`,
+  indicateurVariationReference: (variation: string): string =>
+    `${variation} par rapport à l'année de référence`,
   indicateurReordonnerCible: (cible: string): string => `Réordonner ${cible}`,
   indicateurReinitialiserOrdre: "Réinitialiser l'ordre",
   indicateurOrdreReinitialise: 'Ordre réinitialisé',


### PR DESCRIPTION
## P11 — impact objectif en % (display-only)

Chaque cellule d'une **colonne future** (`année > année de référence`) affiche la **variation signée** de sa valeur par rapport à la **valeur de l'année de référence de la même ligne**, sur les **deux types de cellule** : `user-data` (saisie collectivité) **et** `open-data` (source, ex. `snbc` — 100 % des objectifs futurs en DB locale).

- **Variation neutre** (pas de coloration bien/mal : la direction souhaitable est propre à l'indicateur → différé).
- **Masquée** si la réf est absente/nulle. **Display-only** : zéro backend, zéro méthode de port (réf lue dans `cells`).
- **A11y** : reliée à la cellule focusable via `aria-describedby` (annoncée au clavier malgré le roving tabindex).

## Rendu (itéré avec revue visuelle)
- Format **`(-18 %) valeur`** : `%` muté (`text-[0.625rem]`, `grey-5`) **avant** la valeur, valeur en `text-sm` alignée à droite → colonnes de valeurs alignées.
- **Écart `%`↔valeur constant** : input en largeur-contenu (`field-sizing: content`, `size` en fallback), gap fixe `gap-1`.
- **Input sans bordure** (fond transparent, focus via ring, erreur via ring rouge) — s'écarte du DS `Input` (border non neutralisable sans `!important`).
- **Cellules élargies** (`min-w-[220px]`) + badge open-data poussé à gauche (`shrink-0`/`ml-auto`) → source non tronquée.
- **Fixtures Storybook** : trajectoire décroissante (réf 2026 toujours renseignée) pour démontrer le % sur toutes les colonnes futures + garde-fou dans `render-smoke`.

## Contenu
`compute-objectif-impact.ts` (+spec) · `objectif-impact-hint.tsx` · `user-data-cell.tsx` / `open-data-cell.tsx` / `cell-input.tsx` · `use-get-table.tsx` (`objectifImpactFor`, gate `isObjective`) · `year-column-header.tsx` · `catalog.ts` · fixtures + specs.

## Vérifs
Suite grille **76/76** · `tsc --build` exit 0 · ESLint 0. Base `main` (R0/P3–P8 mergés). Réf plan : `2026-07-01-001-feat-indicateur-values-grid-plan` (P11).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Affichage des variations par rapport à une année de référence dans la grille.
  * Ajout d’indices visuels et d’un texte accessible pour expliquer ces variations.
  * Plus d’espace pour l’en-tête des colonnes d’année.

* **Tests**
  * Ajout de tests couvrant le calcul, le formatage et l’affichage des variations.
  * Renforcement des tests des cellules de saisie et des cellules open data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->