### PR TITLE
Filtre les snapshots des référentiels archivés

### DIFF
--- a/apps/backend/src/referentiels/compute-score/scores.service.spec.ts
+++ b/apps/backend/src/referentiels/compute-score/scores.service.spec.ts
@@ -40,6 +40,7 @@ import { caeReferentiel } from '../models/samples/cae-referentiel';
 import { deeperReferentiel } from '../models/samples/deeper-referentiel';
 import { eciReferentiel } from '../models/samples/eci-referentiel';
 import { simpleReferentiel } from '../models/samples/simple-referentiel';
+import { CollectiviteReferentielModeService } from '../../collectivites/collectivite-referentiel-mode/collectivite-referentiel-mode.service';
 import { SnapshotsService } from '../snapshots/snapshots.service';
 import { ActionStatutsByActionId } from './action-statuts-by-action-id.dto';
 import ScoresService from './scores.service';
@@ -94,7 +95,8 @@ describe('ReferentielsScoringService', () => {
           token === DocumentService ||
           token === ScoreIndicatifService ||
           token === ListActionStatutsRepository ||
-          token === ListActionExplicationsRepository
+          token === ListActionExplicationsRepository ||
+          token === CollectiviteReferentielModeService
         ) {
           return {};
         }

--- a/apps/backend/src/referentiels/snapshots/list-snapshots/list-snapshots.controller.spec.ts
+++ b/apps/backend/src/referentiels/snapshots/list-snapshots/list-snapshots.controller.spec.ts
@@ -1,10 +1,12 @@
 import { INestApplication } from '@nestjs/common';
+import { addTestCollectiviteAndUser } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
 import { ReferentielsRouter } from '@tet/backend/referentiels/referentiels.router';
 import { LIST_DEFAULT_JALONS } from '@tet/backend/referentiels/snapshots/list-snapshots/list-snapshots.api-query';
 import { ListSnapshotsApiResponse } from '@tet/backend/referentiels/snapshots/list-snapshots/list-snapshots.api-response';
 import {
-  getAuthUser,
+  getAuthUserFromUserCredentials,
   getTestApp,
+  getTestDatabase,
   ISO_8601_DATE_REGEX,
   ISO_8601_DATE_TIME_REGEX,
   signInWith,
@@ -12,20 +14,32 @@ import {
 } from '@tet/backend/test';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { ReferentielIdEnum, SnapshotJalonEnum } from '@tet/domain/referentiels';
+import { CollectiviteRole } from '@tet/domain/users';
 import request from 'supertest';
 
 describe('Api pour lister les snapshots', () => {
   let app: INestApplication;
   let yoloDodoToken: string;
   let router: ReferentielsRouter;
-  let yoloDodoUser: AuthenticatedUser;
-  const collectiviteId = 1;
+  let testUser: AuthenticatedUser;
+  let collectiviteId: number;
   const referentielId = ReferentielIdEnum.CAE;
 
   beforeAll(async () => {
     app = await getTestApp();
     router = app.get(ReferentielsRouter);
-    yoloDodoUser = await getAuthUser();
+    const databaseService = await getTestDatabase(app);
+    const { collectivite, user } = await addTestCollectiviteAndUser(
+      databaseService,
+      {
+        user: {
+          role: CollectiviteRole.ADMIN,
+        },
+      }
+    );
+    collectiviteId = collectivite.id;
+    testUser = getAuthUserFromUserCredentials(user);
+
     const yoloDodo = await signInWith(YOLO_DODO);
     yoloDodoToken = yoloDodo.data.session?.access_token || '';
   });
@@ -67,9 +81,9 @@ describe('Api pour lister les snapshots', () => {
   });
 
   test('Liste des snapshots ok', async () => {
-    const caller = router.createCaller({ user: yoloDodoUser });
+    const caller = router.createCaller({ user: testUser });
 
-    // Force à avoir le snapshot courant
+    // force à avoir le snapshot courant
     await caller.snapshots.getCurrent({
       referentielId: referentielId,
       collectiviteId,
@@ -83,7 +97,7 @@ describe('Api pour lister les snapshots', () => {
       .expect(200);
 
     expect(response.body).toMatchObject({
-      collectiviteId: 1,
+      collectiviteId,
       referentielId: referentielId,
       jalons: LIST_DEFAULT_JALONS,
       snapshots: expect.any(Array),

--- a/apps/backend/src/referentiels/snapshots/list-snapshots/list-snapshots.service.e2e-spec.ts
+++ b/apps/backend/src/referentiels/snapshots/list-snapshots/list-snapshots.service.e2e-spec.ts
@@ -1,5 +1,6 @@
 import { INestApplication } from '@nestjs/common';
 import { addTestCollectiviteAndUser } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { collectiviteTable } from '@tet/backend/collectivites/shared/models/collectivite.table';
 import {
   getAuthUserFromUserCredentials,
   getTestApp,
@@ -7,9 +8,14 @@ import {
 } from '@tet/backend/test';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import {
+  CollectiviteReferentielPreferences,
+  defaultCollectivitePreferences,
+} from '@tet/domain/collectivites';
 import { ReferentielIdEnum, SnapshotJalonEnum } from '@tet/domain/referentiels';
 import { CollectiviteRole } from '@tet/domain/users';
 import { roundTo } from '@tet/domain/utils';
+import { eq } from 'drizzle-orm';
 import { ReferentielsRouter } from '../../referentiels.router';
 
 describe('ListSnapshotsService', () => {
@@ -38,6 +44,20 @@ describe('ListSnapshotsService', () => {
   afterAll(async () => {
     await app.close();
   });
+
+  async function setReferentielPreferences(
+    referentiels: CollectiviteReferentielPreferences
+  ) {
+    await databaseService.db
+      .update(collectiviteTable)
+      .set({
+        preferences: {
+          ...defaultCollectivitePreferences,
+          referentiels,
+        },
+      })
+      .where(eq(collectiviteTable.id, collectiviteId));
+  }
 
   test("Création d'un snapshot, liste des snapshots existants suppression", async () => {
     const caller = router.createCaller({ user: testUser });
@@ -116,5 +136,84 @@ describe('ListSnapshotsService', () => {
       );
 
     expect(foundSnapshotAfterDelete).toBeUndefined();
+  });
+
+  test('Filtre le jalon courant sur list et listWithScores quand le mode est archived', async () => {
+    const caller = router.createCaller({ user: testUser });
+
+    onTestFinished(async () => {
+      await setReferentielPreferences({
+        cae: { display: true, mode: 'write' },
+        eci: { display: true, mode: 'write' },
+        te: { display: true, mode: 'readonly' },
+      });
+    });
+
+    await caller.snapshots.getCurrent({
+      collectiviteId,
+      referentielId: ReferentielIdEnum.CAE,
+    });
+
+    await setReferentielPreferences({
+      cae: { display: false, mode: 'archived' },
+      eci: { display: true, mode: 'write' },
+      te: { display: true, mode: 'write' },
+    });
+
+    const archivedList = await caller.snapshots.list({
+      collectiviteId,
+      referentielId: ReferentielIdEnum.CAE,
+      options: {
+        jalons: [
+          SnapshotJalonEnum.COURANT,
+          SnapshotJalonEnum.DATE_PERSONNALISEE,
+        ],
+      },
+    });
+
+    expect(archivedList.jalons).not.toContain(SnapshotJalonEnum.COURANT);
+    expect(
+      archivedList.snapshots.some(
+        (snapshot) => snapshot.jalon === SnapshotJalonEnum.COURANT
+      )
+    ).toBe(false);
+
+    const archivedListWithScores = await caller.snapshots.listWithScores({
+      collectiviteId,
+      referentielId: ReferentielIdEnum.CAE,
+      options: {
+        jalons: [
+          SnapshotJalonEnum.COURANT,
+          SnapshotJalonEnum.DATE_PERSONNALISEE,
+        ],
+      },
+    });
+
+    expect(
+      archivedListWithScores.some(
+        (snapshot) => snapshot.jalon === SnapshotJalonEnum.COURANT
+      )
+    ).toBe(false);
+
+    await setReferentielPreferences({
+      cae: { display: true, mode: 'write' },
+      eci: { display: true, mode: 'write' },
+      te: { display: true, mode: 'readonly' },
+    });
+
+    const writeModeList = await caller.snapshots.list({
+      collectiviteId,
+      referentielId: ReferentielIdEnum.CAE,
+      options: {
+        jalons: [SnapshotJalonEnum.COURANT],
+      },
+    });
+
+    expect(writeModeList.jalons).toContain(SnapshotJalonEnum.COURANT);
+    expect(
+      writeModeList.snapshots.some(
+        (snapshot) => snapshot.jalon === SnapshotJalonEnum.COURANT
+      )
+    ).toBe(true);
   });
 });

--- a/apps/backend/src/referentiels/snapshots/list-snapshots/list-snapshots.service.ts
+++ b/apps/backend/src/referentiels/snapshots/list-snapshots/list-snapshots.service.ts
@@ -1,10 +1,15 @@
 import { Injectable } from '@nestjs/common';
+import {
+  CollectiviteReferentielModeService,
+  isCollectiviteReferentielDisplayId,
+} from '@tet/backend/collectivites/collectivite-referentiel-mode/collectivite-referentiel-mode.service';
 import { LIST_DEFAULT_JALONS } from '@tet/backend/referentiels/snapshots/list-snapshots/list-snapshots.api-query';
 import { sqlToDate, sqlToDateTimeISO } from '@tet/backend/utils/column.utils';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import {
   referentielIdEnumSchema,
   ScoreSnapshot,
+  SnapshotJalonEnum,
   snapshotJalonEnumSchema,
 } from '@tet/domain/referentiels';
 import { roundTo } from '@tet/domain/utils';
@@ -32,7 +37,10 @@ type ListInput = z.output<typeof listInputSchema>;
 
 @Injectable()
 export class ListSnapshotsService {
-  constructor(private readonly databaseService: DatabaseService) {}
+  constructor(
+    private readonly databaseService: DatabaseService,
+    private readonly collectiviteReferentielModeService: CollectiviteReferentielModeService
+  ) {}
   private readonly db = this.databaseService.db;
 
   async listWithScores({
@@ -40,13 +48,18 @@ export class ListSnapshotsService {
     referentielId,
     options: { jalons },
   }: ListInput): Promise<ScoreSnapshot[]> {
+    const effectiveJalons = await this.getEffectiveJalons(
+      collectiviteId,
+      referentielId,
+      jalons
+    );
     const filters = [
       eq(snapshotTable.collectiviteId, collectiviteId),
       eq(snapshotTable.referentielId, referentielId),
     ];
 
-    if (jalons) {
-      filters.push(inArray(snapshotTable.jalon, jalons));
+    if (effectiveJalons) {
+      filters.push(inArray(snapshotTable.jalon, effectiveJalons));
     }
 
     const snapshots = await this.databaseService.db
@@ -65,13 +78,18 @@ export class ListSnapshotsService {
   }: ListInput & {
     additionalSelectColumns?: Parameters<DatabaseService['db']['select']>[0];
   }) {
+    const effectiveJalons = await this.getEffectiveJalons(
+      collectiviteId,
+      referentielId,
+      jalons
+    );
     const filters = [
       eq(snapshotTable.collectiviteId, collectiviteId),
       eq(snapshotTable.referentielId, referentielId),
     ];
 
-    if (jalons) {
-      filters.push(inArray(snapshotTable.jalon, jalons));
+    if (effectiveJalons) {
+      filters.push(inArray(snapshotTable.jalon, effectiveJalons));
     }
 
     // Dynamically build the selection based on withScores flag
@@ -101,7 +119,7 @@ export class ListSnapshotsService {
     const response = {
       collectiviteId: parseInt(collectiviteId as unknown as string),
       referentielId,
-      jalons: jalons ?? [],
+      jalons: effectiveJalons ?? [],
       snapshots: snapshotList.map((snapshot) => {
         const baseSnapshot = {
           ...snapshot,
@@ -120,5 +138,31 @@ export class ListSnapshotsService {
     };
 
     return response;
+  }
+
+  private async getEffectiveJalons(
+    collectiviteId: number,
+    referentielId: ListInput['referentielId'],
+    jalons: ListInput['options']['jalons']
+  ) {
+    if (!isCollectiviteReferentielDisplayId(referentielId)) {
+      return jalons;
+    }
+
+    const referentielModeResult =
+      await this.collectiviteReferentielModeService.getReferentielMode(
+        collectiviteId,
+        referentielId
+      );
+
+    if (!referentielModeResult.success) {
+      return jalons;
+    }
+
+    if (referentielModeResult.data !== 'archived') {
+      return jalons;
+    }
+
+    return jalons.filter((jalon) => jalon !== SnapshotJalonEnum.COURANT);
   }
 }

--- a/apps/backend/src/referentiels/snapshots/snapshots.errors.ts
+++ b/apps/backend/src/referentiels/snapshots/snapshots.errors.ts
@@ -1,3 +1,4 @@
+import { collectivitePreferencesTrpcErrorEntries } from '@tet/backend/collectivites/collectivite-preferences/collectivite-preferences.errors';
 import {
   referentielModeGuardSpecificErrors,
   referentielNotWritableTrpcErrorEntry,
@@ -23,6 +24,7 @@ const snapshotSpecificErrors = [
 const specificErrors = [
   ...snapshotSpecificErrors,
   ...referentielModeGuardSpecificErrors,
+  'PREFERENCES_PARSE_ERROR',
 ] as const;
 type SpecificError = (typeof specificErrors)[number];
 
@@ -67,6 +69,8 @@ export const snapshotsTrpcErrorEntries = {
     message: 'Impossible de sauvegarder le snapshot de score',
   },
   ...referentielNotWritableTrpcErrorEntry,
+  PREFERENCES_PARSE_ERROR:
+    collectivitePreferencesTrpcErrorEntries.PREFERENCES_PARSE_ERROR,
 } as const;
 
 export const snapshotsErrorConfig: TrpcErrorHandlerConfig<SpecificError> = {

--- a/apps/backend/src/referentiels/snapshots/snapshots.router.e2e-spec.ts
+++ b/apps/backend/src/referentiels/snapshots/snapshots.router.e2e-spec.ts
@@ -1,11 +1,19 @@
 import { INestApplication } from '@nestjs/common';
-import { addTestCollectiviteAndUsers } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import {
+  addTestCollectiviteAndUser,
+  addTestCollectiviteAndUsers,
+} from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { collectiviteTable } from '@tet/backend/collectivites/shared/models/collectivite.table';
 import { snapshotTable } from '@tet/backend/referentiels/snapshots/snapshot.table';
 import {
   fixturePourScoreIndicatif,
   insertFixturePourScoreIndicatif,
 } from '@tet/backend/test';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import {
+  CollectiviteReferentielPreferences,
+  defaultCollectivitePreferences,
+} from '@tet/domain/collectivites';
 import {
   ActionDefinitionEssential,
   ActionTreeNode,
@@ -90,6 +98,8 @@ describe('SnapshotsRouter', () => {
   let databaseService: DatabaseService;
   let persoListenerTestCollectiviteId: number;
   let persoListenerTestUser: AuthenticatedUser;
+  let referentielModeTestCollectiviteId: number;
+  let referentielModeTestUser: AuthenticatedUser;
 
   beforeAll(async () => {
     app = await getTestApp();
@@ -132,10 +142,39 @@ describe('SnapshotsRouter', () => {
     const testUserFixture = testCollectiviteAndUsersResult.users[0];
     persoListenerTestUser = getAuthUserFromUserCredentials(testUserFixture);
 
+    const referentielModeTestResult = await addTestCollectiviteAndUser(
+      databaseService,
+      {
+        user: {
+          role: CollectiviteRole.ADMIN,
+        },
+      }
+    );
+    referentielModeTestCollectiviteId =
+      referentielModeTestResult.collectivite.id;
+    referentielModeTestUser = getAuthUserFromUserCredentials(
+      referentielModeTestResult.user
+    );
+
     return async () => {
       await app.close();
     };
   });
+
+  async function setReferentielPreferences(
+    collectiviteId: number,
+    referentiels: CollectiviteReferentielPreferences
+  ) {
+    await databaseService.db
+      .update(collectiviteTable)
+      .set({
+        preferences: {
+          ...defaultCollectivitePreferences,
+          referentiels,
+        },
+      })
+      .where(eq(collectiviteTable.id, collectiviteId));
+  }
 
   test("Création d'un snapshot: not authenticated", async () => {
     const caller = router.createCaller({ user: null });
@@ -375,6 +414,141 @@ describe('SnapshotsRouter', () => {
     };
 
     expect(referentielScoreWithoutActionsEnfant).toEqual(expectedCaeRoot);
+  });
+
+  test('getCurrent conserve score-courant en mode write', async () => {
+    const caller = router.createCaller({ user: referentielModeTestUser });
+
+    onTestFinished(async () => {
+      await setReferentielPreferences(referentielModeTestCollectiviteId, {
+        cae: { display: true, mode: 'write' },
+        eci: { display: true, mode: 'write' },
+        te: { display: true, mode: 'readonly' },
+      });
+    });
+
+    await setReferentielPreferences(referentielModeTestCollectiviteId, {
+      cae: { display: true, mode: 'write' },
+      eci: { display: true, mode: 'write' },
+      te: { display: true, mode: 'write' },
+    });
+
+    const snapshot = await caller.referentiels.snapshots.getCurrent({
+      collectiviteId: referentielModeTestCollectiviteId,
+      referentielId: ReferentielIdEnum.CAE,
+    });
+
+    expect(snapshot.ref).toBe('score-courant');
+    expect(snapshot.jalon).toBe(SnapshotJalonEnum.COURANT);
+  });
+
+  test('getCurrent retourne pre-switch-te en mode archived', async () => {
+    const caller = router.createCaller({ user: referentielModeTestUser });
+
+    onTestFinished(async () => {
+      await setReferentielPreferences(referentielModeTestCollectiviteId, {
+        cae: { display: true, mode: 'write' },
+        eci: { display: true, mode: 'write' },
+        te: { display: true, mode: 'readonly' },
+      });
+    });
+
+    const preSwitchSnapshot =
+      await caller.referentiels.snapshots.computeAndUpsert({
+        collectiviteId: referentielModeTestCollectiviteId,
+        referentielId: ReferentielIdEnum.CAE,
+        jalon: SnapshotJalonEnum.PRE_SWITCH_TE,
+      });
+
+    onTestFinished(async () => {
+      await databaseService.db
+        .delete(snapshotTable)
+        .where(
+          and(
+            eq(snapshotTable.collectiviteId, referentielModeTestCollectiviteId),
+            eq(snapshotTable.referentielId, ReferentielIdEnum.CAE),
+            eq(snapshotTable.ref, preSwitchSnapshot.ref)
+          )
+        );
+    });
+
+    await setReferentielPreferences(referentielModeTestCollectiviteId, {
+      cae: { display: false, mode: 'archived' },
+      eci: { display: true, mode: 'write' },
+      te: { display: true, mode: 'write' },
+    });
+
+    const snapshot = await caller.referentiels.snapshots.getCurrent({
+      collectiviteId: referentielModeTestCollectiviteId,
+      referentielId: ReferentielIdEnum.CAE,
+    });
+
+    expect(snapshot.ref).toBe('pre-switch-te');
+    expect(snapshot.jalon).toBe(SnapshotJalonEnum.PRE_SWITCH_TE);
+  });
+
+  test('getCurrent retourne 404 en mode archived sans pre-switch-te', async () => {
+    const caller = router.createCaller({ user: referentielModeTestUser });
+
+    onTestFinished(async () => {
+      await setReferentielPreferences(referentielModeTestCollectiviteId, {
+        cae: { display: true, mode: 'write' },
+        eci: { display: true, mode: 'write' },
+        te: { display: true, mode: 'readonly' },
+      });
+    });
+
+    await databaseService.db
+      .delete(snapshotTable)
+      .where(
+        and(
+          eq(snapshotTable.collectiviteId, referentielModeTestCollectiviteId),
+          eq(snapshotTable.referentielId, ReferentielIdEnum.CAE),
+          eq(snapshotTable.ref, 'pre-switch-te')
+        )
+      );
+
+    await setReferentielPreferences(referentielModeTestCollectiviteId, {
+      cae: { display: false, mode: 'archived' },
+      eci: { display: true, mode: 'write' },
+      te: { display: true, mode: 'write' },
+    });
+
+    await expect(
+      caller.referentiels.snapshots.getCurrent({
+        collectiviteId: referentielModeTestCollectiviteId,
+        referentielId: ReferentielIdEnum.CAE,
+      })
+    ).rejects.toThrow(
+      /Aucun snapshot de score avec la référence demandée n'a été trouvé/
+    );
+  });
+
+  test('getCurrent lève une erreur si le mode du référentiel ne peut pas être déterminé', async () => {
+    const caller = router.createCaller({ user: referentielModeTestUser });
+
+    onTestFinished(async () => {
+      await setReferentielPreferences(referentielModeTestCollectiviteId, {
+        cae: { display: true, mode: 'write' },
+        eci: { display: true, mode: 'write' },
+        te: { display: true, mode: 'readonly' },
+      });
+    });
+
+    // Forcer un échec de parsing des préférences (fail-closed attendu).
+    await databaseService.db
+      .update(collectiviteTable)
+      // `preferences` est un jsonb: on la force volontairement dans un état invalide
+      // pour déclencher `PREFERENCES_PARSE_ERROR`.
+      .set({ preferences: {} as unknown as any })
+      .where(eq(collectiviteTable.id, referentielModeTestCollectiviteId));
+
+    await expect(
+      caller.referentiels.snapshots.getCurrent({
+        collectiviteId: referentielModeTestCollectiviteId,
+        referentielId: ReferentielIdEnum.CAE,
+      })
+    ).rejects.toThrow(/préférences de la collectivité sont invalides/i);
   });
 
   test('Recompute current snapshot when scoresPayload payloadVersion is outdated', async () => {

--- a/apps/backend/src/referentiels/snapshots/snapshots.router.ts
+++ b/apps/backend/src/referentiels/snapshots/snapshots.router.ts
@@ -81,10 +81,9 @@ export class SnapshotsRouter {
       )
       .query(async ({ input, ctx }) => {
         return this.getResultDataOrThrowError(
-          await this.snapshots.get(
+          await this.snapshots.getCurrent(
             input.collectiviteId,
             input.referentielId,
-            undefined,
             { user: ctx.user }
           )
         );

--- a/apps/backend/src/referentiels/snapshots/snapshots.service.ts
+++ b/apps/backend/src/referentiels/snapshots/snapshots.service.ts
@@ -30,6 +30,10 @@ import { and, eq, getTableColumns, sql } from 'drizzle-orm';
 import { omit } from 'es-toolkit';
 import { DateTime } from 'luxon';
 import { z } from 'zod';
+import {
+  CollectiviteReferentielModeService,
+  isCollectiviteReferentielDisplayId,
+} from '../../collectivites/collectivite-referentiel-mode/collectivite-referentiel-mode.service';
 import { AuthUser } from '../../users/models/auth.models';
 import { DatabaseService } from '../../utils/database/database.service';
 import { Transaction } from '../../utils/database/transaction.utils';
@@ -53,7 +57,8 @@ export class SnapshotsService {
     private readonly scoresService: ScoresService,
     private readonly actionPersonnalisationService: ActionPersonnalisationsService,
     private readonly setPersonnalisationReponseService: SetPersonnalisationReponseService,
-    private readonly referentielDefinitionService: GetReferentielDefinitionService
+    private readonly referentielDefinitionService: GetReferentielDefinitionService,
+    private readonly collectiviteReferentielModeService: CollectiviteReferentielModeService
   ) {
     // Recompute score snapshots when personnalisation answers change.
     this.setPersonnalisationReponseService.registerResponseListener((event) =>
@@ -613,6 +618,56 @@ export class SnapshotsService {
     }
 
     return success(snapshot);
+  }
+
+  async getCurrent(
+    collectiviteId: number,
+    referentielId: ReferentielId,
+    { user, tx }: { user?: AuthUser; tx?: Transaction } = {}
+  ): Promise<Result<ScoreSnapshot, SnapshotsError>> {
+    if (!isCollectiviteReferentielDisplayId(referentielId)) {
+      return this.get(collectiviteId, referentielId, undefined, { user, tx });
+    }
+
+    const referentielModeResult =
+      await this.collectiviteReferentielModeService.getReferentielMode(
+        collectiviteId,
+        referentielId
+      );
+
+    if (!referentielModeResult.success) {
+      // si on ne sait pas si le référentiel est archivé, on ne renvoie pas
+      // `score-courant`
+      this.logger.error(
+        `Unable to resolve referentiel mode for collectivite ${collectiviteId}, referentiel ${referentielId}: ${referentielModeResult.error}`
+      );
+
+      if (
+        referentielModeResult.error === 'PREFERENCES_PARSE_ERROR' ||
+        referentielModeResult.error === 'COLLECTIVITE_NOT_FOUND'
+      ) {
+        return failure(
+          referentielModeResult.error,
+          referentielModeResult.cause
+        );
+      }
+
+      return failure(
+        SnapshotsErrorEnum.SERVER_ERROR,
+        referentielModeResult.cause
+      );
+    }
+
+    if (referentielModeResult.data === 'archived') {
+      return this.get(
+        collectiviteId,
+        referentielId,
+        SNAPSHOTS.PRE_SWITCH_TE_REF,
+        { user, tx }
+      );
+    }
+
+    return this.get(collectiviteId, referentielId, undefined, { user, tx });
   }
 
   async forceRecompute(

--- a/doc/plans/2026-06-11-001-feat-bascule-referentiel-te-prd.md
+++ b/doc/plans/2026-06-11-001-feat-bascule-referentiel-te-prd.md
@@ -225,9 +225,10 @@ Règle transversale : sources `concerne = false` (non concerné explicite ou dé
 - **PR10** : un snapshot par ref. CAE/ECI en `mode: write` au moment de la bascule (refs engagés, source principale de migration).
 - **PR17/PR18** : compléter si besoin pour un ref. `archived` dont des actions d'origine participent quand même à la fusion TE (ex. CAE engagé + ECI archived mais sources ECI fusionnées via `action_origine`) — détection au moment de la migration, pas en PR10.
 
-**Consommation sur ref archivée** :
-- `list` : exclure `score-courant` si `mode === 'archived'`.
-- `getCurrent` : retourner `pre-switch-te` (si créé), **sans recalcul** même si versions obsolètes ; ref sans snapshot (jamais engagé, aucune donnée fusionnée) → pas de cas pertinent.
+**Consommation sur référentiel archivé** :
+
+- `list` / `listWithScores` : exclure `score-courant` si `mode === 'archived'`.
+- `getCurrent` : retourner `pre-switch-te`, **sans recalcul** même si versions obsolètes ; en l'absence de snapshot `pre-switch-te`, retourner `404` (défensif, sans fallback sur `score-courant`).
 - Export score-comparaison : exclure `score-courant` ; proposer `pre-switch-te`.
 
 **TE post-bascule** : coexistence `post-switch-te` (figé à la bascule) + `score-courant` (vivant, recalculé à chaque saisie ou changement de personnalisation TE). Graphiques d'évolution : afficher les deux jalons.
@@ -404,7 +405,10 @@ Feedback rapide possible après PR5–PR7 (lecture seule visible).
 
 ### PR11 — Snapshots sur refs archivées
 
-- Logique `list` / `getCurrent` archivés : cf. [Snapshots](#snapshots).
+- Logique `list` / `listWithScores` / `getCurrent` archivés : cf. [Snapshots](#snapshots).
+- `SnapshotsService.get` reste inchangé (méthode partagée) ; ajouter `SnapshotsService.getCurrent` pour la politique `archived` (`pre-switch-te`).
+- Filtrage `COURANT` factorisé dans `ListSnapshotsService` via méthode privée commune (sans duplication `list`/`listWithScores`).
+- Détail d'implémentation : `doc/plans/2026-06-11-006-feat-bascule-referentiel-te-pr11-plan.md`.
 
 ### PR12 — Fusion statuts
 

--- a/doc/plans/2026-06-11-006-feat-bascule-referentiel-te-pr11-plan.md
+++ b/doc/plans/2026-06-11-006-feat-bascule-referentiel-te-pr11-plan.md
@@ -1,0 +1,142 @@
+---
+name: PR11 Snapshots refs archivées
+overview: "Adapter les lectures de snapshots pour les référentiels `archived` : masquer `score-courant` dans `list` et `listWithScores`, et faire retourner `pre-switch-te` par `getCurrent`, sans modifier la primitive partagée `SnapshotsService.get`."
+todos:
+  - id: list-filter
+    content: Filtrer SnapshotJalonEnum.COURANT pour les refs archived dans list et listWithScores via une méthode privée commune
+    status: completed
+  - id: getcurrent-service
+    content: Ajouter SnapshotsService.getCurrent (politique archived => pre-switch-te) en conservant get inchangé
+    status: completed
+  - id: router-wiring
+    content: Câbler le routeur snapshots.getCurrent vers SnapshotsService.getCurrent
+    status: completed
+  - id: tests-existing
+    content: Étendre les specs existantes list-snapshots et snapshots.router.e2e-spec
+    status: completed
+  - id: run-tests
+    content: Lancer les tests backend ciblés PR11
+    status: completed
+isProject: false
+---
+
+# PR11 — Snapshots sur référentiels archivés
+
+**Parent** : `doc/plans/2026-06-11-001-feat-bascule-referentiel-te-prd.md`
+
+**Branche** : `TE-7303/switch-te-PR11` depuis `main` (PR10 mergée)
+
+**Estimation** : ~300 LOC (code + tests)
+
+---
+
+## Contexte
+
+PR10 a introduit le snapshot `pre-switch-te` et la préparation de la bascule.  
+Le PRD précise pour les référentiels `archived` :
+
+- `list` ne doit plus exposer `score-courant`,
+- `getCurrent` doit retourner `pre-switch-te`,
+- sans recalcul de snapshot courant.
+
+Cette PR reste strictement sur `list` / `listWithScores` / `getCurrent`.  
+L’export score-comparaison reste traité en PR23.
+
+---
+
+## Décisions actées
+
+| Sujet | Décision |
+| --- | --- |
+| Primitive snapshots | `SnapshotsService.get(...)` reste inchangée (méthode partagée par d'autres services) |
+| API getCurrent | Nouvelle méthode `SnapshotsService.getCurrent(...)` dédiée à la politique de lecture PR11 |
+| Règle getCurrent archived | Si `mode === 'archived'` : lecture de `pre-switch-te`; sinon comportement actuel (`score-courant`) |
+| Cas absent | Si `pre-switch-te` est absent : 404 défensif (aucun fallback sur `score-courant`) |
+| Filtrage listes | Filtre `SnapshotJalonEnum.COURANT` sur **`list` et `listWithScores`** |
+| Implémentation filtre | Méthode privée commune dans `ListSnapshotsService` pour éviter la duplication |
+| Test strategy | Étendre les tests existants (`list-snapshots.controller.spec.ts`, `list-snapshots.service.e2e-spec.ts`, `snapshots.router.e2e-spec.ts`) |
+
+---
+
+## Implémentation
+
+### 1) `ListSnapshotsService` — filtrage commun archived
+
+Fichier : `apps/backend/src/referentiels/snapshots/list-snapshots/list-snapshots.service.ts`
+
+- Injecter `CollectiviteReferentielModeService`.
+- Ajouter une méthode privée commune, par exemple :
+  - `getEffectiveJalons(collectiviteId, referentielId, jalons)`
+- Logique :
+  - lire le mode via `collectiviteReferentielModeService`,
+  - si `referentielId` n'est pas un display id (`cae|eci|te`) : ne rien filtrer,
+  - si `mode === 'archived'` : retirer `SnapshotJalonEnum.COURANT`,
+  - sinon : laisser `jalons` inchangé.
+- Réutiliser cette méthode dans **`list`** et **`listWithScores`**.
+
+### 2) `SnapshotsService` — nouvelle méthode `getCurrent`
+
+Fichier : `apps/backend/src/referentiels/snapshots/snapshots.service.ts`
+
+- Ajouter `getCurrent(collectiviteId, referentielId, context?)` où `context` est un `Partial<ServiceSecondArg>` (`{ user?, isUserTrusted?, tx? }`).
+- Logique :
+  - si référentiel non display id : déléguer à `get(..., score-courant)` en propageant `user`, `isUserTrusted` et `tx` du contexte,
+  - lire le mode référentiel,
+  - `archived` => `get(..., pre-switch-te)` (sans recompute) en propageant le même contexte,
+  - sinon => `get(..., score-courant)` (comportement actuel, avec recompute si nécessaire) en propageant le même contexte.
+- La logique de sélection des scores (display id / mode archived / ref snapshot) reste inchangée ; seul le contexte de service est transmis tel quel à `get`.
+- `get(...)` n’est pas modifiée (logique métier inchangée).
+
+### 3) `SnapshotsRouter` — câblage
+
+Fichier : `apps/backend/src/referentiels/snapshots/snapshots.router.ts`
+
+- Route `getCurrent` : appeler `this.snapshots.getCurrent(...)` au lieu de `this.snapshots.get(...)`.
+
+---
+
+## Tests
+
+### A. Extension `list-snapshots.service.e2e-spec.ts`
+
+Ajouter des scénarios de filtrage `archived` :
+
+- quand le mode est `archived`, `list` n’inclut pas `SnapshotJalonEnum.COURANT`,
+- quand le mode est `archived`, `listWithScores` n’inclut pas `SnapshotJalonEnum.COURANT`,
+- quand le mode n’est pas `archived`, `COURANT` reste présent.
+
+### B. Extension `snapshots.router.e2e-spec.ts`
+
+Ajouter des scénarios `getCurrent` :
+
+- mode `write|readonly` : comportement courant inchangé (retourne `score-courant`),
+- mode `archived` avec `pre-switch-te` : `getCurrent` retourne `pre-switch-te`,
+- mode `archived` sans `pre-switch-te` : `getCurrent` retourne 404.
+
+### C. Extension `list-snapshots.controller.spec.ts` (si nécessaire)
+
+- Vérifier que l’API REST de listing reflète le même filtrage `archived` que tRPC.
+
+### Commandes tests
+
+- `pnpm test:backend snapshots.router.e2e-spec`
+- `pnpm test:backend list-snapshots`
+
+---
+
+## Hors scope PR11
+
+- Export score-comparaison (PR23)
+- UI snapshots post-bascule (PR22)
+- Complément snapshot archived pendant fusion (PR17/PR18)
+
+---
+
+## Critères de done
+
+- [x] `list` et `listWithScores` excluent `COURANT` pour les refs `archived`
+- [x] la logique est factorisée via une méthode privée commune (pas de duplication)
+- [x] `SnapshotsService.getCurrent` implémente la politique archived (`pre-switch-te`)
+- [x] `SnapshotsService.get` reste inchangée
+- [x] routeur `getCurrent` branché sur la nouvelle méthode
+- [x] tests existants étendus et verts avec `pnpm test:backend <pattern>`


### PR DESCRIPTION
Masque `score-courant` dans list/listWithScores et retourne `pre-switch-te` via getCurrent quand le mode est `archived`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Nouvelles fonctionnalités**
  - La consultation des snapshots s’adapte désormais au mode du référentiel.
  - En mode archivé, le snapshot `COURANT` est masqué des listes.
  - La consultation du snapshot courant utilise `pre-switch-te` en mode archivé, avec un retour 404 si absent.
  - Les préférences invalides déclenchent une erreur explicite.
- **Tests**
  - Ajout/extension de scénarios E2E et de tests de service couvrant les modes actif/archivé et les cas d’erreur.
- **Documentation**
  - Mise à jour des plans fonctionnels et techniques associés.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->