### PR TITLE
fix(security): bloque la création de membre fantôme dans collectivites.membres.update (TET-7360)

### DIFF
--- a/apps/backend/src/collectivites/membres/mutate-membres/mutate-membres.router.e2e-spec.ts
+++ b/apps/backend/src/collectivites/membres/mutate-membres/mutate-membres.router.e2e-spec.ts
@@ -383,6 +383,36 @@ describe('CollectiviteMembresRouter mutate', () => {
     ).rejects.toThrow();
   });
 
+  test('IDOR TET-7360 : un utilisateur ne peut pas créer un membre fantôme dans une collectivité dont il ne fait pas partie', async () => {
+    // externalUser n'a accès qu'à collectivite3 — tente de s'insérer dans collectivite1
+    const caller = router.createCaller({ user: externalUser });
+
+    await expect(
+      caller.collectivites.membres.update([
+        {
+          collectiviteId: collectivite1.id,
+          userId: externalUser.id,
+          detailsFonction: 'fantôme',
+          fonction: MembreFonctionEnum.TECHNIQUE,
+        },
+      ])
+    ).rejects.toThrow();
+
+    // Vérifie qu'aucune ligne n'a été insérée dans membreTable
+    const [ghostRow] = await db.db
+      .select()
+      .from(membreTable)
+      .where(
+        and(
+          eq(membreTable.userId, externalUser.id),
+          eq(membreTable.collectiviteId, collectivite1.id)
+        )
+      )
+      .limit(1);
+
+    expect(ghostRow).toBeUndefined();
+  });
+
   describe('remove', () => {
     test('admin peut retirer un autre membre', async () => {
       const caller = router.createCaller({ user: adminUser });

--- a/apps/backend/src/collectivites/membres/mutate-membres/mutate-membres.service.ts
+++ b/apps/backend/src/collectivites/membres/mutate-membres/mutate-membres.service.ts
@@ -65,6 +65,20 @@ export class MutateMembresService {
         );
 
         if (hasMembreFields) {
+          // Self-update without admin rights: verify the user is already an
+          // active member of this collectivité before upserting, otherwise any
+          // authenticated user could insert a ghost row into membreTable for a
+          // collectivité they don't belong to (IDOR — TET-7360).
+          if (unauthorizedFailure) {
+            const isMember = await this.listMembresService.isActiveMember({
+              userId,
+              collectiviteId,
+            });
+            if (!isMember) {
+              return unauthorizedFailure;
+            }
+          }
+
           await this.databaseService.db
             .insert(membreTable)
             .values({


### PR DESCRIPTION
## Contexte

Faille IDOR détectée lors de l'audit complémentaire des endpoints tRPC (mai 2026) — finding 🟡 Moyenne n°7.

Ticket : TET-7360

## Problème

Dans `collectivites.membres.update`, le chemin « soi/oui » (`userId === user.id`) permettait à un utilisateur authentifié de contourner le contrôle de permission `collectivites.membres.mutate` et d'insérer une ligne dans `membreTable` pour une **collectivité dont il ne fait pas partie**.

La mutation étant un upsert (`INSERT ... ON CONFLICT DO UPDATE`), si aucune ligne n'existait, elle en créait une — le « membre fantôme ». L'impact réel était limité (pas d'élévation de droits, les permissions venant de `utilisateurCollectiviteAccessTable`), mais la pollution des listes de membres et des jointures était réelle.

## Remédiation (option 1 du ticket)

Avant l'upsert sur `membreTable`, on vérifie désormais via `ListMembresService.isActiveMember` que l'utilisateur possède bien un droit actif `(userId, collectiviteId)` dans `utilisateurCollectiviteAccessTable`. Si ce n'est pas le cas, la requête est rejetée avec `UNAUTHORIZED`.

## Tests

- Test de régression IDOR ajouté : `externalUser` (membre de `collectivite3` uniquement) tente de s'insérer dans `collectivite1` → rejet + vérification qu'aucune ligne n'est créée dans `membreTable`.
- 18/18 tests E2E passent (`mutate-membres.router.e2e-spec.ts`).

## Fichiers modifiés

- `apps/backend/src/collectivites/membres/mutate-membres/mutate-membres.service.ts`
- `apps/backend/src/collectivites/membres/mutate-membres/mutate-membres.router.e2e-spec.ts`