### PR TITLE
fix(indicateurs): affiche le dot open-data meme quand une valeur est saisie

### DIFF
--- a/apps/app/src/indicateurs/valeurs/grid/__tests__/user-data-cell.spec.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/__tests__/user-data-cell.spec.tsx
@@ -2,7 +2,13 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { GridCellServicesProvider } from '../grid-context';
 import { UserDataCell } from '../user-data-cell';
-import { GridCell, toIndicateurId, toYear } from '../types';
+import {
+  GridCell,
+  OpenDataSource,
+  toIndicateurId,
+  toSourceId,
+  toYear,
+} from '../types';
 
 const typeAndCommit = (input: HTMLElement, raw: string): void => {
   fireEvent.focus(input);
@@ -52,6 +58,18 @@ const renderCell = (
 const renderEmptyCell = (
   saveCellValue: ReturnType<typeof vi.fn>
 ): HTMLInputElement => renderCell(emptyUserCell, saveCellValue);
+
+const coveringSources: OpenDataSource[] = [
+  {
+    sourceId: toSourceId('citepa'),
+    libelle: 'CITEPA',
+    value: 42,
+    methodologie: null,
+    dateVersion: '2026-01-01',
+  },
+];
+
+const openDataDotName = 'Valeur open data disponible';
 
 describe('UserDataCell edition', () => {
   it('commit la valeur saisie via saveCellValue a la validation', async () => {
@@ -150,5 +168,29 @@ describe('UserDataCell edition', () => {
     fireEvent.keyDown(input, { key: 'Enter' });
 
     expect(saveCellValue).not.toHaveBeenCalled();
+  });
+});
+
+describe('UserDataCell dot open-data', () => {
+  it('affiche le dot quand une valeur user est saisie et que de l open data est disponible', () => {
+    renderCell({ ...filledUserCell, coveringSources }, vi.fn());
+
+    expect(
+      screen.getByRole('button', { name: openDataDotName })
+    ).toBeDefined();
+  });
+
+  it('affiche le dot sur une cellule vide couverte', () => {
+    renderCell({ ...emptyUserCell, coveringSources }, vi.fn());
+
+    expect(
+      screen.getByRole('button', { name: openDataDotName })
+    ).toBeDefined();
+  });
+
+  it("n'affiche pas le dot quand aucune open data n'est disponible", () => {
+    renderCell(filledUserCell, vi.fn());
+
+    expect(screen.queryByRole('button', { name: openDataDotName })).toBe(null);
   });
 });

--- a/apps/app/src/indicateurs/valeurs/grid/user-data-cell.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/user-data-cell.tsx
@@ -39,9 +39,8 @@ export const UserDataCell = memo(
       currentValue: value,
       onSave,
     });
-    const isEmpty = text === '';
     const showCoverageDot =
-      isEmpty && status === 'idle' && coveringSources.length > 0;
+      status === 'idle' && coveringSources.length > 0;
     return (
       <div className="relative h-full">
         <label className="flex h-full cursor-text items-center justify-end pr-3">


### PR DESCRIPTION
## Problème
Le dot signalant qu'une source open-data couvre une cellule n'était affiché que sur les **cellules vides** :

```ts
const isEmpty = text === '';
const showCoverageDot = isEmpty && status === 'idle' && coveringSources.length > 0;
```

Dès qu'une valeur était saisie, le dot disparaissait — l'utilisateur perdait toute indication (et tout accès) à l'open data disponible. Ce gate `isEmpty` existe depuis le commit initial de la feature (`26496edb29 overlay open-data`) et n'était couvert par **aucun test**.

## Correctif
Le dot s'affiche désormais dès qu'une source couvre la cellule, indépendamment de la valeur user :

```ts
const showCoverageDot = status === 'idle' && coveringSources.length > 0;
```

## Tests ajoutés
`user-data-cell.spec.tsx` (le trou de couverture) :
- affiche le dot quand une valeur est saisie **et** que de l'open data est disponible ;
- affiche le dot sur une cellule vide couverte ;
- n'affiche pas le dot quand aucune open data n'est disponible.

## Périmètre
Uniquement le composant réutilisable `apps/app/src/indicateurs/valeurs/grid/`. Le comportement de *sélection* (l'open data remplace la valeur user, mutuellement exclusifs) est côté consommateur PCAET et fera l'objet d'un changement séparé.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * L’indicateur de disponibilité des données open data s’affiche désormais aussi pour certaines cellules déjà renseignées, dès qu’une source de couverture est disponible.

* **Bug Fixes**
  * L’affichage du point de couverture est ajusté pour mieux refléter la présence de sources open data, y compris dans les cellules vides.
  * Le point n’apparaît plus lorsque aucune source de couverture n’est disponible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->