### PR TITLE
Ajoute le squelette du service de bascule vers le réf. Climat Ressources

### DIFF
--- a/apps/backend/src/collectivites/collectivite-preferences/collectivite-preferences.errors.ts
+++ b/apps/backend/src/collectivites/collectivite-preferences/collectivite-preferences.errors.ts
@@ -3,27 +3,30 @@ import {
   TrpcErrorHandlerConfig,
 } from '@tet/backend/utils/trpc/trpc-error-handler';
 
-const specificErrors = [
+export const collectivitePreferencesSpecificErrors = [
   'PREFERENCES_PARSE_ERROR',
   'COLLECTIVITE_NOT_FOUND',
 ] as const;
-type SpecificError = (typeof specificErrors)[number];
+type SpecificError = (typeof collectivitePreferencesSpecificErrors)[number];
+
+export const collectivitePreferencesTrpcErrorEntries = {
+  PREFERENCES_PARSE_ERROR: {
+    code: 'INTERNAL_SERVER_ERROR',
+    message: 'Les préférences de la collectivité sont invalides',
+  },
+  COLLECTIVITE_NOT_FOUND: {
+    code: 'NOT_FOUND',
+    message: "La collectivité n'est pas trouvée",
+  },
+} as const;
 
 export const collectivitePreferencesErrorConfig: TrpcErrorHandlerConfig<SpecificError> =
   {
-    specificErrors: {
-      PREFERENCES_PARSE_ERROR: {
-        code: 'INTERNAL_SERVER_ERROR',
-        message: 'Les préférences de la collectivité sont invalides',
-      },
-      COLLECTIVITE_NOT_FOUND: {
-        code: 'NOT_FOUND',
-        message: "La collectivité n'est pas trouvée",
-      },
-    },
+    specificErrors: collectivitePreferencesTrpcErrorEntries,
   };
 
-export const CollectivitePreferencesErrorEnum =
-  createErrorsEnum(specificErrors);
+export const CollectivitePreferencesErrorEnum = createErrorsEnum(
+  collectivitePreferencesSpecificErrors
+);
 export type CollectivitePreferencesError =
   keyof typeof CollectivitePreferencesErrorEnum;

--- a/apps/backend/src/collectivites/collectivite-referentiel-mode/collectivite-referentiel-mode.service.ts
+++ b/apps/backend/src/collectivites/collectivite-referentiel-mode/collectivite-referentiel-mode.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { CollectivitePreferencesRepository } from '@tet/backend/collectivites/collectivite-preferences/collectivite-preferences.repository';
+import type { Transaction } from '@tet/backend/utils/database/transaction.utils';
 import { success, type Result } from '@tet/backend/utils/result.type';
 import {
   defaultCollectivitePreferences,
@@ -48,11 +49,13 @@ export class CollectiviteReferentielModeService {
 
   async updateReferentielPreferences(
     collectiviteId: number,
-    referentiels: CollectiviteReferentielPreferences
+    referentiels: CollectiviteReferentielPreferences,
+    tx?: Transaction
   ) {
     return this.collectivitePreferencesRepository.updatePreferences(
       collectiviteId,
-      { referentiels }
+      { referentiels },
+      tx
     );
   }
 }

--- a/apps/backend/src/referentiels/referentiels.module.ts
+++ b/apps/backend/src/referentiels/referentiels.module.ts
@@ -17,6 +17,7 @@ import { CollectivitesModule } from '../collectivites/collectivites.module';
 import { PersonnalisationsModule } from '../collectivites/personnalisations/personnalisations.module';
 import { SheetModule } from '../utils/google-sheets/sheet.module';
 import { TransactionModule } from '../utils/transaction/transaction.module';
+import { TrackingModule } from '../utils/tracking/tracking.module';
 import { ActionPersonnalisationsRouter } from './action-personnalisations/action-personnalisations.router';
 import { ActionPersonnalisationsService } from './action-personnalisations/action-personnalisations.service';
 import ScoresService from './compute-score/scores.service';
@@ -80,6 +81,8 @@ import { ReferentielsCoreModule } from './referentiels-core.module';
 import { ReferentielsRouter } from './referentiels.router';
 import { ResetDisplayPreferencesRouter } from './reset-display-preferences/reset-display-preferences.router';
 import { ResetDisplayPreferencesService } from './reset-display-preferences/reset-display-preferences.service';
+import { SwitchToTeRouter } from './switch-to-te/switch-to-te.router';
+import { SwitchToTeService } from './switch-to-te/switch-to-te.service';
 import { ListSnapshotsService } from './snapshots/list-snapshots/list-snapshots.service';
 import { SnapshotsRouter } from './snapshots/snapshots.router';
 import { SnapshotsService } from './snapshots/snapshots.service';
@@ -99,6 +102,7 @@ import { UpdateActionStatutService } from './update-action-statut/update-action-
     FichesModule,
     ReferentielsCoreModule,
     TransactionModule,
+    TrackingModule,
     BullModule.registerQueue({
       name: PREUVES_ARCHIVE_QUEUE_NAME,
       defaultJobOptions: PREUVES_ARCHIVE_JOB_OPTIONS,
@@ -187,6 +191,9 @@ import { UpdateActionStatutService } from './update-action-statut/update-action-
 
     ResetDisplayPreferencesService,
     ResetDisplayPreferencesRouter,
+
+    SwitchToTeService,
+    SwitchToTeRouter,
 
     HistoriqueRouter,
     ListHistoriqueRepository,

--- a/apps/backend/src/referentiels/referentiels.router.ts
+++ b/apps/backend/src/referentiels/referentiels.router.ts
@@ -19,6 +19,7 @@ import { GetPreuvesArchiveRouter } from './preuves-archive/get-preuves-archive/g
 import { ListPreuvesArchiveRouter } from './preuves-archive/list-preuves-archive/list-preuves-archive.router';
 import { RequestPreuvesArchiveRouter } from './preuves-archive/request-preuves-archive/request-preuves-archive.router';
 import { ResetDisplayPreferencesRouter } from './reset-display-preferences/reset-display-preferences.router';
+import { SwitchToTeRouter } from './switch-to-te/switch-to-te.router';
 import { ActionPersonnalisationsRouter } from './action-personnalisations/action-personnalisations.router';
 import { SnapshotsRouter } from './snapshots/snapshots.router';
 import { UpdateActionCommentaireRouter } from './update-action-commentaire/update-action-commentaire.router';
@@ -51,7 +52,8 @@ export class ReferentielsRouter {
     private readonly historiqueRouter: HistoriqueRouter,
     private readonly requestPreuvesArchiveRouter: RequestPreuvesArchiveRouter,
     private readonly getPreuvesArchiveRouter: GetPreuvesArchiveRouter,
-    private readonly listPreuvesArchiveRouter: ListPreuvesArchiveRouter
+    private readonly listPreuvesArchiveRouter: ListPreuvesArchiveRouter,
+    private readonly switchToTeRouter: SwitchToTeRouter
   ) {}
 
   router = this.trpc.router({
@@ -91,6 +93,8 @@ export class ReferentielsRouter {
       this.getPreuvesArchiveRouter.router,
       this.listPreuvesArchiveRouter.router
     ),
+
+    switchToTe: this.switchToTeRouter.switchToTe,
   });
 
   createCaller = this.trpc.createCallerFactory(this.router);

--- a/apps/backend/src/referentiels/switch-to-te/switch-to-te.errors.ts
+++ b/apps/backend/src/referentiels/switch-to-te/switch-to-te.errors.ts
@@ -1,0 +1,48 @@
+import {
+  collectivitePreferencesSpecificErrors,
+  collectivitePreferencesTrpcErrorEntries,
+} from '@tet/backend/collectivites/collectivite-preferences/collectivite-preferences.errors';
+import {
+  createErrorsEnum,
+  TrpcErrorHandlerConfig,
+} from '@tet/backend/utils/trpc/trpc-error-handler';
+
+const specificErrors = [
+  'REFERENTIEL_TE_DISABLED',
+  'ALREADY_SWITCHED',
+  'NOT_ELIGIBLE',
+  'SWITCH_NOT_IMPLEMENTED',
+  ...collectivitePreferencesSpecificErrors,
+] as const;
+
+export const switchToTeTrpcErrorEntries = {
+  REFERENTIEL_TE_DISABLED: {
+    code: 'FORBIDDEN',
+    message: "Le référentiel TE n'est pas activé pour cette collectivité",
+  },
+  ALREADY_SWITCHED: {
+    code: 'CONFLICT',
+    message: 'La bascule vers TE a déjà été effectuée',
+  },
+  NOT_ELIGIBLE: {
+    code: 'BAD_REQUEST',
+    message:
+      "Cette collectivité n'est pas éligible à la bascule (TE non en lecture seule ou aucun référentiel CAE/ECI engagé)",
+  },
+  SWITCH_NOT_IMPLEMENTED: {
+    code: 'NOT_IMPLEMENTED',
+    message: "La bascule n'est pas encore disponible",
+  },
+} as const;
+
+type SpecificError = (typeof specificErrors)[number];
+
+export const switchToTeErrorConfig: TrpcErrorHandlerConfig<SpecificError> = {
+  specificErrors: {
+    ...switchToTeTrpcErrorEntries,
+    ...collectivitePreferencesTrpcErrorEntries,
+  },
+};
+
+export const SwitchToTeErrorEnum = createErrorsEnum(specificErrors);
+export type SwitchToTeError = keyof typeof SwitchToTeErrorEnum;

--- a/apps/backend/src/referentiels/switch-to-te/switch-to-te.input.ts
+++ b/apps/backend/src/referentiels/switch-to-te/switch-to-te.input.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const switchToTeInputSchema = z.object({
+  collectiviteId: z.number(),
+});
+
+export type SwitchToTeInput = z.infer<typeof switchToTeInputSchema>;

--- a/apps/backend/src/referentiels/switch-to-te/switch-to-te.output.ts
+++ b/apps/backend/src/referentiels/switch-to-te/switch-to-te.output.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const switchToTeNotImplementedOutputSchema = z.object({
+  status: z.literal('not_implemented'),
+});
+
+export type SwitchToTeNotImplementedOutput = z.infer<
+  typeof switchToTeNotImplementedOutputSchema
+>;

--- a/apps/backend/src/referentiels/switch-to-te/switch-to-te.router.e2e-spec.ts
+++ b/apps/backend/src/referentiels/switch-to-te/switch-to-te.router.e2e-spec.ts
@@ -1,0 +1,177 @@
+import { INestApplication } from '@nestjs/common';
+import { addTestCollectiviteAndUsers } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import {
+  getAuthUserFromUserCredentials,
+  getTestApp,
+  getTestDatabase,
+  getTestRouter,
+} from '@tet/backend/test';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import {
+  addAndEnableUserSuperAdminMode,
+  addTestUser,
+} from '@tet/backend/users/users/users.test-fixture';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
+import {
+  Collectivite,
+  type CollectiviteReferentielPreferences,
+} from '@tet/domain/collectivites';
+import { CollectiviteRole } from '@tet/domain/users';
+import { switchToTeTrpcErrorEntries } from './switch-to-te.errors';
+
+describe('SwitchToTeRouter', () => {
+  let app: INestApplication;
+  let router: TrpcRouter;
+  let databaseService: DatabaseService;
+  let supportCaller: ReturnType<TrpcRouter['createCaller']>;
+  let adminUser: AuthenticatedUser;
+  let lectureUser: AuthenticatedUser;
+  let collectivite: Collectivite;
+  let cleanupSupportUser: () => Promise<void>;
+  let cleanupSuperAdminMode: () => Promise<void>;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    router = await getTestRouter(app);
+    databaseService = await getTestDatabase(app);
+
+    const supportUserResult = await addTestUser(databaseService);
+    cleanupSupportUser = supportUserResult.cleanup;
+    const supportUser = getAuthUserFromUserCredentials(supportUserResult.user);
+    supportCaller = router.createCaller({ user: supportUser });
+    const superAdminMode = await addAndEnableUserSuperAdminMode({
+      app,
+      caller: supportCaller,
+      userId: supportUser.id,
+    });
+    cleanupSuperAdminMode = superAdminMode.cleanup;
+
+    const testCollectiviteAndUsersResult = await addTestCollectiviteAndUsers(
+      databaseService,
+      {
+        users: [
+          { role: CollectiviteRole.ADMIN },
+          { role: CollectiviteRole.LECTURE },
+        ],
+      }
+    );
+
+    collectivite = testCollectiviteAndUsersResult.collectivite;
+    adminUser = getAuthUserFromUserCredentials(
+      testCollectiviteAndUsersResult.users[0]
+    );
+    lectureUser = getAuthUserFromUserCredentials(
+      testCollectiviteAndUsersResult.users[1]
+    );
+  });
+
+  afterAll(async () => {
+    await cleanupSuperAdminMode();
+    await cleanupSupportUser();
+    await app.close();
+  });
+
+  async function setReferentielPreferences(
+    referentiels: CollectiviteReferentielPreferences
+  ) {
+    await supportCaller.collectivites.preferences.update({
+      collectiviteId: collectivite.id,
+      preferences: { referentiels },
+    });
+  }
+
+  test('retourne SWITCH_NOT_IMPLEMENTED quand les guards passent (squelette)', async () => {
+    await setReferentielPreferences({
+      cae: { display: true, mode: 'write' },
+      eci: { display: false, mode: 'archived' },
+      te: { display: true, mode: 'readonly' },
+    });
+
+    const adminCaller = router.createCaller({ user: adminUser });
+
+    await expect(
+      adminCaller.referentiels.switchToTe({ collectiviteId: collectivite.id })
+    ).rejects.toThrow(
+      switchToTeTrpcErrorEntries.SWITCH_NOT_IMPLEMENTED.message
+    );
+  });
+
+  test('refuse si la bascule a déjà été effectuée', async () => {
+    const switchedFixture = await addTestCollectiviteAndUsers(databaseService, {
+      users: [{ role: CollectiviteRole.ADMIN }],
+    });
+    onTestFinished(() => switchedFixture.cleanup());
+    const switchedAdminUser = getAuthUserFromUserCredentials(
+      switchedFixture.users[0]
+    );
+
+    await supportCaller.collectivites.preferences.update({
+      collectiviteId: switchedFixture.collectivite.id,
+      preferences: {
+        referentiels: {
+          cae: { display: false, mode: 'archived' },
+          eci: { display: false, mode: 'archived' },
+          te: {
+            display: true,
+            mode: 'write',
+            populatedFromCaeEci: {
+              populatedAt: '2026-06-01T00:00:00.000Z',
+              populatedBy: switchedAdminUser.id,
+            },
+          },
+        },
+      },
+    });
+
+    const adminCaller = router.createCaller({ user: switchedAdminUser });
+
+    await expect(
+      adminCaller.referentiels.switchToTe({
+        collectiviteId: switchedFixture.collectivite.id,
+      })
+    ).rejects.toThrow(switchToTeTrpcErrorEntries.ALREADY_SWITCHED.message);
+  });
+
+  test('refuse une CT non engagée (TE en write)', async () => {
+    await setReferentielPreferences({
+      cae: { display: false, mode: 'archived' },
+      eci: { display: false, mode: 'archived' },
+      te: { display: true, mode: 'write' },
+    });
+
+    const adminCaller = router.createCaller({ user: adminUser });
+
+    await expect(
+      adminCaller.referentiels.switchToTe({ collectiviteId: collectivite.id })
+    ).rejects.toThrow(switchToTeTrpcErrorEntries.NOT_ELIGIBLE.message);
+  });
+
+  test('refuse quand TE readonly mais aucune source CAE/ECI engagée', async () => {
+    await setReferentielPreferences({
+      cae: { display: false, mode: 'archived' },
+      eci: { display: false, mode: 'archived' },
+      te: { display: true, mode: 'readonly' },
+    });
+
+    const adminCaller = router.createCaller({ user: adminUser });
+
+    await expect(
+      adminCaller.referentiels.switchToTe({ collectiviteId: collectivite.id })
+    ).rejects.toThrow(switchToTeTrpcErrorEntries.NOT_ELIGIBLE.message);
+  });
+
+  test('refuse sans permission REFERENTIELS.MUTATE', async () => {
+    await setReferentielPreferences({
+      cae: { display: true, mode: 'write' },
+      eci: { display: false, mode: 'archived' },
+      te: { display: true, mode: 'readonly' },
+    });
+
+    const lectureCaller = router.createCaller({ user: lectureUser });
+
+    await expect(
+      lectureCaller.referentiels.switchToTe({ collectiviteId: collectivite.id })
+    ).rejects.toThrow("Vous n'avez pas les permissions nécessaires");
+  });
+});

--- a/apps/backend/src/referentiels/switch-to-te/switch-to-te.router.ts
+++ b/apps/backend/src/referentiels/switch-to-te/switch-to-te.router.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@nestjs/common';
+import { createTrpcErrorHandler } from '@tet/backend/utils/trpc/trpc-error-handler';
+import { TrpcService } from '@tet/backend/utils/trpc/trpc.service';
+import { switchToTeErrorConfig } from './switch-to-te.errors';
+import { switchToTeInputSchema } from './switch-to-te.input';
+import { SwitchToTeService } from './switch-to-te.service';
+
+@Injectable()
+export class SwitchToTeRouter {
+  constructor(
+    private readonly trpc: TrpcService,
+    private readonly switchToTeService: SwitchToTeService
+  ) {}
+
+  private readonly getResultDataOrThrowError = createTrpcErrorHandler(
+    switchToTeErrorConfig
+  );
+
+  switchToTe = this.trpc.authedProcedure
+    .input(switchToTeInputSchema)
+    .mutation(async ({ ctx: { user }, input: { collectiviteId } }) => {
+      const result = await this.switchToTeService.switchToTe(collectiviteId, {
+        user,
+      });
+      return this.getResultDataOrThrowError(result);
+    });
+
+  router = this.trpc.router({
+    switchToTe: this.switchToTe,
+  });
+}

--- a/apps/backend/src/referentiels/switch-to-te/switch-to-te.rules.spec.ts
+++ b/apps/backend/src/referentiels/switch-to-te/switch-to-te.rules.spec.ts
@@ -1,0 +1,52 @@
+import type { CollectiviteReferentielPreferences } from '@tet/domain/collectivites';
+import { describe, expect, it } from 'vitest';
+import { canSwitchToTe } from './switch-to-te.rules';
+
+describe('canSwitchToTe', () => {
+  it('retourne true quand TE readonly et CAE engagé', () => {
+    const prefs: CollectiviteReferentielPreferences = {
+      cae: { display: true, mode: 'write' },
+      eci: { display: false, mode: 'archived' },
+      te: { display: true, mode: 'readonly' },
+    };
+
+    expect(canSwitchToTe(prefs)).toBe(true);
+  });
+
+  it('retourne false pour une CT non engagée (TE en write)', () => {
+    const prefs: CollectiviteReferentielPreferences = {
+      cae: { display: false, mode: 'archived' },
+      eci: { display: false, mode: 'archived' },
+      te: { display: true, mode: 'write' },
+    };
+
+    expect(canSwitchToTe(prefs)).toBe(false);
+  });
+
+  it('retourne false quand TE readonly mais aucune source à migrer', () => {
+    const prefs: CollectiviteReferentielPreferences = {
+      cae: { display: false, mode: 'archived' },
+      eci: { display: false, mode: 'archived' },
+      te: { display: true, mode: 'readonly' },
+    };
+
+    expect(canSwitchToTe(prefs)).toBe(false);
+  });
+
+  it('retourne false quand la bascule a déjà été effectuée', () => {
+    const prefs: CollectiviteReferentielPreferences = {
+      cae: { display: false, mode: 'archived' },
+      eci: { display: false, mode: 'archived' },
+      te: {
+        display: true,
+        mode: 'write',
+        populatedFromCaeEci: {
+          populatedAt: '2026-06-01T00:00:00.000Z',
+          populatedBy: 'user-id',
+        },
+      },
+    };
+
+    expect(canSwitchToTe(prefs)).toBe(false);
+  });
+});

--- a/apps/backend/src/referentiels/switch-to-te/switch-to-te.rules.ts
+++ b/apps/backend/src/referentiels/switch-to-te/switch-to-te.rules.ts
@@ -1,0 +1,10 @@
+import type { CollectiviteReferentielPreferences } from '@tet/domain/collectivites';
+
+export function canSwitchToTe(
+  prefs: CollectiviteReferentielPreferences
+): boolean {
+  if (prefs.te.populatedFromCaeEci) return false;
+  if (prefs.te.mode !== 'readonly') return false;
+  // proxy engagement : au moins une source encore en écriture
+  return prefs.cae.mode === 'write' || prefs.eci.mode === 'write';
+}

--- a/apps/backend/src/referentiels/switch-to-te/switch-to-te.service.ts
+++ b/apps/backend/src/referentiels/switch-to-te/switch-to-te.service.ts
@@ -1,0 +1,66 @@
+import { Injectable } from '@nestjs/common';
+import { CollectiviteReferentielModeService } from '@tet/backend/collectivites/collectivite-referentiel-mode/collectivite-referentiel-mode.service';
+import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
+import type { ServiceSecondArg } from '@tet/backend/utils/nest/service-second-arg.utils';
+import { failure, type Result } from '@tet/backend/utils/result.type';
+import { TrackingService } from '@tet/backend/utils/tracking/tracking.service';
+import { PermissionOperationEnum, ResourceType } from '@tet/domain/users';
+import {
+  SwitchToTeErrorEnum,
+  type SwitchToTeError,
+} from './switch-to-te.errors';
+import { canSwitchToTe } from './switch-to-te.rules';
+import type { SwitchToTeNotImplementedOutput } from './switch-to-te.output';
+
+@Injectable()
+export class SwitchToTeService {
+  constructor(
+    private readonly trackingService: TrackingService,
+    private readonly permissionService: PermissionService,
+    private readonly collectiviteReferentielModeService: CollectiviteReferentielModeService
+  ) {}
+
+  async switchToTe(
+    collectiviteId: number,
+    { user }: ServiceSecondArg
+  ): Promise<Result<SwitchToTeNotImplementedOutput, SwitchToTeError>> {
+    const isAllowed = await this.permissionService.isAllowed(
+      user,
+      PermissionOperationEnum['REFERENTIELS.MUTATE'],
+      ResourceType.COLLECTIVITE,
+      collectiviteId,
+      true
+    );
+    if (!isAllowed) {
+      return failure('UNAUTHORIZED');
+    }
+
+    const isReferentielTeEnabled = await this.trackingService.isFeatureEnabled(
+      'is-referentiel-te-enabled',
+      user.id,
+      collectiviteId
+    );
+    if (!isReferentielTeEnabled) {
+      return failure(SwitchToTeErrorEnum.REFERENTIEL_TE_DISABLED);
+    }
+
+    const preferencesResult =
+      await this.collectiviteReferentielModeService.getReferentielPreferences(
+        collectiviteId
+      );
+    if (!preferencesResult.success) {
+      return preferencesResult;
+    }
+
+    const prefs = preferencesResult.data;
+    if (prefs.te.populatedFromCaeEci) {
+      return failure(SwitchToTeErrorEnum.ALREADY_SWITCHED);
+    }
+
+    if (!canSwitchToTe(prefs)) {
+      return failure(SwitchToTeErrorEnum.NOT_ELIGIBLE);
+    }
+
+    return failure(SwitchToTeErrorEnum.SWITCH_NOT_IMPLEMENTED);
+  }
+}

--- a/doc/plans/2026-06-11-003-feat-bascule-referentiel-te-pr8-plan.md
+++ b/doc/plans/2026-06-11-003-feat-bascule-referentiel-te-pr8-plan.md
@@ -1,0 +1,238 @@
+---
+name: PR8 SwitchToTe squelette
+overview: "Implémenter le squelette backend de la bascule TE : `SwitchToTeService` (pattern Result ADR 0012), endpoint tRPC `referentiels.switchToTe`, guards permissions/idempotence/éligibilité/feature-flag, et propagation `tx?` sur les prefs — sans orchestration transactionnelle (PR18)."
+todos:
+  - id: domain-rule
+    content: Ajouter canSwitchToTe dans packages/domain + tests unitaires
+    status: pending
+  - id: errors-io
+    content: Créer switch-to-te.errors.ts, input.ts, output.ts
+    status: pending
+  - id: service-skeleton
+    content: Implémenter SwitchToTeService (guards + SWITCH_NOT_IMPLEMENTED)
+    status: pending
+  - id: tx-propagation
+    content: Propager tx? sur CollectiviteReferentielModeService.updateReferentielPreferences
+    status: pending
+  - id: router-wiring
+    content: SwitchToTeRouter + merge dans ReferentielsRouter + ReferentielsModule
+    status: pending
+  - id: e2e-guards
+    content: Tests e2e switch-to-te.router.e2e-spec.ts (permissions, idempotence, éligibilité, squelette)
+    status: pending
+isProject: false
+---
+
+# PR8 — Service de bascule (squelette)
+
+**Parent** : [doc/plans/2026-06-11-001-feat-bascule-referentiel-te-prd.md](doc/plans/2026-06-11-001-feat-bascule-referentiel-te-prd.md)
+
+**Branche** : `TE-7303/switch-te-PR8` depuis `main` (PR4 mergé ; PR5–PR7 parallélisables, non bloquants)
+
+**Estimation** : ~500 LOC (code + tests e2e)
+
+---
+
+## Contexte
+
+PR4 a posé [`CollectiviteReferentielModeService`](apps/backend/src/collectivites/collectivite-referentiel-mode/collectivite-referentiel-mode.service.ts) et [`ReferentielModeGuard`](apps/backend/src/collectivites/collectivite-referentiel-mode/referentiel-mode-guard.service.ts). Le repository prefs accepte déjà `tx?` ([`collectivite-preferences.repository.ts`](apps/backend/src/collectivites/collectivite-preferences/collectivite-preferences.repository.ts) L33–L68) mais `updateReferentielPreferences` du mode service ne le propage pas encore (reporté en PR4).
+
+PR8 crée l’orchestrateur vide que PR9–PR17 brancheront étape par étape ; PR18 complète la transaction et retire le garde squelette.
+
+```mermaid
+sequenceDiagram
+  participant Router
+  participant SwitchToTeService
+  participant Guards
+  participant TxManager
+
+  Router->>SwitchToTeService: switchToTe(collectiviteId, user)
+  SwitchToTeService->>Guards: feature flag + permissions + idempotence + éligibilité
+  alt guard échoue
+    Guards-->>Router: Result failure typé
+  else guards OK (PR8)
+    SwitchToTeService-->>Router: SWITCH_NOT_IMPLEMENTED
+  else guards OK (PR18)
+    SwitchToTeService->>TxManager: snapshots → migrate → scores → prefs
+  end
+```
+
+---
+
+## Décisions actées
+
+| Sujet | Décision |
+|---|---|
+| Verrouillage prod PR8–PR17 | Feature flag `is-referentiel-te-enabled` via `TrackingService.isFeatureEnabled` (même pattern que [`list-personnalisation-questions.service.ts`](apps/backend/src/collectivites/personnalisations/list-personnalisation-questions/list-personnalisation-questions.service.ts)) |
+| Comportement squelette | Après guards OK → `failure(SWITCH_NOT_IMPLEMENTED)` ; PR18 remplace par l’orchestration réelle |
+| Permission | `REFERENTIELS.MUTATE` sur la collectivité |
+| Idempotence | `te.populatedFromCaeEci` absent |
+| Éligibilité | `canSwitchToTe(prefs)` : TE `readonly` + pas encore basculé + **au moins un ref. CAE/ECI en `write`** (proxy du niveau de remplissage déjà encodé par `deriveReferentielPreferences`) |
+| `ReferentielModeGuard` | **Non utilisé** — `switchToTe` est une exception explicite (cf. plan PR4) |
+| `tx?` | Propager sur `CollectiviteReferentielModeService.updateReferentielPreferences` ; shell `TransactionManager.executeSingle` préparé mais vide en PR8 |
+
+---
+
+## 1. Règle domaine pure
+
+**Fichier** : `packages/domain/src/collectivites/can-switch-to-te.rules.ts`
+
+Le niveau de remplissage n'est **pas recalculé** à la bascule (pas d'I/O dans le domaine). Il est **encodé dans les prefs** par `deriveReferentielPreferences` / le batch reset : une CT engagée a au moins un ref. CAE ou ECI en `mode: write` ; une CT non engagée a `te: write` et CAE/ECI `archived`.
+
+```typescript
+export function canSwitchToTe(
+  prefs: CollectiviteReferentielPreferences
+): boolean {
+  if (prefs.te.populatedFromCaeEci) return false;
+  if (prefs.te.mode !== 'readonly') return false;
+  // proxy engagement : au moins une source encore en écriture
+  return prefs.cae.mode === 'write' || prefs.eci.mode === 'write';
+}
+```
+
+**Cas limites** :
+
+| État prefs | `canSwitchToTe` | Interprétation |
+|---|---|---|
+| `te: readonly`, `cae: write`, `eci: archived` | `true` | CAE engagé — bascule possible |
+| `te: write`, `cae/eci: archived` | `false` | CT non engagée — démarrage TE direct |
+| `te: readonly`, `cae/eci: archived` | `false` | Aucune source à migrer |
+| `te.populatedFromCaeEci` renseigné | `false` | Déjà basculé |
+
+> **État transitoire pré-batch** (PRD) : migration Sqitch met toutes les CT en `te: readonly` avant le batch reset. Une CT non engagée peut passer le guard prefs-proxy tant que CAE/ECI restent en `write`. Mitigation ops : batch reset avant levée du flag TE ; en PR8 le squelette retourne `SWITCH_NOT_IMPLEMENTED` de toute façon.
+
+**Tests unitaires** (`can-switch-to-te.rules.spec.ts`) : couvrir le tableau ci-dessus.
+
+- Export dans `packages/domain/src/collectivites/index.ts`
+- Réutilisable en PR19 (CTA UI) sans duplication
+
+---
+
+## 2. Feature backend `switch-to-te/`
+
+Emplacement : `apps/backend/src/referentiels/switch-to-te/` (convention ADR 0011)
+
+| Fichier | Rôle |
+|---|---|
+| `switch-to-te.input.ts` | `{ collectiviteId: z.number() }` |
+| `switch-to-te.output.ts` | Stub PR8 : `{ status: 'not_implemented' }` ; PR18 : `{ populatedAt, populatedBy }` |
+| `switch-to-te.errors.ts` | Erreurs typées + config tRPC |
+| `switch-to-te.service.ts` | Guards + squelette |
+| `switch-to-te.router.ts` | `authedProcedure` + `createTrpcErrorHandler` |
+| `switch-to-te.router.e2e-spec.ts` | Tests guards |
+
+### Erreurs spécifiques
+
+| Code | tRPC | Message (indicatif) |
+|---|---|---|
+| `REFERENTIEL_TE_DISABLED` | `FORBIDDEN` | Le référentiel TE n'est pas activé pour cette collectivité |
+| `ALREADY_SWITCHED` | `CONFLICT` | La bascule vers TE a déjà été effectuée |
+| `NOT_ELIGIBLE` | `BAD_REQUEST` | Cette collectivité n'est pas éligible à la bascule (TE non en lecture seule ou aucun référentiel CAE/ECI engagé) |
+| `SWITCH_NOT_IMPLEMENTED` | `NOT_IMPLEMENTED` | La bascule n'est pas encore disponible (retiré en PR18) |
+| `UNAUTHORIZED` | `FORBIDDEN` | (common) |
+
+### `SwitchToTeService.switchToTe`
+
+Ordre des guards (hors transaction, état commité — cf. plan PR4) :
+
+1. `trackingService.isFeatureEnabled('is-referentiel-te-enabled', user.id, collectiviteId)`
+2. `permissionService.isAllowed(user, REFERENTIELS.MUTATE, COLLECTIVITE, collectiviteId, true)`
+3. `collectiviteReferentielModeService.getReferentielPreferences(collectiviteId)`
+4. Si `te.populatedFromCaeEci` → `ALREADY_SWITCHED`
+5. Si `!canSwitchToTe(prefs)` → `NOT_ELIGIBLE`
+6. **PR8** : `failure(SWITCH_NOT_IMPLEMENTED)`
+7. **PR18** (hors scope PR8) : `transactionManager.executeSingle(async (tx) => { … })`
+
+Signature service : `switchToTe(collectiviteId, { user }: ServiceSecondArg)` — pas de `tx` exposé au routeur en PR8.
+
+---
+
+## 3. Propagation `tx?` sur le mode service
+
+Modifier [`collectivite-referentiel-mode.service.ts`](apps/backend/src/collectivites/collectivite-referentiel-mode/collectivite-referentiel-mode.service.ts) :
+
+```typescript
+async updateReferentielPreferences(
+  collectiviteId: number,
+  referentiels: CollectiviteReferentielPreferences,
+  tx?: Transaction
+)
+```
+
+Déléguer à `repository.updatePreferences(collectiviteId, { referentiels }, tx)`.
+
+---
+
+## 4. Câblage module + routeur
+
+### `ReferentielsRouter`
+
+Ajouter via `mergeRouters` pour obtenir `referentiels.switchToTe` (pas de double nesting) :
+
+```typescript
+router = this.trpc.mergeRouters(
+  this.trpc.router({ actions: ..., preferences: ..., ... }),
+  this.switchToTeRouter.router  // { switchToTe: procedure }
+);
+```
+
+### `ReferentielsModule`
+
+- Providers : `SwitchToTeService`, `SwitchToTeRouter`
+- Import `TrackingModule` si pas déjà transitif (vérifier via `CollectivitesModule` / `UtilsModule`)
+
+---
+
+## 5. Stratégie de tests
+
+Fichier : `switch-to-te.router.e2e-spec.ts`
+
+Setup : `addTestCollectiviteAndUser` + prefs via `collectivites.preferences.update` (super-admin), comme [`referentiel-mode-guard.router.e2e-spec.ts`](apps/backend/src/collectivites/collectivite-referentiel-mode/referentiel-mode-guard.router.e2e-spec.ts).
+
+| Scénario | Prefs / rôle | Attendu |
+|---|---|---|
+| Succès guards (squelette) | `te: readonly`, CAE `write`, user admin | `SWITCH_NOT_IMPLEMENTED` |
+| Déjà basculé | `te.populatedFromCaeEci` renseigné | `ALREADY_SWITCHED` |
+| Non éligible — CT non engagée | `te: write`, CAE/ECI `archived` | `NOT_ELIGIBLE` |
+| Non éligible — aucune source | `te: readonly`, CAE/ECI `archived` | `NOT_ELIGIBLE` |
+| Sans permission | user lecture seule | `UNAUTHORIZED` |
+
+Le **feature flag** (`REFERENTIEL_TE_DISABLED`) n'est pas testé : le flag `is-referentiel-te-enabled` est toujours `true` en dev/ci (non basculable en E2E) et le guard est trivial (`if (!enabled) return failure(...)`). Un test unitaire mocké n'apporterait qu'une couverture de câblage, à contre-courant de la préférence E2E du backend.
+
+Commande : `pnpm test:backend switch-to-te`
+
+---
+
+## 6. Hors scope PR8 (PRs suivantes)
+
+| PR | Ajout dans `SwitchToTeService` |
+|---|---|
+| PR9 | Guards COT / demande d'audit / audit en cours |
+| PR10 | Snapshots `pre-switch-te` |
+| PR12–PR17 | `mergeStatuts`, migration données |
+| PR18 | Transaction complète, prefs + `populatedFromCaeEci`, retrait `SWITCH_NOT_IMPLEMENTED` |
+| PR19–PR20 | UI CTA + modale (appelle `referentiels.switchToTe`) |
+
+---
+
+## 7. Ordre d'implémentation (tracer bullet)
+
+1. Règle domaine `canSwitchToTe` + tests unitaires
+2. `switch-to-te.errors.ts` + input/output
+3. `SwitchToTeService` (guards + squelette)
+4. `tx?` sur `CollectiviteReferentielModeService`
+5. `SwitchToTeRouter` + merge dans `ReferentielsRouter` + module
+6. E2E guards + `pnpm test:backend switch-to-te`
+
+---
+
+## Critères de done
+
+- [ ] `canSwitchToTe` testée en unitaire
+- [ ] Endpoint `referentiels.switchToTe` typé dans `AppRouter`
+- [ ] Guards : feature flag, `REFERENTIELS.MUTATE`, idempotence, éligibilité `canSwitchToTe` (readonly + source CAE/ECI en write)
+- [ ] Aucune écriture DB en PR8 (pas de prefs modifiées, pas de migration)
+- [ ] `updateReferentielPreferences(..., tx?)` propagé jusqu'au repository
+- [ ] E2E : 5 scénarios guards ci-dessus (squelette, idempotence, 2× éligibilité, permission)
+- [ ] Feature flag non testé (flag toujours `true` en CI, guard trivial) — documenté
+- [ ] Déployable en prod sans risque utilisateur (squelette + flag TE requis)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Ajout d’une action tRPC `switchToTe` pour basculer vers le référentiel TE, avec contrôles d’autorisations, prérequis d’éligibilité et réponses d’erreurs structurées.
  * Cadrage du “switch” via de nouveaux schémas d’entrée/sortie et valeurs d’erreur dédiées.
* **Tests**
  * Ajout de tests unitaires pour la règle d’éligibilité.
  * Ajout de tests e2e couvrant les principaux refus, dont le mode “pas encore implémenté”.
* **Documentation**
  * Mise à jour de la note de cadrage sur le périmètre et le flux attendu pour cette étape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->