### PR TITLE
refactor(referentiels): reformule les labels d'archive en telechargement de documents

### DIFF
--- a/apps/app/src/labels/catalog.ts
+++ b/apps/app/src/labels/catalog.ts
@@ -270,32 +270,32 @@ export const appLabels = {
   editerReferentiel: 'Éditer le référentiel',
   enregistrer: 'Enregistrer',
 
-  preuvesArchiveVoir: 'Voir les archives',
-  preuvesArchiveGenerer: 'Générer une archive',
-  preuvesArchiveAucune: 'Aucune archive générée pour le moment.',
-  preuvesArchivePanelTitre: 'Les archives',
-  preuvesArchiveValiditeInfo:
-    'Les archives restent valides 7 jours, puis sont supprimées.',
-  preuvesArchiveFermerPanel: 'Fermer le panneau des archives',
-  preuvesArchiveLigneTitre: ({
+  preuvesTelechargementVoir: 'Voir les téléchargements',
+  preuvesTelechargementDemarrer: 'Télécharger tous les documents',
+  preuvesTelechargementAucun: 'Aucun téléchargement préparé pour le moment.',
+  preuvesTelechargementPanelTitre: 'Téléchargement des documents',
+  preuvesTelechargementValiditeInfo:
+    'Les fichiers préparés restent disponibles 7 jours, puis sont supprimés.',
+  preuvesTelechargementFermerPanel: 'Fermer le panneau des téléchargements',
+  preuvesTelechargementLigneTitre: ({
     referentiel,
     collectivite,
   }: {
     referentiel: string;
     collectivite: string;
   }): string => `${referentiel} · ${collectivite}`,
-  preuvesArchiveProgression: ({
+  preuvesTelechargementProgression: ({
     processed,
     total,
   }: {
     processed: number;
     total: number;
   }): string => `${processed} / ${total} fichiers`,
-  preuvesArchiveNombreFichiers: ({ count }: { count: number }): string =>
+  preuvesTelechargementNombreFichiers: ({ count }: { count: number }): string =>
     `${count} fichier${count > 1 ? 's' : ''}`,
-  preuvesArchiveTelecharger: "Télécharger l'archive",
-  preuvesArchiveReessayer: 'Réessayer',
-  preuvesArchiveErreurGenerique: "La génération de l'archive a échoué.",
+  preuvesTelechargementLien: 'Télécharger le dossier',
+  preuvesTelechargementReessayer: 'Réessayer',
+  preuvesTelechargementErreur: 'La préparation des documents a échoué.',
 
   erreurConnexionReseau:
     "Erreur de connexion réseau. Veuillez attendre que votre connexion soit rétablie pour utiliser l'application.",

--- a/apps/app/src/referentiels/archives-panel/archive-details.spec.tsx
+++ b/apps/app/src/referentiels/archives-panel/archive-details.spec.tsx
@@ -104,7 +104,9 @@ describe('ArchiveDetails', () => {
       />
     );
 
-    expect(screen.getByText("La génération de l'archive a échoué.")).toBeTruthy();
+    expect(
+      screen.getByText('La préparation des documents a échoué.')
+    ).toBeTruthy();
     expect(screen.queryByRole('button', { name: /Réessayer/ })).toBeNull();
   });
 });

--- a/apps/app/src/referentiels/archives-panel/archive-details.tsx
+++ b/apps/app/src/referentiels/archives-panel/archive-details.tsx
@@ -41,7 +41,7 @@ function ArchiveTitle({
 }): JSX.Element {
   return (
     <span className="truncate text-sm font-semibold leading-tight text-primary-9">
-      {appLabels.preuvesArchiveLigneTitre({
+      {appLabels.preuvesTelechargementLigneTitre({
         referentiel: referentielLabel,
         collectivite: collectiviteNom,
       })}
@@ -93,8 +93,8 @@ function ArchiveDetailsAction({
           size="xs"
           variant="outlined"
           icon="download-line"
-          title={appLabels.preuvesArchiveTelecharger}
-          aria-label={appLabels.preuvesArchiveTelecharger}
+          title={appLabels.preuvesTelechargementLien}
+          aria-label={appLabels.preuvesTelechargementLien}
           onClick={onDownload}
         />
       );
@@ -104,8 +104,8 @@ function ArchiveDetailsAction({
           size="xs"
           variant="outlined"
           icon="refresh-line"
-          title={appLabels.preuvesArchiveReessayer}
-          aria-label={appLabels.preuvesArchiveReessayer}
+          title={appLabels.preuvesTelechargementReessayer}
+          aria-label={appLabels.preuvesTelechargementReessayer}
           onClick={onRetry}
         />
       ) : null;
@@ -114,13 +114,13 @@ function ArchiveDetailsAction({
 
 function progressLabelFor(state: ArchiveDetailsState): string | null {
   if (state.kind === 'preparing' && !state.indeterminate) {
-    return appLabels.preuvesArchiveProgression({
+    return appLabels.preuvesTelechargementProgression({
       processed: state.processed,
       total: state.total,
     });
   }
   if (state.kind === 'ready') {
-    return appLabels.preuvesArchiveNombreFichiers({
+    return appLabels.preuvesTelechargementNombreFichiers({
       count: state.totalFiles,
     });
   }
@@ -145,7 +145,7 @@ export function ArchiveDetails({
 
   const errorMessage =
     state.kind === 'error'
-      ? state.backendMessage ?? appLabels.preuvesArchiveErreurGenerique
+      ? state.backendMessage ?? appLabels.preuvesTelechargementErreur
       : null;
 
   return (

--- a/apps/app/src/referentiels/archives-panel/archives-panel-layout.tsx
+++ b/apps/app/src/referentiels/archives-panel/archives-panel-layout.tsx
@@ -15,10 +15,10 @@ export function ArchivesPanelLayout({
 }: ArchivesPanelLayoutProps): JSX.Element {
   return (
     <FloatingPanel
-      title={appLabels.preuvesArchivePanelTitre}
-      subtitle={appLabels.preuvesArchiveValiditeInfo}
+      title={appLabels.preuvesTelechargementPanelTitre}
+      subtitle={appLabels.preuvesTelechargementValiditeInfo}
       onClose={onClose}
-      closeLabel={appLabels.preuvesArchiveFermerPanel}
+      closeLabel={appLabels.preuvesTelechargementFermerPanel}
     >
       <FloatingPanel.Content>
         <ul className="m-0 flex list-none flex-col gap-6 p-0">{children}</ul>

--- a/apps/app/src/referentiels/archives-panel/data/use-download-archive.spec.ts
+++ b/apps/app/src/referentiels/archives-panel/data/use-download-archive.spec.ts
@@ -48,7 +48,7 @@ describe('useDownloadArchive', () => {
 
     expect(setToast).toHaveBeenCalledWith(
       'error',
-      appLabels.preuvesArchiveErreurGenerique
+      appLabels.preuvesTelechargementErreur
     );
   });
 
@@ -60,7 +60,7 @@ describe('useDownloadArchive', () => {
 
     expect(setToast).toHaveBeenCalledWith(
       'error',
-      appLabels.preuvesArchiveErreurGenerique
+      appLabels.preuvesTelechargementErreur
     );
   });
 });

--- a/apps/app/src/referentiels/archives-panel/data/use-download-archive.ts
+++ b/apps/app/src/referentiels/archives-panel/data/use-download-archive.ts
@@ -25,12 +25,12 @@ export function useDownloadArchive(): (archiveId: string) => Promise<void> {
         staleTime: 0,
       });
       if (archive.downloadUrl === null) {
-        setToast('error', appLabels.preuvesArchiveErreurGenerique);
+        setToast('error', appLabels.preuvesTelechargementErreur);
         return;
       }
       triggerBrowserDownload(archive.downloadUrl);
     } catch {
-      setToast('error', appLabels.preuvesArchiveErreurGenerique);
+      setToast('error', appLabels.preuvesTelechargementErreur);
     }
   };
 }

--- a/apps/app/src/referentiels/archives-panel/data/use-generate-archive.ts
+++ b/apps/app/src/referentiels/archives-panel/data/use-generate-archive.ts
@@ -33,7 +33,7 @@ export function useGenerateArchive({
       { collectiviteId, referentielId },
       {
         onError: () =>
-          setToast('error', appLabels.preuvesArchiveErreurGenerique),
+          setToast('error', appLabels.preuvesTelechargementErreur),
       }
     );
   };

--- a/apps/app/src/referentiels/archives-panel/index.tsx
+++ b/apps/app/src/referentiels/archives-panel/index.tsx
@@ -22,7 +22,9 @@ export type ArchivesPanelParams = {
 
 function NoArchivePlaceholder(): JSX.Element {
   return (
-    <li className="m-0 text-sm text-grey-7">{appLabels.preuvesArchiveAucune}</li>
+    <li className="m-0 text-sm text-grey-7">
+      {appLabels.preuvesTelechargementAucun}
+    </li>
   );
 }
 
@@ -51,7 +53,7 @@ export function ArchivesPanel({
       disabled={isGenerating}
       onClick={generate}
     >
-      {appLabels.preuvesArchiveGenerer}
+      {appLabels.preuvesTelechargementDemarrer}
     </Button>
   );
 

--- a/apps/app/src/referentiels/audit-labellisation/checklist-page-header/referentiel-menu.button.tsx
+++ b/apps/app/src/referentiels/audit-labellisation/checklist-page-header/referentiel-menu.button.tsx
@@ -40,7 +40,7 @@ export const ReferentielMenuButton = ({
     onClick: () => setIsSaveOpen(true),
   };
   const voirArchivesAction: MenuAction = {
-    label: appLabels.preuvesArchiveVoir,
+    label: appLabels.preuvesTelechargementVoir,
     icon: 'folder-zip-line',
     onClick: () =>
       openPanel({


### PR DESCRIPTION
## Pourquoi

Le terme « archive » dans le panneau de génération prêtait à confusion (il évoque « archiver / mettre de côté » alors qu'il s'agit de télécharger un ZIP de tous les documents de preuve, valable 7 jours). On reformule tout le lexique côté « télécharger les documents ».

## Ce qui change

Uniquement des labels UI (`apps/app/src/labels/catalog.ts` + consommateurs). Renommage des clés `appLabels.preuvesArchive*` → `preuvesTelechargement*` et reformulation des textes :

| Avant | Après |
|-------|-------|
| Générer une archive | Télécharger tous les documents |
| Les archives | Téléchargement des documents |
| Voir les archives | Voir les téléchargements |
| Télécharger l'archive | Télécharger le dossier |
| Aucune archive générée pour le moment. | Aucun téléchargement préparé pour le moment. |
| Les archives restent valides 7 jours, puis sont supprimées. | Les fichiers préparés restent disponibles 7 jours, puis sont supprimés. |
| La génération de l'archive a échoué. | La préparation des documents a échoué. |
| Fermer le panneau des archives | Fermer le panneau des téléchargements |

## Hors périmètre (volontaire)

- Le **routeur tRPC** `referentiels.preuvesArchive` reste inchangé (contrat d'API front/back).
- Les **noms de fichiers/composants** (`archives-panel/`, `ArchiveDetails`, `use-generate-archive.ts`…) conservent « archive » : l'artefact reste techniquement un ZIP. À aligner dans un lot séparé si souhaité.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Les libellés de l’espace de téléchargement ont été harmonisés pour parler de “documents” plutôt que d’“archives”.
  * Le panneau affiche désormais de nouveaux textes plus explicites, dont “Téléchargement des documents” et “Télécharger tous les documents”.
  * Les actions, états de progression et messages de réessai ont été mis à jour avec un wording plus clair.

* **Bug Fixes**
  * Les messages d’erreur de génération et de téléchargement utilisent désormais un texte dédié et plus précis.
  * Le bouton et les notifications affichent des intitulés cohérents dans tous les états.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->