### PR TITLE
fix(ai-plan-import): repare les imports e2e casses par le merge #4565 + #4707

### DIFF
--- a/apps/backend/src/plans/plans/ai-plan-import/ai-plan-import.full-flow.e2e-spec.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/ai-plan-import.full-flow.e2e-spec.ts
@@ -27,13 +27,13 @@ import request from 'supertest';
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import { AI_PLAN_IMPORT_QUEUE_NAME } from './ai-plan-import.queue';
 import { aiPlanImportJobTable } from './models/ai-plan-import-job.table';
-import { consolidationResponseSchema } from './generate-import-draft/consolidate-actions/consolidate-actions.schema';
-import { enrichmentResponseSchema } from './generate-import-draft/enrich-sous-actions/enrich-sous-actions.schema';
-import { extractionResponseSchema } from './generate-import-draft/extract-actions/extract-actions.schema';
+import { consolidationResponseSchema } from './pipeline/consolidate-actions/consolidate-actions.schema';
+import { enrichmentResponseSchema } from './pipeline/enrich-sous-actions/enrich-sous-actions.schema';
+import { extractionResponseSchema } from './pipeline/extract-actions/extract-actions.schema';
 import { GenerateImportDraftService } from './generate-import-draft/generate-import-draft.service';
 import { GenerateImportDraftWorker } from './generate-import-draft/generate-import-draft.worker';
-import { qualitativeReviewResponseSchema } from './generate-import-draft/qualitative-review/qualitative-review.schema';
-import { scoringResponseSchema } from './generate-import-draft/score-actions/score-actions.schema';
+import { qualitativeReviewResponseSchema } from './pipeline/qualitative-review/qualitative-review.schema';
+import { scoringResponseSchema } from './pipeline/score-actions/score-actions.schema';
 
 const QUALITATIVE_REVIEW_TEXT = 'Plan cohérent et bien structuré.';
 


### PR DESCRIPTION
## Problème

`main` est **cassé** au typecheck backend :
```
ai-plan-import.full-flow.e2e-spec.ts: Cannot find module './generate-import-draft/…/…schema' (x5)
```

## Cause — conflit sémantique de merge

- **#4565** a ajouté `ai-plan-import.full-flow.e2e-spec.ts`, qui importe 5 schémas d'étapes depuis `generate-import-draft/`.
- **#4707** a déplacé ces étapes dans `pipeline/`, mais sur une base antérieure à #4565 : ce spec n'existait pas encore, ses imports n'ont donc pas été réécrits.
- Chaque PR était verte isolément ; le merge des deux a cassé `main`.

## Fix

Réécrit les 5 imports du spec (`consolidate-actions`, `enrich-sous-actions`, `extract-actions`, `qualitative-review`, `score-actions`) vers `./pipeline/…`. Aucun autre fichier n'était concerné (scan global). Typecheck backend vert (hors erreur `vitest.config.mts` préexistante).