### PR TITLE
Ajoute la fusion des statuts d'origine vers les actions du référentiel CR

### DIFF
--- a/apps/backend/src/referentiels/compute-score/score-map.rules.ts
+++ b/apps/backend/src/referentiels/compute-score/score-map.rules.ts
@@ -1,0 +1,26 @@
+import {
+  type ActionScore,
+  type ActionTreeNode,
+} from '@tet/domain/referentiels';
+
+/**
+ * Indexe récursivement un arbre de scores en Map actionId → ActionScore.
+ * Extrait de ScoresService.fillScoreMap pour réutilisation hors service.
+ */
+export const buildScoreMapByActionId = <
+  T extends { actionId: string; score: ActionScore },
+>(
+  root: ActionTreeNode<T>
+): Map<string, ActionScore> => {
+  const scoreMap = new Map<string, ActionScore>();
+
+  const visit = (action: ActionTreeNode<T>) => {
+    scoreMap.set(action.actionId, action.score);
+    for (const child of action.actionsEnfant) {
+      visit(child as ActionTreeNode<T>);
+    }
+  };
+
+  visit(root);
+  return scoreMap;
+};

--- a/apps/backend/src/referentiels/compute-score/scores.service.ts
+++ b/apps/backend/src/referentiels/compute-score/scores.service.ts
@@ -45,7 +45,6 @@ import { chunk, isEqual, isNil, pick } from 'es-toolkit';
 import { DateTime } from 'luxon';
 import { PersonnalisationConsequencesByActionId } from '../../collectivites/personnalisations/models/personnalisation-consequence.dto';
 import PersonnalisationsExpressionService from '../../collectivites/personnalisations/services/personnalisations-expression.service';
-import PersonnalisationsService from '../../collectivites/personnalisations/services/personnalisations-service';
 import CollectivitesService from '../../collectivites/services/collectivites.service';
 import {
   AuthenticatedUser,
@@ -80,6 +79,7 @@ import { GetReferentielMultipleScoresRequestType } from '../models/get-referenti
 import { GetReferentielScoresRequestType } from '../models/get-referentiel-scores.request';
 import { inferStatutDetailleAuPourcentageFromStatut } from '../update-action-statut/action-statut-create-to-action-statut-in-database.adapter';
 import { ActionStatutsByActionId } from './action-statuts-by-action-id.dto';
+import { buildScoreMapByActionId } from './score-map.rules';
 
 type ActionWithScore = ActionTreeNode<ActionDefinitionEssential & ScoreFields>;
 
@@ -100,7 +100,6 @@ export default class ScoresService {
     private readonly databaseService: DatabaseService,
     private readonly getReferentielsService: GetReferentielService,
     private readonly getReferentielDefinitionService: GetReferentielDefinitionService,
-    private readonly personnalisationService: PersonnalisationsService,
     private readonly actionPersonnalisationsService: ActionPersonnalisationsService,
     private readonly personnalisationsExpressionService: PersonnalisationsExpressionService,
     private readonly labellisationService: LabellisationService,
@@ -1535,18 +1534,7 @@ export default class ScoresService {
   private fillScoreMap(
     action: ActionTreeNode<ActionDefinitionEssential & ScoreFinalFields>
   ): ScoresByActionId {
-    const actionScoresOfChildren = action.actionsEnfant.reduce(
-      (acc, actionEnfant) => ({
-        ...acc,
-        ...this.fillScoreMap(actionEnfant),
-      }),
-      {}
-    );
-
-    return {
-      [action.actionId]: action.score,
-      ...actionScoresOfChildren,
-    };
+    return Object.fromEntries(buildScoreMapByActionId(action));
   }
 
   private fillScorePercentageMap(

--- a/apps/backend/src/referentiels/referentiels.module.ts
+++ b/apps/backend/src/referentiels/referentiels.module.ts
@@ -82,6 +82,8 @@ import { ReferentielsRouter } from './referentiels.router';
 import { ResetDisplayPreferencesRouter } from './reset-display-preferences/reset-display-preferences.router';
 import { ResetDisplayPreferencesService } from './reset-display-preferences/reset-display-preferences.service';
 import { CreatePreSwitchSnapshotsService } from './switch-to-te/create-pre-switch-snapshots.service';
+import { BuildSwitchToTeContextService } from './switch-to-te/build-switch-to-te-context.service';
+import { MergeStatutsService } from './switch-to-te/merge-statuts/merge-statuts.service';
 import { SwitchToTeRouter } from './switch-to-te/switch-to-te.router';
 import { SwitchToTeService } from './switch-to-te/switch-to-te.service';
 import { ListSnapshotsService } from './snapshots/list-snapshots/list-snapshots.service';
@@ -196,6 +198,8 @@ import { UpdateActionStatutService } from './update-action-statut/update-action-
     SwitchToTeService,
     SwitchToTeRouter,
     CreatePreSwitchSnapshotsService,
+    BuildSwitchToTeContextService,
+    MergeStatutsService,
 
     HistoriqueRouter,
     ListHistoriqueRepository,

--- a/apps/backend/src/referentiels/switch-to-te/build-switch-to-te-context.service.ts
+++ b/apps/backend/src/referentiels/switch-to-te/build-switch-to-te-context.service.ts
@@ -1,0 +1,118 @@
+import { Injectable } from '@nestjs/common';
+import { buildScoreMapByActionId } from '@tet/backend/referentiels/compute-score/score-map.rules';
+import ScoresService from '@tet/backend/referentiels/compute-score/scores.service';
+import { GetReferentielService } from '@tet/backend/referentiels/get-referentiel/get-referentiel.service';
+import { SNAPSHOTS } from '@tet/backend/referentiels/snapshots/snapshots.constants';
+import type { ServiceSecondArg } from '@tet/backend/utils/nest/service-second-arg.utils';
+import { failure, success, type Result } from '@tet/backend/utils/result.type';
+import { type CollectiviteReferentielPreferences } from '@tet/domain/collectivites';
+import {
+  ReferentielIdEnum,
+  type ActionScore,
+  type ReferentielId,
+  type ScoreSnapshot,
+} from '@tet/domain/referentiels';
+import { listActionCiblesSousActionsEtTaches } from './shared/action-cible';
+import { type SwitchToTeContext } from './shared/switch-to-te-context';
+import {
+  SwitchToTeErrorEnum,
+  type SwitchToTeError,
+} from './switch-to-te.errors';
+
+@Injectable()
+export class BuildSwitchToTeContextService {
+  private static readonly SOURCE_REFERENTIELS = [
+    ReferentielIdEnum.CAE,
+    ReferentielIdEnum.ECI,
+  ] as const;
+
+  constructor(
+    private readonly scoresService: ScoresService,
+    private readonly getReferentielService: GetReferentielService
+  ) {}
+
+  async build(
+    collectiviteId: number,
+    prefs: CollectiviteReferentielPreferences,
+    preSwitchSnapshots: ScoreSnapshot[],
+    { user }: ServiceSecondArg
+  ): Promise<Result<SwitchToTeContext, SwitchToTeError>> {
+    const sourceReferentiels =
+      BuildSwitchToTeContextService.SOURCE_REFERENTIELS.filter(
+        (referentielId) => prefs[referentielId].mode === 'write'
+      );
+
+    const scoreMapsResult = this.buildScoreMapsFromPreSwitchSnapshots(
+      collectiviteId,
+      sourceReferentiels,
+      preSwitchSnapshots
+    );
+    if (!scoreMapsResult.success) {
+      return scoreMapsResult;
+    }
+
+    const referentielTe = await this.getReferentielService.getReferentielTree(
+      ReferentielIdEnum.TE,
+      true,
+      true
+    );
+
+    const { scoresPayload } =
+      await this.scoresService.computeScoreForCollectivite(
+        ReferentielIdEnum.TE,
+        collectiviteId,
+        { avecReferentielsOrigine: false },
+        user
+      );
+
+    const teScoreMap = buildScoreMapByActionId(scoresPayload.scores);
+    const cibles = {
+      sousActionsEtTaches: listActionCiblesSousActionsEtTaches({
+        referentielTe,
+        scoreMapsByReferentiel: scoreMapsResult.data,
+        teScoreMap,
+      }),
+    };
+
+    return success({
+      collectiviteId,
+      sourceReferentiels,
+      scoreMapsByReferentiel: scoreMapsResult.data,
+      referentielTe,
+      teScoreMap,
+      cibles,
+    });
+  }
+
+  private buildScoreMapsFromPreSwitchSnapshots(
+    collectiviteId: number,
+    sourceReferentiels: ReferentielId[],
+    preSwitchSnapshots: ScoreSnapshot[]
+  ): Result<Map<ReferentielId, Map<string, ActionScore>>, SwitchToTeError> {
+    const snapshotsByReferentielId = new Map(
+      preSwitchSnapshots
+        .filter((snapshot) => snapshot.ref === SNAPSHOTS.PRE_SWITCH_TE_REF)
+        .map((snapshot) => [snapshot.referentielId, snapshot] as const)
+    );
+
+    const scoreMapsByReferentiel = new Map<
+      ReferentielId,
+      Map<string, ActionScore>
+    >();
+
+    for (const referentielId of sourceReferentiels) {
+      const snapshot = snapshotsByReferentielId.get(referentielId);
+
+      if (!snapshot || snapshot.collectiviteId !== collectiviteId) {
+        return failure(SwitchToTeErrorEnum.PRE_SWITCH_SNAPSHOT_MISSING);
+      }
+
+      scoreMapsByReferentiel.set(
+        referentielId,
+        buildScoreMapByActionId(snapshot.scoresPayload.scores)
+      );
+    }
+
+    return success(scoreMapsByReferentiel);
+  }
+}

--- a/apps/backend/src/referentiels/switch-to-te/merge-statuts/merge-statuts.rules.spec.ts
+++ b/apps/backend/src/referentiels/switch-to-te/merge-statuts/merge-statuts.rules.spec.ts
@@ -1,0 +1,170 @@
+import { StatutAvancementEnum } from '@tet/domain/referentiels';
+import {
+  arrondiTripletCinqPourcent,
+  deriveStatutDetailleAuPourcentage,
+  deriveStatutDiscret,
+  deriveStatutFromProjection,
+  deriveTripletFromProjectedPoints,
+  isTripletStatutDiscret,
+  MERGE_STATUTS_STATUT_DISCRET_EPSILON,
+} from './merge-statuts.rules';
+
+describe('merge-statuts.rules', () => {
+  describe('deriveTripletFromProjectedPoints', () => {
+    it('calcule les fractions à partir des points projetés', () => {
+      expect(
+        deriveTripletFromProjectedPoints({
+          pointFait: 7,
+          pointProgramme: 0,
+          pointPasFait: 3,
+          pointPotentiel: 10,
+        })
+      ).toEqual([0.7, 0, 0.3]);
+    });
+
+    it('retourne [0,0,0] si pointPotentiel est nul', () => {
+      expect(
+        deriveTripletFromProjectedPoints({
+          pointFait: 1,
+          pointProgramme: 0,
+          pointPasFait: 0,
+          pointPotentiel: 0,
+        })
+      ).toEqual([0, 0, 0]);
+    });
+  });
+
+  describe('isTripletStatutDiscret', () => {
+    it('détecte un triplet pur [1,0,0]', () => {
+      expect(isTripletStatutDiscret([1, 0, 0])).toBe(true);
+    });
+
+    it('absorbe le résidu post-arrondi scoring [0.999, 0, 0.001]', () => {
+      expect(isTripletStatutDiscret([0.999, 0, 0.001])).toBe(true);
+    });
+
+    it('rejette un triplet détaillé [0.74, 0, 0.26]', () => {
+      expect(isTripletStatutDiscret([0.74, 0, 0.26])).toBe(false);
+    });
+
+    it('rejette le bord détaillé [0.99, 0, 0.01] (0.01 > ε)', () => {
+      expect(isTripletStatutDiscret([0.99, 0, 0.01])).toBe(false);
+      expect(0.01).toBeGreaterThan(MERGE_STATUTS_STATUT_DISCRET_EPSILON);
+    });
+  });
+
+  describe('deriveStatutDiscret', () => {
+    it('retourne fait pour un triplet dominant fait', () => {
+      expect(deriveStatutDiscret([1, 0, 0])).toEqual({
+        statut: StatutAvancementEnum.FAIT,
+      });
+    });
+
+    it('retourne fait pour un résidu post-arrondi scoring', () => {
+      expect(deriveStatutDiscret([0.999, 0, 0.001])).toEqual({
+        statut: StatutAvancementEnum.FAIT,
+      });
+    });
+  });
+
+  describe('arrondiTripletCinqPourcent', () => {
+    it('arrondit à l inférieur au pas de 5 % (74 % → 70 %)', () => {
+      expect(arrondiTripletCinqPourcent([0.74, 0, 0.26])).toEqual([
+        0.7, 0, 0.3,
+      ]);
+    });
+
+    it('recalcule pas_fait pour compléter à 100 %', () => {
+      expect(arrondiTripletCinqPourcent([0.5, 0.5, 0])).toEqual([0.5, 0.5, 0]);
+    });
+  });
+
+  describe('deriveStatutDetailleAuPourcentage', () => {
+    it('retourne detaille avec le triplet arrondi', () => {
+      expect(deriveStatutDetailleAuPourcentage([0.7, 0, 0.3])).toEqual({
+        statut: StatutAvancementEnum.DETAILLE_AU_POURCENTAGE,
+        statutDetailleAuPourcentage: [0.7, 0, 0.3],
+      });
+    });
+  });
+
+  describe('deriveStatutFromProjection', () => {
+    it('retourne NON_CONCERNE sans source concernée', () => {
+      expect(
+        deriveStatutFromProjection({
+          concernedSourceCount: 0,
+          pointFait: 0,
+          pointProgramme: 0,
+          pointPasFait: 0,
+          pointPotentiel: 5,
+        })
+      ).toEqual({ statut: StatutAvancementEnum.NON_CONCERNE });
+    });
+
+    it('retourne NON_RENSEIGNE si sources concernées sans avancement', () => {
+      expect(
+        deriveStatutFromProjection({
+          concernedSourceCount: 1,
+          pointFait: 0,
+          pointProgramme: 0,
+          pointPasFait: 0,
+          pointPotentiel: 5,
+        })
+      ).toEqual({ statut: StatutAvancementEnum.NON_RENSEIGNE });
+    });
+
+    it('retourne fait pour un triplet discret [1,0,0]', () => {
+      expect(
+        deriveStatutFromProjection({
+          concernedSourceCount: 1,
+          pointFait: 5,
+          pointProgramme: 0,
+          pointPasFait: 0,
+          pointPotentiel: 5,
+        })
+      ).toEqual({ statut: StatutAvancementEnum.FAIT });
+    });
+
+    it('retourne fait pour un résidu post-arrondi scoring', () => {
+      expect(
+        deriveStatutFromProjection({
+          concernedSourceCount: 1,
+          pointFait: 4.995,
+          pointProgramme: 0,
+          pointPasFait: 0.005,
+          pointPotentiel: 5,
+        })
+      ).toEqual({ statut: StatutAvancementEnum.FAIT });
+    });
+
+    it('retourne detaille + triplet arrondi pour [0.74, 0, 0.26]', () => {
+      expect(
+        deriveStatutFromProjection({
+          concernedSourceCount: 1,
+          pointFait: 3.7,
+          pointProgramme: 0,
+          pointPasFait: 1.3,
+          pointPotentiel: 5,
+        })
+      ).toEqual({
+        statut: StatutAvancementEnum.DETAILLE_AU_POURCENTAGE,
+        statutDetailleAuPourcentage: [0.7, 0, 0.3],
+      });
+    });
+
+    it('retourne detaille pour le bord [0.99, 0, 0.01]', () => {
+      expect(
+        deriveStatutFromProjection({
+          concernedSourceCount: 1,
+          pointFait: 4.95,
+          pointProgramme: 0,
+          pointPasFait: 0.05,
+          pointPotentiel: 5,
+        })
+      ).toEqual({
+        statut: StatutAvancementEnum.DETAILLE_AU_POURCENTAGE,
+        statutDetailleAuPourcentage: [0.95, 0, 0.05],
+      });
+    });
+  });
+});

--- a/apps/backend/src/referentiels/switch-to-te/merge-statuts/merge-statuts.rules.ts
+++ b/apps/backend/src/referentiels/switch-to-te/merge-statuts/merge-statuts.rules.ts
@@ -1,0 +1,142 @@
+import {
+  type ActionScoreFinal,
+  type ActionStatutCreate,
+  StatutAvancementEnum,
+  type StatutDetailleAuPourcentage,
+} from '@tet/domain/referentiels';
+
+/** aligné sur ScoresService.DEFAULT_ROUNDING_DIGITS (3 décimales) */
+export const MERGE_STATUTS_STATUT_DISCRET_EPSILON = 1e-3;
+
+export type MergeStatutsProjectedPoints = Pick<
+  ActionScoreFinal,
+  'pointFait' | 'pointProgramme' | 'pointPasFait' | 'pointPotentiel'
+>;
+
+export type StatutProjectionInput = MergeStatutsProjectedPoints & {
+  concernedSourceCount: number;
+};
+
+export type DerivedMergeStatut =
+  | {
+      statut: typeof StatutAvancementEnum.DETAILLE_AU_POURCENTAGE;
+      statutDetailleAuPourcentage: StatutDetailleAuPourcentage;
+    }
+  | {
+      statut: Exclude<
+        ActionStatutCreate['statut'],
+        | typeof StatutAvancementEnum.DETAILLE_AU_POURCENTAGE
+        | typeof StatutAvancementEnum.DETAILLE_A_LA_TACHE
+      >;
+    };
+
+export const toActionStatutCreate = (
+  collectiviteId: number,
+  actionId: string,
+  derived: DerivedMergeStatut
+): ActionStatutCreate => {
+  if (derived.statut === StatutAvancementEnum.DETAILLE_AU_POURCENTAGE) {
+    return {
+      collectiviteId,
+      actionId,
+      statut: derived.statut,
+      statutDetailleAuPourcentage: derived.statutDetailleAuPourcentage,
+    };
+  }
+
+  return {
+    collectiviteId,
+    actionId,
+    statut: derived.statut,
+  };
+};
+
+export const deriveTripletFromProjectedPoints = ({
+  pointFait,
+  pointProgramme,
+  pointPasFait,
+  pointPotentiel,
+}: MergeStatutsProjectedPoints): StatutDetailleAuPourcentage => {
+  if (pointPotentiel === 0) {
+    return [0, 0, 0];
+  }
+
+  return [
+    pointFait / pointPotentiel,
+    pointProgramme / pointPotentiel,
+    pointPasFait / pointPotentiel,
+  ];
+};
+
+export const isTripletStatutDiscret = (
+  triplet: StatutDetailleAuPourcentage,
+  epsilon = MERGE_STATUTS_STATUT_DISCRET_EPSILON
+): boolean => {
+  const [fait, programme, pasFait] = triplet;
+
+  return (
+    (fait >= 1 - epsilon && programme <= epsilon && pasFait <= epsilon) ||
+    (programme >= 1 - epsilon && fait <= epsilon && pasFait <= epsilon) ||
+    (pasFait >= 1 - epsilon && fait <= epsilon && programme <= epsilon)
+  );
+};
+
+export const deriveStatutDiscret = (
+  triplet: StatutDetailleAuPourcentage,
+  epsilon = MERGE_STATUTS_STATUT_DISCRET_EPSILON
+): DerivedMergeStatut => {
+  const [fait, programme] = triplet;
+
+  if (fait >= 1 - epsilon) {
+    return { statut: StatutAvancementEnum.FAIT };
+  }
+  if (programme >= 1 - epsilon) {
+    return { statut: StatutAvancementEnum.PROGRAMME };
+  }
+  return { statut: StatutAvancementEnum.PAS_FAIT };
+};
+
+export const arrondiCinqPourcent = (value: number) =>
+  Math.floor((value * 100) / 5) * 5;
+
+export const arrondiTripletCinqPourcent = (
+  triplet: StatutDetailleAuPourcentage
+): StatutDetailleAuPourcentage => {
+  const faitPercent = arrondiCinqPourcent(triplet[0]);
+  const programmePercent = arrondiCinqPourcent(triplet[1]);
+  const pasFaitPercent = 100 - faitPercent - programmePercent;
+
+  return [faitPercent / 100, programmePercent / 100, pasFaitPercent / 100];
+};
+
+export const deriveStatutDetailleAuPourcentage = (
+  triplet: StatutDetailleAuPourcentage
+): DerivedMergeStatut => ({
+  statut: StatutAvancementEnum.DETAILLE_AU_POURCENTAGE,
+  statutDetailleAuPourcentage: triplet,
+});
+
+export const deriveStatutFromProjection = (
+  input: StatutProjectionInput
+): DerivedMergeStatut => {
+  if (input.concernedSourceCount === 0) {
+    return { statut: StatutAvancementEnum.NON_CONCERNE };
+  }
+
+  const allProjectedPointsZero =
+    input.pointFait === 0 &&
+    input.pointProgramme === 0 &&
+    input.pointPasFait === 0;
+
+  if (allProjectedPointsZero) {
+    return { statut: StatutAvancementEnum.NON_RENSEIGNE };
+  }
+
+  const triplet = deriveTripletFromProjectedPoints(input);
+
+  if (isTripletStatutDiscret(triplet)) {
+    return deriveStatutDiscret(triplet);
+  }
+
+  return deriveStatutDetailleAuPourcentage(arrondiTripletCinqPourcent(triplet));
+};

--- a/apps/backend/src/referentiels/switch-to-te/merge-statuts/merge-statuts.service.e2e-spec.ts
+++ b/apps/backend/src/referentiels/switch-to-te/merge-statuts/merge-statuts.service.e2e-spec.ts
@@ -1,0 +1,375 @@
+import { INestApplication } from '@nestjs/common';
+import { addTestCollectiviteAndUser } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { snapshotTable } from '@tet/backend/referentiels/snapshots/snapshot.table';
+import { SNAPSHOTS } from '@tet/backend/referentiels/snapshots/snapshots.constants';
+import { cleanupReferentielActionStatutsAndLabellisations } from '@tet/backend/referentiels/update-action-statut/referentiel-action-statut.test-fixture';
+import {
+  getAuthUserFromUserCredentials,
+  getTestApp,
+  getTestDatabase,
+  getTestRouter,
+} from '@tet/backend/test';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
+import {
+  type Collectivite,
+  type CollectiviteReferentielPreferences,
+} from '@tet/domain/collectivites';
+import {
+  StatutAvancementEnum,
+  type ScoreSnapshot,
+} from '@tet/domain/referentiels';
+import { CollectiviteRole } from '@tet/domain/users';
+import { and, eq } from 'drizzle-orm';
+import { BuildSwitchToTeContextService } from '../build-switch-to-te-context.service';
+import { CreatePreSwitchSnapshotsService } from '../create-pre-switch-snapshots.service';
+import { buildSwitchToTeContextForTest } from '../switch-to-te-context.test-fixture';
+import { SwitchToTeErrorEnum } from '../switch-to-te.errors';
+import { MergeStatutsService } from './merge-statuts.service';
+
+const prefsEligibleCaeOnly: CollectiviteReferentielPreferences = {
+  cae: { display: true, mode: 'write' },
+  eci: { display: false, mode: 'archived' },
+  te: { display: true, mode: 'readonly' },
+};
+
+const prefsEligibleCaeAndEci: CollectiviteReferentielPreferences = {
+  cae: { display: true, mode: 'write' },
+  eci: { display: true, mode: 'write' },
+  te: { display: true, mode: 'readonly' },
+};
+
+/**
+ * Exemples figés depuis `import-referentiel/samples/referentiel-te-structure.csv`.
+ * À mettre à jour si le CSV TE change
+ */
+const MERGE_STATUTS_FIXTURE = {
+  /** TE 1.1.1.2 ← Cae_1.1.2.2.1 (correspondance 1→1) */
+  teActionCae1to1: {
+    teActionId: 'te_1.1.1.2',
+    caeOrigineActionId: 'cae_1.1.2.2.1',
+  },
+  /** TE 5.1.2.3 ← Cae_5.1.2.3 + Eci_1.1.3.3 (fusion 2→1, pondération 1 chacune) */
+  teActionCaeAndEci: {
+    teActionId: 'te_5.1.2.3',
+    caeOrigineActionId: 'cae_5.1.2.3',
+    eciOrigineActionId: 'eci_1.1.3.3',
+  },
+  /** TE 1.1.1.3 : origine « Nouvelle action », sans source CAE/ECI */
+  teNativeActionId: 'te_1.1.1.3',
+} as const;
+
+describe('MergeStatutsService', () => {
+  let app: INestApplication;
+  let databaseService: DatabaseService;
+  let router: TrpcRouter;
+  let mergeService: MergeStatutsService;
+  let buildSwitchToTeContextService: BuildSwitchToTeContextService;
+  let createPreSwitchSnapshotsService: CreatePreSwitchSnapshotsService;
+  let collectivite: Collectivite;
+  let user: AuthenticatedUser;
+  let cleanupFixture: () => Promise<void>;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    databaseService = await getTestDatabase(app);
+    router = await getTestRouter(app);
+    mergeService = app.get(MergeStatutsService);
+    buildSwitchToTeContextService = app.get(BuildSwitchToTeContextService);
+    createPreSwitchSnapshotsService = app.get(CreatePreSwitchSnapshotsService);
+
+    const fixture = await addTestCollectiviteAndUser(databaseService, {
+      user: { role: CollectiviteRole.ADMIN },
+    });
+    collectivite = fixture.collectivite;
+    cleanupFixture = fixture.cleanup;
+    user = getAuthUserFromUserCredentials(fixture.user);
+  });
+
+  afterAll(async () => {
+    await cleanupFixture();
+    await app.close();
+  });
+
+  async function cleanupCollectiviteReferentielData() {
+    await cleanupReferentielActionStatutsAndLabellisations(
+      databaseService,
+      collectivite.id
+    );
+    await databaseService.db
+      .delete(snapshotTable)
+      .where(
+        and(
+          eq(snapshotTable.collectiviteId, collectivite.id),
+          eq(snapshotTable.ref, SNAPSHOTS.PRE_SWITCH_TE_REF)
+        )
+      );
+  }
+
+  async function setupTest() {
+    await cleanupCollectiviteReferentielData();
+  }
+
+  async function setActionStatut(
+    actionId: string,
+    statut: 'fait' | 'pas_fait' | 'non_concerne'
+  ) {
+    const caller = router.createCaller({ user });
+    await caller.referentiels.actions.updateStatuts({
+      actionStatuts: [
+        {
+          collectiviteId: collectivite.id,
+          actionId,
+          statut,
+        },
+      ],
+    });
+  }
+
+  async function setActionStatutDetaille(
+    actionId: string,
+    statutDetailleAuPourcentage: [number, number, number]
+  ) {
+    const caller = router.createCaller({ user });
+    await caller.referentiels.actions.updateStatuts({
+      actionStatuts: [
+        {
+          collectiviteId: collectivite.id,
+          actionId,
+          statut: StatutAvancementEnum.DETAILLE_AU_POURCENTAGE,
+          statutDetailleAuPourcentage,
+        },
+      ],
+    });
+  }
+
+  async function buildCtx(
+    prefs: CollectiviteReferentielPreferences,
+    preSwitchSnapshots?: ScoreSnapshot[]
+  ) {
+    return buildSwitchToTeContextForTest(
+      collectivite.id,
+      prefs,
+      {
+        createPreSwitchSnapshotsService,
+        buildSwitchToTeContextService,
+      },
+      { user, preSwitchSnapshots }
+    );
+  }
+
+  async function mergeFromPrefs(
+    prefs: CollectiviteReferentielPreferences,
+    preSwitchSnapshots?: ScoreSnapshot[]
+  ) {
+    const ctxResult = await buildCtx(prefs, preSwitchSnapshots);
+    expect(ctxResult.success).toBe(true);
+    if (!ctxResult.success) {
+      throw new Error('buildSwitchToTeContext a échoué');
+    }
+    return mergeService.merge(ctxResult.data);
+  }
+
+  test('CAE seul, 1→1 fait : TE reçoit fait sur la sous-action cible', async () => {
+    onTestFinished(cleanupCollectiviteReferentielData);
+    await setupTest();
+
+    const { teActionId, caeOrigineActionId } =
+      MERGE_STATUTS_FIXTURE.teActionCae1to1;
+
+    await setActionStatut(caeOrigineActionId, StatutAvancementEnum.FAIT);
+    const result = await mergeFromPrefs(prefsEligibleCaeOnly);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const teStatut = result.data.find(
+      (statut) => statut.actionId === teActionId
+    );
+    expect(teStatut?.statut).toBe(StatutAvancementEnum.FAIT);
+  });
+
+  test('CAE + ECI write, fusion N→1 : statut TE cohérent avec projection pondérée', async () => {
+    onTestFinished(cleanupCollectiviteReferentielData);
+    await setupTest();
+
+    const { teActionId, caeOrigineActionId, eciOrigineActionId } =
+      MERGE_STATUTS_FIXTURE.teActionCaeAndEci;
+
+    await setActionStatut(caeOrigineActionId, StatutAvancementEnum.FAIT);
+    await setActionStatut(eciOrigineActionId, StatutAvancementEnum.PAS_FAIT);
+    const result = await mergeFromPrefs(prefsEligibleCaeAndEci);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const teStatut = result.data.find(
+      (statut) => statut.actionId === teActionId
+    );
+    expect(teStatut).toEqual({
+      collectiviteId: collectivite.id,
+      actionId: teActionId,
+      statut: StatutAvancementEnum.DETAILLE_AU_POURCENTAGE,
+      statutDetailleAuPourcentage: [0.35, 0, 0.65],
+    });
+  });
+
+  test('toutes sources non concerne : TE reçoit NON_CONCERNE', async () => {
+    onTestFinished(cleanupCollectiviteReferentielData);
+    await setupTest();
+
+    const { teActionId, caeOrigineActionId, eciOrigineActionId } =
+      MERGE_STATUTS_FIXTURE.teActionCaeAndEci;
+
+    await setActionStatut(caeOrigineActionId, 'non_concerne');
+    await setActionStatut(eciOrigineActionId, 'non_concerne');
+    const result = await mergeFromPrefs(prefsEligibleCaeAndEci);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const teStatut = result.data.find(
+      (statut) => statut.actionId === teActionId
+    );
+    expect(teStatut?.statut).toBe(StatutAvancementEnum.NON_CONCERNE);
+  });
+
+  test('CAE seul, fusion N→1 : origine ECI archivée ignorée, TE = statut CAE', async () => {
+    onTestFinished(cleanupCollectiviteReferentielData);
+    await setupTest();
+
+    const { teActionId, caeOrigineActionId } =
+      MERGE_STATUTS_FIXTURE.teActionCaeAndEci;
+
+    await setActionStatut(caeOrigineActionId, StatutAvancementEnum.FAIT);
+    const result = await mergeFromPrefs(prefsEligibleCaeOnly);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const teStatut = result.data.find(
+      (statut) => statut.actionId === teActionId
+    );
+    expect(teStatut?.statut).toBe(StatutAvancementEnum.FAIT);
+  });
+
+  test('source non concerne ignorée : TE = statut de la source restante', async () => {
+    onTestFinished(cleanupCollectiviteReferentielData);
+    await setupTest();
+
+    const { teActionId, caeOrigineActionId, eciOrigineActionId } =
+      MERGE_STATUTS_FIXTURE.teActionCaeAndEci;
+
+    await setActionStatut(caeOrigineActionId, StatutAvancementEnum.FAIT);
+    await setActionStatut(eciOrigineActionId, 'non_concerne');
+    const result = await mergeFromPrefs(prefsEligibleCaeAndEci);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const teStatut = result.data.find(
+      (statut) => statut.actionId === teActionId
+    );
+
+    // 1 fait + 1 non_concerne → équivalent 1→1 sur la source restante (PRD bascule TE)
+    expect(teStatut?.statut).toBe(StatutAvancementEnum.FAIT);
+  });
+
+  test('source concernée sans avancement : TE reçoit NON_RENSEIGNE', async () => {
+    onTestFinished(cleanupCollectiviteReferentielData);
+    await setupTest();
+
+    const { teActionId } = MERGE_STATUTS_FIXTURE.teActionCae1to1;
+
+    const result = await mergeFromPrefs(prefsEligibleCaeOnly);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const teStatut = result.data.find(
+      (statut) => statut.actionId === teActionId
+    );
+    expect(teStatut?.statut).toBe(StatutAvancementEnum.NON_RENSEIGNE);
+  });
+
+  test('1→1 detaille au % : projection + arrondi inférieur 5 % (74 % → 70 %)', async () => {
+    onTestFinished(cleanupCollectiviteReferentielData);
+    await setupTest();
+
+    const { teActionId, caeOrigineActionId } =
+      MERGE_STATUTS_FIXTURE.teActionCae1to1;
+
+    await setActionStatutDetaille(caeOrigineActionId, [0.74, 0, 0.26]);
+
+    const result = await mergeFromPrefs(prefsEligibleCaeOnly);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const teStatut = result.data.find(
+      (statut) => statut.actionId === teActionId
+    );
+    expect(teStatut).toEqual({
+      collectiviteId: collectivite.id,
+      actionId: teActionId,
+      statut: StatutAvancementEnum.DETAILLE_AU_POURCENTAGE,
+      statutDetailleAuPourcentage: [0.7, 0, 0.3],
+    });
+  });
+
+  test('action TE non concernée (personnalisation) : NON_CONCERNE malgré sources CAE concernées', async () => {
+    onTestFinished(cleanupCollectiviteReferentielData);
+    await setupTest();
+
+    const { teActionId, caeOrigineActionId } =
+      MERGE_STATUTS_FIXTURE.teActionCae1to1;
+
+    await setActionStatut(caeOrigineActionId, StatutAvancementEnum.FAIT);
+
+    const caller = router.createCaller({ user });
+    await caller.collectivites.personnalisations.setReponse({
+      collectiviteId: collectivite.id,
+      questionId: 'PCAET_1',
+      reponse: false,
+    });
+
+    const result = await mergeFromPrefs(prefsEligibleCaeOnly);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const teStatut = result.data.find(
+      (statut) => statut.actionId === teActionId
+    );
+    expect(teStatut?.statut).toBe(StatutAvancementEnum.NON_CONCERNE);
+  });
+
+  test('sans pre-switch-te : failure PRE_SWITCH_SNAPSHOT_MISSING', async () => {
+    onTestFinished(cleanupCollectiviteReferentielData);
+    await setupTest();
+
+    const result = await buildCtx(prefsEligibleCaeOnly, []);
+
+    expect(result).toEqual({
+      success: false,
+      error: SwitchToTeErrorEnum.PRE_SWITCH_SNAPSHOT_MISSING,
+    });
+  });
+
+  test('action TE native (sans origine) absente du résultat', async () => {
+    onTestFinished(cleanupCollectiviteReferentielData);
+    await setupTest();
+
+    const result = await mergeFromPrefs(prefsEligibleCaeOnly);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    expect(
+      result.data.some(
+        (statut) => statut.actionId === MERGE_STATUTS_FIXTURE.teNativeActionId
+      )
+    ).toBe(false);
+  });
+});

--- a/apps/backend/src/referentiels/switch-to-te/merge-statuts/merge-statuts.service.ts
+++ b/apps/backend/src/referentiels/switch-to-te/merge-statuts/merge-statuts.service.ts
@@ -1,0 +1,75 @@
+import { Injectable } from '@nestjs/common';
+import ScoresService from '@tet/backend/referentiels/compute-score/scores.service';
+import { success, type Result } from '@tet/backend/utils/result.type';
+import {
+  StatutAvancementEnum,
+  type ActionStatutCreate,
+} from '@tet/domain/referentiels';
+import { type SwitchToTeContext } from '../shared/switch-to-te-context';
+import { type SwitchToTeError } from '../switch-to-te.errors';
+import { getPointPotentiel } from '../shared/origine-resolution';
+import {
+  deriveStatutFromProjection,
+  toActionStatutCreate,
+  type DerivedMergeStatut,
+} from './merge-statuts.rules';
+
+const SCORE_ROUNDING_DIGITS = 3;
+
+@Injectable()
+export class MergeStatutsService {
+  constructor(private readonly scoresService: ScoresService) {}
+
+  merge(
+    ctx: SwitchToTeContext
+  ): Result<ActionStatutCreate[], SwitchToTeError> {
+    const actionStatuts: ActionStatutCreate[] = [];
+
+    for (const cible of ctx.cibles.sousActionsEtTaches) {
+      const tePointPotentiel = getPointPotentiel(
+        ctx.teScoreMap,
+        cible.actionId
+      );
+
+      let derivedStatut: DerivedMergeStatut;
+
+      // l'action TE désactivée/non concernée prime sur la projection des sources
+      if (!cible.concernee) {
+        derivedStatut = { statut: StatutAvancementEnum.NON_CONCERNE };
+      } else if (cible.originesConcernees.length === 0) {
+        derivedStatut = deriveStatutFromProjection({
+          concernedSourceCount: 0,
+          pointFait: 0,
+          pointProgramme: 0,
+          pointPasFait: 0,
+          pointPotentiel: tePointPotentiel,
+        });
+      } else {
+        const ratio = this.scoresService.getRatioFromOrigineActions(
+          cible.originesConcernees,
+          tePointPotentiel
+        );
+        const projected = this.scoresService.getScoreFromOrigineActionsAndRatio(
+          ratio,
+          cible.originesConcernees,
+          SCORE_ROUNDING_DIGITS,
+          tePointPotentiel
+        );
+
+        derivedStatut = deriveStatutFromProjection({
+          concernedSourceCount: cible.originesConcernees.length,
+          pointFait: projected.pointFait ?? 0,
+          pointProgramme: projected.pointProgramme ?? 0,
+          pointPasFait: projected.pointPasFait ?? 0,
+          pointPotentiel: tePointPotentiel,
+        });
+      }
+
+      actionStatuts.push(
+        toActionStatutCreate(ctx.collectiviteId, cible.actionId, derivedStatut)
+      );
+    }
+
+    return success(actionStatuts);
+  }
+}

--- a/apps/backend/src/referentiels/switch-to-te/shared/action-cible.ts
+++ b/apps/backend/src/referentiels/switch-to-te/shared/action-cible.ts
@@ -1,0 +1,61 @@
+import { type CorrelatedAction } from '@tet/backend/referentiels/correlated-actions/referentiel-action-origine.dto';
+import { type CorrelatedActionWithScore } from '@tet/backend/referentiels/correlated-actions/referentiel-action-origine-with-score.dto';
+import { type ReferentielResponse } from '@tet/backend/referentiels/get-referentiel/get-referentiel.service';
+import {
+  ActionTypeEnum,
+  flatMapActionsEnfants,
+  type ActionScore,
+  type ReferentielId,
+} from '@tet/domain/referentiels';
+import {
+  buildCorrelatedActionsWithScore,
+  filterOriginesConcernees,
+  isCibleConcernee,
+} from './origine-resolution';
+
+/**
+ * Action destination de la bascule + origines résolues depuis les snapshots pre-switch-te.
+ * Artefact runtime backend — ne pas confondre avec ActionOrigine (entité BDD @tet/domain).
+ */
+export type ActionCible = {
+  actionId: string;
+  /** false si désactivée / non concernée par personnalisation TE */
+  concernee: boolean;
+  /** origines brutes (ordre arbre) — pour tri CAE puis ECI côté rules */
+  actionsOrigine: CorrelatedAction[];
+  /** origines avec score snapshot + filtre concerne !== false */
+  originesConcernees: CorrelatedActionWithScore[];
+};
+
+export const listActionCiblesSousActionsEtTaches = (input: {
+  referentielTe: ReferentielResponse;
+  scoreMapsByReferentiel: Map<ReferentielId, Map<string, ActionScore>>;
+  teScoreMap: Map<string, ActionScore>;
+}): ActionCible[] => {
+  const teActionsWithOrigine = flatMapActionsEnfants(
+    input.referentielTe.itemsTree
+  ).filter(
+    (action) =>
+      (action.actionType === ActionTypeEnum.SOUS_ACTION ||
+        action.actionType === ActionTypeEnum.TACHE) &&
+      (action.actionsOrigine?.length ?? 0) > 0
+  );
+
+  return teActionsWithOrigine.map((teAction) => {
+    const actionsOrigine = teAction.actionsOrigine ?? [];
+    const correlatedActions = buildCorrelatedActionsWithScore(
+      actionsOrigine,
+      input.scoreMapsByReferentiel
+    );
+
+    return {
+      actionId: teAction.actionId,
+      concernee: isCibleConcernee(input.teScoreMap, teAction.actionId),
+      actionsOrigine,
+      originesConcernees: filterOriginesConcernees(
+        correlatedActions,
+        input.scoreMapsByReferentiel
+      ),
+    };
+  });
+};

--- a/apps/backend/src/referentiels/switch-to-te/shared/origine-resolution.spec.ts
+++ b/apps/backend/src/referentiels/switch-to-te/shared/origine-resolution.spec.ts
@@ -1,0 +1,118 @@
+import { type CorrelatedActionWithScore } from '@tet/backend/referentiels/correlated-actions/referentiel-action-origine-with-score.dto';
+import {
+  type ActionScore,
+  ReferentielIdEnum,
+  type ReferentielId,
+} from '@tet/domain/referentiels';
+import {
+  filterOriginesConcernees,
+  isCibleConcernee,
+} from '../shared/origine-resolution';
+
+const createActionScore = (
+  overrides: Partial<ActionScore> = {}
+): ActionScore =>
+  ({
+    concerne: true,
+    pointReferentiel: 1,
+    ...overrides,
+  }) as ActionScore;
+
+const createCorrelatedAction = (
+  referentielId: ReferentielId,
+  actionId: string
+): CorrelatedActionWithScore => ({
+  referentielId,
+  actionId,
+  ponderation: 1,
+  nom: null,
+  score: null,
+});
+
+describe('filterOriginesConcernees', () => {
+  it('conserve une source concernée présente dans le snapshot', () => {
+    const caeScoreMap = new Map<string, ActionScore>([
+      ['cae_1', createActionScore({ concerne: true })],
+    ]);
+    const scoreMapsByReferentiel = new Map<ReferentielId, Map<string, ActionScore>>([
+      [ReferentielIdEnum.CAE, caeScoreMap],
+    ]);
+
+    expect(
+      filterOriginesConcernees(
+        [createCorrelatedAction(ReferentielIdEnum.CAE, 'cae_1')],
+        scoreMapsByReferentiel
+      )
+    ).toHaveLength(1);
+  });
+
+  it('exclut une source non_concerne', () => {
+    const caeScoreMap = new Map<string, ActionScore>([
+      ['cae_1', createActionScore({ concerne: false })],
+    ]);
+    const scoreMapsByReferentiel = new Map<ReferentielId, Map<string, ActionScore>>([
+      [ReferentielIdEnum.CAE, caeScoreMap],
+    ]);
+
+    expect(
+      filterOriginesConcernees(
+        [createCorrelatedAction(ReferentielIdEnum.CAE, 'cae_1')],
+        scoreMapsByReferentiel
+      )
+    ).toHaveLength(0);
+  });
+
+  it('exclut une origine dont le référentiel n a pas de snapshot (ex. ECI archivé)', () => {
+    const caeScoreMap = new Map<string, ActionScore>([
+      ['cae_1', createActionScore()],
+    ]);
+    const scoreMapsByReferentiel = new Map<ReferentielId, Map<string, ActionScore>>([
+      [ReferentielIdEnum.CAE, caeScoreMap],
+    ]);
+
+    expect(
+      filterOriginesConcernees(
+        [createCorrelatedAction(ReferentielIdEnum.ECI, 'eci_1')],
+        scoreMapsByReferentiel
+      )
+    ).toHaveLength(0);
+  });
+
+  it('exclut une origine absente du snapshot de son référentiel', () => {
+    const caeScoreMap = new Map<string, ActionScore>([
+      ['cae_1', createActionScore()],
+    ]);
+    const scoreMapsByReferentiel = new Map<ReferentielId, Map<string, ActionScore>>([
+      [ReferentielIdEnum.CAE, caeScoreMap],
+    ]);
+
+    expect(
+      filterOriginesConcernees(
+        [createCorrelatedAction(ReferentielIdEnum.CAE, 'cae_inconnue')],
+        scoreMapsByReferentiel
+      )
+    ).toHaveLength(0);
+  });
+});
+
+describe('isCibleConcernee', () => {
+  it('retourne true si le score est absent', () => {
+    expect(isCibleConcernee(new Map(), 'te_1')).toBe(true);
+  });
+
+  it('retourne true si concerne est true', () => {
+    const scoreMap = new Map<string, ActionScore>([
+      ['te_1', createActionScore({ concerne: true })],
+    ]);
+
+    expect(isCibleConcernee(scoreMap, 'te_1')).toBe(true);
+  });
+
+  it('retourne false si concerne est false (personnalisation / désactivation)', () => {
+    const scoreMap = new Map<string, ActionScore>([
+      ['te_1', createActionScore({ concerne: false, pointPotentiel: 0 })],
+    ]);
+
+    expect(isCibleConcernee(scoreMap, 'te_1')).toBe(false);
+  });
+});

--- a/apps/backend/src/referentiels/switch-to-te/shared/origine-resolution.ts
+++ b/apps/backend/src/referentiels/switch-to-te/shared/origine-resolution.ts
@@ -1,0 +1,87 @@
+import { type CorrelatedActionWithScore } from '@tet/backend/referentiels/correlated-actions/referentiel-action-origine-with-score.dto';
+import { type CorrelatedAction } from '@tet/backend/referentiels/correlated-actions/referentiel-action-origine.dto';
+import {
+  type ActionScore,
+  type ActionScoreWithOnlyPointsAndStatuts,
+  type ReferentielId,
+} from '@tet/domain/referentiels';
+
+export const isOrigineConcernee = (actionScore: ActionScore): boolean =>
+  actionScore.concerne !== false;
+
+export const actionScoreToCorrelatedActionScore = (
+  actionScore: ActionScore
+): ActionScoreWithOnlyPointsAndStatuts => ({
+  pointFait: actionScore.pointFait || 0,
+  pointProgramme: actionScore.pointProgramme || 0,
+  pointPasFait: actionScore.pointPasFait || 0,
+  pointNonRenseigne: actionScore.pointNonRenseigne || 0,
+  pointPotentiel: actionScore.pointPotentiel || 0,
+  pointReferentiel: actionScore.pointReferentiel || 0,
+  totalTachesCount: actionScore.totalTachesCount || 0,
+  faitTachesAvancement: actionScore.faitTachesAvancement || 0,
+  programmeTachesAvancement: actionScore.programmeTachesAvancement || 0,
+  pasFaitTachesAvancement: actionScore.pasFaitTachesAvancement || 0,
+  pasConcerneTachesAvancement: actionScore.pasConcerneTachesAvancement || 0,
+  ...(actionScore.etoiles !== undefined
+    ? { etoiles: actionScore.etoiles }
+    : {}),
+});
+
+export const buildCorrelatedActionsWithScore = (
+  actionsOrigine: CorrelatedAction[],
+  scoreMapsByReferentiel: Map<ReferentielId, Map<string, ActionScore>>
+): CorrelatedActionWithScore[] =>
+  actionsOrigine.map((origine) => {
+    const scoreMap = scoreMapsByReferentiel.get(
+      origine.referentielId as ReferentielId
+    );
+    const actionScore = scoreMap?.get(origine.actionId);
+
+    return {
+      ...origine,
+      score: actionScore
+        ? actionScoreToCorrelatedActionScore(actionScore)
+        : null,
+    };
+  });
+
+export const filterOriginesConcernees = (
+  correlatedActions: CorrelatedActionWithScore[],
+  scoreMapsByReferentiel: Map<ReferentielId, Map<string, ActionScore>>
+): CorrelatedActionWithScore[] =>
+  correlatedActions.filter((origine) => {
+    const scoreMap = scoreMapsByReferentiel.get(
+      origine.referentielId as ReferentielId
+    );
+    if (!scoreMap) {
+      return false;
+    }
+
+    const actionScore = scoreMap.get(origine.actionId);
+    if (!actionScore) {
+      return false;
+    }
+
+    return isOrigineConcernee(actionScore);
+  });
+
+export const getPointPotentiel = (
+  scoreMap: Map<string, ActionScore>,
+  actionId: string
+): number => {
+  const score = scoreMap.get(actionId);
+  return score?.pointPotentiel ?? score?.pointReferentiel ?? 0;
+};
+
+export const isCibleConcernee = (
+  teScoreMap: Map<string, ActionScore>,
+  actionId: string
+): boolean => {
+  const score = teScoreMap.get(actionId);
+  if (!score) {
+    return true;
+  }
+
+  return score.concerne !== false;
+};

--- a/apps/backend/src/referentiels/switch-to-te/shared/switch-to-te-context.ts
+++ b/apps/backend/src/referentiels/switch-to-te/shared/switch-to-te-context.ts
@@ -1,0 +1,16 @@
+import { type ReferentielResponse } from '@tet/backend/referentiels/get-referentiel/get-referentiel.service';
+import { type ActionScore, type ReferentielId } from '@tet/domain/referentiels';
+import { type ActionCible } from './action-cible';
+
+export type SwitchToTeContext = {
+  collectiviteId: number;
+  /** refs sources en write au moment du build — dérivé des prefs, figé dans le contexte */
+  sourceReferentiels: ReferentielId[];
+  scoreMapsByReferentiel: Map<ReferentielId, Map<string, ActionScore>>;
+  referentielTe: ReferentielResponse;
+  teScoreMap: Map<string, ActionScore>;
+  cibles: {
+    /** PR12, PR13 — origines directes sur sous-action / tâche */
+    sousActionsEtTaches: ActionCible[];
+  };
+};

--- a/apps/backend/src/referentiels/switch-to-te/switch-to-te-context.test-fixture.ts
+++ b/apps/backend/src/referentiels/switch-to-te/switch-to-te-context.test-fixture.ts
@@ -1,0 +1,48 @@
+import { type AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { type Result } from '@tet/backend/utils/result.type';
+import { type CollectiviteReferentielPreferences } from '@tet/domain/collectivites';
+import { type ScoreSnapshot } from '@tet/domain/referentiels';
+import { BuildSwitchToTeContextService } from './build-switch-to-te-context.service';
+import { CreatePreSwitchSnapshotsService } from './create-pre-switch-snapshots.service';
+import { type SwitchToTeContext } from './shared/switch-to-te-context';
+import { type SwitchToTeError } from './switch-to-te.errors';
+
+export async function buildSwitchToTeContextForTest(
+  collectiviteId: number,
+  prefs: CollectiviteReferentielPreferences,
+  services: {
+    createPreSwitchSnapshotsService: CreatePreSwitchSnapshotsService;
+    buildSwitchToTeContextService: BuildSwitchToTeContextService;
+  },
+  {
+    user,
+    preSwitchSnapshots,
+  }: {
+    user: AuthenticatedUser;
+    preSwitchSnapshots?: ScoreSnapshot[];
+  }
+): Promise<Result<SwitchToTeContext, SwitchToTeError>> {
+  let snapshots = preSwitchSnapshots;
+
+  if (!snapshots) {
+    const snapshotsResult =
+      await services.createPreSwitchSnapshotsService.createPreSwitchSnapshots(
+        collectiviteId,
+        prefs,
+        { user }
+      );
+
+    if (!snapshotsResult.success) {
+      return snapshotsResult;
+    }
+
+    snapshots = snapshotsResult.data;
+  }
+
+  return services.buildSwitchToTeContextService.build(
+    collectiviteId,
+    prefs,
+    snapshots,
+    { user }
+  );
+}

--- a/apps/backend/src/referentiels/switch-to-te/switch-to-te.errors.ts
+++ b/apps/backend/src/referentiels/switch-to-te/switch-to-te.errors.ts
@@ -16,6 +16,7 @@ const specificErrors = [
   'AUDIT_IN_PROGRESS',
   'SWITCH_NOT_IMPLEMENTED',
   'PRE_SWITCH_SNAPSHOT_FAILED',
+  'PRE_SWITCH_SNAPSHOT_MISSING',
   ...collectivitePreferencesSpecificErrors,
 ] as const;
 
@@ -55,6 +56,11 @@ export const switchToTeTrpcErrorEntries = {
   PRE_SWITCH_SNAPSHOT_FAILED: {
     code: 'INTERNAL_SERVER_ERROR',
     message: 'Impossible de créer le snapshot pré-bascule',
+  },
+  PRE_SWITCH_SNAPSHOT_MISSING: {
+    code: 'PRECONDITION_FAILED',
+    message:
+      'Snapshot pre-switch-te manquant — exécuter createPreSwitchSnapshots avant mergeStatuts',
   },
 } as const;
 

--- a/doc/plans/2026-06-11-001-feat-bascule-referentiel-te-prd.md
+++ b/doc/plans/2026-06-11-001-feat-bascule-referentiel-te-prd.md
@@ -499,17 +499,17 @@ La bascule produit des statuts TE **cohérents avec le pipeline de scoring**, en
 
 **Orchestration amont (PR12)** — avant d'appeler `getRatioFromOrigineActions` / `getScoreFromOrigineActionsAndRatio`, construire pour chaque action TE la **liste de ses actions sources CAE/ECI avec score** (`CorrelatedActionWithScore[]`) :
 
-Chaque entrée = une ligne `action_origine` (identifiant source, référentiel, pondération, nom) + le **score déjà calculé** sur cette action dans son référentiel d'origine (`pointReferentiel`, avancement fait/programme/pas fait, etc.).
+Chaque entrée = une ligne `action_origine` (identifiant source, référentiel, pondération, nom) + le **score figé** sur cette action dans le snapshot `pre-switch-te` de son référentiel d'origine (`pointReferentiel`, avancement fait/programme/pas fait, etc.).
 
-1. Appeler `computeScoreForCollectivite` pour chaque réf. CAE/ECI concerné (personnalisation courante au moment T).
-2. Pour chaque action TE, récupérer ses correspondances d'origine et y attacher le score de l'action source correspondante (étape 1).
-3. Passer cette liste à `getRatioFromOrigineActions` puis `getScoreFromOrigineActionsAndRatio`.
+1. Lire les snapshots `pre-switch-te` créés par `CreatePreSwitchSnapshotsService` (un par ref. CAE/ECI en `mode: write`) — **injectés en mémoire** par l'orchestrateur (`createPreSwitchSnapshots` → `mergeStatuts`), sans re-read DB (cohérence transactionnelle PR18).
+2. Recalculer uniquement le score TE (`computeScoreForCollectivite('te')`) pour les potentiels personnalisés.
+3. Pour chaque action TE, attacher le score source depuis le snapshot figé injecté, puis passer la liste à `getRatioFromOrigineActions` puis `getScoreFromOrigineActionsAndRatio`.
 
 > Ne pas réutiliser directement `computeScoreFromReferentielsOrigine` (privée, pipeline projection lecture seule) — la bascule persiste des statuts, pas une projection à la volée.
 
 Pour chaque action TE avec correspondance d'origine :
 
-1. Recalculer scores CAE/ECI avec personnalisation courante ; filtrer sources `concerne = false` ; appliquer arbre TE avec **personnalisation courante** ; projeter via pondération d'origine.
+1. Lire les scores sources depuis les snapshots `pre-switch-te` ; filtrer sources `concerne = false` ; appliquer arbre TE avec **personnalisation courante** ; projeter via pondération d'origine.
 2. Dériver triplet `[fait, programme, pas_fait]` depuis points projetés.
 3. **Post-traitement TE** : arrondi à l'inférieur au pas de 5 % pour triplets mixtes (`fait` et `programme` → multiple de 5 % immédiatement inférieur ; ex. 74 % → 70 %) ; `pas_fait = 1 - fait - programme` ; triplet pur → statut discret.
 4. Persister : triplet pur → `fait`/`programme`/`pas_fait` ; mixte → `detaille` ; aucune source concernée → `non_renseigne` + `concerne = false` ; sources concernées sans avancement → `non_renseigne` + `concerne = true`.

--- a/doc/plans/2026-06-11-007-feat-bascule-referentiel-te-pr12-plan.md
+++ b/doc/plans/2026-06-11-007-feat-bascule-referentiel-te-pr12-plan.md
@@ -1,0 +1,432 @@
+---
+name: PR12 Fusion statuts
+overview: "Implémenter mergeStatuts : projection des statuts CAE/ECI vers TE via ScoresService, avec scores sources lus depuis les snapshots pre-switch-te figés, règles TE (statut discret vs détaillé au %, arrondi 5 %), SwitchToTeContext partagé (infra + cibles pré-résolues) et service métier testé — sans persistance ni câblage dans switchToTe() (PR17/PR18)."
+todos:
+  - id: switch-to-te-context
+    content: Créer SwitchToTeContext + ActionCible (backend switch-to-te/shared/) + BuildSwitchToTeContextService + switch-to-te-context.test-fixture.ts
+    status: pending
+  - id: rules-pures
+    content: Créer merge-statuts.rules.ts (triplet, statut discret vs détaillé, arrondi 5 %) + merge-statuts.rules.spec.ts (cas annexe A PRD)
+    status: pending
+  - id: origine-resolution
+    content: Migrer origine-resolution.ts (résolution score source, filtre concerne, isCibleConcernee) depuis l'adapter PR12
+    status: pending
+  - id: merge-service
+    content: Créer MergeStatutsService.merge(ctx) — itère ctx.cibles, projection ScoresService, sans I/O
+    status: pending
+  - id: errors
+    content: Ajouter PRE_SWITCH_SNAPSHOT_MISSING dans switch-to-te.errors.ts
+    status: pending
+  - id: module-wiring
+    content: Enregistrer BuildSwitchToTeContextService + MergeStatutsService dans ReferentielsModule (switchToTe inchangé)
+    status: pending
+  - id: e2e
+    content: Tests e2e merge-statuts.service.e2e-spec.ts via buildSwitchToTeContext (fixture partagé)
+    status: pending
+  - id: prd-reconcile
+    content: Mettre à jour le PRD annexe A (orchestration amont = pre-switch-te + SwitchToTeContext, pas recalcul CAE/ECI)
+    status: pending
+isProject: false
+---
+
+# PR12 — Fusion statuts (`mergeStatuts`)
+
+**Parent** : [doc/plans/2026-06-11-001-feat-bascule-referentiel-te-prd.md](2026-06-11-001-feat-bascule-referentiel-te-prd.md)
+
+**Branche** : `TE-7303/switch-te-PR12` depuis `main` (PR8 + PR10 mergés ; PR11 optionnelle)
+
+**Estimation** : ~700 LOC (code + tests) — PR la plus volumineuse du lot migration ; **ne pas fragmenter**
+
+**Prod** : Non (endpoint) — `switchToTe()` reste `SWITCH_NOT_IMPLEMENTED` jusqu'à PR18
+
+> **Note — statut discret vs statut détaillé au %**  
+> Après projection des points sources sur une action TE, on dérive un triplet `[fait, programme, pas_fait]` (fractions entre 0 et 1, somme = 1), puis on choisit le **type de statut** persisté — le même vocabulaire que dans l'app (`fait` / `programme` / `pas_fait` vs « Détaillé au % »).
+>
+> - **Statut discret** : un seul composant du triplet est « plein » (≥ `1 - ε`, les autres ≤ `ε`) — ex. `[1, 0, 0]`, ou résidu d'arrondi scoring `[0.999, 0, 0.001]`. On persiste `fait`, `programme` ou `pas_fait` — **pas d'arrondi 5 % TE**.
+> - **Statut détaillé au %** (`detaille`) : au moins deux composants significatifs (> `ε`) — ex. `[0.74, 0, 0.26]` ou `[0.5, 0.5, 0]`. On applique l'arrondi inférieur au pas de 5 % sur `fait` et `programme`, puis `pas_fait = 1 - fait - programme`, et on persiste `detaille` + `statutDetailleAuPourcentage`.
+>
+> `ε` = `MERGE_STATUTS_STATUT_DISCRET_EPSILON` (`1e-3`), calibré sur l'arrondi à 3 décimales de `ScoresService` — **pas** `Number.EPSILON` (~`2e-16`), trop strict pour absorber les résidus `0.001` après `roundTo(3)`.
+>
+> Hors scope : `detaille_a_la_tache` (agrégation de tâches sur une sous-action) — le merge ne produit que discret ou `detaille` au %.
+
+---
+
+## Contexte
+
+PR8 a posé `SwitchToTeService` (guards + idempotence). PR10 a introduit `CreatePreSwitchSnapshotsService` qui fige un snapshot `pre-switch-te` par ref. CAE/ECI en `mode: write` (score + `personnalisation_reponses` au moment T).
+
+PR12 implémente la **règle de fusion des statuts** : pour chaque action **cible** (sous-action / tâche TE) ayant des correspondances `action_origine`, projeter les avancements sources vers un statut cohérent avec le pipeline de scoring, puis choisir **statut discret** ou **détaillé au %** (arrondi 5 % TE si détaillé).
+
+PR12 pose aussi **`SwitchToTeContext`** — objet d'infrastructure partagé par tous les merges (PR13–PR16) : validation snapshots, score maps sources, arbre TE, score map TE, et **cibles** pré-résolues (`ActionCible`). Construit une fois via `BuildSwitchToTeContextService`, consommé par chaque `mergeXxx(ctx)`. Les types de bascule restent **dans le backend** (`switch-to-te/shared/`) — pas d'exposition dans `@tet/domain` (à distinguer de `ActionOrigine`, entité BDD du domaine).
+
+Les tests e2e passent par un fixture commun.
+
+PR17 branchera la persistance dans `MigrateCollectiviteDataService`. PR18 câblera l'orchestration transactionnelle complète.
+
+```mermaid
+sequenceDiagram
+  participant PR18 as SwitchToTeService (PR18)
+  participant Pre as CreatePreSwitchSnapshotsService (PR10)
+  participant Ctx as BuildSwitchToTeContextService (PR12)
+  participant Merge as MergeStatutsService (PR12)
+  participant Scores as ScoresService
+
+  Note over PR18: PR12 — hors switchToTe
+  Pre->>Pre: computeAndUpsert(PRE_SWITCH_TE) cae/eci write
+  Pre-->>Ctx: ScoreSnapshot[] (in-memory, même transaction)
+  Ctx->>Ctx: valider snapshots + score maps sources
+  Ctx->>Ctx: getReferentielTree(te) + computeScoreForCollectivite(te)
+  Ctx->>Ctx: lister ActionCible (sous-actions et tâches)
+  Ctx-->>Merge: SwitchToTeContext
+  loop ActionCible dans ctx.cibles.sousActionsEtTaches
+    Merge->>Merge: origines déjà filtrées concerne=false
+    Merge->>Scores: getRatioFromOrigineActions + getScoreFromOrigineActionsAndRatio
+    Merge->>Merge: deriveTriplet → discret ou détaillé au % (arrondi 5 %)
+  end
+  Merge-->>PR18: Result ActionStatutCreate[]
+
+  Note over PR18: PR17 persiste action_statut TE
+```
+
+---
+
+## Décisions actées
+
+| Sujet | Décision |
+| ----- | -------- |
+| Scores sources CAE/ECI | **Injection** des `ScoreSnapshot[]` retournés par `createPreSwitchSnapshots` (payload `scoresPayload` en mémoire) — **pas** de `SnapshotsService.get` ni de `computeScoreForCollectivite` sur les sources |
+| Prérequis snapshots | **Strict** : `BuildSwitchToTeContextService` valide la présence d'un snapshot `pre-switch-te` par ref en `write` ; absent ou `collectiviteId` incohérent → `failure(PRE_SWITCH_SNAPSHOT_MISSING)` |
+| Refs sources lues | Uniquement celles en `mode: write` (aligné PR10 — un `pre-switch-te` par ref engagée) |
+| Potentiel TE | **Recalcul** `computeScoreForCollectivite('te', ...)` dans `BuildSwitchToTeContextService` — `teScoreMap` disponible pour tous les merges |
+| Filtrage non concerné | Règle transverse PRD — factorisée dans `switch-to-te/shared/origine-resolution.ts` ; appliquée à la construction des `ActionCible` |
+| Cibles TE ↔ origines | `SwitchToTeContext.cibles.sousActionsEtTaches: ActionCible[]` — action **destination** + `actionsOrigine` (brutes) + `originesConcernees` (filtrées) + `concernee` ; évite duplication PR12/PR13 ; `cibles.mesures` en PR14–16 |
+| Types bascule | **Backend only** (`apps/backend/.../switch-to-te/shared/`) — ne pas exporter dans `@tet/domain` ; `ActionCible` ≠ `ActionOrigine` (ligne BDD domaine) |
+| Projection scoring | Déléguer à `ScoresService.getRatioFromOrigineActions` + `getScoreFromOrigineActionsAndRatio` — **pas** `computeScoreFromReferentielsOrigine` (privée, projection lecture seule) |
+| Arrondi | **Uniquement si statut détaillé au %** : conversion en % entiers, `floor(ratio * 100 / 5) * 5` sur `fait` et `programme` ; `pas_fait% = 100 - fait% - programme%` |
+| Discret vs détaillé | Détection **avant** arrondi, avec `MERGE_STATUTS_STATUT_DISCRET_EPSILON = 1e-3` : triplet compatible statut discret si un composant ≥ `1 - ε` et les autres ≤ `ε` → `fait`/`programme`/`pas_fait` **sans** arrondi ; sinon → arrondi 5 % → `detaille` |
+| Statut final | `deriveStatutDiscret` ou `deriveStatutDetailleAuPourcentage` ; adapter BDD réservé à PR17 |
+| Granularité cible | **Sous-actions + tâches** ayant au moins une ligne `action_origine` ; actions natives (sans origine) → absentes de `cibles` |
+| `detaille_a_la_tache` source | Pas de chemin spécial : le snapshot `pre-switch-te` contient déjà `faitTachesAvancement` / `totalTachesCount` |
+| Architecture | `SwitchToTeContext` + `ActionCible` + `BuildSwitchToTeContextService` (infra) ; `merge-statuts.rules.ts` (pures) ; `merge-statuts.service.ts` (métier, `merge(ctx)` sans I/O) |
+| Persistance | **Calcul seulement** — retourne `ActionStatutCreate[]` ; PR17 fait adapter + upsert transactionnel |
+| Câblage PR12 | Services isolés dans `switch-to-te/` ; **non branché** dans `switchToTe()` |
+| Tests e2e | Setup via `switch-to-te-context.test-fixture.ts` (`createPreSwitchSnapshots` → `buildSwitchToTeContext`) — pattern réutilisable PR13+ |
+
+---
+
+## Implémentation
+
+### 0) `SwitchToTeContext` — infrastructure + cibles
+
+> Tous les fichiers ci-dessous dans `apps/backend/src/referentiels/switch-to-te/shared/` — **pas** dans `packages/domain`.
+
+#### Primitives — `origine-resolution.ts`
+
+Fonctions pures réutilisées par le builder **et** par les merges à parcours custom (PR14–16) :
+
+| Fonction | Rôle |
+| -------- | ---- |
+| `isOrigineConcernee` | `actionScore.concerne !== false` |
+| `isCibleConcernee` | depuis `teScoreMap` — personnalisation TE prime sur les sources |
+| `buildCorrelatedActionsWithScore` | `actionsOrigine` + score maps → `CorrelatedActionWithScore[]` |
+| `filterOriginesConcernees` | filtre `isOrigineConcernee` |
+| `getPointPotentiel` | `pointPotentiel` cible depuis `teScoreMap` |
+| `actionScoreToCorrelatedActionScore` | `ActionScore` → points + avancement tâches |
+
+> L'adapter `snapshot-to-correlated-action-with-score.adapter.ts` migre vers `origine-resolution.ts` (`origine-resolution.spec.ts`).
+
+#### Action cible — `action-cible.ts`
+
+```ts
+/**
+ * Action destination de la bascule + origines résolues depuis les snapshots pre-switch-te.
+ * Artefact runtime backend — ne pas confondre avec ActionOrigine (entité BDD @tet/domain).
+ */
+export type ActionCible = {
+  actionId: string;
+  /** false si désactivée / non concernée par personnalisation TE */
+  concernee: boolean;
+  /** origines brutes (ordre arbre) — pour tri CAE puis ECI côté rules */
+  actionsOrigine: CorrelatedAction[];
+  /** origines avec score snapshot + filtre concerne !== false */
+  originesConcernees: CorrelatedActionWithScore[];
+};
+
+export const listActionCiblesSousActionsEtTaches = (input: {
+  referentielTe: ReferentielDefinition;
+  scoreMapsByReferentiel: Map<ReferentielId, Map<string, ActionScore>>;
+  teScoreMap: Map<string, ActionScore>;
+}): ActionCible[]
+```
+
+Algorithme `listActionCiblesSousActionsEtTaches` :
+
+1. `flatMapActionsEnfants(referentielTe.itemsTree)`.
+2. Filtrer `SOUS_ACTION` / `TACHE` avec `actionsOrigine.length > 0`.
+3. Pour chaque nœud : `originesConcernees = filterOriginesConcernees(buildCorrelatedActionsWithScore(...))`, `concernee = isCibleConcernee(teScoreMap, actionId)`.
+
+> Le **niveau hiérarchique** est porté par la clé de collection (`sousActionsEtTaches`, puis `mesures`), pas par le nom du type `ActionCible`.
+
+#### Type — `switch-to-te-context.ts`
+
+```ts
+export type SwitchToTeContext = {
+  collectiviteId: number;
+  /** refs sources en write au moment du build — dérivé des prefs, figé dans le contexte */
+  sourceReferentiels: ReferentielId[];
+  scoreMapsByReferentiel: Map<ReferentielId, Map<string, ActionScore>>;
+  referentielTe: ReferentielDefinition;
+  teScoreMap: Map<string, ActionScore>;
+  cibles: {
+    /** PR12, PR13 — origines directes sur sous-action / tâche */
+    sousActionsEtTaches: ActionCible[];
+    // PR14–16 : cibles.mesures: ActionCible[] — agrégation descendants + remontée ancêtre
+  };
+};
+```
+
+> `prefs` reste un **paramètre d'entrée** de `BuildSwitchToTeContextService.build(...)` (dérivation `sourceReferentiels` + validation snapshots), mais n'est **pas** stocké dans le contexte — les merges n'en ont pas besoin.
+
+> **Pas dans le contexte PR12** : `cibles.mesures` (PR14–16), filtre « explication non vide » (rules PR13), données BDD pilotes/services/fiches.
+
+#### Builder — `build-switch-to-te-context.service.ts`
+
+```ts
+@Injectable()
+export class BuildSwitchToTeContextService {
+  async build(
+    collectiviteId: number,
+    prefs: CollectiviteReferentielPreferences,
+    preSwitchSnapshots: ScoreSnapshot[],
+    { user }: ServiceSecondArg
+  ): Promise<Result<SwitchToTeContext, SwitchToTeError>>
+}
+```
+
+**Algorithme** :
+
+1. Filtrer refs sources en `write` (`cae`, `eci`).
+2. Indexer `preSwitchSnapshots` par `referentielId` (filtre `ref === PRE_SWITCH_TE_SNAPSHOT_REF`).
+3. Pour chaque ref en `write`, valider snapshot présent + `collectiviteId` cohérent — sinon `PRE_SWITCH_SNAPSHOT_MISSING`.
+4. Construire `scoreMapsByReferentiel` via `buildScoreMapByActionId(snapshot.scoresPayload.scores)`.
+5. Charger l'arbre TE : `getReferentielService.getReferentielTree('te', true, true)`.
+6. Recalculer score TE : `scoresService.computeScoreForCollectivite('te', collectiviteId, { avecReferentielsOrigine: false }, user)` → `teScoreMap`.
+7. Construire `cibles.sousActionsEtTaches` via `listActionCiblesSousActionsEtTaches(...)`.
+8. Retourner `success({ collectiviteId, sourceReferentiels, scoreMapsByReferentiel, referentielTe, teScoreMap, cibles })`.
+
+**Injections** : `ScoresService`, `GetReferentielService`. Pas de `SnapshotsService`.
+
+#### Fixture test — `switch-to-te-context.test-fixture.ts`
+
+```ts
+export async function buildSwitchToTeContextForTest(
+  app: INestApplication,
+  collectiviteId: number,
+  prefs: CollectiviteReferentielPreferences,
+  user: AuthenticatedUser,
+  preSwitchSnapshots: ScoreSnapshot[]
+): Promise<SwitchToTeContext>
+```
+
+Enchaîne `CreatePreSwitchSnapshotsService` (si snapshots non fournis) + `BuildSwitchToTeContextService.build(...)`.
+
+### 1) Rules pures — `merge-statuts.rules.ts`
+
+Fichier : `apps/backend/src/referentiels/switch-to-te/merge-statuts/merge-statuts.rules.ts`
+
+Fonctions exportées (toutes pures, sans dépendance Nest/DB) :
+
+| Fonction | Rôle |
+| -------- | ---- |
+| `MERGE_STATUTS_STATUT_DISCRET_EPSILON` | `1e-3` — aligné sur `ScoresService.DEFAULT_ROUNDING_DIGITS` |
+| `deriveTripletFromProjectedPoints` | Calcule `[fait, programme, pas_fait]` en fractions depuis points projetés |
+| `isTripletStatutDiscret` | `true` si triplet compatible statut discret (ε) |
+| `deriveStatutDiscret` | Composant dominant → `fait` / `programme` / `pas_fait` |
+| `arrondiTripletCinqPourcent` | Arrondi inférieur pas 5 % pour le chemin détaillé au % |
+| `deriveStatutDetailleAuPourcentage` | `detaille` + `statutDetailleAuPourcentage` |
+| `StatutProjectionInput` | Entrée rule : points projetés + `concernedSourceCount` (ex-`MergeStatutsProjectionContext`) |
+| `deriveStatutFromProjection` | Orchestre le pipeline complet à partir de `StatutProjectionInput` |
+| `toActionStatutCreate` | Mappe `DerivedMergeStatut` → `ActionStatutCreate` |
+
+**Pipeline** `deriveStatutFromProjection` :
+
+```
+1. 0 source concernée        → NON_CONCERNE
+2. points projetés tous à 0 → NON_RENSEIGNE
+3. deriveTripletFromProjectedPoints
+4. isTripletStatutDiscret ?
+   oui → deriveStatutDiscret
+   non → arrondiTripletCinqPourcent → deriveStatutDetailleAuPourcentage
+```
+
+### 2) Service — `merge-statuts.service.ts`
+
+Fichier : `apps/backend/src/referentiels/switch-to-te/merge-statuts/merge-statuts.service.ts`
+
+```ts
+async merge(
+  ctx: SwitchToTeContext
+): Promise<Result<ActionStatutCreate[], SwitchToTeError>>
+```
+
+> **Pas d'I/O** dans ce service — tout est dans `ctx`. Injection : `ScoresService` uniquement (projection `getRatioFromOrigineActions` / `getScoreFromOrigineActionsAndRatio`).
+
+**Algorithme** :
+
+1. Itérer `ctx.cibles.sousActionsEtTaches` (pas de re-parcours arbre ni re-filtre concerne).
+2. Pour chaque `cible` :
+   - `pointPotentiel = getPointPotentiel(ctx.teScoreMap, cible.actionId)`.
+   - Si `!cible.concernee` → `NON_CONCERNE`.
+   - Sinon si `cible.originesConcernees.length === 0` → `deriveStatutFromProjection` (non concerné).
+   - Sinon : projection via `ScoresService` sur `cible.originesConcernees` → `deriveStatutFromProjection`.
+   - `toActionStatutCreate(ctx.collectiviteId, cible.actionId, derivedStatut)`.
+3. Retourner `success(actionStatuts)`.
+
+### 3) Erreurs
+
+Fichier : `apps/backend/src/referentiels/switch-to-te/switch-to-te.errors.ts`
+
+```ts
+'PRE_SWITCH_SNAPSHOT_MISSING'
+// code: PRECONDITION_FAILED
+// message: "Snapshot pre-switch-te manquant — exécuter createPreSwitchSnapshots avant mergeStatuts"
+```
+
+Levée par `BuildSwitchToTeContextService` — réutilisable par tous les merges (PR13+).
+
+### 4) Module
+
+Fichier : `apps/backend/src/referentiels/referentiels.module.ts`
+
+- Enregistrer `BuildSwitchToTeContextService` + `MergeStatutsService`.
+- `SwitchToTeService` **inchangé** (`SWITCH_NOT_IMPLEMENTED`).
+
+---
+
+## Tests
+
+### A. `merge-statuts.rules.spec.ts` (unitaire pur)
+
+Couvrir la table [Annexe A — mergeStatuts](2026-06-11-001-feat-bascule-referentiel-te-prd.md#a--algorithmes-de-fusion) :
+
+| Cas | Assertion |
+| --- | --------- |
+| 1→1 discret, pondération 1 | `fait` copié directement |
+| 1→1 `detaille` | projection + arrondi inférieur 5 % (ex. 74 % → 70 %) |
+| N→1 pondérations hétérogènes | pipeline + arrondi si détaillé au % |
+| Source `non concerne` ignorée | projection sur sources concernées uniquement |
+| 1 `fait` + 1 `non concerne` | équivalent 1→1 |
+| Fusion CAE + ECI → même TE | toutes sources concernées agrégées |
+| Toutes sources `non concerne` | `NON_CONCERNE` |
+| Sources concernées sans avancement | `NON_RENSEIGNE` |
+| Triplet discret (`[1,0,0]`) | `fait`, pas `detaille` |
+| Résidu arrondi scoring (`[0.999, 0, 0.001]`) | statut discret `fait` (ε = `1e-3`) |
+| Triplet détaillé (`[0.74, 0, 0.26]`) | `detaille` + triplet arrondi (`70/0/30`) |
+| Bord détaillé (`[0.99, 0, 0.01]`) | `detaille` (`0.01` > ε) |
+
+Les tests rules injectent des points projetés / triplets en entrée — **pas de DB**.
+
+### B. `merge-statuts.service.e2e-spec.ts`
+
+Setup (via `switch-to-te-context.test-fixture.ts`) :
+
+1. `addTestCollectiviteAndUser` + prefs avec au moins `cae: write`.
+2. Seed minimal : statuts CAE sur actions avec correspondance TE (`MERGE_STATUTS_FIXTURE`).
+3. `createPreSwitchSnapshots(...)` → `result.data`.
+4. `buildSwitchToTeContextForTest(...)` → `ctx`.
+5. `MergeStatutsService.merge(ctx)`.
+
+Scénarios :
+
+| Scénario | Vérif |
+| -------- | ----- |
+| CAE seul, 1→1 `fait` | action cible reçoit `fait` |
+| CAE + ECI write, fusion N→1 | statut cohérent avec projection pondérée |
+| Source `non concerne` | ignorée ; cible = statut de la source restante |
+| Toutes sources `non concerne` | `NON_CONCERNE` |
+| Source concernée sans avancement | `NON_RENSEIGNE` |
+| 1→1 `detaille` 74 % | arrondi inférieur 5 % → 70 % |
+| Action cible non concernée (personnalisation) | `NON_CONCERNE` malgré origines concernées |
+| Sans `pre-switch-te` (snapshots vides) | `failure` à `buildSwitchToTeContext` |
+| Action native (sans origine) | absente de `cibles` et du résultat |
+
+### C. `action-cible` + `build-switch-to-te-context` (spec dédié)
+
+| Cas | Assertion |
+| --- | --------- |
+| Snapshots valides CAE + ECI write | `success` avec `scoreMapsByReferentiel` peuplé |
+| Snapshot manquant pour ref en `write` | `PRE_SWITCH_SNAPSHOT_MISSING` |
+| `collectiviteId` incohérent | `PRE_SWITCH_SNAPSHOT_MISSING` |
+| `teScoreMap` peuplé | au moins une action avec `pointPotentiel` |
+| `cibles.sousActionsEtTaches` | contient les actions fixture avec `originesConcernees` filtrées |
+| Source `non_concerne` | absente de `originesConcernees`, toujours dans `actionsOrigine` |
+| Action cible personnalisée non concernée | `concernee: false` |
+
+### D. Références existantes
+
+- `scores.service.spec.ts` — `getRatioFromOrigineActions` / `getScoreFromOrigineActionsAndRatio`
+- `score-map.rules.ts` — `buildScoreMapByActionId`
+- `create-pre-switch-snapshots.service.e2e-spec.ts` — setup snapshots
+- `packages/domain/.../action-origine.schema.ts` — `ActionOrigine` BDD (≠ `ActionCible` runtime)
+
+### Commandes
+
+```bash
+pnpm test:backend merge-statuts
+pnpm test:backend merge-statuts.rules.spec
+pnpm test:backend build-switch-to-te-context
+pnpm test:backend action-cible
+```
+
+---
+
+## Hors scope PR12
+
+- Persistance `action_statut` (PR17)
+- `mergeCommentaires`, `mergePilotes`, `mergeServices`, `mergeFicheActionLinks` (PR13–PR16) — consommeront `SwitchToTeContext`
+- Câblage dans `switchToTe()` (PR18)
+- Snapshot `post-switch-te` + recalcul scores TE persistés (PR18)
+- Complément `pre-switch-te` pour ref `archived` participant à la fusion (PR17/PR18)
+- Exposition prod de l'endpoint bascule
+- `cibles.mesures` (agrégation descendants + remontée ancêtre — PR14–16)
+- Filtre « explication non vide » dans le contexte (reste dans rules PR13)
+- Export des types bascule dans `@tet/domain`
+
+---
+
+## PRD — réconciliation à faire
+
+Mettre à jour [Annexe A — orchestration amont](2026-06-11-001-feat-bascule-referentiel-te-prd.md#a--algorithmes-de-fusion) :
+
+**Remplacer** l'étape 1 « Appeler `computeScoreForCollectivite` pour chaque réf. CAE/ECI » par :
+
+> 1. Créer les snapshots `pre-switch-te` via `CreatePreSwitchSnapshotsService` (un par ref. CAE/ECI en `mode: write`).
+> 2. Construire un `SwitchToTeContext` via `BuildSwitchToTeContextService` (validation snapshots + score maps + arbre TE + `teScoreMap` + `cibles`).
+> 3. Passer le contexte à `mergeStatuts(ctx)` (et aux autres merges PR13–PR16).
+
+---
+
+## Critères de done
+
+- [ ] `origine-resolution.ts` + `action-cible.ts` (`listActionCiblesSousActionsEtTaches`) + tests — **backend only**
+- [ ] `SwitchToTeContext` avec `cibles.sousActionsEtTaches: ActionCible[]` + `BuildSwitchToTeContextService` + tests
+- [ ] `switch-to-te-context.test-fixture.ts` — `buildSwitchToTeContextForTest` utilisable en e2e
+- [ ] `merge-statuts.rules.ts` + tests unitaires (cas annexe A) ; `StatutProjectionInput` (renommage ex-`MergeStatutsProjectionContext`)
+- [ ] `score-map.rules.ts` — `buildScoreMapByActionId` (extrait de `fillScoreMap`)
+- [ ] `MergeStatutsService.merge(ctx)` itère `ctx.cibles.sousActionsEtTaches` — **sans I/O** ; retourne `Result<ActionStatutCreate[], SwitchToTeError>`
+- [ ] Filtre `concerne=false` dans `originesConcernees` ; `concernee` sur action cible
+- [ ] `MERGE_STATUTS_STATUT_DISCRET_EPSILON` (`1e-3`) ; discret vs détaillé au % **avant** arrondi ; arrondi 5 % **uniquement** si détaillé
+- [ ] `BuildSwitchToTeContextService` + `MergeStatutsService` enregistrés dans `ReferentielsModule` ; `switchToTe()` inchangé
+- [ ] Tests e2e verts (via fixture contexte)
+- [ ] PRD annexe A mise à jour
+
+---
+
+## Suite (PR13+)
+
+| PR | Suite |
+| -- | ----- |
+| PR13 | `mergeCommentaires` — `merge(ctx)` itère `ctx.cibles.sousActionsEtTaches` + filtre explication côté rules |
+| PR14–PR16 | Étendre `ctx.cibles.mesures` (`ActionCible[]`) via `origine-resolution` + parcours mesure/ancêtre |
+| PR17 | `MigrateCollectiviteDataService` — `buildSwitchToTeContext` une fois → `mergeStatuts(ctx)` + `mergeCommentaires(ctx)` + persiste |
+| PR18 | Transaction : `createPreSwitchSnapshots` → `buildSwitchToTeContext` → merges(ctx) → recalcul TE → `post-switch-te` |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Ajout de la fusion des statuts CAE/ECI vers les actions du référentiel TE.
  * Prise en charge des statuts « fait », « non concerné », « non renseigné » et détaillés au pourcentage.
  * Validation des snapshots pré-bascule requis, avec message d’erreur explicite en cas d’absence.

* **Améliorations**
  * Les scores sources sont désormais basés sur des snapshots figés avant le basculement.
  * Les actions concernées et leurs origines sont automatiquement identifiées et filtrées.

* **Tests**
  * Ajout de tests unitaires et de bout en bout couvrant les scénarios de fusion et d’arrondi.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->