### PR TITLE
feat(indicateurs): grille en mode plat ou groupe selon la forme du prop

### DIFF
--- a/apps/app/src/indicateurs/valeurs/grid/__tests__/grid-fixtures.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/__tests__/grid-fixtures.ts
@@ -2,6 +2,7 @@ import {
   generateCellKey,
   CellKey,
   GridCell,
+  GridGroups,
   GridRowGroup,
   IndicateurValuesGridActions,
   OpenDataSource,
@@ -31,6 +32,13 @@ export const fakeGroups: GridRowGroup[] = sectors.map((sector, sectorIndex) => (
     label: pollutant,
   })),
 }));
+
+export const toGridInput = (groups: GridRowGroup[]): GridGroups =>
+  Object.fromEntries(
+    groups.map((group) => [group.id, { label: group.label, rows: group.rows }])
+  );
+
+export const fakeGroupsInput: GridGroups = toGridInput(fakeGroups);
 
 const sourceDefs = [
   {
@@ -113,9 +121,11 @@ const buildCell = (indicateurId: number, year: number): GridCell => {
   };
 };
 
-export const fakeCells = (): Map<CellKey, GridCell> =>
+export const fakeCellsForGroups = (
+  groups: GridRowGroup[]
+): Map<CellKey, GridCell> =>
   new Map(
-    fakeGroups.flatMap((group) =>
+    groups.flatMap((group) =>
       group.rows.flatMap((row) =>
         fakeYears.map(
           (year) =>
@@ -124,6 +134,9 @@ export const fakeCells = (): Map<CellKey, GridCell> =>
       )
     )
   );
+
+export const fakeCells = (): Map<CellKey, GridCell> =>
+  fakeCellsForGroups(fakeGroups);
 
 export const fakeGridActions: IndicateurValuesGridActions = {
   saveCellValue: async () => ({ ok: true, value: undefined }),

--- a/apps/app/src/indicateurs/valeurs/grid/__tests__/indicateur-values-grid.stories.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/__tests__/indicateur-values-grid.stories.tsx
@@ -4,20 +4,25 @@ import { Button } from '@tet/ui';
 import { JSX, useCallback, useMemo, useState } from 'react';
 import {
   fakeCells,
+  fakeCellsForGroups,
   fakeGridActions,
   fakeGroups,
+  fakeGroupsInput,
   fakeReferenceYear,
   fakeYears,
+  toGridInput,
 } from './grid-fixtures';
 import { IndicateurValuesGrid } from '../indicateur-values-grid';
 import { rowDragId } from '../drag-reorder/use-grid-reorder';
 import {
   generateCellKey,
   parseCellKey,
+  toIndicateurId,
   SelectOpenDataInput,
   CellKey,
   CellValueInput,
   GridCell,
+  GridRow,
   GridRowGroup,
   IndicateurValuesGridActions,
   Year,
@@ -210,7 +215,7 @@ const InteractiveGrid = (): JSX.Element => {
         {"Réinitialiser l'ordre des polluants"}
       </Button>
       <IndicateurValuesGrid
-        groups={groups}
+        rows={toGridInput(groups)}
         years={state.years}
         referenceYear={state.referenceYear}
         unit="t/an"
@@ -228,9 +233,98 @@ export const Polluants: Story = {
   render: () => <InteractiveGrid />,
 };
 
+const secteurLabels = [
+  'Résidentiel',
+  'Tertiaire',
+  'Transport routier',
+  'Agriculture',
+  'Industrie',
+];
+
+const polluantLabels = ['NOx', 'PM10'] as const;
+type PolluantLabel = (typeof polluantLabels)[number];
+
+const secteurRows = (firstIndicateurId: number): GridRow[] =>
+  secteurLabels.map((secteur, index) => ({
+    indicateurId: toIndicateurId(firstIndicateurId + index),
+    label: secteur,
+  }));
+
+const rowsByPolluant: Record<PolluantLabel, GridRow[]> = {
+  NOx: secteurRows(100),
+  PM10: secteurRows(200),
+};
+
+const PolluantSwitchGrid = (): JSX.Element => {
+  const [selectedPolluant, setSelectedPolluant] =
+    useState<PolluantLabel>('NOx');
+  const [cells, setCells] = useState<Map<CellKey, GridCell>>(() =>
+    fakeCellsForGroups(
+      polluantLabels.map((polluant) => ({
+        id: polluant,
+        label: polluant,
+        rows: rowsByPolluant[polluant],
+      }))
+    )
+  );
+
+  const actions = useMemo<IndicateurValuesGridActions>(
+    () => ({
+      ...fakeGridActions,
+      saveCellValue: async (input) => {
+        setCells((previous) => withValues(previous, [input]));
+        return { ok: true, value: undefined };
+      },
+      saveCellValues: async (inputs) => {
+        setCells((previous) => withValues(previous, inputs));
+        return { ok: true, value: { written: inputs.length, failed: [] } };
+      },
+      selectOpenData: async (input) => {
+        setCells((previous) => selectOpenDataInCells(previous, input));
+        return { ok: true, value: undefined };
+      },
+    }),
+    []
+  );
+
+  return (
+    <div className="flex flex-col items-start gap-2">
+      <div role="group" aria-label="Choix du polluant" className="flex gap-2">
+        {polluantLabels.map((polluant) => {
+          const isSelected = polluant === selectedPolluant;
+          return (
+            <Button
+              key={polluant}
+              size="xs"
+              variant={isSelected ? 'primary' : 'outlined'}
+              aria-pressed={isSelected}
+              onClick={() => setSelectedPolluant(polluant)}
+            >
+              {polluant}
+            </Button>
+          );
+        })}
+      </div>
+      <IndicateurValuesGrid
+        rows={rowsByPolluant[selectedPolluant]}
+        years={fakeYears}
+        referenceYear={fakeReferenceYear}
+        unit="t/an"
+        cells={cells}
+        actions={actions}
+        notify={(message) => window.alert(message)}
+      />
+    </div>
+  );
+};
+
+export const SwitchEntrePolluants: Story = {
+  render: () => <PolluantSwitchGrid />,
+};
+
 export const Vide: Story = {
   args: {
-    groups: fakeGroups,
+    rows: fakeGroupsInput,
     years: fakeYears,
     referenceYear: fakeReferenceYear,
     unit: 't/an',

--- a/apps/app/src/indicateurs/valeurs/grid/__tests__/render-smoke.spec.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/__tests__/render-smoke.spec.tsx
@@ -3,16 +3,17 @@ import { describe, expect, it } from 'vitest';
 import {
   fakeCells,
   fakeGridActions,
-  fakeGroups,
+  fakeGroupsInput,
   fakeReferenceYear,
   fakeYears,
 } from './grid-fixtures';
 import { IndicateurValuesGrid } from '../indicateur-values-grid';
+import { GridGroups, GridRow, toIndicateurId } from '../types';
 
 const renderGrid = (): void => {
   render(
     <IndicateurValuesGrid
-      groups={fakeGroups}
+      rows={fakeGroupsInput}
       years={fakeYears}
       referenceYear={fakeReferenceYear}
       cells={fakeCells()}
@@ -32,5 +33,59 @@ describe('IndicateurValuesGrid smoke', () => {
     expect(
       screen.getAllByText(/par rapport à l'année de référence/).length
     ).toBeGreaterThan(0);
+  });
+});
+
+const secteursDuPolluant: GridRow[] = [
+  { indicateurId: toIndicateurId(1), label: 'Résidentiel' },
+  { indicateurId: toIndicateurId(2), label: 'Transport routier' },
+];
+
+const polluantUnique: GridGroups = {
+  nox: { label: 'NOx', rows: secteursDuPolluant },
+};
+
+describe('IndicateurValuesGrid colonne de groupe', () => {
+  it('affiche le libelle du groupe quand le prop est un objet groupe', () => {
+    render(
+      <IndicateurValuesGrid
+        rows={fakeGroupsInput}
+        years={fakeYears}
+        referenceYear={fakeReferenceYear}
+        cells={fakeCells()}
+        actions={fakeGridActions}
+      />
+    );
+
+    expect(screen.getByText('Résidentiel')).toBeDefined();
+  });
+
+  it('affiche le libelle du groupe meme quand le groupe est unique', () => {
+    render(
+      <IndicateurValuesGrid
+        rows={polluantUnique}
+        years={fakeYears}
+        referenceYear={fakeReferenceYear}
+        cells={new Map()}
+        actions={fakeGridActions}
+      />
+    );
+
+    expect(screen.getByText('NOx')).toBeDefined();
+  });
+
+  it('masque la colonne de groupe quand le prop est un tableau plat', () => {
+    render(
+      <IndicateurValuesGrid
+        rows={secteursDuPolluant}
+        years={fakeYears}
+        referenceYear={fakeReferenceYear}
+        cells={new Map()}
+        actions={fakeGridActions}
+      />
+    );
+
+    expect(screen.queryByText('NOx')).toBeNull();
+    expect(screen.getByText('Résidentiel')).toBeDefined();
   });
 });

--- a/apps/app/src/indicateurs/valeurs/grid/drag-reorder/sortable-group-body.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/drag-reorder/sortable-group-body.tsx
@@ -16,9 +16,11 @@ import { groupDragId, rowDragId } from './use-grid-reorder';
 export const SortableGroupBody = ({
   group,
   rows,
+  isGrouped,
 }: {
   group: GridRowGroup;
   rows: Row<GridDisplayRow>[];
+  isGrouped: boolean;
 }): JSX.Element => {
   const {
     attributes,
@@ -47,7 +49,7 @@ export const SortableGroupBody = ({
             key={row.id}
             row={row}
             groupHandle={
-              row.original.isGroupStart
+              isGrouped && row.original.isGroupStart
                 ? { attributes, listeners, setActivatorNodeRef }
                 : undefined
             }

--- a/apps/app/src/indicateurs/valeurs/grid/grid-body.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/grid-body.tsx
@@ -12,9 +12,11 @@ import { GridRowGroup } from './types';
 export const GridBody = ({
   rows,
   groups,
+  isGrouped,
 }: {
   rows: Row<GridDisplayRow>[];
   groups: GridRowGroup[];
+  isGrouped: boolean;
 }): JSX.Element => (
   <SortableContext
     items={groups.map((group) => groupDragId(group.id))}
@@ -25,6 +27,7 @@ export const GridBody = ({
         key={group.id}
         group={group}
         rows={rows.filter((row) => row.original.groupId === group.id)}
+        isGrouped={isGrouped}
       />
     ))}
   </SortableContext>

--- a/apps/app/src/indicateurs/valeurs/grid/grid-context.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/grid-context.tsx
@@ -11,6 +11,7 @@ import {
 
 export type GridContextValue = {
   groups: GridRowGroup[];
+  isGrouped: boolean;
   years: Year[];
   referenceYear: Year | null;
   unit: string | null;
@@ -58,6 +59,7 @@ export const useGridCellServices = (): GridCellServices => {
 export const GridProvider = ({
   children,
   groups,
+  isGrouped,
   years,
   referenceYear,
   unit,
@@ -71,6 +73,7 @@ export const GridProvider = ({
   const value = useMemo<GridContextValue>(
     () => ({
       groups,
+      isGrouped,
       years,
       referenceYear,
       unit,
@@ -83,6 +86,7 @@ export const GridProvider = ({
     }),
     [
       groups,
+      isGrouped,
       years,
       referenceYear,
       unit,

--- a/apps/app/src/indicateurs/valeurs/grid/grid-frame.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/grid-frame.tsx
@@ -28,6 +28,7 @@ const dragType = (dragId: string): string => dragId.split('-')[0];
 export const GridFrame = (): JSX.Element => {
   const {
     groups,
+    isGrouped,
     years,
     referenceYear,
     unit,
@@ -203,9 +204,14 @@ export const GridFrame = (): JSX.Element => {
               years={orderedYears}
               unit={unit}
               referenceYear={referenceYear}
+              isGrouped={isGrouped}
               onReferenceYearChange={onReferenceYearChange}
             />
-            <GridBody rows={table.getRowModel().rows} groups={orderedGroups} />
+            <GridBody
+              rows={table.getRowModel().rows}
+              groups={orderedGroups}
+              isGrouped={isGrouped}
+            />
           </table>
         </div>
       </div>

--- a/apps/app/src/indicateurs/valeurs/grid/grid-head.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/grid-head.tsx
@@ -11,6 +11,7 @@ type GridHeadProps = {
   years: Year[];
   unit: string | null;
   referenceYear: Year | null;
+  isGrouped: boolean;
   onReferenceYearChange?: (year: Year) => void;
 };
 
@@ -18,14 +19,17 @@ export const GridHead = ({
   years,
   unit,
   referenceYear,
+  isGrouped,
   onReferenceYearChange,
 }: GridHeadProps): JSX.Element => (
   <thead>
     <tr role="row">
-      <th
-        scope="col"
-        className="sticky left-0 top-0 z-30 border border-grey-3 bg-grey-1 p-2"
-      />
+      {isGrouped && (
+        <th
+          scope="col"
+          className="sticky left-0 top-0 z-30 border border-grey-3 bg-grey-1 p-2"
+        />
+      )}
       <th
         scope="col"
         className="sticky top-0 z-20 border border-grey-3 bg-grey-1 p-2"

--- a/apps/app/src/indicateurs/valeurs/grid/grid-model.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/grid-model.ts
@@ -2,10 +2,33 @@ import {
   generateCellKey,
   CellKey,
   GridCell,
+  GridInput,
   GridRowGroup,
   IndicateurId,
   Year,
 } from './types';
+
+export const FLAT_GROUP_ID = '__flat__';
+
+export type NormalizedGridInput = {
+  groups: GridRowGroup[];
+  isGrouped: boolean;
+};
+
+export const normalizeGridInput = (input: GridInput): NormalizedGridInput =>
+  Array.isArray(input)
+    ? {
+        groups: [{ id: FLAT_GROUP_ID, label: '', rows: input }],
+        isGrouped: false,
+      }
+    : {
+        groups: Object.entries(input).map(([id, { label, rows }]) => ({
+          id,
+          label,
+          rows,
+        })),
+        isGrouped: true,
+      };
 
 export type GridDisplayRow = {
   indicateurId: IndicateurId;

--- a/apps/app/src/indicateurs/valeurs/grid/indicateur-values-grid.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/indicateur-values-grid.tsx
@@ -3,16 +3,17 @@
 import { JSX } from 'react';
 import { GridProvider } from './grid-context';
 import { GridFrame } from './grid-frame';
+import { normalizeGridInput } from './grid-model';
 import {
   CellKey,
   GridCell,
-  GridRowGroup,
+  GridInput,
   IndicateurValuesGridActions,
   Year,
 } from './types';
 
 export type IndicateurValuesGridProps = {
-  groups: GridRowGroup[];
+  rows: GridInput;
   years: Year[];
   referenceYear?: Year;
   unit?: string;
@@ -25,7 +26,7 @@ export type IndicateurValuesGridProps = {
 };
 
 export const IndicateurValuesGrid = ({
-  groups,
+  rows,
   years,
   referenceYear,
   unit,
@@ -35,21 +36,25 @@ export const IndicateurValuesGrid = ({
   notify,
   onReorderRows,
   onReferenceYearChange,
-}: IndicateurValuesGridProps): JSX.Element => (
-  <GridProvider
-    groups={groups}
-    years={years}
-    referenceYear={referenceYear ?? null}
-    unit={unit ?? null}
-    cells={cells}
-    isLoading={isLoading}
-    actions={actions}
-    notify={notify}
-    onReorderRows={onReorderRows}
-    onReferenceYearChange={onReferenceYearChange}
-  >
-    <div className="rounded-xl border border-grey-3 bg-white p-4">
-      <GridFrame />
-    </div>
-  </GridProvider>
-);
+}: IndicateurValuesGridProps): JSX.Element => {
+  const { groups, isGrouped } = normalizeGridInput(rows);
+  return (
+    <GridProvider
+      groups={groups}
+      isGrouped={isGrouped}
+      years={years}
+      referenceYear={referenceYear ?? null}
+      unit={unit ?? null}
+      cells={cells}
+      isLoading={isLoading}
+      actions={actions}
+      notify={notify}
+      onReorderRows={onReorderRows}
+      onReferenceYearChange={onReferenceYearChange}
+    >
+      <div className="rounded-xl border border-grey-3 bg-white p-4">
+        <GridFrame />
+      </div>
+    </GridProvider>
+  );
+};

--- a/apps/app/src/indicateurs/valeurs/grid/keyboard-navigation/keyboard-nav.spec.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/keyboard-navigation/keyboard-nav.spec.tsx
@@ -11,7 +11,7 @@ import {
   generateCellKey,
   CellKey,
   GridCell,
-  GridRowGroup,
+  GridRow,
   IndicateurValuesGridActions,
   toIndicateurId,
   toYear,
@@ -21,16 +21,10 @@ afterEach(cleanup);
 
 const years = [2030, 2036].map(toYear);
 
-const groups: GridRowGroup[] = [
-  {
-    id: 'g',
-    label: 'G',
-    rows: [
-      { indicateurId: toIndicateurId(1), label: 'A' },
-      { indicateurId: toIndicateurId(2), label: 'B' },
-      { indicateurId: toIndicateurId(3), label: 'C' },
-    ],
-  },
+const rows: GridRow[] = [
+  { indicateurId: toIndicateurId(1), label: 'A' },
+  { indicateurId: toIndicateurId(2), label: 'B' },
+  { indicateurId: toIndicateurId(3), label: 'C' },
 ];
 
 const userData: GridCell = { kind: 'user-data', value: null, coveringSources: [] };
@@ -56,7 +50,7 @@ const renderGrid = (
 ): HTMLElement =>
   render(
     <IndicateurValuesGrid
-      groups={groups}
+      rows={rows}
       years={years}
       cells={cells}
       actions={actions}
@@ -133,7 +127,7 @@ describe('IndicateurValuesGrid keyboard navigation', () => {
   it('préserve le roving tabindex quand la map cells est reconstruite', () => {
     const { container, rerender } = render(
       <IndicateurValuesGrid
-        groups={groups}
+        rows={rows}
         years={years}
         cells={cells}
         actions={fakeGridActions}
@@ -144,7 +138,7 @@ describe('IndicateurValuesGrid keyboard navigation', () => {
 
     rerender(
       <IndicateurValuesGrid
-        groups={groups}
+        rows={rows}
         years={years}
         cells={new Map(cells)}
         actions={fakeGridActions}
@@ -157,7 +151,7 @@ describe('IndicateurValuesGrid keyboard navigation', () => {
   it('rétablit une cellule tabbable après remplacement du nœud tabbable', () => {
     const { container, rerender } = render(
       <IndicateurValuesGrid
-        groups={groups}
+        rows={rows}
         years={years}
         cells={cells}
         actions={fakeGridActions}
@@ -169,7 +163,7 @@ describe('IndicateurValuesGrid keyboard navigation', () => {
     swapped.set(generateCellKey(toIndicateurId(1), toYear(2030)), openData);
     rerender(
       <IndicateurValuesGrid
-        groups={groups}
+        rows={rows}
         years={years}
         cells={swapped}
         actions={fakeGridActions}
@@ -187,7 +181,7 @@ describe('IndicateurValuesGrid keyboard navigation', () => {
     sparseCells.delete(generateCellKey(toIndicateurId(2), toYear(2030)));
     const container = render(
       <IndicateurValuesGrid
-        groups={groups}
+        rows={rows}
         years={years}
         cells={sparseCells}
         actions={fakeGridActions}

--- a/apps/app/src/indicateurs/valeurs/grid/paste/grid-paste.spec.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/paste/grid-paste.spec.tsx
@@ -7,7 +7,7 @@ import {
   generateCellKey,
   CellKey,
   GridCell,
-  GridRowGroup,
+  GridRow,
   IndicateurValuesGridActions,
   toIndicateurId,
   toYear,
@@ -17,15 +17,9 @@ afterEach(cleanup);
 
 const years = [2030, 2036].map(toYear);
 
-const groups: GridRowGroup[] = [
-  {
-    id: 'g',
-    label: 'G',
-    rows: [
-      { indicateurId: toIndicateurId(1), label: 'A' },
-      { indicateurId: toIndicateurId(2), label: 'B' },
-    ],
-  },
+const rows: GridRow[] = [
+  { indicateurId: toIndicateurId(1), label: 'A' },
+  { indicateurId: toIndicateurId(2), label: 'B' },
 ];
 
 const userData: GridCell = { kind: 'user-data', value: null, coveringSources: [] };
@@ -50,7 +44,7 @@ const renderGrid = (
 ): HTMLElement =>
   render(
     <IndicateurValuesGrid
-      groups={groups}
+      rows={rows}
       years={years}
       cells={cells}
       actions={actions}

--- a/apps/app/src/indicateurs/valeurs/grid/types.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/types.ts
@@ -74,6 +74,15 @@ export type GridRowGroup = {
   rows: GridRow[];
 };
 
+export type GridGroupInput = {
+  label: string;
+  rows: GridRow[];
+};
+
+export type GridGroups = Record<string, GridGroupInput>;
+
+export type GridInput = GridRow[] | GridGroups;
+
 export type Result<T = void> =
   | { ok: true; value: T }
   | { ok: false; error: string };


### PR DESCRIPTION
## Ce que ça fait

La grille de valeurs accepte deux formes de données et affiche l'une ou l'autre selon la forme reçue.

`IndicateurValuesGrid` prend `rows: GridInput` :

```ts
type GridInput =
  | GridRow[]                                    // tableau plat
  | Record<string, { label; rows: GridRow[] }>   // objet indexe par groupe
```

- **Tableau plat** : colonnes = années, lignes = les `GridRow`. Pas de colonne de groupe, pas de poignee de reordonnancement de groupe.
- **Objet groupe** : une colonne de groupe (libelle + `rowSpan`) precede les lignes de chaque groupe, comme avant.

`normalizeGridInput` (`grid-model.ts`) discrimine par `Array.isArray`, produit les `GridRowGroup[]` internes et le drapeau `isGrouped` propage via le contexte.

La navigation clavier et le collage sont identiques dans les deux modes : ils sont indexes sur les `CellKey` (`indicateurId:year`), pas sur les colonnes.

## Fichiers

- `types.ts` — `GridInput`, `GridGroups`, `GridGroupInput`.
- `grid-model.ts` — `normalizeGridInput`.
- `indicateur-values-grid.tsx` — API `rows` + normalisation.
- `grid-context.tsx`, `grid-frame.tsx`, `grid-body.tsx`, `grid-head.tsx`, `drag-reorder/sortable-group-body.tsx` — propagation et gating sur `isGrouped`.
- Fixtures — `fakeCellsForGroups`, `toGridInput`, `fakeGroupsInput`.
- Specs `keyboard-nav` / `grid-paste` — en tableau plat.

## Tests

- `render-smoke.spec.tsx` : objet groupe → libelle de groupe affiche ; objet mono-groupe → affiche ; tableau plat → masque.
- Suite grille : 83 tests verts.

## Story

`SwitchEntrePolluants` : un selecteur NOx/PM10 hors grille bascule entre deux polluants, chacun rendu en tableau plat de secteurs, saisies conservees au switch.
