### PR TITLE
feat(indicateurs): masque le réordonnancement de la grille sans onReorderRows

### DIFF
--- a/apps/app/src/indicateurs/valeurs/grid/__tests__/reorderable.spec.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/__tests__/reorderable.spec.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import {
+  fakeCells,
+  fakeGridActions,
+  fakeGroupsInput,
+  fakeReferenceYear,
+  fakeYears,
+} from './grid-fixtures';
+import { IndicateurValuesGrid } from '../indicateur-values-grid';
+
+const reorderHandles = (): HTMLElement[] =>
+  screen.queryAllByRole('button', { name: /^Réordonner / });
+
+describe('IndicateurValuesGrid réordonnancement', () => {
+  it('affiche des poignées de réordonnancement quand onReorderRows est fourni', () => {
+    render(
+      <IndicateurValuesGrid
+        rows={fakeGroupsInput}
+        years={fakeYears}
+        referenceYear={fakeReferenceYear}
+        cells={fakeCells()}
+        actions={fakeGridActions}
+        onReorderRows={() => undefined}
+      />
+    );
+
+    expect(reorderHandles().length).toBeGreaterThan(0);
+  });
+
+  it('ne rend aucune poignée quand onReorderRows est absent', () => {
+    render(
+      <IndicateurValuesGrid
+        rows={fakeGroupsInput}
+        years={fakeYears}
+        referenceYear={fakeReferenceYear}
+        cells={fakeCells()}
+        actions={fakeGridActions}
+      />
+    );
+
+    expect(reorderHandles()).toHaveLength(0);
+  });
+});

--- a/apps/app/src/indicateurs/valeurs/grid/drag-reorder/sortable-grid-row.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/drag-reorder/sortable-grid-row.tsx
@@ -18,10 +18,14 @@ type GroupHandle = {
 
 export const SortableGridRow = ({
   row,
-  groupHandle,
+  isReorderable,
+  showGroupHeader,
+  groupDragHandle,
 }: {
   row: Row<GridDisplayRow>;
-  groupHandle?: GroupHandle;
+  isReorderable: boolean;
+  showGroupHeader: boolean;
+  groupDragHandle?: GroupHandle;
 }): JSX.Element => {
   const {
     attributes,
@@ -33,6 +37,7 @@ export const SortableGridRow = ({
   } = useSortable({
     id: rowDragId(row.original.indicateurId),
     attributes: { roleDescription: appLabels.indicateurLigne },
+    disabled: !isReorderable,
   });
   return (
     <tr
@@ -41,19 +46,16 @@ export const SortableGridRow = ({
       style={{ transform: CSS.Transform.toString(transform), transition }}
       className={cn(isDragging && 'opacity-50')}
     >
-      {groupHandle !== undefined && (
+      {showGroupHeader && (
         <GroupHeaderCell
           label={row.original.groupLabel}
           rowSpan={row.original.groupSize}
-          attributes={groupHandle.attributes}
-          listeners={groupHandle.listeners}
-          setActivatorNodeRef={groupHandle.setActivatorNodeRef}
+          dragHandle={groupDragHandle}
         />
       )}
       <RowHeader
         label={row.original.rowLabel}
-        attributes={attributes}
-        listeners={listeners}
+        dragHandle={isReorderable ? { attributes, listeners } : undefined}
       />
       {row.getVisibleCells().map((cell) => (
         <td

--- a/apps/app/src/indicateurs/valeurs/grid/drag-reorder/sortable-group-body.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/drag-reorder/sortable-group-body.tsx
@@ -17,10 +17,12 @@ export const SortableGroupBody = ({
   group,
   rows,
   isGrouped,
+  isReorderable,
 }: {
   group: GridRowGroup;
   rows: Row<GridDisplayRow>[];
   isGrouped: boolean;
+  isReorderable: boolean;
 }): JSX.Element => {
   const {
     attributes,
@@ -33,6 +35,7 @@ export const SortableGroupBody = ({
   } = useSortable({
     id: groupDragId(group.id),
     attributes: { roleDescription: appLabels.indicateurGroupe },
+    disabled: !isReorderable,
   });
   return (
     <tbody
@@ -44,17 +47,22 @@ export const SortableGroupBody = ({
         items={rows.map((row) => rowDragId(row.original.indicateurId))}
         strategy={verticalListSortingStrategy}
       >
-        {rows.map((row) => (
-          <SortableGridRow
-            key={row.id}
-            row={row}
-            groupHandle={
-              isGrouped && row.original.isGroupStart
-                ? { attributes, listeners, setActivatorNodeRef }
-                : undefined
-            }
-          />
-        ))}
+        {rows.map((row) => {
+          const showGroupHeader = isGrouped && row.original.isGroupStart;
+          return (
+            <SortableGridRow
+              key={row.id}
+              row={row}
+              isReorderable={isReorderable}
+              showGroupHeader={showGroupHeader}
+              groupDragHandle={
+                isReorderable && showGroupHeader
+                  ? { attributes, listeners, setActivatorNodeRef }
+                  : undefined
+              }
+            />
+          );
+        })}
       </SortableContext>
     </tbody>
   );

--- a/apps/app/src/indicateurs/valeurs/grid/grid-body.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/grid-body.tsx
@@ -13,10 +13,12 @@ export const GridBody = ({
   rows,
   groups,
   isGrouped,
+  isReorderable,
 }: {
   rows: Row<GridDisplayRow>[];
   groups: GridRowGroup[];
   isGrouped: boolean;
+  isReorderable: boolean;
 }): JSX.Element => (
   <SortableContext
     items={groups.map((group) => groupDragId(group.id))}
@@ -28,6 +30,7 @@ export const GridBody = ({
         group={group}
         rows={rows.filter((row) => row.original.groupId === group.id)}
         isGrouped={isGrouped}
+        isReorderable={isReorderable}
       />
     ))}
   </SortableContext>

--- a/apps/app/src/indicateurs/valeurs/grid/grid-context.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/grid-context.tsx
@@ -17,6 +17,7 @@ export type GridContextValue = {
   unit: string | null;
   cells: Map<CellKey, GridCell>;
   isLoading: boolean;
+  isReorderable: boolean;
   actions: IndicateurValuesGridActions;
   notify?: (message: string) => void;
   onReorderRows?: (groupId: string, activeId: string, overId: string) => void;
@@ -66,6 +67,7 @@ export const GridProvider = ({
   unit,
   cells,
   isLoading,
+  isReorderable,
   actions,
   notify,
   onReorderRows,
@@ -80,6 +82,7 @@ export const GridProvider = ({
       unit,
       cells,
       isLoading,
+      isReorderable,
       actions,
       notify,
       onReorderRows,
@@ -93,6 +96,7 @@ export const GridProvider = ({
       unit,
       cells,
       isLoading,
+      isReorderable,
       actions,
       notify,
       onReorderRows,

--- a/apps/app/src/indicateurs/valeurs/grid/grid-frame.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/grid-frame.tsx
@@ -33,6 +33,7 @@ export const GridFrame = (): JSX.Element => {
     referenceYear,
     unit,
     cells,
+    isReorderable,
     actions,
     notify,
     onReorderRows,
@@ -205,12 +206,14 @@ export const GridFrame = (): JSX.Element => {
               unit={unit}
               referenceYear={referenceYear}
               isGrouped={isGrouped}
+              isReorderable={isReorderable}
               onReferenceYearChange={onReferenceYearChange}
             />
             <GridBody
               rows={table.getRowModel().rows}
               groups={orderedGroups}
               isGrouped={isGrouped}
+              isReorderable={isReorderable}
             />
           </table>
         </div>

--- a/apps/app/src/indicateurs/valeurs/grid/grid-head.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/grid-head.tsx
@@ -12,6 +12,7 @@ type GridHeadProps = {
   unit: string | null;
   referenceYear: Year | null;
   isGrouped: boolean;
+  isReorderable: boolean;
   onReferenceYearChange?: (year: Year) => void;
 };
 
@@ -20,6 +21,7 @@ export const GridHead = ({
   unit,
   referenceYear,
   isGrouped,
+  isReorderable,
   onReferenceYearChange,
 }: GridHeadProps): JSX.Element => (
   <thead>
@@ -45,6 +47,7 @@ export const GridHead = ({
             year={year}
             unit={unit}
             isReference={year === referenceYear}
+            isReorderable={isReorderable}
             onReferenceYearChange={onReferenceYearChange}
           />
         ))}

--- a/apps/app/src/indicateurs/valeurs/grid/group-header-cell.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/group-header-cell.tsx
@@ -2,20 +2,22 @@ import { DraggableAttributes, DraggableSyntheticListeners } from '@dnd-kit/core'
 import { JSX } from 'react';
 import { DragHandle } from './drag-reorder/drag-handle';
 
-type GroupHeaderCellProps = {
-  label: string;
-  rowSpan: number;
+type GroupDragHandle = {
   attributes: DraggableAttributes;
   listeners: DraggableSyntheticListeners;
   setActivatorNodeRef: (element: HTMLElement | null) => void;
 };
 
+type GroupHeaderCellProps = {
+  label: string;
+  rowSpan: number;
+  dragHandle?: GroupDragHandle;
+};
+
 export const GroupHeaderCell = ({
   label,
   rowSpan,
-  attributes,
-  listeners,
-  setActivatorNodeRef,
+  dragHandle,
 }: GroupHeaderCellProps): JSX.Element => (
   <th
     scope="rowgroup"
@@ -23,12 +25,14 @@ export const GroupHeaderCell = ({
     className="sticky left-0 z-10 border border-grey-3 bg-grey-1 p-2 align-top text-left font-bold text-primary-9"
   >
     <div className="flex items-center gap-1">
-      <DragHandle
-        attributes={attributes}
-        listeners={listeners}
-        setActivatorNodeRef={setActivatorNodeRef}
-        targetLabel={label}
-      />
+      {dragHandle !== undefined && (
+        <DragHandle
+          attributes={dragHandle.attributes}
+          listeners={dragHandle.listeners}
+          setActivatorNodeRef={dragHandle.setActivatorNodeRef}
+          targetLabel={label}
+        />
+      )}
       {label}
     </div>
   </th>

--- a/apps/app/src/indicateurs/valeurs/grid/indicateur-values-grid.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/indicateur-values-grid.tsx
@@ -42,6 +42,7 @@ export const IndicateurValuesGrid = ({
   onSnapshotChange,
 }: IndicateurValuesGridProps): JSX.Element => {
   const { groups, isGrouped } = normalizeGridInput(rows);
+  const isReorderable = onReorderRows !== undefined;
   useChoicesSnapshot(cells, onSnapshotChange);
   return (
     <GridProvider
@@ -52,6 +53,7 @@ export const IndicateurValuesGrid = ({
       unit={unit ?? null}
       cells={cells}
       isLoading={isLoading}
+      isReorderable={isReorderable}
       actions={actions}
       notify={notify}
       onReorderRows={onReorderRows}

--- a/apps/app/src/indicateurs/valeurs/grid/row-header.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/row-header.tsx
@@ -2,16 +2,19 @@ import { DraggableAttributes, DraggableSyntheticListeners } from '@dnd-kit/core'
 import { JSX } from 'react';
 import { DragHandle } from './drag-reorder/drag-handle';
 
-type RowHeaderProps = {
-  label: string;
+type RowDragHandle = {
   attributes: DraggableAttributes;
   listeners: DraggableSyntheticListeners;
 };
 
+type RowHeaderProps = {
+  label: string;
+  dragHandle?: RowDragHandle;
+};
+
 export const RowHeader = ({
   label,
-  attributes,
-  listeners,
+  dragHandle,
 }: RowHeaderProps): JSX.Element => (
   <th
     scope="row"
@@ -19,7 +22,13 @@ export const RowHeader = ({
     className="border border-grey-3 bg-white p-2 text-left font-medium text-primary-9"
   >
     <div className="flex items-center gap-1">
-      <DragHandle attributes={attributes} listeners={listeners} targetLabel={label} />
+      {dragHandle !== undefined && (
+        <DragHandle
+          attributes={dragHandle.attributes}
+          listeners={dragHandle.listeners}
+          targetLabel={label}
+        />
+      )}
       {label}
     </div>
   </th>

--- a/apps/app/src/indicateurs/valeurs/grid/year-column-header.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/year-column-header.tsx
@@ -13,6 +13,7 @@ type YearColumnHeaderProps = {
   year: Year;
   unit: string | null;
   isReference: boolean;
+  isReorderable: boolean;
   onReferenceYearChange?: (year: Year) => void;
 };
 
@@ -46,12 +47,14 @@ export const YearColumnHeader = memo(
     year,
     unit,
     isReference,
+    isReorderable,
     onReferenceYearChange,
   }: YearColumnHeaderProps): JSX.Element => {
     const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
       useSortable({
         id: dragId,
         attributes: { roleDescription: appLabels.indicateurColonneAnnee },
+        disabled: !isReorderable,
       });
     return (
       <th
@@ -66,13 +69,15 @@ export const YearColumnHeader = memo(
       >
         <div className="flex flex-col items-end">
           <div className="flex items-center gap-1">
-            <DragHandle
-              attributes={attributes}
-              listeners={listeners}
-              targetLabel={
-                isReference ? appLabels.indicateurAnneeReference(year) : String(year)
-              }
-            />
+            {isReorderable && (
+              <DragHandle
+                attributes={attributes}
+                listeners={listeners}
+                targetLabel={
+                  isReference ? appLabels.indicateurAnneeReference(year) : String(year)
+                }
+              />
+            )}
             <YearHeaderLabel
               year={year}
               isReference={isReference}


### PR DESCRIPTION
## Contexte

La grille de valeurs d'indicateurs (`IndicateurValuesGrid`) rendait **toujours** les poignées de drag et gardait les 3 axes de réordonnancement actifs (années, groupes, lignes). Le prop `onReorderRows` ne gatait que la *délégation* du reorder des lignes — les années et groupes se réordonnaient en local même sans handler. Aucun moyen de monter une grille **non réordonnable** (nécessaire pour une structure figée, ex. référentiel cae_4 des polluants atmosphériques PCAET).

## Changement

- Déduit `isReorderable = onReorderRows !== undefined` **au lieu d'ajouter un prop** — une seule surface d'API.
- Quand `onReorderRows` est absent : les `DragHandle` (années, en-tête de groupe, en-tête de ligne) ne sont plus rendues et les `useSortable` passent `disabled: true` → plus de poignée, plus de curseur grab, aucun activateur de drag.
- Découplage : la cellule d'en-tête de groupe (`GroupHeaderCell`) s'affiche toujours en mode groupé ; seule sa poignée dépend de la réordonnabilité. Les primitives `RowHeader`/`GroupHeaderCell` reçoivent un `dragHandle?` optionnel (pas de lecture de contexte composite).

## Tests

- Nouveau `reorderable.spec.tsx` : poignées présentes ssi `onReorderRows` fourni.
- Dossier grille complet vert : **89 tests** (dont keyboard-nav et paste qui montent la grille entière).

## Note

Prérequis générique pour l'intégration de la grille sur la page polluants atmosphériques PCAET (une grille sans `onReorderRows` y sera montée).