### PR TITLE
refactor(referentiels): reformule le label de demande d'audit ou labe…

### DIFF
--- a/apps/app/src/labels/catalog.ts
+++ b/apps/app/src/labels/catalog.ts
@@ -1554,7 +1554,7 @@ export const appLabels = {
   ou: 'ou',
   acteCandidatureDownloadLink:
     "Télécharger le document d'acte de candidature à la labellisation",
-  demandeAuditOuLabellisation: 'Demander un audit ou une labellisation',
+  demandeAuditOuLabellisation: "Les attendus pour l'audit ou la labellisation",
   completudeCritere:
     'Renseigner les statuts de toutes les mesures du référentiel',
   voirLaMesure: 'Voir la mesure',

--- a/e2e/tests/referentiels/labellisations/new-audit-labellisation.pom.ts
+++ b/e2e/tests/referentiels/labellisations/new-audit-labellisation.pom.ts
@@ -36,7 +36,7 @@ export class NewAuditLabellisationPom {
   constructor(readonly page: Page) {
     this.documentsPom = new DocumentsPom(page);
     this.title = page.getByRole('heading', {
-      name: 'Demander un audit ou une labellisation',
+      name: "Les attendus pour l'audit ou la labellisation",
     });
     this.demanderPremiereEtoileButton = page.getByRole('button', {
       name: 'Obtenir la première étoile',


### PR DESCRIPTION
…llisation

"Demander un audit ou une labellisation" devient "Les attendus pour l'audit ou la labellisation".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Le titre affiché sur la page d’audit/labellisation a été mis à jour pour mieux refléter son contenu.
  * Les tests de navigation ont été ajustés pour prendre en compte ce nouveau libellé.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->