### PR TITLE
Ajoute la fusion des explications d'origine vers les actions du référentiel CR

### DIFF
--- a/apps/backend/src/referentiels/referentiels.module.ts
+++ b/apps/backend/src/referentiels/referentiels.module.ts
@@ -83,6 +83,7 @@ import { ResetDisplayPreferencesRouter } from './reset-display-preferences/reset
 import { ResetDisplayPreferencesService } from './reset-display-preferences/reset-display-preferences.service';
 import { CreatePreSwitchSnapshotsService } from './switch-to-te/create-pre-switch-snapshots.service';
 import { BuildSwitchToTeContextService } from './switch-to-te/build-switch-to-te-context.service';
+import { MergeCommentairesService } from './switch-to-te/merge-commentaires/merge-commentaires.service';
 import { MergeStatutsService } from './switch-to-te/merge-statuts/merge-statuts.service';
 import { SwitchToTeRouter } from './switch-to-te/switch-to-te.router';
 import { SwitchToTeService } from './switch-to-te/switch-to-te.service';
@@ -200,6 +201,7 @@ import { UpdateActionStatutService } from './update-action-statut/update-action-
     CreatePreSwitchSnapshotsService,
     BuildSwitchToTeContextService,
     MergeStatutsService,
+    MergeCommentairesService,
 
     HistoriqueRouter,
     ListHistoriqueRepository,

--- a/apps/backend/src/referentiels/switch-to-te/merge-commentaires/merge-commentaires.rules.spec.ts
+++ b/apps/backend/src/referentiels/switch-to-te/merge-commentaires/merge-commentaires.rules.spec.ts
@@ -1,0 +1,184 @@
+import {
+  ReferentielIdEnum,
+  StatutAvancementEnum,
+  type ActionScore,
+} from '@tet/domain/referentiels';
+import {
+  buildSourceBlock,
+  buildSourceBlockHeader,
+  formatSourceScoreLabel,
+  isExplicationNonVide,
+  MERGE_COMMENTAIRES_BLOCK_SEPARATOR,
+  MERGE_COMMENTAIRES_PREFIX,
+  mergeCommentairesFromSources,
+  sortMergeCommentaireSources,
+  type MergeCommentaireSource,
+} from './merge-commentaires.rules';
+
+const baseActionScore = (
+  overrides: Partial<ActionScore> = {}
+): ActionScore => ({
+  actionId: 'cae_1.2.3',
+  pointReferentiel: 10,
+  pointPotentiel: 10,
+  pointPotentielPerso: null,
+  pointFait: 0,
+  pointProgramme: 0,
+  pointPasFait: 0,
+  pointNonRenseigne: 10,
+  totalTachesCount: 1,
+  completedTachesCount: 0,
+  faitTachesAvancement: 0,
+  programmeTachesAvancement: 0,
+  pasFaitTachesAvancement: 0,
+  pasConcerneTachesAvancement: 0,
+  concerne: true,
+  desactive: false,
+  renseigne: false,
+  ...overrides,
+});
+
+const source = (
+  overrides: Partial<MergeCommentaireSource> = {}
+): MergeCommentaireSource => ({
+  referentielId: ReferentielIdEnum.CAE,
+  origineActionId: 'cae_1.2.3',
+  nom: 'Définir et mettre en oeuvre la stratégie',
+  scoreLabel: '42 % FAIT',
+  explication:
+    '<p class="!text-base">Service Espace Conseil Rénovation : 16 personnes…</p>',
+  ...overrides,
+});
+
+describe('merge-commentaires.rules', () => {
+  describe('isExplicationNonVide', () => {
+    it('rejette le HTML vide', () => {
+      expect(isExplicationNonVide('<p></p>')).toBe(false);
+      expect(isExplicationNonVide('<p>&nbsp;</p>')).toBe(false);
+    });
+
+    it('accepte le texte brut et le HTML avec contenu', () => {
+      expect(isExplicationNonVide('ligne 1 du texte brut')).toBe(true);
+      expect(isExplicationNonVide('<p>Contenu</p>')).toBe(true);
+    });
+  });
+
+  describe('formatSourceScoreLabel', () => {
+    it('retourne les libellés discrets en majuscules', () => {
+      expect(
+        formatSourceScoreLabel(
+          baseActionScore({ avancement: StatutAvancementEnum.FAIT })
+        )
+      ).toBe('FAIT');
+      expect(
+        formatSourceScoreLabel(
+          baseActionScore({ avancement: StatutAvancementEnum.PROGRAMME })
+        )
+      ).toBe('PROGRAMMÉ');
+      expect(
+        formatSourceScoreLabel(
+          baseActionScore({ avancement: StatutAvancementEnum.PAS_FAIT })
+        )
+      ).toBe('PAS FAIT');
+      expect(
+        formatSourceScoreLabel(
+          baseActionScore({ avancement: undefined, pointNonRenseigne: 10 })
+        )
+      ).toBe('NON RENSEIGNÉ');
+    });
+
+    it('retourne le pourcentage fait arrondi à l inférieur pour detaille', () => {
+      expect(
+        formatSourceScoreLabel(
+          baseActionScore({
+            avancement: StatutAvancementEnum.DETAILLE_AU_POURCENTAGE,
+            pointFait: 4.2,
+            pointPasFait: 5.8,
+            pointNonRenseigne: 0,
+          })
+        )
+      ).toBe('42 % FAIT');
+    });
+  });
+
+  describe('buildSourceBlockHeader', () => {
+    it("formate l'en-tête traçable", () => {
+      expect(buildSourceBlockHeader(source())).toBe(
+        '<p><strong>cae_1.2.3 - Définir et mettre en oeuvre la stratégie - 42 % FAIT</strong></p>'
+      );
+    });
+
+    it('utilise une chaîne vide si nom est null', () => {
+      expect(buildSourceBlockHeader(source({ nom: null }))).toBe(
+        '<p><strong>cae_1.2.3 - 42 % FAIT</strong></p>'
+      );
+    });
+  });
+
+  describe('sortMergeCommentaireSources', () => {
+    it('trie CAE avant ECI en conservant l ordre d entrée', () => {
+      const eciFirst = source({
+        referentielId: ReferentielIdEnum.ECI,
+        origineActionId: 'eci_4.1',
+        explication: 'ECI',
+      });
+      const caeSecond = source({
+        referentielId: ReferentielIdEnum.CAE,
+        origineActionId: 'cae_1.1',
+        explication: 'CAE 2',
+      });
+      const caeFirst = source({
+        referentielId: ReferentielIdEnum.CAE,
+        origineActionId: 'cae_1.0',
+        explication: 'CAE 1',
+      });
+
+      expect(
+        sortMergeCommentaireSources([eciFirst, caeSecond, caeFirst]).map(
+          (item) => item.origineActionId
+        )
+      ).toEqual(['cae_1.1', 'cae_1.0', 'eci_4.1']);
+    });
+  });
+
+  describe('mergeCommentairesFromSources', () => {
+    it('retourne null sans source avec texte', () => {
+      expect(
+        mergeCommentairesFromSources([
+          source({ explication: '<p></p>' }),
+          source({ explication: '   ' }),
+        ])
+      ).toBeNull();
+    });
+
+    it('concatène le préfixe, les blocs CAE puis ECI et conserve les corps', () => {
+      const caeSource = source({
+        scoreLabel: '42 % FAIT',
+        explication:
+          '<p class="!text-base !text-grey-8 font-[Marianne]">explications 1</p>',
+      });
+      const eciSource = source({
+        referentielId: ReferentielIdEnum.ECI,
+        origineActionId: 'eci_4.1',
+        nom: 'Connaître les coûts',
+        scoreLabel: 'FAIT',
+        explication:
+          'ligne 1 du texte brut hérité\nligne 2 du texte brut hérité',
+      });
+
+      const result = mergeCommentairesFromSources([eciSource, caeSource]);
+
+      expect(result).toBe(
+        `${MERGE_COMMENTAIRES_PREFIX}${buildSourceBlock(
+          caeSource
+        )}${MERGE_COMMENTAIRES_BLOCK_SEPARATOR}${buildSourceBlock(eciSource)}`
+      );
+    });
+
+    it('ignore les sources sans texte non vide (annexe A — 1→1 sans texte)', () => {
+      expect(
+        mergeCommentairesFromSources([source({ explication: '<p>&nbsp;</p>' })])
+      ).toBeNull();
+    });
+  });
+});

--- a/apps/backend/src/referentiels/switch-to-te/merge-commentaires/merge-commentaires.rules.ts
+++ b/apps/backend/src/referentiels/switch-to-te/merge-commentaires/merge-commentaires.rules.ts
@@ -1,0 +1,114 @@
+import { sortByReferentielOrder } from '../shared/origine-resolution';
+import {
+  getScoreRatios,
+  getStatutAvancement,
+  StatutAvancementEnum,
+  type ActionScore,
+  type ReferentielId,
+} from '@tet/domain/referentiels';
+import { htmlToText } from '@tet/domain/utils';
+
+export const MERGE_COMMENTAIRES_PREFIX =
+  '<p><span data-text-color="red">Les textes ci-après et les statuts associés sont issus de la bascule depuis les anciens référentiels CAE et/ou ECi. Ils sont à actualiser pour répondre à l\'actuelle sous-mesure.</span></p>\n<p>&nbsp;</p>';
+
+export const MERGE_COMMENTAIRES_BLOCK_SEPARATOR = '<p>&nbsp;</p>\n';
+
+export type MergeCommentaireSource = {
+  referentielId: ReferentielId;
+  origineActionId: string;
+  nom: string | null;
+  scoreLabel: string;
+  explication: string;
+};
+
+export const isExplicationNonVide = (explication: string): boolean =>
+  htmlToText(explication).trim().length > 0;
+
+export const formatSourceScoreLabel = (actionScore: ActionScore): string => {
+  const statut = getStatutAvancement({
+    avancement: actionScore.avancement,
+    desactive: actionScore.desactive,
+    concerne: actionScore.concerne,
+  });
+
+  switch (statut) {
+    case StatutAvancementEnum.FAIT:
+      return 'FAIT';
+    case StatutAvancementEnum.PROGRAMME:
+      return 'PROGRAMMÉ';
+    case StatutAvancementEnum.PAS_FAIT:
+      return 'PAS FAIT';
+    case StatutAvancementEnum.NON_RENSEIGNE:
+    case StatutAvancementEnum.NON_RENSEIGNABLE:
+      return 'NON RENSEIGNÉ';
+    case StatutAvancementEnum.DETAILLE_AU_POURCENTAGE:
+    case StatutAvancementEnum.DETAILLE_A_LA_TACHE: {
+      const { ratioFait } = getScoreRatios({
+        pointFait: actionScore.pointFait ?? 0,
+        pointProgramme: actionScore.pointProgramme ?? 0,
+        pointPasFait: actionScore.pointPasFait ?? 0,
+        pointNonRenseigne: actionScore.pointNonRenseigne ?? 0,
+        pointPotentiel: actionScore.pointPotentiel ?? 0,
+        pointReferentiel: actionScore.pointReferentiel ?? 0,
+        completedTachesCount: actionScore.completedTachesCount ?? 0,
+        totalTachesCount: actionScore.totalTachesCount ?? 0,
+        pasFaitTachesAvancement: actionScore.pasFaitTachesAvancement ?? 0,
+        faitTachesAvancement: actionScore.faitTachesAvancement ?? 0,
+        programmeTachesAvancement: actionScore.programmeTachesAvancement ?? 0,
+        pasConcerneTachesAvancement:
+          actionScore.pasConcerneTachesAvancement ?? 0,
+        pointPotentielPerso: actionScore.pointPotentielPerso ?? null,
+        concerne: actionScore.concerne,
+        desactive: actionScore.desactive,
+        renseigne: actionScore.renseigne,
+        actionId: actionScore.actionId,
+      });
+      const faitPercent = Math.floor(ratioFait * 100);
+      return `${faitPercent} % FAIT`;
+    }
+    case StatutAvancementEnum.NON_CONCERNE:
+      throw new Error(
+        'formatSourceScoreLabel ne doit pas être appelé pour une source non concernée'
+      );
+    default: {
+      return statut;
+    }
+  }
+};
+
+export const buildSourceBlockHeader = (
+  source: MergeCommentaireSource
+): string => {
+  const titleParts = [source.origineActionId];
+  if (source.nom) {
+    titleParts.push(source.nom);
+  }
+  titleParts.push(source.scoreLabel);
+  return `<p><strong>${titleParts.join(' - ')}</strong></p>`;
+};
+
+export const buildSourceBlock = (source: MergeCommentaireSource): string =>
+  `${buildSourceBlockHeader(source)}\n${source.explication}`;
+
+export const sortMergeCommentaireSources = (
+  sources: MergeCommentaireSource[]
+): MergeCommentaireSource[] => sortByReferentielOrder(sources);
+
+export const mergeCommentairesFromSources = (
+  sources: MergeCommentaireSource[]
+): string | null => {
+  const sourcesWithText = sources.filter((source) =>
+    isExplicationNonVide(source.explication)
+  );
+
+  if (sourcesWithText.length === 0) {
+    return null;
+  }
+
+  const sortedSources = sortMergeCommentaireSources(sourcesWithText);
+  const blocks = sortedSources.map((source) => buildSourceBlock(source));
+
+  return `${MERGE_COMMENTAIRES_PREFIX}${blocks.join(
+    MERGE_COMMENTAIRES_BLOCK_SEPARATOR
+  )}`;
+};

--- a/apps/backend/src/referentiels/switch-to-te/merge-commentaires/merge-commentaires.service.e2e-spec.ts
+++ b/apps/backend/src/referentiels/switch-to-te/merge-commentaires/merge-commentaires.service.e2e-spec.ts
@@ -1,0 +1,309 @@
+import { INestApplication } from '@nestjs/common';
+import { addTestCollectiviteAndUser } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { snapshotTable } from '@tet/backend/referentiels/snapshots/snapshot.table';
+import { SNAPSHOTS } from '@tet/backend/referentiels/snapshots/snapshots.constants';
+import { cleanupReferentielActionStatutsAndLabellisations } from '@tet/backend/referentiels/update-action-statut/referentiel-action-statut.test-fixture';
+import {
+  getAuthUserFromUserCredentials,
+  getTestApp,
+  getTestDatabase,
+  getTestRouter,
+} from '@tet/backend/test';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
+import {
+  type Collectivite,
+  type CollectiviteReferentielPreferences,
+} from '@tet/domain/collectivites';
+import {
+  StatutAvancementEnum,
+  type ScoreSnapshot,
+} from '@tet/domain/referentiels';
+import { CollectiviteRole } from '@tet/domain/users';
+import { and, eq } from 'drizzle-orm';
+import { BuildSwitchToTeContextService } from '../build-switch-to-te-context.service';
+import { CreatePreSwitchSnapshotsService } from '../create-pre-switch-snapshots.service';
+import { MERGE_COMMENTAIRES_PREFIX } from './merge-commentaires.rules';
+import { MergeCommentairesService } from './merge-commentaires.service';
+import { buildSwitchToTeContextForTest } from '../switch-to-te-context.test-fixture';
+import { SwitchToTeErrorEnum } from '../switch-to-te.errors';
+
+const prefsEligibleCaeOnly: CollectiviteReferentielPreferences = {
+  cae: { display: true, mode: 'write' },
+  eci: { display: false, mode: 'archived' },
+  te: { display: true, mode: 'readonly' },
+};
+
+const prefsEligibleCaeAndEci: CollectiviteReferentielPreferences = {
+  cae: { display: true, mode: 'write' },
+  eci: { display: true, mode: 'write' },
+  te: { display: true, mode: 'readonly' },
+};
+
+/**
+ * Exemples figés depuis `import-referentiel/samples/referentiel-te-structure.csv`.
+ * À mettre à jour si le CSV TE change
+ */
+const MERGE_COMMENTAIRES_FIXTURE = {
+  /** TE 1.1.1.2 ← Cae_1.1.2.2.1 (correspondance 1→1) */
+  teActionCae1to1: {
+    teActionId: 'te_1.1.1.2',
+    caeOrigineActionId: 'cae_1.1.2.2.1',
+  },
+  /** TE 5.1.2.3 ← Cae_5.1.2.3 + Eci_1.1.3.3 (fusion 2→1) */
+  teActionCaeAndEci: {
+    teActionId: 'te_5.1.2.3',
+    caeOrigineActionId: 'cae_5.1.2.3',
+    eciOrigineActionId: 'eci_1.1.3.3',
+  },
+  /** TE 1.1.1.3 : origine « Nouvelle action », sans source CAE/ECI */
+  teNativeActionId: 'te_1.1.1.3',
+} as const;
+
+describe('MergeCommentairesService', () => {
+  let app: INestApplication;
+  let databaseService: DatabaseService;
+  let router: TrpcRouter;
+  let mergeService: MergeCommentairesService;
+  let buildSwitchToTeContextService: BuildSwitchToTeContextService;
+  let createPreSwitchSnapshotsService: CreatePreSwitchSnapshotsService;
+  let collectivite: Collectivite;
+  let user: AuthenticatedUser;
+  let cleanupFixture: () => Promise<void>;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    databaseService = await getTestDatabase(app);
+    router = await getTestRouter(app);
+    mergeService = app.get(MergeCommentairesService);
+    buildSwitchToTeContextService = app.get(BuildSwitchToTeContextService);
+    createPreSwitchSnapshotsService = app.get(CreatePreSwitchSnapshotsService);
+
+    const fixture = await addTestCollectiviteAndUser(databaseService, {
+      user: { role: CollectiviteRole.ADMIN },
+    });
+    collectivite = fixture.collectivite;
+    cleanupFixture = fixture.cleanup;
+    user = getAuthUserFromUserCredentials(fixture.user);
+  });
+
+  afterAll(async () => {
+    await cleanupFixture();
+    await app.close();
+  });
+
+  async function cleanupCollectiviteReferentielData() {
+    await cleanupReferentielActionStatutsAndLabellisations(
+      databaseService,
+      collectivite.id
+    );
+    await databaseService.db
+      .delete(snapshotTable)
+      .where(
+        and(
+          eq(snapshotTable.collectiviteId, collectivite.id),
+          eq(snapshotTable.ref, SNAPSHOTS.PRE_SWITCH_TE_REF)
+        )
+      );
+  }
+
+  async function setupTest() {
+    await cleanupCollectiviteReferentielData();
+  }
+
+  async function setActionStatut(
+    actionId: string,
+    statut: 'fait' | 'pas_fait' | 'non_concerne'
+  ) {
+    const caller = router.createCaller({ user });
+    await caller.referentiels.actions.updateStatuts({
+      actionStatuts: [
+        {
+          collectiviteId: collectivite.id,
+          actionId,
+          statut,
+        },
+      ],
+    });
+  }
+
+  async function setActionCommentaire(actionId: string, commentaire: string) {
+    const caller = router.createCaller({ user });
+    await caller.referentiels.actions.updateCommentaire({
+      collectiviteId: collectivite.id,
+      actionId,
+      commentaire,
+    });
+  }
+
+  async function buildCtx(
+    prefs: CollectiviteReferentielPreferences,
+    preSwitchSnapshots?: ScoreSnapshot[]
+  ) {
+    return buildSwitchToTeContextForTest(
+      collectivite.id,
+      prefs,
+      {
+        createPreSwitchSnapshotsService,
+        buildSwitchToTeContextService,
+      },
+      { user, preSwitchSnapshots }
+    );
+  }
+
+  async function mergeFromPrefs(
+    prefs: CollectiviteReferentielPreferences,
+    preSwitchSnapshots?: ScoreSnapshot[]
+  ) {
+    const ctxResult = await buildCtx(prefs, preSwitchSnapshots);
+    expect(ctxResult.success).toBe(true);
+    if (!ctxResult.success) {
+      throw new Error('buildSwitchToTeContext a échoué');
+    }
+    return mergeService.merge(ctxResult.data);
+  }
+
+  test('CAE seul, 1→1 avec explication : commentaire fusionné (préfixe + bloc source)', async () => {
+    onTestFinished(cleanupCollectiviteReferentielData);
+    await setupTest();
+
+    const { teActionId, caeOrigineActionId } =
+      MERGE_COMMENTAIRES_FIXTURE.teActionCae1to1;
+    const sourceCommentaire =
+      '<p>Explication CAE figée au moment T pour la bascule TE.</p>';
+
+    await setActionStatut(caeOrigineActionId, StatutAvancementEnum.FAIT);
+    await setActionCommentaire(caeOrigineActionId, sourceCommentaire);
+
+    const result = await mergeFromPrefs(prefsEligibleCaeOnly);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const teCommentaire = result.data.find(
+      (commentaire) => commentaire.actionId === teActionId
+    );
+
+    expect(teCommentaire?.commentaire.startsWith(MERGE_COMMENTAIRES_PREFIX)).toBe(
+      true
+    );
+    expect(teCommentaire?.commentaire).toContain(caeOrigineActionId);
+    expect(teCommentaire?.commentaire).toContain('FAIT');
+    expect(teCommentaire?.commentaire).toContain(sourceCommentaire);
+  });
+
+  test('CAE + ECI write, fusion N→1 : deux blocs ordonnés CAE puis ECI', async () => {
+    onTestFinished(cleanupCollectiviteReferentielData);
+    await setupTest();
+
+    const { teActionId, caeOrigineActionId, eciOrigineActionId } =
+      MERGE_COMMENTAIRES_FIXTURE.teActionCaeAndEci;
+
+    await setActionStatut(caeOrigineActionId, StatutAvancementEnum.FAIT);
+    await setActionStatut(eciOrigineActionId, StatutAvancementEnum.PAS_FAIT);
+    await setActionCommentaire(
+      caeOrigineActionId,
+      '<p>Bloc CAE pour fusion commentaires.</p>'
+    );
+    await setActionCommentaire(
+      eciOrigineActionId,
+      'Bloc ECI en texte brut pour fusion commentaires.'
+    );
+
+    const result = await mergeFromPrefs(prefsEligibleCaeAndEci);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const teCommentaire = result.data.find(
+      (commentaire) => commentaire.actionId === teActionId
+    );
+    const commentaire = teCommentaire?.commentaire ?? '';
+
+    expect(commentaire.indexOf(caeOrigineActionId)).toBeLessThan(
+      commentaire.indexOf(eciOrigineActionId)
+    );
+    expect(commentaire).toContain('Bloc CAE pour fusion commentaires.');
+    expect(commentaire).toContain('Bloc ECI en texte brut pour fusion commentaires.');
+  });
+
+  test('source non concerne ignorée : commentaire TE basé sur la source restante', async () => {
+    onTestFinished(cleanupCollectiviteReferentielData);
+    await setupTest();
+
+    const { teActionId, caeOrigineActionId, eciOrigineActionId } =
+      MERGE_COMMENTAIRES_FIXTURE.teActionCaeAndEci;
+
+    await setActionStatut(caeOrigineActionId, StatutAvancementEnum.FAIT);
+    await setActionStatut(eciOrigineActionId, 'non_concerne');
+    await setActionCommentaire(
+      caeOrigineActionId,
+      '<p>Seule explication CAE conservée.</p>'
+    );
+    await setActionCommentaire(
+      eciOrigineActionId,
+      '<p>Explication ECI ignorée car non concerne.</p>'
+    );
+
+    const result = await mergeFromPrefs(prefsEligibleCaeAndEci);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const teCommentaire = result.data.find(
+      (commentaire) => commentaire.actionId === teActionId
+    );
+
+    expect(teCommentaire?.commentaire).toContain(caeOrigineActionId);
+    expect(teCommentaire?.commentaire).not.toContain(eciOrigineActionId);
+  });
+
+  test('source concernée sans texte : pas de commentaire TE', async () => {
+    onTestFinished(cleanupCollectiviteReferentielData);
+    await setupTest();
+
+    const { teActionId, caeOrigineActionId } =
+      MERGE_COMMENTAIRES_FIXTURE.teActionCae1to1;
+
+    await setActionStatut(caeOrigineActionId, StatutAvancementEnum.FAIT);
+
+    const result = await mergeFromPrefs(prefsEligibleCaeOnly);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    expect(
+      result.data.some((commentaire) => commentaire.actionId === teActionId)
+    ).toBe(false);
+  });
+
+  test('sans pre-switch-te : failure PRE_SWITCH_SNAPSHOT_MISSING', async () => {
+    onTestFinished(cleanupCollectiviteReferentielData);
+    await setupTest();
+
+    const result = await buildCtx(prefsEligibleCaeOnly, []);
+
+    expect(result).toEqual({
+      success: false,
+      error: SwitchToTeErrorEnum.PRE_SWITCH_SNAPSHOT_MISSING,
+    });
+  });
+
+  test('action TE native absente du résultat', async () => {
+    onTestFinished(cleanupCollectiviteReferentielData);
+    await setupTest();
+
+    const result = await mergeFromPrefs(prefsEligibleCaeOnly);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    expect(
+      result.data.some(
+        (commentaire) =>
+          commentaire.actionId === MERGE_COMMENTAIRES_FIXTURE.teNativeActionId
+      )
+    ).toBe(false);
+  });
+});

--- a/apps/backend/src/referentiels/switch-to-te/merge-commentaires/merge-commentaires.service.ts
+++ b/apps/backend/src/referentiels/switch-to-te/merge-commentaires/merge-commentaires.service.ts
@@ -1,0 +1,70 @@
+import { Injectable } from '@nestjs/common';
+import { success, type Result } from '@tet/backend/utils/result.type';
+import {
+  type ActionCommentaireCreate,
+  type ReferentielId,
+} from '@tet/domain/referentiels';
+import { ActionCible } from '../shared/action-cible';
+import { type SwitchToTeContext } from '../shared/switch-to-te-context';
+import { type SwitchToTeError } from '../switch-to-te.errors';
+import {
+  formatSourceScoreLabel,
+  isExplicationNonVide,
+  mergeCommentairesFromSources,
+  type MergeCommentaireSource,
+} from './merge-commentaires.rules';
+
+@Injectable()
+export class MergeCommentairesService {
+  merge(
+    ctx: SwitchToTeContext
+  ): Result<ActionCommentaireCreate[], SwitchToTeError> {
+    const actionCommentaires: ActionCommentaireCreate[] = [];
+
+    for (const cible of ctx.cibles.sousActionsEtTaches) {
+      const sources = this.buildSourcesFromCible(ctx, cible.originesConcernees);
+      const commentaire = mergeCommentairesFromSources(sources);
+
+      if (commentaire === null) {
+        continue;
+      }
+
+      actionCommentaires.push({
+        collectiviteId: ctx.collectiviteId,
+        actionId: cible.actionId,
+        commentaire,
+      });
+    }
+
+    return success(actionCommentaires);
+  }
+
+  private buildSourcesFromCible(
+    ctx: SwitchToTeContext,
+    originesConcernees: ActionCible['originesConcernees']
+  ): MergeCommentaireSource[] {
+    const sources: MergeCommentaireSource[] = [];
+
+    for (const origine of originesConcernees) {
+      const scoreMap = ctx.scoreMapsByReferentiel.get(
+        origine.referentielId as ReferentielId
+      );
+      const actionScore = scoreMap?.get(origine.actionId);
+      const explication = actionScore?.explication;
+
+      if (!explication || !isExplicationNonVide(explication)) {
+        continue;
+      }
+
+      sources.push({
+        referentielId: origine.referentielId as ReferentielId,
+        origineActionId: origine.actionId,
+        nom: origine.nom,
+        scoreLabel: formatSourceScoreLabel(actionScore),
+        explication,
+      });
+    }
+
+    return sources;
+  }
+}

--- a/apps/backend/src/referentiels/switch-to-te/shared/origine-resolution.spec.ts
+++ b/apps/backend/src/referentiels/switch-to-te/shared/origine-resolution.spec.ts
@@ -7,6 +7,7 @@ import {
 import {
   filterOriginesConcernees,
   isCibleConcernee,
+  sortByReferentielOrder,
 } from '../shared/origine-resolution';
 
 const createActionScore = (
@@ -92,6 +93,29 @@ describe('filterOriginesConcernees', () => {
         scoreMapsByReferentiel
       )
     ).toHaveLength(0);
+  });
+});
+
+describe('sortByReferentielOrder', () => {
+  it('trie CAE avant ECI en conservant l ordre d entrée', () => {
+    const eciFirst = {
+      referentielId: ReferentielIdEnum.ECI,
+      id: 'eci_4.1',
+    };
+    const caeSecond = {
+      referentielId: ReferentielIdEnum.CAE,
+      id: 'cae_1.1',
+    };
+    const caeFirst = {
+      referentielId: ReferentielIdEnum.CAE,
+      id: 'cae_1.0',
+    };
+
+    expect(
+      sortByReferentielOrder([eciFirst, caeSecond, caeFirst]).map(
+        (item) => item.id
+      )
+    ).toEqual(['cae_1.1', 'cae_1.0', 'eci_4.1']);
   });
 });
 

--- a/apps/backend/src/referentiels/switch-to-te/shared/origine-resolution.ts
+++ b/apps/backend/src/referentiels/switch-to-te/shared/origine-resolution.ts
@@ -1,10 +1,28 @@
 import { type CorrelatedActionWithScore } from '@tet/backend/referentiels/correlated-actions/referentiel-action-origine-with-score.dto';
 import { type CorrelatedAction } from '@tet/backend/referentiels/correlated-actions/referentiel-action-origine.dto';
 import {
+  ReferentielIdEnum,
   type ActionScore,
   type ActionScoreWithOnlyPointsAndStatuts,
   type ReferentielId,
 } from '@tet/domain/referentiels';
+
+/** CAE puis ECI, ordre d'entrée préservé dans chaque groupe */
+export const sortByReferentielOrder = <T extends { referentielId: ReferentielId }>(
+  items: T[]
+): T[] => {
+  const cae: T[] = [];
+  const eci: T[] = [];
+  const autres: T[] = [];
+
+  for (const item of items) {
+    if (item.referentielId === ReferentielIdEnum.CAE) cae.push(item);
+    else if (item.referentielId === ReferentielIdEnum.ECI) eci.push(item);
+    else autres.push(item);
+  }
+
+  return [...cae, ...eci, ...autres];
+};
 
 export const isOrigineConcernee = (actionScore: ActionScore): boolean =>
   actionScore.concerne !== false;

--- a/apps/backend/src/referentiels/switch-to-te/switch-to-te-context.test-fixture.ts
+++ b/apps/backend/src/referentiels/switch-to-te/switch-to-te-context.test-fixture.ts
@@ -2,8 +2,8 @@ import { type AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { type Result } from '@tet/backend/utils/result.type';
 import { type CollectiviteReferentielPreferences } from '@tet/domain/collectivites';
 import { type ScoreSnapshot } from '@tet/domain/referentiels';
-import { BuildSwitchToTeContextService } from './build-switch-to-te-context.service';
-import { CreatePreSwitchSnapshotsService } from './create-pre-switch-snapshots.service';
+import { type BuildSwitchToTeContextService } from './build-switch-to-te-context.service';
+import { type CreatePreSwitchSnapshotsService } from './create-pre-switch-snapshots.service';
 import { type SwitchToTeContext } from './shared/switch-to-te-context';
 import { type SwitchToTeError } from './switch-to-te.errors';
 
@@ -14,35 +14,32 @@ export async function buildSwitchToTeContextForTest(
     createPreSwitchSnapshotsService: CreatePreSwitchSnapshotsService;
     buildSwitchToTeContextService: BuildSwitchToTeContextService;
   },
-  {
-    user,
-    preSwitchSnapshots,
-  }: {
+  options: {
     user: AuthenticatedUser;
     preSwitchSnapshots?: ScoreSnapshot[];
   }
 ): Promise<Result<SwitchToTeContext, SwitchToTeError>> {
-  let snapshots = preSwitchSnapshots;
+  let preSwitchSnapshots = options.preSwitchSnapshots;
 
-  if (!snapshots) {
-    const snapshotsResult =
+  if (preSwitchSnapshots === undefined) {
+    const createResult =
       await services.createPreSwitchSnapshotsService.createPreSwitchSnapshots(
         collectiviteId,
         prefs,
-        { user }
+        { user: options.user }
       );
 
-    if (!snapshotsResult.success) {
-      return snapshotsResult;
+    if (!createResult.success) {
+      return createResult;
     }
 
-    snapshots = snapshotsResult.data;
+    preSwitchSnapshots = createResult.data;
   }
 
   return services.buildSwitchToTeContextService.build(
     collectiviteId,
     prefs,
-    snapshots,
-    { user }
+    preSwitchSnapshots,
+    { user: options.user }
   );
 }

--- a/doc/plans/2026-06-11-008-feat-bascule-referentiel-te-pr13-plan.md
+++ b/doc/plans/2026-06-11-008-feat-bascule-referentiel-te-pr13-plan.md
@@ -1,0 +1,266 @@
+---
+
+name: PR13 Fusion explications
+overview: "Implémenter mergeCommentaires : concaténation des explications CAE/ECI vers TE avec traçabilité source (bloc par action d'origine, score figé depuis pre-switch-te), règles pures + service métier `merge(ctx)` consommant SwitchToTeContext (PR12) — sans persistance ni câblage dans switchToTe() (PR17/PR18)."
+todos:
+
+- id: rules-pures
+content: Créer merge-commentaires.rules.ts + merge-commentaires.rules.spec.ts (cas annexe A PRD)
+status: pending
+- id: merge-service
+content: Créer MergeCommentairesService.merge(ctx) — itère ctx.cibles.sousActionsEtTaches, lit explication depuis scoreMapsByReferentiel, sans I/O
+status: pending
+- id: module-wiring
+content: Enregistrer MergeCommentairesService dans ReferentielsModule (switchToTe inchangé ; BuildSwitchToTeContextService déjà PR12)
+status: pending
+- id: e2e
+content: Tests e2e merge-commentaires.service.e2e-spec.ts via buildSwitchToTeContextForTest (fixture partagé PR12)
+status: pending
+isProject: false
+
+---
+
+
+
+# PR13 — Fusion explications (`mergeCommentaires`)
+
+**Parent** : [doc/plans/2026-06-11-001-feat-bascule-referentiel-te-prd.md](2026-06-11-001-feat-bascule-referentiel-te-prd.md)
+
+**Branche** : `TE-7303/switch-te-PR13` depuis `main` (PR12 mergée)
+
+**Estimation** : 200–300 LOC
+
+**Prod** : Non (endpoint) — `switchToTe()` reste `SWITCH_NOT_IMPLEMENTED` jusqu'à PR18
+
+---
+
+
+
+## Contexte
+
+Consomme `**SwitchToTeContext**` posé par [PR12](2026-06-11-007-feat-bascule-referentiel-te-pr12-plan.md) (cibles, score maps, fixture e2e). PR13 ajoute la **fusion des explications** (`action_commentaire`, libellé UI `explication`) : concaténation avec traçabilité par origine. Format de sortie HTML — cf. [§ Format de sortie](#format-de-sortie).
+
+Diagramme et orchestration : cf. PR12 — delta PR13 = pas de `ScoresService`, lecture `explication`, **pas de ligne TE sans texte source** à migrer.
+
+---
+
+
+
+## Décisions actées
+
+**Hérite PR12** pour : contrat `merge(ctx)` sans I/O, `ctx.scoreMapsByReferentiel`, validation snapshots (`PRE_SWITCH_SNAPSHOT_MISSING`), `ctx.cibles.sousActionsEtTaches`, filtrage `concerne`, ordre CAE puis ECI, persistance PR17, câblage hors `switchToTe()`. Détail : [PR12 § Décisions](2026-06-11-007-feat-bascule-referentiel-te-pr12-plan.md#décisions-actées).
+
+
+| Sujet                       | Décision PR13                                                                                                                   |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| Textes sources              | `ActionScore.explication` dans `scoreMapsByReferentiel` (peuplé au snapshot PR10) — pas de requête directe `action_commentaire` |
+| Résultat                    | **Une entrée par action TE avec texte uniquement** — pas de ligne si aucune source avec explication non vide (contrairement aux statuts PR12, une entrée par cible) |
+| Format de sortie            | HTML concaténé — [§ Format de sortie](#format-de-sortie)                                                                        |
+| Corps des blocs             | Conservés tels quels (HTML ou texte brut hérité) ; `htmlToText` réservé au filtre vide                                          |
+| Libellé score en-tête       | État **source figé** au moment T via `formatSourceScoreLabel` — pas projection TE (cf. PR12)                                    |
+| `modifiedBy` / `modifiedAt` | Hors scope — PR17                                                                                                               |
+
+
+---
+
+
+
+## Implémentation
+
+
+
+### 1) Rules pures — `merge-commentaires.rules.ts`
+
+Fichier : `apps/backend/src/referentiels/switch-to-te/merge-commentaires/merge-commentaires.rules.ts`
+
+#### Format de sortie
+
+Les `action_commentaire` sources peuvent contenir du HTML (rich text BlockNote) ou du texte brut hérité. Le merge **concatène** sans normaliser les corps.
+
+```ts
+export const MERGE_COMMENTAIRES_PREFIX =
+  '<p><span data-text-color="red">Les textes ci-après et les statuts associés sont issus de la bascule depuis les anciens référentiels CAE et/ou ECi. Ils sont à actualiser pour répondre à l\'actuelle sous-mesure.</span></p>\n<p>&nbsp;</p>';
+```
+
+> Formulation PRD telle quelle (casse « ECi » incluse) — ajustement copywriter possible en PR20 (modale) si besoin.
+
+**En-tête de bloc** (`buildSourceBlockHeader`) :
+
+```html
+<p><strong>{origineActionId} - {nom} - {scoreLabel}</strong></p>
+```
+
+suivi de `\n`, puis le corps source inchangé.
+
+**Séparateur entre blocs** : `<p>&nbsp;</p>\n`
+
+**Exemple** (1 bloc CAE HTML + 1 bloc ECI texte brut) :
+
+```html
+<p><span data-text-color="red">Les textes ci-après…</span></p>
+<p>&nbsp;</p>
+<p><strong>cae_1.2.3 - Définir et mettre en oeuvre la stratégie - 42 % FAIT</strong></p>
+<p class="!text-base !text-grey-8 font-[Marianne]">Service Espace Conseil Rénovation : 16 personnes…</p>
+<p>&nbsp;</p>
+<p><strong>eci_4.1 - Connaître les coûts - FAIT</strong></p>
+ligne 1 du texte brut hérité
+ligne 2 du texte brut hérité
+```
+
+**Rendu front** — `RichTextEditor` : si `content.trim().startsWith('<')` → `tryParseHTMLToBlocks` (chemin emprunté ici). Pas de parsing particulier dans les rules de merge.
+
+> `data-text-color="red"` : attribut BlockNote pour la couleur de texte (cf. `RichTextEditor.stories.tsx`).
+
+
+
+#### Types
+
+```ts
+export type MergeCommentaireSource = {
+  referentielId: ReferentielId; // pour tri CAE puis ECI
+  origineActionId: string;
+  nom: string | null; // actionsOrigine.nom
+  scoreLabel: string;
+  explication: string; // texte brut ou HTML — conservé tel quel depuis le snapshot
+};
+```
+
+
+
+#### Fonctions exportées
+
+
+| Fonction                       | Rôle                                                                          |
+| ------------------------------ | ----------------------------------------------------------------------------- |
+| `formatSourceScoreLabel`       | Libellé score en-tête depuis `ActionScore` snapshot — cf. table ci-dessous    |
+| `buildSourceBlockHeader`       | En-tête traçable (cf. [§ Format de sortie](#format-de-sortie))                |
+| `buildSourceBlock`             | `buildSourceBlockHeader(...) + explication`                                   |
+| `isExplicationNonVide`         | `htmlToText(explication).trim().length > 0` — filtre uniquement               |
+| `sortMergeCommentaireSources`  | Tri stable : `cae` avant `eci`, puis ordre d'entrée                           |
+| `mergeCommentairesFromSources` | Concatène `MERGE_COMMENTAIRES_PREFIX` + blocs ; retourne `null` si aucun bloc |
+
+
+
+
+#### `formatSourceScoreLabel`
+
+À partir du `ActionScore` **source** du snapshot (état figé au moment T, pas projection TE) :
+
+```ts
+const statut = getStatutAvancement({
+  avancement: actionScore.avancement,
+  desactive: actionScore.desactive,
+  concerne: actionScore.concerne,
+});
+```
+
+
+| Cas (`getStatutAvancement`)                   | Libellé en-tête                                                                                   |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `fait`                                        | `FAIT`                                                                                            |
+| `programme`                                   | `PROGRAMMÉ`                                                                                       |
+| `pas_fait`                                    | `PAS FAIT`                                                                                        |
+| `detaille` / `detaille_au_pourcentage`        | `{faitPercent} % FAIT` — `faitPercent = floor(ratioFait × 100)`, `ratioFait` via `getScoreRatios` |
+| `non_renseigne` (source concernée avec texte) | `NON RENSEIGNÉ`                                                                                   |
+| `non_concerne`                                | ne doit pas arriver — filtré en amont                                                             |
+
+
+Règles : libellés en **majuscules** ; pas d'arrondi 5 % TE ; si `nom` null → `nom ?? ''`.
+
+#### `mergeCommentairesFromSources`
+
+```
+1. Filtrer sources avec isExplicationNonVide(explication)
+2. Si liste vide → return null
+3. Trier (CAE puis ECI)
+4. return `${MERGE_COMMENTAIRES_PREFIX}${blocks.join('<p>&nbsp;</p>\n')}`
+```
+
+
+
+### 2) Service — `merge-commentaires.service.ts`
+
+Fichier : `apps/backend/src/referentiels/switch-to-te/merge-commentaires/merge-commentaires.service.ts`
+
+```ts
+@Injectable()
+export class MergeCommentairesService {
+  merge(
+    ctx: SwitchToTeContext
+  ): Result<ActionCommentaireCreate[], SwitchToTeError>
+}
+```
+
+**Même squelette que** `MergeStatutsService` ([PR12](2026-06-11-007-feat-bascule-referentiel-te-pr12-plan.md)) — deltas :
+
+1. Lit `actionScore.explication` depuis `scoreMapsByReferentiel` (`CorrelatedActionWithScore.score` ne porte pas `explication`).
+2. Filtre via `isExplicationNonVide` ; corps passé **tel quel** au bloc.
+3. Ignorer la cible si `mergeCommentairesFromSources(sources)` → `null` — **aucune ligne** `action_commentaire` pour cette action TE.
+
+Enregistrer `MergeCommentairesService` dans `ReferentielsModule` ; `SwitchToTeService` **inchangé**. Pas de code d'erreur dédié PR13.
+
+---
+
+
+
+## Tests
+
+
+
+### A. `merge-commentaires.rules.spec.ts` (unitaire pur)
+
+Couvrir [Annexe A — mergeCommentaires](2026-06-11-001-feat-bascule-referentiel-te-prd.md#a--algorithmes-de-fusion) + compléments PR13 :
+
+- cas annexe A (ordre CAE/ECI, `non concerne`, N→1, 1→1 sans texte → `null`)
+- format : `MERGE_COMMENTAIRES_PREFIX`, séparateur inter-blocs, corps HTML / texte brut conservés
+- `isExplicationNonVide` : HTML vide (`<p></p>`, `<p>&nbsp;</p>`)
+- `formatSourceScoreLabel` : cf. table [§ formatSourceScoreLabel](#formatsourcescorelabel)
+
+Entrées fabriquées — pas de DB. Filtrage `concerne` : `isOrigineConcernee` (`origine-resolution.ts`).
+
+### B. `merge-commentaires.service.e2e-spec.ts`
+
+Pattern e2e : calquer sur `merge-statuts.service.e2e-spec.ts` — fixture `buildSwitchToTeContextForTest`, seed `MERGE_STATUTS_FIXTURE`.
+
+
+| Scénario                           | Vérif                                        |
+| ---------------------------------- | -------------------------------------------- |
+| CAE seul, 1→1 avec explication     | commentaire fusionné (préfixe + bloc source) |
+| CAE + ECI, fusion N→1              | deux blocs ordonnés CAE puis ECI             |
+| Source `non concerne` / sans texte | ignorée ou pas de commentaire TE             |
+| Sans `pre-switch-te`               | `failure` à `buildSwitchToTeContext`         |
+| Action TE native ou sans texte à migrer | aucune ligne dans le résultat |
+
+
+
+
+### Références
+
+- `merge-statuts.service.e2e-spec.ts`, `switch-to-te-context.test-fixture.ts` (PR12)
+- `htmlToText` — `packages/domain/src/utils/html-to-text.ts`
+- `RichTextEditor` — `packages/ui/src/design-system/RichTextEditor/RichTextEditor.tsx`
+
+```bash
+pnpm test:backend merge-commentaires
+pnpm test:backend merge-commentaires.rules.spec
+```
+
+---
+
+
+
+## Hors scope
+
+Cf. [PR12 § Hors scope](2026-06-11-007-feat-bascule-referentiel-te-pr12-plan.md) — PR13 n'ajoute rien. Suite PR14+ : cf. [PR12 § Suite](2026-06-11-007-feat-bascule-referentiel-te-pr12-plan.md#suite-pr13).
+
+---
+
+
+
+## Critères de done
+
+- [ ] `merge-commentaires.rules.ts` + spec (annexe A + cas HTML/vide)
+- [ ] `MergeCommentairesService.merge(ctx)` — module enregistré, `switchToTe()` inchangé ; résultat filtré (lignes uniquement pour les actions avec texte à migrer)
+- [ ] Format de sortie conforme à [§ Format de sortie](#format-de-sortie)
+- [ ] Tests e2e verts (fixture PR12)
+- [ ] PRD annexe A `mergeCommentaires` alignée sur § Format de sortie (exemple HTML, plus texte brut seul)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Fusion des commentaires issus des référentiels CAE et ECI lors du passage vers TE.
  * Affichage des commentaires dans un ordre déterminé, avec identification de la source et du statut.
  * Exclusion des commentaires vides ou sans contenu exploitable.

* **Tests**
  * Ajout de tests unitaires et de bout en bout couvrant la fusion, le tri, les statuts et les cas d’erreur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->