### PR TITLE
feat(indicateurs): listener de snapshot des choix de la grille de valeurs

### DIFF
--- a/apps/app/src/indicateurs/valeurs/grid/__tests__/grid-fixtures.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/__tests__/grid-fixtures.ts
@@ -28,7 +28,7 @@ export const fakeGroups: GridRowGroup[] = sectors.map((sector, sectorIndex) => (
   id: `secteur-${sectorIndex}`,
   label: sector,
   rows: pollutants.map((pollutant, pollutantIndex) => ({
-    indicateurId: toIndicateurId(sectorIndex * 10 + pollutantIndex),
+    indicateurId: toIndicateurId(1200 + sectorIndex * 10 + pollutantIndex),
     label: pollutant,
   })),
 }));

--- a/apps/app/src/indicateurs/valeurs/grid/__tests__/indicateur-values-grid.stories.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/__tests__/indicateur-values-grid.stories.tsx
@@ -12,6 +12,7 @@ import {
   fakeYears,
   toGridInput,
 } from './grid-fixtures';
+import { IndicateurChoicesSnapshot } from '../choices-snapshot';
 import { IndicateurValuesGrid } from '../indicateur-values-grid';
 import { rowDragId } from '../drag-reorder/use-grid-reorder';
 import {
@@ -128,6 +129,7 @@ const InteractiveGrid = (): JSX.Element => {
     cells: fakeCells(),
   }));
   const [groups, setGroups] = useState<GridRowGroup[]>(fakeGroups);
+  const [snapshot, setSnapshot] = useState<IndicateurChoicesSnapshot>({});
 
   const actions = useMemo<IndicateurValuesGridActions>(
     () => ({
@@ -211,9 +213,18 @@ const InteractiveGrid = (): JSX.Element => {
 
   return (
     <div className="flex flex-col items-start gap-2">
-      <Button size="xs" variant="outlined" onClick={resetRowOrder}>
-        {"Réinitialiser l'ordre des polluants"}
-      </Button>
+      <div className="flex gap-2">
+        <Button size="xs" variant="outlined" onClick={resetRowOrder}>
+          {"Réinitialiser l'ordre des polluants"}
+        </Button>
+        <Button
+          size="xs"
+          variant="outlined"
+          onClick={() => window.alert(JSON.stringify(snapshot, null, 2))}
+        >
+          Afficher le snapshot
+        </Button>
+      </div>
       <IndicateurValuesGrid
         rows={toGridInput(groups)}
         years={state.years}
@@ -224,6 +235,7 @@ const InteractiveGrid = (): JSX.Element => {
         notify={(message) => window.alert(message)}
         onReorderRows={onReorderRows}
         onReferenceYearChange={onReferenceYearChange}
+        onSnapshotChange={setSnapshot}
       />
     </div>
   );

--- a/apps/app/src/indicateurs/valeurs/grid/choices-snapshot.spec.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/choices-snapshot.spec.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { toChoicesSnapshot } from './choices-snapshot';
+import {
+  CellKey,
+  GridCell,
+  generateCellKey,
+  toIndicateurId,
+  toYear,
+} from './types';
+
+const cellAt = (
+  indicateurId: number,
+  year: number,
+  cell: GridCell
+): [CellKey, GridCell] => [
+  generateCellKey(toIndicateurId(indicateurId), toYear(year)),
+  cell,
+];
+
+const openDataCell: GridCell = {
+  kind: 'open-data',
+  value: 180,
+  selectedSourceId: 'citepa',
+  source: {
+    sourceId: 'citepa',
+    libelle: 'CITEPA',
+    methodologie: null,
+    dateVersion: '2026-01-01',
+  },
+  coveringSources: [],
+};
+
+const filledUserCell: GridCell = {
+  kind: 'user-data',
+  value: 168,
+  valueId: 42,
+  coveringSources: [],
+};
+
+const emptyUserCell: GridCell = {
+  kind: 'user-data',
+  value: null,
+  coveringSources: [],
+};
+
+describe('toChoicesSnapshot', () => {
+  it('regroupe les choix par indicateur (valeur maison = source null, open data = source)', () => {
+    const snapshot = toChoicesSnapshot(
+      new Map([
+        cellAt(3, 2026, filledUserCell),
+        cellAt(3, 2030, openDataCell),
+      ])
+    );
+    expect(snapshot).toEqual({
+      [toIndicateurId(3)]: [
+        { year: toYear(2026), value: 168, source: null },
+        {
+          year: toYear(2030),
+          value: 180,
+          source: { sourceId: 'citepa', libelle: 'CITEPA' },
+        },
+      ],
+    });
+  });
+
+  it('ignore les cellules user-data sans valeur (aucun choix)', () => {
+    expect(toChoicesSnapshot(new Map([cellAt(3, 2036, emptyUserCell)]))).toEqual(
+      {}
+    );
+  });
+});

--- a/apps/app/src/indicateurs/valeurs/grid/choices-snapshot.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/choices-snapshot.ts
@@ -1,0 +1,46 @@
+import { CellKey, GridCell, IndicateurId, Year, parseCellKey } from './types';
+
+export type ChoiceSource = { sourceId: string; libelle: string };
+
+export type IndicateurYearChoice = {
+  year: Year;
+  value: number;
+  source: ChoiceSource | null;
+};
+
+export type IndicateurChoicesSnapshot = Record<IndicateurId, IndicateurYearChoice[]>;
+
+const toYearValue = (
+  cell: GridCell
+): { value: number; source: ChoiceSource | null } | null => {
+  if (cell.kind === 'open-data') {
+    return {
+      value: cell.value,
+      source: { sourceId: cell.selectedSourceId, libelle: cell.source.libelle },
+    };
+  }
+  if (cell.value === null) {
+    return null;
+  }
+  return { value: cell.value, source: null };
+};
+
+export const toChoicesSnapshot = (
+  cells: Map<CellKey, GridCell>
+): IndicateurChoicesSnapshot =>
+  Array.from(cells)
+    .flatMap(([key, cell]) => {
+      const yearValue = toYearValue(cell);
+      if (yearValue === null) {
+        return [];
+      }
+      const { indicateurId, year } = parseCellKey(key);
+      return [{ indicateurId, year, ...yearValue }];
+    })
+    .reduce<IndicateurChoicesSnapshot>(
+      (snapshot, { indicateurId, ...yearChoice }) => ({
+        ...snapshot,
+        [indicateurId]: [...(snapshot[indicateurId] ?? []), yearChoice],
+      }),
+      {}
+    );

--- a/apps/app/src/indicateurs/valeurs/grid/indicateur-values-grid.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/indicateur-values-grid.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { JSX } from 'react';
+import { IndicateurChoicesSnapshot } from './choices-snapshot';
 import { GridProvider } from './grid-context';
 import { GridFrame } from './grid-frame';
 import { normalizeGridInput } from './grid-model';
@@ -11,6 +12,7 @@ import {
   IndicateurValuesGridActions,
   Year,
 } from './types';
+import { useChoicesSnapshot } from './use-choices-snapshot';
 
 export type IndicateurValuesGridProps = {
   rows: GridInput;
@@ -23,6 +25,7 @@ export type IndicateurValuesGridProps = {
   notify?: (message: string) => void;
   onReorderRows?: (groupId: string, activeId: string, overId: string) => void;
   onReferenceYearChange?: (year: Year) => void;
+  onSnapshotChange?: (snapshot: IndicateurChoicesSnapshot) => void;
 };
 
 export const IndicateurValuesGrid = ({
@@ -36,8 +39,10 @@ export const IndicateurValuesGrid = ({
   notify,
   onReorderRows,
   onReferenceYearChange,
+  onSnapshotChange,
 }: IndicateurValuesGridProps): JSX.Element => {
   const { groups, isGrouped } = normalizeGridInput(rows);
+  useChoicesSnapshot(cells, onSnapshotChange);
   return (
     <GridProvider
       groups={groups}

--- a/apps/app/src/indicateurs/valeurs/grid/use-choices-snapshot.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/use-choices-snapshot.ts
@@ -1,0 +1,16 @@
+import { useEffect, useMemo } from 'react';
+import {
+  IndicateurChoicesSnapshot,
+  toChoicesSnapshot,
+} from './choices-snapshot';
+import { CellKey, GridCell } from './types';
+
+export const useChoicesSnapshot = (
+  cells: Map<CellKey, GridCell>,
+  onSnapshotChange?: (snapshot: IndicateurChoicesSnapshot) => void
+): void => {
+  const snapshot = useMemo(() => toChoicesSnapshot(cells), [cells]);
+  useEffect(() => {
+    onSnapshotChange?.(snapshot);
+  }, [snapshot, onSnapshotChange]);
+};


### PR DESCRIPTION
## Contexte

La grille de valeurs indicateurs doit pouvoir exposer le snapshot des choix de l'utilisateur, pour qu'une future démarche PCAET puisse le capturer. Cette PR ajoute uniquement l'exposition côté grille — aucune persistance.

## Changement

- **`choices-snapshot.ts`** — fonction pure `toChoicesSnapshot(cells)` qui produit un objet simple `{ [indicateurId]: [{ year, value, source }] }` :
  - `source: null` → valeur maison (saisie utilisateur) ;
  - `source: { sourceId, libelle }` → valeur open data avec sa source.
  - Les cellules sans valeur sont ignorées.
- **`use-choices-snapshot.ts`** — hook qui dérive le snapshot (`useMemo` sur `cells`) et le pousse via `onSnapshotChange` (effet ; l'effet reçoit la valeur en argument).
- **`IndicateurValuesGrid`** — nouvelle prop optionnelle `onSnapshotChange?`.
- **Story** — bouton « Afficher le snapshot » : le listener met à jour un état en silence, le bouton affiche le snapshot courant à la demande (plus d'alerte à chaque saisie).

## Hors scope

- Aucune persistance du snapshot (destinataire = future table démarche PCAET, hors de cette PR).
- Aucun endpoint backend.

## Tests

- `choices-snapshot.spec.ts` : regroupement par indicateur (maison vs open data), cellule vide ignorée.
- Lint + typecheck OK sur les fichiers touchés.
