### PR TITLE
feat(csp): add Crisp helpdesk URL to Content Security Policy

### DIFF
--- a/apps/app/content-security-policy.config.ts
+++ b/apps/app/content-security-policy.config.ts
@@ -33,6 +33,7 @@ export function getContentSecurityPolicy(url: URL, nonce: string): string {
   const authUrl = process.env.NEXT_PUBLIC_AUTH_URL ?? '';
   const posthogHost = process.env.POSTHOG_HOST ?? '';
   const crispUrl = 'https://*.crisp.chat';
+  const crispHelpdeskUrl = 'https://*.crisp.help';
   const sentryOrigin = getSentryOrigin();
   const rootDomain = getRootDomain(url.hostname);
 
@@ -59,7 +60,7 @@ export function getContentSecurityPolicy(url: URL, nonce: string): string {
     base-uri 'self';
     form-action 'self';
     frame-ancestors 'none';
-    frame-src ${crispUrl};
+    frame-src ${crispUrl} ${crispHelpdeskUrl};
     block-all-mixed-content;
     ${
       /* activé uniquement en prod pour éviter que safari redirige tjrs en https en dev */


### PR DESCRIPTION
Includes the Crisp helpdesk URL in the frame-src directive to enhance security and allow embedding of helpdesk content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Les contenus intégrés en iframe peuvent désormais charger des pages provenant de `crisp.help` en plus de `crisp.chat`.

* **Correctifs**
  * La politique de sécurité du contenu a été élargie pour autoriser davantage de sources de frames, ce qui améliore l’affichage de certains éléments intégrés.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->