### PR TITLE
[TET-7335] fix(referentiels): neutralise l'injection CSV dans les exports référentiel

### DIFF
--- a/apps/backend/src/referentiels/export-score/export-score-comparison.service.ts
+++ b/apps/backend/src/referentiels/export-score/export-score-comparison.service.ts
@@ -3,6 +3,7 @@ import {
   ExportScoreComparisonRequestQuery,
   ReferentielId,
 } from '@tet/domain/referentiels';
+import { sanitizeWorksheetForCsvExport } from '@tet/backend/utils/excel/export-excel.utils';
 import { Workbook } from 'exceljs';
 import { buildRows } from './build-rows';
 import { LoadScoreComparisonService } from './load-score-comparison.service';
@@ -37,6 +38,10 @@ export class ExportScoreComparisonService {
     const workbook = new Workbook();
     const worksheet = workbook.addWorksheet(exportTitle);
     buildRows(scoreComparisonData, worksheet);
+
+    if (exportFormat === 'csv') {
+      sanitizeWorksheetForCsvExport(worksheet);
+    }
 
     const buffer =
       exportFormat === 'excel'

--- a/apps/backend/src/utils/excel/export-excel.utils.spec.ts
+++ b/apps/backend/src/utils/excel/export-excel.utils.spec.ts
@@ -1,0 +1,60 @@
+import { Workbook } from 'exceljs';
+import { describe, expect, it } from 'vitest';
+import {
+  neutralizeCsvValue,
+  sanitizeWorksheetForCsvExport,
+} from './export-excel.utils';
+
+describe('neutralizeCsvValue', () => {
+  it('préfixe les valeurs commençant par =', () => {
+    expect(neutralizeCsvValue('=SUM(A1)')).toBe("'=SUM(A1)");
+  });
+
+  it('préfixe les valeurs commençant par +', () => {
+    expect(neutralizeCsvValue('+cmd')).toBe("'+cmd");
+  });
+
+  it('préfixe les valeurs commençant par -', () => {
+    expect(neutralizeCsvValue('-2+3')).toBe("'-2+3");
+  });
+
+  it('préfixe les valeurs commençant par @', () => {
+    expect(neutralizeCsvValue('@test')).toBe("'@test");
+  });
+
+  it('préfixe les valeurs commençant par une tabulation', () => {
+    expect(neutralizeCsvValue('\tcmd')).toBe("'\tcmd");
+  });
+
+  it('préfixe les valeurs commençant par un retour chariot', () => {
+    expect(neutralizeCsvValue('\rcmd')).toBe("'\rcmd");
+  });
+
+  it('laisse les valeurs ordinaires inchangées', () => {
+    expect(neutralizeCsvValue('texte normal')).toBe('texte normal');
+    expect(neutralizeCsvValue('Action 1.1.1')).toBe('Action 1.1.1');
+    expect(neutralizeCsvValue('')).toBe('');
+  });
+
+  it('ne préfixe pas les valeurs commençant par un chiffre', () => {
+    expect(neutralizeCsvValue('42%')).toBe('42%');
+  });
+});
+
+describe('sanitizeWorksheetForCsvExport', () => {
+  it('neutralise les cellules string et laisse les nombres et dates inchangés', () => {
+    const workbook = new Workbook();
+    const worksheet = workbook.addWorksheet('test');
+    const date = new Date('2024-06-15');
+
+    worksheet.getCell('A1').value = '=SUM(A1)';
+    worksheet.getCell('B1').value = 42;
+    worksheet.getCell('C1').value = date;
+
+    sanitizeWorksheetForCsvExport(worksheet);
+
+    expect(worksheet.getCell('A1').value).toBe("'=SUM(A1)");
+    expect(worksheet.getCell('B1').value).toBe(42);
+    expect(worksheet.getCell('C1').value).toBe(date);
+  });
+});

--- a/apps/backend/src/utils/excel/export-excel.utils.ts
+++ b/apps/backend/src/utils/excel/export-excel.utils.ts
@@ -239,6 +239,30 @@ export const cleanHtmlDescription = (htmlDescription: string): string => {
   return cleaned;
 };
 
+/**
+ * Préfixe les valeurs commençant par un caractère de formule (`=`, `+`, `-`, `@`, tab, CR)
+ * pour empêcher leur interprétation comme formule lors de l'ouverture d'un CSV dans Excel / LibreOffice.
+ * À appliquer uniquement sur les exports CSV (pas XLSX — exceljs stocke déjà les valeurs comme strings).
+ */
+const CSV_FORMULA_TRIGGERS = new Set(['=', '+', '-', '@', '\t', '\r']);
+
+export function neutralizeCsvValue(value: string): string {
+  const firstChar = value[0];
+  return firstChar !== undefined && CSV_FORMULA_TRIGGERS.has(firstChar)
+    ? `'${value}`
+    : value;
+}
+
+export function sanitizeWorksheetForCsvExport(worksheet: Worksheet): void {
+  worksheet.eachRow({ includeEmpty: false }, (row) => {
+    row.eachCell({ includeEmpty: false }, (cell) => {
+      if (typeof cell.value === 'string') {
+        cell.value = neutralizeCsvValue(cell.value);
+      }
+    });
+  });
+}
+
 // pour convertir un index en lettre de colonnes (A..Z, AA, AB..ZZ)
 export function getColumLetter(colIndex: number) {
   if (colIndex < 26) {


### PR DESCRIPTION
## Contexte

Pentest V7 (ORHUS-302 §V7) : les valeurs texte des exports CSV du référentiel pouvaient déclencher l'exécution de formules à l'ouverture du fichier dans Excel / LibreOffice si elles commençaient par `=`, `+`, `-` ou `@`.

Ticket Notion : https://app.notion.com/p/36e6523d57d78106b860fe7edf62dfb7

## Changements

- **`apps/backend/src/utils/excel/export-excel.utils.ts`** : ajout de deux fonctions utilitaires partagées :
  - `neutralizeCsvValue(value: string): string` — préfixe par `'` les valeurs commençant par un caractère de formule
  - `sanitizeWorksheetForCsvExport(worksheet: Worksheet): void` — itère sur toutes les cellules string du workbook et applique la neutralisation

- **`apps/backend/src/referentiels/export-score/export-score-comparison.service.ts`** : appel de `sanitizeWorksheetForCsvExport(worksheet)` uniquement avant `workbook.csv.writeBuffer()` (l'XLSX est immunisé nativement — exceljs stocke les valeurs comme `SharedString`, pas comme formules)

- **`apps/backend/src/utils/excel/export-excel.utils.spec.ts`** (nouveau) : tests unitaires pour `neutralizeCsvValue` couvrant les 5 caractères déclencheurs (`=`, `+`, `-`, `@`, `\t`) et les valeurs ordinaires

## Note scope

Le seul export CSV via exceljs dans le backend est l'export de comparaison de scores référentiel. La fonction `buildLiensCsv` (preuves archive) a déjà sa propre protection depuis l'origine.

## Test plan

- [ ] `nx test backend 'export-excel.utils.spec'` passe
- [ ] Exporter un référentiel en CSV : les valeurs commençant par `=`, `+`, `-`, `@` sont précédées de `'` dans le fichier généré
- [ ] Exporter en Excel (XLSX) : aucune modification visible (la sanitization n'est pas appliquée)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Améliorations**
  * Les exports CSV neutralisent désormais les valeurs susceptibles d’être interprétées comme des formules par Excel ou LibreOffice.
  * Les valeurs textuelles concernées sont automatiquement sécurisées, tandis que les autres formats d’export restent inchangés.

* **Tests**
  * Ajout de tests couvrant les différents préfixes à risque et la conservation des valeurs ordinaires.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->