### PR TITLE
feat(app): reserve l'import IA d'un plan aux super admins

### DIFF
--- a/apps/app/src/plans/plans/create-plan/components/create-plan-option-link.list.tsx/index.tsx
+++ b/apps/app/src/plans/plans/create-plan/components/create-plan-option-link.list.tsx/index.tsx
@@ -6,7 +6,8 @@ import {
   makeCollectivitePlansActionsImporterIaUrl,
   makeCollectivitePlansActionsImporterUrl,
 } from '@/app/app/paths';
-import { Event, useEventTracker } from '@tet/ui';
+import { useSuperAdminMode } from '@/app/users/authorizations/super-admin-mode/super-admin-mode.provider';
+import { Event, useEventTracker, VisibleWhen } from '@tet/ui';
 import CreateWithActions from './create-with-actions.svg';
 import CreatePlanPicto from './create.svg';
 import ImportPlanPicto from './import.svg';
@@ -20,6 +21,7 @@ export const CreatePlanOptionLinksList = ({
   panierId: string | undefined;
 }) => {
   const tracker = useEventTracker();
+  const { isSuperAdminRoleEnabled } = useSuperAdminMode();
   return (
     <div data-test="choix-creation-plan" className="flex gap-4">
       <Link
@@ -45,17 +47,19 @@ export const CreatePlanOptionLinksList = ({
           tracker(Event.plans.importPlan);
         }}
       />
-      <Link
-        title={appLabels.importPlanIaTitre}
-        subTitle={appLabels.importPlanIaSousTitre}
-        icon={<ImportPlanPicto />}
-        url={makeCollectivitePlansActionsImporterIaUrl({
-          collectiviteId,
-        })}
-        onClickCallback={() => {
-          tracker(Event.plans.importPlan);
-        }}
-      />
+      <VisibleWhen condition={isSuperAdminRoleEnabled}>
+        <Link
+          title={appLabels.importPlanIaTitre}
+          subTitle={appLabels.importPlanIaSousTitre}
+          icon={<ImportPlanPicto />}
+          url={makeCollectivitePlansActionsImporterIaUrl({
+            collectiviteId,
+          })}
+          onClickCallback={() => {
+            tracker(Event.plans.importPlan);
+          }}
+        />
+      </VisibleWhen>
       <Link
         title="Initier votre plan"
         subTitle={appLabels.planOptionActionsAImpact}

--- a/apps/app/src/plans/plans/import-plan/ai-import.view.tsx
+++ b/apps/app/src/plans/plans/import-plan/ai-import.view.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { appLabels } from '@/app/labels/catalog';
+import { useSuperAdminMode } from '@/app/users/authorizations/super-admin-mode/super-admin-mode.provider';
 import { useToastContext } from '@/app/utils/toast/toast-context';
 import { useCollectiviteId } from '@tet/api/collectivites';
 import { getErrorMessage } from '@tet/domain/utils';
@@ -53,7 +54,7 @@ const CheckingOngoingImport = () => (
   </div>
 );
 
-export const AiImportView = () => {
+const AiImportContent = () => {
   const collectiviteId = useCollectiviteId();
   const { setToast } = useToastContext();
   const { data: currentImport, isLoading: isCheckingOngoingImport } =
@@ -118,4 +119,14 @@ export const AiImportView = () => {
       </div>
     </div>
   );
+};
+
+export const AiImportView = () => {
+  const { isSuperAdminRoleEnabled } = useSuperAdminMode();
+
+  if (!isSuperAdminRoleEnabled) {
+    return null;
+  }
+
+  return <AiImportContent />;
 };


### PR DESCRIPTION
## Contexte

La carte de creation « Importer un plan avec l'IA » et la page `importer-ia` s'affichaient pour tout admin de collectivite, alors que la fonctionnalite doit rester reservee aux super admins.

## Constat

- **Backend deja restreint** : `enqueue`, `getStatus` et `getCurrentImport` verifient la permission `plans.fiches.import`, presente uniquement dans le bundle `PlatformRole.SUPER_ADMIN`. Un admin de collectivite est deja refuse cote serveur. Aucun changement backend.
- **Trou cote front** : la carte et la vue restaient accessibles.

## Changements

- `create-plan-option-link.list.tsx` : le `Link` d'import IA est enveloppe dans `<VisibleWhen condition={isSuperAdminRoleEnabled}>`.
- `ai-import.view.tsx` : scinde en `AiImportContent` (logique + hooks) et `AiImportView` (gate exporte). Un non-super-admin qui ouvre l'URL directement obtient `null`, sans declencher de requete tRPC (respect des regles des hooks).

Meme mecanisme (`useSuperAdminMode`) que la page d'import legacy.

## Verification

- `nx lint app` : OK.
- Typecheck front : les seules erreurs `tsc` locales portent sur des fichiers non modifies (`use-get-current-ai-import.ts`, types du routeur `@tet/api` non regeneres localement) — divergence connue local vs CI, sans lien avec ce diff.