### PR TITLE
feat(indicateurs): open data en primary + confirmation du changement d'année de référence

### DIFF
--- a/apps/app/src/indicateurs/valeurs/grid/open-data-cell.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/open-data-cell.tsx
@@ -47,7 +47,7 @@ export const OpenDataCell = memo(
             source: cell.source.libelle,
           })}
           aria-describedby={impactId}
-          className="flex h-full w-full items-center gap-2 bg-success-2 px-3 text-sm outline-none focus:ring-2 focus:ring-inset focus:ring-primary-5"
+          className="flex h-full w-full items-center gap-2 bg-primary-2 px-3 text-sm outline-none focus:ring-2 focus:ring-inset focus:ring-primary-5"
         >
           <span className="shrink-0">
             <SourceBadge source={cell.source} />
@@ -57,7 +57,7 @@ export const OpenDataCell = memo(
             hintId={impactId}
             className="ml-auto"
           >
-            <span className="text-success-1">{cell.value}</span>
+            <span className="text-primary-8">{cell.value}</span>
           </ValueWithVariation>
         </button>
       </OpenDataSelector>

--- a/apps/app/src/indicateurs/valeurs/grid/open-data-picker/coverage-dot.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/open-data-picker/coverage-dot.tsx
@@ -18,7 +18,7 @@ type CoverageDotProps = {
 
 const OpenDataDot = (): JSX.Element => (
   <Tooltip label={appLabels.indicateurCelluleOpenDataDisponible}>
-    <span className="h-2 w-2 rounded-full bg-success-1 ring-2 ring-success-2" />
+    <span className="h-2 w-2 rounded-full bg-primary-7 ring-2 ring-primary-2" />
   </Tooltip>
 );
 

--- a/apps/app/src/indicateurs/valeurs/grid/open-data-picker/open-data-picker.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/open-data-picker/open-data-picker.tsx
@@ -44,7 +44,7 @@ const SourceValue = ({
   unit: string | null;
   isSelected: boolean;
 }): JSX.Element => (
-  <span className="flex items-center gap-1 whitespace-nowrap text-sm font-bold text-success-1">
+  <span className="flex items-center gap-1 whitespace-nowrap text-sm font-bold text-primary-8">
     {isSelected ? <Icon icon="checkbox-circle-fill" size="sm" /> : null}
     {unit !== null ? `${value} ${unit}` : value}
   </span>
@@ -70,7 +70,7 @@ const SourceCard = ({
     className={cn(
       'flex w-full items-start justify-between gap-3 rounded-lg border p-3 text-left transition-colors',
       isSelected
-        ? 'border-success-1 bg-success-1/5'
+        ? 'border-primary-7 bg-primary-7/5'
         : 'border-grey-3 hover:border-primary-4 hover:bg-primary-0'
     )}
   >
@@ -137,7 +137,7 @@ const ColumnSelectionButton = ({
   <button
     type="button"
     onClick={onSelect}
-    className="rounded-lg border border-dashed border-success-1 bg-success-1/10 p-3 text-left text-sm text-success-1 transition-colors hover:bg-success-1/20"
+    className="rounded-lg border border-dashed border-primary-7 bg-primary-7/10 p-3 text-left text-sm text-primary-8 transition-colors hover:bg-primary-7/20"
   >
     {appLabels.indicateurSelectionnerPourColonne(libelle, count, groupLabel)}
   </button>

--- a/apps/app/src/indicateurs/valeurs/grid/reference-year/reference-year-change-modal.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/reference-year/reference-year-change-modal.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { Modal, ModalFooterOKCancel } from '@tet/ui';
+import { JSX } from 'react';
+import { appLabels } from '@/app/labels/catalog';
+
+type ReferenceYearChangeModalProps = {
+  isOpen: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+export const ReferenceYearChangeModal = ({
+  isOpen,
+  onConfirm,
+  onCancel,
+}: ReferenceYearChangeModalProps): JSX.Element => (
+  <Modal
+    size="xs"
+    title={appLabels.indicateurChangerAnneeReferenceTitre}
+    openState={{
+      isOpen,
+      setIsOpen: (open) => {
+        if (!open) {
+          onCancel();
+        }
+      },
+    }}
+    render={() => (
+      <p className="mb-0 text-sm text-grey-8">
+        {appLabels.indicateurChangerAnneeReferenceDescription}
+      </p>
+    )}
+    renderFooter={({ close }) => (
+      <ModalFooterOKCancel
+        btnCancelProps={{ children: appLabels.annuler, onClick: close }}
+        btnOKProps={{ children: appLabels.confirmer, onClick: onConfirm }}
+      />
+    )}
+  />
+);

--- a/apps/app/src/indicateurs/valeurs/grid/reference-year/reference-year-editor.spec.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/reference-year/reference-year-editor.spec.tsx
@@ -35,33 +35,71 @@ const isEditorClosed = (): boolean =>
     name: appLabels.indicateurAnneeReferenceChamp,
   }) === null;
 
+const findConfirmButton = (): Promise<HTMLElement> =>
+  screen.findByRole('button', { name: appLabels.confirmer });
+
 describe('ReferenceYearEditor', () => {
-  it("enregistre l'année saisie à la validation", async () => {
+  it("enregistre l'année saisie après confirmation", async () => {
     const onReferenceYearChange = vi.fn();
     const input = openEditor(onReferenceYearChange);
     fireEvent.change(input, { target: { value: '2018' } });
     submitForm(input);
+    const confirm = await findConfirmButton();
+    expect(onReferenceYearChange).not.toHaveBeenCalled();
+    fireEvent.click(confirm);
     await waitFor(() =>
       expect(onReferenceYearChange).toHaveBeenCalledWith(2018)
     );
   });
 
-  it("affiche le message et n'enregistre pas une année hors bornes", async () => {
+  it("n'enregistre pas quand la confirmation est annulée", async () => {
     const onReferenceYearChange = vi.fn();
     const input = openEditor(onReferenceYearChange);
-    fireEvent.change(input, { target: { value: '1800' } });
+    fireEvent.change(input, { target: { value: '2018' } });
     submitForm(input);
-    await screen.findByText(
-      appLabels.indicateurAnneeReferenceInvalide(1900, 2100)
+    await findConfirmButton();
+    fireEvent.click(screen.getByRole('button', { name: appLabels.annuler }));
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('button', { name: appLabels.confirmer })
+      ).toBeNull()
     );
     expect(onReferenceYearChange).not.toHaveBeenCalled();
   });
 
-  it("annule sans enregistrer quand l'année est inchangée", async () => {
+  it("affiche le message et n'enregistre pas une année avant 2010", async () => {
+    const onReferenceYearChange = vi.fn();
+    const input = openEditor(onReferenceYearChange);
+    fireEvent.change(input, { target: { value: '2009' } });
+    submitForm(input);
+    await screen.findByText(
+      appLabels.indicateurAnneeReferenceInvalide(2010, 2029)
+    );
+    expect(
+      screen.queryByRole('button', { name: appLabels.confirmer })
+    ).toBeNull();
+    expect(onReferenceYearChange).not.toHaveBeenCalled();
+  });
+
+  it("affiche le message et n'enregistre pas une année après 2029", async () => {
+    const onReferenceYearChange = vi.fn();
+    const input = openEditor(onReferenceYearChange);
+    fireEvent.change(input, { target: { value: '2030' } });
+    submitForm(input);
+    await screen.findByText(
+      appLabels.indicateurAnneeReferenceInvalide(2010, 2029)
+    );
+    expect(onReferenceYearChange).not.toHaveBeenCalled();
+  });
+
+  it("ne demande pas de confirmation quand l'année est inchangée", async () => {
     const onReferenceYearChange = vi.fn();
     const input = openEditor(onReferenceYearChange);
     submitForm(input);
     await waitFor(() => expect(isEditorClosed()).toBe(true));
+    expect(
+      screen.queryByRole('button', { name: appLabels.confirmer })
+    ).toBeNull();
     expect(onReferenceYearChange).not.toHaveBeenCalled();
   });
 

--- a/apps/app/src/indicateurs/valeurs/grid/reference-year/reference-year-editor.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/reference-year/reference-year-editor.tsx
@@ -1,13 +1,14 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { cn, Field, Icon, InlineEditWrapper, Input } from '@tet/ui';
-import { ComponentProps, JSX } from 'react';
+import { ComponentProps, JSX, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { appLabels } from '@/app/labels/catalog';
 import { toYear, Year } from '../types';
+import { ReferenceYearChangeModal } from './reference-year-change-modal';
 
-const MIN_REFERENCE_YEAR = 1900;
-const MAX_REFERENCE_YEAR = 2100;
+const MIN_REFERENCE_YEAR = 2010;
+const MAX_REFERENCE_YEAR = 2029;
 const referenceYearMessage = appLabels.indicateurAnneeReferenceInvalide(
   MIN_REFERENCE_YEAR,
   MAX_REFERENCE_YEAR
@@ -82,36 +83,54 @@ const ReferenceYearInput = ({
 export const ReferenceYearEditor = ({
   year,
   onReferenceYearChange,
-}: ReferenceYearEditorProps): JSX.Element => (
-  <InlineEditWrapper
-    renderOnEdit={({ openState }) => (
-      <ReferenceYearInput
-        year={year}
-        onSubmit={(next) => {
-          if (next !== year) {
-            onReferenceYearChange(next);
-          }
-          openState.setIsOpen(false);
-        }}
-        onCancel={() => openState.setIsOpen(false)}
-      />
-    )}
-  >
-    {(triggerProps: ComponentProps<'button'>) => (
-      <button
-        type="button"
-        {...triggerProps}
-        aria-label={appLabels.indicateurModifierAnneeReference(year)}
-        className={cn(
-          triggerProps.className,
-          'inline-flex items-center gap-1 font-bold text-primary-9'
+}: ReferenceYearEditorProps): JSX.Element => {
+  const [pendingYear, setPendingYear] = useState<Year | null>(null);
+
+  const confirmReferenceYearChange = (): void => {
+    if (pendingYear !== null) {
+      onReferenceYearChange(pendingYear);
+    }
+    setPendingYear(null);
+  };
+
+  return (
+    <>
+      <InlineEditWrapper
+        renderOnEdit={({ openState }) => (
+          <ReferenceYearInput
+            year={year}
+            onSubmit={(next) => {
+              if (next !== year) {
+                setPendingYear(next);
+              }
+              openState.setIsOpen(false);
+            }}
+            onCancel={() => openState.setIsOpen(false)}
+          />
         )}
       >
-        <span className="underline decoration-dotted underline-offset-2">
-          {appLabels.indicateurAnneeReference(year)}
-        </span>
-        <Icon icon="edit-line" size="xs" aria-hidden />
-      </button>
-    )}
-  </InlineEditWrapper>
-);
+        {(triggerProps: ComponentProps<'button'>) => (
+          <button
+            type="button"
+            {...triggerProps}
+            aria-label={appLabels.indicateurModifierAnneeReference(year)}
+            className={cn(
+              triggerProps.className,
+              'inline-flex items-center gap-1 font-bold text-primary-9'
+            )}
+          >
+            <span className="underline decoration-dotted underline-offset-2">
+              {appLabels.indicateurAnneeReference(year)}
+            </span>
+            <Icon icon="edit-line" size="xs" aria-hidden />
+          </button>
+        )}
+      </InlineEditWrapper>
+      <ReferenceYearChangeModal
+        isOpen={pendingYear !== null}
+        onConfirm={confirmReferenceYearChange}
+        onCancel={() => setPendingYear(null)}
+      />
+    </>
+  );
+};

--- a/apps/app/src/labels/catalog.ts
+++ b/apps/app/src/labels/catalog.ts
@@ -1752,6 +1752,9 @@ export const appLabels = {
     `réf. ${year}, modifier l'année de référence`,
   indicateurAnneeReferenceInvalide: (min: number, max: number): string =>
     `Saisissez une année entre ${min} et ${max}.`,
+  indicateurChangerAnneeReferenceTitre: "Changer l'année de référence ?",
+  indicateurChangerAnneeReferenceDescription:
+    "Les valeurs de la colonne de référence seront récupérées depuis les indicateurs si elles sont disponibles, sinon réinitialisées.",
   indicateurColonneAnnee: 'colonne année',
   indicateurLigne: 'ligne',
   indicateurGroupe: 'groupe',


### PR DESCRIPTION
## Contexte

Deux ajustements sur la grille de valeurs d'indicateurs (`apps/app/src/indicateurs/valeurs/grid`) :

1. **Open data en primary plutôt qu'en vert** — la pastille de disponibilité, la cellule open data et les accents du sélecteur (`success`) passent au `primary`. Le témoin d'enregistrement (`save-ack`) reste volontairement en `success`.
2. **Changement d'année de référence plus engageant** — une modale de confirmation précède désormais l'application du changement et précise que les valeurs de la colonne seront reprises depuis les indicateurs si disponibles, sinon réinitialisées. Les bornes de saisie passent de 1900-2100 à **2010-2029**.

Mapping couleurs retenu : `success-1 (#48A775) → primary-7` (fond pastille, bordures), `success-2 (#E4FCEF) → primary-2` (fond cellule, halo), `text-success-1 → text-primary-8 (#5555C3)` pour les textes (meilleur contraste sur fond primary clair).

## Surface de review

**Attention humaine :**
- `reference-year/reference-year-editor.tsx` — passe en composant à état : `pendingYear` diffère l'appel à `onReferenceYearChange` jusqu'à confirmation. Bornes 2010-2029.
- `reference-year/reference-year-change-modal.tsx` (nouveau) — modale de confirmation muette (`Modal` + `ModalFooterOKCancel` du DS), `isOpen`/`onConfirm`/`onCancel`.
- `reference-year/reference-year-editor.spec.tsx` — couvre confirmation, annulation, bornes 2010/2029, année inchangée (pas de modale), Échap.

**Mécaniques :**
- `open-data-cell.tsx`, `open-data-picker/coverage-dot.tsx`, `open-data-picker/open-data-picker.tsx` — remplacement de classes `success-*` par `primary-*`.
- `labels/catalog.ts` — deux libellés (`indicateurChangerAnneeReferenceTitre`, `...Description`).

## Hypothèses

- « OD » = toutes les surfaces open data (pastille + cellule + accents du picker), confirmé avec l'auteur ; `save-ack` exclu car sémantiquement « enregistré ».
- Modale = **confirmation avant application** (Annuler / Confirmer), confirmé avec l'auteur. La reprise/réinitialisation effective des valeurs reste à la charge du consommateur via `onReferenceYearChange` (feature non encore branchée hors stories).

## Anti-duplication

Recherche effectuée : `Modal`/`ModalFooterOKCancel` (DS `@tet/ui`) réutilisés — pas de nouvelle primitive de modale. `openState` contrôlé via `pendingYear`, pattern identique à `save-score.modal.tsx`. Aucun helper de confirmation équivalent trouvé dans le repo.

## Zones de moindre confiance

- Rendu jsdom de la `Modal` (FloatingPortal) : validé par les specs (`getByRole('button', { name: 'Confirmer' })`), aligné sur `packages/ui/.../Modal.behavior.test.tsx`.

## Vérifications

- `vitest` grille indicateurs : **109/109** verts (dont 6 sur `ReferenceYearEditor`).
- `eslint` sur les fichiers touchés : 0 erreur.
- `tsc -p apps/app/tsconfig.project.json` : 0 erreur sur les fichiers touchés (les erreurs `void` préexistantes viennent des types tRPC non générés en worktree, présentes sur `main`).

> Plan : demande directe de l'auteur (pas d'artefact de plan dédié).