### PR TITLE
refactor(indicateurs): grille - structure DnD (parseDragId, useGridDragHandlers, DraggableHeaderLabel)

### DIFF
--- a/apps/app/src/indicateurs/valeurs/grid/drag-reorder/draggable-header-label.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/drag-reorder/draggable-header-label.tsx
@@ -1,0 +1,29 @@
+import { DraggableAttributes, DraggableSyntheticListeners } from '@dnd-kit/core';
+import { JSX } from 'react';
+import { DragHandle } from './drag-handle';
+
+export type HeaderDragHandle = {
+  attributes: DraggableAttributes;
+  listeners: DraggableSyntheticListeners;
+  setActivatorNodeRef?: (element: HTMLElement | null) => void;
+};
+
+export const DraggableHeaderLabel = ({
+  label,
+  dragHandle,
+}: {
+  label: string;
+  dragHandle?: HeaderDragHandle;
+}): JSX.Element => (
+  <div className="flex items-center gap-1">
+    {dragHandle !== undefined && (
+      <DragHandle
+        attributes={dragHandle.attributes}
+        listeners={dragHandle.listeners}
+        setActivatorNodeRef={dragHandle.setActivatorNodeRef}
+        targetLabel={label}
+      />
+    )}
+    {label}
+  </div>
+);

--- a/apps/app/src/indicateurs/valeurs/grid/drag-reorder/use-grid-drag-handlers.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/drag-reorder/use-grid-drag-handlers.ts
@@ -1,0 +1,142 @@
+import {
+  Announcements,
+  CollisionDetection,
+  DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  SensorDescriptor,
+  SensorOptions,
+  closestCenter,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import { sortableKeyboardCoordinates } from '@dnd-kit/sortable';
+import { Table } from '@tanstack/react-table';
+import { appLabels } from '@/app/labels/catalog';
+import { GridDisplayRow } from '../grid-model';
+import { GridRowGroup } from '../types';
+import { parseDragId } from './use-grid-reorder';
+
+export const useGridDragHandlers = ({
+  orderedGroups,
+  table,
+  reorderYears,
+  reorderGroups,
+  reorderRows,
+}: {
+  orderedGroups: GridRowGroup[];
+  table: Table<GridDisplayRow>;
+  reorderYears: (activeId: string, overId: string) => void;
+  reorderGroups: (activeId: string, overId: string) => void;
+  reorderRows: (groupId: string, activeId: string, overId: string) => void;
+}): {
+  sensors: SensorDescriptor<SensorOptions>[];
+  collisionDetection: CollisionDetection;
+  onDragEnd: (event: DragEndEvent) => void;
+  announcements: Announcements;
+} => {
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
+  const groupIdOf = (dragId: string): string | undefined => {
+    const parsed = parseDragId(dragId);
+    if (parsed?.type !== 'row') {
+      return undefined;
+    }
+    return orderedGroups.find((group) =>
+      group.rows.some((row) => row.indicateurId === parsed.indicateurId)
+    )?.id;
+  };
+
+  const collisionDetection: CollisionDetection = (args) => {
+    const activeId = String(args.active.id);
+    const activeType = parseDragId(activeId)?.type;
+    const activeGroup = activeType === 'row' ? groupIdOf(activeId) : undefined;
+    return closestCenter({
+      ...args,
+      droppableContainers: args.droppableContainers.filter((container) => {
+        const containerId = String(container.id);
+        if (parseDragId(containerId)?.type !== activeType) {
+          return false;
+        }
+        return activeType !== 'row' || groupIdOf(containerId) === activeGroup;
+      }),
+    });
+  };
+
+  const describeDragId = (dragId: string): string => {
+    const parsed = parseDragId(dragId);
+    if (parsed === null) {
+      return dragId;
+    }
+    if (parsed.type === 'year') {
+      return String(parsed.year);
+    }
+    if (parsed.type === 'group') {
+      return (
+        orderedGroups.find((group) => group.id === parsed.groupId)?.label ??
+        dragId
+      );
+    }
+    return (
+      table
+        .getRowModel()
+        .rows.find((row) => row.original.indicateurId === parsed.indicateurId)
+        ?.original.rowLabel ?? dragId
+    );
+  };
+
+  const onDragEnd = (event: DragEndEvent): void => {
+    const { active, over } = event;
+    const isNoOpDrop = over === null || active.id === over.id;
+    if (isNoOpDrop) {
+      return;
+    }
+    const activeId = String(active.id);
+    const overId = String(over.id);
+    const parsed = parseDragId(activeId);
+    if (parsed === null) {
+      return;
+    }
+    if (parsed.type === 'year') {
+      reorderYears(activeId, overId);
+      return;
+    }
+    if (parsed.type === 'group') {
+      reorderGroups(activeId, overId);
+      return;
+    }
+    const group = groupIdOf(activeId);
+    const isSameGroup = group !== undefined && group === groupIdOf(overId);
+    if (isSameGroup) {
+      reorderRows(group, activeId, overId);
+    }
+  };
+
+  const announcements: Announcements = {
+    onDragStart: ({ active }) =>
+      appLabels.indicateurReordonnerPrise(describeDragId(String(active.id))),
+    onDragOver: ({ active, over }) =>
+      over === null
+        ? undefined
+        : appLabels.indicateurReordonnerSurvol(
+            describeDragId(String(active.id)),
+            describeDragId(String(over.id))
+          ),
+    onDragEnd: ({ active, over }) => {
+      const isCancelledDrop = over === null || active.id === over.id;
+      return isCancelledDrop
+        ? appLabels.indicateurReordonnerAnnule(describeDragId(String(active.id)))
+        : appLabels.indicateurReordonnerDepose(
+            describeDragId(String(active.id)),
+            describeDragId(String(over.id))
+          );
+    },
+    onDragCancel: ({ active }) =>
+      appLabels.indicateurReordonnerAnnule(describeDragId(String(active.id))),
+  };
+
+  return { sensors, collisionDetection, onDragEnd, announcements };
+};

--- a/apps/app/src/indicateurs/valeurs/grid/drag-reorder/use-grid-reorder.spec.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/drag-reorder/use-grid-reorder.spec.ts
@@ -2,11 +2,39 @@ import { act, renderHook } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import {
   groupDragId,
+  parseDragId,
   rowDragId,
   useGridReorder,
   yearDragId,
 } from './use-grid-reorder';
 import { GridRowGroup, toIndicateurId, toYear } from '../types';
+
+describe('parseDragId', () => {
+  it('decode un id d annee', () => {
+    expect(parseDragId(yearDragId(toYear(2030)))).toEqual({
+      type: 'year',
+      year: 2030,
+    });
+  });
+
+  it('decode un id de groupe, y compris avec des tirets', () => {
+    expect(parseDragId(groupDragId('secteur-0'))).toEqual({
+      type: 'group',
+      groupId: 'secteur-0',
+    });
+  });
+
+  it('decode un id de ligne', () => {
+    expect(parseDragId(rowDragId(toIndicateurId(12)))).toEqual({
+      type: 'row',
+      indicateurId: 12,
+    });
+  });
+
+  it('rend null pour un id non reconnu', () => {
+    expect(parseDragId('unknown')).toBeNull();
+  });
+});
 
 const years = [2030, 2036, 2050].map(toYear);
 

--- a/apps/app/src/indicateurs/valeurs/grid/drag-reorder/use-grid-reorder.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/drag-reorder/use-grid-reorder.ts
@@ -1,6 +1,12 @@
 import { arrayMove } from '@dnd-kit/sortable';
 import { useCallback, useMemo, useState } from 'react';
-import { GridRowGroup, IndicateurId, Year } from '../types';
+import {
+  GridRowGroup,
+  IndicateurId,
+  Year,
+  toIndicateurId,
+  toYear,
+} from '../types';
 
 export type YearDragId = `year-${number}`;
 export type RowDragId = `row-${number}`;
@@ -10,6 +16,27 @@ export const yearDragId = (year: Year): YearDragId => `year-${year}`;
 export const rowDragId = (indicateurId: IndicateurId): RowDragId =>
   `row-${indicateurId}`;
 export const groupDragId = (groupId: string): GroupDragId => `group-${groupId}`;
+
+export type ParsedDragId =
+  | { type: 'year'; year: Year }
+  | { type: 'group'; groupId: string }
+  | { type: 'row'; indicateurId: IndicateurId };
+
+export const parseDragId = (dragId: string): ParsedDragId | null => {
+  if (dragId.startsWith('year-')) {
+    return { type: 'year', year: toYear(Number(dragId.slice('year-'.length))) };
+  }
+  if (dragId.startsWith('group-')) {
+    return { type: 'group', groupId: dragId.slice('group-'.length) };
+  }
+  if (dragId.startsWith('row-')) {
+    return {
+      type: 'row',
+      indicateurId: toIndicateurId(Number(dragId.slice('row-'.length))),
+    };
+  }
+  return null;
+};
 
 const orderBy = <T>(
   items: T[],

--- a/apps/app/src/indicateurs/valeurs/grid/grid-frame.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/grid-frame.tsx
@@ -1,17 +1,6 @@
 'use client';
 
-import {
-  Announcements,
-  CollisionDetection,
-  DndContext,
-  DragEndEvent,
-  KeyboardSensor,
-  PointerSensor,
-  closestCenter,
-  useSensor,
-  useSensors,
-} from '@dnd-kit/core';
-import { sortableKeyboardCoordinates } from '@dnd-kit/sortable';
+import { DndContext } from '@dnd-kit/core';
 import { Button } from '@tet/ui';
 import { JSX, useState } from 'react';
 import { appLabels } from '@/app/labels/catalog';
@@ -19,7 +8,8 @@ import { useGridContext } from './grid-context';
 import { useGetTable } from './use-get-table';
 import { useGridKeyboardNav } from './keyboard-navigation/use-grid-keyboard-nav';
 import { useGridCopyPaste } from './paste/use-grid-copy-paste';
-import { parseDragId, useGridReorder } from './drag-reorder/use-grid-reorder';
+import { useGridReorder } from './drag-reorder/use-grid-reorder';
+import { useGridDragHandlers } from './drag-reorder/use-grid-drag-handlers';
 import { GridHead } from './grid-head';
 import { GridBody } from './grid-body';
 
@@ -68,113 +58,19 @@ export const GridFrame = (): JSX.Element => {
     notify,
   });
 
-  const sensors = useSensors(
-    useSensor(PointerSensor),
-    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
-  );
-
-  const groupIdOf = (dragId: string): string | undefined => {
-    const parsed = parseDragId(dragId);
-    if (parsed?.type !== 'row') {
-      return undefined;
-    }
-    return orderedGroups.find((group) =>
-      group.rows.some((row) => row.indicateurId === parsed.indicateurId)
-    )?.id;
-  };
-
-  const collisionDetection: CollisionDetection = (args) => {
-    const activeId = String(args.active.id);
-    const activeType = parseDragId(activeId)?.type;
-    const activeGroup = activeType === 'row' ? groupIdOf(activeId) : undefined;
-    return closestCenter({
-      ...args,
-      droppableContainers: args.droppableContainers.filter((container) => {
-        const containerId = String(container.id);
-        if (parseDragId(containerId)?.type !== activeType) {
-          return false;
-        }
-        return activeType !== 'row' || groupIdOf(containerId) === activeGroup;
-      }),
+  const { sensors, collisionDetection, onDragEnd, announcements } =
+    useGridDragHandlers({
+      orderedGroups,
+      table,
+      reorderYears,
+      reorderGroups,
+      reorderRows,
     });
-  };
-
-  const describeDragId = (dragId: string): string => {
-    const parsed = parseDragId(dragId);
-    if (parsed === null) {
-      return dragId;
-    }
-    if (parsed.type === 'year') {
-      return String(parsed.year);
-    }
-    if (parsed.type === 'group') {
-      return (
-        orderedGroups.find((group) => group.id === parsed.groupId)?.label ??
-        dragId
-      );
-    }
-    return (
-      table
-        .getRowModel()
-        .rows.find((row) => row.original.indicateurId === parsed.indicateurId)
-        ?.original.rowLabel ?? dragId
-    );
-  };
-
-  const onDragEnd = (event: DragEndEvent): void => {
-    const { active, over } = event;
-    const isNoOpDrop = over === null || active.id === over.id;
-    if (isNoOpDrop) {
-      return;
-    }
-    const activeId = String(active.id);
-    const overId = String(over.id);
-    const parsed = parseDragId(activeId);
-    if (parsed === null) {
-      return;
-    }
-    if (parsed.type === 'year') {
-      reorderYears(activeId, overId);
-      return;
-    }
-    if (parsed.type === 'group') {
-      reorderGroups(activeId, overId);
-      return;
-    }
-    const group = groupIdOf(activeId);
-    const isSameGroup = group !== undefined && group === groupIdOf(overId);
-    if (isSameGroup) {
-      reorderRows(group, activeId, overId);
-    }
-  };
 
   const handleReset = (): void => {
     reset();
     setResetMessage(appLabels.indicateurOrdreReinitialise);
     notify(appLabels.indicateurOrdreReinitialise);
-  };
-
-  const announcements: Announcements = {
-    onDragStart: ({ active }) =>
-      appLabels.indicateurReordonnerPrise(describeDragId(String(active.id))),
-    onDragOver: ({ active, over }) =>
-      over === null
-        ? undefined
-        : appLabels.indicateurReordonnerSurvol(
-            describeDragId(String(active.id)),
-            describeDragId(String(over.id))
-          ),
-    onDragEnd: ({ active, over }) => {
-      const isCancelledDrop = over === null || active.id === over.id;
-      return isCancelledDrop
-        ? appLabels.indicateurReordonnerAnnule(describeDragId(String(active.id)))
-        : appLabels.indicateurReordonnerDepose(
-            describeDragId(String(active.id)),
-            describeDragId(String(over.id))
-          );
-    },
-    onDragCancel: ({ active }) =>
-      appLabels.indicateurReordonnerAnnule(describeDragId(String(active.id))),
   };
 
   return (

--- a/apps/app/src/indicateurs/valeurs/grid/grid-frame.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/grid-frame.tsx
@@ -19,11 +19,9 @@ import { useGridContext } from './grid-context';
 import { useGetTable } from './use-get-table';
 import { useGridKeyboardNav } from './keyboard-navigation/use-grid-keyboard-nav';
 import { useGridCopyPaste } from './paste/use-grid-copy-paste';
-import { groupDragId, rowDragId, useGridReorder } from './drag-reorder/use-grid-reorder';
+import { parseDragId, useGridReorder } from './drag-reorder/use-grid-reorder';
 import { GridHead } from './grid-head';
 import { GridBody } from './grid-body';
-
-const dragType = (dragId: string): string => dragId.split('-')[0];
 
 export const GridFrame = (): JSX.Element => {
   const {
@@ -75,20 +73,25 @@ export const GridFrame = (): JSX.Element => {
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
   );
 
-  const groupIdOf = (dragId: string): string | undefined =>
-    orderedGroups.find((group) =>
-      group.rows.some((row) => rowDragId(row.indicateurId) === dragId)
+  const groupIdOf = (dragId: string): string | undefined => {
+    const parsed = parseDragId(dragId);
+    if (parsed?.type !== 'row') {
+      return undefined;
+    }
+    return orderedGroups.find((group) =>
+      group.rows.some((row) => row.indicateurId === parsed.indicateurId)
     )?.id;
+  };
 
   const collisionDetection: CollisionDetection = (args) => {
     const activeId = String(args.active.id);
-    const activeType = dragType(activeId);
+    const activeType = parseDragId(activeId)?.type;
     const activeGroup = activeType === 'row' ? groupIdOf(activeId) : undefined;
     return closestCenter({
       ...args,
       droppableContainers: args.droppableContainers.filter((container) => {
         const containerId = String(container.id);
-        if (dragType(containerId) !== activeType) {
+        if (parseDragId(containerId)?.type !== activeType) {
           return false;
         }
         return activeType !== 'row' || groupIdOf(containerId) === activeGroup;
@@ -97,19 +100,23 @@ export const GridFrame = (): JSX.Element => {
   };
 
   const describeDragId = (dragId: string): string => {
-    if (dragId.startsWith('year-')) {
-      return dragId.slice('year-'.length);
+    const parsed = parseDragId(dragId);
+    if (parsed === null) {
+      return dragId;
     }
-    if (dragId.startsWith('group-')) {
+    if (parsed.type === 'year') {
+      return String(parsed.year);
+    }
+    if (parsed.type === 'group') {
       return (
-        orderedGroups.find((group) => groupDragId(group.id) === dragId)?.label ??
+        orderedGroups.find((group) => group.id === parsed.groupId)?.label ??
         dragId
       );
     }
     return (
       table
         .getRowModel()
-        .rows.find((row) => rowDragId(row.original.indicateurId) === dragId)
+        .rows.find((row) => row.original.indicateurId === parsed.indicateurId)
         ?.original.rowLabel ?? dragId
     );
   };
@@ -122,11 +129,15 @@ export const GridFrame = (): JSX.Element => {
     }
     const activeId = String(active.id);
     const overId = String(over.id);
-    if (activeId.startsWith('year-')) {
+    const parsed = parseDragId(activeId);
+    if (parsed === null) {
+      return;
+    }
+    if (parsed.type === 'year') {
       reorderYears(activeId, overId);
       return;
     }
-    if (activeId.startsWith('group-')) {
+    if (parsed.type === 'group') {
       reorderGroups(activeId, overId);
       return;
     }

--- a/apps/app/src/indicateurs/valeurs/grid/group-header-cell.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/group-header-cell.tsx
@@ -1,6 +1,6 @@
 import { DraggableAttributes, DraggableSyntheticListeners } from '@dnd-kit/core';
 import { JSX } from 'react';
-import { DragHandle } from './drag-reorder/drag-handle';
+import { DraggableHeaderLabel } from './drag-reorder/draggable-header-label';
 
 type GroupDragHandle = {
   attributes: DraggableAttributes;
@@ -24,16 +24,6 @@ export const GroupHeaderCell = ({
     rowSpan={rowSpan}
     className="sticky left-0 z-10 border border-grey-3 bg-grey-1 p-2 align-top text-left font-bold text-primary-9"
   >
-    <div className="flex items-center gap-1">
-      {dragHandle !== undefined && (
-        <DragHandle
-          attributes={dragHandle.attributes}
-          listeners={dragHandle.listeners}
-          setActivatorNodeRef={dragHandle.setActivatorNodeRef}
-          targetLabel={label}
-        />
-      )}
-      {label}
-    </div>
+    <DraggableHeaderLabel label={label} dragHandle={dragHandle} />
   </th>
 );

--- a/apps/app/src/indicateurs/valeurs/grid/row-header.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/row-header.tsx
@@ -1,6 +1,6 @@
 import { DraggableAttributes, DraggableSyntheticListeners } from '@dnd-kit/core';
 import { JSX } from 'react';
-import { DragHandle } from './drag-reorder/drag-handle';
+import { DraggableHeaderLabel } from './drag-reorder/draggable-header-label';
 
 type RowDragHandle = {
   attributes: DraggableAttributes;
@@ -21,15 +21,6 @@ export const RowHeader = ({
     role="rowheader"
     className="border border-grey-3 bg-white p-2 text-left font-medium text-primary-9"
   >
-    <div className="flex items-center gap-1">
-      {dragHandle !== undefined && (
-        <DragHandle
-          attributes={dragHandle.attributes}
-          listeners={dragHandle.listeners}
-          targetLabel={label}
-        />
-      )}
-      {label}
-    </div>
+    <DraggableHeaderLabel label={label} dragHandle={dragHandle} />
   </th>
 );


### PR DESCRIPTION
## Nature

Refactor structure du drag-and-drop de la grille. **PR empilee sur #4685** (base = `refactor/indicateur-grid-types-api`) : ne mergera qu'apres #4682 puis #4685. Implemente le groupe « C » de l'analyse.

## Contenu (3 commits)

- **C2** `parseDragId` typé : le format des drag-ids etait decode a la main dans `grid-frame` (`dragType` via `split('-')`, `.startsWith('year-')`, `.slice('year-'.length)`), en doublon des encodeurs `yearDragId`/`rowDragId`/`groupDragId`. Ajoute `parseDragId` (union discriminee) a cote des encodeurs + spec ; `grid-frame` matche sur le type parse et compare `indicateurId`/`groupId` directement.
- **C1** extrait `useGridDragHandlers` : `GridFrame` noyait ~90 lignes d'orchestration DnD (sensors, collision, `onDragEnd`, `describeDragId`, annonces a11y) devant son JSX. Extrait dans un hook ; `GridFrame` redevient une reassemblage (`DndContext` + `GridHead` + `GridBody`).
- **C3** primitive `DraggableHeaderLabel` : `RowHeader`/`GroupHeaderCell` repetaient le bloc « poignee + libelle ». Extrait ; chaque header ne porte plus que son `<th>` propre.

## Surface de review

`drag-reorder/use-grid-drag-handlers.ts` (nouveau, pur deplacement de logique) et `parseDragId`. `grid-frame.tsx` : verifier qu'il ne reste que la reassemblage.

## Verification

- Typecheck source (`tsconfig.project.json`) propre.
- 18 fichiers / 99 tests de la grille au vert (+4 tests `parseDragId`).
- Lint propre sur les fichiers touches.

## Hors scope

Restent (analyse) : D3 (`parseCellNumber` util partage, touche du legacy), D4 (forme duale `GridInput`, demande produit), et les trous de tests E (`OpenDataSelector` failure wiring...). Analyse : `compound-knowledge-db/docs/plans/2026-07-03-002-refactor-indicateur-value-grid-analyse.md`.
