### PR TITLE
fix(indicateurs): contraste et alignement de la grille de valeurs

### DIFF
--- a/apps/app/src/indicateurs/valeurs/grid/drag-reorder/drag-handle.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/drag-reorder/drag-handle.tsx
@@ -22,7 +22,7 @@ export const DragHandle = ({
     ref={setActivatorNodeRef}
     type="button"
     aria-label={appLabels.indicateurReordonnerCible(targetLabel)}
-    className={cn('cursor-grab touch-none text-grey-5', className)}
+    className={cn('cursor-grab touch-none text-grey-7', className)}
     {...attributes}
     {...listeners}
   >

--- a/apps/app/src/indicateurs/valeurs/grid/drag-reorder/sortable-grid-row.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/drag-reorder/sortable-grid-row.tsx
@@ -61,7 +61,7 @@ export const SortableGridRow = ({
         <td
           key={cell.id}
           role="gridcell"
-          className="h-10 border border-grey-3 p-0"
+          className="h-10 p-0"
         >
           {flexRender(cell.column.columnDef.cell, cell.getContext())}
         </td>

--- a/apps/app/src/indicateurs/valeurs/grid/grid-frame.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/grid-frame.tsx
@@ -105,7 +105,7 @@ export const GridFrame = (): JSX.Element => {
             onFocus={onFocus}
             onPasteCapture={onPaste}
             aria-label={appLabels.indicateurValeursGrille}
-            className="w-full border-collapse text-sm"
+            className="w-full border-collapse text-sm [&_td]:border [&_td]:border-grey-3 [&_th]:border [&_th]:border-grey-3"
             role="grid"
           >
             <GridHead

--- a/apps/app/src/indicateurs/valeurs/grid/grid-head.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/grid-head.tsx
@@ -29,12 +29,12 @@ export const GridHead = ({
       {isGrouped && (
         <th
           scope="col"
-          className="sticky left-0 top-0 z-30 border border-grey-3 bg-grey-1 p-2"
+          className="sticky left-0 top-0 z-30 bg-grey-1 p-2"
         />
       )}
       <th
         scope="col"
-        className="sticky top-0 z-20 border border-grey-3 bg-grey-1 p-2"
+        className="sticky top-0 z-20 bg-grey-1 p-2"
       />
       <SortableContext
         items={years.map(yearDragId)}

--- a/apps/app/src/indicateurs/valeurs/grid/group-header-cell.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/group-header-cell.tsx
@@ -22,7 +22,7 @@ export const GroupHeaderCell = ({
   <th
     scope="rowgroup"
     rowSpan={rowSpan}
-    className="sticky left-0 z-10 border border-grey-3 bg-grey-1 p-2 align-top text-left font-bold text-primary-9"
+    className="sticky left-0 z-10 bg-grey-1 p-2 align-top text-left font-bold text-primary-9"
   >
     <DraggableHeaderLabel label={label} dragHandle={dragHandle} />
   </th>

--- a/apps/app/src/indicateurs/valeurs/grid/row-header.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/row-header.tsx
@@ -19,7 +19,7 @@ export const RowHeader = ({
   <th
     scope="row"
     role="rowheader"
-    className="border border-grey-3 bg-white p-2 text-left font-medium text-primary-9"
+    className="bg-white p-2 text-left font-medium text-primary-9"
   >
     <DraggableHeaderLabel label={label} dragHandle={dragHandle} />
   </th>

--- a/apps/app/src/indicateurs/valeurs/grid/unit.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/unit.tsx
@@ -1,5 +1,5 @@
 import { JSX } from 'react';
 
 export const Unit = ({ children }: { children: string }): JSX.Element => (
-  <span className="text-xs font-normal text-grey-5">{children}</span>
+  <span className="text-xs font-normal text-grey-8">{children}</span>
 );

--- a/apps/app/src/indicateurs/valeurs/grid/variation/variation-hint.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/variation/variation-hint.tsx
@@ -19,7 +19,7 @@ const VariationHint = ({
 }): JSX.Element => {
   const label = formatVariation(ratio);
   return (
-    <span className="pointer-events-none shrink-0 text-[0.625rem] font-normal text-grey-5">
+    <span className="pointer-events-none shrink-0 text-[0.625rem] font-normal text-grey-8">
       <span aria-hidden>{`(${label})`}</span>
       <span id={id} className="sr-only">
         {appLabels.indicateurVariationReference(label)}

--- a/apps/app/src/indicateurs/valeurs/grid/year-column-header.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/year-column-header.tsx
@@ -63,7 +63,7 @@ export const YearColumnHeader = memo(
         role="columnheader"
         style={{ transform: CSS.Transform.toString(transform), transition }}
         className={cn(
-          'sticky top-0 z-20 min-w-[220px] border border-grey-3 bg-grey-1 p-2 text-right font-bold text-primary-9',
+          'sticky top-0 z-20 min-w-[220px] bg-grey-1 py-2 pl-2 pr-3 text-right font-bold text-primary-9',
           isDragging && 'opacity-50'
         )}
       >


### PR DESCRIPTION
## Contexte

Deux petits soucis visuels sur la grille de saisie des valeurs d'indicateurs, remontes en revue : contraste insuffisant et desalignement en-tete/valeurs.

## Changements

**Accessibilite (contraste)** — tous depuis `text-grey-5` (#CECECE, ~1.4:1 sur blanc, sous les seuils WCAG) :
- Chiffres de variation `(±X%)` → `grey-8` (5.7:1, AA texte)
- Labels d'unite → `grey-8` (5.7:1, AA texte)
- Poignees de drag → `grey-7` (3.45:1, > 3:1 element UI)

**Alignement** :
- En-tete d'annee : padding droit `p-2` → `py-2 pl-2 pr-3` (8px → 12px), pour aligner les annees sur les valeurs de leur colonne. Verifie au pixel dans Storybook (0px d'ecart en-tete/valeurs sur les colonnes d'annees).

## Verification

- Rendu valide dans Storybook (`Indicateurs/Grille de saisie › Polluants`)
- `nx run app:lint` ✓ (0 error)
- `tsc --build apps/app` ✓
