### PR TITLE
fix(fiche-action-pdf-export): exclut les sous-actions de la section fiches liées

### DIFF
--- a/apps/backend/src/plans/fiches/fiche-action-pdf-export/fiche-export-payload.service.e2e-spec.ts
+++ b/apps/backend/src/plans/fiches/fiche-action-pdf-export/fiche-export-payload.service.e2e-spec.ts
@@ -1,0 +1,154 @@
+import { INestApplication } from '@nestjs/common';
+import { getAuthUser, getTestApp, getTestRouter, YOLO_DODO } from '@tet/backend/test';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
+import { createFiche } from '../fiches.test-fixture';
+import { FicheExportPayloadService } from './fiche-export-payload.service';
+
+let app: INestApplication;
+let router: TrpcRouter;
+let payloadService: FicheExportPayloadService;
+let yoloDodo: AuthenticatedUser;
+
+const COLLECTIVITE_ID = YOLO_DODO.collectiviteId.admin;
+
+beforeAll(async () => {
+  app = await getTestApp();
+  router = await getTestRouter(app);
+  payloadService = app.get(FicheExportPayloadService);
+  yoloDodo = await getAuthUser(YOLO_DODO);
+});
+
+describe('buildFicheExportPayload - fiches liées', () => {
+  it('inclut une fiche liée mais jamais ses sous-fiches', async () => {
+    const caller = router.createCaller({ user: yoloDodo });
+
+    const ficheLieeId = await createFiche({
+      caller,
+      ficheInput: {
+        collectiviteId: COLLECTIVITE_ID,
+        titre: 'Fiche liée parente',
+      },
+    });
+
+    await createFiche({
+      caller,
+      ficheInput: {
+        collectiviteId: COLLECTIVITE_ID,
+        titre: 'Sous-fiche de la fiche liée',
+        parentId: ficheLieeId,
+      },
+    });
+
+    const ficheId = await createFiche({
+      caller,
+      ficheInput: {
+        collectiviteId: COLLECTIVITE_ID,
+        titre: 'Fiche exportée',
+      },
+    });
+
+    await caller.plans.fiches.update({
+      ficheId,
+      ficheFields: { fichesLiees: [{ id: ficheLieeId }] },
+      isNotificationEnabled: false,
+    });
+
+    const result = await payloadService.buildFicheExportPayload({
+      ficheId,
+      user: yoloDodo,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    expect(result.data.fichesLiees.map((ficheLiee) => ficheLiee.id)).toEqual([
+      ficheLieeId,
+    ]);
+  }, 30_000);
+
+  it("n'inclut pas une fiche liée qui est une sous-action", async () => {
+    const caller = router.createCaller({ user: yoloDodo });
+
+    const parentId = await createFiche({
+      caller,
+      ficheInput: {
+        collectiviteId: COLLECTIVITE_ID,
+        titre: 'Fiche parente',
+      },
+    });
+
+    const sousActionLieeId = await createFiche({
+      caller,
+      ficheInput: {
+        collectiviteId: COLLECTIVITE_ID,
+        titre: 'Sous-action ensuite liée',
+        parentId,
+      },
+    });
+
+    const ficheId = await createFiche({
+      caller,
+      ficheInput: {
+        collectiviteId: COLLECTIVITE_ID,
+        titre: 'Fiche exportée liée à une sous-action',
+      },
+    });
+
+    await caller.plans.fiches.update({
+      ficheId,
+      ficheFields: { fichesLiees: [{ id: sousActionLieeId }] },
+      isNotificationEnabled: false,
+    });
+
+    const result = await payloadService.buildFicheExportPayload({
+      ficheId,
+      user: yoloDodo,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    expect(result.data.fichesLiees.map((ficheLiee) => ficheLiee.id)).toEqual(
+      []
+    );
+  }, 30_000);
+
+  it('inclut une fiche liée même quand le lien a été créé depuis l\'autre fiche', async () => {
+    const caller = router.createCaller({ user: yoloDodo });
+
+    const ficheId = await createFiche({
+      caller,
+      ficheInput: {
+        collectiviteId: COLLECTIVITE_ID,
+        titre: 'Fiche exportée (cible du lien)',
+      },
+    });
+
+    const ficheSourceId = await createFiche({
+      caller,
+      ficheInput: {
+        collectiviteId: COLLECTIVITE_ID,
+        titre: 'Fiche qui initie le lien',
+      },
+    });
+
+    await caller.plans.fiches.update({
+      ficheId: ficheSourceId,
+      ficheFields: { fichesLiees: [{ id: ficheId }] },
+      isNotificationEnabled: false,
+    });
+
+    const result = await payloadService.buildFicheExportPayload({
+      ficheId,
+      user: yoloDodo,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    expect(result.data.fichesLiees.map((ficheLiee) => ficheLiee.id)).toEqual([
+      ficheSourceId,
+    ]);
+  }, 30_000);
+});

--- a/apps/backend/src/plans/fiches/fiche-action-pdf-export/fiche-export-payload.service.ts
+++ b/apps/backend/src/plans/fiches/fiche-action-pdf-export/fiche-export-payload.service.ts
@@ -106,16 +106,11 @@ export class FicheExportPayloadService {
     fiche: FicheWithRelations;
     user: AuthenticatedUser;
   }): Promise<FicheWithRelations[]> {
-    const linkedIds = (fiche.fichesLiees ?? []).map((f) => f.id);
-    if (linkedIds.length === 0) {
-      return [];
-    }
-
     try {
-      const { data } = await this.listFichesService.listFichesQuery(null, {
-        ficheIds: linkedIds,
-        withChildren: true,
-      });
+      const { data } = await this.listFichesService.listFichesQuery(
+        fiche.collectiviteId,
+        { linkedFicheIds: [fiche.id] }
+      );
       const accessResults = await Promise.all(
         data.map((ficheLiee) =>
           this.fichePermissions


### PR DESCRIPTION
## Symptôme

L'export PDF d'une fiche action **unique** divergeait de l'app sur la section « fiches liées » :
1. il affichait des fiches étrangères — des « Action non classée » (cartes) et des fiches d'autres axes du plan ;
2. après un premier nettoyage, il montrait **6 fiches liées là où l'app en affiche 7**.

## Causes (deux bugs cumulés dans `loadFichesLiees`)

L'export partait de `fiche.fichesLiees` puis ré-interrogeait la base avec `{ ficheIds, withChildren: true }`.

- **Sous-fiches parasites** — `withChildren: true` fait `WHERE id IN (linkedIds) OR parent_id IN (linkedIds)` : toutes les **sous-fiches des fiches liées** remontaient dans l'export.
- **Sens unique** — `fiche.fichesLiees` est peuplé de façon **unidirectionnelle** (`getFicheActionFichesLieesQuery` : `WHERE fiche_une IN (...)`). Les liens créés **depuis l'autre fiche** (la fiche exportée est `fiche_deux`) étaient donc absents, alors que l'app les affiche via le filtre **bidirectionnel** `linkedFicheIds`. D'où le 6 au lieu de 7.

## Fix

`loadFichesLiees` utilise désormais la **requête canonique de l'app** :

```ts
listFichesQuery(fiche.collectiviteId, { linkedFicheIds: [fiche.id] })
```

Parité app/export garantie par construction : bidirectionnel, sous-actions exclues (défaut `parent_id IS NULL`), aucun enfant parasite.

## Tests (e2e, `fiche-export-payload.service.e2e-spec.ts`, TDD)

1. les **enfants** d'une fiche liée sont exclus de l'export ;
2. une fiche liée qui est une **sous-action** est exclue (aligné sur l'app et la règle métier « pas de sous-action en fiche liée ») ;
3. une fiche qui a **lié vers** la fiche exportée apparaît bien (cas 6-vs-7).

13 tests de régression de l'export PDF, typecheck et lint : verts.

## Suivi

La règle « une fiche liée n'est jamais une sous-action » n'est pas contrainte à l'écriture (un lien vers une sous-action reste créable via l'API `updateFiche` / import de plan). Cette PR l'exclut à l'affichage (comme l'app le fait déjà) ; une PR dédiée devra l'empêcher à la source.