### PR TITLE
Grille d'indicateurs : contrôleur de données + overlay open-data + résolution de layout (agnostique)

### DIFF
--- a/apps/app/src/indicateurs/valeurs/grid/apply-open-data-selections.spec.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/apply-open-data-selections.spec.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CellKey,
+  GridCell,
+  OpenDataSource,
+  generateCellKey,
+  toIndicateurId,
+  toSourceId,
+  toYear,
+} from './types';
+import { applyOpenDataSelections } from './apply-open-data-selections';
+
+const citepa: OpenDataSource = {
+  sourceId: toSourceId('citepa'),
+  libelle: 'CITEPA',
+  value: 100,
+  methodologie: 'Inventaire national',
+  dateVersion: '2026-01-01',
+};
+
+const year = toYear(2030);
+const key = generateCellKey(toIndicateurId(1), year);
+
+const coveredEmpty = (): GridCell => ({
+  kind: 'user-data',
+  value: null,
+  coveringSources: [citepa],
+});
+
+describe('applyOpenDataSelections', () => {
+  it('convertit une cellule vide couverte en open data avec la source selectionnee', () => {
+    const cells = new Map<CellKey, GridCell>([[key, coveredEmpty()]]);
+
+    expect(applyOpenDataSelections(cells, { [key]: toSourceId('citepa') }).get(key)).toEqual({
+      kind: 'open-data',
+      value: 100,
+      selectedSourceId: 'citepa',
+      source: {
+        sourceId: 'citepa',
+        libelle: 'CITEPA',
+        methodologie: 'Inventaire national',
+        dateVersion: '2026-01-01',
+      },
+      coveringSources: [citepa],
+    });
+  });
+
+  it('laisse la cellule inchangee sans selection', () => {
+    const cells = new Map<CellKey, GridCell>([[key, coveredEmpty()]]);
+
+    expect(applyOpenDataSelections(cells, {}).get(key)).toEqual(coveredEmpty());
+  });
+
+  it('laisse la cellule inchangee quand la source selectionnee ne la couvre pas', () => {
+    const cells = new Map<CellKey, GridCell>([[key, coveredEmpty()]]);
+
+    expect(applyOpenDataSelections(cells, { [key]: toSourceId('insee') }).get(key)).toEqual(
+      coveredEmpty()
+    );
+  });
+
+  it('laisse une cellule deja renseignee inchangee', () => {
+    const filled: GridCell = {
+      kind: 'user-data',
+      value: 42,
+      coveringSources: [citepa],
+    };
+    const cells = new Map<CellKey, GridCell>([[key, filled]]);
+
+    expect(applyOpenDataSelections(cells, { [key]: toSourceId('citepa') }).get(key)).toEqual(
+      filled
+    );
+  });
+});

--- a/apps/app/src/indicateurs/valeurs/grid/apply-open-data-selections.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/apply-open-data-selections.ts
@@ -1,0 +1,39 @@
+import { CellKey, GridCell, SourceId } from './types';
+
+export const applyOpenDataSelections = (
+  cells: Map<CellKey, GridCell>,
+  selections: Record<CellKey, SourceId>
+): Map<CellKey, GridCell> =>
+  new Map(
+    [...cells].map(([key, cell]): [CellKey, GridCell] => {
+      const selectedSourceId = selections[key];
+      const isSelectableEmptyCell =
+        selectedSourceId !== undefined &&
+        cell.kind === 'user-data' &&
+        cell.value === null;
+      if (!isSelectableEmptyCell) {
+        return [key, cell];
+      }
+      const source = cell.coveringSources.find(
+        (covering) => covering.sourceId === selectedSourceId
+      );
+      if (source === undefined) {
+        return [key, cell];
+      }
+      return [
+        key,
+        {
+          kind: 'open-data',
+          value: source.value,
+          selectedSourceId: source.sourceId,
+          source: {
+            sourceId: source.sourceId,
+            libelle: source.libelle,
+            methodologie: source.methodologie,
+            dateVersion: source.dateVersion,
+          },
+          coveringSources: cell.coveringSources,
+        },
+      ];
+    })
+  );

--- a/apps/app/src/indicateurs/valeurs/grid/grid-layout.spec.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/grid-layout.spec.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { applyRowOrder, GridLayout, layoutToGridGroups } from './grid-layout';
+
+describe('layoutToGridGroups', () => {
+  it('résout les identifiants en indicateurIds en conservant l\'ordre du layout', () => {
+    const layout: GridLayout = {
+      NOx: { Résidentiel: 'cae_4.aa', Agriculture: 'cae_4.ac' },
+    };
+    const idByIdentifiant = new Map([
+      ['cae_4.aa', 11],
+      ['cae_4.ac', 13],
+    ]);
+
+    expect(layoutToGridGroups(layout, idByIdentifiant)).toEqual({
+      NOx: {
+        label: 'NOx',
+        rows: [
+          { indicateurId: 11, label: 'Résidentiel' },
+          { indicateurId: 13, label: 'Agriculture' },
+        ],
+      },
+    });
+  });
+
+  it('ignore une ligne dont l\'identifiant n\'est pas résolu', () => {
+    const layout: GridLayout = {
+      NOx: { Résidentiel: 'cae_4.aa', Inconnu: 'cae_4.zz' },
+    };
+
+    const groups = layoutToGridGroups(layout, new Map([['cae_4.aa', 11]]));
+
+    expect(groups.NOx.rows).toEqual([{ indicateurId: 11, label: 'Résidentiel' }]);
+  });
+});
+
+describe('applyRowOrder', () => {
+  const layout: GridLayout = {
+    NOx: {
+      Résidentiel: 'cae_4.aa',
+      Agriculture: 'cae_4.ac',
+      Transport: 'cae_4.ae',
+    },
+  };
+
+  it('réordonne les lignes du groupe selon les identifiants stockés', () => {
+    expect(
+      Object.entries(
+        applyRowOrder(layout, { NOx: ['cae_4.ae', 'cae_4.aa', 'cae_4.ac'] }).NOx
+      )
+    ).toEqual([
+      ['Transport', 'cae_4.ae'],
+      ['Résidentiel', 'cae_4.aa'],
+      ['Agriculture', 'cae_4.ac'],
+    ]);
+  });
+
+  it('garde l\'ordre initial pour un groupe sans ordre stocké', () => {
+    expect(Object.entries(applyRowOrder(layout, {}).NOx)).toEqual(
+      Object.entries(layout.NOx)
+    );
+  });
+
+  it('place les lignes absentes de l\'ordre stocké après les lignes ordonnées', () => {
+    expect(
+      Object.entries(applyRowOrder(layout, { NOx: ['cae_4.ae'] }).NOx)
+    ).toEqual([
+      ['Transport', 'cae_4.ae'],
+      ['Résidentiel', 'cae_4.aa'],
+      ['Agriculture', 'cae_4.ac'],
+    ]);
+  });
+});

--- a/apps/app/src/indicateurs/valeurs/grid/grid-layout.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/grid-layout.ts
@@ -1,0 +1,65 @@
+import { sortBy } from 'es-toolkit';
+import {
+  GridGroups,
+  GridRow,
+  toIndicateurId,
+} from './types';
+
+export type GridLayout = Record<string, Record<string, string>>;
+
+export type RowOrder = Record<string, string[]>;
+
+export const layoutToGridGroups = (
+  layout: GridLayout,
+  idByIdentifiant: Map<string, number>
+): GridGroups =>
+  Object.fromEntries(
+    Object.entries(layout).map(([groupLabel, rowsByLabel]) => [
+      groupLabel,
+      {
+        label: groupLabel,
+        rows: Object.entries(rowsByLabel).flatMap(
+          ([rowLabel, identifiant]): GridRow[] => {
+            const indicateurId = idByIdentifiant.get(identifiant);
+            return indicateurId === undefined
+              ? []
+              : [{ indicateurId: toIndicateurId(indicateurId), label: rowLabel }];
+          }
+        ),
+      },
+    ])
+  );
+
+export const layoutIdentifiants = (layout: GridLayout): string[] =>
+  Object.values(layout).flatMap((rowsByLabel) => Object.values(rowsByLabel));
+
+export const applyRowOrder = (
+  layout: GridLayout,
+  rowOrder: RowOrder
+): GridLayout =>
+  Object.fromEntries(
+    Object.entries(layout).map(
+      ([groupLabel, rowsByLabel]): [string, Record<string, string>] => {
+        const order = rowOrder[groupLabel];
+        if (order === undefined) {
+          return [groupLabel, rowsByLabel];
+        }
+        const positionByIdentifiant = new Map(
+          order.map((identifiant, index): [string, number] => [
+            identifiant,
+            index,
+          ])
+        );
+        const entries = Object.entries(rowsByLabel);
+        return [
+          groupLabel,
+          Object.fromEntries(
+            sortBy(entries, [
+              ([, identifiant]) =>
+                positionByIdentifiant.get(identifiant) ?? entries.length,
+            ])
+          ),
+        ];
+      }
+    )
+  );

--- a/apps/app/src/indicateurs/valeurs/grid/use-indicateur-grid-data.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/use-indicateur-grid-data.ts
@@ -1,0 +1,113 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useCollectiviteId } from '@tet/api/collectivites';
+import { fromIndicateur } from './adapters/indicateur-grid-adapter';
+import { useListIndicateurs } from '@/app/indicateurs/indicateurs/use-list-indicateurs';
+import { useListIndicateurValeurs } from '@/app/indicateurs/valeurs/use-list-indicateur-valeurs';
+import {
+  CellKey,
+  GridCell,
+  GridGroups,
+  generateCellKey,
+  SourceId,
+  toIndicateurId,
+  Year,
+} from './types';
+import { applyOpenDataSelections } from './apply-open-data-selections';
+import {
+  GridLayout,
+  layoutIdentifiants,
+  layoutToGridGroups,
+} from './grid-layout';
+
+export type IndicateurGridData = {
+  groups: GridGroups;
+  cells: Map<CellKey, GridCell>;
+  identifiantById: Map<number, string>;
+  unit: string | undefined;
+  isLoading: boolean;
+};
+
+const emptyUserCell = (): GridCell => ({
+  kind: 'user-data',
+  value: null,
+  coveringSources: [],
+});
+
+export const useIndicateurGridData = ({
+  layout,
+  referenceYear,
+  years,
+  openDataSelections,
+}: {
+  layout: GridLayout;
+  referenceYear: Year;
+  years: Year[];
+  openDataSelections: Record<CellKey, SourceId>;
+}): IndicateurGridData => {
+  const collectiviteId = useCollectiviteId();
+  const identifiantsReferentiel = useMemo(
+    () => layoutIdentifiants(layout).sort(),
+    [layout]
+  );
+
+  const definitions = useListIndicateurs({
+    collectiviteId,
+    filters: { identifiantsReferentiel },
+  });
+  const valeurs = useListIndicateurValeurs({ identifiantsReferentiel });
+
+  return useMemo<IndicateurGridData>(() => {
+    const definitionItems = definitions.data?.data ?? [];
+    const idByIdentifiant = new Map(
+      definitionItems.flatMap((definition) =>
+        definition.identifiantReferentiel === null
+          ? []
+          : [[definition.identifiantReferentiel, definition.id] as const]
+      )
+    );
+    const identifiantById = new Map(
+      definitionItems.flatMap((definition) =>
+        definition.identifiantReferentiel === null
+          ? []
+          : [[definition.id, definition.identifiantReferentiel] as const]
+      )
+    );
+
+    const baseCells = new Map<CellKey, GridCell>(
+      [...idByIdentifiant.values()].flatMap((id) =>
+        years.map(
+          (year): [CellKey, GridCell] => [
+            generateCellKey(toIndicateurId(id), year),
+            emptyUserCell(),
+          ]
+        )
+      )
+    );
+    const filledCells = fromIndicateur(
+      valeurs.data?.indicateurs ?? [],
+      referenceYear
+    );
+
+    return {
+      groups: layoutToGridGroups(layout, idByIdentifiant),
+      cells: applyOpenDataSelections(
+        new Map([...baseCells, ...filledCells]),
+        openDataSelections
+      ),
+      identifiantById,
+      unit: definitionItems[0]?.unite,
+      isLoading: definitions.isLoading || valeurs.isLoading,
+    };
+  }, [
+    layout,
+    referenceYear,
+    years,
+    openDataSelections,
+    definitions.data,
+    definitions.isLoading,
+    valeurs.data,
+    valeurs.isLoading,
+  ]);
+};

--- a/apps/app/src/indicateurs/valeurs/grid/use-indicateur-grid-write-actions.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/use-indicateur-grid-write-actions.ts
@@ -1,0 +1,49 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useCollectiviteId } from '@tet/api/collectivites';
+import { toIndicateur } from './adapters/indicateur-grid-adapter';
+import {
+  CellValueInput,
+  IndicateurValuesGridActions,
+  Result,
+  Year,
+} from './types';
+import { useUpsertIndicateurValeur } from '@/app/indicateurs/valeurs/use-upsert-indicateur-valeur';
+
+export type IndicateurGridWriteActions = Pick<
+  IndicateurValuesGridActions,
+  'saveCellValue' | 'saveCellValues' | 'clearCell'
+>;
+
+export const useIndicateurGridWriteActions = (
+  referenceYear: Year | null
+): IndicateurGridWriteActions => {
+  const collectiviteId = useCollectiviteId();
+  const { mutateAsync } = useUpsertIndicateurValeur();
+
+  return useMemo<IndicateurGridWriteActions>(() => {
+    const write = async (input: CellValueInput): Promise<Result> => {
+      try {
+        await mutateAsync(toIndicateur(input, { collectiviteId, referenceYear }));
+        return { ok: true, value: undefined };
+      } catch {
+        return { ok: false };
+      }
+    };
+
+    return {
+      saveCellValue: write,
+      saveCellValues: async (inputs) => {
+        const results = await Promise.all(inputs.map(write));
+        const failed = inputs.filter((_, index) => !results[index].ok);
+        return {
+          ok: true,
+          value: { written: inputs.length - failed.length, failed },
+        };
+      },
+      clearCell: ({ indicateurId, year }) =>
+        write({ indicateurId, year, value: null }),
+    };
+  }, [mutateAsync, collectiviteId, referenceYear]);
+};


### PR DESCRIPTION
Module **réutilisable** de grille d'indicateurs, agnostique du PCAET, mergeable seul. Son premier consommateur (l'adapter PCAET `VoletGridView`) arrivera dans une PR séparée qui se branchera dessus (stack).

## Contenu (3 commits, `indicateurs/valeurs/grid/`)

1. **`feat` — résolution de layout** (`grid-layout.ts` + spec) : `GridLayout` (groupes → lignes labellisées → identifiant référentiel), `layoutToGridGroups` / `layoutIdentifiants` (résolution en `indicateurId`), `applyRowOrder` (réapplique un ordre de lignes persisté). Purs, testés.
2. **`feat` — overlay open-data** (`apply-open-data-selections.ts` + spec) : `applyOpenDataSelections` convertit une cellule vide couverte en cellule `open-data` depuis un choix de source persisté (`cellKey → sourceId`). Comble un trou du composant : la grille modélisait le `kind: 'open-data'` sans pouvoir le **produire** depuis un choix.
3. **`feat` — contrôleur de données** (`use-indicateur-grid-data.ts`, `use-indicateur-grid-write-actions.ts`) : fetch définitions + valeurs par identifiants, construit les cellules (base éditable + valeurs réelles via `fromIndicateur`) + overlay ; write-actions save/saveMany/clear via upsert. Réutilisable pour toute grille d'indicateurs.

## Note de périmètre
Pas de consommateur sur `main` pour l'instant (comme le composant `IndicateurValuesGrid` de #4704) : infra réutilisable dont le premier client arrivera dans une PR séparée. D'où le **draft** — à sortir de draft / merger quand le consommateur est prêt.

## Vérifications
- `tsc` (`apps/app`) : **0 erreur**
- specs : **9/9** (`grid-layout` 5, `apply-open-data-selections` 4)
- eslint : clean
