### PR TITLE
fix(collectivites): corrige le filtre "Type de collectivité" (TET-7420)

### DIFF
--- a/apps/backend/src/collectivites/recherches/filters.request.spec.ts
+++ b/apps/backend/src/collectivites/recherches/filters.request.spec.ts
@@ -54,6 +54,14 @@ describe('filtersRequestSchema', () => {
       expect(result.success).toBe(true);
     });
 
+    it('accepte les codes nature INSEE des EPCI (CA, CC, CU, METRO…)', () => {
+      const result = filtersRequestSchema.safeParse({
+        ...baseInput,
+        typesCollectivite: ['CA', 'CC', 'CU', 'METRO', 'EPT', 'PETR', 'POLEM'],
+      });
+      expect(result.success).toBe(true);
+    });
+
     it('accepte les niveaux de labellisation 0-5', () => {
       const result = filtersRequestSchema.safeParse({
         ...baseInput,

--- a/apps/backend/src/collectivites/recherches/filters.request.ts
+++ b/apps/backend/src/collectivites/recherches/filters.request.ts
@@ -16,10 +16,11 @@ const filterIntervalleIdSchema = z
   .string()
   .regex(/^[A-Za-z0-9_<>=-]+$/, 'Identifiant de tranche invalide');
 
-// Types de collectivité (enum `collectiviteTypeEnum` + alias `syndicat`).
+// Types de collectivité : enum `collectiviteTypeEnum` (lowercase), alias
+// `syndicat`, et codes nature INSEE des EPCI (ex. CA, CC, CU, METRO, EPT…).
 const typeCollectiviteSchema = z
   .string()
-  .regex(/^[a-z_]+$/, 'Type de collectivité invalide');
+  .regex(/^[a-zA-Z_]+$/, 'Type de collectivité invalide');
 
 // Niveau de labellisation : 0 à 5 étoiles.
 const niveauLabelSchema = z


### PR DESCRIPTION
## Problème

Le filtre « Type de collectivité » sur la page Collectivités engagées retournait une erreur **400 BAD_REQUEST** dès qu'on sélectionnait un type EPCI (CA, CC, CU, METRO, EPT, PETR, POLEM).

**Cause** : le schéma Zod `typeCollectiviteSchema` validait avec le regex `/^[a-z_]+$/` (lettres minuscules uniquement). Or, la requête SQL de recherche renvoie les codes `natureInsee` des EPCI directement depuis la table `collectivite_banatic_type`, et ces codes sont en **majuscules** (ex. `CA`, `METRO`).

## Solution

Le regex passe à `/^[a-zA-Z_]+$/` pour accepter ces codes uppercase.

La protection contre les injections SQL reste intacte : aucun caractère spécial SQL (apostrophe, tiret, parenthèse…) n'est autorisé.

## Test plan

- [ ] Vérifier que les tests unitaires passent : `nx test backend 'filters.request.spec.ts'`
- [ ] Sur la page `/collectivites-engagees`, sélectionner un filtre « Communauté de communes (CC) » ou « Communauté d'agglomération (CA) » → la liste filtrée s'affiche sans erreur 400

Fixes [TET-7420](https://app.notion.com/p/37d6523d57d78127af72f874a028a523)