### PR TITLE
feat(indicateurs): édite l'année de référence dans une seule modale

### DIFF
--- a/apps/app/src/indicateurs/valeurs/grid/__tests__/indicateur-values-grid.stories.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/__tests__/indicateur-values-grid.stories.tsx
@@ -114,7 +114,10 @@ const clearCellInCells = (
   return next;
 };
 
-const rekeyReferenceColumn = ({
+const refetchedReferenceValue = (indicateurId: number, year: number): number =>
+  Math.round(180 + (indicateurId % 6) * 40 + (year % 12) * 9);
+
+const refetchReferenceColumn = ({
   cells,
   referenceYear,
   nextYear,
@@ -125,13 +128,17 @@ const rekeyReferenceColumn = ({
 }): Map<CellKey, GridCell> =>
   new Map(
     Array.from(cells, ([key, cell]) => {
-      const parsed = parseCellKey(key);
-      const belongsToReferenceColumn =
-        parsed !== null && parsed.year === referenceYear;
-      const nextKey = belongsToReferenceColumn
-        ? generateCellKey(parsed.indicateurId, nextYear)
-        : key;
-      return [nextKey, cell] as const;
+      const { indicateurId, year } = parseCellKey(key);
+      if (year !== referenceYear) {
+        return [key, cell] as const;
+      }
+      const refetchedCell: GridCell = {
+        kind: 'user-data',
+        value: refetchedReferenceValue(indicateurId, nextYear),
+        valueId: indicateurId * 10000 + nextYear,
+        coveringSources: [],
+      };
+      return [generateCellKey(indicateurId, nextYear), refetchedCell] as const;
     })
   );
 
@@ -236,7 +243,7 @@ const InteractiveGrid = (): JSX.Element => {
           year === previous.referenceYear ? nextYear : year
         ),
         referenceYear: nextYear,
-        cells: rekeyReferenceColumn({
+        cells: refetchReferenceColumn({
           cells: previous.cells,
           referenceYear: previous.referenceYear,
           nextYear,

--- a/apps/app/src/indicateurs/valeurs/grid/reference-year/reference-year-change-modal.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/reference-year/reference-year-change-modal.tsx
@@ -1,41 +1,108 @@
 'use client';
 
-import { Modal, ModalFooterOKCancel } from '@tet/ui';
-import { JSX } from 'react';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Field, Input, Modal, ModalFooterOKCancel } from '@tet/ui';
+import { JSX, useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
 import { appLabels } from '@/app/labels/catalog';
+import { toYear, Year } from '../types';
+
+const MIN_REFERENCE_YEAR = 2010;
+const MAX_REFERENCE_YEAR = 2029;
+
+const referenceYearMessage = appLabels.indicateurAnneeReferenceInvalide(
+  MIN_REFERENCE_YEAR,
+  MAX_REFERENCE_YEAR
+);
+
+const referenceYearSchema = z.object({
+  year: z
+    .number({ message: referenceYearMessage })
+    .int(referenceYearMessage)
+    .min(MIN_REFERENCE_YEAR, referenceYearMessage)
+    .max(MAX_REFERENCE_YEAR, referenceYearMessage),
+});
+type ReferenceYearForm = z.infer<typeof referenceYearSchema>;
 
 type ReferenceYearChangeModalProps = {
   isOpen: boolean;
-  onConfirm: () => void;
-  onCancel: () => void;
+  currentYear: Year;
+  onConfirm: (year: Year) => void;
+  onClose: () => void;
 };
 
 export const ReferenceYearChangeModal = ({
   isOpen,
+  currentYear,
   onConfirm,
-  onCancel,
-}: ReferenceYearChangeModalProps): JSX.Element => (
-  <Modal
-    size="xs"
-    title={appLabels.indicateurChangerAnneeReferenceTitre}
-    openState={{
-      isOpen,
-      setIsOpen: (open) => {
-        if (!open) {
-          onCancel();
-        }
-      },
-    }}
-    render={() => (
-      <p className="mb-0 text-sm text-grey-8">
-        {appLabels.indicateurChangerAnneeReferenceDescription}
-      </p>
-    )}
-    renderFooter={({ close }) => (
-      <ModalFooterOKCancel
-        btnCancelProps={{ children: appLabels.annuler, onClick: close }}
-        btnOKProps={{ children: appLabels.confirmer, onClick: onConfirm }}
-      />
-    )}
-  />
-);
+  onClose,
+}: ReferenceYearChangeModalProps): JSX.Element => {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<ReferenceYearForm>({
+    resolver: zodResolver(referenceYearSchema),
+    defaultValues: { year: currentYear },
+    mode: 'onChange',
+  });
+
+  useEffect(() => {
+    if (isOpen) {
+      reset({ year: currentYear });
+    }
+  }, [isOpen, currentYear, reset]);
+
+  const submitReferenceYear = handleSubmit(({ year }) =>
+    onConfirm(toYear(year))
+  );
+
+  return (
+    <Modal
+      size="xs"
+      title={appLabels.indicateurChangerAnneeReferenceTitre}
+      openState={{
+        isOpen,
+        setIsOpen: (open) => {
+          if (!open) {
+            onClose();
+          }
+        },
+      }}
+      render={() => (
+        <form onSubmit={submitReferenceYear} className="flex flex-col gap-3">
+          <p className="mb-0 text-sm text-grey-8">
+            {appLabels.indicateurChangerAnneeReferenceDescription}
+          </p>
+          <Field
+            small
+            state={errors.year ? 'error' : 'default'}
+            message={errors.year?.message}
+          >
+            <Input
+              type="text"
+              inputMode="numeric"
+              autoFocus
+              aria-label={appLabels.indicateurAnneeReferenceChamp}
+              displaySize="sm"
+              className="w-24 text-right"
+              {...register('year', { valueAsNumber: true })}
+              onFocus={(event) => event.currentTarget.select()}
+            />
+          </Field>
+        </form>
+      )}
+      renderFooter={({ close }) => (
+        <ModalFooterOKCancel
+          btnCancelProps={{ children: appLabels.annuler, onClick: close }}
+          btnOKProps={{
+            children: appLabels.confirmer,
+            onClick: () => submitReferenceYear(),
+          }}
+        />
+      )}
+    />
+  );
+};

--- a/apps/app/src/indicateurs/valeurs/grid/reference-year/reference-year-change-modal.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/reference-year/reference-year-change-modal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Field, Input, Modal, ModalFooterOKCancel } from '@tet/ui';
+import { Input, Modal, ModalFooterOKCancel } from '@tet/ui';
 import { JSX, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
@@ -76,22 +76,35 @@ export const ReferenceYearChangeModal = ({
           <p className="mb-0 text-sm text-grey-8">
             {appLabels.indicateurChangerAnneeReferenceDescription}
           </p>
-          <Field
-            small
-            state={errors.year ? 'error' : 'default'}
-            message={errors.year?.message}
-          >
-            <Input
-              type="text"
-              inputMode="numeric"
-              autoFocus
-              aria-label={appLabels.indicateurAnneeReferenceChamp}
-              displaySize="sm"
-              className="w-24 text-right"
-              {...register('year', { valueAsNumber: true })}
-              onFocus={(event) => event.currentTarget.select()}
-            />
-          </Field>
+          <div className="flex flex-col gap-1">
+            <div className="flex items-center justify-between gap-3">
+              <label
+                htmlFor="reference-year-input"
+                className="mb-0 text-sm font-medium text-primary-9"
+              >
+                {appLabels.indicateurNouvelleAnneeReferenceChamp}
+              </label>
+              <Input
+                id="reference-year-input"
+                type="text"
+                inputMode="numeric"
+                autoFocus
+                aria-invalid={errors.year !== undefined}
+                aria-describedby="reference-year-error"
+                displaySize="sm"
+                className="w-24 text-right"
+                {...register('year', { valueAsNumber: true })}
+                onFocus={(event) => event.currentTarget.select()}
+              />
+            </div>
+            <p
+              id="reference-year-error"
+              role="alert"
+              className="mb-0 min-h-[1.25rem] text-right text-xs text-error-1"
+            >
+              {errors.year?.message ?? ''}
+            </p>
+          </div>
         </form>
       )}
       renderFooter={({ close }) => (

--- a/apps/app/src/indicateurs/valeurs/grid/reference-year/reference-year-change-modal.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/reference-year/reference-year-change-modal.tsx
@@ -3,7 +3,7 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Input, Modal, ModalFooterOKCancel } from '@tet/ui';
 import { JSX, useEffect } from 'react';
-import { useForm } from 'react-hook-form';
+import { FieldError, useForm, UseFormRegister } from 'react-hook-form';
 import { z } from 'zod';
 import { appLabels } from '@/app/labels/catalog';
 import { toYear, Year } from '../types';
@@ -24,6 +24,44 @@ const referenceYearSchema = z.object({
     .max(MAX_REFERENCE_YEAR, referenceYearMessage),
 });
 type ReferenceYearForm = z.infer<typeof referenceYearSchema>;
+
+const ReferenceYearField = ({
+  register,
+  error,
+}: {
+  register: UseFormRegister<ReferenceYearForm>;
+  error?: FieldError;
+}): JSX.Element => (
+  <div className="flex flex-col gap-1">
+    <div className="flex items-center justify-between gap-3">
+      <label
+        htmlFor="reference-year-input"
+        className="mb-0 text-sm font-medium text-primary-9"
+      >
+        {appLabels.indicateurNouvelleAnneeReferenceChamp}
+      </label>
+      <Input
+        id="reference-year-input"
+        type="text"
+        inputMode="numeric"
+        autoFocus
+        aria-invalid={error !== undefined}
+        aria-describedby="reference-year-error"
+        displaySize="sm"
+        className="w-24 text-right"
+        {...register('year', { valueAsNumber: true })}
+        onFocus={(event) => event.currentTarget.select()}
+      />
+    </div>
+    <p
+      id="reference-year-error"
+      role="alert"
+      className="mb-0 min-h-[1.25rem] text-right text-xs text-error-1"
+    >
+      {error?.message ?? ''}
+    </p>
+  </div>
+);
 
 type ReferenceYearChangeModalProps = {
   isOpen: boolean;
@@ -76,35 +114,7 @@ export const ReferenceYearChangeModal = ({
           <p className="mb-0 text-sm text-grey-8">
             {appLabels.indicateurChangerAnneeReferenceDescription}
           </p>
-          <div className="flex flex-col gap-1">
-            <div className="flex items-center justify-between gap-3">
-              <label
-                htmlFor="reference-year-input"
-                className="mb-0 text-sm font-medium text-primary-9"
-              >
-                {appLabels.indicateurNouvelleAnneeReferenceChamp}
-              </label>
-              <Input
-                id="reference-year-input"
-                type="text"
-                inputMode="numeric"
-                autoFocus
-                aria-invalid={errors.year !== undefined}
-                aria-describedby="reference-year-error"
-                displaySize="sm"
-                className="w-24 text-right"
-                {...register('year', { valueAsNumber: true })}
-                onFocus={(event) => event.currentTarget.select()}
-              />
-            </div>
-            <p
-              id="reference-year-error"
-              role="alert"
-              className="mb-0 min-h-[1.25rem] text-right text-xs text-error-1"
-            >
-              {errors.year?.message ?? ''}
-            </p>
-          </div>
+          <ReferenceYearField register={register} error={errors.year} />
         </form>
       )}
       renderFooter={({ close }) => (

--- a/apps/app/src/indicateurs/valeurs/grid/reference-year/reference-year-editor.spec.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/reference-year/reference-year-editor.spec.tsx
@@ -4,7 +4,7 @@ import { appLabels } from '../../../../labels/catalog';
 import { toYear } from '../types';
 import { ReferenceYearEditor } from './reference-year-editor';
 
-const openEditor = (onReferenceYearChange: () => void): HTMLInputElement => {
+const openModal = (onReferenceYearChange: () => void): HTMLInputElement => {
   const year = toYear(2020);
   render(
     <ReferenceYearEditor
@@ -22,92 +22,79 @@ const openEditor = (onReferenceYearChange: () => void): HTMLInputElement => {
   }) as HTMLInputElement;
 };
 
-const submitForm = (input: HTMLInputElement): void => {
-  const form = input.closest('form');
-  if (form === null) {
-    throw new Error('form not found');
-  }
-  fireEvent.submit(form);
-};
+const clickConfirm = (): void =>
+  fireEvent.click(screen.getByRole('button', { name: appLabels.confirmer }));
 
-const isEditorClosed = (): boolean =>
+const isModalClosed = (): boolean =>
   screen.queryByRole('textbox', {
     name: appLabels.indicateurAnneeReferenceChamp,
   }) === null;
 
-const findConfirmButton = (): Promise<HTMLElement> =>
-  screen.findByRole('button', { name: appLabels.confirmer });
-
 describe('ReferenceYearEditor', () => {
-  it("enregistre l'année saisie après confirmation", async () => {
+  it("ouvre la modale de saisie au clic sur l'année", () => {
+    openModal(vi.fn());
+
+    expect(
+      screen.getByRole('textbox', {
+        name: appLabels.indicateurAnneeReferenceChamp,
+      })
+    ).toBeDefined();
+    expect(
+      screen.getByRole('button', { name: appLabels.confirmer })
+    ).toBeDefined();
+  });
+
+  it("enregistre l'année saisie à la confirmation", async () => {
     const onReferenceYearChange = vi.fn();
-    const input = openEditor(onReferenceYearChange);
+    const input = openModal(onReferenceYearChange);
     fireEvent.change(input, { target: { value: '2018' } });
-    submitForm(input);
-    const confirm = await findConfirmButton();
-    expect(onReferenceYearChange).not.toHaveBeenCalled();
-    fireEvent.click(confirm);
+    clickConfirm();
+
     await waitFor(() =>
       expect(onReferenceYearChange).toHaveBeenCalledWith(2018)
     );
   });
 
-  it("n'enregistre pas quand la confirmation est annulée", async () => {
+  it("n'enregistre pas quand la modale est annulée", async () => {
     const onReferenceYearChange = vi.fn();
-    const input = openEditor(onReferenceYearChange);
+    const input = openModal(onReferenceYearChange);
     fireEvent.change(input, { target: { value: '2018' } });
-    submitForm(input);
-    await findConfirmButton();
     fireEvent.click(screen.getByRole('button', { name: appLabels.annuler }));
-    await waitFor(() =>
-      expect(
-        screen.queryByRole('button', { name: appLabels.confirmer })
-      ).toBeNull()
-    );
+
+    await waitFor(() => expect(isModalClosed()).toBe(true));
     expect(onReferenceYearChange).not.toHaveBeenCalled();
   });
 
   it("affiche le message et n'enregistre pas une année avant 2010", async () => {
     const onReferenceYearChange = vi.fn();
-    const input = openEditor(onReferenceYearChange);
+    const input = openModal(onReferenceYearChange);
     fireEvent.change(input, { target: { value: '2009' } });
-    submitForm(input);
+    clickConfirm();
+
     await screen.findByText(
       appLabels.indicateurAnneeReferenceInvalide(2010, 2029)
     );
-    expect(
-      screen.queryByRole('button', { name: appLabels.confirmer })
-    ).toBeNull();
     expect(onReferenceYearChange).not.toHaveBeenCalled();
   });
 
   it("affiche le message et n'enregistre pas une année après 2029", async () => {
     const onReferenceYearChange = vi.fn();
-    const input = openEditor(onReferenceYearChange);
+    const input = openModal(onReferenceYearChange);
     fireEvent.change(input, { target: { value: '2030' } });
-    submitForm(input);
+    clickConfirm();
+
     await screen.findByText(
       appLabels.indicateurAnneeReferenceInvalide(2010, 2029)
     );
     expect(onReferenceYearChange).not.toHaveBeenCalled();
   });
 
-  it("ne demande pas de confirmation quand l'année est inchangée", async () => {
+  it("n'enregistre pas et ferme quand l'année est inchangée", async () => {
     const onReferenceYearChange = vi.fn();
-    const input = openEditor(onReferenceYearChange);
-    submitForm(input);
-    await waitFor(() => expect(isEditorClosed()).toBe(true));
-    expect(
-      screen.queryByRole('button', { name: appLabels.confirmer })
-    ).toBeNull();
-    expect(onReferenceYearChange).not.toHaveBeenCalled();
-  });
+    openModal(onReferenceYearChange);
+    clickConfirm();
 
-  it('annule sur Échap sans enregistrer', () => {
-    const onReferenceYearChange = vi.fn();
-    const input = openEditor(onReferenceYearChange);
-    fireEvent.keyDown(input, { key: 'Escape' });
-    expect(isEditorClosed()).toBe(true);
+    await waitFor(() => expect(isModalClosed()).toBe(true));
     expect(onReferenceYearChange).not.toHaveBeenCalled();
   });
 });

--- a/apps/app/src/indicateurs/valeurs/grid/reference-year/reference-year-editor.spec.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/reference-year/reference-year-editor.spec.tsx
@@ -18,7 +18,7 @@ const openModal = (onReferenceYearChange: () => void): HTMLInputElement => {
     })
   );
   return screen.getByRole('textbox', {
-    name: appLabels.indicateurAnneeReferenceChamp,
+    name: appLabels.indicateurNouvelleAnneeReferenceChamp,
   }) as HTMLInputElement;
 };
 
@@ -27,7 +27,7 @@ const clickConfirm = (): void =>
 
 const isModalClosed = (): boolean =>
   screen.queryByRole('textbox', {
-    name: appLabels.indicateurAnneeReferenceChamp,
+    name: appLabels.indicateurNouvelleAnneeReferenceChamp,
   }) === null;
 
 describe('ReferenceYearEditor', () => {
@@ -36,7 +36,7 @@ describe('ReferenceYearEditor', () => {
 
     expect(
       screen.getByRole('textbox', {
-        name: appLabels.indicateurAnneeReferenceChamp,
+        name: appLabels.indicateurNouvelleAnneeReferenceChamp,
       })
     ).toBeDefined();
     expect(

--- a/apps/app/src/indicateurs/valeurs/grid/reference-year/reference-year-editor.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/reference-year/reference-year-editor.tsx
@@ -1,135 +1,45 @@
-import { zodResolver } from '@hookform/resolvers/zod';
-import { cn, Field, Icon, InlineEditWrapper, Input } from '@tet/ui';
-import { ComponentProps, JSX, useState } from 'react';
-import { useForm } from 'react-hook-form';
-import { z } from 'zod';
+'use client';
+
+import { Icon } from '@tet/ui';
+import { JSX, useState } from 'react';
 import { appLabels } from '@/app/labels/catalog';
-import { toYear, Year } from '../types';
+import { Year } from '../types';
 import { ReferenceYearChangeModal } from './reference-year-change-modal';
-
-const MIN_REFERENCE_YEAR = 2010;
-const MAX_REFERENCE_YEAR = 2029;
-const referenceYearMessage = appLabels.indicateurAnneeReferenceInvalide(
-  MIN_REFERENCE_YEAR,
-  MAX_REFERENCE_YEAR
-);
-
-const referenceYearSchema = z.object({
-  year: z
-    .number({ message: referenceYearMessage })
-    .int(referenceYearMessage)
-    .min(MIN_REFERENCE_YEAR, referenceYearMessage)
-    .max(MAX_REFERENCE_YEAR, referenceYearMessage),
-});
-type ReferenceYearForm = z.infer<typeof referenceYearSchema>;
 
 type ReferenceYearEditorProps = {
   year: Year;
   onReferenceYearChange: (year: Year) => void;
 };
 
-type ReferenceYearInputProps = {
-  year: Year;
-  onSubmit: (year: Year) => void;
-  onCancel: () => void;
-};
-
-const ReferenceYearInput = ({
-  year,
-  onSubmit,
-  onCancel,
-}: ReferenceYearInputProps): JSX.Element => {
-  const {
-    register,
-    handleSubmit,
-    formState: { errors },
-  } = useForm<ReferenceYearForm>({
-    resolver: zodResolver(referenceYearSchema),
-    defaultValues: { year },
-    mode: 'onChange',
-  });
-
-  return (
-    <form
-      className="w-24"
-      onSubmit={handleSubmit(({ year: nextYear }) => onSubmit(toYear(nextYear)))}
-    >
-      <Field
-        small
-        state={errors.year ? 'error' : 'default'}
-        message={errors.year?.message}
-      >
-        <Input
-          type="text"
-          inputMode="numeric"
-          autoFocus
-          aria-label={appLabels.indicateurAnneeReferenceChamp}
-          displaySize="sm"
-          className="text-right"
-          {...register('year', { valueAsNumber: true })}
-          onFocus={(event) => event.currentTarget.select()}
-          onKeyDown={(event) => {
-            if (event.key === 'Escape') {
-              event.preventDefault();
-              onCancel();
-            }
-          }}
-        />
-      </Field>
-    </form>
-  );
-};
-
 export const ReferenceYearEditor = ({
   year,
   onReferenceYearChange,
 }: ReferenceYearEditorProps): JSX.Element => {
-  const [pendingYear, setPendingYear] = useState<Year | null>(null);
-
-  const confirmReferenceYearChange = (): void => {
-    if (pendingYear !== null) {
-      onReferenceYearChange(pendingYear);
-    }
-    setPendingYear(null);
-  };
+  const [isOpen, setIsOpen] = useState(false);
 
   return (
     <>
-      <InlineEditWrapper
-        renderOnEdit={({ openState }) => (
-          <ReferenceYearInput
-            year={year}
-            onSubmit={(next) => {
-              if (next !== year) {
-                setPendingYear(next);
-              }
-              openState.setIsOpen(false);
-            }}
-            onCancel={() => openState.setIsOpen(false)}
-          />
-        )}
+      <button
+        type="button"
+        onClick={() => setIsOpen(true)}
+        aria-label={appLabels.indicateurModifierAnneeReference(year)}
+        className="inline-flex items-center gap-1 font-bold text-primary-9"
       >
-        {(triggerProps: ComponentProps<'button'>) => (
-          <button
-            type="button"
-            {...triggerProps}
-            aria-label={appLabels.indicateurModifierAnneeReference(year)}
-            className={cn(
-              triggerProps.className,
-              'inline-flex items-center gap-1 font-bold text-primary-9'
-            )}
-          >
-            <span className="underline decoration-dotted underline-offset-2">
-              {appLabels.indicateurAnneeReference(year)}
-            </span>
-            <Icon icon="edit-line" size="xs" aria-hidden />
-          </button>
-        )}
-      </InlineEditWrapper>
+        <span className="underline decoration-dotted underline-offset-2">
+          {appLabels.indicateurAnneeReference(year)}
+        </span>
+        <Icon icon="edit-line" size="xs" aria-hidden />
+      </button>
       <ReferenceYearChangeModal
-        isOpen={pendingYear !== null}
-        onConfirm={confirmReferenceYearChange}
-        onCancel={() => setPendingYear(null)}
+        isOpen={isOpen}
+        currentYear={year}
+        onConfirm={(next) => {
+          if (next !== year) {
+            onReferenceYearChange(next);
+          }
+          setIsOpen(false);
+        }}
+        onClose={() => setIsOpen(false)}
       />
     </>
   );

--- a/apps/app/src/indicateurs/valeurs/grid/reference-year/reference-year-editor.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/reference-year/reference-year-editor.tsx
@@ -34,7 +34,8 @@ export const ReferenceYearEditor = ({
         isOpen={isOpen}
         currentYear={year}
         onConfirm={(next) => {
-          if (next !== year) {
+          const hasYearChanged = next !== year;
+          if (hasYearChanged) {
             onReferenceYearChange(next);
           }
           setIsOpen(false);

--- a/apps/app/src/labels/catalog.ts
+++ b/apps/app/src/labels/catalog.ts
@@ -1748,6 +1748,7 @@ export const appLabels = {
   indicateurOrdreReinitialise: 'Ordre réinitialisé',
   indicateurAnneeReference: (year: number): string => `réf. ${year}`,
   indicateurAnneeReferenceChamp: 'Année de référence',
+  indicateurNouvelleAnneeReferenceChamp: 'Nouvelle année de référence',
   indicateurModifierAnneeReference: (year: number): string =>
     `réf. ${year}, modifier l'année de référence`,
   indicateurAnneeReferenceInvalide: (min: number, max: number): string =>


### PR DESCRIPTION
## Contexte

Changer l'année de référence de la grille demandait **3 étapes** : clic sur l'année → input inline (`InlineEditWrapper`) → soumission → **modale de confirmation** séparée. UX lourde.

## Changement

Le clic sur l'année ouvre **directement une seule modale** qui contient le champ éditable + description + Confirmer/Annuler. Plus d'input inline ni d'état intermédiaire.

- `reference-year-change-modal.tsx` porte désormais le formulaire (RHF + zod, validation 2010–2029), reset du champ à l'ouverture.
- `reference-year-editor.tsx` réduit à un bouton + la modale ; suppression de `InlineEditWrapper`, du RHF côté éditeur et de l'état `pendingYear`.
- Année inchangée → ferme sans rien appliquer.

## Tests

- `reference-year-editor.spec.tsx` réécrit pour le flow modale unique (ouverture, enregistrement, annulation, bornes 2010/2029, année inchangée). 6 tests.
- Dossier grille complet vert : 109 tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * La modification de l’année de référence se fait désormais via une fenêtre dédiée avec saisie directe de l’année.
  * Le champ affiche un libellé plus clair pour guider la saisie.

* **Corrections**
  * La colonne de référence se met maintenant à jour avec de nouvelles valeurs après changement d’année.
  * La validation bloque les années hors plage et affiche un message d’erreur adapté.
  * La confirmation et l’annulation ferment correctement la fenêtre.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->