### PR TITLE
fix(security): valide fichierId contre la collectivité dans addAnnexe (TET-7359)

### DIFF
--- a/apps/backend/src/plans/fiches/add-annexe/add-annexe.repository.ts
+++ b/apps/backend/src/plans/fiches/add-annexe/add-annexe.repository.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { annexeTable } from '@tet/backend/collectivites/documents/models/annexe.table';
+import { bibliothequeFichierTable } from '@tet/backend/collectivites/documents/models/bibliotheque-fichier.table';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { failure, Result, success } from '@tet/backend/utils/result.type';
 import { CommonErrorEnum } from '@tet/backend/utils/trpc/common-errors';
@@ -104,6 +105,14 @@ export class AddAnnexeRepository {
         error instanceof Error ? error : new Error(getErrorMessage(error))
       );
     }
+  }
+
+  async getFichierCollectiviteId(fichierId: number): Promise<number | null> {
+    const [row] = await this.databaseService.db
+      .select({ collectiviteId: bibliothequeFichierTable.collectiviteId })
+      .from(bibliothequeFichierTable)
+      .where(eq(bibliothequeFichierTable.id, fichierId));
+    return row?.collectiviteId ?? null;
   }
 
   async loadRawAnnexesForDuplication(

--- a/apps/backend/src/plans/fiches/add-annexe/add-annexe.router.e2e-spec.ts
+++ b/apps/backend/src/plans/fiches/add-annexe/add-annexe.router.e2e-spec.ts
@@ -1,6 +1,9 @@
 import { INestApplication } from '@nestjs/common';
 import { addTestCollectiviteAndUsers } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
-import { uploadCreateTestDocument } from '@tet/backend/collectivites/documents/documents.test-fixture';
+import {
+  OTHER_PDF_SAMPLE_FILE,
+  uploadCreateTestDocument,
+} from '@tet/backend/collectivites/documents/documents.test-fixture';
 import {
   getAuthUserFromUserCredentials,
   getTestApp,
@@ -115,6 +118,44 @@ describe('AddAnnexeRouter', () => {
     expect(annexe.id).toBeDefined();
     expect(annexe.collectiviteId).toBe(collectivite.id);
     expect(annexe.fichierId).toBe(fichierId);
+  });
+
+  test("un éditeur ne peut pas associer un fichier d'une autre collectivité (IDOR)", async () => {
+    const { collectivite: autreCollectivite, users: autreUsers } =
+      await addTestCollectiviteAndUsers(db, {
+        users: [{ role: CollectiviteRole.EDITION }],
+      });
+    const autreEditor = autreUsers[0];
+    const signInAutre = await signInWith({
+      email: autreEditor.email,
+      password: autreEditor.password,
+    });
+    const autreAuthToken = signInAutre.data.session?.access_token ?? '';
+
+    const testAgent = request(app.getHttpServer());
+    const autreDoc = await uploadCreateTestDocument({
+      collectiviteId: autreCollectivite.id,
+      testAgent,
+      token: autreAuthToken,
+      fileName: 'autre-collectivite.pdf',
+      sampleFileName: OTHER_PDF_SAMPLE_FILE,
+    });
+
+    const editorCaller = router.createCaller({ user: editorUser });
+    const ficheId = await createFiche({
+      caller: editorCaller,
+      ficheInput: {
+        titre: 'Fiche IDOR annexe',
+        collectiviteId: collectivite.id,
+      },
+    });
+
+    await expect(
+      editorCaller.plans.fiches.addAnnexe({
+        ficheId,
+        fichierId: autreDoc.id,
+      })
+    ).rejects.toThrow(/n'existe pas/i);
   });
 
   test("un visiteur ne peut pas créer d'annexe sur une fiche d'une collectivité", async () => {

--- a/apps/backend/src/plans/fiches/add-annexe/add-annexe.service.ts
+++ b/apps/backend/src/plans/fiches/add-annexe/add-annexe.service.ts
@@ -47,19 +47,26 @@ export class AddAnnexeService {
 
     const commentaire = input.commentaire ?? '';
 
-    return 'fichierId' in input
-      ? this.addAnnexeRepository.addFile({
-          ...input,
-          collectiviteId,
-          commentaire,
-          modifiedBy: user.id,
-        })
-      : this.addAnnexeRepository.addUrl({
-          ...input,
-          collectiviteId,
-          commentaire,
-          modifiedBy: user.id,
-        });
+    if ('fichierId' in input) {
+      const fichierCollectiviteId =
+        await this.addAnnexeRepository.getFichierCollectiviteId(input.fichierId);
+      if (fichierCollectiviteId !== collectiviteId) {
+        return failure(CommonErrorEnum.NOT_FOUND);
+      }
+      return this.addAnnexeRepository.addFile({
+        ...input,
+        collectiviteId,
+        commentaire,
+        modifiedBy: user.id,
+      });
+    }
+
+    return this.addAnnexeRepository.addUrl({
+      ...input,
+      collectiviteId,
+      commentaire,
+      modifiedBy: user.id,
+    });
   }
 
   loadRawAnnexesForDuplication(


### PR DESCRIPTION
## Résumé

- **Faille** (TET-7359) : `plans.fiches.addAnnexe` acceptait un `fichierId` provenant de n'importe quelle collectivité, permettant à un admin de A d'associer un fichier de B à une fiche de A (IDOR inter-collectivités).
- **Correction** : avant l'insertion, on vérifie que `bibliothequeFichier.collectiviteId` correspond au `collectiviteId` de la fiche. Si non, retourne `NOT_FOUND`.
- **Test** : ajout d'un test e2e qui tente l'attaque cross-collectivité et vérifie le rejet.

## Plan de test

- [ ] `nx test backend 'add-annexe.router.e2e-spec'` : tous les tests passent, y compris le nouveau cas IDOR
- [ ] Vérifier que l'association d'un fichier appartenant à la bonne collectivité fonctionne toujours