### PR TITLE
refactor(ai-plan-import): expose les placeholders des prompts via fillPrompt

### DIFF
--- a/apps/backend/src/plans/plans/ai-plan-import/pipeline/consolidate-actions/consolidate-actions.prompt.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/pipeline/consolidate-actions/consolidate-actions.prompt.ts
@@ -1,6 +1,7 @@
 import { DisableableField } from '../../models/disableable-field';
 import { CONSOLIDATION_PROMPT } from '../../prompts/consolidation.prompt';
 import { buildIgnoreDirective } from '../../prompts/ignore-directive';
+import { generatePrompt } from '../../prompts/prompt-template';
 
 export type ConsolidationPromptInput = {
   renderedActionsToImprove: string;
@@ -14,7 +15,7 @@ export const buildConsolidationPrompt = ({
   disabledFields,
 }: ConsolidationPromptInput): string =>
   buildIgnoreDirective(disabledFields) +
-  CONSOLIDATION_PROMPT.replaceAll(
-    '{actions_a_ameliorer}',
-    renderedActionsToImprove
-  ).replaceAll('{texte_pdf_a_analyser}', text);
+  generatePrompt(CONSOLIDATION_PROMPT, {
+    actionsAAmeliorer: renderedActionsToImprove,
+    textePdfAAnalyser: text,
+  });

--- a/apps/backend/src/plans/plans/ai-plan-import/pipeline/enrich-sous-actions/enrich-sous-actions.prompt.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/pipeline/enrich-sous-actions/enrich-sous-actions.prompt.ts
@@ -1,6 +1,7 @@
 import { DisableableField } from '../../models/disableable-field';
 import { ENRICHMENT_PROMPT } from '../../prompts/enrichment.prompt';
 import { buildIgnoreDirective } from '../../prompts/ignore-directive';
+import { generatePrompt } from '../../prompts/prompt-template';
 
 export type EnrichmentPromptInput = {
   renderedSousActions: string;
@@ -14,7 +15,7 @@ export const buildEnrichmentPrompt = ({
   disabledFields,
 }: EnrichmentPromptInput): string =>
   buildIgnoreDirective(disabledFields) +
-  ENRICHMENT_PROMPT.replaceAll(
-    '{sous_actions_list}',
-    renderedSousActions
-  ).replaceAll('{texte_pdf_a_analyser}', text);
+  generatePrompt(ENRICHMENT_PROMPT, {
+    sousActionsList: renderedSousActions,
+    textePdfAAnalyser: text,
+  });

--- a/apps/backend/src/plans/plans/ai-plan-import/pipeline/extract-actions/extract-actions.prompt.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/pipeline/extract-actions/extract-actions.prompt.ts
@@ -1,6 +1,7 @@
 import { DisableableField } from '../../models/disableable-field';
 import { EXTRACTION_PROMPT } from '../../prompts/extraction.prompt';
 import { buildIgnoreDirective } from '../../prompts/ignore-directive';
+import { generatePrompt } from '../../prompts/prompt-template';
 
 export type ExtractionPromptInput = {
   text: string;
@@ -16,6 +17,8 @@ export const buildExtractionPrompt = ({
   currentDate,
 }: ExtractionPromptInput): string =>
   buildIgnoreDirective(disabledFields) +
-  EXTRACTION_PROMPT.replaceAll('{instructions}', instructions)
-    .replaceAll('{texte_pdf_a_analyser}', text)
-    .replaceAll('{date_du_jour}', currentDate);
+  generatePrompt(EXTRACTION_PROMPT, {
+    instructions,
+    textePdfAAnalyser: text,
+    dateDuJour: currentDate,
+  });

--- a/apps/backend/src/plans/plans/ai-plan-import/pipeline/qualitative-review/qualitative-review.prompt.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/pipeline/qualitative-review/qualitative-review.prompt.ts
@@ -1,3 +1,4 @@
+import { generatePrompt } from '../../prompts/prompt-template';
 import { QUALITATIVE_REVIEW_PROMPT } from '../../prompts/qualitative-review.prompt';
 
 export type QualitativeReviewPromptInput = {
@@ -7,4 +8,4 @@ export type QualitativeReviewPromptInput = {
 export const buildQualitativeReviewPrompt = ({
   renderedActions,
 }: QualitativeReviewPromptInput): string =>
-  QUALITATIVE_REVIEW_PROMPT.replaceAll('{reponse_ia}', renderedActions);
+  generatePrompt(QUALITATIVE_REVIEW_PROMPT, { reponseIa: renderedActions });

--- a/apps/backend/src/plans/plans/ai-plan-import/pipeline/score-actions/score-actions.prompt.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/pipeline/score-actions/score-actions.prompt.ts
@@ -1,3 +1,4 @@
+import { generatePrompt } from '../../prompts/prompt-template';
 import { SCORING_PROMPT } from '../../prompts/scoring.prompt';
 
 export type ScoringPromptInput = {
@@ -9,7 +10,7 @@ export const buildScoringPrompt = ({
   renderedActions,
   text,
 }: ScoringPromptInput): string =>
-  SCORING_PROMPT.replaceAll('{reponse_ia}', renderedActions).replaceAll(
-    '{texte_pdf_a_analyser}',
-    text
-  );
+  generatePrompt(SCORING_PROMPT, {
+    reponseIa: renderedActions,
+    textePdfAAnalyser: text,
+  });

--- a/apps/backend/src/plans/plans/ai-plan-import/prompts/consolidation.prompt.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/prompts/consolidation.prompt.ts
@@ -1,4 +1,10 @@
-export const CONSOLIDATION_PROMPT = `
+import { definePrompt } from './prompt-template';
+
+const actionsAAmeliorer = '{actions_a_ameliorer}';
+const textePdfAAnalyser = '{texte_pdf_a_analyser}';
+
+export const CONSOLIDATION_PROMPT = definePrompt({
+  template: `
 Vous êtes un agent d’extraction documentaire spécialisé dans les plans d’actions de transition écologique des collectivités, y compris les PCAET.
 
 Contexte
@@ -12,13 +18,13 @@ Actions ciblées à traiter
 Ces actions sont données sous forme de titres d'actions, préfixées de leur index entre barres verticales :
 
 -------- DEBUT LISTE --------
-{actions_a_ameliorer}
+${actionsAAmeliorer}
 --------- FIN LISTE ---------
 
 Texte source du plan d’actions. Il peut y avoir des artefacts de mise en page.
 
 --------- TEXTE SOURCE ---------
-{texte_pdf_a_analyser}
+${textePdfAAnalyser}
 --------- FIN TEXTE SOURCE ---------
 
 Objectif
@@ -73,4 +79,6 @@ Sortie attendue
 2) Ne rien ajouter avant ni après le JSON
 3) Ne pas utiliser de balises Markdown
 4) Le tableau ne doit contenir QUE les actions demandées qui ont pu être retrouvées dans le texte source
-`;
+`,
+  placeholders: { actionsAAmeliorer, textePdfAAnalyser },
+});

--- a/apps/backend/src/plans/plans/ai-plan-import/prompts/enrichment.prompt.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/prompts/enrichment.prompt.ts
@@ -1,4 +1,10 @@
-export const ENRICHMENT_PROMPT = `
+import { definePrompt } from './prompt-template';
+
+const sousActionsList = '{sous_actions_list}';
+const textePdfAAnalyser = '{texte_pdf_a_analyser}';
+
+export const ENRICHMENT_PROMPT = definePrompt({
+  template: `
 Vous êtes un agent d'enrichissement documentaire spécialisé dans les plans d'actions de transition écologique des collectivités, y compris les PCAET.
 
 Contexte
@@ -32,13 +38,13 @@ Liste des sous-actions à enrichir
 Chaque ligne est préfixée de l'index de la sous-action.
 
 -------- DEBUT LISTE --------
-{sous_actions_list}
+${sousActionsList}
 --------- FIN LISTE ---------
 
 Texte source du plan d'actions
 
 --------- TEXTE SOURCE ---------
-{texte_pdf_a_analyser}
+${textePdfAAnalyser}
 --------- FIN TEXTE SOURCE ---------
 
 Format de sortie
@@ -78,4 +84,6 @@ Exemple de format attendu
     "date_fin": ""
   }
 ]
-`;
+`,
+  placeholders: { sousActionsList, textePdfAAnalyser },
+});

--- a/apps/backend/src/plans/plans/ai-plan-import/prompts/extraction.prompt.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/prompts/extraction.prompt.ts
@@ -1,4 +1,11 @@
-export const EXTRACTION_PROMPT = `
+import { definePrompt } from './prompt-template';
+
+const instructions = '{instructions}';
+const textePdfAAnalyser = '{texte_pdf_a_analyser}';
+const dateDuJour = '{date_du_jour}';
+
+export const EXTRACTION_PROMPT = definePrompt({
+  template: `
 Vous êtes un agent d’extraction documentaire spécialisé dans les plans d’actions de transition écologique des collectivités, y compris les PCAET.
 
 Contexte du fichier en entrée
@@ -73,7 +80,7 @@ Tâches obligatoires et ordre d’exécution
    • Associer chaque action à son sous axe et à son axe
 5 Complétude des champs
    • Remplir "objectifs", "structure pilote", "direction ou service pilote", "personne pilote", "budget" et "statut" uniquement si l’information est explicite et non ambiguë. "objectifs" et "structure pilote" sont des champs facultatifs : ne pas inventer, laisser "" en l'absence d'information explicite
-   • Lorsque le texte présente pour une action des dates ou un calendrier (sans libellé de statut explicite pour cette action), vous pouvez déduire « statut » uniquement parmi « À venir » et « En cours » en vous appuyant sur ces dates et la date du jour ({date_du_jour}). Si seule une année est mentionnée sans mois précis (par exemple "2026"), considérer le statut comme « En cours » si cette année correspond à l'année actuelle, et « À venir » si elle est dans le futur
+   • Lorsque le texte présente pour une action des dates ou un calendrier (sans libellé de statut explicite pour cette action), vous pouvez déduire « statut » uniquement parmi « À venir » et « En cours » en vous appuyant sur ces dates et la date du jour (${dateDuJour}). Si seule une année est mentionnée sans mois précis (par exemple "2026"), considérer le statut comme « En cours » si cette année correspond à l'année actuelle, et « À venir » si elle est dans le futur
 6 Validation du format
    • Produire un JSON valide
    • Vérifier que chaque objet contient exactement les champs définis
@@ -161,10 +168,12 @@ Jusqu’à présent, le prompt décrivait les règles générales d’extraction
 Elles peuvent modifier ou affiner l’interprétation de la structure du plan. Elles prévalent sur les règles générales lorsqu’il existe une contradiction ou une ambiguïté.
 
 --- Consignes spécifiques IMPORTANTES (à appliquer strictement si présentes) qui prennent le dessus sur les règles générales ---
-{instructions}
+${instructions}
 --- Fin des consignes spécifiques IMPORTANTES ---
 
 
 Voici le texte à analyser :
-{texte_pdf_a_analyser}
-`;
+${textePdfAAnalyser}
+`,
+  placeholders: { instructions, textePdfAAnalyser, dateDuJour },
+});

--- a/apps/backend/src/plans/plans/ai-plan-import/prompts/prompt-template.spec.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/prompts/prompt-template.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { definePrompt, generatePrompt } from './prompt-template';
+
+describe('generatePrompt', () => {
+  const prompt = definePrompt({
+    template: 'Montant: {montant}, texte: {texte}',
+    placeholders: { montant: '{montant}', texte: '{texte}' },
+  });
+
+  it('interpole chaque placeholder par sa valeur', () => {
+    expect(generatePrompt(prompt, { montant: '1000', texte: 'plan' })).toBe(
+      'Montant: 1000, texte: plan'
+    );
+  });
+
+  it('insere les valeurs litteralement sans interpreter les motifs $ de remplacement', () => {
+    expect(
+      generatePrompt(prompt, { montant: '$100 $$ $& $1', texte: "$'" })
+    ).toBe("Montant: $100 $$ $& $1, texte: $'");
+  });
+});

--- a/apps/backend/src/plans/plans/ai-plan-import/prompts/prompt-template.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/prompts/prompt-template.ts
@@ -1,0 +1,17 @@
+export type Prompt<Key extends string> = {
+  readonly template: string;
+  readonly placeholders: Readonly<Record<Key, string>>;
+};
+
+export const definePrompt = <const Key extends string>(
+  prompt: Prompt<Key>
+): Prompt<Key> => prompt;
+
+export const generatePrompt = <Key extends string>(
+  { template, placeholders }: Prompt<Key>,
+  values: Record<Key, string>
+): string =>
+  (Object.keys(placeholders) as Key[]).reduce<string>(
+    (filled, key) => filled.replaceAll(placeholders[key], () => values[key]),
+    template
+  );

--- a/apps/backend/src/plans/plans/ai-plan-import/prompts/qualitative-review.prompt.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/prompts/qualitative-review.prompt.ts
@@ -1,4 +1,9 @@
-export const QUALITATIVE_REVIEW_PROMPT = `
+import { definePrompt } from './prompt-template';
+
+const reponseIa = '{reponse_ia}';
+
+export const QUALITATIVE_REVIEW_PROMPT = definePrompt({
+  template: `
 Vous êtes un auditeur qualité spécialisé dans les plans d'actions de transition écologique.
 
 Contexte
@@ -7,7 +12,7 @@ On vous fournit une extraction déjà structurée avec les éléments suivants :
 Les actions classiques ont "titre" rempli. Les sous-actions apparaissent comme des lignes séparées marquées [SA], avec "titre" vide et "titre de la sous-action" rempli.
 
 Voici la sortie à évaluer
-{reponse_ia}
+${reponseIa}
 
 Objectif
 Votre travail n'est pas de corriger la sortie ni de la réécrire, mais de porter un jugement qualitatif sur sa qualité globale et de signaler les erreurs manifestes.
@@ -38,4 +43,6 @@ Exemple de format attendu
 {
   "avis": "Extraction globalement cohérente avec quelques points à surveiller. 1.2.4 description trop générale."
 }
-`;
+`,
+  placeholders: { reponseIa },
+});

--- a/apps/backend/src/plans/plans/ai-plan-import/prompts/scoring.prompt.ts
+++ b/apps/backend/src/plans/plans/ai-plan-import/prompts/scoring.prompt.ts
@@ -1,4 +1,10 @@
-export const SCORING_PROMPT = `
+import { definePrompt } from './prompt-template';
+
+const reponseIa = '{reponse_ia}';
+const textePdfAAnalyser = '{texte_pdf_a_analyser}';
+
+export const SCORING_PROMPT = definePrompt({
+  template: `
 Tu es un agent de validation d’extractions documentaires extrêmement strict.
 
 Contexte
@@ -68,8 +74,10 @@ Contraintes supplémentaires
 • Chaque action du texte extrait doit apparaître exactement une fois dans le tableau, identifiée par son index.
 
 Voici le texte extrait par l'IA :
-{reponse_ia}
+${reponseIa}
 
 Voici le texte original :
-{texte_pdf_a_analyser}
-`;
+${textePdfAAnalyser}
+`,
+  placeholders: { reponseIa, textePdfAAnalyser },
+});


### PR DESCRIPTION
## Problème

Les builders remplaçaient des **strings magiques** (`PROMPT.replaceAll('{reponse_ia}', …)`) : le token à remplacer était invisible depuis le type, dupliqué entre le template et l'appelant, et un `replaceAll` sur un token renommé no-op silencieusement.

## Solution

Chaque prompt exporte `{ template, placeholders }`. Le marqueur de chaque placeholder est une **const nommée**, interpolée dans le template via `${...}` **et** ré-exportée en shorthand :

```ts
const reponseIa = '{reponse_ia}';
const textePdfAAnalyser = '{texte_pdf_a_analyser}';

export const SCORING_PROMPT = {
  template: `… ${reponseIa} … ${textePdfAAnalyser} …`,
  placeholders: { reponseIa, textePdfAAnalyser },
};
```

Source unique par marqueur → **aucun drift**. Les builders remplacent via `fillPrompt(prompt, values)`, dont les clés sont **type-checkées** contre les placeholders déclarés.

## Notes

- Accolades JSON littérales des templates préservées.
- Sortie des prompts **inchangée** (spec `extract-actions.prompt.spec` vert, typecheck vert).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Améliorations**
  * La génération des contenus d’import de plans est désormais plus cohérente et homogène.
  * Les différentes étapes d’analyse et de notation des actions bénéficient d’une construction de texte plus robuste.

* **Bug Fixes**
  * Réduction des risques d’erreurs de substitution dans les contenus envoyés au moteur IA.
  * Meilleure fiabilité lors du traitement de réponses longues ou de champs dynamiques.

* **Refactor**
  * Unification de la gestion des modèles de texte pour simplifier les futures évolutions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->