### PR TITLE
fix(ui): scintillement du curseur au survol de la pastille open data

### DIFF
--- a/apps/app/src/indicateurs/valeurs/grid/open-data-picker/coverage-dot.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/open-data-picker/coverage-dot.tsx
@@ -17,7 +17,7 @@ type CoverageDotProps = {
 };
 
 const OpenDataDot = (): JSX.Element => (
-  <Tooltip label={appLabels.indicateurCelluleOpenDataDisponible}>
+  <Tooltip label={appLabels.indicateurCelluleOpenDataDisponible} interactive={false}>
     <span className="h-2 w-2 rounded-full bg-primary-7 ring-2 ring-primary-2" />
   </Tooltip>
 );

--- a/packages/ui/src/design-system/Tooltip/Tooltip.tsx
+++ b/packages/ui/src/design-system/Tooltip/Tooltip.tsx
@@ -40,6 +40,8 @@ export type TooltipProps = {
   placement?: Placement;
   /** Affichage d'une flèche sur la tooltip */
   withArrow?: boolean;
+  /** Autorise le déplacement du curseur vers l'info-bulle (safePolygon). À désactiver pour une info-bulle purement informative sur une petite cible, ce qui évite le scintillement du curseur. */
+  interactive?: boolean;
   /** Surchage des classnames de la tooltip */
   className?: string;
 };
@@ -55,6 +57,7 @@ export const Tooltip = ({
   closingDelay = 0,
   placement = 'top',
   withArrow = true,
+  interactive = true,
   className,
 }: TooltipProps) => {
   const [isOpen, setIsOpen] = useState(false);
@@ -105,7 +108,7 @@ export const Tooltip = ({
   const { getReferenceProps, getFloatingProps } = useInteractions([
     (activatedBy === 'click' ? useClick : useHover)(context, {
       delay: { open: openingDelay, close: closingDelay },
-      handleClose: safePolygon(),
+      handleClose: interactive ? safePolygon() : null,
     }),
     useFocus(context),
     useRole(context, { role: 'tooltip' }),


### PR DESCRIPTION
## Symptôme

Scintillement bizarre du curseur au survol de la pastille verte « open data disponible » d'une cellule de la grille de valeurs. Apparu maintenant que la pastille s'affiche réellement (les sources open data couvrantes sont peuplées).

## Cause

Le `Tooltip` du DS force `handleClose: safePolygon()` sur son `useHover`. `safePolygon` génère un overlay invisible entre le déclencheur et l'info-bulle (pour permettre au curseur d'y voyager). Sur une cible minuscule (pastille de 8px), cet overlay alterne sous le curseur → le curseur oscille entre deux formes. Le `DropdownFloater` sous-jacent est en `useClick`, donc hors de cause.

## Correctif

- `Tooltip` (DS) : nouvelle prop `interactive?: boolean` (défaut `true`, comportement inchangé partout). Quand `false`, `handleClose` passe à `null` → pas de `safePolygon`, adapté à une info-bulle purement informative.
- `coverage-dot.tsx` : passe `interactive={false}` sur la pastille. L'info-bulle stylée reste (ouverture au survol inchangée), sans overlay ni scintillement.

## Tests

- `coverage-dot.spec.tsx` : l'info-bulle s'affiche toujours au survol (inchangé).
- Additif et rétro-compatible : aucun autre consommateur du `Tooltip` impacté (défaut `true`).

## Validation

Le scintillement se vérifie visuellement (jsdom ne rend pas le curseur) — à confirmer en survolant la pastille dans l'app.