### PR TITLE
Grille de saisie : renomme GridLayout en IndicateurGridShape (agnostique)

### DIFF
--- a/apps/app/src/indicateurs/valeurs/grid/indicateur-grid-shape.spec.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/indicateur-grid-shape.spec.ts
@@ -1,17 +1,21 @@
 import { describe, expect, it } from 'vitest';
-import { applyRowOrder, GridLayout, layoutToGridGroups } from './grid-layout';
+import {
+  applyRowOrder,
+  IndicateurGridShape,
+  shapeToGridGroups,
+} from './indicateur-grid-shape';
 
-describe('layoutToGridGroups', () => {
-  it('résout les identifiants en indicateurIds en conservant l\'ordre du layout', () => {
-    const layout: GridLayout = {
+describe('shapeToGridGroups', () => {
+  it('résout les identifiants en indicateurIds en conservant l\'ordre de la shape', () => {
+    const shape: IndicateurGridShape = {
       NOx: { Résidentiel: 'cae_4.aa', Agriculture: 'cae_4.ac' },
     };
-    const idByIdentifiant = new Map([
+    const indicateurIdByIdentifiantReferentiel = new Map([
       ['cae_4.aa', 11],
       ['cae_4.ac', 13],
     ]);
 
-    expect(layoutToGridGroups(layout, idByIdentifiant)).toEqual({
+    expect(shapeToGridGroups(shape, indicateurIdByIdentifiantReferentiel)).toEqual({
       NOx: {
         label: 'NOx',
         rows: [
@@ -23,18 +27,18 @@ describe('layoutToGridGroups', () => {
   });
 
   it('ignore une ligne dont l\'identifiant n\'est pas résolu', () => {
-    const layout: GridLayout = {
+    const shape: IndicateurGridShape = {
       NOx: { Résidentiel: 'cae_4.aa', Inconnu: 'cae_4.zz' },
     };
 
-    const groups = layoutToGridGroups(layout, new Map([['cae_4.aa', 11]]));
+    const groups = shapeToGridGroups(shape, new Map([['cae_4.aa', 11]]));
 
     expect(groups.NOx.rows).toEqual([{ indicateurId: 11, label: 'Résidentiel' }]);
   });
 });
 
 describe('applyRowOrder', () => {
-  const layout: GridLayout = {
+  const shape: IndicateurGridShape = {
     NOx: {
       Résidentiel: 'cae_4.aa',
       Agriculture: 'cae_4.ac',
@@ -45,7 +49,7 @@ describe('applyRowOrder', () => {
   it('réordonne les lignes du groupe selon les identifiants stockés', () => {
     expect(
       Object.entries(
-        applyRowOrder(layout, { NOx: ['cae_4.ae', 'cae_4.aa', 'cae_4.ac'] }).NOx
+        applyRowOrder(shape, { NOx: ['cae_4.ae', 'cae_4.aa', 'cae_4.ac'] }).NOx
       )
     ).toEqual([
       ['Transport', 'cae_4.ae'],
@@ -55,14 +59,14 @@ describe('applyRowOrder', () => {
   });
 
   it('garde l\'ordre initial pour un groupe sans ordre stocké', () => {
-    expect(Object.entries(applyRowOrder(layout, {}).NOx)).toEqual(
-      Object.entries(layout.NOx)
+    expect(Object.entries(applyRowOrder(shape, {}).NOx)).toEqual(
+      Object.entries(shape.NOx)
     );
   });
 
   it('place les lignes absentes de l\'ordre stocké après les lignes ordonnées', () => {
     expect(
-      Object.entries(applyRowOrder(layout, { NOx: ['cae_4.ae'] }).NOx)
+      Object.entries(applyRowOrder(shape, { NOx: ['cae_4.ae'] }).NOx)
     ).toEqual([
       ['Transport', 'cae_4.ae'],
       ['Résidentiel', 'cae_4.aa'],

--- a/apps/app/src/indicateurs/valeurs/grid/indicateur-grid-shape.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/indicateur-grid-shape.ts
@@ -1,26 +1,22 @@
 import { sortBy } from 'es-toolkit';
-import {
-  GridGroups,
-  GridRow,
-  toIndicateurId,
-} from './types';
+import { GridGroups, GridRow, toIndicateurId } from './types';
 
-export type GridLayout = Record<string, Record<string, string>>;
+export type IndicateurGridShape = Record<string, Record<string, string>>;
 
 export type RowOrder = Record<string, string[]>;
 
-export const layoutToGridGroups = (
-  layout: GridLayout,
-  idByIdentifiant: Map<string, number>
+export const shapeToGridGroups = (
+  shape: IndicateurGridShape,
+  indicateurIdByIdentifiantReferentiel: Map<string, number>
 ): GridGroups =>
   Object.fromEntries(
-    Object.entries(layout).map(([groupLabel, rowsByLabel]) => [
+    Object.entries(shape).map(([groupLabel, rowsByLabel]) => [
       groupLabel,
       {
         label: groupLabel,
         rows: Object.entries(rowsByLabel).flatMap(
           ([rowLabel, identifiant]): GridRow[] => {
-            const indicateurId = idByIdentifiant.get(identifiant);
+            const indicateurId = indicateurIdByIdentifiantReferentiel.get(identifiant);
             return indicateurId === undefined
               ? []
               : [{ indicateurId: toIndicateurId(indicateurId), label: rowLabel }];
@@ -30,15 +26,15 @@ export const layoutToGridGroups = (
     ])
   );
 
-export const layoutIdentifiants = (layout: GridLayout): string[] =>
-  Object.values(layout).flatMap((rowsByLabel) => Object.values(rowsByLabel));
+export const shapeIdentifiants = (shape: IndicateurGridShape): string[] =>
+  Object.values(shape).flatMap((rowsByLabel) => Object.values(rowsByLabel));
 
 export const applyRowOrder = (
-  layout: GridLayout,
+  shape: IndicateurGridShape,
   rowOrder: RowOrder
-): GridLayout =>
+): IndicateurGridShape =>
   Object.fromEntries(
-    Object.entries(layout).map(
+    Object.entries(shape).map(
       ([groupLabel, rowsByLabel]): [string, Record<string, string>] => {
         const order = rowOrder[groupLabel];
         if (order === undefined) {

--- a/apps/app/src/indicateurs/valeurs/grid/use-indicateur-grid-data.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/use-indicateur-grid-data.ts
@@ -16,10 +16,10 @@ import {
 } from './types';
 import { applyOpenDataSelections } from './apply-open-data-selections';
 import {
-  GridLayout,
-  layoutIdentifiants,
-  layoutToGridGroups,
-} from './grid-layout';
+  IndicateurGridShape,
+  shapeIdentifiants,
+  shapeToGridGroups,
+} from './indicateur-grid-shape';
 
 export type IndicateurGridData = {
   groups: GridGroups;
@@ -63,20 +63,20 @@ const emptyUserCells = (
   );
 
 export const useIndicateurGridData = ({
-  layout,
+  shape,
   referenceYear,
   years,
   openDataSelections,
 }: {
-  layout: GridLayout;
+  shape: IndicateurGridShape;
   referenceYear: Year;
   years: Year[];
   openDataSelections: Record<CellKey, SourceId>;
 }): IndicateurGridData => {
   const collectiviteId = useCollectiviteId();
   const identifiantsReferentiel = useMemo(
-    () => layoutIdentifiants(layout).sort(),
-    [layout]
+    () => shapeIdentifiants(shape).sort(),
+    [shape]
   );
 
   const definitions = useListIndicateurs({
@@ -95,7 +95,7 @@ export const useIndicateurGridData = ({
     );
 
     return {
-      groups: layoutToGridGroups(layout, indicateurIdByIdentifiantReferentiel),
+      groups: shapeToGridGroups(shape, indicateurIdByIdentifiantReferentiel),
       cells: applyOpenDataSelections(
         new Map([...baseCells, ...filledCells]),
         openDataSelections
@@ -105,7 +105,7 @@ export const useIndicateurGridData = ({
       isLoading: definitions.isLoading || valeurs.isLoading,
     };
   }, [
-    layout,
+    shape,
     referenceYear,
     years,
     openDataSelections,


### PR DESCRIPTION
Rename agnostique sur le module de grille (`indicateurs/valeurs/grid/`) : le type décrivait **quels indicateurs** (par identifiant référentiel) composent la grille, groupés et labellisés — pas un placement visuel. « layout » était trompeur.

## Contenu (1 commit)
- `GridLayout` → **`IndicateurGridShape`**
- `layoutToGridGroups` → `shapeToGridGroups` · `layoutIdentifiants` → `shapeIdentifiants`
- fichier `grid-layout.ts` → `indicateur-grid-shape.ts` (+ spec)
- `use-indicateur-grid-data.ts` : imports + param `layout` → `shape` (seul consommateur agnostique)

Les **constantes PCAET** (`SEQUESTRATION_GRID_SHAPE` & co, `VOLET_GRID_SHAPES`, prop `initialShape`) restent sur la branche PCAET — hors périmètre.

## Coordination
Touche `use-indicateur-grid-data.ts`, comme #4716 (légende + simplification du contrôleur). Petit conflit de hunks proches quand le second mergera. Ordre conseillé : merger #4716 d'abord, puis rebaser ce rename. Pas de consommateur sur `main` → **draft**.

## Vérifications
- `tsc` : **0 erreur** · specs grille : **129/129** · eslint : clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * La grille d’indicateurs utilise désormais une structure plus cohérente pour organiser les données, sans changement visible dans l’interface.
  * Le traitement de l’ordre des lignes et des groupes a été mis à jour pour rester stable avec cette nouvelle structure.

* **Tests**
  * Les tests ont été ajustés pour couvrir le nouvel enchaînement de traitement.
  * Les cas vérifient toujours le bon ordre d’affichage et l’ignorance des éléments non résolus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->