### PR TITLE
refactor(indicateurs): OpenDataSelector - handlers testables + couverture des echecs

### DIFF
--- a/apps/app/src/indicateurs/valeurs/grid/open-data-picker/build-open-data-handlers.spec.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/open-data-picker/build-open-data-handlers.spec.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest';
+import { appLabels } from '../../../../labels/catalog';
+import { buildOpenDataHandlers } from './build-open-data-handlers';
+import { ColumnSelection } from './open-data-picker';
+import { OpenDataSource, toIndicateurId, toSourceId, toYear } from '../types';
+
+const baseArgs = () => ({
+  indicateurId: toIndicateurId(1),
+  year: toYear(2030),
+  close: vi.fn(),
+  notify: vi.fn(),
+  selectOpenData: vi.fn().mockResolvedValue({ ok: true, value: undefined }),
+  clearCell: vi.fn().mockResolvedValue({ ok: true, value: undefined }),
+});
+
+const source: OpenDataSource = {
+  sourceId: toSourceId('citepa'),
+  libelle: 'CITEPA',
+  value: 100,
+  methodologie: null,
+  dateVersion: '2026-01-01',
+};
+
+describe('buildOpenDataHandlers', () => {
+  it('ferme apres une selection open data reussie', async () => {
+    const args = baseArgs();
+    await buildOpenDataHandlers(args).onSelect(toSourceId('citepa'));
+
+    expect(args.close).toHaveBeenCalledTimes(1);
+    expect(args.notify).not.toHaveBeenCalled();
+  });
+
+  it('notifie l echec et ne ferme pas quand la selection open data echoue', async () => {
+    const args = { ...baseArgs(), selectOpenData: vi.fn().mockResolvedValue({ ok: false }) };
+    await buildOpenDataHandlers(args).onSelect(toSourceId('citepa'));
+
+    expect(args.notify).toHaveBeenCalledWith(
+      appLabels.indicateurSelectionnerValeurEchec
+    );
+    expect(args.close).not.toHaveBeenCalled();
+  });
+
+  it('ferme apres un retour en saisie manuelle reussi', async () => {
+    const args = baseArgs();
+    await buildOpenDataHandlers(args).onReset();
+
+    expect(args.close).toHaveBeenCalledTimes(1);
+    expect(args.notify).not.toHaveBeenCalled();
+  });
+
+  it('notifie l echec et ne ferme pas quand le retour en saisie manuelle echoue', async () => {
+    const args = { ...baseArgs(), clearCell: vi.fn().mockResolvedValue({ ok: false }) };
+    await buildOpenDataHandlers(args).onReset();
+
+    expect(args.notify).toHaveBeenCalledWith(
+      appLabels.indicateurRepasserSaisieEchec
+    );
+    expect(args.close).not.toHaveBeenCalled();
+  });
+
+  it('notifie et rend false quand la selection de colonne n aboutit pas', async () => {
+    const columnSelection: ColumnSelection = {
+      source,
+      count: 3,
+      onSelect: vi.fn().mockResolvedValue(false),
+    };
+    const args = { ...baseArgs(), columnSelection };
+    const handlers = buildOpenDataHandlers(args);
+
+    expect(await handlers.columnSelection?.onSelect()).toBe(false);
+    expect(args.notify).toHaveBeenCalledWith(
+      appLabels.indicateurSelectionnerValeurEchec
+    );
+    expect(args.close).not.toHaveBeenCalled();
+  });
+
+  it('ferme quand la selection de colonne aboutit', async () => {
+    const columnSelection: ColumnSelection = {
+      source,
+      count: 3,
+      onSelect: vi.fn().mockResolvedValue(true),
+    };
+    const args = { ...baseArgs(), columnSelection };
+    const handlers = buildOpenDataHandlers(args);
+
+    expect(await handlers.columnSelection?.onSelect()).toBe(true);
+    expect(args.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('laisse columnSelection undefined quand aucune n est fournie', () => {
+    expect(buildOpenDataHandlers(baseArgs()).columnSelection).toBeUndefined();
+  });
+});

--- a/apps/app/src/indicateurs/valeurs/grid/open-data-picker/build-open-data-handlers.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/open-data-picker/build-open-data-handlers.ts
@@ -1,0 +1,65 @@
+import { appLabels } from '@/app/labels/catalog';
+import { GridCellServices } from '../grid-context';
+import { IndicateurId, SourceId, Year } from '../types';
+import { ColumnSelection } from './open-data-picker';
+
+export const buildOpenDataHandlers = ({
+  indicateurId,
+  year,
+  selectOpenData,
+  clearCell,
+  notify,
+  columnSelection,
+  close,
+}: {
+  indicateurId: IndicateurId;
+  year: Year;
+  selectOpenData: GridCellServices['selectOpenData'];
+  clearCell: GridCellServices['clearCell'];
+  notify: GridCellServices['notify'];
+  columnSelection?: ColumnSelection;
+  close: () => void;
+}): {
+  onSelect: (sourceId: SourceId) => Promise<void>;
+  onReset: () => Promise<void>;
+  columnSelection?: ColumnSelection;
+} => {
+  const onSelect = async (sourceId: SourceId): Promise<void> => {
+    const selectionResult = await selectOpenData({ indicateurId, year, sourceId });
+    if (selectionResult.ok) {
+      close();
+    } else {
+      notify(appLabels.indicateurSelectionnerValeurEchec);
+    }
+  };
+
+  const onReset = async (): Promise<void> => {
+    const resetResult = await clearCell({ indicateurId, year });
+    if (resetResult.ok) {
+      close();
+    } else {
+      notify(appLabels.indicateurRepasserSaisieEchec);
+    }
+  };
+
+  if (columnSelection === undefined) {
+    return { onSelect, onReset, columnSelection: undefined };
+  }
+
+  return {
+    onSelect,
+    onReset,
+    columnSelection: {
+      ...columnSelection,
+      onSelect: async (): Promise<boolean> => {
+        const allSelected = await columnSelection.onSelect();
+        if (allSelected) {
+          close();
+        } else {
+          notify(appLabels.indicateurSelectionnerValeurEchec);
+        }
+        return allSelected;
+      },
+    },
+  };
+};

--- a/apps/app/src/indicateurs/valeurs/grid/open-data-picker/open-data-selector.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/open-data-picker/open-data-selector.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import { JSX } from 'react';
-import { appLabels } from '@/app/labels/catalog';
 import DropdownFloater from '@/app/ui/shared/floating-ui/DropdownFloater';
 import { useGridCellServices } from '../grid-context';
 import { OpenDataSource, IndicateurId, Year } from '../types';
 import { ColumnSelection, OpenDataPicker } from './open-data-picker';
+import { buildOpenDataHandlers } from './build-open-data-handlers';
 
 type OpenDataSelectorProps = {
   groupLabel: string;
@@ -33,53 +33,35 @@ export const OpenDataSelector = ({
     <DropdownFloater
       placement="bottom-end"
       offsetValue={2}
-      render={({ close }) => (
-        <OpenDataPicker
-          groupLabel={groupLabel}
-          rowLabel={rowLabel}
-          year={year}
-          unit={unit}
-          sources={sources}
-          selectedSourceId={selectedSourceId}
-          onSelect={async (sourceId) => {
-            const selectionResult = await selectOpenData({
-              indicateurId,
-              year,
-              sourceId,
-            });
-            if (selectionResult.ok) {
-              close();
-            } else {
-              notify(appLabels.indicateurSelectionnerValeurEchec);
-            }
-          }}
-          onClose={close}
-          onReset={async () => {
-            const resetResult = await clearCell({ indicateurId, year });
-            if (resetResult.ok) {
-              close();
-            } else {
-              notify(appLabels.indicateurRepasserSaisieEchec);
-            }
-          }}
-          columnSelection={
-            columnSelection === undefined
-              ? undefined
-              : {
-                  ...columnSelection,
-                  onSelect: async () => {
-                    const allSelected = await columnSelection.onSelect();
-                    if (allSelected) {
-                      close();
-                    } else {
-                      notify(appLabels.indicateurSelectionnerValeurEchec);
-                    }
-                    return allSelected;
-                  },
-                }
-          }
-        />
-      )}
+      render={({ close }) => {
+        const {
+          onSelect,
+          onReset,
+          columnSelection: wrappedColumnSelection,
+        } = buildOpenDataHandlers({
+          indicateurId,
+          year,
+          selectOpenData,
+          clearCell,
+          notify,
+          columnSelection,
+          close,
+        });
+        return (
+          <OpenDataPicker
+            groupLabel={groupLabel}
+            rowLabel={rowLabel}
+            year={year}
+            unit={unit}
+            sources={sources}
+            selectedSourceId={selectedSourceId}
+            onSelect={onSelect}
+            onClose={close}
+            onReset={onReset}
+            columnSelection={wrappedColumnSelection}
+          />
+        );
+      }}
     >
       {children}
     </DropdownFloater>


### PR DESCRIPTION
## Nature

Refactor + test : rend testables les branches d'echec d'`OpenDataSelector` et les couvre. **Base = `main`** (independant de #4686 — ne touche pas les memes fichiers). Implemente le trou de test « E » (P2) de l'analyse.

## Contenu (2 commits)

- **refactor** extrait `buildOpenDataHandlers` : les 3 handlers async (selection open data, retour saisie manuelle, selection de colonne) etaient inline dans le render-prop du `DropdownFloater` (Floating UI), donc non testables en jsdom. Extraits dans un builder pur (comme `buildColumnSelection`) ; `OpenDataSelector` ne fait plus que cabler les services au picker. Comportement identique.
- **test** couvre succes ET echec de chaque handler : `selectOpenData`/`clearCell`/selection de colonne qui echouent -> `notify(...)` sans `close()`. C'etait le seul chemin d'echec non teste de la grille.

## Verification

- Typecheck source propre.
- 19 fichiers / 102 tests de la grille au vert (+7 nouveaux).
- Lint propre.

## Reste du backlog (analyse)

- **D3** `parseCellNumber` -> util partage (touche 2 fichiers legacy) — PR separee.
- **D4** forme duale `GridInput` (plat|groupe) — **bloque sur une reponse produit** (« la grille est-elle toujours groupee ? »).
- E mineurs restants (P3) : branches `variation` annee future, gardes fail-fast des contextes.

Analyse : `compound-knowledge-db/docs/plans/2026-07-03-002-refactor-indicateur-value-grid-analyse.md`.
