### PR TITLE
Ajoute la création des snapshots pré-bascule vers  le référentiel Climat Ressources

### DIFF
--- a/apps/backend/src/plans/fiches/fiche-action-etape/fiche-action-etape.router.e2e-spec.ts
+++ b/apps/backend/src/plans/fiches/fiche-action-etape/fiche-action-etape.router.e2e-spec.ts
@@ -1,4 +1,6 @@
 import { INestApplication } from '@nestjs/common';
+import { addTestCollectiviteAndUser } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { createFiche } from '@tet/backend/plans/fiches/fiches.test-fixture';
 import {
   getAuthUserFromUserCredentials,
   getTestApp,
@@ -6,13 +8,10 @@ import {
   getTestRouter,
 } from '@tet/backend/test';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
-import { addTestUser } from '@tet/backend/users/users/users.test-fixture';
-import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { AppRouter, TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
+import { Collectivite } from '@tet/domain/collectivites';
 import { CollectiviteRole } from '@tet/domain/users';
 import { inferProcedureInput } from '@trpc/server';
-import { eq } from 'drizzle-orm';
-import { ficheActionEtapeTable } from './fiche-action-etape.table';
 
 type upsertInput = inferProcedureInput<
   AppRouter['plans']['fiches']['etapes']['upsert']
@@ -28,18 +27,19 @@ describe('Route CRUD des étapes des fiches actions', () => {
   let app: INestApplication;
   let router: TrpcRouter;
   let authenticatedUser: AuthenticatedUser;
-  let databaseService: DatabaseService;
+  let collectivite: Collectivite;
 
   beforeAll(async () => {
     app = await getTestApp();
     router = await getTestRouter(app);
-    databaseService = await getTestDatabase(app);
+    const databaseService = await getTestDatabase(app);
 
-    const testUserResult = await addTestUser(databaseService, {
-      collectiviteId: 1,
-      role: CollectiviteRole.ADMIN,
-    });
-    authenticatedUser = getAuthUserFromUserCredentials(testUserResult.user);
+    const { collectivite: testCollectivite, user } =
+      await addTestCollectiviteAndUser(databaseService, {
+        user: { role: CollectiviteRole.ADMIN },
+      });
+    collectivite = testCollectivite;
+    authenticatedUser = getAuthUserFromUserCredentials(user);
   });
 
   afterAll(async () => {
@@ -48,19 +48,16 @@ describe('Route CRUD des étapes des fiches actions', () => {
 
   test(`Test la gestion de l'ordre des étapes d'une fiche action`, async () => {
     const caller = router.createCaller({ user: authenticatedUser });
-    const ficheId: listInput = {
-      ficheId: 1,
-    };
-
-    onTestFinished(async () => {
-      try {
-        await databaseService.db
-          .delete(ficheActionEtapeTable)
-          .where(eq(ficheActionEtapeTable.ficheId, 1));
-      } catch (error) {
-        console.error('Erreur lors de la suppression:', error);
-      }
+    const ficheIdValue = await createFiche({
+      caller,
+      ficheInput: {
+        titre: 'Fiche test étapes',
+        collectiviteId: collectivite.id,
+      },
     });
+    const ficheId: listInput = {
+      ficheId: ficheIdValue,
+    };
 
     const etapeA: upsertInput = {
       ficheId: ficheId.ficheId,

--- a/apps/backend/src/plans/fiches/migrations/migrate-etapes-to-sous-actions/migrate-etapes-to-sous-actions.e2e-spec.ts
+++ b/apps/backend/src/plans/fiches/migrations/migrate-etapes-to-sous-actions/migrate-etapes-to-sous-actions.e2e-spec.ts
@@ -46,8 +46,6 @@ describe('migrate-etapes-to-sous-actions.e2e-spec', () => {
       })
       .returning();
 
-    await dbService.db.delete(ficheActionEtapeTable);
-
     await dbService.db.insert(ficheActionEtapeTable).values([
       {
         ficheId: fiche.id,
@@ -105,7 +103,9 @@ describe('migrate-etapes-to-sous-actions.e2e-spec', () => {
       await dbService.db
         .delete(ficheActionTable)
         .where(eq(ficheActionTable.id, fiche.id));
-      await dbService.db.delete(ficheActionEtapeTable);
+      await dbService.db
+        .delete(ficheActionEtapeTable)
+        .where(eq(ficheActionEtapeTable.ficheId, fiche.id));
       await cleanup();
     }
   });

--- a/apps/backend/src/referentiels/referentiels.module.ts
+++ b/apps/backend/src/referentiels/referentiels.module.ts
@@ -81,6 +81,7 @@ import { ReferentielsCoreModule } from './referentiels-core.module';
 import { ReferentielsRouter } from './referentiels.router';
 import { ResetDisplayPreferencesRouter } from './reset-display-preferences/reset-display-preferences.router';
 import { ResetDisplayPreferencesService } from './reset-display-preferences/reset-display-preferences.service';
+import { CreatePreSwitchSnapshotsService } from './switch-to-te/create-pre-switch-snapshots.service';
 import { SwitchToTeRouter } from './switch-to-te/switch-to-te.router';
 import { SwitchToTeService } from './switch-to-te/switch-to-te.service';
 import { ListSnapshotsService } from './snapshots/list-snapshots/list-snapshots.service';
@@ -194,6 +195,7 @@ import { UpdateActionStatutService } from './update-action-statut/update-action-
 
     SwitchToTeService,
     SwitchToTeRouter,
+    CreatePreSwitchSnapshotsService,
 
     HistoriqueRouter,
     ListHistoriqueRepository,

--- a/apps/backend/src/referentiels/snapshots/snapshots.service.ts
+++ b/apps/backend/src/referentiels/snapshots/snapshots.service.ts
@@ -52,6 +52,9 @@ export class SnapshotsService {
   static readonly JOUR_SNAPSHOT_REF_PREFIX = 'jour-';
   static readonly SCORE_PERSONNALISE_REF_PREFIX = 'user-';
   static readonly JOUR_SNAPSHOT_NOM_PREFIX = ' - jour du ';
+  static readonly PRE_SWITCH_TE_SNAPSHOT_REF = 'pre-switch-te';
+  static readonly PRE_SWITCH_TE_SNAPSHOT_NOM =
+    'État pré-bascule Climat Ressources';
 
   static USER_DELETION_ALLOWED_SNAPSHOT_TYPES: SnapshotJalon[] = [
     SnapshotJalonEnum.DATE_PERSONNALISEE,
@@ -153,6 +156,11 @@ export class SnapshotsService {
 
       case SnapshotJalonEnum.DATE_PERSONNALISEE:
         ref = nom ? toSlug(nom) : '';
+        break;
+
+      case SnapshotJalonEnum.PRE_SWITCH_TE:
+        ref = SnapshotsService.PRE_SWITCH_TE_SNAPSHOT_REF;
+        nom = SnapshotsService.PRE_SWITCH_TE_SNAPSHOT_NOM;
         break;
 
       default:

--- a/apps/backend/src/referentiels/switch-to-te/create-pre-switch-snapshots.service.e2e-spec.ts
+++ b/apps/backend/src/referentiels/switch-to-te/create-pre-switch-snapshots.service.e2e-spec.ts
@@ -1,0 +1,177 @@
+import { INestApplication } from '@nestjs/common';
+import { snapshotTable } from '@tet/backend/referentiels/snapshots/snapshot.table';
+import { SnapshotsService } from '@tet/backend/referentiels/snapshots/snapshots.service';
+import {
+  getAuthUserFromUserCredentials,
+  getTestApp,
+  getTestDatabase,
+} from '@tet/backend/test';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { addTestUser } from '@tet/backend/users/users/users.test-fixture';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { type CollectiviteReferentielPreferences } from '@tet/domain/collectivites';
+import { ReferentielIdEnum, SnapshotJalonEnum } from '@tet/domain/referentiels';
+import { CollectiviteRole } from '@tet/domain/users';
+import { and, eq } from 'drizzle-orm';
+import { CreatePreSwitchSnapshotsService } from './create-pre-switch-snapshots.service';
+
+// collectivité seedée avec des données CAE réelles
+const COLLECTIVITE_ID = 1;
+
+// prefs éligibles : cae en write, eci archivé
+const prefsEligibleCaeOnly: CollectiviteReferentielPreferences = {
+  cae: { display: true, mode: 'write' },
+  eci: { display: false, mode: 'archived' },
+  te: { display: true, mode: 'readonly' },
+};
+
+// prefs avec les deux référentiels sources en write
+const prefsEligibleCaeAndEci: CollectiviteReferentielPreferences = {
+  cae: { display: true, mode: 'write' },
+  eci: { display: true, mode: 'write' },
+  te: { display: true, mode: 'readonly' },
+};
+
+describe('CreatePreSwitchSnapshotsService', () => {
+  let app: INestApplication;
+  let databaseService: DatabaseService;
+  let service: CreatePreSwitchSnapshotsService;
+  let user: AuthenticatedUser;
+  let cleanupUser: () => Promise<void>;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    databaseService = await getTestDatabase(app);
+    service = app.get(CreatePreSwitchSnapshotsService);
+
+    const userResult = await addTestUser(databaseService, {
+      collectiviteId: COLLECTIVITE_ID,
+      role: CollectiviteRole.ADMIN,
+    });
+    cleanupUser = userResult.cleanup;
+    user = getAuthUserFromUserCredentials(userResult.user);
+  });
+
+  afterAll(async () => {
+    await cleanupUser();
+    await app.close();
+  });
+
+  // supprime les snapshots pré-bascule créés sur la collectivité seedée
+  async function cleanupPreSwitchSnapshots() {
+    await databaseService.db
+      .delete(snapshotTable)
+      .where(
+        and(
+          eq(snapshotTable.collectiviteId, COLLECTIVITE_ID),
+          eq(snapshotTable.ref, SnapshotsService.PRE_SWITCH_TE_SNAPSHOT_REF)
+        )
+      );
+  }
+
+  test('CAE seul en write : 1 snapshot pré-bascule figé', async () => {
+    onTestFinished(cleanupPreSwitchSnapshots);
+
+    const result = await service.createPreSwitchSnapshots(
+      COLLECTIVITE_ID,
+      prefsEligibleCaeOnly,
+      { user }
+    );
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    expect(result.data).toHaveLength(1);
+    const [snapshot] = result.data;
+    expect(snapshot.referentielId).toBe(ReferentielIdEnum.CAE);
+    expect(snapshot.ref).toBe(SnapshotsService.PRE_SWITCH_TE_SNAPSHOT_REF);
+    expect(snapshot.nom).toBe(SnapshotsService.PRE_SWITCH_TE_SNAPSHOT_NOM);
+    expect(snapshot.jalon).toBe(SnapshotJalonEnum.PRE_SWITCH_TE);
+    expect(snapshot.scoresPayload).toBeDefined();
+    expect(snapshot.scoresPayload.scores).toBeDefined();
+    expect(snapshot.personnalisationReponses).toBeDefined();
+  });
+
+  test('CAE + ECI en write : 2 snapshots (cae puis eci)', async () => {
+    onTestFinished(cleanupPreSwitchSnapshots);
+
+    const result = await service.createPreSwitchSnapshots(
+      COLLECTIVITE_ID,
+      prefsEligibleCaeAndEci,
+      { user }
+    );
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    expect(result.data).toHaveLength(2);
+    // ordre déterministe : cae puis eci
+    expect(result.data.map((snapshot) => snapshot.referentielId)).toEqual([
+      ReferentielIdEnum.CAE,
+      ReferentielIdEnum.ECI,
+    ]);
+  });
+
+  test('ECI hors write : aucun snapshot eci en base', async () => {
+    onTestFinished(cleanupPreSwitchSnapshots);
+
+    await service.createPreSwitchSnapshots(
+      COLLECTIVITE_ID,
+      prefsEligibleCaeOnly,
+      { user }
+    );
+
+    const eciSnapshots = await databaseService.db
+      .select()
+      .from(snapshotTable)
+      .where(
+        and(
+          eq(snapshotTable.collectiviteId, COLLECTIVITE_ID),
+          eq(snapshotTable.referentielId, ReferentielIdEnum.ECI),
+          eq(snapshotTable.ref, SnapshotsService.PRE_SWITCH_TE_SNAPSHOT_REF)
+        )
+      );
+
+    expect(eciSnapshots).toHaveLength(0);
+  });
+
+  test('idempotence : 2 appels → 1 ligne, modifiedAt mis à jour', async () => {
+    onTestFinished(cleanupPreSwitchSnapshots);
+
+    const firstResult = await service.createPreSwitchSnapshots(
+      COLLECTIVITE_ID,
+      prefsEligibleCaeOnly,
+      { user }
+    );
+    expect(firstResult.success).toBe(true);
+    if (!firstResult.success) return;
+
+    const secondResult = await service.createPreSwitchSnapshots(
+      COLLECTIVITE_ID,
+      prefsEligibleCaeOnly,
+      { user }
+    );
+    expect(secondResult.success).toBe(true);
+    if (!secondResult.success) return;
+
+    const rows = await databaseService.db
+      .select()
+      .from(snapshotTable)
+      .where(
+        and(
+          eq(snapshotTable.collectiviteId, COLLECTIVITE_ID),
+          eq(snapshotTable.referentielId, ReferentielIdEnum.CAE),
+          eq(snapshotTable.ref, SnapshotsService.PRE_SWITCH_TE_SNAPSHOT_REF)
+        )
+      );
+
+    // une seule ligne par (collectivite_id, referentiel_id, ref)
+    expect(rows).toHaveLength(1);
+
+    const firstModifiedAt = new Date(firstResult.data[0].modifiedAt).getTime();
+    const secondModifiedAt = new Date(
+      secondResult.data[0].modifiedAt
+    ).getTime();
+    expect(secondModifiedAt).toBeGreaterThanOrEqual(firstModifiedAt);
+  });
+});

--- a/apps/backend/src/referentiels/switch-to-te/create-pre-switch-snapshots.service.ts
+++ b/apps/backend/src/referentiels/switch-to-te/create-pre-switch-snapshots.service.ts
@@ -1,0 +1,74 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { SnapshotsService } from '@tet/backend/referentiels/snapshots/snapshots.service';
+import type { ServiceSecondArg } from '@tet/backend/utils/nest/service-second-arg.utils';
+import { failure, success, type Result } from '@tet/backend/utils/result.type';
+import { type CollectiviteReferentielPreferences } from '@tet/domain/collectivites';
+import {
+  ReferentielIdEnum,
+  ScoreSnapshot,
+  SnapshotJalonEnum,
+} from '@tet/domain/referentiels';
+import {
+  SwitchToTeErrorEnum,
+  type SwitchToTeError,
+} from './switch-to-te.errors';
+
+/**
+ * Étape 1 du flux de bascule (cf. PRD) : fige l'état pré-bascule des
+ * référentiels sources CAE/ECI encore en `mode: write` via un snapshot
+ * `pre-switch-te`.
+ */
+@Injectable()
+export class CreatePreSwitchSnapshotsService {
+  private readonly logger = new Logger(CreatePreSwitchSnapshotsService.name);
+
+  // ordre déterministe : cae puis eci
+  private static readonly SOURCE_REFERENTIELS = [
+    ReferentielIdEnum.CAE,
+    ReferentielIdEnum.ECI,
+  ] as const;
+
+  constructor(private readonly snapshotsService: SnapshotsService) {}
+
+  /**
+   * Fige un snapshot `pre-switch-te` par référentiel source en `mode: write`.
+   * Les permissions ne sont pas re-vérifiées : `switchToTe` a déjà validé
+   * `REFERENTIELS.MUTATE`. `prefs` est fourni par l'appelant (évite un re-fetch).
+   */
+  async createPreSwitchSnapshots(
+    collectiviteId: number,
+    prefs: CollectiviteReferentielPreferences,
+    { user, tx }: ServiceSecondArg
+  ): Promise<Result<ScoreSnapshot[], SwitchToTeError>> {
+    const referentielsToSnapshot =
+      CreatePreSwitchSnapshotsService.SOURCE_REFERENTIELS.filter(
+        (referentielId) => prefs[referentielId].mode === 'write'
+      );
+
+    const snapshots: ScoreSnapshot[] = [];
+
+    try {
+      for (const referentielId of referentielsToSnapshot) {
+        const snapshot = await this.snapshotsService.computeAndUpsert({
+          collectiviteId,
+          referentielId,
+          jalon: SnapshotJalonEnum.PRE_SWITCH_TE,
+          user,
+          tx,
+        });
+        snapshots.push(snapshot);
+      }
+    } catch (error) {
+      this.logger.error(
+        `Échec de la création des snapshots pré-bascule pour la collectivité ${collectiviteId}`,
+        error instanceof Error ? error.stack : undefined
+      );
+      return failure(
+        SwitchToTeErrorEnum.PRE_SWITCH_SNAPSHOT_FAILED,
+        error instanceof Error ? error : undefined
+      );
+    }
+
+    return success(snapshots);
+  }
+}

--- a/apps/backend/src/referentiels/switch-to-te/switch-to-te.errors.ts
+++ b/apps/backend/src/referentiels/switch-to-te/switch-to-te.errors.ts
@@ -15,6 +15,7 @@ const specificErrors = [
   'AUDIT_REQUEST_IN_PROGRESS',
   'AUDIT_IN_PROGRESS',
   'SWITCH_NOT_IMPLEMENTED',
+  'PRE_SWITCH_SNAPSHOT_FAILED',
   ...collectivitePreferencesSpecificErrors,
 ] as const;
 
@@ -50,6 +51,10 @@ export const switchToTeTrpcErrorEntries = {
   SWITCH_NOT_IMPLEMENTED: {
     code: 'NOT_IMPLEMENTED',
     message: "La bascule n'est pas encore disponible",
+  },
+  PRE_SWITCH_SNAPSHOT_FAILED: {
+    code: 'INTERNAL_SERVER_ERROR',
+    message: 'Impossible de créer le snapshot pré-bascule',
   },
 } as const;
 

--- a/doc/plans/2026-06-11-001-feat-bascule-referentiel-te-prd.md
+++ b/doc/plans/2026-06-11-001-feat-bascule-referentiel-te-prd.md
@@ -214,13 +214,16 @@ Règle transversale : sources `concerne = false` (non concerné explicite ou dé
 
 | Snapshot | `ref` | `jalon` | `nom` | Comportement |
 |---|---|---|---|---|
-| Pré-bascule | `pre-switch-te` | `pre_switch_te` | État pré-bascule TE | Figé à la bascule ; jalon système non éditable (comme `pre_audit`) |
+| Pré-bascule | `pre-switch-te` | `pre_switch_te` | État pré-bascule Climat Ressources | Figé à la bascule ; jalon système non éditable (comme `pre_audit`) |
 | Post-bascule TE | `post-switch-te` | `post_switch_te` | État initial TE | Figé à la bascule ; jalon système non éditable |
 | Score courant | `score-courant` | `score_courant` | Score courant | Vivant sur TE post-bascule ; **masqué** sur CAE/ECI archivés (ligne conservée en BDD) |
 
 > **Convention `ref` / `jalon`** — `ref` (kebab-case) pour API/UI/exports ; `jalon` (snake_case) pour enum BDD `SnapshotJalonEnum`. Ne pas unifier.
 
-**Création `pre-switch-te`** : un snapshot par ref. CAE/ECI en `mode: write` **ou** dont au moins une action d'origine participe à la fusion — y compris ref `archived` dans ce cas (ex. CAE engagé + ECI archived mais sources ECI fusionnées).
+**Création `pre-switch-te`** :
+
+- **PR10** : un snapshot par ref. CAE/ECI en `mode: write` au moment de la bascule (refs engagés, source principale de migration).
+- **PR17/PR18** : compléter si besoin pour un ref. `archived` dont des actions d'origine participent quand même à la fusion TE (ex. CAE engagé + ECI archived mais sources ECI fusionnées via `action_origine`) — détection au moment de la migration, pas en PR10.
 
 **Consommation sur ref archivée** :
 - `list` : exclure `score-courant` si `mode === 'archived'`.
@@ -322,14 +325,14 @@ Objectif de découpage : **PRs reviewables en une session**. Règle générale ~
 | PR7 | Désactivation contrôles d'édition côté app | PR4 | ~350 | Oui |
 | PR8 | SwitchToTeService squelette + guards permissions / idempotence | PR4 | ~500 | Non (endpoint) |
 | PR9 | Guards COT/demande/audit | PR8 | ~350 | Non (endpoint) |
-| PR10 | Snapshots `pre-switch-te` | PR2, PR8 | ~400 | Non (endpoint) |
+| PR10 | Snapshots `pre-switch-te` (refs en `write` uniquement ; service isolé, non câblé dans `switchToTe`) | PR2, PR8 | ~400 | Non (endpoint) |
 | PR11 | `list` / `getCurrent` sur refs archivées | PR2, PR4 | ~300 | Oui |
 | PR12 | `mergeStatuts` + tests | PR8 | ~650 | Non (endpoint) |
 | PR13 | `mergeCommentaires` + tests | PR12 | ~250 | Non (endpoint) |
 | PR14 | `mergePilotes` + tests | PR12 | ~200 | Non (endpoint) |
 | PR15 | `mergeServices` + correctif Drizzle PK + tests | PR12 | ~250 | Non (endpoint) |
 | PR16 | `mergeFicheActionLinks` + tests | PR12 | ~250 | Non (endpoint) |
-| PR17 | MigrateCollectiviteDataService | PR13–PR16 | ~300 | Non (endpoint) |
+| PR17 | MigrateCollectiviteDataService (+ détection sources fusionnées pour snapshots archived si besoin) | PR13–PR16 | ~300 | Non (endpoint) |
 | PR18 | Recalcul scores + snapshot post-switch-te + transaction + prefs + **exposition prod** | PR9, PR10, PR17 | ~550 | **Oui (endpoint)** |
 | PR19 | UI bascule — CTA + états disabled (COT/demande/audit) | PR18 | ~350 | Oui |
 | PR20 | UI bascule — modale irréversible (migré / non migré) | PR19 | ~350 | Oui |
@@ -393,7 +396,11 @@ Feedback rapide possible après PR5–PR7 (lecture seule visible).
 
 ### PR10 — Snapshots pré-bascule
 
-- Création snapshots `pre-switch-te` : cf. [Snapshots](#snapshots).
+- `CreatePreSwitchSnapshotsService` : un snapshot `pre-switch-te` par ref. CAE/ECI en `mode: write` (score courant + `personnalisation_reponses` figés) ; écritures séquentielles, `tx?` propagé, `Result<ScoreSnapshot[], SwitchToTeError>`.
+- Extension `SnapshotsService` (jalon `PRE_SWITCH_TE`, ref `pre-switch-te`, nom « État pré-bascule Climat Ressources »).
+- Erreur typée `PRE_SWITCH_SNAPSHOT_FAILED` (`INTERNAL_SERVER_ERROR`) dans `switch-to-te.errors.ts`.
+- Service isolé, testé en e2e (cae seul, cae + eci, eci ignoré, idempotence) ; **non branché** dans `switchToTe()` avant PR18.
+- Cas ref. `archived` participant à la fusion : cf. [Snapshots](#snapshots) (PR17/PR18).
 
 ### PR11 — Snapshots sur refs archivées
 

--- a/doc/plans/2026-06-11-005-feat-bascule-referentiel-te-pr10-plan.md
+++ b/doc/plans/2026-06-11-005-feat-bascule-referentiel-te-pr10-plan.md
@@ -1,0 +1,269 @@
+---
+
+name: PR10 Snapshots pre-bascule
+overview: "Implémenter la création des snapshots `pre-switch-te` pour les référentiels CAE/ECI en `mode: write`, via un service dédié testé en e2e, extension minimale de SnapshotsService, et câblage NestJS — sans brancher dans switchToTe() (PR18)."
+todos:
+
+- id: snapshots-metadata
+content: Étendre SnapshotsService (constantes PRE_SWITCH_TE + case getDefaultSnapshotMetadata)
+status: pending
+- id: create-service
+content: Créer CreatePreSwitchSnapshotsService (sélection refs write, computeAndUpsert séquentiel, Result ADR 0012)
+status: pending
+- id: errors
+content: Ajouter PRE_SWITCH_SNAPSHOT_FAILED dans switch-to-te.errors.ts
+status: pending
+- id: module-wiring
+content: Enregistrer CreatePreSwitchSnapshotsService dans ReferentielsModule (SwitchToTeService inchangé)
+status: pending
+- id: e2e
+content: Tests e2e create-pre-switch-snapshots.service.e2e-spec.ts (1 ref, 2 refs, eci hors write, idempotence)
+status: pending
+- id: prd-reconcile
+content: Mettre à jour le PRD (section Snapshots + lignes PR10/PR17/PR18)
+status: pending
+isProject: false
+
+---
+
+
+
+# PR10 — Snapshots pré-bascule
+
+**Parent** : [doc/plans/2026-06-11-001-feat-bascule-referentiel-te-prd.md](doc/plans/2026-06-11-001-feat-bascule-referentiel-te-prd.md)
+
+**Branche** : `TE-7303/switch-te-PR10` depuis `main` (PR8 + PR9 mergés)
+
+**Estimation** : ~400 LOC (code + tests e2e) — endpoint `referentiels.switchToTe` toujours **non exposé prod** (`SWITCH_NOT_IMPLEMENTED` conservé jusqu'à PR18)
+
+---
+
+
+
+## Contexte
+
+PR2 a ajouté les jalons `pre_switch_te` / `post_switch_te` dans `[SnapshotJalonEnum](packages/domain/src/referentiels/scores/snapshot-jalon.enum.ts)`. `[SnapshotsService](apps/backend/src/referentiels/snapshots/snapshots.service.ts)` sait déjà calculer et persister un snapshot via `computeAndUpsert({ collectiviteId, referentielId, jalon, user, tx })` — y compris `personnalisationReponses` — mais `getDefaultSnapshotMetadata` ne gère pas encore `PRE_SWITCH_TE` (throw pour jalon inconnu).
+
+PR8–PR9 ont posé `[SwitchToTeService](apps/backend/src/referentiels/switch-to-te/switch-to-te.service.ts)` avec tous les guards, puis `SWITCH_NOT_IMPLEMENTED`. PR10 implémente **l'étape 1** du flux transactionnel (cf. [Flux de bascule](doc/plans/2026-06-11-001-feat-bascule-referentiel-te-prd.md#flux-de-bascule)) comme **unité isolée** : non appelée par `switchToTe()` avant PR18.
+
+```mermaid
+sequenceDiagram
+  participant PR18 as SwitchToTeService (PR18)
+  participant Create as CreatePreSwitchSnapshotsService
+  participant Snap as SnapshotsService
+  participant Scores as ScoresService
+
+  Note over PR18: PR10 — hors switchToTe
+  Create->>Create: sélectionner refs cae/eci mode write
+  loop par ref source (cae puis eci)
+    Create->>Snap: computeAndUpsert(jalon PRE_SWITCH_TE, tx)
+    Snap->>Scores: computeScoreForCollectivite
+    Snap-->>Create: ScoreSnapshot figé
+  end
+  Create-->>PR18: Result ScoreSnapshot[]
+
+  Note over PR18: PR18 câble dans executeSingle(tx)
+```
+
+
+
+---
+
+
+
+## Décisions actées
+
+
+| Sujet                   | Décision                                                                                                                                                                                                                                                                                                                                                                        |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Câblage PR10            | **Unité isolée** : `CreatePreSwitchSnapshotsService` testé via `app.get(...)`. `switchToTe()` **inchangé** (toujours `SWITCH_NOT_IMPLEMENTED`). PR18 injecte et appelle dans `transactionManager.executeSingle`.                                                                                                                                                                |
+| Emplacement             | Service dédié `[create-pre-switch-snapshots.service.ts](apps/backend/src/referentiels/switch-to-te/create-pre-switch-snapshots.service.ts)` dans le feature folder `switch-to-te/`.                                                                                                                                                                                             |
+| Référentiels snapshotés | **Uniquement** `cae` / `eci` avec `prefs[ref].mode === 'write'`. Ordre déterministe : `cae` puis `eci`. Cas « ref `archived` dont des actions participent à la fusion » → **reporté PR17/PR18** (détection au moment de la migration, quand la logique de fusion existe).                                                                                                       |
+| Mécanisme snapshot      | Extension minimale de `SnapshotsService` : constantes `PRE_SWITCH_TE_SNAPSHOT_REF = 'pre-switch-te'`, `PRE_SWITCH_TE_SNAPSHOT_NOM = 'État pré-bascule Climat Ressources'` + `case SnapshotJalonEnum.PRE_SWITCH_TE` dans `getDefaultSnapshotMetadata`. Appel `computeAndUpsert({ jalon: PRE_SWITCH_TE })` **sans** `nom` ni `ref` (évite le guard `snapshotNom` L1068–1076 de `ScoresService`). |
+| Signature               | `createPreSwitchSnapshots(collectiviteId, prefs, { user, tx })` → `Promise<Result<ScoreSnapshot[], SwitchToTeError>>`. Prefs passées par l'appelant (PR18 les a déjà chargées ; évite re-fetch ; facilite les tests).                                                                                                                                                           |
+| Erreurs                 | `try/catch` autour de chaque `computeAndUpsert` → `failure(PRE_SWITCH_SNAPSHOT_FAILED, cause)`. Code `INTERNAL_SERVER_ERROR` dans `[switch-to-te.errors.ts](apps/backend/src/referentiels/switch-to-te/switch-to-te.errors.ts)`.                                                                                                                                                |
+| Permissions             | **Pas de re-check** dans le service dédié : `REFERENTIELS.MUTATE` déjà vérifié par `switchToTe` (PR8). `user` sert à `createdBy` / `modifiedBy` du snapshot.                                                                                                                                                                                                                    |
+| Concurrence             | Écritures **séquentielles** (`for await`) — une transaction = une connexion ; pas de `Promise.all` sur le même `tx`.                                                                                                                                                                                                                                                            |
+| Module NestJS           | Provider dans `[ReferentielsModule](apps/backend/src/referentiels/referentiels.module.ts)` uniquement. **Ne pas** injecter dans `SwitchToTeService` en PR10 (YAGNI).                                                                                                                                                                                                            |
+| Tests                   | e2e niveau service (`app.get(CreatePreSwitchSnapshotsService)`), collectivité seedée `1` (données CAE réelles) + prefs fabriquées à la main.                                                                                                                                                                                                                                    |
+| Hors scope PR10         | Snapshot `post-switch-te` (PR18), `list` / `getCurrent` sur refs archivées (PR11), UI snapshots (PR22), suppression utilisateur (déjà bloquée : `USER_DELETION_ALLOWED_SNAPSHOT_TYPES` n'inclut pas `pre_switch_te`).                                                                                                                                                           |
+
+> **Évolution possible à PR18** : le service dédié se justifie surtout par la livraison isolée de PR10 (testable avant câblage). Sa logique reste mince (filtre `write` + boucle `computeAndUpsert`). Au moment de PR18, si l'isolation n'apporte plus de valeur, envisager de passer `CreatePreSwitchSnapshotsService` en méthode privée de `SwitchToTeService` (étape 1 de la transaction).
+
+---
+
+## Implémentation
+
+### 1. Extension `SnapshotsService`
+
+Fichier : `[snapshots.service.ts](apps/backend/src/referentiels/snapshots/snapshots.service.ts)`
+
+```typescript
+static readonly PRE_SWITCH_TE_SNAPSHOT_REF = 'pre-switch-te';
+static readonly PRE_SWITCH_TE_SNAPSHOT_NOM = 'État pré-bascule Climat Ressources';
+```
+
+Dans `getDefaultSnapshotMetadata`, ajouter :
+
+```typescript
+case SnapshotJalonEnum.PRE_SWITCH_TE:
+  ref = SnapshotsService.PRE_SWITCH_TE_SNAPSHOT_REF;
+  nom = SnapshotsService.PRE_SWITCH_TE_SNAPSHOT_NOM;
+  break;
+```
+
+> **Note** : ajouter aussi `POST_SWITCH_TE` (constantes + case) en PR10 si souhaité pour préparer PR18 sans coût ; sinon report strict PR18.
+
+Comportement attendu de `computeAndUpsert` avec `jalon: PRE_SWITCH_TE` :
+
+- Score courant du référentiel source (personnalisation au moment T).
+- `personnalisationReponses` capturées automatiquement.
+- Chemin `snapshotForceUpdate` + `upsertScoreSnapshot` → **idempotent** (2e appel = update, pas de doublon sur `(collectivite_id, referentiel_id, ref)`).
+
+
+
+### 2. `CreatePreSwitchSnapshotsService`
+
+Fichier : `apps/backend/src/referentiels/switch-to-te/create-pre-switch-snapshots.service.ts`
+
+```typescript
+@Injectable()
+export class CreatePreSwitchSnapshotsService {
+  private static readonly SOURCE_REFERENTIELS = [
+    ReferentielIdEnum.CAE,
+    ReferentielIdEnum.ECI,
+  ] as const;
+
+  constructor(private readonly snapshotsService: SnapshotsService) {}
+
+  async createPreSwitchSnapshots(
+    collectiviteId: number,
+    prefs: CollectiviteReferentielPreferences,
+    { user, tx }: ServiceSecondArg & { tx?: Transaction }
+  ): Promise<Result<ScoreSnapshot[], SwitchToTeError>> {
+    const referentielsToSnapshot =
+      CreatePreSwitchSnapshotsService.SOURCE_REFERENTIELS.filter(
+        (referentiel) => prefs[referentiel].mode === 'write'
+      );
+
+    const snapshots: ScoreSnapshot[] = [];
+
+    try {
+      for (const referentielId of referentielsToSnapshot) {
+        const snapshot = await this.snapshotsService.computeAndUpsert({
+          collectiviteId,
+          referentielId,
+          jalon: SnapshotJalonEnum.PRE_SWITCH_TE,
+          user,
+          tx,
+        });
+        snapshots.push(snapshot);
+      }
+    } catch (error) {
+      return failure(
+        SwitchToTeErrorEnum.PRE_SWITCH_SNAPSHOT_FAILED,
+        error instanceof Error ? error : undefined
+      );
+    }
+
+    return success(snapshots);
+  }
+}
+```
+
+
+
+### 3. Erreur — `[switch-to-te.errors.ts](apps/backend/src/referentiels/switch-to-te/switch-to-te.errors.ts)`
+
+Ajouter à `specificErrors` + `switchToTeTrpcErrorEntries` :
+
+
+| Code                         | tRPC                    | Message (indicatif)                         |
+| ---------------------------- | ----------------------- | ------------------------------------------- |
+| `PRE_SWITCH_SNAPSHOT_FAILED` | `INTERNAL_SERVER_ERROR` | Impossible de créer le snapshot pré-bascule |
+
+
+
+
+### 4. Câblage module
+
+`[referentiels.module.ts](apps/backend/src/referentiels/referentiels.module.ts)` : ajouter `CreatePreSwitchSnapshotsService` aux `providers`.
+
+**Ne pas modifier** `[switch-to-te.service.ts](apps/backend/src/referentiels/switch-to-te/switch-to-te.service.ts)` en PR10.
+
+---
+
+
+
+## Tests
+
+Fichier : `apps/backend/src/referentiels/switch-to-te/create-pre-switch-snapshots.service.e2e-spec.ts`
+
+Setup : `getTestApp()` + `app.get(CreatePreSwitchSnapshotsService)` + user admin via `addTestCollectiviteAndUser` ou user seedé avec droits sur collectivité `1`.
+
+Helper : fabriquer `CollectiviteReferentielPreferences` sans écrire en BDD :
+
+```typescript
+function prefsEligibleCaeOnly(): CollectiviteReferentielPreferences {
+  return {
+    te: { display: true, mode: 'readonly' },
+    cae: { display: true, mode: 'write' },
+    eci: { display: false, mode: 'archived' },
+  };
+}
+```
+
+
+| Scénario           | Prefs                            | Attendu                                                                                                                                                                       |
+| ------------------ | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| CAE seul en write  | `cae: write`, `eci: archived`    | `success`, 1 snapshot ; `ref === 'pre-switch-te'`, `jalon === pre_switch_te`, `nom === 'État pré-bascule Climat Ressources'` ; `scoresPayload` non vide ; `personnalisationReponses` présent |
+| CAE + ECI en write | les deux `write`                 | `success`, 2 snapshots (cae + eci)                                                                                                                                            |
+| ECI hors write     | `cae: write`, `eci: archived`    | aucun snapshot `eci` en base pour cette CT                                                                                                                                    |
+| Idempotence        | 2 appels consécutifs mêmes prefs | 1 ligne par `(collectivite_id, referentiel_id, ref)` ; 2e appel met à jour `modifiedAt`                                                                                       |
+
+
+Nettoyage : `onTestFinished` — supprimer les snapshots `pre-switch-te` créés (`delete` service-role ou `DELETE FROM client_scores WHERE ref = 'pre-switch-te'`).
+
+Commande : `pnpm test:backend create-pre-switch-snapshots`
+
+---
+
+
+
+## Hors scope PR10 (PRs suivantes)
+
+
+| PR   | Ajout                                                                                                                                                                                                                 |
+| ---- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| PR11 | `list` / `getCurrent` sur refs archivées (masquer `score-courant`, retourner `pre-switch-te`)                                                                                                                         |
+| PR17 | `MigrateCollectiviteDataService` — détection des sources fusionnées (y compris ref archived)                                                                                                                          |
+| PR18 | Câbler `createPreSwitchSnapshots` en **étape 1** de `transactionManager.executeSingle` ; compléter snapshots archived si fusion ; `post-switch-te` ; prefs + `populatedFromCaeEci` ; retrait `SWITCH_NOT_IMPLEMENTED` |
+| PR22 | UI snapshots post-bascule + masquage CTA « Figer l'état des lieux »                                                                                                                                                   |
+
+
+---
+
+
+
+## Ordre d'implémentation
+
+1. Constantes + `case PRE_SWITCH_TE` dans `SnapshotsService.getDefaultSnapshotMetadata`
+2. `PRE_SWITCH_SNAPSHOT_FAILED` dans `switch-to-te.errors.ts`
+3. `CreatePreSwitchSnapshotsService`
+4. Provider dans `ReferentielsModule`
+5. e2e `create-pre-switch-snapshots.service.e2e-spec.ts` + `pnpm test:backend create-pre-switch-snapshots`
+6. Mise à jour PRD (section Snapshots + plan de livraison)
+
+---
+
+
+
+## Critères de done
+
+- [ ] `SnapshotsService` gère `jalon: PRE_SWITCH_TE` (`ref`, `nom` dérivés)
+- [ ] `CreatePreSwitchSnapshotsService` : sélection `mode === 'write'`, ordre cae → eci, `tx?` propagé, `Result<ScoreSnapshot[]>`
+- [ ] `PRE_SWITCH_SNAPSHOT_FAILED` typé
+- [ ] Provider enregistré ; `SwitchToTeService` **inchangé**
+- [ ] e2e : 4 scénarios (1 ref, 2 refs, eci ignoré, idempotence)
+- [ ] PRD mis à jour (création pre-switch-te = write only en PR10 ; cas archived → PR17/PR18)
+- [ ] Déployable en prod sans risque utilisateur (aucun changement sur `switchToTe`)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Nouvelles fonctionnalités**
  - Ajout de la création de snapshots « pré-bascule » pour les référentiels CAE et ECI actifs en écriture.
  - Génération dans un ordre déterministe et mise à jour sans doublon lors d’exécutions répétées.
  - Ajout d’un libellé et d’une référence dédiés à ces snapshots.

- **Améliorations**
  - Ajout d’un message d’erreur spécifique en cas d’échec de création.

- **Tests**
  - Couverture des scénarios de création, d’exclusion et d’idempotence des snapshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->