### PR TITLE
fix(security): bloque l'injection IDOR de relations cross-collectivité dans plans.fiches.update (TET-7358)

### DIFF
--- a/apps/backend/src/plans/fiches/fiche-action.repository.ts
+++ b/apps/backend/src/plans/fiches/fiche-action.repository.ts
@@ -1,5 +1,11 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { financeurTagTable } from '@tet/backend/collectivites/tags/financeur-tag.table';
 import { instanceGouvernanceTagTable } from '@tet/backend/collectivites/tags/instance-gouvernance-tag.table';
+import { libreTagTable } from '@tet/backend/collectivites/tags/libre-tag.table';
+import { partenaireTagTable } from '@tet/backend/collectivites/tags/partenaire-tag.table';
+import { personneTagTable } from '@tet/backend/collectivites/tags/personnes/personne-tag.table';
+import { serviceTagTable } from '@tet/backend/collectivites/tags/service-tag.table';
+import { structureTagTable } from '@tet/backend/collectivites/tags/structure-tag.table';
 import { Transaction } from '@tet/backend/utils/database/transaction.utils';
 import { isErrorWithCause } from '@tet/backend/utils/nest/errors.utils';
 import { failure, Result, success } from '@tet/backend/utils/result.type';
@@ -24,6 +30,7 @@ import { partition } from 'es-toolkit';
 import { toCamel } from 'ts-case-convert';
 import { AuthenticatedUser } from '../../users/models/auth.models';
 import { ficheActionNoteTable } from './fiche-action-note/fiche-action-note.table';
+import { axeTable } from './shared/models/axe.table';
 import { ficheActionActionImpactTable } from './shared/models/fiche-action-action-impact.table';
 import { ficheActionActionTable } from './shared/models/fiche-action-action.table';
 import { ficheActionAxeTable } from './shared/models/fiche-action-axe.table';
@@ -46,6 +53,7 @@ import { UpdateFicheInput } from './update-fiche/update-fiche.input';
 export type FicheActionWriteError =
   | 'INSTANCE_GOUVERNANCE_COLLECTIVITE_MISMATCH'
   | 'INSTANCE_GOUVERNANCE_TAG_NOT_FOUND'
+  | 'RELATION_COLLECTIVITE_MISMATCH'
   | 'SERVER_ERROR';
 
 type ColumnType = Column<
@@ -171,6 +179,17 @@ export class FicheActionRepository {
       }
 
       if (axes !== undefined) {
+        const axeIds = (axes ?? []).map((a) => a.id);
+        const axeCheck = await this.assertIdsInCollectivite(
+          axeIds,
+          existingFiche.collectiviteId,
+          (ids) =>
+            tx
+              .select({ id: axeTable.id, collectiviteId: axeTable.collectiviteId })
+              .from(axeTable)
+              .where(inArray(axeTable.id, ids))
+        );
+        if (!axeCheck.success) return axeCheck;
         await this.updateRelations(
           ficheId,
           axes,
@@ -207,6 +226,17 @@ export class FicheActionRepository {
       }
 
       if (partenaires !== undefined) {
+        const partenaireIds = (partenaires ?? []).map((p) => p.id);
+        const partenaireCheck = await this.assertIdsInCollectivite(
+          partenaireIds,
+          existingFiche.collectiviteId,
+          (ids) =>
+            tx
+              .select({ id: partenaireTagTable.id, collectiviteId: partenaireTagTable.collectiviteId })
+              .from(partenaireTagTable)
+              .where(inArray(partenaireTagTable.id, ids))
+        );
+        if (!partenaireCheck.success) return partenaireCheck;
         await this.updateRelations(
           ficheId,
           partenaires,
@@ -219,6 +249,17 @@ export class FicheActionRepository {
       }
 
       if (structures !== undefined) {
+        const structureIds = (structures ?? []).map((s) => s.id);
+        const structureCheck = await this.assertIdsInCollectivite(
+          structureIds,
+          existingFiche.collectiviteId,
+          (ids) =>
+            tx
+              .select({ id: structureTagTable.id, collectiviteId: structureTagTable.collectiviteId })
+              .from(structureTagTable)
+              .where(inArray(structureTagTable.id, ids))
+        );
+        if (!structureCheck.success) return structureCheck;
         await this.updateRelations(
           ficheId,
           structures,
@@ -231,6 +272,19 @@ export class FicheActionRepository {
       }
 
       if (pilotes !== undefined) {
+        const piloteTagIds = (pilotes ?? [])
+          .map((p) => p.tagId)
+          .filter((id): id is number => id != null);
+        const piloteCheck = await this.assertIdsInCollectivite(
+          piloteTagIds,
+          existingFiche.collectiviteId,
+          (ids) =>
+            tx
+              .select({ id: personneTagTable.id, collectiviteId: personneTagTable.collectiviteId })
+              .from(personneTagTable)
+              .where(inArray(personneTagTable.id, ids))
+        );
+        if (!piloteCheck.success) return piloteCheck;
         await this.updateRelations(
           ficheId,
           pilotes,
@@ -243,6 +297,19 @@ export class FicheActionRepository {
       }
 
       if (referents !== undefined) {
+        const referentTagIds = (referents ?? [])
+          .map((r) => r.tagId)
+          .filter((id): id is number => id != null);
+        const referentCheck = await this.assertIdsInCollectivite(
+          referentTagIds,
+          existingFiche.collectiviteId,
+          (ids) =>
+            tx
+              .select({ id: personneTagTable.id, collectiviteId: personneTagTable.collectiviteId })
+              .from(personneTagTable)
+              .where(inArray(personneTagTable.id, ids))
+        );
+        if (!referentCheck.success) return referentCheck;
         await this.updateRelations(
           ficheId,
           referents,
@@ -279,6 +346,17 @@ export class FicheActionRepository {
       }
 
       if (services !== undefined) {
+        const serviceIds = (services ?? []).map((s) => s.id);
+        const serviceCheck = await this.assertIdsInCollectivite(
+          serviceIds,
+          existingFiche.collectiviteId,
+          (ids) =>
+            tx
+              .select({ id: serviceTagTable.id, collectiviteId: serviceTagTable.collectiviteId })
+              .from(serviceTagTable)
+              .where(inArray(serviceTagTable.id, ids))
+        );
+        if (!serviceCheck.success) return serviceCheck;
         await this.updateRelations(
           ficheId,
           services,
@@ -291,6 +369,19 @@ export class FicheActionRepository {
       }
 
       if (financeurs !== undefined) {
+        const financeurTagIds = (financeurs ?? [])
+          .map((f) => f.financeurTag?.id)
+          .filter((id): id is number => id != null);
+        const financeurCheck = await this.assertIdsInCollectivite(
+          financeurTagIds,
+          existingFiche.collectiviteId,
+          (ids) =>
+            tx
+              .select({ id: financeurTagTable.id, collectiviteId: financeurTagTable.collectiviteId })
+              .from(financeurTagTable)
+              .where(inArray(financeurTagTable.id, ids))
+        );
+        if (!financeurCheck.success) return financeurCheck;
         const flatFinanceurs = this.extractIdsAndMontants(financeurs);
         await this.updateRelations(
           ficheId,
@@ -353,6 +444,17 @@ export class FicheActionRepository {
       }
 
       if (libreTags !== undefined) {
+        const libreTagIds = (libreTags ?? []).map((t) => t.id);
+        const libreTagCheck = await this.assertIdsInCollectivite(
+          libreTagIds,
+          existingFiche.collectiviteId,
+          (ids) =>
+            tx
+              .select({ id: libreTagTable.id, collectiviteId: libreTagTable.collectiviteId })
+              .from(libreTagTable)
+              .where(inArray(libreTagTable.id, ids))
+        );
+        if (!libreTagCheck.success) return libreTagCheck;
         await tx
           .delete(ficheActionLibreTagTable)
           .where(eq(ficheActionLibreTagTable.ficheId, ficheId));
@@ -395,6 +497,23 @@ export class FicheActionRepository {
     } catch (error) {
       return this.toServerError(error);
     }
+  }
+
+  private async assertIdsInCollectivite(
+    ids: number[],
+    collectiviteId: number,
+    fetchRows: (ids: number[]) => Promise<{ id: number; collectiviteId: number }[]>
+  ): Promise<Result<void, 'RELATION_COLLECTIVITE_MISMATCH'>> {
+    if (ids.length === 0) return success(undefined);
+    const uniqueIds = [...new Set(ids)];
+    const rows = await fetchRows(uniqueIds);
+    if (
+      rows.length !== uniqueIds.length ||
+      rows.some((r) => r.collectiviteId !== collectiviteId)
+    ) {
+      return failure('RELATION_COLLECTIVITE_MISMATCH');
+    }
+    return success(undefined);
   }
 
   private toServerError(

--- a/apps/backend/src/plans/fiches/update-fiche/update-fiche.errors.ts
+++ b/apps/backend/src/plans/fiches/update-fiche/update-fiche.errors.ts
@@ -14,6 +14,7 @@ const specificErrors = [
   'FICHE_NOT_FOUND',
   'INSTANCE_GOUVERNANCE_COLLECTIVITE_MISMATCH',
   'INSTANCE_GOUVERNANCE_TAG_NOT_FOUND',
+  'RELATION_COLLECTIVITE_MISMATCH',
   ...referentielModeGuardSpecificErrors,
 ] as const;
 type SpecificError = (typeof specificErrors)[number];
@@ -45,6 +46,11 @@ export const updateFicheErrorConfig: TrpcErrorHandlerConfig<SpecificError> = {
     INSTANCE_GOUVERNANCE_TAG_NOT_FOUND: {
       code: 'BAD_REQUEST',
       message: "Une ou plusieurs instances de gouvernance n'existent pas",
+    },
+    RELATION_COLLECTIVITE_MISMATCH: {
+      code: 'BAD_REQUEST',
+      message:
+        "Une ou plusieurs relations pointent vers des entités d'une autre collectivité",
     },
     ...referentielNotWritableTrpcErrorEntry,
   },

--- a/apps/backend/src/plans/fiches/update-fiche/update-fiche.router.e2e-spec.ts
+++ b/apps/backend/src/plans/fiches/update-fiche/update-fiche.router.e2e-spec.ts
@@ -23,7 +23,7 @@ import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { CibleEnum, PiliersEciEnum, StatutEnum } from '@tet/domain/plans';
 import { CollectiviteRole } from '@tet/domain/users';
 import { and, eq } from 'drizzle-orm';
-import { describe, expect, onTestFinished } from 'vitest';
+import { beforeAll, describe, expect, onTestFinished } from 'vitest';
 import {
   actionsFixture,
   effetsAttendusFixture,
@@ -850,6 +850,136 @@ describe('UpdateFicheService', () => {
       ).rejects.toThrowError(
         /même collectivité que la fiche parente|Droits insuffisants/i
       );
+    });
+
+    describe('IDOR — cross-collectivité relation injection', () => {
+      let otherCollectiviteId: number;
+      let otherAxeId: number;
+      let otherPartenaireTagId: number;
+      let otherPersonneTagId: number;
+      let otherServiceTagId: number;
+      let otherFinanceurTagId: number;
+      let otherLibreTagId: number;
+      let otherStructureTagId: number;
+
+      beforeAll(async () => {
+        const { collectivite: other } = await addTestCollectivite(db);
+        otherCollectiviteId = other.id;
+
+        const [axe] = await db.db
+          .insert(axeTable)
+          .values({
+            nom: 'Plan autre collectivité',
+            collectiviteId: otherCollectiviteId,
+          })
+          .returning();
+        otherAxeId = axe.id;
+
+        const [partenaire] = await db.db
+          .insert(partenaireTagTable)
+          .values({
+            nom: 'Partenaire autre collectivité',
+            collectiviteId: otherCollectiviteId,
+          })
+          .returning();
+        otherPartenaireTagId = partenaire.id;
+
+        const [personne] = await db.db
+          .insert(personneTagTable)
+          .values({
+            nom: 'Personne autre collectivité',
+            collectiviteId: otherCollectiviteId,
+          })
+          .returning();
+        otherPersonneTagId = personne.id;
+
+        const [service] = await db.db
+          .insert(serviceTagTable)
+          .values({
+            nom: 'Service autre collectivité',
+            collectiviteId: otherCollectiviteId,
+          })
+          .returning();
+        otherServiceTagId = service.id;
+
+        const [financeur] = await db.db
+          .insert(financeurTagTable)
+          .values({
+            nom: 'Financeur autre collectivité',
+            collectiviteId: otherCollectiviteId,
+          })
+          .returning();
+        otherFinanceurTagId = financeur.id;
+
+        const [libreTag] = await db.db
+          .insert(libreTagTable)
+          .values({
+            nom: 'Libre tag autre collectivité',
+            collectiviteId: otherCollectiviteId,
+          })
+          .returning();
+        otherLibreTagId = libreTag.id;
+
+        const [structure] = await db.db
+          .insert(structureTagTable)
+          .values({
+            nom: 'Structure autre collectivité',
+            collectiviteId: otherCollectiviteId,
+          })
+          .returning();
+        otherStructureTagId = structure.id;
+      });
+
+      const expectIdorRejection = async (ficheFields: UpdateFicheInput) => {
+        const caller = fichesRouter.createCaller({ user: testUser });
+        await expect(caller.update({ ficheId, ficheFields })).rejects.toMatchObject({
+          code: 'BAD_REQUEST',
+          message:
+            "Une ou plusieurs relations pointent vers des entités d'une autre collectivité",
+        });
+      };
+
+      test('should reject axes from another collectivité', async () => {
+        await expectIdorRejection({ axes: [{ id: otherAxeId }] });
+      });
+
+      test('should reject partenaires from another collectivité', async () => {
+        await expectIdorRejection({
+          partenaires: [{ id: otherPartenaireTagId }],
+        });
+      });
+
+      test('should reject pilote tag from another collectivité', async () => {
+        await expectIdorRejection({ pilotes: [{ tagId: otherPersonneTagId }] });
+      });
+
+      test('should reject referent tag from another collectivité', async () => {
+        await expectIdorRejection({
+          referents: [{ tagId: otherPersonneTagId }],
+        });
+      });
+
+      test('should reject services from another collectivité', async () => {
+        await expectIdorRejection({ services: [{ id: otherServiceTagId }] });
+      });
+
+      test('should reject financeurs from another collectivité', async () => {
+        await expectIdorRejection({
+          financeurs: [
+            { financeurTag: { id: otherFinanceurTagId }, montantTtc: 100 },
+          ],
+        });
+      });
+
+      test('should reject libreTags from another collectivité', async () => {
+        await expectIdorRejection({ libreTags: [{ id: otherLibreTagId }] });
+      });
+
+      test('should reject structures from another collectivité', async () => {
+        await expectIdorRejection({
+          structures: [{ id: otherStructureTagId }],
+        });
+      });
     });
 
     test('should allow update if fiche action is in user’s collectivite', async () => {


### PR DESCRIPTION
## Contexte

Faille **🟡 Moyenne n°5** détectée lors de l'audit IDOR du 2026-06-01.

`plans.fiches.update` validait le droit d'écriture sur la fiche (`canWriteFiche`) et bloquait la réécriture de `collectiviteId` — mais acceptait sans vérification des IDs d'entités scopées-collectivité provenant d'une autre collectivité dans les tableaux de relations.

Un pilote de la collectivité A pouvait ainsi rattacher sa fiche à des **axes** d'un plan de la collectivité B, ou l'associer à des **tags** (partenaires, services, financeurs…) appartenant à B.

## Changements

- **`fiche-action.repository.ts`** : ajoute `assertIdsInCollectivite` (helper privé) qui vérifie, avant chaque écriture de relation scopée, que tous les IDs fournis appartiennent bien à la même collectivité que la fiche. Couvre : `axes`, `partenaires`, `structures`, `pilotes` (tagId), `referents` (tagId), `services`, `financeurs`, `libreTags`.
- **`update-fiche.errors.ts`** : ajoute l'erreur `RELATION_COLLECTIVITE_MISMATCH` (HTTP 400).
- **`update-fiche.router.e2e-spec.ts`** : ajoute 8 tests e2e IDOR (un par type de relation scopée).

## Test plan

- [ ] `nx test backend update-fiche.router.e2e-spec.ts` — tous les nouveaux tests passent
- [ ] Les tests existants de `UpdateFicheService` ne régressent pas
- [ ] Tentative d'injection avec axes/partenaires/pilotes/structures/services/financeurs/libreTags d'une autre collectivité → `BAD_REQUEST`
- [ ] Mise à jour avec des IDs de la bonne collectivité → succès inchangé

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Améliorations**
  * Renforcement de la sécurité lors de la mise à jour des fiches : les relations référencées doivent appartenir à la même collectivité que la fiche.
  * Les références provenant d’une autre collectivité sont désormais systématiquement bloquées.

* **Gestion des erreurs**
  * Un message d’erreur explicite est retourné lorsque des relations invalides sont détectées.

* **Tests**
  * Ajout de contrôles couvrant les axes, partenaires, pilotes, référents, services, financeurs, structures et tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->