### PR TITLE
fix(indicateurs): supprime le flicker de valeur a la sauvegarde d'une cellule

### DIFF
--- a/apps/app/src/indicateurs/valeurs/grid/use-cell-edit.spec.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/use-cell-edit.spec.ts
@@ -81,6 +81,28 @@ describe('useCellEdit', () => {
     await waitFor(() => expect(onSave).toHaveBeenCalledWith(10));
   });
 
+  it("garde la valeur saisie apres sauvegarde tant que la valeur courante n'est pas rafraichie", async () => {
+    const onSave = vi.fn().mockResolvedValue(ok);
+    const { result, rerender } = renderHook(
+      ({ currentValue }: { currentValue: number | null }) =>
+        useCellEdit({ currentValue, onSave }),
+      { initialProps: { currentValue: 10 as number | null } }
+    );
+
+    act(() => result.current.onChange('12'));
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(result.current.text).toBe('12');
+
+    rerender({ currentValue: 12 });
+    expect(result.current.text).toBe('12');
+
+    rerender({ currentValue: 30 });
+    expect(result.current.text).toBe('30');
+  });
+
   it('vide une cellule renseignee en enregistrant null', async () => {
     const onSave = vi.fn().mockResolvedValue(ok);
     const { result } = renderHook(() =>

--- a/apps/app/src/indicateurs/valeurs/grid/use-cell-edit.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/use-cell-edit.ts
@@ -26,6 +26,7 @@ export const useCellEdit = ({
   const [status, setStatus] = useState<CellEditStatus>('idle');
   const isSaving = useRef(false);
   const hasPendingSave = useRef(false);
+  const pendingSavedRaw = useRef<string | undefined>(undefined);
   const draftValueRef = useRef<string | null>(null);
   draftValueRef.current = draftValue;
   const currentValueRef = useRef(currentValue);
@@ -41,6 +42,18 @@ export const useCellEdit = ({
     const timer = setTimeout(() => setStatus('idle'), SAVED_ACKNOWLEDGEMENT_MS);
     return () => clearTimeout(timer);
   }, [status]);
+
+  useEffect(() => {
+    const savedRaw = pendingSavedRaw.current;
+    const currentValueReflectsSave =
+      savedRaw !== undefined &&
+      draftValueRef.current === savedRaw &&
+      currentValue === parseCellNumber(savedRaw);
+    if (currentValueReflectsSave) {
+      pendingSavedRaw.current = undefined;
+      setDraftValue(null);
+    }
+  }, [currentValue]);
 
   const onChange = useCallback((raw: string) => {
     setDraftValue(raw.replace(DISALLOWED_CHARS, ''));
@@ -78,7 +91,7 @@ export const useCellEdit = ({
     try {
       const writeResult = await onSave(parsedValue);
       if (writeResult.ok) {
-        setDraftValue((current) => (current === savedRaw ? null : current));
+        pendingSavedRaw.current = savedRaw;
         setStatus((current) => (current === 'saving' ? 'saved' : current));
       } else {
         setStatus('error');


### PR DESCRIPTION
## Problème
En modifiant une valeur de cellule, l'ancienne valeur réapparaissait un instant avant la nouvelle : **10 → 12 → 10 → 12**.

Dans `use-cell-edit.ts`, le brouillon saisi (`draftValue`) était effacé **dès** la sauvegarde réussie :

```ts
setDraftValue((current) => (current === savedRaw ? null : current));
```

Or `currentValue` (la donnée de la grille) ne se met à jour qu'**après** le cycle `invalidateQueries → refetch` (asynchrone). Entre les deux, `text = draftValue ?? currentText` retombait sur l'**ancienne** `currentValue` → flicker.

## Correctif
Le brouillon est conservé jusqu'à ce que `currentValue` reflète la valeur sauvée, puis résorbé sans à-coup :

```ts
useEffect(() => {
  const savedRaw = pendingSavedRaw.current;
  const currentValueReflectsSave =
    savedRaw !== undefined &&
    draftValueRef.current === savedRaw &&
    currentValue === parseCellNumber(savedRaw);
  if (currentValueReflectsSave) {
    pendingSavedRaw.current = undefined;
    setDraftValue(null);
  }
}, [currentValue]);
```

Le garde `draftValueRef.current === savedRaw` évite d'écraser une saisie plus récente (édition pendant une sauvegarde en vol).

## Test
`use-cell-edit.spec.ts` : la valeur saisie reste affichée après sauvegarde tant que `currentValue` n'est pas rafraîchie, puis suit `currentValue` une fois le brouillon résorbé.

## Périmètre
Uniquement le composant réutilisable `apps/app/src/indicateurs/valeurs/grid/`. Revue `te-en-t-style-enforcer` passée (condition composée nommée en variable d'intention).