### PR TITLE
fix(indicateurs): propage la severite au notify de la grille de saisie

### DIFF
--- a/apps/app/src/indicateurs/valeurs/grid/grid-context.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/grid-context.tsx
@@ -6,6 +6,7 @@ import {
   GridCell,
   GridRowGroup,
   IndicateurValuesGridActions,
+  NotifyGridEvent,
   Year,
 } from './types';
 
@@ -19,7 +20,7 @@ export type GridContextValue = {
   isLoading: boolean;
   isReorderable: boolean;
   actions: IndicateurValuesGridActions;
-  notify: (message: string) => void;
+  notify: NotifyGridEvent;
   onReorderRows?: (params: {
     groupId: string;
     activeId: string;
@@ -35,7 +36,7 @@ export type GridCellServices = {
   selectOpenData: IndicateurValuesGridActions['selectOpenData'];
   clearCell: IndicateurValuesGridActions['clearCell'];
   unit: string | null;
-  notify: (message: string) => void;
+  notify: NotifyGridEvent;
 };
 
 const GridCellServicesContext = createContext<GridCellServices | null>(null);

--- a/apps/app/src/indicateurs/valeurs/grid/grid-frame.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/grid-frame.tsx
@@ -71,7 +71,7 @@ export const GridFrame = (): JSX.Element => {
   const handleReset = (): void => {
     reset();
     setResetMessage(appLabels.indicateurOrdreReinitialise);
-    notify(appLabels.indicateurOrdreReinitialise);
+    notify(appLabels.indicateurOrdreReinitialise, 'success');
   };
 
   return (

--- a/apps/app/src/indicateurs/valeurs/grid/indicateur-values-grid.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/indicateur-values-grid.tsx
@@ -9,6 +9,7 @@ import {
   GridCell,
   GridInput,
   IndicateurValuesGridActions,
+  NotifyGridEvent,
   Year,
 } from './types';
 
@@ -20,7 +21,7 @@ export type IndicateurValuesGridProps = {
   cells: Map<CellKey, GridCell>;
   isLoading?: boolean;
   actions: IndicateurValuesGridActions;
-  notify: (message: string) => void;
+  notify: NotifyGridEvent;
   onReorderRows?: (params: {
     groupId: string;
     activeId: string;

--- a/apps/app/src/indicateurs/valeurs/grid/open-data-picker/build-open-data-handlers.spec.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/open-data-picker/build-open-data-handlers.spec.ts
@@ -35,7 +35,8 @@ describe('buildOpenDataHandlers', () => {
     await buildOpenDataHandlers(args).onSelect(toSourceId('citepa'));
 
     expect(args.notify).toHaveBeenCalledWith(
-      appLabels.indicateurSelectionnerValeurEchec
+      appLabels.indicateurSelectionnerValeurEchec,
+      'error'
     );
     expect(args.close).not.toHaveBeenCalled();
   });
@@ -53,7 +54,8 @@ describe('buildOpenDataHandlers', () => {
     await buildOpenDataHandlers(args).onReset();
 
     expect(args.notify).toHaveBeenCalledWith(
-      appLabels.indicateurRepasserSaisieEchec
+      appLabels.indicateurRepasserSaisieEchec,
+      'error'
     );
     expect(args.close).not.toHaveBeenCalled();
   });
@@ -69,7 +71,8 @@ describe('buildOpenDataHandlers', () => {
 
     expect(await handlers.columnSelection?.onSelect()).toBe(false);
     expect(args.notify).toHaveBeenCalledWith(
-      appLabels.indicateurSelectionnerValeurEchec
+      appLabels.indicateurSelectionnerValeurEchec,
+      'error'
     );
     expect(args.close).not.toHaveBeenCalled();
   });

--- a/apps/app/src/indicateurs/valeurs/grid/open-data-picker/build-open-data-handlers.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/open-data-picker/build-open-data-handlers.ts
@@ -29,7 +29,7 @@ export const buildOpenDataHandlers = ({
     if (selectionResult.ok) {
       close();
     } else {
-      notify(appLabels.indicateurSelectionnerValeurEchec);
+      notify(appLabels.indicateurSelectionnerValeurEchec, 'error');
     }
   };
 
@@ -38,7 +38,7 @@ export const buildOpenDataHandlers = ({
     if (resetResult.ok) {
       close();
     } else {
-      notify(appLabels.indicateurRepasserSaisieEchec);
+      notify(appLabels.indicateurRepasserSaisieEchec, 'error');
     }
   };
 
@@ -56,7 +56,7 @@ export const buildOpenDataHandlers = ({
         if (allSelected) {
           close();
         } else {
-          notify(appLabels.indicateurSelectionnerValeurEchec);
+          notify(appLabels.indicateurSelectionnerValeurEchec, 'error');
         }
         return allSelected;
       },

--- a/apps/app/src/indicateurs/valeurs/grid/paste/grid-paste.spec.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/paste/grid-paste.spec.tsx
@@ -82,7 +82,8 @@ describe('IndicateurValuesGrid paste', () => {
       { indicateurId: toIndicateurId(2), year: toYear(2036), value: 40 },
     ]);
     expect(notify).toHaveBeenCalledWith(
-      appLabels.indicateurCollageIgnore({ count: 2 })
+      appLabels.indicateurCollageIgnore({ count: 2 }),
+      'info'
     );
   });
 
@@ -120,7 +121,8 @@ describe('IndicateurValuesGrid paste', () => {
     await waitFor(() => expect(saveCellValues).toHaveBeenCalledTimes(1));
     await waitFor(() =>
       expect(notify).toHaveBeenCalledWith(
-        appLabels.indicateurCollageEchec({ count: 1 })
+        appLabels.indicateurCollageEchec({ count: 1 }),
+        'error'
       )
     );
   });
@@ -137,7 +139,8 @@ describe('IndicateurValuesGrid paste', () => {
     await waitFor(() => expect(saveCellValues).toHaveBeenCalledTimes(1));
     await waitFor(() =>
       expect(notify).toHaveBeenCalledWith(
-        appLabels.indicateurCollageEchec({ count: 4 })
+        appLabels.indicateurCollageEchec({ count: 4 }),
+        'error'
       )
     );
   });
@@ -154,7 +157,8 @@ describe('IndicateurValuesGrid paste', () => {
     await waitFor(() => expect(saveCellValues).toHaveBeenCalledTimes(1));
     await waitFor(() =>
       expect(notify).toHaveBeenCalledWith(
-        appLabels.indicateurCollageEchec({ count: 4 })
+        appLabels.indicateurCollageEchec({ count: 4 }),
+        'error'
       )
     );
   });

--- a/apps/app/src/indicateurs/valeurs/grid/paste/use-grid-copy-paste.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/paste/use-grid-copy-paste.ts
@@ -9,6 +9,7 @@ import {
   GridRowGroup,
   IndicateurValuesGridActions,
   isCellKey,
+  NotifyGridEvent,
   parseCellKey,
   Year,
 } from '../types';
@@ -20,7 +21,7 @@ const writeAndReportFailures = async ({
 }: {
   cellsToWrite: CellValueInput[];
   saveCellValues: IndicateurValuesGridActions['saveCellValues'];
-  notify: (message: string) => void;
+  notify: NotifyGridEvent;
 }): Promise<void> => {
   try {
     const result = await saveCellValues(cellsToWrite);
@@ -28,10 +29,13 @@ const writeAndReportFailures = async ({
       ? result.value.failed.length
       : cellsToWrite.length;
     if (failedCount > 0) {
-      notify(appLabels.indicateurCollageEchec({ count: failedCount }));
+      notify(appLabels.indicateurCollageEchec({ count: failedCount }), 'error');
     }
   } catch {
-    notify(appLabels.indicateurCollageEchec({ count: cellsToWrite.length }));
+    notify(
+      appLabels.indicateurCollageEchec({ count: cellsToWrite.length }),
+      'error'
+    );
   }
 };
 
@@ -46,7 +50,7 @@ export const useGridCopyPaste = ({
   years: Year[];
   cells: Map<CellKey, GridCell>;
   saveCellValues: IndicateurValuesGridActions['saveCellValues'];
-  notify: (message: string) => void;
+  notify: NotifyGridEvent;
 }): {
   onPaste: (event: ClipboardEvent<HTMLElement>) => void;
 } => {
@@ -75,7 +79,7 @@ export const useGridCopyPaste = ({
       }
       event.preventDefault();
       if (skipped > 0) {
-        notify(appLabels.indicateurCollageIgnore({ count: skipped }));
+        notify(appLabels.indicateurCollageIgnore({ count: skipped }), 'info');
       }
       if (cellsToWrite.length === 0) {
         return;

--- a/apps/app/src/indicateurs/valeurs/grid/types.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/types.ts
@@ -82,6 +82,13 @@ export type GridInput = GridRow[] | GridGroups;
 
 export type Result<T = void> = { ok: true; value: T } | { ok: false };
 
+export type GridNotificationLevel = 'success' | 'error' | 'info';
+
+export type NotifyGridEvent = (
+  message: string,
+  level: GridNotificationLevel
+) => void;
+
 export type ValeurField = 'resultat' | 'objectif';
 
 export type CellValueInput = {


### PR DESCRIPTION
## Problème

Le contrat `notify` de la grille de saisie (`IndicateurValuesGrid`) ne transportait qu'un `message: string`. Les appels internes couvrent pourtant plusieurs sévérités :

- **échec** : sélection open data en erreur, retour en saisie manuelle en erreur, collage partiellement/totalement échoué ;
- **succès** : réinitialisation de l'ordre des lignes ;
- **info** : cellules ignorées lors d'un collage.

Comme la sévérité était perdue, le consommateur ne pouvait la restituer : un échec d'enregistrement pouvait être rendu comme un toast de succès.

## Correctif

`notify` prend désormais un niveau explicite :

```ts
export type GridNotificationLevel = 'success' | 'error' | 'info';
export type NotifyGridEvent = (message: string, level: GridNotificationLevel) => void;
```

Chaque appel interne renseigne son niveau (`'error'` pour les échecs, `'success'` pour le reset, `'info'` pour le collage ignoré). Le consommateur peut mapper `level` vers son système de toast.

Non-breaking : un handler `(message) => void` existant reste assignable à la nouvelle signature (2ᵉ paramètre ignoré).

## Périmètre

Uniquement le composant réutilisable `apps/app/src/indicateurs/valeurs/grid/` (contrat + call-sites internes + specs). Aucun consommateur applicatif sur `main`.

## Tests

- `build-open-data-handlers.spec.ts` + `grid-paste.spec.tsx` : 12/12, assertions mises à jour avec le niveau.
- Typecheck + lint OK sur les fichiers touchés.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Les notifications de la grille prennent désormais un niveau explicite : succès, erreur ou information.
  * Les actions de réinitialisation, d’échec de sélection et de collage affichent des retours plus précis selon le résultat.

* **Bug Fixes**
  * Les erreurs liées aux sélections, à la réinitialisation et au collage sont maintenant signalées de façon cohérente avec le bon niveau d’alerte.
  * Les opérations de collage ignorées ou partiellement appliquées sont mieux distinguées dans les messages affichés.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->