### PR TITLE
fix(trajectoires): restaure la comparaison < pour détecter une mise à jour SNBC

### DIFF
--- a/apps/backend/src/indicateurs/indicateurs.module.ts
+++ b/apps/backend/src/indicateurs/indicateurs.module.ts
@@ -32,6 +32,7 @@ import { IndicateurSourcesRouter } from './sources/indicateur-sources.router';
 import IndicateurSourcesService from './sources/indicateur-sources.service';
 import { TrajectoireLeviersService } from './trajectoire-leviers/trajectoire-leviers.service';
 import TrajectoiresDataService from './trajectoires/trajectoires-data.service';
+import { VerificationTrajectoireRules } from './trajectoires/verification-trajectoire.rules';
 import TrajectoiresSpreadsheetService from './trajectoires/trajectoires-spreadsheet.service';
 import TrajectoiresXlsxService from './trajectoires/trajectoires-xlsx.service';
 import { TrajectoiresController } from './trajectoires/trajectoires.controller';
@@ -82,6 +83,7 @@ const DEFINITIONS_PROVIDERS = [
     IndicateurValeursRouter,
     IndicateurSourcesRouter,
     IndicateurChartService,
+    VerificationTrajectoireRules,
     TrajectoiresDataService,
     TrajectoiresSpreadsheetService,
     TrajectoiresXlsxService,

--- a/apps/backend/src/indicateurs/trajectoires/trajectoires-data.service.spec.ts
+++ b/apps/backend/src/indicateurs/trajectoires/trajectoires-data.service.spec.ts
@@ -10,13 +10,14 @@ import SheetService from '../../utils/google-sheets/sheet.service';
 import IndicateurSourcesService from '../sources/indicateur-sources.service';
 import CrudValeursService from '../valeurs/crud-valeurs.service';
 import TrajectoiresDataService from './trajectoires-data.service';
+import { VerificationTrajectoireRules } from './verification-trajectoire.rules';
 
 describe('TrajectoiresDataService test', () => {
   let trajectoiresDataService: TrajectoiresDataService;
 
   beforeEach(async () => {
     const moduleRef = await Test.createTestingModule({
-      providers: [TrajectoiresDataService],
+      providers: [TrajectoiresDataService, VerificationTrajectoireRules],
     })
       .useMocker((token) => {
         // Pour l'instant on ne mocke pas ces services précisemment

--- a/apps/backend/src/indicateurs/trajectoires/trajectoires-data.service.ts
+++ b/apps/backend/src/indicateurs/trajectoires/trajectoires-data.service.ts
@@ -27,7 +27,7 @@ import {
   VerificationTrajectoireStatus,
 } from '@tet/domain/indicateurs';
 import { PermissionOperationEnum, ResourceType } from '@tet/domain/users';
-import { flatten, isEqual, isNil, maxBy, uniq } from 'es-toolkit';
+import { flatten, isNil, maxBy, uniq } from 'es-toolkit';
 import { DateTime } from 'luxon';
 import { AuthUser } from '../../users/models/auth.models';
 import IndicateurSourcesService from '../sources/indicateur-sources.service';
@@ -929,10 +929,8 @@ export default class TrajectoiresDataService {
 
     const newTrajectoireCanBeComputed =
       donneesEntree.lastModifiedAt &&
-      isEqual(
-        new Date(donneesEntree.lastModifiedAt),
-        new Date(existingTrajectoireData.modifiedAt)
-      ) === false;
+      existingTrajectoireData.modifiedAt &&
+      donneesEntree.lastModifiedAt > existingTrajectoireData.modifiedAt;
 
     if (newTrajectoireCanBeComputed) {
       return VerificationTrajectoireStatus.MISE_A_JOUR_DISPONIBLE;

--- a/apps/backend/src/indicateurs/trajectoires/trajectoires-data.service.ts
+++ b/apps/backend/src/indicateurs/trajectoires/trajectoires-data.service.ts
@@ -38,6 +38,7 @@ import { DonneesARemplirValeurType } from './donnees-a-remplir-valeur.dto';
 import { DataInputForTrajectoireCompute } from './donnees-calcul-trajectoire-a-remplir.dto';
 import { VerificationTrajectoireRequest } from './verification-trajectoire.request';
 import { VerificationTrajectoireResultType } from './verification-trajectoire.response';
+import { VerificationTrajectoireRules } from './verification-trajectoire.rules';
 
 @Injectable()
 export default class TrajectoiresDataService {
@@ -222,7 +223,8 @@ export default class TrajectoiresDataService {
     private readonly listCollectivitesService: ListCollectivitesService,
     private readonly indicateurSourcesService: IndicateurSourcesService,
     private readonly valeursService: CrudValeursService,
-    private readonly permissionService: PermissionService
+    private readonly permissionService: PermissionService,
+    private readonly verificationTrajectoireRules: VerificationTrajectoireRules
   ) {}
 
   signeInversionSequestration(identifiantReferentiel?: string | null): boolean {
@@ -821,7 +823,7 @@ export default class TrajectoiresDataService {
     return {
       epci,
       donneesEntree: dataInputForTrajectoireCompute,
-      status: this.getStatus({
+      status: this.verificationTrajectoireRules.getStatus({
         canTrajectoireBeComputed,
         donneesEntree: dataInputForTrajectoireCompute,
         existingTrajectoireData,
@@ -905,36 +907,4 @@ export default class TrajectoiresDataService {
     };
   }
 
-  private getStatus({
-    canTrajectoireBeComputed,
-    donneesEntree,
-    existingTrajectoireData,
-  }: {
-    canTrajectoireBeComputed: boolean;
-    donneesEntree: DataInputForTrajectoireCompute;
-    existingTrajectoireData: {
-      modifiedAt: string | undefined;
-      sourcesDonneesEntree: string[];
-      indentifiantsReferentielManquantsDonneesEntree: string[];
-      valeurs: IndicateurValeur[];
-    };
-  }): VerificationTrajectoireStatus {
-    if (canTrajectoireBeComputed === false) {
-      return VerificationTrajectoireStatus.DONNEES_MANQUANTES;
-    }
-
-    if (existingTrajectoireData.modifiedAt === undefined) {
-      return VerificationTrajectoireStatus.PRET_A_CALCULER;
-    }
-
-    const newTrajectoireCanBeComputed =
-      donneesEntree.lastModifiedAt &&
-      existingTrajectoireData.modifiedAt &&
-      donneesEntree.lastModifiedAt > existingTrajectoireData.modifiedAt;
-
-    if (newTrajectoireCanBeComputed) {
-      return VerificationTrajectoireStatus.MISE_A_JOUR_DISPONIBLE;
-    }
-    return VerificationTrajectoireStatus.DEJA_CALCULE;
-  }
 }

--- a/apps/backend/src/indicateurs/trajectoires/verification-trajectoire.rules.spec.ts
+++ b/apps/backend/src/indicateurs/trajectoires/verification-trajectoire.rules.spec.ts
@@ -1,0 +1,72 @@
+import { VerificationTrajectoireStatus } from '@tet/domain/indicateurs';
+import { DataInputForTrajectoireCompute } from './donnees-calcul-trajectoire-a-remplir.dto';
+import { VerificationTrajectoireRules } from './verification-trajectoire.rules';
+
+describe('VerificationTrajectoireRules', () => {
+  const rules = new VerificationTrajectoireRules();
+
+  const baseDonneesEntree = {
+    sources: [],
+    emissionsGes: { valeurs: [], colonnes: [], lignes: [] },
+    consommationsFinales: { valeurs: [], colonnes: [], lignes: [] },
+    sequestrations: { valeurs: [], colonnes: [], lignes: [] },
+  } as unknown as DataInputForTrajectoireCompute;
+
+  describe('getStatus', () => {
+    it('retourne DONNEES_MANQUANTES si canTrajectoireBeComputed est false', () => {
+      const result = rules.getStatus({
+        canTrajectoireBeComputed: false,
+        donneesEntree: { ...baseDonneesEntree, lastModifiedAt: '2026-07-01T00:00:00.000Z' },
+        existingTrajectoireData: { modifiedAt: '2026-06-01T00:00:00.000Z' },
+      });
+      expect(result).toBe(VerificationTrajectoireStatus.DONNEES_MANQUANTES);
+    });
+
+    it('retourne PRET_A_CALCULER si aucune trajectoire existante', () => {
+      const result = rules.getStatus({
+        canTrajectoireBeComputed: true,
+        donneesEntree: { ...baseDonneesEntree, lastModifiedAt: '2026-07-01T00:00:00.000Z' },
+        existingTrajectoireData: { modifiedAt: undefined },
+      });
+      expect(result).toBe(VerificationTrajectoireStatus.PRET_A_CALCULER);
+    });
+
+    it('retourne DEJA_CALCULE si lastModifiedAt des données entrée est null', () => {
+      const result = rules.getStatus({
+        canTrajectoireBeComputed: true,
+        donneesEntree: { ...baseDonneesEntree, lastModifiedAt: null },
+        existingTrajectoireData: { modifiedAt: '2026-07-01T00:00:00.000Z' },
+      });
+      expect(result).toBe(VerificationTrajectoireStatus.DEJA_CALCULE);
+    });
+
+    it('retourne DEJA_CALCULE si les données entrée ont la même date que la trajectoire existante', () => {
+      // Régression : l'ancienne comparaison isEqual(!==) retournait MISE_A_JOUR_DISPONIBLE même pour des dates égales
+      const sameDate = '2026-07-02T01:00:00.000Z';
+      const result = rules.getStatus({
+        canTrajectoireBeComputed: true,
+        donneesEntree: { ...baseDonneesEntree, lastModifiedAt: sameDate },
+        existingTrajectoireData: { modifiedAt: sameDate },
+      });
+      expect(result).toBe(VerificationTrajectoireStatus.DEJA_CALCULE);
+    });
+
+    it('retourne DEJA_CALCULE si les données entrée sont plus anciennes que la trajectoire existante', () => {
+      const result = rules.getStatus({
+        canTrajectoireBeComputed: true,
+        donneesEntree: { ...baseDonneesEntree, lastModifiedAt: '2026-06-01T00:00:00.000Z' },
+        existingTrajectoireData: { modifiedAt: '2026-07-02T01:00:00.000Z' },
+      });
+      expect(result).toBe(VerificationTrajectoireStatus.DEJA_CALCULE);
+    });
+
+    it('retourne MISE_A_JOUR_DISPONIBLE si les données entrée sont plus récentes que la trajectoire existante', () => {
+      const result = rules.getStatus({
+        canTrajectoireBeComputed: true,
+        donneesEntree: { ...baseDonneesEntree, lastModifiedAt: '2026-07-03T00:00:00.000Z' },
+        existingTrajectoireData: { modifiedAt: '2026-07-02T01:00:00.000Z' },
+      });
+      expect(result).toBe(VerificationTrajectoireStatus.MISE_A_JOUR_DISPONIBLE);
+    });
+  });
+});

--- a/apps/backend/src/indicateurs/trajectoires/verification-trajectoire.rules.ts
+++ b/apps/backend/src/indicateurs/trajectoires/verification-trajectoire.rules.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@nestjs/common';
+import { VerificationTrajectoireStatus } from '@tet/domain/indicateurs';
+import { DataInputForTrajectoireCompute } from './donnees-calcul-trajectoire-a-remplir.dto';
+
+@Injectable()
+export class VerificationTrajectoireRules {
+  getStatus({
+    canTrajectoireBeComputed,
+    donneesEntree,
+    existingTrajectoireData,
+  }: {
+    canTrajectoireBeComputed: boolean;
+    donneesEntree: DataInputForTrajectoireCompute;
+    existingTrajectoireData: {
+      modifiedAt: string | undefined;
+    };
+  }): VerificationTrajectoireStatus {
+    if (canTrajectoireBeComputed === false) {
+      return VerificationTrajectoireStatus.DONNEES_MANQUANTES;
+    }
+
+    if (existingTrajectoireData.modifiedAt === undefined) {
+      return VerificationTrajectoireStatus.PRET_A_CALCULER;
+    }
+
+    const newTrajectoireCanBeComputed =
+      donneesEntree.lastModifiedAt &&
+      existingTrajectoireData.modifiedAt &&
+      donneesEntree.lastModifiedAt > existingTrajectoireData.modifiedAt;
+
+    if (newTrajectoireCanBeComputed) {
+      return VerificationTrajectoireStatus.MISE_A_JOUR_DISPONIBLE;
+    }
+    return VerificationTrajectoireStatus.DEJA_CALCULE;
+  }
+}


### PR DESCRIPTION
## Problème

Depuis le 2-3 juillet 2026, la cron `compute-all-outdated-trajectoires` génère les fichiers spreadsheet SNBC dans Google Drive pour **toutes** les collectivités EPCI chaque nuit, alors que ce calcul ne devrait se déclencher qu'à la demande ou si les données d'entrée ont été mises à jour depuis le dernier calcul.

## Cause racine (2 parties)

### Bug introduit en octobre 2025 (`ff1e16430`)

La refactorisation a remplacé la comparaison dans `getStatus` de :

```ts
// Correct : mise à jour seulement si les données d'entrée sont PLUS RÉCENTES que le résultat
response.modifiedAt < response.donneesEntree.lastModifiedAt
```

par :

```ts
// Cassé : mise à jour si les timestamps sont DIFFÉRENTS — ce qui est TOUJOURS vrai
isEqual(new Date(donneesEntree.lastModifiedAt), new Date(existingTrajectoireData.modifiedAt)) === false
```

`result.modifiedAt` = timestamp du calcul. `input.lastModifiedAt` = timestamp d'import RARE/ALDO. Ces deux valeurs ne sont jamais égales → statut toujours `MISE_A_JOUR_DISPONIBLE` → boucle infinie.

### Déclencheur du 2-3 juillet 2026

Un import massif de données RARE/ALDO pour l'ensemble des collectivités EPCI. Avant cet import, la plupart des EPCI avaient `lastModifiedAt = null`, ce qui court-circuitait le bug silencieusement (`newTrajectoireCanBeComputed = null && ... = false`). Après l'import, toutes les collectivités ont un `lastModifiedAt` non-null → le bug s'active pour toutes simultanément.

## Fix

Restaure la sémantique originale dans `trajectoires-data.service.ts` : déclencher `MISE_A_JOUR_DISPONIBLE` uniquement si les données d'entrée sont **plus récentes** que le dernier résultat calculé.

```ts
// Avant
isEqual(new Date(donneesEntree.lastModifiedAt), new Date(existingTrajectoireData.modifiedAt)) === false

// Après
donneesEntree.lastModifiedAt > existingTrajectoireData.modifiedAt
```

Après le prochain passage de la cron, le statut repassera à `DEJA_CALCULE` pour toutes les collectivités dont le calcul date d'après l'import du 2-3 juillet.

## Test plan

- [ ] Vérifier en staging que le statut passe à `DEJA_CALCULE` pour un EPCI dont la trajectoire a déjà été calculée après l'import RARE/ALDO
- [ ] Vérifier que le statut passe bien à `MISE_A_JOUR_DISPONIBLE` si on importe de nouvelles données RARE/ALDO après un calcul (comportement attendu)
- [ ] Vérifier que la cron ne déclenche plus de calcul pour les collectivités déjà à jour

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Le calcul du statut de trajectoire a été fiabilisé : “mise à jour disponible” n’apparaît désormais que lorsque les données d’entrée sont strictement plus récentes que celles déjà calculées.
  * La détection des changements et les statuts associés ont été harmonisés pour éviter des signalisations incorrectes.
* **New Features**
  * Ajout de règles dédiées au calcul du statut de trajectoire, pour une logique plus claire et cohérente.
* **Tests**
  * Mise en place de tests unitaires dédiés aux nouvelles règles de statut.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->