### PR TITLE
feat(indicateurs): infobulle au survol de la pastille open data

### DIFF
--- a/apps/app/src/indicateurs/valeurs/grid/open-data-picker/coverage-dot.spec.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/open-data-picker/coverage-dot.spec.tsx
@@ -1,0 +1,51 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { GridCellServicesProvider } from '../grid-context';
+import { OpenDataSource, toIndicateurId, toYear } from '../types';
+import { CoverageDot } from './coverage-dot';
+
+const coveringSources: OpenDataSource[] = [
+  {
+    sourceId: 'citepa',
+    libelle: 'CITEPA',
+    value: 42,
+    methodologie: null,
+    dateVersion: '2026-01-01',
+  },
+];
+
+const renderDot = (): void => {
+  render(
+    <GridCellServicesProvider
+      services={{
+        saveCellValue: vi.fn(),
+        selectOpenData: vi.fn(),
+        clearCell: vi.fn(),
+        unit: 't',
+      }}
+    >
+      <CoverageDot
+        coveringSources={coveringSources}
+        groupLabel="Résidentiel"
+        rowLabel="NOx"
+        indicateurId={toIndicateurId(25)}
+        year={toYear(2050)}
+      />
+    </GridCellServicesProvider>
+  );
+};
+
+describe('CoverageDot', () => {
+  it('affiche une infobulle au survol de la pastille', async () => {
+    renderDot();
+
+    const [pastille] = screen
+      .getByRole('button', { name: 'Valeur open data disponible' })
+      .getElementsByTagName('span');
+    fireEvent.mouseEnter(pastille);
+
+    expect(
+      await screen.findByText('Open data disponible pour cette cellule')
+    ).toBeDefined();
+  });
+});

--- a/apps/app/src/indicateurs/valeurs/grid/open-data-picker/coverage-dot.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/open-data-picker/coverage-dot.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Button } from '@tet/ui';
+import { Button, Tooltip } from '@tet/ui';
 import { JSX } from 'react';
 import { appLabels } from '@/app/labels/catalog';
 import { IndicateurId, OpenDataSource, Year } from '../types';
@@ -37,7 +37,9 @@ export const CoverageDot = ({
       aria-label={appLabels.indicateurValeurOpenDataDisponible}
       className="absolute right-0.5 top-0.5 flex items-center justify-center p-1"
     >
-      <span className="h-2 w-2 rounded-full bg-success-1 ring-2 ring-success-2" />
+      <Tooltip label={appLabels.indicateurCelluleOpenDataDisponible}>
+        <span className="h-2 w-2 rounded-full bg-success-1 ring-2 ring-success-2" />
+      </Tooltip>
     </Button>
   </OpenDataSelector>
 );

--- a/apps/app/src/indicateurs/valeurs/grid/open-data-picker/coverage-dot.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/open-data-picker/coverage-dot.tsx
@@ -16,6 +16,12 @@ type CoverageDotProps = {
   columnSelection?: ColumnSelection;
 };
 
+const OpenDataDot = (): JSX.Element => (
+  <Tooltip label={appLabels.indicateurCelluleOpenDataDisponible}>
+    <span className="h-2 w-2 rounded-full bg-success-1 ring-2 ring-success-2" />
+  </Tooltip>
+);
+
 export const CoverageDot = ({
   coveringSources,
   groupLabel,
@@ -37,9 +43,7 @@ export const CoverageDot = ({
       aria-label={appLabels.indicateurValeurOpenDataDisponible}
       className="absolute right-0.5 top-0.5 flex items-center justify-center p-1"
     >
-      <Tooltip label={appLabels.indicateurCelluleOpenDataDisponible}>
-        <span className="h-2 w-2 rounded-full bg-success-1 ring-2 ring-success-2" />
-      </Tooltip>
+      <OpenDataDot />
     </Button>
   </OpenDataSelector>
 );

--- a/apps/app/src/labels/catalog.ts
+++ b/apps/app/src/labels/catalog.ts
@@ -1774,6 +1774,7 @@ export const appLabels = {
   }),
   indicateurSelectionnerValeurOpenData: 'Sélectionner une valeur open data',
   indicateurValeurOpenDataDisponible: 'Valeur open data disponible',
+  indicateurCelluleOpenDataDisponible: 'Open data disponible pour cette cellule',
   indicateurSelectionnerValeurEchec:
     'La sélection de la valeur open data a échoué',
   indicateurRepasserSaisieManuelle: 'Repasser en saisie manuelle',


### PR DESCRIPTION
## Changement

Au survol de la pastille verte de couverture open data (dans une cellule vide), affiche une infobulle « Open data disponible pour cette cellule ».

- `Tooltip` du DS posé sur le `<span>` de la pastille (élément DOM distinct du `Button`, qui reste le déclencheur clic du sélecteur `OpenDataSelector`) → pas de conflit entre les deux primitives flottantes.
- Libellé via `appLabels.indicateurCelluleOpenDataDisponible`, distinct de l'aria-label existant du bouton (« Valeur open data disponible »).

## Tests

- `coverage-dot.spec.tsx` : le survol de la pastille ouvre l'infobulle.
- Dossier grille complet vert : **96 tests**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * La pastille indiquant des données Open Data affiche désormais une infobulle explicite au survol.

* **Tests**
  * Ajout d’un test unitaire vérifiant que l’infobulle apparaît correctement lors du survol de la pastille.

* **Documentation**
  * Ajout d’une nouvelle libellé d’interface pour signaler qu’une cellule dispose de données Open Data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->