### PR TITLE
Grille de saisie : légende (open data + collage) + simplification du contrôleur de données

### DIFF
--- a/apps/app/src/indicateurs/valeurs/grid/grid-frame.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/grid-frame.tsx
@@ -12,6 +12,7 @@ import { useGridReorder } from './drag-reorder/use-grid-reorder';
 import { useGridDragHandlers } from './drag-reorder/use-grid-drag-handlers';
 import { GridHead } from './grid-head';
 import { GridBody } from './grid-body';
+import { GridLegend } from './grid-legend';
 
 export const GridFrame = (): JSX.Element => {
   const {
@@ -98,6 +99,7 @@ export const GridFrame = (): JSX.Element => {
             </Button>
           </div>
         )}
+        <GridLegend />
         <div className="max-h-[70vh] overflow-auto">
           <table
             ref={tableRef}

--- a/apps/app/src/indicateurs/valeurs/grid/grid-legend.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/grid-legend.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { Icon } from '@tet/ui';
+import { JSX } from 'react';
+import { appLabels } from '@/app/labels/catalog';
+
+export const GridLegend = (): JSX.Element => (
+  <ul className="m-0 flex flex-wrap items-center gap-x-6 gap-y-1 p-0 list-none text-xs text-grey-7">
+    <li className="flex items-center gap-2">
+      <span className="h-2 w-2 rounded-full bg-primary-7 ring-2 ring-primary-2" />
+      {appLabels.indicateurLegendeOpenData}
+    </li>
+    <li className="flex items-center gap-2">
+      <Icon icon="clipboard-line" size="sm" />
+      {appLabels.indicateurLegendeCollage}
+    </li>
+  </ul>
+);

--- a/apps/app/src/indicateurs/valeurs/grid/use-indicateur-grid-data.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/use-indicateur-grid-data.ts
@@ -24,7 +24,7 @@ import {
 export type IndicateurGridData = {
   groups: GridGroups;
   cells: Map<CellKey, GridCell>;
-  identifiantById: Map<number, string>;
+  identifiantReferentielByIndicateurId: Map<number, string>;
   unit: string | undefined;
   isLoading: boolean;
 };
@@ -34,6 +34,33 @@ const emptyUserCell = (): GridCell => ({
   value: null,
   coveringSources: [],
 });
+
+const toIndicateurIdByIdentifiantReferentiel = (
+  definitions: { id: number; identifiantReferentiel: string | null }[]
+): Map<string, number> =>
+  new Map(
+    definitions.flatMap((definition) =>
+      definition.identifiantReferentiel === null
+        ? []
+        : [[definition.identifiantReferentiel, definition.id] as const]
+    )
+  );
+
+const invertMap = <K, V>(map: Map<K, V>): Map<V, K> =>
+  new Map([...map].map(([key, value]) => [value, key]));
+
+const emptyUserCells = (
+  ids: number[],
+  years: Year[]
+): Map<CellKey, GridCell> =>
+  new Map(
+    ids.flatMap((id) =>
+      years.map((year): [CellKey, GridCell] => [
+        generateCellKey(toIndicateurId(id), year),
+        emptyUserCell(),
+      ])
+    )
+  );
 
 export const useIndicateurGridData = ({
   layout,
@@ -60,43 +87,20 @@ export const useIndicateurGridData = ({
 
   return useMemo<IndicateurGridData>(() => {
     const definitionItems = definitions.data?.data ?? [];
-    const idByIdentifiant = new Map(
-      definitionItems.flatMap((definition) =>
-        definition.identifiantReferentiel === null
-          ? []
-          : [[definition.identifiantReferentiel, definition.id] as const]
-      )
-    );
-    const identifiantById = new Map(
-      definitionItems.flatMap((definition) =>
-        definition.identifiantReferentiel === null
-          ? []
-          : [[definition.id, definition.identifiantReferentiel] as const]
-      )
-    );
-
-    const baseCells = new Map<CellKey, GridCell>(
-      [...idByIdentifiant.values()].flatMap((id) =>
-        years.map(
-          (year): [CellKey, GridCell] => [
-            generateCellKey(toIndicateurId(id), year),
-            emptyUserCell(),
-          ]
-        )
-      )
-    );
+    const indicateurIdByIdentifiantReferentiel = toIndicateurIdByIdentifiantReferentiel(definitionItems);
+    const baseCells = emptyUserCells([...indicateurIdByIdentifiantReferentiel.values()], years);
     const filledCells = fromIndicateur(
       valeurs.data?.indicateurs ?? [],
       referenceYear
     );
 
     return {
-      groups: layoutToGridGroups(layout, idByIdentifiant),
+      groups: layoutToGridGroups(layout, indicateurIdByIdentifiantReferentiel),
       cells: applyOpenDataSelections(
         new Map([...baseCells, ...filledCells]),
         openDataSelections
       ),
-      identifiantById,
+      identifiantReferentielByIndicateurId: invertMap(indicateurIdByIdentifiantReferentiel),
       unit: definitionItems[0]?.unite,
       isLoading: definitions.isLoading || valeurs.isLoading,
     };

--- a/apps/app/src/labels/catalog.ts
+++ b/apps/app/src/labels/catalog.ts
@@ -1797,6 +1797,9 @@ export const appLabels = {
   indicateurValeurOpenDataDisponible: 'Valeur open data disponible',
   indicateurCelluleOpenDataDisponible:
     'Open data disponible pour cette cellule',
+  indicateurLegendeOpenData: 'Valeur open data disponible',
+  indicateurLegendeCollage:
+    'Collez une sélection de valeurs depuis un tableur (Ctrl+V)',
   indicateurSelectionnerValeurEchec:
     'La sélection de la valeur open data a échoué',
   indicateurRepasserSaisieManuelle: 'Repasser en saisie manuelle',


### PR DESCRIPTION
Deux améliorations sur le module agnostique de grille d'indicateurs (`indicateurs/valeurs/grid/`), indépendantes.

## Contenu (2 commits)

### `refactor(indicateurs)` — simplification du contrôleur de données
`use-indicateur-grid-data.ts` construisait **deux Maps miroir** (`identifiant→id` et `id→identifiant`) avec le même `flatMap` + garde-null dupliqué. Désormais `identifiantById` est dérivé par **inversion** de `idByIdentifiant`, et la logique est extraite en petites fonctions pures (`toIdByIdentifiant`, `invertMap`, `emptyUserCells`). Le `useMemo` passe de ~40 à ~15 lignes, chaque étape nommée. Aucun changement de comportement.

### `feat(indicateurs)` — légende de la grille
Ajoute une légende au-dessus de la grille expliquant les **deux affordances par défaut** :
- 🔵 pastille bleue = **valeur open data disponible** pour la cellule
- **collage** d'une sélection de valeurs depuis un tableur (Ctrl+V)

Composant `GridLegend` rendu dans `GridFrame`, 2 labels dédiés dans le catalog.

## Note de coordination
Basé sur `main` (noms actuels `GridLayout`/`layoutToGridGroups`). Un rename `→ IndicateurGridShape` est en attente sur une autre branche ; les deux touchent `use-indicateur-grid-data.ts` → petit conflit à résoudre au merge du second (hunks proches). Pas de consommateur sur `main` (comme #4712) → **draft** jusqu'à ce que la grille soit câblée.

## Vérifications
- `tsc` : **0 erreur**
- specs grille : **129/129**
- eslint : clean
