### PR TITLE
fix(rls): auditeur peut ecrire preuves et storage pendant 15j apres cloture

### DIFF
--- a/apps/backend/src/referentiels/labellisations/storage-upload-fenetre-edition.e2e-spec.ts
+++ b/apps/backend/src/referentiels/labellisations/storage-upload-fenetre-edition.e2e-spec.ts
@@ -1,0 +1,101 @@
+import { addTestCollectivite, addTestCollectiviteAndUsers } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { collectiviteBucketTable } from '@tet/backend/collectivites/shared/models/collectivite-bucket.table';
+import {
+  getSupabaseClient,
+  getTestApp,
+  getTestDatabase,
+  signInWith,
+} from '@tet/backend/test';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { ReferentielIdEnum } from '@tet/domain/referentiels';
+import { CollectiviteRole } from '@tet/domain/users';
+import { eq, sql } from 'drizzle-orm';
+import { beforeAll, describe, expect, test } from 'vitest';
+import { auditTable } from './audit.table';
+import {
+  addAuditeurPermission,
+  createAudit,
+} from './labellisations.test-fixture';
+
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+const daysAgo = (days: number): string =>
+  new Date(Date.now() - days * DAY_IN_MS).toISOString();
+
+const fakePng = Buffer.from('\x89PNG fake bytes for storage rls test');
+
+describe("RLS storage.objects - fenetre d'edition de l'auditeur", () => {
+  let databaseService: DatabaseService;
+  let bucketInWindow: string;
+  let bucketOutWindow: string;
+
+  beforeAll(async () => {
+    const app = await getTestApp();
+    databaseService = await getTestDatabase(app);
+    const db = databaseService.db;
+
+    // Auditeur externe : membre d'aucune des collectivites auditees, sinon
+    // is_bucket_writer passerait par is_any_role_on et masquerait la policy.
+    const { users } = await addTestCollectiviteAndUsers(databaseService, {
+      users: [{ role: CollectiviteRole.LECTURE }],
+    });
+    const auditeur = users[0];
+
+    const createBucketFor = async (collectiviteId: number): Promise<string> => {
+      await db.execute(
+        sql`select private.create_bucket(c) from public.collectivite c where c.id = ${collectiviteId}`
+      );
+      const [bucket] = await db
+        .select({ id: collectiviteBucketTable.bucketId })
+        .from(collectiviteBucketTable)
+        .where(eq(collectiviteBucketTable.collectiviteId, collectiviteId));
+      return bucket.id;
+    };
+
+    const assignClosAudit = async (
+      collectiviteId: number,
+      dateFin: string
+    ): Promise<void> => {
+      const { audit } = await createAudit({
+        databaseService,
+        collectiviteId,
+        referentielId: ReferentielIdEnum.CAE,
+        clos: true,
+      });
+      await db
+        .update(auditTable)
+        .set({ dateFin })
+        .where(eq(auditTable.id, audit.id));
+      await addAuditeurPermission({
+        databaseService,
+        auditId: audit.id,
+        userId: auditeur.id,
+      });
+    };
+
+    const { collectivite: inWindow } = await addTestCollectivite(databaseService);
+    const { collectivite: outWindow } =
+      await addTestCollectivite(databaseService);
+    bucketInWindow = await createBucketFor(inWindow.id);
+    bucketOutWindow = await createBucketFor(outWindow.id);
+    await assignClosAudit(inWindow.id, daysAgo(2));
+    await assignClosAudit(outWindow.id, daysAgo(20));
+
+    await signInWith({ email: auditeur.email, password: auditeur.password });
+  });
+
+  test("autorise l'upload storage sur un audit clos depuis 2 jours", async () => {
+    const { error } = await getSupabaseClient()
+      .storage.from(bucketInWindow)
+      .upload('rapport-audit.png', fakePng, { contentType: 'image/png' });
+
+    expect(error).toBeNull();
+  });
+
+  test("refuse l'upload storage sur un audit clos depuis 20 jours", async () => {
+    const { error } = await getSupabaseClient()
+      .storage.from(bucketOutWindow)
+      .upload('rapport-audit.png', fakePng, { contentType: 'image/png' });
+
+    expect(error).not.toBeNull();
+  });
+});

--- a/data_layer/sqitch/deploy/collectivite/bucket_rls_auditeur_edit_window.sql
+++ b/data_layer/sqitch/deploy/collectivite/bucket_rls_auditeur_edit_window.sql
@@ -1,0 +1,53 @@
+-- Deploy tet:collectivite/bucket_rls_auditeur_edit_window to pg
+-- requires: collectivite/bucket_rls_super_admin_write
+
+BEGIN;
+
+create or replace function private.est_auditeur_audit_dans_fenetre_edition(audit_id integer)
+    returns boolean
+    security definer
+    language sql
+    stable
+begin
+    atomic
+    select coalesce(bool_or(
+        a.date_fin is not null
+        and (a.clos or a.valide)
+        and a.date_fin > now() - interval '15 days'
+    ), false)
+    from labellisation.audit a
+             join public.audit_auditeur aa on aa.audit_id = a.id
+    where a.id = est_auditeur_audit_dans_fenetre_edition.audit_id
+      and aa.auditeur = auth.uid();
+end;
+comment on function private.est_auditeur_audit_dans_fenetre_edition(integer) is
+    'Vrai si l''utilisateur courant est auditeur de cet audit clos ou valide depuis moins de 15 jours (fenetre d''edition post-cloture, alignee sur AUDIT_REPORT_UPDATE_WINDOW_DAYS / canUpdateAuditReport).';
+
+create or replace function private.est_auditeur_bucket_dans_fenetre_edition(bucket_id text)
+    returns boolean
+    security definer
+    language sql
+    stable
+begin
+    atomic
+    select coalesce(bool_or(private.est_auditeur_audit_dans_fenetre_edition(a.id)), false)
+    from public.collectivite_bucket cb
+             join labellisation.audit a on a.collectivite_id = cb.collectivite_id
+    where cb.bucket_id = est_auditeur_bucket_dans_fenetre_edition.bucket_id;
+end;
+comment on function private.est_auditeur_bucket_dans_fenetre_edition(text) is
+    'Transpose est_auditeur_audit_dans_fenetre_edition au niveau du bucket (via collectivite_bucket), pour les policies storage.objects qui ne connaissent que le bucket.';
+
+create policy allow_insert_auditeur_fenetre_edition on preuve_audit
+    for insert with check (private.est_auditeur_audit_dans_fenetre_edition(audit_id));
+create policy allow_update_auditeur_fenetre_edition on preuve_audit
+    for update using (private.est_auditeur_audit_dans_fenetre_edition(audit_id));
+create policy allow_delete_auditeur_fenetre_edition on preuve_audit
+    for delete using (private.est_auditeur_audit_dans_fenetre_edition(audit_id));
+
+create policy allow_insert_auditeur_fenetre_edition on storage.objects
+    for insert with check (private.est_auditeur_bucket_dans_fenetre_edition(bucket_id));
+create policy allow_update_auditeur_fenetre_edition on storage.objects
+    for update with check (private.est_auditeur_bucket_dans_fenetre_edition(bucket_id));
+
+COMMIT;

--- a/data_layer/sqitch/revert/collectivite/bucket_rls_auditeur_edit_window.sql
+++ b/data_layer/sqitch/revert/collectivite/bucket_rls_auditeur_edit_window.sql
@@ -1,0 +1,15 @@
+-- Revert tet:collectivite/bucket_rls_auditeur_edit_window from pg
+
+BEGIN;
+
+drop policy if exists allow_insert_auditeur_fenetre_edition on storage.objects;
+drop policy if exists allow_update_auditeur_fenetre_edition on storage.objects;
+
+drop policy if exists allow_insert_auditeur_fenetre_edition on preuve_audit;
+drop policy if exists allow_update_auditeur_fenetre_edition on preuve_audit;
+drop policy if exists allow_delete_auditeur_fenetre_edition on preuve_audit;
+
+drop function if exists private.est_auditeur_bucket_dans_fenetre_edition(text);
+drop function if exists private.est_auditeur_audit_dans_fenetre_edition(integer);
+
+COMMIT;

--- a/data_layer/sqitch/sqitch.plan
+++ b/data_layer/sqitch/sqitch.plan
@@ -1006,3 +1006,4 @@ collectivite/bucket_rls_visiteur_read [collectivite/bucket_rls_ademe_read] 2026-
 
 referentiel/add_thematique_sgpe [referentiel/add_adaptation_niveau] 2026-07-01T10:00:00Z Marc Rutkowski <marc@attractive-media.fr> # Ajoute la colonne thematique_sgpe sur action_definition
 referentiel/rename_te 2026-07-02T07:57:03Z Marc Rutkowski <marc@attractive-media.fr> # Renomme le référentiel "te"
+collectivite/bucket_rls_auditeur_edit_window [collectivite/bucket_rls_super_admin_write] 2026-07-06T12:48:17Z Gaël Servaud <gaelservaud@Host-002.lan> # Autorise l'auditeur a ecrire preuves d'audit et storage.objects pendant 15 jours apres la cloture : ajoute des policies permissives dediees (fenetre d'edition) sur preuve_audit et storage.objects

--- a/data_layer/sqitch/verify/collectivite/bucket_rls_auditeur_edit_window.sql
+++ b/data_layer/sqitch/verify/collectivite/bucket_rls_auditeur_edit_window.sql
@@ -1,0 +1,8 @@
+-- Verify tet:collectivite/bucket_rls_auditeur_edit_window on pg
+
+BEGIN;
+
+select has_function_privilege('private.est_auditeur_audit_dans_fenetre_edition(integer)', 'execute');
+select has_function_privilege('private.est_auditeur_bucket_dans_fenetre_edition(text)', 'execute');
+
+ROLLBACK;

--- a/data_layer/tests/collectivite/bucket_rls_auditeur_edit_window.sql
+++ b/data_layer/tests/collectivite/bucket_rls_auditeur_edit_window.sql
@@ -1,0 +1,68 @@
+begin;
+select plan(4);
+
+-- Un auditeur externe (aucun droit sur la collectivite 1) affecte a deux audits
+-- clos : l'un dans la fenetre d'edition de 15 jours, l'autre au-dela.
+do $$
+declare
+    auditeur_id uuid := '33333333-3333-3333-3333-333333333333';
+    v_in_window int;
+    v_out_window int;
+begin
+    perform test_create_user(auditeur_id, 'Audi', 'Teur', 'audi.teur@example.com');
+
+    insert into labellisation.audit(collectivite_id, referentiel, date_debut, date_fin, clos)
+    values (1, 'eci', now() - interval '40 days', now() - interval '2 days', true)
+    returning id into v_in_window;
+
+    insert into labellisation.audit(collectivite_id, referentiel, date_debut, date_fin, clos)
+    values (1, 'te', now() - interval '40 days', now() - interval '20 days', true)
+    returning id into v_out_window;
+
+    insert into audit_auditeur(audit_id, auditeur)
+    values (v_in_window, auditeur_id), (v_out_window, auditeur_id);
+
+    create temporary table t_audit(label text primary key, id int) on commit drop;
+    insert into t_audit values ('in_window', v_in_window), ('out_window', v_out_window);
+end
+$$;
+
+select test.identify_as('audi.teur@example.com');
+
+select ok(
+       private.est_auditeur_audit_dans_fenetre_edition(
+           (select id from t_audit where label = 'in_window')),
+       'Un auditeur peut ecrire une preuve d''un audit clos depuis moins de 15 jours'
+   );
+
+select ok(
+       not private.est_auditeur_audit_dans_fenetre_edition(
+           (select id from t_audit where label = 'out_window')),
+       'Un auditeur ne peut plus ecrire une preuve d''un audit clos depuis plus de 15 jours'
+   );
+
+select ok(
+       private.est_auditeur_bucket_dans_fenetre_edition(
+           (select cb.bucket_id from collectivite_bucket cb where cb.collectivite_id = 1)),
+       'Un auditeur dans la fenetre de 15 jours peut ecrire dans le bucket storage de la collectivite'
+   );
+
+-- Controle negatif : un utilisateur verifie qui n'est pas auditeur ne beneficie
+-- jamais de la fenetre d'edition.
+do $$
+declare
+    outsider_id uuid := '44444444-4444-4444-4444-444444444444';
+begin
+    perform test_create_user(outsider_id, 'Lambda', 'Verifie', 'lambda.fenetre@example.com');
+end
+$$;
+
+select test.identify_as('lambda.fenetre@example.com');
+
+select ok(
+       not private.est_auditeur_audit_dans_fenetre_edition(
+           (select id from t_audit where label = 'in_window')),
+       'Un utilisateur non auditeur ne beneficie pas de la fenetre d''edition'
+   );
+
+rollback;


### PR DESCRIPTION
## Problème

En staging, un auditeur ne peut plus téléverser de document pour un audit qu'il vient de clore : `POST /storage/v1/object/...` renvoie **403 `new row violates row-level security policy`**.

## Cause

Le chemin d'écriture des preuves d'audit part du **client** (supabase-js), donc soumis à la RLS :
- `storage.objects` → `is_bucket_writer(bucket_id)` → `private.est_auditeur(collectivite_id)`
- `preuve_audit` → `est_auditeur_audit(audit_id)`

Ces deux prédicats reposent sur `active_audit` (plage de dates + `clos = false`). À la clôture, le trigger passe `clos = true` et `date_fin = now()` → l'audit sort de `active_audit` → les prédicats passent à `false` → RLS 403.

Or la règle métier `canUpdateAuditReport` accorde à l'auditeur une **fenêtre d'édition de 15 jours** après la clôture (`AUDIT_REPORT_UPDATE_WINDOW_DAYS`). La RLS ne l'honorait pas.

## Correctif

Migration **100 % additive** (aucune policy existante réécrite) :

- `private.est_auditeur_audit_dans_fenetre_edition(audit_id)` : auditeur d'un audit clos/validé depuis moins de 15 jours (transposition SQL de `canUpdateAuditReport`).
- `private.est_auditeur_bucket_dans_fenetre_edition(bucket_id)` : même règle au niveau bucket (via `collectivite_bucket`), pour `storage.objects` qui ne connaît que le bucket.
- **Policies permissives dédiées** (Postgres les combine en OR avec l'existant) :
  - `preuve_audit` : insert / update / delete
  - `storage.objects` : insert / update

Revert = `drop policy` ×5 + `drop function` ×2. Fonctions `security definer` en `begin atomic`, relations qualifiées (`public.audit_auditeur`, `public.collectivite_bucket`).

## Tests

- **e2e** `storage-upload-fenetre-edition.e2e-spec.ts` : en session auditeur réelle (`signInWith`), `supabase.storage.from(bucket).upload()` — le vrai chemin qui renvoyait le 403. Auditeur **non-membre** des collectivités auditées (pour isoler la policy de `is_any_role_on`). Audit clos depuis 2 j → autorisé ; clos depuis 20 j → refusé.
- **pgTAP** `bucket_rls_auditeur_edit_window.sql` : le prédicat au niveau DB (dans la fenêtre / hors fenêtre / non-auditeur).

Vérifié en local en plus : **vrai upload HTTP** (Kong → storage-api → RLS) auditeur **200** / outsider **403** ; bornes 14 j / 16 j.

## Note produit

En l'état, l'upload reste autorisé **jusqu'à 15 jours après une labellisation validée** (le trigger passe `clos = true` sans toucher `date_fin`) — cohérent avec `canUpdateAuditReport` / le guard front. Si ce n'est pas voulu, il faut couper sur `valide_labellisation` dans `canUpdateAuditReport` (source unique) puis répercuter dans les prédicats RLS.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Mise en place d’une “fenêtre d’édition” pour les auditeurs : possibilité de saisir/modifier des preuves et d’écrire sur le stockage lié à une collectivité pendant 15 jours après la clôture d’un audit.
  * Les actions sont autorisées uniquement lorsque l’audit se trouve dans cette période ; elles sont refusées au-delà.
* **Tests**
  * Ajout de tests SQL et e2e automatisés couvrant les cas autorisé (audit à J-2) et refusé (audit à J-20) pour l’upload sur le stockage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->