### PR TITLE
Interdit dans certaines conditions la bascule vers le référentiel Climat Ressources

### DIFF
--- a/apps/backend/src/referentiels/labellisations/get-labellisation.service.ts
+++ b/apps/backend/src/referentiels/labellisations/get-labellisation.service.ts
@@ -375,6 +375,94 @@ export class GetLabellisationService {
     return cotResult.length > 0;
   }
 
+  /**
+   * Vrai si la collectivité a un COT explicitement actif (`cot.actif = true`).
+   * Contrairement à `isCot`, on teste bien le flag `actif` et pas seulement
+   * l'existence de la ligne.
+   */
+  async isCotActif(collectiviteId: number): Promise<boolean> {
+    const cotResult = await this.db
+      .select({ actif: cotTable.actif })
+      .from(cotTable)
+      .where(
+        and(
+          eq(cotTable.collectiviteId, collectiviteId),
+          eq(cotTable.actif, true)
+        )
+      )
+      .limit(1);
+    return cotResult.length > 0;
+  }
+
+  /**
+   * Lecture read-only (sans création) de l'audit et de la demande courants
+   * d'un couple (collectivité, référentiel), au format attendu par
+   * `getParcoursLabellisationStatus`.
+   *
+   * - audit : l'audit non-`clos` le plus récent ;
+   * - demande : uniquement celle liée à l'audit courant (`audit.demandeId`).
+   *
+   * On ne lit PAS « la dernière demande du couple » en l'absence d'audit
+   * non-clos : une demande envoyée coexiste toujours avec un audit non-clos
+   * (créé par `getParcours` avant `requestLabellisation`), donc une demande
+   * `en_cours = false` sans audit non-clos n'est qu'un reliquat d'un cycle
+   * déjà clos (audit validé) — la considérer produirait un faux
+   * `demande_envoyee`. `getOrCreateCurrentAuditAndDemande` recrée d'ailleurs
+   * un cycle vierge dans ce cas.
+   *
+   * Contrairement à `getOrCreateCurrentAuditAndDemande`, ne crée aucune ligne.
+   */
+  async getCurrentDemandeAndAudit(
+    collectiviteId: number,
+    referentielId: ReferentielId
+  ): Promise<{
+    demande: { en_cours: boolean } | null;
+    audit: {
+      valide: boolean;
+      date_debut: string | null;
+      date_fin: string | null;
+    } | null;
+  }> {
+    const [currentAudit] = await this.db
+      .select({
+        demandeId: auditTable.demandeId,
+        valide: auditTable.valide,
+        dateDebut: auditTable.dateDebut,
+        dateFin: auditTable.dateFin,
+      })
+      .from(auditTable)
+      .where(
+        and(
+          eq(auditTable.collectiviteId, collectiviteId),
+          eq(auditTable.referentielId, referentielId),
+          not(auditTable.clos)
+        )
+      )
+      .orderBy(desc(auditTable.dateDebut))
+      .limit(1);
+
+    let currentDemande: { enCours: boolean } | null = null;
+    if (currentAudit?.demandeId) {
+      currentDemande = await this.db
+        .select({ enCours: labellisationDemandeTable.enCours })
+        .from(labellisationDemandeTable)
+        .where(eq(labellisationDemandeTable.id, currentAudit.demandeId))
+        .limit(1)
+        .then((rows) => rows[0] ?? null);
+    }
+
+    return {
+      audit: currentAudit
+        ? {
+            valide: currentAudit.valide,
+            date_debut: currentAudit.dateDebut,
+            date_fin: currentAudit.dateFin,
+          }
+        : null,
+      demande: currentDemande ? { en_cours: currentDemande.enCours } : null,
+    };
+  }
+
   async getConditionFichiers(demandeId: number) {
     return this.db
       .select({

--- a/apps/backend/src/referentiels/switch-to-te/switch-to-te.errors.ts
+++ b/apps/backend/src/referentiels/switch-to-te/switch-to-te.errors.ts
@@ -11,6 +11,9 @@ const specificErrors = [
   'REFERENTIEL_TE_DISABLED',
   'ALREADY_SWITCHED',
   'NOT_ELIGIBLE',
+  'COT_ACTIVE',
+  'AUDIT_REQUEST_IN_PROGRESS',
+  'AUDIT_IN_PROGRESS',
   'SWITCH_NOT_IMPLEMENTED',
   ...collectivitePreferencesSpecificErrors,
 ] as const;
@@ -28,6 +31,21 @@ export const switchToTeTrpcErrorEntries = {
     code: 'BAD_REQUEST',
     message:
       "Cette collectivité n'est pas éligible à la bascule (TE non en lecture seule ou aucun référentiel CAE/ECI engagé)",
+  },
+  COT_ACTIVE: {
+    code: 'FORBIDDEN',
+    message:
+      "La bascule n'est pas possible : un contrat d'objectif (COT) est actif pour cette collectivité",
+  },
+  AUDIT_REQUEST_IN_PROGRESS: {
+    code: 'CONFLICT',
+    message:
+      "La bascule n'est pas possible : une demande d'audit est en cours sur un référentiel CAE/ECI",
+  },
+  AUDIT_IN_PROGRESS: {
+    code: 'CONFLICT',
+    message:
+      "La bascule n'est pas possible : un audit est en cours sur un référentiel CAE/ECI",
   },
   SWITCH_NOT_IMPLEMENTED: {
     code: 'NOT_IMPLEMENTED',

--- a/apps/backend/src/referentiels/switch-to-te/switch-to-te.router.e2e-spec.ts
+++ b/apps/backend/src/referentiels/switch-to-te/switch-to-te.router.e2e-spec.ts
@@ -1,5 +1,9 @@
 import { INestApplication } from '@nestjs/common';
-import { addTestCollectiviteAndUsers } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import {
+  addTestCollectiviteAndUsers,
+  setCollectiviteAsCOT,
+} from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { createAudit } from '@tet/backend/referentiels/labellisations/labellisations.test-fixture';
 import {
   getAuthUserFromUserCredentials,
   getTestApp,
@@ -173,5 +177,135 @@ describe('SwitchToTeRouter', () => {
     await expect(
       lectureCaller.referentiels.switchToTe({ collectiviteId: collectivite.id })
     ).rejects.toThrow("Vous n'avez pas les permissions nécessaires");
+  });
+
+  // crée une collectivité éligible à la bascule (te readonly) avec ses préférences
+  async function setupEligibleCollectivite(
+    referentiels: CollectiviteReferentielPreferences
+  ) {
+    const fixture = await addTestCollectiviteAndUsers(databaseService, {
+      users: [{ role: CollectiviteRole.ADMIN }],
+    });
+    onTestFinished(() => fixture.cleanup());
+
+    await supportCaller.collectivites.preferences.update({
+      collectiviteId: fixture.collectivite.id,
+      preferences: { referentiels },
+    });
+
+    const adminCaller = router.createCaller({
+      user: getAuthUserFromUserCredentials(fixture.users[0]),
+    });
+
+    return { collectiviteId: fixture.collectivite.id, adminCaller };
+  }
+
+  test('bloque quand un COT est actif (cae write)', async () => {
+    const { collectiviteId, adminCaller } = await setupEligibleCollectivite({
+      cae: { display: true, mode: 'write' },
+      eci: { display: false, mode: 'archived' },
+      te: { display: true, mode: 'readonly' },
+    });
+    await setCollectiviteAsCOT(databaseService, collectiviteId, true);
+
+    await expect(
+      adminCaller.referentiels.switchToTe({ collectiviteId })
+    ).rejects.toThrow(switchToTeTrpcErrorEntries.COT_ACTIVE.message);
+  });
+
+  test('bloque quand un audit est en cours (cae write)', async () => {
+    const { collectiviteId, adminCaller } = await setupEligibleCollectivite({
+      cae: { display: true, mode: 'write' },
+      eci: { display: false, mode: 'archived' },
+      te: { display: true, mode: 'readonly' },
+    });
+    const { cleanup } = await createAudit({
+      databaseService,
+      collectiviteId,
+      referentielId: 'cae',
+      dateDebut: new Date('2025-01-01').toISOString(),
+      valide: false,
+      clos: false,
+    });
+    onTestFinished(() => cleanup());
+
+    await expect(
+      adminCaller.referentiels.switchToTe({ collectiviteId })
+    ).rejects.toThrow(switchToTeTrpcErrorEntries.AUDIT_IN_PROGRESS.message);
+  });
+
+  test("bloque quand une demande d'audit est en cours (cae write)", async () => {
+    const { collectiviteId, adminCaller } = await setupEligibleCollectivite({
+      cae: { display: true, mode: 'write' },
+      eci: { display: false, mode: 'archived' },
+      te: { display: true, mode: 'readonly' },
+    });
+    // demande envoyée sans audit démarré : dateDebut null + demande enCours:false
+    const { cleanup } = await createAudit({
+      databaseService,
+      collectiviteId,
+      referentielId: 'cae',
+      dateDebut: null,
+      valide: false,
+      clos: false,
+      withDemande: true,
+    });
+    onTestFinished(() => cleanup());
+
+    await expect(
+      adminCaller.referentiels.switchToTe({ collectiviteId })
+    ).rejects.toThrow(
+      switchToTeTrpcErrorEntries.AUDIT_REQUEST_IN_PROGRESS.message
+    );
+  });
+
+  test("ne bloque pas quand l'audit est validé et clos (retourne SWITCH_NOT_IMPLEMENTED)", async () => {
+    const { collectiviteId, adminCaller } = await setupEligibleCollectivite({
+      cae: { display: true, mode: 'write' },
+      eci: { display: false, mode: 'archived' },
+      te: { display: true, mode: 'readonly' },
+    });
+    // état réel après labellisation : audit validé => clos, avec sa demande
+    // envoyée (enCours:false) qui subsiste ; ne doit PAS bloquer
+    const { cleanup } = await createAudit({
+      databaseService,
+      collectiviteId,
+      referentielId: 'cae',
+      dateDebut: new Date('2025-01-01').toISOString(),
+      valide: true,
+      clos: true,
+      withDemande: true,
+    });
+    onTestFinished(() => cleanup());
+
+    await expect(
+      adminCaller.referentiels.switchToTe({ collectiviteId })
+    ).rejects.toThrow(
+      switchToTeTrpcErrorEntries.SWITCH_NOT_IMPLEMENTED.message
+    );
+  });
+
+  test('ignore un audit en cours sur un référentiel archived (cae archived + eci write)', async () => {
+    const { collectiviteId, adminCaller } = await setupEligibleCollectivite({
+      cae: { display: false, mode: 'archived' },
+      eci: { display: true, mode: 'write' },
+      te: { display: true, mode: 'readonly' },
+    });
+    // audit en cours sur cae (archived) → doit être ignoré
+    const { cleanup } = await createAudit({
+      databaseService,
+      collectiviteId,
+      referentielId: 'cae',
+      dateDebut: new Date('2025-01-01').toISOString(),
+      valide: false,
+      clos: false,
+    });
+    onTestFinished(() => cleanup());
+
+    await expect(
+      adminCaller.referentiels.switchToTe({ collectiviteId })
+    ).rejects.toThrow(
+      switchToTeTrpcErrorEntries.SWITCH_NOT_IMPLEMENTED.message
+    );
   });
 });

--- a/apps/backend/src/referentiels/switch-to-te/switch-to-te.rules.spec.ts
+++ b/apps/backend/src/referentiels/switch-to-te/switch-to-te.rules.spec.ts
@@ -1,6 +1,6 @@
 import type { CollectiviteReferentielPreferences } from '@tet/domain/collectivites';
 import { describe, expect, it } from 'vitest';
-import { canSwitchToTe } from './switch-to-te.rules';
+import { canSwitchToTe, getSwitchToTeBlockers } from './switch-to-te.rules';
 
 describe('canSwitchToTe', () => {
   it('retourne true quand TE readonly et CAE engagé', () => {
@@ -48,5 +48,72 @@ describe('canSwitchToTe', () => {
     };
 
     expect(canSwitchToTe(prefs)).toBe(false);
+  });
+});
+
+describe('getSwitchToTeBlockers', () => {
+  test('COT actif seul → un blocage COT_ACTIVE', () => {
+    expect(
+      getSwitchToTeBlockers({ cotActif: true, referentielsEnWrite: [] })
+    ).toEqual([{ type: 'COT_ACTIVE' }]);
+  });
+
+  test('audit en cours sur cae → AUDIT_IN_PROGRESS', () => {
+    expect(
+      getSwitchToTeBlockers({
+        cotActif: false,
+        referentielsEnWrite: [{ referentiel: 'cae', status: 'audit_en_cours' }],
+      })
+    ).toEqual([{ type: 'AUDIT_IN_PROGRESS', referentiel: 'cae' }]);
+  });
+
+  test('demande envoyée sur eci → AUDIT_REQUEST_IN_PROGRESS', () => {
+    expect(
+      getSwitchToTeBlockers({
+        cotActif: false,
+        referentielsEnWrite: [
+          { referentiel: 'eci', status: 'demande_envoyee' },
+        ],
+      })
+    ).toEqual([{ type: 'AUDIT_REQUEST_IN_PROGRESS', referentiel: 'eci' }]);
+  });
+
+  test('ref en write non bloquant (audit_valide / non_demandee)', () => {
+    expect(
+      getSwitchToTeBlockers({
+        cotActif: false,
+        referentielsEnWrite: [
+          { referentiel: 'cae', status: 'audit_valide' },
+          { referentiel: 'eci', status: 'non_demandee' },
+        ],
+      })
+    ).toEqual([]);
+  });
+
+  test('multi-blocages : COT en premier puis cae avant eci', () => {
+    expect(
+      getSwitchToTeBlockers({
+        cotActif: true,
+        referentielsEnWrite: [
+          { referentiel: 'cae', status: 'audit_en_cours' },
+          { referentiel: 'eci', status: 'demande_envoyee' },
+        ],
+      })
+    ).toEqual([
+      { type: 'COT_ACTIVE' },
+      { type: 'AUDIT_IN_PROGRESS', referentiel: 'cae' },
+      { type: 'AUDIT_REQUEST_IN_PROGRESS', referentiel: 'eci' },
+    ]);
+  });
+
+  test("un ref hors write n'est simplement pas dans la liste fournie", () => {
+    // le filtrage mode==='write' est fait par l'appelant ;
+    // ici on vérifie qu'une liste vide ne produit aucun blocage
+    expect(
+      getSwitchToTeBlockers({
+        cotActif: false,
+        referentielsEnWrite: [],
+      })
+    ).toEqual([]);
   });
 });

--- a/apps/backend/src/referentiels/switch-to-te/switch-to-te.rules.ts
+++ b/apps/backend/src/referentiels/switch-to-te/switch-to-te.rules.ts
@@ -1,4 +1,8 @@
 import type { CollectiviteReferentielPreferences } from '@tet/domain/collectivites';
+import type {
+  ParcoursLabellisationStatus,
+  ReferentielId,
+} from '@tet/domain/referentiels';
 
 export function canSwitchToTe(
   prefs: CollectiviteReferentielPreferences
@@ -7,4 +11,47 @@ export function canSwitchToTe(
   if (prefs.te.mode !== 'readonly') return false;
   // proxy engagement : au moins une source encore en écriture
   return prefs.cae.mode === 'write' || prefs.eci.mode === 'write';
+}
+
+/**
+ * Blocage empêchant la bascule vers TE.
+ * `referentielId` permettra à la PR19 (UI) de construire des messages
+ * détaillés par référentiel.
+ */
+export type SwitchToTeBlocker =
+  | { type: 'COT_ACTIVE' }
+  | { type: 'AUDIT_IN_PROGRESS'; referentiel: ReferentielId }
+  | { type: 'AUDIT_REQUEST_IN_PROGRESS'; referentiel: ReferentielId };
+
+/**
+ * Détermine les blocages à la bascule vers TE à partir de l'état fourni.
+ *
+ * Ordre des blocages : COT d'abord (niveau collectivité), puis par référentiel
+ * dans l'ordre fourni (`cae` avant `eci`). Un audit en cours prime sur une
+ * simple demande envoyée pour un même référentiel.
+ */
+export function getSwitchToTeBlockers(input: {
+  cotActif: boolean;
+  referentielsEnWrite: {
+    referentiel: ReferentielId;
+    status: ParcoursLabellisationStatus;
+  }[];
+}): SwitchToTeBlocker[] {
+  const blockers: SwitchToTeBlocker[] = [];
+
+  if (input.cotActif) {
+    blockers.push({ type: 'COT_ACTIVE' });
+  }
+
+  for (const { referentiel, status } of input.referentielsEnWrite) {
+    // audit en cours prime sur demande envoyée
+    if (status === 'audit_en_cours') {
+      blockers.push({ type: 'AUDIT_IN_PROGRESS', referentiel });
+    } else if (status === 'demande_envoyee') {
+      blockers.push({ type: 'AUDIT_REQUEST_IN_PROGRESS', referentiel });
+    }
+    // non_demandee et audit_valide ne sont pas bloquants
+  }
+
+  return blockers;
 }

--- a/apps/backend/src/referentiels/switch-to-te/switch-to-te.service.ts
+++ b/apps/backend/src/referentiels/switch-to-te/switch-to-te.service.ts
@@ -4,21 +4,79 @@ import { PermissionService } from '@tet/backend/users/authorizations/permission.
 import type { ServiceSecondArg } from '@tet/backend/utils/nest/service-second-arg.utils';
 import { failure, type Result } from '@tet/backend/utils/result.type';
 import { TrackingService } from '@tet/backend/utils/tracking/tracking.service';
+import { type CollectiviteReferentielPreferences } from '@tet/domain/collectivites';
+import {
+  getParcoursLabellisationStatus,
+  ReferentielIdEnum,
+} from '@tet/domain/referentiels';
 import { PermissionOperationEnum, ResourceType } from '@tet/domain/users';
+import { GetLabellisationService } from '../labellisations/get-labellisation.service';
 import {
   SwitchToTeErrorEnum,
   type SwitchToTeError,
 } from './switch-to-te.errors';
-import { canSwitchToTe } from './switch-to-te.rules';
 import type { SwitchToTeNotImplementedOutput } from './switch-to-te.output';
+import {
+  canSwitchToTe,
+  getSwitchToTeBlockers,
+  type SwitchToTeBlocker,
+} from './switch-to-te.rules';
 
 @Injectable()
 export class SwitchToTeService {
   constructor(
     private readonly trackingService: TrackingService,
     private readonly permissionService: PermissionService,
-    private readonly collectiviteReferentielModeService: CollectiviteReferentielModeService
+    private readonly collectiviteReferentielModeService: CollectiviteReferentielModeService,
+    private readonly getLabellisationService: GetLabellisationService
   ) {}
+
+  // référentiels sources pouvant bloquer la bascule
+  private static readonly SOURCE_REFERENTIELS = [
+    ReferentielIdEnum.CAE,
+    ReferentielIdEnum.ECI,
+  ] as const;
+
+  private static readonly BLOCKER_ERROR: Record<
+    SwitchToTeBlocker['type'],
+    SwitchToTeError
+  > = {
+    COT_ACTIVE: SwitchToTeErrorEnum.COT_ACTIVE,
+    AUDIT_REQUEST_IN_PROGRESS: SwitchToTeErrorEnum.AUDIT_REQUEST_IN_PROGRESS,
+    AUDIT_IN_PROGRESS: SwitchToTeErrorEnum.AUDIT_IN_PROGRESS,
+  };
+
+  /**
+   * Calcule les blocages COT / demande / audit à partir de lectures read-only.
+   * N'itère que sur les référentiels sources (cae/eci) encore en `mode: write`.
+   */
+  async getSwitchToTeBlockers(
+    collectiviteId: number,
+    prefs: CollectiviteReferentielPreferences
+  ): Promise<SwitchToTeBlocker[]> {
+    const referentielsToCheck = SwitchToTeService.SOURCE_REFERENTIELS.filter(
+      (referentiel) => prefs[referentiel].mode === 'write'
+    );
+
+    const [cotActif, referentielsEnWrite] = await Promise.all([
+      this.getLabellisationService.isCotActif(collectiviteId),
+      Promise.all(
+        referentielsToCheck.map(async (referentiel) => {
+          const demandeEtAudit =
+            await this.getLabellisationService.getCurrentDemandeAndAudit(
+              collectiviteId,
+              referentiel
+            );
+          return {
+            referentiel,
+            status: getParcoursLabellisationStatus(demandeEtAudit),
+          };
+        })
+      ),
+    ]);
+
+    return getSwitchToTeBlockers({ cotActif, referentielsEnWrite });
+  }
 
   async switchToTe(
     collectiviteId: number,
@@ -59,6 +117,11 @@ export class SwitchToTeService {
 
     if (!canSwitchToTe(prefs)) {
       return failure(SwitchToTeErrorEnum.NOT_ELIGIBLE);
+    }
+
+    const blockers = await this.getSwitchToTeBlockers(collectiviteId, prefs);
+    if (blockers.length > 0) {
+      return failure(SwitchToTeService.BLOCKER_ERROR[blockers[0].type]);
     }
 
     return failure(SwitchToTeErrorEnum.SWITCH_NOT_IMPLEMENTED);

--- a/doc/plans/2026-06-11-004-feat-bascule-referentiel-te-pr9-plan.md
+++ b/doc/plans/2026-06-11-004-feat-bascule-referentiel-te-pr9-plan.md
@@ -1,0 +1,138 @@
+---
+name: PR9 guards COT audit
+overview: Ajouter à SwitchToTeService les guards de blocage COT actif / demande d'audit en cours / audit en cours, via une règle pure co-localisée (switch-to-te.rules.ts) et des lectures read-only étendues sur GetLabellisationService, sans toucher à l'orchestration transactionnelle (PR18).
+todos:
+  - id: domain-rule
+    content: Créer apps/backend/src/referentiels/switch-to-te/switch-to-te.rules.ts (getSwitchToTeBlockers + type SwitchToTeBlocker) + tests unitaires purs
+    status: pending
+  - id: label-reads
+    content: "Étendre GetLabellisationService : isCotActif + getCurrentDemandeAndAudit read-only (sans création)"
+    status: pending
+  - id: errors
+    content: Ajouter COT_ACTIVE / AUDIT_REQUEST_IN_PROGRESS / AUDIT_IN_PROGRESS dans switch-to-te.errors.ts
+    status: pending
+  - id: service-guard
+    content: "SwitchToTeService : injecter GetLabellisationService, getSwitchToTeBlockers, insérer le guard avant SWITCH_NOT_IMPLEMENTED"
+    status: pending
+  - id: module-wiring
+    content: Vérifier disponibilité de GetLabellisationService dans referentiels.module.ts
+    status: pending
+  - id: e2e
+    content: Compléter switch-to-te.router.e2e-spec.ts (COT, audit en cours, demande en cours, non bloquants, ref archived) via fixtures COT/audit
+    status: pending
+isProject: false
+---
+
+# PR9 — Guards COT / demande / audit
+
+**Parent** : [doc/plans/2026-06-11-001-feat-bascule-referentiel-te-prd.md](doc/plans/2026-06-11-001-feat-bascule-referentiel-te-prd.md)
+**Branche** : `TE-7303/switch-te-PR9` depuis `main` (PR8 mergé)
+**Estimation** : ~350 LOC (code + tests) — endpoint toujours **non exposé prod** (SWITCH_NOT_IMPLEMENTED conservé jusqu'à PR18)
+
+## Contexte
+
+PR8 a posé `[SwitchToTeService](apps/backend/src/referentiels/switch-to-te/switch-to-te.service.ts)` avec les guards feature-flag / permission / idempotence / éligibilité, puis retourne `SWITCH_NOT_IMPLEMENTED`. PR9 insère un guard supplémentaire **entre `canSwitchToTe` et `SWITCH_NOT_IMPLEMENTED`** : blocage si COT actif ou si une demande/audit est en cours sur un référentiel CAE/ECI encore en `mode: write`.
+
+Modèle d'état existant réutilisé :
+
+- `cot.actif` — [cot.table.ts](apps/backend/src/referentiels/labellisations/cot.table.ts).
+- Statut par référentiel dérivé par la fonction pure `getParcoursLabellisationStatus({demande, audit})` — [request-labellisation.rules.ts](packages/domain/src/referentiels/labellisations/request-labellisation/request-labellisation.rules.ts) : `demande_envoyee` = « demande d'audit en cours », `audit_en_cours` = « audit en cours ».
+
+## Décisions actées
+
+- **COT** : blocage **strict** sur `cot.actif === true` (littéral PRD ; désactivation COT = ops/support après audit final). Ne PAS réutiliser `isCot()` qui teste seulement l'existence de la ligne.
+- **Détection audit/demande** : lectures **read-only légères** (pas `getOrCreateCurrentAuditAndDemande` qui crée des lignes) + fonction pure `getParcoursLabellisationStatus`.
+- **Structure** : méthode réutilisable renvoyant des blocages structurés `{ type, referentiel? }` ; le guard convertit le 1er blocage en **3 erreurs typées** (`COT_ACTIVE`, `AUDIT_REQUEST_IN_PROGRESS`, `AUDIT_IN_PROGRESS`).
+- **Placement** : logique pure dans `switch-to-te.rules.ts` **co-localisée avec le service** (`apps/backend/src/referentiels/switch-to-te/`) ; I/O dans `SwitchToTeService` ; extension de `GetLabellisationService`. Types `ParcoursLabellisationStatus` / `ReferentielId` importés de `@tet/domain`.
+- **Portée refs** : uniquement `cae`/`eci` en `mode: write` (un ref `archived` avec un vieil audit n'est PAS bloquant).
+- **Non bloquant** : `audit_valide`, `non_demandee`, audit `clos`.
+
+## Flux du guard
+
+```mermaid
+sequenceDiagram
+  participant Service as SwitchToTeService
+  participant Label as GetLabellisationService
+  participant Rule as switch-to-te.rules (pure)
+
+  Service->>Label: isCotActif(collectiviteId)
+  loop cae/eci en mode write
+    Service->>Label: getCurrentDemandeAndAudit(coll, ref) [read-only]
+    Service->>Rule: getParcoursLabellisationStatus({demande, audit})
+  end
+  Service->>Rule: getSwitchToTeBlockers({cotActif, refsEnWrite})
+  alt blockers non vide
+    Service-->>Service: failure(COT_ACTIVE | AUDIT_* )
+  else
+    Service-->>Service: SWITCH_NOT_IMPLEMENTED (inchangé)
+  end
+```
+
+
+
+## Implémentation
+
+### 1. Règle pure — `apps/backend/src/referentiels/switch-to-te/switch-to-te.rules.ts`
+
+```typescript
+export type SwitchToTeBlocker =
+  | { type: 'COT_ACTIVE' }
+  | { type: 'AUDIT_IN_PROGRESS'; referentiel: ReferentielId }
+  | { type: 'AUDIT_REQUEST_IN_PROGRESS'; referentiel: ReferentielId };
+
+export function getSwitchToTeBlockers(input: {
+  cotActif: boolean;
+  referentielsEnWrite: {
+    referentiel: ReferentielId;
+    status: ParcoursLabellisationStatus;
+  }[];
+}): SwitchToTeBlocker[]
+```
+
+- COT poussé en premier (niveau collectivité), puis par ref (`cae` avant `eci`) : `audit_en_cours` → `AUDIT_IN_PROGRESS`, `demande_envoyee` → `AUDIT_REQUEST_IN_PROGRESS`.
+- Le type `SwitchToTeBlocker` (avec `referentiel`) est exporté depuis le module `switch-to-te`. Les éléments devant être partagés côté front seront, si nécessaire, extraits dans `@tet/domain` dans le cadre de la PR19.
+
+### 2. Lectures read-only — [get-labellisation.service.ts](apps/backend/src/referentiels/labellisations/get-labellisation.service.ts)
+
+- `isCotActif(collectiviteId)` : `select cot where collectiviteId and actif = true` (ne pas modifier `isCot()`).
+- `getCurrentDemandeAndAudit(collectiviteId, referentielId)` : read-only, **sans création** — audit non-`clos` le plus récent (réutiliser la requête de `getCurrentAudit`) ; demande = celle liée (`audit.demandeId`) sinon la dernière demande du couple (coll, ref) ; retourne `{ demande, audit }` (nullable) au format attendu par `getParcoursLabellisationStatus`.
+
+### 3. `SwitchToTeService` — [switch-to-te.service.ts](apps/backend/src/referentiels/switch-to-te/switch-to-te.service.ts)
+
+- Injecter `GetLabellisationService`.
+- Méthode `getSwitchToTeBlockers(collectiviteId, prefs)` : `isCotActif` + itération sur `['cae','eci']` filtrée `mode==='write'` (statuts en parallèle via `Promise.all`), délègue à la règle pure.
+- Dans `switchToTe`, **après** `canSwitchToTe` et **avant** `SWITCH_NOT_IMPLEMENTED` : si blockers non vide → `failure` mappé sur le type du 1er blocage.
+
+### 4. Erreurs — [switch-to-te.errors.ts](apps/backend/src/referentiels/switch-to-te/switch-to-te.errors.ts)
+
+Ajouter aux `specificErrors` + entries tRPC :
+
+- `COT_ACTIVE` → `FORBIDDEN`
+- `AUDIT_REQUEST_IN_PROGRESS` → `CONFLICT`
+- `AUDIT_IN_PROGRESS` → `CONFLICT`
+
+Messages génériques (sans `{ref}`) ; la PR19 (UI) construira les messages détaillés par référentiel + liens à partir de `SwitchToTeBlocker`.
+
+### 5. Câblage module
+
+Vérifier que `GetLabellisationService` est fourni/importable dans le contexte de `SwitchToTeService` — [referentiels.module.ts](apps/backend/src/referentiels/referentiels.module.ts) (même module).
+
+## Tests
+
+- **Unitaires purs** `switch-to-te.rules.spec.ts` : COT seul ; `audit_en_cours` cae ; `demande_envoyee` eci ; ref `write` non bloquant (`audit_valide`/`non_demandee`) ; multi-blocages (ordre COT d'abord) ; ref hors `write` ignoré.
+- **e2e** [switch-to-te.router.e2e-spec.ts](apps/backend/src/referentiels/switch-to-te/switch-to-te.router.e2e-spec.ts) (compléter l'existant) via fixtures `setCollectiviteAsCOT` et `createAudit` ([labellisations.test-fixture.ts](apps/backend/src/referentiels/labellisations/labellisations.test-fixture.ts)) :
+  - COT actif (cae write) → `COT_ACTIVE`.
+  - `createAudit({dateDebut, valide:false, clos:false})` sur cae write → `AUDIT_IN_PROGRESS`.
+  - demande envoyée (audit `dateDebut:null` + `withDemande:true`, ou demande `enCours:false` seule) sur cae write → `AUDIT_REQUEST_IN_PROGRESS`.
+  - Non bloquant : `createAudit({valide:true})` → `SWITCH_NOT_IMPLEMENTED`.
+  - Ref archived ignoré : audit_en_cours sur cae `archived` + eci `write` engagé → `SWITCH_NOT_IMPLEMENTED`.
+
+Commande : `pnpm test:backend switch-to-te`.
+
+## Critères de done
+
+- [ ] `getSwitchToTeBlockers` pure testée (co-localisée `switch-to-te.rules.ts`).
+- [ ] `isCotActif` + `getCurrentDemandeAndAudit` read-only (aucune écriture/création).
+- [ ] Guard inséré entre éligibilité et `SWITCH_NOT_IMPLEMENTED` ; 3 erreurs typées.
+- [ ] e2e : COT, audit en cours, demande en cours, cas non bloquants, ref archived ignoré.
+- [ ] Endpoint toujours non exposé prod (squelette conservé).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Nouvelles fonctionnalités**
  - La bascule vers TE est désormais bloquée lorsqu’un COT est actif, qu’un audit est en cours ou qu’une demande d’audit est en cours.
  - Les blocages sont signalés avec des messages d’erreur adaptés à chaque situation.
  - Les audits clôturés ou liés à des référentiels archivés ne bloquent pas la bascule.

- **Tests**
  - Ajout de tests couvrant les différents scénarios de blocage et leurs combinaisons.

- **Documentation**
  - Ajout d’un plan détaillant l’évolution des contrôles de bascule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->