### PR TITLE
fix(referentiel): badge de niveau d'acces dans le header sticky d'une mesure

### DIFF
--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/action/[actionId]/_components/header/action.header.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/action/[actionId]/_components/header/action.header.tsx
@@ -9,6 +9,7 @@ import { cn, PageHeader } from '@tet/ui';
 import { useState } from 'react';
 import { ActionSidePanelToolbar } from './action-side-panel-toolbar';
 import { ActionBreadcrumb } from './breadcrumb/action.breadcrumb';
+import { CurrentCollectiviteBadge } from './current-collectivite.badge';
 import { DisplaySettingsButtons } from './display-settings-buttons';
 import { Infos } from './infos';
 import { PreviousAndNextActionsLinks } from './previous-and-next-actions.links';
@@ -35,6 +36,12 @@ export const ActionHeader = ({ action }: { action: ActionListItem }) => {
       <PageHeader.Title>
         {action.identifiant} {action.nom}
       </PageHeader.Title>
+
+      {isSticky && (
+        <PageHeader.Actions>
+          <CurrentCollectiviteBadge />
+        </PageHeader.Actions>
+      )}
 
       <PageHeader.Subtitle>
         <ActionBreadcrumb action={action} />

--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/action/[actionId]/_components/header/current-collectivite.badge.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/action/[actionId]/_components/header/current-collectivite.badge.tsx
@@ -1,0 +1,26 @@
+import { BadgeNiveauAcces } from '@/app/users/BadgeNiveauAcces';
+import { useCurrentCollectivite } from '@tet/api/collectivites';
+import { Badge } from '@tet/ui';
+
+export const CurrentCollectiviteBadge = () => {
+  const currentCollectivite = useCurrentCollectivite();
+  const { collectiviteNom, role } = currentCollectivite;
+
+  return (
+    <div className="shrink-0 flex border-[0.5px] border-info-3 rounded-md">
+      <BadgeNiveauAcces
+        collectivite={currentCollectivite}
+        className="!rounded-r-none border-none"
+      />
+      <Badge
+        title={collectiviteNom}
+        variant={role === null ? 'new' : 'info'}
+        type="outlined"
+        uppercase={false}
+        className="!rounded-l-none border-none"
+        size="xs"
+        trim={false}
+      />
+    </div>
+  );
+};

--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/action/[actionId]/_components/header/previous-and-next-actions.links.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/action/[actionId]/_components/header/previous-and-next-actions.links.tsx
@@ -49,11 +49,8 @@ export const PreviousAndNextActionsLinks = ({
   action,
   headerIsSticky = false,
 }: Props) => {
-  const {
-    collectiviteId,
-    role,
-    nom: currentCollectiviteName,
-  } = useCurrentCollectivite();
+  const currentCollectivite = useCurrentCollectivite();
+  const { collectiviteId, collectiviteNom, role } = currentCollectivite;
   const currentSearchParams = useSearchParams();
 
   const { prevActionLink, nextActionLink } = getPrevAndNextActionLinks({
@@ -84,11 +81,11 @@ export const PreviousAndNextActionsLinks = ({
       {headerIsSticky && (
         <div className="m-auto shrink-0 flex border-[0.5px] border-info-3 rounded-md">
           <BadgeNiveauAcces
-            acces={role}
+            collectivite={currentCollectivite}
             className="!rounded-r-none border-none"
           />
           <Badge
-            title={currentCollectiviteName}
+            title={collectiviteNom}
             variant={role === null ? 'new' : 'info'}
             type="outlined"
             uppercase={false}

--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/action/[actionId]/_components/header/previous-and-next-actions.links.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/action/[actionId]/_components/header/previous-and-next-actions.links.tsx
@@ -2,9 +2,8 @@ import { JSX } from 'react';
 
 import { getPrevAndNextActionLinks } from '@/app/referentiels/actions/get-prev-and-next-action-links.utils';
 import { ActionListItem } from '@/app/referentiels/actions/use-list-actions';
-import { BadgeNiveauAcces } from '@/app/users/BadgeNiveauAcces';
 import { useCurrentCollectivite } from '@tet/api/collectivites';
-import { Badge, Button, cn } from '@tet/ui';
+import { Button, cn } from '@tet/ui';
 import { useSearchParams } from 'next/navigation';
 import { getActionInfoPanelSearchParams } from '../side-panel/informations.config';
 
@@ -49,8 +48,7 @@ export const PreviousAndNextActionsLinks = ({
   action,
   headerIsSticky = false,
 }: Props) => {
-  const currentCollectivite = useCurrentCollectivite();
-  const { collectiviteId, collectiviteNom, role } = currentCollectivite;
+  const { collectiviteId } = useCurrentCollectivite();
   const currentSearchParams = useSearchParams();
 
   const { prevActionLink, nextActionLink } = getPrevAndNextActionLinks({
@@ -65,7 +63,7 @@ export const PreviousAndNextActionsLinks = ({
 
   return (
     <div
-      className={cn('flex justify-between border-b border-b-primary-3', {
+      className={cn('flex border-b border-b-primary-3', {
         'py-1': !headerIsSticky,
         'py-0.5 border-b-2': headerIsSticky,
       })}
@@ -78,29 +76,12 @@ export const PreviousAndNextActionsLinks = ({
         />
       )}
 
-      {headerIsSticky && (
-        <div className="m-auto shrink-0 flex border-[0.5px] border-info-3 rounded-md">
-          <BadgeNiveauAcces
-            collectivite={currentCollectivite}
-            className="!rounded-r-none border-none"
-          />
-          <Badge
-            title={collectiviteNom}
-            variant={role === null ? 'new' : 'info'}
-            type="outlined"
-            uppercase={false}
-            className="!rounded-l-none border-none"
-            size="xs"
-            trim={false}
-          />
-        </div>
-      )}
-
       {nextActionLink && (
         <ActionNavigationButton
           direction="next"
           href={nextActionLink}
           size={size}
+          className="ml-auto"
         />
       )}
     </div>

--- a/apps/app/src/ui/layout/header/main-nav/collectivite/generate-collectivite-nav-item.tsx
+++ b/apps/app/src/ui/layout/header/main-nav/collectivite/generate-collectivite-nav-item.tsx
@@ -1,16 +1,12 @@
 import { makeTdbCollectiviteUrl } from '@/app/app/paths';
 import { BadgeNiveauAcces } from '@/app/users/BadgeNiveauAcces';
-import { CollectiviteCurrent } from '@tet/api/collectivites';
-import {
-  CollectiviteRolesAndPermissions,
-  isUserAuditeur,
-  UserRolesAndPermissions,
-} from '@tet/domain/users';
+import { CollectiviteCurrent, toCollectiviteCurrent } from '@tet/api/collectivites';
+import { UserWithRolesAndPermissions } from '@tet/domain/users';
 import { NavItem, Tooltip } from '@tet/ui';
 import { cn } from '@tet/ui/utils/cn';
 
 export const generateCollectiviteNavItem = (
-  user: UserRolesAndPermissions,
+  user: UserWithRolesAndPermissions,
   currentCollectivite: CollectiviteCurrent
 ): NavItem => {
   const listCollectivites = user.collectivites.filter(
@@ -33,7 +29,9 @@ export const generateCollectiviteNavItem = (
       <CollectiviteWithBadge collectivite={currentCollectivite} isActive />
     ),
     links: listCollectivites.map((c) => ({
-      children: <CollectiviteWithBadge collectivite={c} />,
+      children: (
+        <CollectiviteWithBadge collectivite={toCollectiviteCurrent(c, user)} />
+      ),
       href: makeTdbCollectiviteUrl({
         collectiviteId: c.collectiviteId,
       }),
@@ -45,7 +43,7 @@ const CollectiviteWithBadge = ({
   collectivite,
   isActive,
 }: {
-  collectivite: CollectiviteRolesAndPermissions;
+  collectivite: CollectiviteCurrent;
   isActive?: boolean;
 }) => {
   return (
@@ -64,10 +62,7 @@ const CollectiviteWithBadge = ({
           {collectivite.collectiviteNom}
         </span>
       </Tooltip>
-      <BadgeNiveauAcces
-        acces={collectivite.role}
-        isAuditeur={isUserAuditeur(collectivite)}
-      />
+      <BadgeNiveauAcces collectivite={collectivite} />
     </div>
   );
 };

--- a/apps/app/src/ui/layout/header/main-nav/collectivite/make-role-edition-actions-indicateurs-nav.ts
+++ b/apps/app/src/ui/layout/header/main-nav/collectivite/make-role-edition-actions-indicateurs-nav.ts
@@ -1,5 +1,5 @@
 import { CollectiviteCurrent } from '@tet/api/collectivites';
-import { isUserVisitor, UserRolesAndPermissions } from '@tet/domain/users';
+import { isUserVisitor, UserWithRolesAndPermissions } from '@tet/domain/users';
 import { HeaderProps } from '@tet/ui';
 import { generateCollectiviteNavItem } from './generate-collectivite-nav-item';
 import { generateTdbPersonalLink } from './generate-tdb-personal-link';
@@ -9,7 +9,7 @@ export const makeSimplifiedViewNav = ({
   user,
   currentCollectivite,
 }: {
-  user: UserRolesAndPermissions;
+  user: UserWithRolesAndPermissions;
   currentCollectivite: CollectiviteCurrent;
 }): HeaderProps['mainNav'] => {
   const endItems: CollectiviteNavItem[] = [

--- a/apps/app/src/users/BadgeNiveauAcces.tsx
+++ b/apps/app/src/users/BadgeNiveauAcces.tsx
@@ -1,43 +1,35 @@
 import { getCollectiviteRoleLabel } from '@/app/users/authorizations/collectivite-role.utils';
-import { SizeVariant } from '@tet/design-tokens';
-import { CollectiviteRole } from '@tet/domain/users';
-import { Badge } from '@tet/ui';
-import classNames from 'classnames';
+import { CollectiviteCurrent } from '@tet/api/collectivites';
+import { Badge, cn } from '@tet/ui';
 
-type Props = {
-  acces: CollectiviteRole | null;
-  isAuditeur?: boolean;
-  size?: SizeVariant;
-  className?: string;
-};
+type CollectiviteAcces = Pick<CollectiviteCurrent, 'role' | 'isRoleAuditeur'>;
 
 /** Représente le niveau d'accès à une collectivité par un badge */
-export const BadgeNiveauAcces = (props: Props) => {
-  const { acces, className, size = 'xs', isAuditeur } = props;
-  const displayedAcces = getLabel({ acces, isAuditeur });
-
+export const BadgeNiveauAcces = ({
+  collectivite,
+  className,
+}: {
+  collectivite: CollectiviteAcces;
+  className?: string;
+}) => {
   return (
     <Badge
-      title={displayedAcces}
-      size={size}
-      variant={acces === null ? 'new' : 'info'}
-      className={classNames(className, 'pointer-events-none')}
+      title={getLabel(collectivite)}
+      size="xs"
+      variant={collectivite.role === null ? 'new' : 'info'}
+      className={cn('pointer-events-none', className)}
     />
   );
 };
 
-const getLabel = ({
-  acces,
-  isAuditeur,
-}: {
-  acces: CollectiviteRole | null;
-  isAuditeur?: boolean;
-}): string => {
-  if (isAuditeur) {
+const getLabel = (collectivite: CollectiviteAcces): string => {
+  if (collectivite.isRoleAuditeur) {
     return 'audit';
   }
-  if (!acces) {
+
+  if (!collectivite.role) {
     return 'visite';
   }
-  return getCollectiviteRoleLabel(acces);
+
+  return getCollectiviteRoleLabel(collectivite.role);
 };

--- a/packages/api/src/collectivites/collectivite-context/collectivite-context.tsx
+++ b/packages/api/src/collectivites/collectivite-context/collectivite-context.tsx
@@ -1,16 +1,13 @@
 'use client';
 
 import {
-  CollectiviteRole,
   CollectiviteRolesAndPermissions,
-  hasPermission,
-  isUserAuditeur,
-  PermissionOperation,
   UserWithRolesAndPermissions,
 } from '@tet/domain/users';
 import { createContext, ReactNode, useState } from 'react';
 import useLocalStorage from 'react-use/lib/useLocalStorage';
-import { CollectiviteCurrent } from './collectivite-provider.no-ssr';
+import { CollectiviteCurrent } from './type';
+import { toCollectiviteCurrent } from './utils';
 
 const STORAGE_KEY_PREFIX = 'tet_collectivite';
 
@@ -73,34 +70,13 @@ export function CollectiviteProvider_OnlyImportWithoutSSR({
     }
   }
 
-  const toCollectiviteCurrent = (
-    collectivite: CollectiviteRolesAndPermissions
-  ): CollectiviteCurrent => {
-    return {
-      ...collectivite,
-
-      nom: collectivite.collectiviteNom,
-      accesRestreint: collectivite.collectiviteAccesRestreint,
-
-      isSimplifiedView:
-        collectivite.role === CollectiviteRole.EDITION_FICHES_INDICATEURS,
-
-      isRoleAuditeur: isUserAuditeur(collectivite),
-
-      hasCollectivitePermission: (permission: PermissionOperation) =>
-        hasPermission(user, permission, {
-          collectiviteId: collectivite.collectiviteId,
-        }),
-
-      user,
-    };
-  };
-
   return (
     <CollectiviteContext
       value={{
         collectiviteId: collectivite?.collectiviteId,
-        collectivite: collectivite ? toCollectiviteCurrent(collectivite) : null,
+        collectivite: collectivite
+          ? toCollectiviteCurrent(collectivite, user)
+          : null,
         setCollectivite,
       }}
     >
@@ -112,13 +88,3 @@ export function CollectiviteProvider_OnlyImportWithoutSSR({
 function getStorageKey(userId: string) {
   return `${STORAGE_KEY_PREFIX}_${userId}`;
 }
-
-// accesRestreint: collectivite.access_restreint || false,
-//     isReadOnly:
-//       (collectivite.niveau_acces === null ||
-//         collectivite.niveau_acces === CollectiviteRoleEnum.LECTURE) &&
-//       !collectivite.est_auditeur,
-//     isSimplifiedView:
-//       collectivite.niveau_acces ===
-//       CollectiviteRoleEnum.EDITION_FICHES_INDICATEURS,
-//   };

--- a/packages/api/src/collectivites/collectivite-context/collectivite-provider.no-ssr.tsx
+++ b/packages/api/src/collectivites/collectivite-context/collectivite-provider.no-ssr.tsx
@@ -1,26 +1,9 @@
 'use client';
 
-import {
-  CollectiviteRolesAndPermissions,
-  PermissionOperation,
-  UserInfo,
-} from '@tet/domain/users';
 import dynamic from 'next/dynamic';
 import { useContext } from 'react';
 import { CollectiviteContext } from './collectivite-context';
-
-export interface CollectiviteCurrent extends CollectiviteRolesAndPermissions {
-  nom: string;
-  accesRestreint: boolean;
-
-  isRoleAuditeur: boolean;
-  isSimplifiedView: boolean;
-
-  hasCollectivitePermission: (permission: PermissionOperation) => boolean;
-
-  // user info also here for convenience access
-  user: UserInfo;
-}
+import { CollectiviteCurrent } from './type';
 
 export const CollectiviteProvider = dynamic(
   () =>

--- a/packages/api/src/collectivites/collectivite-context/type.ts
+++ b/packages/api/src/collectivites/collectivite-context/type.ts
@@ -1,0 +1,18 @@
+import {
+  CollectiviteRolesAndPermissions,
+  PermissionOperation,
+  UserInfo,
+} from '@tet/domain/users';
+
+export interface CollectiviteCurrent extends CollectiviteRolesAndPermissions {
+  nom: string;
+  accesRestreint: boolean;
+
+  isRoleAuditeur: boolean;
+  isSimplifiedView: boolean;
+
+  hasCollectivitePermission: (permission: PermissionOperation) => boolean;
+
+  // user info also here for convenience access
+  user: UserInfo;
+}

--- a/packages/api/src/collectivites/collectivite-context/utils.ts
+++ b/packages/api/src/collectivites/collectivite-context/utils.ts
@@ -1,0 +1,33 @@
+import {
+  CollectiviteRole,
+  CollectiviteRolesAndPermissions,
+  hasPermission,
+  isUserAuditeur,
+  PermissionOperation,
+  UserWithRolesAndPermissions,
+} from '@tet/domain/users';
+import { CollectiviteCurrent } from './type';
+
+export const toCollectiviteCurrent = (
+  collectivite: CollectiviteRolesAndPermissions,
+  user: UserWithRolesAndPermissions
+): CollectiviteCurrent => {
+  return {
+    ...collectivite,
+
+    nom: collectivite.collectiviteNom,
+    accesRestreint: collectivite.collectiviteAccesRestreint,
+
+    isSimplifiedView:
+      collectivite.role === CollectiviteRole.EDITION_FICHES_INDICATEURS,
+
+    isRoleAuditeur: isUserAuditeur(collectivite),
+
+    hasCollectivitePermission: (permission: PermissionOperation) =>
+      hasPermission(user, permission, {
+        collectiviteId: collectivite.collectiviteId,
+      }),
+
+    user,
+  };
+};

--- a/packages/api/src/collectivites/index.ts
+++ b/packages/api/src/collectivites/index.ts
@@ -1,1 +1,3 @@
 export * from './collectivite-context/collectivite-provider.no-ssr';
+export * from './collectivite-context/type';
+export * from './collectivite-context/utils';


### PR DESCRIPTION
## Problème

Sur le header sticky d'une mesure, le badge de niveau d'accès :
1. affichait **« visite » au lieu d'« audit »** pour un auditeur externe (`role === null` mais bien auditeur via `audits`) — l'appelant ne passait pas `isAuditeur` ;
2. était **mal positionné** : centré via `m-auto` dans la rangée de navigation prev/next, flottant selon la présence des liens.

## Changements

**Fiabilisation (`6d7d88f`)**
- `BadgeNiveauAcces` reçoit la collectivité et lit `isRoleAuditeur`, **calculé une seule fois** dans `toCollectiviteCurrent` — plus de props `acces`/`isAuditeur` séparés qu'un appelant peut oublier.
- Le badge est typé sur `Pick<CollectiviteCurrent, 'role' | 'isRoleAuditeur'>` : contrat minimal, découplé du type contexte complet.
- Le contexte collectivité est séparé en `type.ts` + `utils.ts`, `CollectiviteCurrent` + `toCollectiviteCurrent` exposés via `@tet/api/collectivites` ; la liste des autres collectivités du menu convertit ses entrées brutes via `toCollectiviteCurrent`.

**Repositionnement (`b54df6e`)**
- Le badge (`CurrentCollectiviteBadge`, extrait) passe dans `PageHeader.Actions` → **à droite du titre**, sticky-only.
- La rangée de navigation redevient purement prev/next ; « Mesure suivante » tenue à droite via `ml-auto`.

## Vérification
- `nx run app:typecheck` + `nx run app:lint` verts sur le scope.
- Cas couvert : auditeur externe (audit démarré / non démarré) → « audit ».