### PR TITLE
feat(indicateurs): repasser en saisie manuelle depuis le picker open data

### DIFF
--- a/apps/app/src/indicateurs/valeurs/grid/__tests__/indicateur-values-grid.stories.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/__tests__/indicateur-values-grid.stories.tsx
@@ -20,6 +20,7 @@ import {
   parseCellKey,
   toIndicateurId,
   SelectOpenDataInput,
+  ClearCellInput,
   CellKey,
   CellValueInput,
   GridCell,
@@ -95,6 +96,24 @@ const selectOpenDataInCells = (
   return next;
 };
 
+const clearCellInCells = (
+  cells: Map<CellKey, GridCell>,
+  { indicateurId, year }: ClearCellInput
+): Map<CellKey, GridCell> => {
+  const key = generateCellKey(indicateurId, year);
+  const current = cells.get(key);
+  if (current === undefined) {
+    return cells;
+  }
+  const next = new Map(cells);
+  next.set(key, {
+    kind: 'user-data',
+    value: null,
+    coveringSources: current.coveringSources,
+  });
+  return next;
+};
+
 const rekeyReferenceColumn = ({
   cells,
   referenceYear,
@@ -158,6 +177,13 @@ const InteractiveGrid = (): JSX.Element => {
         setState((previous) => ({
           ...previous,
           cells: selectOpenDataInCells(previous.cells, input),
+        }));
+        return { ok: true, value: undefined };
+      },
+      clearCell: async (input) => {
+        setState((previous) => ({
+          ...previous,
+          cells: clearCellInCells(previous.cells, input),
         }));
         return { ok: true, value: undefined };
       },

--- a/apps/app/src/indicateurs/valeurs/grid/grid-context.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/grid-context.tsx
@@ -28,6 +28,7 @@ const GridContext = createContext<GridContextValue | null>(null);
 export type GridCellServices = {
   saveCellValue: IndicateurValuesGridActions['saveCellValue'];
   selectOpenData: IndicateurValuesGridActions['selectOpenData'];
+  clearCell: IndicateurValuesGridActions['clearCell'];
   unit: string | null;
   notify?: (message: string) => void;
 };
@@ -102,10 +103,17 @@ export const GridProvider = ({
     () => ({
       saveCellValue: actions.saveCellValue,
       selectOpenData: actions.selectOpenData,
+      clearCell: actions.clearCell,
       unit,
       notify,
     }),
-    [actions.saveCellValue, actions.selectOpenData, unit, notify]
+    [
+      actions.saveCellValue,
+      actions.selectOpenData,
+      actions.clearCell,
+      unit,
+      notify,
+    ]
   );
   return (
     <GridContext.Provider value={value}>

--- a/apps/app/src/indicateurs/valeurs/grid/open-data-picker/open-data-picker.spec.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/open-data-picker/open-data-picker.spec.tsx
@@ -32,6 +32,7 @@ const renderPicker = (
       sources={sources}
       onSelect={vi.fn()}
       onClose={vi.fn()}
+      onReset={vi.fn()}
       {...overrides}
     />
   );
@@ -84,5 +85,17 @@ describe('OpenDataPicker', () => {
   it("n'affiche pas la sélection en lot sans columnSelection", () => {
     renderPicker();
     expect(screen.queryByText(/Sélectionner .* pour les/)).toBeNull();
+  });
+
+  it('propose de repasser en saisie manuelle quand une source est sélectionnée', () => {
+    const onReset = vi.fn();
+    renderPicker({ selectedSourceId: 'ame', onReset });
+    fireEvent.click(screen.getByText('Repasser en saisie manuelle'));
+    expect(onReset).toHaveBeenCalled();
+  });
+
+  it('ne propose pas la saisie manuelle quand aucune source n est selectionnee', () => {
+    renderPicker();
+    expect(screen.queryByText('Repasser en saisie manuelle')).toBeNull();
   });
 });

--- a/apps/app/src/indicateurs/valeurs/grid/open-data-picker/open-data-picker.stories.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/open-data-picker/open-data-picker.stories.tsx
@@ -43,6 +43,7 @@ const baseArgs = {
   sources,
   onSelect: (sourceId: string) => window.alert(`Sélection : ${sourceId}`),
   onClose: () => window.alert('Fermeture'),
+  onReset: () => window.alert('Repasser en saisie manuelle'),
 };
 
 export const Selecteur: Story = {

--- a/apps/app/src/indicateurs/valeurs/grid/open-data-picker/open-data-picker.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/open-data-picker/open-data-picker.tsx
@@ -143,6 +143,21 @@ const ColumnSelectionButton = ({
   </button>
 );
 
+const ManualEntryButton = ({
+  onClick,
+}: {
+  onClick: () => void;
+}): JSX.Element => (
+  <button
+    type="button"
+    onClick={onClick}
+    className="mt-2 flex items-center gap-2 rounded-lg border border-grey-3 p-3 text-left text-sm text-grey-8 transition-colors hover:border-primary-4 hover:bg-primary-0"
+  >
+    <Icon icon="edit-line" size="sm" />
+    {appLabels.indicateurRepasserSaisieManuelle}
+  </button>
+);
+
 export type ColumnSelection = {
   source: OpenDataSource;
   count: number;
@@ -158,6 +173,7 @@ type OpenDataPickerProps = {
   selectedSourceId?: string;
   onSelect: (sourceId: string) => void;
   onClose: () => void;
+  onReset: () => void;
   columnSelection?: ColumnSelection;
 };
 
@@ -170,32 +186,37 @@ export const OpenDataPicker = ({
   selectedSourceId,
   onSelect,
   onClose,
+  onReset,
   columnSelection,
-}: OpenDataPickerProps): JSX.Element => (
-  <section
-    aria-label={appLabels.indicateurCompleterOpenData}
-    className="flex w-80 flex-col p-3"
-  >
-    <PickerHeader
-      secteur={secteur}
-      polluant={polluant}
-      year={year}
-      onClose={onClose}
-    />
-    <SourceList
-      sources={sources}
-      year={year}
-      unit={unit}
-      selectedSourceId={selectedSourceId}
-      onSelect={onSelect}
-    />
-    {columnSelection !== undefined ? (
-      <ColumnSelectionButton
-        libelle={columnSelection.source.libelle}
-        count={columnSelection.count}
+}: OpenDataPickerProps): JSX.Element => {
+  const canGoBackToManualMode = selectedSourceId !== undefined;
+  return (
+    <section
+      aria-label={appLabels.indicateurCompleterOpenData}
+      className="flex w-80 flex-col p-3"
+    >
+      <PickerHeader
         secteur={secteur}
-        onSelect={columnSelection.onSelect}
+        polluant={polluant}
+        year={year}
+        onClose={onClose}
       />
-    ) : null}
-  </section>
-);
+      <SourceList
+        sources={sources}
+        year={year}
+        unit={unit}
+        selectedSourceId={selectedSourceId}
+        onSelect={onSelect}
+      />
+      {columnSelection !== undefined ? (
+        <ColumnSelectionButton
+          libelle={columnSelection.source.libelle}
+          count={columnSelection.count}
+          secteur={secteur}
+          onSelect={columnSelection.onSelect}
+        />
+      ) : null}
+      {canGoBackToManualMode ? <ManualEntryButton onClick={onReset} /> : null}
+    </section>
+  );
+};

--- a/apps/app/src/indicateurs/valeurs/grid/open-data-picker/open-data-selector.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/open-data-picker/open-data-selector.tsx
@@ -28,7 +28,7 @@ export const OpenDataSelector = ({
   columnSelection,
   children,
 }: OpenDataSelectorProps): JSX.Element => {
-  const { selectOpenData, unit, notify } = useGridCellServices();
+  const { selectOpenData, clearCell, unit, notify } = useGridCellServices();
   return (
     <DropdownFloater
       placement="bottom-end"
@@ -54,6 +54,14 @@ export const OpenDataSelector = ({
             }
           }}
           onClose={close}
+          onReset={async () => {
+            const resetResult = await clearCell({ indicateurId, year });
+            if (resetResult.ok) {
+              close();
+            } else {
+              notify?.(appLabels.indicateurRepasserSaisieEchec);
+            }
+          }}
           columnSelection={
             columnSelection === undefined
               ? undefined

--- a/apps/app/src/indicateurs/valeurs/grid/types.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/types.ts
@@ -102,7 +102,7 @@ export type SelectOpenDataInput = {
 
 export type ClearCellInput = {
   indicateurId: IndicateurId;
-  valueId: number;
+  year: Year;
 };
 
 export type BulkOutcome = {

--- a/apps/app/src/labels/catalog.ts
+++ b/apps/app/src/labels/catalog.ts
@@ -1772,6 +1772,9 @@ export const appLabels = {
   indicateurValeurOpenDataDisponible: 'Valeur open data disponible',
   indicateurSelectionnerValeurEchec:
     'La sélection de la valeur open data a échoué',
+  indicateurRepasserSaisieManuelle: 'Repasser en saisie manuelle',
+  indicateurRepasserSaisieEchec:
+    'Le retour en saisie manuelle a échoué',
   indicateurCompleterOpenData: "Compléter avec de l'open data",
   indicateurContexteCellule: (
     secteur: string,


### PR DESCRIPTION
## P9 (réduit) — sortir de l'adoption open data

Détail de P9 après revue du code existant : sur les trois actions prévues (Remplacer / Changer / Vider), **« Changer de source » est déjà couvert** par P8 (recliquer une cellule adoptée rouvre le `OpenDataSelector` → on choisit une autre source). Il ne restait que **retirer l'adoption** — d'où cette version réduite, **sans `Modal`** : une action en bas du picker existant (fidèle à l'ethos « réutiliser les primitives »).

### Comportement
- Quand une cellule a **adopté** une source (`selectedSourceId` défini), le picker affiche en bas **« Repasser en saisie manuelle »**.
- Au clic → `clearCell` → la cellule redevient **user-data vide et éditable** → l'utilisateur peut ressaisir sa valeur (= « remplacer ») ou la laisser vide (= « vider »). Une seule action couvre les deux.
- Masqué quand la cellule n'est pas adoptée.

### Contrat
`ClearCellInput` passe de `{ indicateurId, valueId }` à **`{ indicateurId, year }`** (identité de position) : une cellule adoptée n'expose pas de `valueId`, et la position identifie la cellule pour les deux types. Safe : `clearCell` n'avait **aucun consommateur** avant cette PR.

### Contenu
- `open-data-picker.tsx` : `ManualEntryButton` + prop `onReset` (requise) + `canGoBackToManualMode`.
- `open-data-selector.tsx` : câble `onReset` → `clearCell({ indicateurId, year })` (close/notify).
- `grid-context.tsx` : `clearCell` exposé dans `GridCellServices`.
- `types.ts` : `ClearCellInput` par position.
- `catalog.ts` : libellés `indicateurRepasserSaisieManuelle` / `…Echec`.
- Stories (picker + grille : reconcile `clearCell` → cellule vide) + spec picker (bouton visible/masqué + `onReset` appelé).

### Vérifs
Suite grille **68/68** · `tsc --build` exit 0 · ESLint 0. Base `main` (P8 mergé). Indépendant de #4677.

Réf plan : `2026-07-01-001-…-grid-plan` (P9 — version réduite, `Modal` abandonné car « Changer » déjà inline).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Ajout d’une action pour revenir à la saisie manuelle depuis le sélecteur de source.
  * Possibilité d’effacer la valeur d’une cellule dans la grille d’indicateurs.

* **Correctifs**
  * Le retour à la saisie manuelle met désormais bien à jour l’affichage et ferme le panneau en cas de succès.
  * Un संदेश d’erreur s’affiche si l’opération de retour à la saisie manuelle échoue.

* **Tests**
  * Couverture ajoutée pour vérifier l’affichage et le fonctionnement du bouton de retour à la saisie manuelle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->