### PR TITLE
feat(indicateurs): mode lecture seule de la grille de valeurs

### DIFF
--- a/apps/app/src/indicateurs/valeurs/grid/__tests__/readonly.spec.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/__tests__/readonly.spec.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import {
+  fakeCells,
+  fakeGridActions,
+  fakeGroupsInput,
+  fakeReferenceYear,
+  fakeYears,
+} from './grid-fixtures';
+import { IndicateurValuesGrid } from '../indicateur-values-grid';
+
+const renderGrid = (isReadonly: boolean) =>
+  render(
+    <IndicateurValuesGrid
+      rows={fakeGroupsInput}
+      years={fakeYears}
+      referenceYear={fakeReferenceYear}
+      cells={fakeCells()}
+      actions={fakeGridActions}
+      isReadonly={isReadonly}
+    />
+  );
+
+const editableTargets = (container: HTMLElement): NodeListOf<Element> =>
+  container.querySelectorAll('[data-cell-id]');
+
+describe('IndicateurValuesGrid lecture seule', () => {
+  it('expose des cibles éditables (saisie + sélecteur open data) par défaut', () => {
+    const { container } = renderGrid(false);
+
+    expect(editableTargets(container).length).toBeGreaterThan(0);
+  });
+
+  it('ne rend aucune cible éditable en lecture seule', () => {
+    const { container } = renderGrid(true);
+
+    expect(editableTargets(container)).toHaveLength(0);
+  });
+
+  it('affiche toujours les valeurs et variations en lecture seule', () => {
+    renderGrid(true);
+
+    expect(
+      screen.getAllByText(/par rapport à l'année de référence/).length
+    ).toBeGreaterThan(0);
+  });
+});

--- a/apps/app/src/indicateurs/valeurs/grid/grid-context.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/grid-context.tsx
@@ -17,6 +17,7 @@ export type GridContextValue = {
   unit: string | null;
   cells: Map<CellKey, GridCell>;
   isLoading: boolean;
+  isReadonly: boolean;
   isReorderable: boolean;
   actions: IndicateurValuesGridActions;
   notify?: (message: string) => void;
@@ -67,6 +68,7 @@ export const GridProvider = ({
   unit,
   cells,
   isLoading,
+  isReadonly,
   isReorderable,
   actions,
   notify,
@@ -82,6 +84,7 @@ export const GridProvider = ({
       unit,
       cells,
       isLoading,
+      isReadonly,
       isReorderable,
       actions,
       notify,
@@ -96,6 +99,7 @@ export const GridProvider = ({
       unit,
       cells,
       isLoading,
+      isReadonly,
       isReorderable,
       actions,
       notify,

--- a/apps/app/src/indicateurs/valeurs/grid/grid-frame.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/grid-frame.tsx
@@ -33,6 +33,7 @@ export const GridFrame = (): JSX.Element => {
     referenceYear,
     unit,
     cells,
+    isReadonly,
     isReorderable,
     actions,
     notify,
@@ -196,7 +197,7 @@ export const GridFrame = (): JSX.Element => {
             ref={tableRef}
             onKeyDown={onKeyDown}
             onFocus={onFocus}
-            onPasteCapture={onPaste}
+            onPasteCapture={isReadonly ? undefined : onPaste}
             aria-label={appLabels.indicateurValeursGrille}
             className="w-full border-collapse text-sm"
             role="grid"

--- a/apps/app/src/indicateurs/valeurs/grid/indicateur-values-grid.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/indicateur-values-grid.tsx
@@ -21,6 +21,7 @@ export type IndicateurValuesGridProps = {
   unit?: string;
   cells: Map<CellKey, GridCell>;
   isLoading?: boolean;
+  isReadonly?: boolean;
   actions: IndicateurValuesGridActions;
   notify?: (message: string) => void;
   onReorderRows?: (groupId: string, activeId: string, overId: string) => void;
@@ -35,6 +36,7 @@ export const IndicateurValuesGrid = ({
   unit,
   cells,
   isLoading = false,
+  isReadonly = false,
   actions,
   notify,
   onReorderRows,
@@ -53,6 +55,7 @@ export const IndicateurValuesGrid = ({
       unit={unit ?? null}
       cells={cells}
       isLoading={isLoading}
+      isReadonly={isReadonly}
       isReorderable={isReorderable}
       actions={actions}
       notify={notify}

--- a/apps/app/src/indicateurs/valeurs/grid/readonly-cell.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/readonly-cell.tsx
@@ -1,0 +1,67 @@
+import { JSX, memo } from 'react';
+import { appLabels } from '@/app/labels/catalog';
+import { GridCellProps } from './cell-props';
+import {
+  ValueWithVariation,
+  variationHintId,
+} from './variation/variation-hint';
+import { SourceBadge } from './source-badge';
+import { generateCellKey, GridCell } from './types';
+
+type ReadonlyCellProps = GridCellProps & {
+  cell: GridCell;
+};
+
+export const ReadonlyCell = memo(
+  ({
+    cell,
+    polluant,
+    indicateurId,
+    year,
+    variationToReferenceYear,
+  }: ReadonlyCellProps): JSX.Element => {
+    const cellId = generateCellKey(indicateurId, year);
+    const impactId = variationHintId(cellId, variationToReferenceYear);
+    if (cell.kind === 'open-data') {
+      return (
+        <div
+          aria-label={appLabels.indicateurCelluleOpenData({
+            rowLabel: polluant,
+            year,
+            value: cell.value,
+            source: cell.source.libelle,
+          })}
+          aria-describedby={impactId}
+          className="flex h-full w-full items-center gap-2 bg-success-2 px-3 text-sm"
+        >
+          <span className="shrink-0">
+            <SourceBadge source={cell.source} />
+          </span>
+          <ValueWithVariation
+            variationToReferenceYear={variationToReferenceYear}
+            hintId={impactId}
+            className="ml-auto"
+          >
+            <span className="text-success-1">{cell.value}</span>
+          </ValueWithVariation>
+        </div>
+      );
+    }
+    return (
+      <div
+        aria-label={appLabels.indicateurCellule(polluant, year)}
+        aria-describedby={impactId}
+        className="flex h-full items-center justify-end pr-3 text-sm text-grey-8"
+      >
+        <ValueWithVariation
+          variationToReferenceYear={variationToReferenceYear}
+          hintId={impactId}
+        >
+          <span>{cell.value ?? ''}</span>
+        </ValueWithVariation>
+      </div>
+    );
+  }
+);
+
+ReadonlyCell.displayName = 'ReadonlyCell';

--- a/apps/app/src/indicateurs/valeurs/grid/use-get-table.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/use-get-table.tsx
@@ -13,6 +13,7 @@ import { findCell, GridDisplayRow, toDisplayRows } from './grid-model';
 import { OpenDataCell } from './open-data-cell';
 import { buildColumnSelection } from './open-data-picker/build-column-selection';
 import { ColumnSelection } from './open-data-picker/open-data-picker';
+import { ReadonlyCell } from './readonly-cell';
 import { UserDataCell } from './user-data-cell';
 import { GridCell, GridRowGroup, IndicateurId, Year } from './types';
 
@@ -28,6 +29,7 @@ const renderCell = ({
   groupLabel,
   columnSelection,
   variationToReferenceYear,
+  isReadonly,
 }: {
   cell: GridCell | null;
   indicateurId: IndicateurId;
@@ -36,6 +38,7 @@ const renderCell = ({
   groupLabel: string;
   columnSelection?: ColumnSelection;
   variationToReferenceYear: number | null;
+  isReadonly: boolean;
 }): JSX.Element => {
   if (cell === null) {
     return <EmptyCell />;
@@ -48,6 +51,9 @@ const renderCell = ({
     columnSelection,
     variationToReferenceYear,
   };
+  if (isReadonly) {
+    return <ReadonlyCell cell={cell} {...commonProps} />;
+  }
   if (cell.kind === 'open-data') {
     return <OpenDataCell cell={cell} {...commonProps} />;
   }
@@ -64,7 +70,7 @@ export const useGetTable = ({
   table: Table<GridDisplayRow>;
   tableRef: RefObject<HTMLTableElement | null>;
 } => {
-  const { cells, actions, referenceYear } = useGridContext();
+  const { cells, actions, referenceYear, isReadonly } = useGridContext();
 
   const displayRows = useMemo<GridDisplayRow[]>(
     () => toDisplayRows(groups),
@@ -108,11 +114,12 @@ export const useGetTable = ({
                 year,
                 referenceYear,
               }),
+              isReadonly,
             });
           },
         })
       ),
-    [years, cells, groups, actions.selectOpenData, referenceYear]
+    [years, cells, groups, actions.selectOpenData, referenceYear, isReadonly]
   );
 
   const table = useReactTable({


### PR DESCRIPTION
## Contexte

Suite de #4683 (stackée dessus). La grille de valeurs d'indicateurs n'avait aucun moyen de verrouiller la saisie — nécessaire pour une démarche publiée ou un rôle viewer (cf. verrou PCAET sur une démarche publiée).

## Changement

- Nouveau prop `isReadonly?: boolean` (défaut `false`), threadé via le contexte. Concern **indépendant** de la réordonnabilité, donc prop dédié (pas une dérivation — règle 56 de l'enforcer).
- En lecture seule, le dispatcher `renderCell` monte un `ReadonlyCell` : valeur + variation statiques (badge de source pour l'open data) au lieu de `UserDataCell` (input) et `OpenDataCell` (sélecteur). Le collage (`onPasteCapture`) est désactivé.
- `ReadonlyCell` compose les primitives existantes (`ValueWithVariation`, `SourceBadge`) — aucune cible `data-cell-id`, donc aucune surface d'édition.

## Tests

- Nouveau `readonly.spec.tsx` : invariant unique `[data-cell-id]` (porté par l'input **et** le bouton open data) → présent par défaut, **0** en lecture seule ; valeurs + variations toujours affichées.
- Dossier grille complet vert : **92 tests**.

## Note

Prérequis générique pour l'intégration PCAET (grille montée en `isReadonly` quand la démarche est publiée).