### PR TITLE
refactor(indicateurs): grille - types & API (GridCell, SourceId, notify, onReorderRows, Result)

### DIFF
--- a/apps/app/src/indicateurs/valeurs/grid/__tests__/grid-fixtures.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/__tests__/grid-fixtures.ts
@@ -7,6 +7,7 @@ import {
   IndicateurValuesGridActions,
   OpenDataSource,
   toIndicateurId,
+  toSourceId,
   toYear,
   Year,
 } from '../types';
@@ -42,19 +43,19 @@ export const fakeGroupsInput: GridGroups = toGridInput(fakeGroups);
 
 const sourceDefs = [
   {
-    sourceId: 'citepa',
+    sourceId: toSourceId('citepa'),
     libelle: 'CITEPA',
     methodologie: 'Inventaire national spatialisé',
     dateVersion: '2026-01-01',
   },
   {
-    sourceId: 'insee',
+    sourceId: toSourceId('insee'),
     libelle: 'INSEE',
     methodologie: null,
     dateVersion: '2024-01-01',
   },
   {
-    sourceId: 'ademe',
+    sourceId: toSourceId('ademe'),
     libelle: 'ADEME',
     methodologie: 'Base Carbone',
     dateVersion: '2025-01-01',

--- a/apps/app/src/indicateurs/valeurs/grid/__tests__/indicateur-values-grid.stories.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/__tests__/indicateur-values-grid.stories.tsx
@@ -192,7 +192,15 @@ const InteractiveGrid = (): JSX.Element => {
   );
 
   const onReorderRows = useCallback(
-    (groupId: string, activeId: string, overId: string) => {
+    ({
+      groupId,
+      activeId,
+      overId,
+    }: {
+      groupId: string;
+      activeId: string;
+      overId: string;
+    }) => {
       setGroups((previous) => {
         const group = previous.find((candidate) => candidate.id === groupId);
         if (group === undefined) {

--- a/apps/app/src/indicateurs/valeurs/grid/__tests__/user-data-cell.spec.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/__tests__/user-data-cell.spec.tsx
@@ -77,7 +77,7 @@ describe('UserDataCell edition', () => {
   });
 
   it('conserve la saisie et signale une erreur quand le write echoue', async () => {
-    const saveCellValue = vi.fn().mockResolvedValue({ ok: false, error: 'boom' });
+    const saveCellValue = vi.fn().mockResolvedValue({ ok: false });
     const input = renderEmptyCell(saveCellValue);
 
     typeAndCommit(input, '7');

--- a/apps/app/src/indicateurs/valeurs/grid/choices-snapshot.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/choices-snapshot.ts
@@ -1,6 +1,13 @@
-import { CellKey, GridCell, IndicateurId, Year, parseCellKey } from './types';
+import {
+  CellKey,
+  GridCell,
+  IndicateurId,
+  SourceId,
+  Year,
+  parseCellKey,
+} from './types';
 
-export type ChoiceSource = { sourceId: string; libelle: string };
+export type ChoiceSource = { sourceId: SourceId; libelle: string };
 
 export type IndicateurYearChoice = {
   year: Year;

--- a/apps/app/src/indicateurs/valeurs/grid/drag-reorder/use-grid-reorder.spec.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/drag-reorder/use-grid-reorder.spec.ts
@@ -94,7 +94,11 @@ describe('useGridReorder', () => {
       )
     );
 
-    expect(onReorderRows).toHaveBeenCalledWith('secteur', 'row-1', 'row-3');
+    expect(onReorderRows).toHaveBeenCalledWith({
+      groupId: 'secteur',
+      activeId: 'row-1',
+      overId: 'row-3',
+    });
     expect(
       result.current.orderedGroups[0].rows.map((row) => row.indicateurId)
     ).toEqual([1, 2, 3]);

--- a/apps/app/src/indicateurs/valeurs/grid/drag-reorder/use-grid-reorder.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/drag-reorder/use-grid-reorder.ts
@@ -44,7 +44,11 @@ export const useGridReorder = ({
 }: {
   years: Year[];
   groups: GridRowGroup[];
-  onReorderRows?: (groupId: string, activeId: string, overId: string) => void;
+  onReorderRows?: (params: {
+    groupId: string;
+    activeId: string;
+    overId: string;
+  }) => void;
 }): GridReorder => {
   const [yearOrder, setYearOrder] = useState<string[] | null>(null);
   const [groupOrder, setGroupOrder] = useState<string[] | null>(null);
@@ -106,7 +110,7 @@ export const useGridReorder = ({
   const reorderRows = useCallback(
     (groupId: string, activeId: string, overId: string) => {
       if (onReorderRows !== undefined) {
-        onReorderRows(groupId, activeId, overId);
+        onReorderRows({ groupId, activeId, overId });
         return;
       }
       const group = orderedGroups.find((candidate) => candidate.id === groupId);

--- a/apps/app/src/indicateurs/valeurs/grid/grid-context.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/grid-context.tsx
@@ -20,7 +20,11 @@ export type GridContextValue = {
   isReorderable: boolean;
   actions: IndicateurValuesGridActions;
   notify: (message: string) => void;
-  onReorderRows?: (groupId: string, activeId: string, overId: string) => void;
+  onReorderRows?: (params: {
+    groupId: string;
+    activeId: string;
+    overId: string;
+  }) => void;
   onReferenceYearChange?: (year: Year) => void;
 };
 

--- a/apps/app/src/indicateurs/valeurs/grid/grid-context.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/grid-context.tsx
@@ -19,7 +19,7 @@ export type GridContextValue = {
   isLoading: boolean;
   isReorderable: boolean;
   actions: IndicateurValuesGridActions;
-  notify?: (message: string) => void;
+  notify: (message: string) => void;
   onReorderRows?: (groupId: string, activeId: string, overId: string) => void;
   onReferenceYearChange?: (year: Year) => void;
 };
@@ -31,7 +31,7 @@ export type GridCellServices = {
   selectOpenData: IndicateurValuesGridActions['selectOpenData'];
   clearCell: IndicateurValuesGridActions['clearCell'];
   unit: string | null;
-  notify?: (message: string) => void;
+  notify: (message: string) => void;
 };
 
 const GridCellServicesContext = createContext<GridCellServices | null>(null);

--- a/apps/app/src/indicateurs/valeurs/grid/grid-frame.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/grid-frame.tsx
@@ -140,7 +140,7 @@ export const GridFrame = (): JSX.Element => {
   const handleReset = (): void => {
     reset();
     setResetMessage(appLabels.indicateurOrdreReinitialise);
-    notify?.(appLabels.indicateurOrdreReinitialise);
+    notify(appLabels.indicateurOrdreReinitialise);
   };
 
   const announcements: Announcements = {

--- a/apps/app/src/indicateurs/valeurs/grid/indicateur-values-grid.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/indicateur-values-grid.tsx
@@ -23,7 +23,11 @@ export type IndicateurValuesGridProps = {
   isLoading?: boolean;
   actions: IndicateurValuesGridActions;
   notify: (message: string) => void;
-  onReorderRows?: (groupId: string, activeId: string, overId: string) => void;
+  onReorderRows?: (params: {
+    groupId: string;
+    activeId: string;
+    overId: string;
+  }) => void;
   onReferenceYearChange?: (year: Year) => void;
   onSnapshotChange?: (snapshot: IndicateurChoicesSnapshot) => void;
 };

--- a/apps/app/src/indicateurs/valeurs/grid/indicateur-values-grid.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/indicateur-values-grid.tsx
@@ -22,7 +22,7 @@ export type IndicateurValuesGridProps = {
   cells: Map<CellKey, GridCell>;
   isLoading?: boolean;
   actions: IndicateurValuesGridActions;
-  notify?: (message: string) => void;
+  notify: (message: string) => void;
   onReorderRows?: (groupId: string, activeId: string, overId: string) => void;
   onReferenceYearChange?: (year: Year) => void;
   onSnapshotChange?: (snapshot: IndicateurChoicesSnapshot) => void;

--- a/apps/app/src/indicateurs/valeurs/grid/open-data-picker/build-column-selection.spec.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/open-data-picker/build-column-selection.spec.ts
@@ -108,7 +108,7 @@ describe('buildColumnSelection', () => {
     const selectOpenData = vi
       .fn()
       .mockResolvedValueOnce({ ok: true, value: undefined })
-      .mockResolvedValueOnce({ ok: false, error: 'boom' });
+      .mockResolvedValueOnce({ ok: false });
     const selection = buildColumnSelection({
       cell: coveredEmpty(),
       group,

--- a/apps/app/src/indicateurs/valeurs/grid/open-data-picker/open-data-picker.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/open-data-picker/open-data-picker.tsx
@@ -1,7 +1,7 @@
 import { appLabels } from '@/app/labels/catalog';
 import { Button, cn, Icon } from '@tet/ui';
 import { JSX } from 'react';
-import { OpenDataSource, Year } from '../types';
+import { OpenDataSource, SourceId, Year } from '../types';
 
 const publicationYear = (dateVersion: string): number =>
   new Date(dateVersion).getFullYear();
@@ -103,7 +103,7 @@ const SourceList = ({
   year: Year;
   unit: string | null;
   selectedSourceId?: string;
-  onSelect: (sourceId: string) => void;
+  onSelect: (sourceId: SourceId) => void;
 }): JSX.Element => (
   <ul
     aria-label={appLabels.indicateurSelectionnerValeurOpenData}
@@ -171,7 +171,7 @@ type OpenDataPickerProps = {
   unit: string | null;
   sources: OpenDataSource[];
   selectedSourceId?: string;
-  onSelect: (sourceId: string) => void;
+  onSelect: (sourceId: SourceId) => void;
   onClose: () => void;
   onReset: () => void;
   columnSelection?: ColumnSelection;

--- a/apps/app/src/indicateurs/valeurs/grid/open-data-picker/open-data-selector.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/open-data-picker/open-data-selector.tsx
@@ -50,7 +50,7 @@ export const OpenDataSelector = ({
             if (selectionResult.ok) {
               close();
             } else {
-              notify?.(appLabels.indicateurSelectionnerValeurEchec);
+              notify(appLabels.indicateurSelectionnerValeurEchec);
             }
           }}
           onClose={close}
@@ -59,7 +59,7 @@ export const OpenDataSelector = ({
             if (resetResult.ok) {
               close();
             } else {
-              notify?.(appLabels.indicateurRepasserSaisieEchec);
+              notify(appLabels.indicateurRepasserSaisieEchec);
             }
           }}
           columnSelection={
@@ -72,7 +72,7 @@ export const OpenDataSelector = ({
                     if (allSelected) {
                       close();
                     } else {
-                      notify?.(appLabels.indicateurSelectionnerValeurEchec);
+                      notify(appLabels.indicateurSelectionnerValeurEchec);
                     }
                     return allSelected;
                   },

--- a/apps/app/src/indicateurs/valeurs/grid/paste/grid-paste.spec.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/paste/grid-paste.spec.tsx
@@ -144,7 +144,7 @@ describe('IndicateurValuesGrid paste', () => {
   });
 
   it('signale toutes les cellules quand le collage echoue entierement', async () => {
-    const saveCellValues = vi.fn().mockResolvedValue({ ok: false, error: 'boom' });
+    const saveCellValues = vi.fn().mockResolvedValue({ ok: false });
     const notify = vi.fn();
     const container = renderGrid({ ...fakeGridActions, saveCellValues }, notify);
     const anchor = cellInput(container, '1:2030');

--- a/apps/app/src/indicateurs/valeurs/grid/paste/use-grid-copy-paste.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/paste/use-grid-copy-paste.ts
@@ -20,7 +20,7 @@ const writeAndReportFailures = async ({
 }: {
   cellsToWrite: CellValueInput[];
   saveCellValues: IndicateurValuesGridActions['saveCellValues'];
-  notify?: (message: string) => void;
+  notify: (message: string) => void;
 }): Promise<void> => {
   try {
     const result = await saveCellValues(cellsToWrite);
@@ -28,10 +28,10 @@ const writeAndReportFailures = async ({
       ? result.value.failed.length
       : cellsToWrite.length;
     if (failedCount > 0) {
-      notify?.(appLabels.indicateurCollageEchec({ count: failedCount }));
+      notify(appLabels.indicateurCollageEchec({ count: failedCount }));
     }
   } catch {
-    notify?.(appLabels.indicateurCollageEchec({ count: cellsToWrite.length }));
+    notify(appLabels.indicateurCollageEchec({ count: cellsToWrite.length }));
   }
 };
 
@@ -46,7 +46,7 @@ export const useGridCopyPaste = ({
   years: Year[];
   cells: Map<CellKey, GridCell>;
   saveCellValues: IndicateurValuesGridActions['saveCellValues'];
-  notify?: (message: string) => void;
+  notify: (message: string) => void;
 }): {
   onPaste: (event: ClipboardEvent<HTMLElement>) => void;
 } => {
@@ -75,7 +75,7 @@ export const useGridCopyPaste = ({
       }
       event.preventDefault();
       if (skipped > 0) {
-        notify?.(appLabels.indicateurCollageIgnore({ count: skipped }));
+        notify(appLabels.indicateurCollageIgnore({ count: skipped }));
       }
       if (cellsToWrite.length === 0) {
         return;

--- a/apps/app/src/indicateurs/valeurs/grid/types.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/types.ts
@@ -45,13 +45,7 @@ export type OpenDataSource = {
 export type GridCell =
   | {
       kind: 'user-data';
-      value: number;
-      valueId: number;
-      coveringSources: OpenDataSource[];
-    }
-  | {
-      kind: 'user-data';
-      value: null;
+      value: number | null;
       valueId?: number;
       coveringSources: OpenDataSource[];
     }

--- a/apps/app/src/indicateurs/valeurs/grid/types.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/types.ts
@@ -81,9 +81,7 @@ export type GridGroups = Record<string, GridGroupInput>;
 
 export type GridInput = GridRow[] | GridGroups;
 
-export type Result<T = void> =
-  | { ok: true; value: T }
-  | { ok: false; error: string };
+export type Result<T = void> = { ok: true; value: T } | { ok: false };
 
 export type CellValueInput = {
   indicateurId: IndicateurId;

--- a/apps/app/src/indicateurs/valeurs/grid/types.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/types.ts
@@ -7,6 +7,10 @@ declare const yearBrand: unique symbol;
 export type Year = number & { readonly [yearBrand]: true };
 export const toYear = (value: number): Year => value as Year;
 
+declare const sourceIdBrand: unique symbol;
+export type SourceId = string & { readonly [sourceIdBrand]: true };
+export const toSourceId = (value: string): SourceId => value as SourceId;
+
 export type CellKey = `${number}:${number}`;
 
 export const CELL_ID_ATTRIBUTE = 'data-cell-id';
@@ -28,14 +32,14 @@ export const parseCellKey = (
 };
 
 export type SourceInfo = {
-  sourceId: string;
+  sourceId: SourceId;
   libelle: string;
   methodologie: string | null;
   dateVersion: string;
 };
 
 export type OpenDataSource = {
-  sourceId: string;
+  sourceId: SourceId;
   libelle: string;
   value: number;
   methodologie: string | null;
@@ -52,7 +56,7 @@ export type GridCell =
   | {
       kind: 'open-data';
       value: number;
-      selectedSourceId: string;
+      selectedSourceId: SourceId;
       source: SourceInfo;
       coveringSources: OpenDataSource[];
     };
@@ -91,7 +95,7 @@ export type CellValueInput = {
 export type SelectOpenDataInput = {
   indicateurId: IndicateurId;
   year: Year;
-  sourceId: string;
+  sourceId: SourceId;
 };
 
 export type ClearCellInput = {


### PR DESCRIPTION
## Nature

Refactor types/API de la grille de valeurs d'indicateurs. **PR empilee sur #4682** (base = `fix/indicateur-grid-value-loss-and-cleanup`) : ne mergera qu'apres #4682. Implemente le groupe « B » de l'analyse.

## Contenu (5 commits, une intention par commit)

- **B1** `GridCell` : deux membres partageaient le meme discriminant `kind:'user-data'` (le vrai discriminant etait `value===null`), ce qui casse un match exhaustif. Fusionnes en une variante bien formee (`value: number|null`, `valueId?`). `value` reste un accesseur commun aux deux kinds -> zero churn consommateur.
- **B5** brande `SourceId` (`+ toSourceId`) : la grille brandait deja `IndicateurId`/`Year` mais laissait `sourceId` en `string` nu. Applique a `SourceInfo`, `OpenDataSource`, `selectedSourceId`, `SelectOpenDataInput`, `ChoiceSource`, `onSelect` du picker.
- **B3** `notify` devient requis : il etait optionnel de bout en bout, donc un montage sans `notify` avalait silencieusement les echecs d'action. `notify?.()` -> `notify()`.
- **B6** `onReorderRows` en argument objet nomme (3 params positionnels de meme type invitaient a l'inversion).
- **B4** `Result` : retire le champ `error: string` mort (aucun consommateur ne le lit ; la grille affiche ses propres messages via `notify`/`appLabels`).

## Surface de review

Attention humaine : `types.ts` (B1 union, B5 brand, B4 Result). Le reste est mecanique (threading du brand, flips `notify`, argument nomme).

## Verification

- Typecheck source (`tsconfig.project.json`, celui de la CI) propre.
- 18 fichiers / 95 tests de la grille au vert.
- Lint propre sur les fichiers touches.

## Rebase / reconciliation

`main` a avance avec `caa2b9269` (« masque le reordonnancement sans onReorderRows », soit `isReorderable = onReorderRows !== undefined`). #4682 a ete rebase sur `main` (aucun recouvrement de fichiers), puis cette branche rebase sur #4682 : `isReorderable` (main), `notify` requis (B3) et `onReorderRows` nomme (B6) coexistent correctement dans `grid-context`/`indicateur-values-grid` (verifie).

## Hors scope (analyse)

Restent : C1-C3 (structure : extraction `useGridDragHandlers`, `parseDragId` type, primitive d'en-tete), D3/D4, et les trous de tests E (`OpenDataSelector` failure wiring, etc.). Analyse complete : `compound-knowledge-db/docs/plans/2026-07-03-002-refactor-indicateur-value-grid-analyse.md`.
