### PR TITLE
Répare la configuration de l'extension vitest-explorer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,10 +11,13 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true
   },
-  "typescript.preferences.importModuleSpecifier": "shortest",
-  "typescript.tsdk": "node_modules/typescript/lib",
-  "typescript.enablePromptUseWorkspaceTsdk": true,
-  "nxConsole.generateAiAgentRules": true,
+  "js/ts.preferences.importModuleSpecifier": "shortest",
+  "js/ts.tsdk.path": "node_modules/typescript/lib",
+  "js/ts.tsdk.promptToUseWorkspaceVersion": true,
   "eslint.enable": true,
-  "eslint.useFlatConfig": true
+  "eslint.useFlatConfig": true,
+  "vitest.workspaceConfig": "vitest.workspace.ts",
+  "vitest.ignoreWorkspace": false,
+  "vitest.configSearchPatternInclude": "{apps,packages}/**/vitest.config.mts",
+  "vitest.configSearchPatternExclude": "{**/node_modules/**,**/vendor/**,**/.*/**,**/out-tsc/**,**/dist/**,**/*.d.ts}"
 }

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,0 +1,10 @@
+export default [
+  'apps/backend/vitest.config.mts',
+  'apps/app/vitest.config.mts',
+  'apps/tools/vitest.config.mts',
+  'packages/api/vitest.config.mts',
+  'packages/domain/vitest.config.mts',
+  'packages/ui/vitest.config.mts',
+  'packages/ui/vitest.storybook.config.mts',
+  'packages/pdf-components/vitest.config.mts',
+];


### PR DESCRIPTION
Ajoute `vitest.workspace.ts` et configure `settings.json` pour que l’extension Vitest Explorer ne s’appuie pas sur le `vitest.config.ts` root et retrouve correctement les fichiers `*.e2e-spec.ts` du backend.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Amélioration de la configuration de l’environnement de développement avec des réglages modernisés pour TypeScript, ESLint et Vitest.
  * Ajout d’une configuration d’espace de travail pour Vitest afin de couvrir plusieurs applications et packages du projet.

* **Chores**
  * Mise à jour des paramètres de projet pour mieux harmoniser l’exécution des tests et l’expérience dans l’éditeur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->