### PR TITLE
feat(indicateurs): adaptateur to-grid-cells (valeurs list -> Map<CellKey,GridCell>)

### DIFF
--- a/apps/app/src/indicateurs/valeurs/grid/adapters/to-grid-cells.spec.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/adapters/to-grid-cells.spec.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+import { generateCellKey, toIndicateurId, toYear } from '../types';
+import { IndicateurAvecSources, toGridCells } from './to-grid-cells';
+
+const collectivite = (
+  id: number,
+  valeurs: Array<{ id: number; dateValeur: string; resultat: number | null }>
+): IndicateurAvecSources => ({
+  definition: { id },
+  sources: {
+    collectivite: { libelle: 'Collectivité', metadonnees: [], valeurs },
+  },
+});
+
+const key = (id: number, year: number) =>
+  generateCellKey(toIndicateurId(id), toYear(year));
+
+describe('toGridCells', () => {
+  it('indexe les valeurs saisies par indicateur et année', () => {
+    const cells = toGridCells([
+      collectivite(42, [
+        { id: 1, dateValeur: '2030-01-01', resultat: 12 },
+        { id: 2, dateValeur: '2050-01-01', resultat: 8 },
+      ]),
+    ]);
+
+    expect(cells.get(key(42, 2030))).toEqual({
+      kind: 'user-data',
+      value: 12,
+      valueId: 1,
+      coveringSources: [],
+    });
+    expect(cells.get(key(42, 2050))?.value).toBe(8);
+  });
+
+  it('conserve une valeur nulle sans planter', () => {
+    const cells = toGridCells([
+      collectivite(7, [{ id: 3, dateValeur: '2030-01-01', resultat: null }]),
+    ]);
+
+    expect(cells.get(key(7, 2030))?.value).toBeNull();
+  });
+
+  it('ignore les indicateurs sans aucune source', () => {
+    const cells = toGridCells([{ definition: { id: 9 }, sources: {} }]);
+
+    expect(cells.size).toBe(0);
+  });
+
+  it('assemble les sources open data couvrant une cellule', () => {
+    const cells = toGridCells([
+      {
+        definition: { id: 42 },
+        sources: {
+          collectivite: {
+            libelle: 'Collectivité',
+            metadonnees: [],
+            valeurs: [{ id: 1, dateValeur: '2030-01-01', resultat: 12 }],
+          },
+          citepa: {
+            libelle: 'CITEPA',
+            metadonnees: [
+              { id: 5, methodologie: 'Inventaire', dateVersion: '2026-01-01' },
+            ],
+            valeurs: [
+              { id: 90, dateValeur: '2030-01-01', resultat: 15, metadonneeId: 5 },
+            ],
+          },
+        },
+      },
+    ]);
+
+    expect(cells.get(key(42, 2030))).toEqual({
+      kind: 'user-data',
+      value: 12,
+      valueId: 1,
+      coveringSources: [
+        {
+          sourceId: 'citepa',
+          libelle: 'CITEPA',
+          value: 15,
+          methodologie: 'Inventaire',
+          dateVersion: '2026-01-01',
+        },
+      ],
+    });
+  });
+
+  it('émet une cellule vide couverte quand seule une source open data existe', () => {
+    const cells = toGridCells([
+      {
+        definition: { id: 8 },
+        sources: {
+          citepa: {
+            libelle: 'CITEPA',
+            metadonnees: [
+              { id: 5, methodologie: null, dateVersion: '2026-01-01' },
+            ],
+            valeurs: [
+              { id: 90, dateValeur: '2050-01-01', resultat: 20, metadonneeId: 5 },
+            ],
+          },
+        },
+      },
+    ]);
+
+    expect(cells.get(key(8, 2050))).toEqual({
+      kind: 'user-data',
+      value: null,
+      valueId: undefined,
+      coveringSources: [
+        {
+          sourceId: 'citepa',
+          libelle: 'CITEPA',
+          value: 20,
+          methodologie: null,
+          dateVersion: '2026-01-01',
+        },
+      ],
+    });
+  });
+
+  it('exclut les valeurs open data à résultat nul de la couverture', () => {
+    const cells = toGridCells([
+      {
+        definition: { id: 3 },
+        sources: {
+          citepa: {
+            libelle: 'CITEPA',
+            metadonnees: [{ id: 5, methodologie: null, dateVersion: '2026-01-01' }],
+            valeurs: [
+              { id: 90, dateValeur: '2030-01-01', resultat: null, metadonneeId: 5 },
+            ],
+          },
+        },
+      },
+    ]);
+
+    expect(cells.size).toBe(0);
+  });
+});

--- a/apps/app/src/indicateurs/valeurs/grid/adapters/to-grid-cells.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/adapters/to-grid-cells.ts
@@ -1,0 +1,107 @@
+import { groupBy, isNil } from 'es-toolkit';
+import {
+  CellKey,
+  generateCellKey,
+  GridCell,
+  OpenDataSource,
+  toIndicateurId,
+  toSourceId,
+  toYear,
+  Year,
+} from '../types';
+
+const COLLECTIVITE_SOURCE_ID = 'collectivite';
+
+const yearOf = (dateValeur: string): Year => toYear(Number(dateValeur.slice(0, 4)));
+
+type ValeurGroupee = {
+  id: number;
+  dateValeur: string;
+  resultat?: number | null;
+  metadonneeId?: number | null;
+};
+
+type SourceMetadonnee = {
+  id: number;
+  methodologie: string | null;
+  dateVersion: string;
+};
+
+type SourceGroupee = {
+  libelle: string;
+  metadonnees: SourceMetadonnee[];
+  valeurs: ValeurGroupee[];
+};
+
+export type IndicateurAvecSources = {
+  definition: { id: number };
+  sources: Record<string, SourceGroupee>;
+};
+
+type CoveringAtYear = { year: Year; source: OpenDataSource };
+
+const sourceCoverings = (
+  sourceId: string,
+  group: SourceGroupee
+): CoveringAtYear[] =>
+  group.valeurs.flatMap((valeur): CoveringAtYear[] => {
+    if (isNil(valeur.resultat)) {
+      return [];
+    }
+    const metadonnee = group.metadonnees.find((m) => m.id === valeur.metadonneeId);
+    return [
+      {
+        year: yearOf(valeur.dateValeur),
+        source: {
+          sourceId: toSourceId(sourceId),
+          libelle: group.libelle,
+          value: valeur.resultat,
+          methodologie: metadonnee?.methodologie ?? null,
+          dateVersion: metadonnee?.dateVersion ?? '',
+        },
+      },
+    ];
+  });
+
+const coveringSourcesByYear = (
+  sources: Record<string, SourceGroupee>
+): Map<Year, OpenDataSource[]> => {
+  const coverings = Object.entries(sources)
+    .filter(([sourceId]) => sourceId !== COLLECTIVITE_SOURCE_ID)
+    .flatMap(([sourceId, group]) => sourceCoverings(sourceId, group));
+
+  return new Map(
+    Object.entries(groupBy(coverings, (covering) => covering.year)).map(
+      ([year, group]) => [toYear(Number(year)), group.map((covering) => covering.source)]
+    )
+  );
+};
+
+export const toGridCells = (
+  indicateurs: IndicateurAvecSources[]
+): Map<CellKey, GridCell> =>
+  new Map(
+    indicateurs.flatMap(({ definition, sources }) => {
+      const indicateurId = toIndicateurId(definition.id);
+      const userValues = sources[COLLECTIVITE_SOURCE_ID]?.valeurs ?? [];
+      const covering = coveringSourcesByYear(sources);
+
+      const userValueByYear = new Map(
+        userValues.map((valeur) => [yearOf(valeur.dateValeur), valeur])
+      );
+      const years = new Set([...userValueByYear.keys(), ...covering.keys()]);
+
+      return Array.from(years, (year): [CellKey, GridCell] => {
+        const userValue = userValueByYear.get(year);
+        return [
+          generateCellKey(indicateurId, year),
+          {
+            kind: 'user-data',
+            value: userValue?.resultat ?? null,
+            valueId: userValue?.id,
+            coveringSources: covering.get(year) ?? [],
+          },
+        ];
+      });
+    })
+  );


### PR DESCRIPTION
## Contexte

Binding de lecture générique de `IndicateurValuesGrid` : transforme la sortie de `indicateurs.valeurs.list` en `Map<CellKey, GridCell>` attendue par la grille. La grille reste **contrôlée** (`cells` en prop) ; cet adaptateur est la brique que tout consommateur (page polluants PCAET, future page Indicateurs) réutilise au lieu de la ré-implémenter.

## Changement

- `apps/app/src/indicateurs/valeurs/grid/adapters/to-grid-cells.ts` : pur, n'importe que les types de la grille — **aucun** couplage domaine (cae_4 / polluants / démarche).
- Indexe les valeurs saisies (source `collectivite`) par `:`.

## Portée MVP

- Cellules **user-data** uniquement ; `coveringSources` (sources open data par cellule) = `[]` pour l'instant — l'assemblage open data (via le read groupé-par-source déjà exposé par `list`) viendra dans un second temps.

## Tests

- `to-grid-cells.spec.ts` : indexation par indicateur/année, valeur nulle, absence de source collectivité. 3 tests verts.

## Note

Premier consommateur = l'intégration de la grille sur la page polluants atmosphériques PCAET (branche stackée).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Ajout d’un adaptateur convertissant les indicateurs munis de sources en cellules de grille, avec regroupement des années et normalisation des valeurs manquantes à `null`.
  * Prise en compte des couvertures via sources open data pour enrichir les cellules lorsque les saisies directes ne sont pas disponibles.
* **Tests**
  * Extension des tests pour valider les clés des cellules, la conservation de `null`, l’ignorance des indicateurs sans source exploitable, et le comportement spécifique autour des coverings open data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->