### PR TITLE
Implémente la bascule TE transactionnelle complète 

### DIFF
--- a/apps/backend/src/collectivites/collectivite-referentiel-mode/collectivite-referentiel-mode.service.ts
+++ b/apps/backend/src/collectivites/collectivite-referentiel-mode/collectivite-referentiel-mode.service.ts
@@ -17,13 +17,15 @@ export class CollectiviteReferentielModeService {
   ) {}
 
   async getReferentielPreferences(
-    collectiviteId: number
+    collectiviteId: number,
+    options: { withLock?: boolean; tx?: Transaction } = {}
   ): Promise<
     Result<CollectiviteReferentielPreferences, CollectiviteReferentielModeError>
   > {
     const result =
       await this.collectivitePreferencesRepository.getPreferencesByCollectiviteId(
-        collectiviteId
+        collectiviteId,
+        options
       );
     if (!result.success) {
       return result;

--- a/apps/backend/src/referentiels/snapshots/snapshots.constants.ts
+++ b/apps/backend/src/referentiels/snapshots/snapshots.constants.ts
@@ -12,6 +12,8 @@ export const SNAPSHOTS = {
   JOUR_NOM_PREFIX: ' - jour du ',
   PRE_SWITCH_TE_REF: 'pre-switch-te',
   PRE_SWITCH_TE_NOM: 'État pré-bascule Climat Ressources',
+  POST_SWITCH_TE_REF: 'post-switch-te',
+  POST_SWITCH_TE_NOM: 'État initial Climat Ressources',
 } as const;
 
 export const USER_MUTABLE_SNAPSHOT_JALONS: readonly SnapshotJalon[] = [

--- a/apps/backend/src/referentiels/snapshots/snapshots.service.ts
+++ b/apps/backend/src/referentiels/snapshots/snapshots.service.ts
@@ -171,6 +171,11 @@ export class SnapshotsService {
         nom = SNAPSHOTS.PRE_SWITCH_TE_NOM;
         break;
 
+      case SnapshotJalonEnum.POST_SWITCH_TE:
+        ref = SNAPSHOTS.POST_SWITCH_TE_REF;
+        nom = SNAPSHOTS.POST_SWITCH_TE_NOM;
+        break;
+
       default:
         this.logger.warn(
           `Un nom de snapshot doit être défini pour le jalon ${jalon}`

--- a/apps/backend/src/referentiels/snapshots/snapshots.service.ts
+++ b/apps/backend/src/referentiels/snapshots/snapshots.service.ts
@@ -170,6 +170,11 @@ export class SnapshotsService {
         nom = SNAPSHOTS.PRE_SWITCH_TE_NOM;
         break;
 
+      case SnapshotJalonEnum.POST_SWITCH_TE:
+        ref = SNAPSHOTS.POST_SWITCH_TE_REF;
+        nom = SNAPSHOTS.POST_SWITCH_TE_NOM;
+        break;
+
       default:
         this.logger.warn(
           `Un nom de snapshot doit être défini pour le jalon ${jalon}`

--- a/apps/backend/src/referentiels/switch-to-te/switch-to-te.errors.ts
+++ b/apps/backend/src/referentiels/switch-to-te/switch-to-te.errors.ts
@@ -14,11 +14,11 @@ const specificErrors = [
   'COT_ACTIVE',
   'AUDIT_REQUEST_IN_PROGRESS',
   'AUDIT_IN_PROGRESS',
-  'SWITCH_NOT_IMPLEMENTED',
   'PRE_SWITCH_SNAPSHOT_FAILED',
   'PRE_SWITCH_SNAPSHOT_MISSING',
   'REFERENTIEL_TE_NOT_EMPTY',
   'MIGRATION_FAILED',
+  'POST_SWITCH_RECOMPUTE_FAILED',
   ...collectivitePreferencesSpecificErrors,
 ] as const;
 
@@ -51,10 +51,6 @@ export const switchToTeTrpcErrorEntries = {
     message:
       "La bascule n'est pas possible : un audit est en cours sur un référentiel CAE/ECI",
   },
-  SWITCH_NOT_IMPLEMENTED: {
-    code: 'NOT_IMPLEMENTED',
-    message: "La bascule n'est pas encore disponible",
-  },
   PRE_SWITCH_SNAPSHOT_FAILED: {
     code: 'INTERNAL_SERVER_ERROR',
     message: 'Impossible de créer le snapshot pré-bascule',
@@ -72,6 +68,11 @@ export const switchToTeTrpcErrorEntries = {
   MIGRATION_FAILED: {
     code: 'INTERNAL_SERVER_ERROR',
     message: 'La migration des données vers le référentiel TE a échoué',
+  },
+  POST_SWITCH_RECOMPUTE_FAILED: {
+    code: 'INTERNAL_SERVER_ERROR',
+    message:
+      'La bascule a réussi mais le recalcul des projections post-bascule a échoué',
   },
 } as const;
 

--- a/apps/backend/src/referentiels/switch-to-te/switch-to-te.output.ts
+++ b/apps/backend/src/referentiels/switch-to-te/switch-to-te.output.ts
@@ -1,9 +1,8 @@
 import { z } from 'zod';
 
-export const switchToTeNotImplementedOutputSchema = z.object({
-  status: z.literal('not_implemented'),
+export const switchToTeOutputSchema = z.object({
+  status: z.literal('switched'),
+  populatedAt: z.string(),
 });
 
-export type SwitchToTeNotImplementedOutput = z.infer<
-  typeof switchToTeNotImplementedOutputSchema
->;
+export type SwitchToTeOutput = z.infer<typeof switchToTeOutputSchema>;

--- a/apps/backend/src/referentiels/switch-to-te/switch-to-te.output.ts
+++ b/apps/backend/src/referentiels/switch-to-te/switch-to-te.output.ts
@@ -1,9 +1,8 @@
 import { z } from 'zod';
 
-export const switchToTeNotImplementedOutputSchema = z.object({
-  status: z.literal('not_implemented'),
+export const switchToTeOutputSchema = z.object({
+  status: z.literal('switched'),
+  populatedAt: z.iso.datetime(),
 });
 
-export type SwitchToTeNotImplementedOutput = z.infer<
-  typeof switchToTeNotImplementedOutputSchema
->;
+export type SwitchToTeOutput = z.infer<typeof switchToTeOutputSchema>;

--- a/apps/backend/src/referentiels/switch-to-te/switch-to-te.router.e2e-spec.ts
+++ b/apps/backend/src/referentiels/switch-to-te/switch-to-te.router.e2e-spec.ts
@@ -3,7 +3,11 @@ import {
   addTestCollectiviteAndUsers,
   setCollectiviteAsCOT,
 } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { collectiviteTable } from '@tet/backend/collectivites/shared/models/collectivite.table';
 import { createAudit } from '@tet/backend/referentiels/labellisations/labellisations.test-fixture';
+import { actionStatutTable } from '@tet/backend/referentiels/models/action-statut.table';
+import { snapshotTable } from '@tet/backend/referentiels/snapshots/snapshot.table';
+import { SNAPSHOTS } from '@tet/backend/referentiels/snapshots/snapshots.constants';
 import {
   getAuthUserFromUserCredentials,
   getTestApp,
@@ -19,9 +23,17 @@ import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
 import {
   Collectivite,
+  type CollectivitePreferences,
   type CollectiviteReferentielPreferences,
 } from '@tet/domain/collectivites';
 import { CollectiviteRole } from '@tet/domain/users';
+import { and, eq, inArray } from 'drizzle-orm';
+import {
+  cleanupSwitchToTeCollectiviteReferentielData,
+  prefsEligibleCaeAndEci,
+  prefsEligibleCaeOnly,
+  setActionStatutForCollectivite,
+} from './switch-to-te-context.test-fixture';
 import { switchToTeTrpcErrorEntries } from './switch-to-te.errors';
 
 describe('SwitchToTeRouter', () => {
@@ -85,21 +97,61 @@ describe('SwitchToTeRouter', () => {
     });
   }
 
-  test('retourne SWITCH_NOT_IMPLEMENTED quand les guards passent (squelette)', async () => {
-    await setReferentielPreferences({
-      cae: { display: true, mode: 'write' },
-      eci: { display: false, mode: 'archived' },
-      te: { display: true, mode: 'readonly' },
+  // crée une collectivité éligible avec ses préférences et retourne le caller
+  // admin et l'utilisateur admin associé
+  async function setupEligibleCollectivite(
+    referentiels: CollectiviteReferentielPreferences
+  ) {
+    const fixture = await addTestCollectiviteAndUsers(databaseService, {
+      users: [{ role: CollectiviteRole.ADMIN }],
+    });
+    onTestFinished(() => fixture.cleanup());
+
+    await supportCaller.collectivites.preferences.update({
+      collectiviteId: fixture.collectivite.id,
+      preferences: { referentiels },
     });
 
-    const adminCaller = router.createCaller({ user: adminUser });
+    const fixtureAdminUser = getAuthUserFromUserCredentials(fixture.users[0]);
+    const adminCaller = router.createCaller({ user: fixtureAdminUser });
 
-    await expect(
-      adminCaller.referentiels.switchToTe({ collectiviteId: collectivite.id })
-    ).rejects.toThrow(
-      switchToTeTrpcErrorEntries.SWITCH_NOT_IMPLEMENTED.message
-    );
-  });
+    return {
+      collectiviteId: fixture.collectivite.id,
+      adminCaller,
+      fixtureAdminUser,
+    };
+  }
+
+  // ── helpers DB ──────────────────────────────────────────────────────────────
+
+  async function getCollectivitePreferences(
+    collectiviteId: number
+  ): Promise<CollectivitePreferences | null> {
+    const [row] = await databaseService.db
+      .select({ preferences: collectiviteTable.preferences })
+      .from(collectiviteTable)
+      .where(eq(collectiviteTable.id, collectiviteId));
+    return (row?.preferences as CollectivitePreferences | null) ?? null;
+  }
+
+  async function getSnapshots(collectiviteId: number, refs: string[]) {
+    return databaseService.db
+      .select({
+        ref: snapshotTable.ref,
+        nom: snapshotTable.nom,
+        referentielId: snapshotTable.referentielId,
+        jalon: snapshotTable.jalon,
+      })
+      .from(snapshotTable)
+      .where(
+        and(
+          eq(snapshotTable.collectiviteId, collectiviteId),
+          inArray(snapshotTable.ref, refs)
+        )
+      );
+  }
+
+  // ── Guards ──────────────────────────────────────────────────────────────────
 
   test('refuse si la bascule a déjà été effectuée', async () => {
     const switchedFixture = await addTestCollectiviteAndUsers(databaseService, {
@@ -179,27 +231,6 @@ describe('SwitchToTeRouter', () => {
     ).rejects.toThrow("Vous n'avez pas les permissions nécessaires");
   });
 
-  // crée une collectivité éligible à la bascule (te readonly) avec ses préférences
-  async function setupEligibleCollectivite(
-    referentiels: CollectiviteReferentielPreferences
-  ) {
-    const fixture = await addTestCollectiviteAndUsers(databaseService, {
-      users: [{ role: CollectiviteRole.ADMIN }],
-    });
-    onTestFinished(() => fixture.cleanup());
-
-    await supportCaller.collectivites.preferences.update({
-      collectiviteId: fixture.collectivite.id,
-      preferences: { referentiels },
-    });
-
-    const adminCaller = router.createCaller({
-      user: getAuthUserFromUserCredentials(fixture.users[0]),
-    });
-
-    return { collectiviteId: fixture.collectivite.id, adminCaller };
-  }
-
   test('bloque quand un COT est actif (cae write)', async () => {
     const { collectiviteId, adminCaller } = await setupEligibleCollectivite({
       cae: { display: true, mode: 'write' },
@@ -240,7 +271,6 @@ describe('SwitchToTeRouter', () => {
       eci: { display: false, mode: 'archived' },
       te: { display: true, mode: 'readonly' },
     });
-    // demande envoyée sans audit démarré : dateDebut null + demande enCours:false
     const { cleanup } = await createAudit({
       databaseService,
       collectiviteId,
@@ -259,14 +289,37 @@ describe('SwitchToTeRouter', () => {
     );
   });
 
-  test("ne bloque pas quand l'audit est validé et clos (retourne SWITCH_NOT_IMPLEMENTED)", async () => {
+  test('bascule réussit quand les guards passent (CAE write)', async () => {
+    const { collectiviteId, adminCaller } = await setupEligibleCollectivite(
+      prefsEligibleCaeOnly
+    );
+    onTestFinished(() =>
+      cleanupSwitchToTeCollectiviteReferentielData(
+        databaseService,
+        collectiviteId
+      )
+    );
+
+    const result = await adminCaller.referentiels.switchToTe({
+      collectiviteId,
+    });
+
+    expect(result.status).toBe('switched');
+    expect(result.populatedAt).toBeDefined();
+  });
+
+  test("ne bloque pas quand l'audit est validé et clos — bascule réussit", async () => {
     const { collectiviteId, adminCaller } = await setupEligibleCollectivite({
       cae: { display: true, mode: 'write' },
       eci: { display: false, mode: 'archived' },
       te: { display: true, mode: 'readonly' },
     });
-    // état réel après labellisation : audit validé => clos, avec sa demande
-    // envoyée (enCours:false) qui subsiste ; ne doit PAS bloquer
+    onTestFinished(() =>
+      cleanupSwitchToTeCollectiviteReferentielData(
+        databaseService,
+        collectiviteId
+      )
+    );
     const { cleanup } = await createAudit({
       databaseService,
       collectiviteId,
@@ -278,20 +331,25 @@ describe('SwitchToTeRouter', () => {
     });
     onTestFinished(() => cleanup());
 
-    await expect(
-      adminCaller.referentiels.switchToTe({ collectiviteId })
-    ).rejects.toThrow(
-      switchToTeTrpcErrorEntries.SWITCH_NOT_IMPLEMENTED.message
-    );
+    const result = await adminCaller.referentiels.switchToTe({
+      collectiviteId,
+    });
+
+    expect(result.status).toBe('switched');
   });
 
-  test('ignore un audit en cours sur un référentiel archived (cae archived + eci write)', async () => {
+  test('ignore un audit en cours sur un référentiel archived — bascule réussit', async () => {
     const { collectiviteId, adminCaller } = await setupEligibleCollectivite({
       cae: { display: false, mode: 'archived' },
       eci: { display: true, mode: 'write' },
       te: { display: true, mode: 'readonly' },
     });
-    // audit en cours sur cae (archived) → doit être ignoré
+    onTestFinished(() =>
+      cleanupSwitchToTeCollectiviteReferentielData(
+        databaseService,
+        collectiviteId
+      )
+    );
     const { cleanup } = await createAudit({
       databaseService,
       collectiviteId,
@@ -302,10 +360,226 @@ describe('SwitchToTeRouter', () => {
     });
     onTestFinished(() => cleanup());
 
-    await expect(
-      adminCaller.referentiels.switchToTe({ collectiviteId })
-    ).rejects.toThrow(
-      switchToTeTrpcErrorEntries.SWITCH_NOT_IMPLEMENTED.message
-    );
+    const result = await adminCaller.referentiels.switchToTe({
+      collectiviteId,
+    });
+
+    expect(result.status).toBe('switched');
+  });
+
+  // ── Bascule complète ────────────────────────────────────────────────────────
+
+  describe('bascule nominale CAE seul', () => {
+    test('crée snapshot pre-switch-te + post-switch-te et met à jour les prefs', async () => {
+      const { collectiviteId, adminCaller } = await setupEligibleCollectivite(
+        prefsEligibleCaeOnly
+      );
+      onTestFinished(() =>
+        cleanupSwitchToTeCollectiviteReferentielData(
+          databaseService,
+          collectiviteId
+        )
+      );
+
+      const result = await adminCaller.referentiels.switchToTe({
+        collectiviteId,
+      });
+
+      expect(result.status).toBe('switched');
+      expect(result.populatedAt).toBeDefined();
+
+      // snapshots attendus
+      const snapshots = await getSnapshots(collectiviteId, [
+        SNAPSHOTS.PRE_SWITCH_TE_REF,
+        SNAPSHOTS.POST_SWITCH_TE_REF,
+        SNAPSHOTS.SCORE_COURANT_REF,
+      ]);
+
+      const preSwitch = snapshots.find(
+        (s) => s.ref === SNAPSHOTS.PRE_SWITCH_TE_REF
+      );
+      const postSwitch = snapshots.find(
+        (s) => s.ref === SNAPSHOTS.POST_SWITCH_TE_REF
+      );
+      const scoreCourant = snapshots.find(
+        (s) => s.ref === SNAPSHOTS.SCORE_COURANT_REF
+      );
+
+      expect(preSwitch).toBeDefined();
+      expect(preSwitch?.referentielId).toBe('cae');
+      expect(preSwitch?.nom).toBe(SNAPSHOTS.PRE_SWITCH_TE_NOM);
+
+      expect(postSwitch).toBeDefined();
+      expect(postSwitch?.referentielId).toBe('te');
+      expect(postSwitch?.nom).toBe(SNAPSHOTS.POST_SWITCH_TE_NOM);
+
+      expect(scoreCourant).toBeDefined();
+      expect(scoreCourant?.referentielId).toBe('te');
+
+      // prefs post-bascule
+      const prefs = await getCollectivitePreferences(collectiviteId);
+      const refs = prefs?.referentiels;
+
+      expect(refs?.cae.mode).toBe('archived');
+      expect(refs?.cae.display).toBe(false);
+      expect(refs?.eci.mode).toBe('archived');
+      expect(refs?.te.mode).toBe('write');
+      expect(refs?.te.display).toBe(true);
+      expect(refs?.te.populatedFromCaeEci?.populatedAt).toBe(
+        result.populatedAt
+      );
+    });
+  });
+
+  describe('fusion CAE+ECI', () => {
+    test('crée 2 snapshots pre-switch-te (cae+eci) et archive les deux sources', async () => {
+      const { collectiviteId, adminCaller } = await setupEligibleCollectivite(
+        prefsEligibleCaeAndEci
+      );
+      onTestFinished(() =>
+        cleanupSwitchToTeCollectiviteReferentielData(
+          databaseService,
+          collectiviteId
+        )
+      );
+
+      const result = await adminCaller.referentiels.switchToTe({
+        collectiviteId,
+      });
+
+      expect(result.status).toBe('switched');
+
+      // 2 snapshots pre-switch-te : un par source en write
+      const preSwitchSnapshots = await databaseService.db
+        .select({
+          ref: snapshotTable.ref,
+          referentielId: snapshotTable.referentielId,
+        })
+        .from(snapshotTable)
+        .where(
+          and(
+            eq(snapshotTable.collectiviteId, collectiviteId),
+            eq(snapshotTable.ref, SNAPSHOTS.PRE_SWITCH_TE_REF)
+          )
+        );
+
+      const referentielIds = preSwitchSnapshots.map((s) => s.referentielId);
+      expect(referentielIds).toContain('cae');
+      expect(referentielIds).toContain('eci');
+
+      // cae et eci archivés, te en write
+      const prefs = await getCollectivitePreferences(collectiviteId);
+      expect(prefs?.referentiels.cae.mode).toBe('archived');
+      expect(prefs?.referentiels.eci.mode).toBe('archived');
+      expect(prefs?.referentiels.te.mode).toBe('write');
+    });
+  });
+
+  describe('idempotence', () => {
+    test('rejouer switchToTe après succès retourne ALREADY_SWITCHED', async () => {
+      const { collectiviteId, adminCaller } = await setupEligibleCollectivite(
+        prefsEligibleCaeOnly
+      );
+      onTestFinished(() =>
+        cleanupSwitchToTeCollectiviteReferentielData(
+          databaseService,
+          collectiviteId
+        )
+      );
+
+      // 1re bascule
+      const first = await adminCaller.referentiels.switchToTe({
+        collectiviteId,
+      });
+      expect(first.status).toBe('switched');
+
+      // 2e appel → ALREADY_SWITCHED
+      await expect(
+        adminCaller.referentiels.switchToTe({ collectiviteId })
+      ).rejects.toThrow(switchToTeTrpcErrorEntries.ALREADY_SWITCHED.message);
+    });
+  });
+
+  describe('rollback', () => {
+    test('rollback complet si TE déjà peuplé (REFERENTIEL_TE_NOT_EMPTY)', async () => {
+      const { collectiviteId, adminCaller, fixtureAdminUser } =
+        await setupEligibleCollectivite(prefsEligibleCaeOnly);
+      onTestFinished(() =>
+        cleanupSwitchToTeCollectiviteReferentielData(
+          databaseService,
+          collectiviteId
+        )
+      );
+
+      // simule TE déjà peuplé : insère un statut te_* directement en DB
+      await databaseService.db
+        .insert(actionStatutTable)
+        .values({
+          collectiviteId,
+          actionId: 'te_1.1',
+          avancement: 'fait',
+          avancementDetaille: [1, 0, 0],
+          concerne: true,
+          modifiedBy: fixtureAdminUser.id,
+        })
+        .onConflictDoNothing();
+
+      await expect(
+        adminCaller.referentiels.switchToTe({ collectiviteId })
+      ).rejects.toThrow(
+        switchToTeTrpcErrorEntries.REFERENTIEL_TE_NOT_EMPTY.message
+      );
+
+      // aucun snapshot pre-switch-te créé (rollback total)
+      const snapshots = await getSnapshots(collectiviteId, [
+        SNAPSHOTS.PRE_SWITCH_TE_REF,
+      ]);
+      expect(snapshots).toHaveLength(0);
+
+      // prefs inchangées (cae toujours write, populatedFromCaeEci absent)
+      const prefs = await getCollectivitePreferences(collectiviteId);
+      expect(prefs?.referentiels.cae.mode).toBe('write');
+      expect(prefs?.referentiels.te.populatedFromCaeEci).toBeUndefined();
+    });
+  });
+
+  describe('bascule avec données migrées', () => {
+    test('migre un statut CAE → mesure TE et le retrouve après bascule', async () => {
+      const { collectiviteId, adminCaller, fixtureAdminUser } =
+        await setupEligibleCollectivite(prefsEligibleCaeOnly);
+      onTestFinished(() =>
+        cleanupSwitchToTeCollectiviteReferentielData(
+          databaseService,
+          collectiviteId
+        )
+      );
+
+      // pose un statut sur une mesure CAE qui a une correspondance TE
+      await setActionStatutForCollectivite(
+        router,
+        fixtureAdminUser,
+        collectiviteId,
+        'cae_1.1.2.2.1',
+        'fait'
+      );
+
+      const result = await adminCaller.referentiels.switchToTe({
+        collectiviteId,
+      });
+      expect(result.status).toBe('switched');
+
+      // vérifie que le statut TE correspondant (te_1.1.1.2) a été migré
+      const teStatuts = await databaseService.db
+        .select({ actionId: actionStatutTable.actionId })
+        .from(actionStatutTable)
+        .where(
+          and(
+            eq(actionStatutTable.collectiviteId, collectiviteId),
+            eq(actionStatutTable.actionId, 'te_1.1.1.2')
+          )
+        );
+
+      expect(teStatuts.length).toBeGreaterThan(0);
+    });
   });
 });

--- a/apps/backend/src/referentiels/switch-to-te/switch-to-te.router.e2e-spec.ts
+++ b/apps/backend/src/referentiels/switch-to-te/switch-to-te.router.e2e-spec.ts
@@ -3,7 +3,12 @@ import {
   addTestCollectiviteAndUsers,
   setCollectiviteAsCOT,
 } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { collectiviteTable } from '@tet/backend/collectivites/shared/models/collectivite.table';
 import { createAudit } from '@tet/backend/referentiels/labellisations/labellisations.test-fixture';
+import { actionStatutTable } from '@tet/backend/referentiels/models/action-statut.table';
+import { snapshotTable } from '@tet/backend/referentiels/snapshots/snapshot.table';
+import { SNAPSHOTS } from '@tet/backend/referentiels/snapshots/snapshots.constants';
+import { SnapshotsService } from '@tet/backend/referentiels/snapshots/snapshots.service';
 import {
   getAuthUserFromUserCredentials,
   getTestApp,
@@ -19,15 +24,25 @@ import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
 import {
   Collectivite,
+  type CollectivitePreferences,
   type CollectiviteReferentielPreferences,
 } from '@tet/domain/collectivites';
+import { ReferentielIdEnum, SnapshotJalonEnum } from '@tet/domain/referentiels';
 import { CollectiviteRole } from '@tet/domain/users';
+import { and, eq, inArray } from 'drizzle-orm';
+import {
+  cleanupSwitchToTeCollectiviteReferentielData,
+  prefsEligibleCaeAndEci,
+  prefsEligibleCaeOnly,
+  setActionStatutForCollectivite,
+} from './switch-to-te-context.test-fixture';
 import { switchToTeTrpcErrorEntries } from './switch-to-te.errors';
 
 describe('SwitchToTeRouter', () => {
   let app: INestApplication;
   let router: TrpcRouter;
   let databaseService: DatabaseService;
+  let snapshotsService: SnapshotsService;
   let supportCaller: ReturnType<TrpcRouter['createCaller']>;
   let adminUser: AuthenticatedUser;
   let lectureUser: AuthenticatedUser;
@@ -39,6 +54,7 @@ describe('SwitchToTeRouter', () => {
     app = await getTestApp();
     router = await getTestRouter(app);
     databaseService = await getTestDatabase(app);
+    snapshotsService = app.get(SnapshotsService);
 
     const supportUserResult = await addTestUser(databaseService);
     cleanupSupportUser = supportUserResult.cleanup;
@@ -85,23 +101,63 @@ describe('SwitchToTeRouter', () => {
     });
   }
 
-  test('retourne SWITCH_NOT_IMPLEMENTED quand les guards passent (squelette)', async () => {
-    await setReferentielPreferences({
-      cae: { display: true, mode: 'write' },
-      eci: { display: false, mode: 'archived' },
-      te: { display: true, mode: 'readonly' },
+  // crée une collectivité éligible avec ses préférences et retourne le caller
+  // admin et l'utilisateur admin associé
+  async function setupEligibleCollectivite(
+    referentiels: CollectiviteReferentielPreferences
+  ) {
+    const fixture = await addTestCollectiviteAndUsers(databaseService, {
+      users: [{ role: CollectiviteRole.ADMIN }],
+    });
+    onTestFinished(() => fixture.cleanup());
+
+    await supportCaller.collectivites.preferences.update({
+      collectiviteId: fixture.collectivite.id,
+      preferences: { referentiels },
     });
 
-    const adminCaller = router.createCaller({ user: adminUser });
+    const fixtureAdminUser = getAuthUserFromUserCredentials(fixture.users[0]);
+    const adminCaller = router.createCaller({ user: fixtureAdminUser });
 
-    await expect(
-      adminCaller.referentiels.switchToTe({ collectiviteId: collectivite.id })
-    ).rejects.toThrow(
-      switchToTeTrpcErrorEntries.SWITCH_NOT_IMPLEMENTED.message
-    );
-  });
+    return {
+      collectiviteId: fixture.collectivite.id,
+      adminCaller,
+      fixtureAdminUser,
+    };
+  }
 
-  test('refuse si la bascule a déjà été effectuée', async () => {
+  // ── helpers DB ──────────────────────────────────────────────────────────────
+
+  async function getCollectivitePreferences(
+    collectiviteId: number
+  ): Promise<CollectivitePreferences | null> {
+    const [row] = await databaseService.db
+      .select({ preferences: collectiviteTable.preferences })
+      .from(collectiviteTable)
+      .where(eq(collectiviteTable.id, collectiviteId));
+    return (row?.preferences as CollectivitePreferences | null) ?? null;
+  }
+
+  async function getSnapshots(collectiviteId: number, refs: string[]) {
+    return databaseService.db
+      .select({
+        ref: snapshotTable.ref,
+        nom: snapshotTable.nom,
+        referentielId: snapshotTable.referentielId,
+        jalon: snapshotTable.jalon,
+      })
+      .from(snapshotTable)
+      .where(
+        and(
+          eq(snapshotTable.collectiviteId, collectiviteId),
+          inArray(snapshotTable.ref, refs)
+        )
+      );
+  }
+
+  // ── Guards ──────────────────────────────────────────────────────────────────
+
+  test('refuse si la bascule a déjà été effectuée (snapshot post-switch-te présent)', async () => {
     const switchedFixture = await addTestCollectiviteAndUsers(databaseService, {
       users: [{ role: CollectiviteRole.ADMIN }],
     });
@@ -128,6 +184,17 @@ describe('SwitchToTeRouter', () => {
       },
     });
 
+    // snapshot post-switch-te présent : simule une bascule pleinement aboutie
+    const computeResult = await snapshotsService.computeAndUpsert(
+      {
+        collectiviteId: switchedFixture.collectivite.id,
+        referentielId: ReferentielIdEnum.TE,
+        jalon: SnapshotJalonEnum.POST_SWITCH_TE,
+      },
+      { user: switchedAdminUser }
+    );
+    expect(computeResult.success).toBe(true);
+
     const adminCaller = router.createCaller({ user: switchedAdminUser });
 
     await expect(
@@ -135,6 +202,52 @@ describe('SwitchToTeRouter', () => {
         collectiviteId: switchedFixture.collectivite.id,
       })
     ).rejects.toThrow(switchToTeTrpcErrorEntries.ALREADY_SWITCHED.message);
+  });
+
+  test('répare le snapshot post-switch-te manquant sur une collectivité déjà switchée', async () => {
+    const switchedFixture = await addTestCollectiviteAndUsers(databaseService, {
+      users: [{ role: CollectiviteRole.ADMIN }],
+    });
+    onTestFinished(() => switchedFixture.cleanup());
+    const switchedAdminUser = getAuthUserFromUserCredentials(
+      switchedFixture.users[0]
+    );
+    const populatedAt = '2026-06-01T00:00:00.000Z';
+
+    await supportCaller.collectivites.preferences.update({
+      collectiviteId: switchedFixture.collectivite.id,
+      preferences: {
+        referentiels: {
+          cae: { display: false, mode: 'archived' },
+          eci: { display: false, mode: 'archived' },
+          te: {
+            display: true,
+            mode: 'write',
+            populatedFromCaeEci: {
+              populatedAt,
+              populatedBy: switchedAdminUser.id,
+            },
+          },
+        },
+      },
+    });
+
+    // snapshot post-switch-te volontairement absent : simule un recompute
+    // best-effort échoué lors de la bascule initiale
+    const adminCaller = router.createCaller({ user: switchedAdminUser });
+
+    const result = await adminCaller.referentiels.switchToTe({
+      collectiviteId: switchedFixture.collectivite.id,
+    });
+
+    expect(result.status).toBe('switched');
+    expect(result.populatedAt).toBe(populatedAt);
+
+    const snapshots = await getSnapshots(switchedFixture.collectivite.id, [
+      SNAPSHOTS.POST_SWITCH_TE_REF,
+    ]);
+    expect(snapshots).toHaveLength(1);
+    expect(snapshots[0]?.referentielId).toBe('te');
   });
 
   test('refuse une CT non engagée (TE en write)', async () => {
@@ -179,27 +292,6 @@ describe('SwitchToTeRouter', () => {
     ).rejects.toThrow("Vous n'avez pas les permissions nécessaires");
   });
 
-  // crée une collectivité éligible à la bascule (te readonly) avec ses préférences
-  async function setupEligibleCollectivite(
-    referentiels: CollectiviteReferentielPreferences
-  ) {
-    const fixture = await addTestCollectiviteAndUsers(databaseService, {
-      users: [{ role: CollectiviteRole.ADMIN }],
-    });
-    onTestFinished(() => fixture.cleanup());
-
-    await supportCaller.collectivites.preferences.update({
-      collectiviteId: fixture.collectivite.id,
-      preferences: { referentiels },
-    });
-
-    const adminCaller = router.createCaller({
-      user: getAuthUserFromUserCredentials(fixture.users[0]),
-    });
-
-    return { collectiviteId: fixture.collectivite.id, adminCaller };
-  }
-
   test('bloque quand un COT est actif (cae write)', async () => {
     const { collectiviteId, adminCaller } = await setupEligibleCollectivite({
       cae: { display: true, mode: 'write' },
@@ -240,7 +332,6 @@ describe('SwitchToTeRouter', () => {
       eci: { display: false, mode: 'archived' },
       te: { display: true, mode: 'readonly' },
     });
-    // demande envoyée sans audit démarré : dateDebut null + demande enCours:false
     const { cleanup } = await createAudit({
       databaseService,
       collectiviteId,
@@ -259,14 +350,37 @@ describe('SwitchToTeRouter', () => {
     );
   });
 
-  test("ne bloque pas quand l'audit est validé et clos (retourne SWITCH_NOT_IMPLEMENTED)", async () => {
+  test('bascule réussit quand les guards passent (CAE write)', async () => {
+    const { collectiviteId, adminCaller } = await setupEligibleCollectivite(
+      prefsEligibleCaeOnly
+    );
+    onTestFinished(() =>
+      cleanupSwitchToTeCollectiviteReferentielData(
+        databaseService,
+        collectiviteId
+      )
+    );
+
+    const result = await adminCaller.referentiels.switchToTe({
+      collectiviteId,
+    });
+
+    expect(result.status).toBe('switched');
+    expect(result.populatedAt).toBeDefined();
+  });
+
+  test("ne bloque pas quand l'audit est validé et clos — bascule réussit", async () => {
     const { collectiviteId, adminCaller } = await setupEligibleCollectivite({
       cae: { display: true, mode: 'write' },
       eci: { display: false, mode: 'archived' },
       te: { display: true, mode: 'readonly' },
     });
-    // état réel après labellisation : audit validé => clos, avec sa demande
-    // envoyée (enCours:false) qui subsiste ; ne doit PAS bloquer
+    onTestFinished(() =>
+      cleanupSwitchToTeCollectiviteReferentielData(
+        databaseService,
+        collectiviteId
+      )
+    );
     const { cleanup } = await createAudit({
       databaseService,
       collectiviteId,
@@ -278,20 +392,25 @@ describe('SwitchToTeRouter', () => {
     });
     onTestFinished(() => cleanup());
 
-    await expect(
-      adminCaller.referentiels.switchToTe({ collectiviteId })
-    ).rejects.toThrow(
-      switchToTeTrpcErrorEntries.SWITCH_NOT_IMPLEMENTED.message
-    );
+    const result = await adminCaller.referentiels.switchToTe({
+      collectiviteId,
+    });
+
+    expect(result.status).toBe('switched');
   });
 
-  test('ignore un audit en cours sur un référentiel archived (cae archived + eci write)', async () => {
+  test('ignore un audit en cours sur un référentiel archived — bascule réussit', async () => {
     const { collectiviteId, adminCaller } = await setupEligibleCollectivite({
       cae: { display: false, mode: 'archived' },
       eci: { display: true, mode: 'write' },
       te: { display: true, mode: 'readonly' },
     });
-    // audit en cours sur cae (archived) → doit être ignoré
+    onTestFinished(() =>
+      cleanupSwitchToTeCollectiviteReferentielData(
+        databaseService,
+        collectiviteId
+      )
+    );
     const { cleanup } = await createAudit({
       databaseService,
       collectiviteId,
@@ -302,10 +421,278 @@ describe('SwitchToTeRouter', () => {
     });
     onTestFinished(() => cleanup());
 
-    await expect(
-      adminCaller.referentiels.switchToTe({ collectiviteId })
-    ).rejects.toThrow(
-      switchToTeTrpcErrorEntries.SWITCH_NOT_IMPLEMENTED.message
-    );
+    const result = await adminCaller.referentiels.switchToTe({
+      collectiviteId,
+    });
+
+    expect(result.status).toBe('switched');
+  });
+
+  // ── Bascule complète ────────────────────────────────────────────────────────
+
+  describe('bascule nominale CAE seul', () => {
+    test('crée snapshot pre-switch-te + post-switch-te et met à jour les prefs', async () => {
+      const { collectiviteId, adminCaller } = await setupEligibleCollectivite(
+        prefsEligibleCaeOnly
+      );
+      onTestFinished(() =>
+        cleanupSwitchToTeCollectiviteReferentielData(
+          databaseService,
+          collectiviteId
+        )
+      );
+
+      const result = await adminCaller.referentiels.switchToTe({
+        collectiviteId,
+      });
+
+      expect(result.status).toBe('switched');
+      expect(result.populatedAt).toBeDefined();
+
+      // snapshots attendus — le score-courant n'est PAS calculé ici
+      // (self-healing au premier accès en lecture, voir test dédié plus bas)
+      const snapshots = await getSnapshots(collectiviteId, [
+        SNAPSHOTS.PRE_SWITCH_TE_REF,
+        SNAPSHOTS.POST_SWITCH_TE_REF,
+      ]);
+
+      const preSwitch = snapshots.find(
+        (s) => s.ref === SNAPSHOTS.PRE_SWITCH_TE_REF
+      );
+      const postSwitch = snapshots.find(
+        (s) => s.ref === SNAPSHOTS.POST_SWITCH_TE_REF
+      );
+
+      expect(preSwitch).toBeDefined();
+      expect(preSwitch?.referentielId).toBe('cae');
+      expect(preSwitch?.nom).toBe(SNAPSHOTS.PRE_SWITCH_TE_NOM);
+
+      expect(postSwitch).toBeDefined();
+      expect(postSwitch?.referentielId).toBe('te');
+      expect(postSwitch?.nom).toBe(SNAPSHOTS.POST_SWITCH_TE_NOM);
+
+      // score-courant TE absent juste après la bascule, mais un simple get()
+      // le recrée automatiquement (self-healing) sans effet de bord destructeur
+      const scoreCourantResult = await snapshotsService.get(
+        collectiviteId,
+        ReferentielIdEnum.TE
+      );
+      expect(scoreCourantResult.success).toBe(true);
+
+      // prefs post-bascule
+      const prefs = await getCollectivitePreferences(collectiviteId);
+      const refs = prefs?.referentiels;
+
+      expect(refs?.cae.mode).toBe('archived');
+      expect(refs?.cae.display).toBe(false);
+      expect(refs?.eci.mode).toBe('archived');
+      expect(refs?.te.mode).toBe('write');
+      expect(refs?.te.display).toBe(true);
+      expect(refs?.te.populatedFromCaeEci?.populatedAt).toBe(
+        result.populatedAt
+      );
+    });
+  });
+
+  describe('fusion CAE+ECI', () => {
+    test('crée 2 snapshots pre-switch-te (cae+eci) et archive les deux sources', async () => {
+      const { collectiviteId, adminCaller } = await setupEligibleCollectivite(
+        prefsEligibleCaeAndEci
+      );
+      onTestFinished(() =>
+        cleanupSwitchToTeCollectiviteReferentielData(
+          databaseService,
+          collectiviteId
+        )
+      );
+
+      const result = await adminCaller.referentiels.switchToTe({
+        collectiviteId,
+      });
+
+      expect(result.status).toBe('switched');
+
+      // 2 snapshots pre-switch-te : un par source en write
+      const preSwitchSnapshots = await databaseService.db
+        .select({
+          ref: snapshotTable.ref,
+          referentielId: snapshotTable.referentielId,
+        })
+        .from(snapshotTable)
+        .where(
+          and(
+            eq(snapshotTable.collectiviteId, collectiviteId),
+            eq(snapshotTable.ref, SNAPSHOTS.PRE_SWITCH_TE_REF)
+          )
+        );
+
+      const referentielIds = preSwitchSnapshots.map((s) => s.referentielId);
+      expect(referentielIds).toContain('cae');
+      expect(referentielIds).toContain('eci');
+
+      // cae et eci archivés, te en write
+      const prefs = await getCollectivitePreferences(collectiviteId);
+      expect(prefs?.referentiels.cae.mode).toBe('archived');
+      expect(prefs?.referentiels.eci.mode).toBe('archived');
+      expect(prefs?.referentiels.te.mode).toBe('write');
+    });
+  });
+
+  describe('idempotence', () => {
+    test('rejouer switchToTe après succès retourne ALREADY_SWITCHED', async () => {
+      const { collectiviteId, adminCaller } = await setupEligibleCollectivite(
+        prefsEligibleCaeOnly
+      );
+      onTestFinished(() =>
+        cleanupSwitchToTeCollectiviteReferentielData(
+          databaseService,
+          collectiviteId
+        )
+      );
+
+      // 1re bascule
+      const first = await adminCaller.referentiels.switchToTe({
+        collectiviteId,
+      });
+      expect(first.status).toBe('switched');
+
+      // 2e appel → ALREADY_SWITCHED
+      await expect(
+        adminCaller.referentiels.switchToTe({ collectiviteId })
+      ).rejects.toThrow(switchToTeTrpcErrorEntries.ALREADY_SWITCHED.message);
+    });
+
+    test('deux bascules concurrentes sur la même collectivité : une seule réussit', async () => {
+      const { collectiviteId, adminCaller } = await setupEligibleCollectivite(
+        prefsEligibleCaeOnly
+      );
+      onTestFinished(() =>
+        cleanupSwitchToTeCollectiviteReferentielData(
+          databaseService,
+          collectiviteId
+        )
+      );
+
+      const [firstOutcome, secondOutcome] = await Promise.allSettled([
+        adminCaller.referentiels.switchToTe({ collectiviteId }),
+        adminCaller.referentiels.switchToTe({ collectiviteId }),
+      ]);
+      const outcomes = [firstOutcome, secondOutcome];
+
+      // la relecture verrouillée (FOR UPDATE) + revalidation dans la transaction
+      // sérialise les deux appels : un seul aboutit, l'autre échoue en
+      // ALREADY_SWITCHED sur l'état relu verrouillé
+      const fulfilled = outcomes.filter(
+        (o): o is PromiseFulfilledResult<
+          Awaited<ReturnType<typeof adminCaller.referentiels.switchToTe>>
+        > => o.status === 'fulfilled'
+      );
+      const rejected = outcomes.filter(
+        (o): o is PromiseRejectedResult => o.status === 'rejected'
+      );
+
+      expect(fulfilled).toHaveLength(1);
+      expect(rejected).toHaveLength(1);
+      expect(fulfilled[0].value.status).toBe('switched');
+      expect(rejected[0].reason.message).toContain(
+        switchToTeTrpcErrorEntries.ALREADY_SWITCHED.message
+      );
+
+      // les préférences finales correspondent à l'unique bascule gagnante,
+      // pas à une écriture concurrente qui les aurait écrasées
+      const preferences = await getCollectivitePreferences(collectiviteId);
+      expect(
+        preferences?.referentiels.te.populatedFromCaeEci?.populatedAt
+      ).toBe(fulfilled[0].value.populatedAt);
+    });
+  });
+
+  describe('rollback', () => {
+    test('rollback complet si TE déjà peuplé (REFERENTIEL_TE_NOT_EMPTY)', async () => {
+      const { collectiviteId, adminCaller, fixtureAdminUser } =
+        await setupEligibleCollectivite(prefsEligibleCaeOnly);
+      onTestFinished(() =>
+        cleanupSwitchToTeCollectiviteReferentielData(
+          databaseService,
+          collectiviteId
+        )
+      );
+
+      // simule TE déjà peuplé : insère un statut te_* directement en DB
+      await databaseService.db
+        .insert(actionStatutTable)
+        .values({
+          collectiviteId,
+          actionId: 'te_1.1',
+          avancement: 'fait',
+          avancementDetaille: [1, 0, 0],
+          concerne: true,
+          modifiedBy: fixtureAdminUser.id,
+        })
+        .onConflictDoNothing();
+
+      await expect(
+        adminCaller.referentiels.switchToTe({ collectiviteId })
+      ).rejects.toThrow(
+        switchToTeTrpcErrorEntries.REFERENTIEL_TE_NOT_EMPTY.message
+      );
+
+      // aucun snapshot pre-switch-te créé (rollback total)
+      const snapshots = await getSnapshots(collectiviteId, [
+        SNAPSHOTS.PRE_SWITCH_TE_REF,
+      ]);
+      expect(snapshots).toHaveLength(0);
+
+      // prefs inchangées (cae toujours write, populatedFromCaeEci absent)
+      const prefs = await getCollectivitePreferences(collectiviteId);
+      expect(prefs?.referentiels.cae.mode).toBe('write');
+      expect(prefs?.referentiels.te.populatedFromCaeEci).toBeUndefined();
+    });
+  });
+
+  describe('bascule avec données migrées', () => {
+    test('migre un statut CAE → mesure TE et le retrouve après bascule', async () => {
+      const { collectiviteId, adminCaller, fixtureAdminUser } =
+        await setupEligibleCollectivite(prefsEligibleCaeOnly);
+      onTestFinished(() =>
+        cleanupSwitchToTeCollectiviteReferentielData(
+          databaseService,
+          collectiviteId
+        )
+      );
+
+      // pose un statut sur une mesure CAE qui a une correspondance TE
+      await setActionStatutForCollectivite(
+        router,
+        fixtureAdminUser,
+        collectiviteId,
+        'cae_1.1.2.2.1',
+        'fait'
+      );
+
+      const result = await adminCaller.referentiels.switchToTe({
+        collectiviteId,
+      });
+      expect(result.status).toBe('switched');
+
+      // vérifie que le statut TE correspondant (te_1.1.1.2) a été migré
+      const teStatuts = await databaseService.db
+        .select({
+          actionId: actionStatutTable.actionId,
+          avancement: actionStatutTable.avancement,
+        })
+        .from(actionStatutTable)
+        .where(
+          and(
+            eq(actionStatutTable.collectiviteId, collectiviteId),
+            eq(actionStatutTable.actionId, 'te_1.1.1.2')
+          )
+        );
+
+      expect(teStatuts).toContainEqual({
+        actionId: 'te_1.1.1.2',
+        avancement: 'fait',
+      });
+    });
   });
 });

--- a/apps/backend/src/referentiels/switch-to-te/switch-to-te.rules.spec.ts
+++ b/apps/backend/src/referentiels/switch-to-te/switch-to-te.rules.spec.ts
@@ -1,6 +1,70 @@
 import type { CollectiviteReferentielPreferences } from '@tet/domain/collectivites';
-import { describe, expect, it } from 'vitest';
-import { canSwitchToTe, getSwitchToTeBlockers } from './switch-to-te.rules';
+import { describe, expect, it, test } from 'vitest';
+import {
+  buildPostSwitchPreferences,
+  canSwitchToTe,
+  getSwitchToTeBlockers,
+} from './switch-to-te.rules';
+
+const POPULATED = {
+  populatedAt: '2026-07-16T10:00:00.000Z',
+  populatedBy: 'user-42',
+};
+
+describe('buildPostSwitchPreferences', () => {
+  test('archive CAE write → te en write avec populatedFromCaeEci', () => {
+    const prefs: CollectiviteReferentielPreferences = {
+      cae: { display: true, mode: 'write' },
+      eci: { display: false, mode: 'archived' },
+      te: { display: true, mode: 'readonly' },
+    };
+
+    expect(buildPostSwitchPreferences(prefs, POPULATED)).toEqual({
+      cae: { mode: 'archived', display: false },
+      eci: { mode: 'archived', display: false },
+      te: { mode: 'write', display: true, populatedFromCaeEci: POPULATED },
+    });
+  });
+
+  test('archive CAE et ECI tous les deux en write', () => {
+    const prefs: CollectiviteReferentielPreferences = {
+      cae: { display: true, mode: 'write' },
+      eci: { display: true, mode: 'write' },
+      te: { display: true, mode: 'readonly' },
+    };
+
+    expect(buildPostSwitchPreferences(prefs, POPULATED)).toEqual({
+      cae: { mode: 'archived', display: false },
+      eci: { mode: 'archived', display: false },
+      te: { mode: 'write', display: true, populatedFromCaeEci: POPULATED },
+    });
+  });
+
+  test('laisse inchangée une ref déjà archived', () => {
+    const prefs: CollectiviteReferentielPreferences = {
+      cae: { display: true, mode: 'write' },
+      eci: { display: false, mode: 'archived' },
+      te: { display: true, mode: 'readonly' },
+    };
+
+    const result = buildPostSwitchPreferences(prefs, POPULATED);
+    // eci déjà archived → inchangé (mode archived, display false)
+    expect(result.eci).toEqual({ mode: 'archived', display: false });
+  });
+
+  test("respecte l'invariant archived ⇒ display false", () => {
+    const prefs: CollectiviteReferentielPreferences = {
+      cae: { display: true, mode: 'write' },
+      eci: { display: false, mode: 'archived' },
+      te: { display: true, mode: 'readonly' },
+    };
+
+    const result = buildPostSwitchPreferences(prefs, POPULATED);
+    // CAE archivé → display doit être false
+    expect(result.cae.mode).toBe('archived');
+    expect(result.cae.display).toBe(false);
+  });
+});
 
 describe('canSwitchToTe', () => {
   it('retourne true quand TE readonly et CAE engagé', () => {

--- a/apps/backend/src/referentiels/switch-to-te/switch-to-te.rules.ts
+++ b/apps/backend/src/referentiels/switch-to-te/switch-to-te.rules.ts
@@ -1,8 +1,32 @@
-import type { CollectiviteReferentielPreferences } from '@tet/domain/collectivites';
+import type {
+  CollectiviteReferentielPreferences,
+  PopulatedFromCaeEci,
+  ReferentielPreference,
+} from '@tet/domain/collectivites';
 import type {
   ParcoursLabellisationStatus,
   ReferentielId,
 } from '@tet/domain/referentiels';
+
+/**
+ * Construit les préférences post-bascule :
+ * - refs CAE/ECI en `write` → `{ mode: archived, display: false }`
+ * - refs déjà `archived` → inchangées
+ * - `te` → `{ mode: write, display: true, populatedFromCaeEci: populated }`
+ */
+export function buildPostSwitchPreferences(
+  prefs: CollectiviteReferentielPreferences,
+  populated: PopulatedFromCaeEci
+): CollectiviteReferentielPreferences {
+  const archiveIfWrite = (p: ReferentielPreference): ReferentielPreference =>
+    p.mode === 'write' ? { mode: 'archived', display: false } : p;
+
+  return {
+    cae: archiveIfWrite(prefs.cae),
+    eci: archiveIfWrite(prefs.eci),
+    te: { mode: 'write', display: true, populatedFromCaeEci: populated },
+  };
+}
 
 export function canSwitchToTe(
   prefs: CollectiviteReferentielPreferences

--- a/apps/backend/src/referentiels/switch-to-te/switch-to-te.service.ts
+++ b/apps/backend/src/referentiels/switch-to-te/switch-to-te.service.ts
@@ -1,22 +1,28 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { CollectiviteReferentielModeService } from '@tet/backend/collectivites/collectivite-referentiel-mode/collectivite-referentiel-mode.service';
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
 import type { ServiceSecondArg } from '@tet/backend/utils/nest/service-second-arg.utils';
-import { failure, type Result } from '@tet/backend/utils/result.type';
+import { failure, success, type Result } from '@tet/backend/utils/result.type';
 import { TrackingService } from '@tet/backend/utils/tracking/tracking.service';
+import { TransactionManager } from '@tet/backend/utils/transaction/transaction-manager.service';
 import { type CollectiviteReferentielPreferences } from '@tet/domain/collectivites';
 import {
   getParcoursLabellisationStatus,
   ReferentielIdEnum,
+  SnapshotJalonEnum,
 } from '@tet/domain/referentiels';
 import { PermissionOperationEnum, ResourceType } from '@tet/domain/users';
 import { GetLabellisationService } from '../labellisations/get-labellisation.service';
+import { SnapshotsService } from '../snapshots/snapshots.service';
+import { CreatePreSwitchSnapshotsService } from './create-pre-switch-snapshots.service';
+import { MigrateCollectiviteDataService } from './migrate-collectivite-data/migrate-collectivite-data.service';
 import {
   SwitchToTeErrorEnum,
   type SwitchToTeError,
 } from './switch-to-te.errors';
-import type { SwitchToTeNotImplementedOutput } from './switch-to-te.output';
+import type { SwitchToTeOutput } from './switch-to-te.output';
 import {
+  buildPostSwitchPreferences,
   canSwitchToTe,
   getSwitchToTeBlockers,
   type SwitchToTeBlocker,
@@ -24,11 +30,17 @@ import {
 
 @Injectable()
 export class SwitchToTeService {
+  private readonly logger = new Logger(SwitchToTeService.name);
+
   constructor(
     private readonly trackingService: TrackingService,
     private readonly permissionService: PermissionService,
     private readonly collectiviteReferentielModeService: CollectiviteReferentielModeService,
-    private readonly getLabellisationService: GetLabellisationService
+    private readonly getLabellisationService: GetLabellisationService,
+    private readonly transactionManager: TransactionManager,
+    private readonly createPreSwitchSnapshotsService: CreatePreSwitchSnapshotsService,
+    private readonly migrateCollectiviteDataService: MigrateCollectiviteDataService,
+    private readonly snapshotsService: SnapshotsService
   ) {}
 
   // référentiels sources pouvant bloquer la bascule
@@ -81,7 +93,8 @@ export class SwitchToTeService {
   async switchToTe(
     collectiviteId: number,
     { user }: ServiceSecondArg
-  ): Promise<Result<SwitchToTeNotImplementedOutput, SwitchToTeError>> {
+  ): Promise<Result<SwitchToTeOutput, SwitchToTeError>> {
+    // ── Guards hors transaction ──────────────────────────────────────────────
     const isAllowed = await this.permissionService.isAllowed(
       user,
       PermissionOperationEnum['REFERENTIELS.MUTATE'],
@@ -124,6 +137,93 @@ export class SwitchToTeService {
       return failure(SwitchToTeService.BLOCKER_ERROR[blockers[0].type]);
     }
 
-    return failure(SwitchToTeErrorEnum.SWITCH_NOT_IMPLEMENTED);
+    // ── Transaction unique : données SOURCES (rollback total sur échec) ──────
+    const populatedAt = new Date().toISOString();
+
+    const txResult = await this.transactionManager.executeSingle<
+      void,
+      SwitchToTeError
+    >(async (tx) => {
+      // étape 1 : snapshots pre-switch-te (refs CAE/ECI en write)
+      const snapshotsResult =
+        await this.createPreSwitchSnapshotsService.createPreSwitchSnapshots(
+          collectiviteId,
+          prefs,
+          { user, tx }
+        );
+      if (!snapshotsResult.success) return snapshotsResult;
+
+      // étape 2 : migration données collectivité (te_*)
+      const migrateResult = await this.migrateCollectiviteDataService.migrate(
+        collectiviteId,
+        prefs,
+        snapshotsResult.data,
+        { user, tx }
+      );
+      if (!migrateResult.success) return migrateResult;
+
+      // étape 3 : prefs + populatedFromCaeEci (en dernier de la tx pour l'idempotence)
+      const prefsResult =
+        await this.collectiviteReferentielModeService.updateReferentielPreferences(
+          collectiviteId,
+          buildPostSwitchPreferences(prefs, {
+            populatedAt,
+            populatedBy: user.id,
+          }),
+          tx
+        );
+      if (!prefsResult.success) return prefsResult;
+
+      return success(undefined);
+    });
+
+    if (!txResult.success) return txResult;
+
+    // ── Après COMMIT : projections reconstructibles (hors tx, best-effort) ──
+    // Lit les données te_* committées, comme UpdateActionStatutService.upsertActionStatuts.
+    const recomputeResult = await this.recomputeTeProjections(
+      collectiviteId,
+      user
+    );
+    if (!recomputeResult.success) {
+      // la bascule EST réussie (flag committé) ; projections régénérables
+      this.logger.error(
+        `Bascule TE collectivite=${collectiviteId} : recompute des projections échoué (réparable)`,
+        recomputeResult.cause?.stack
+      );
+    }
+
+    return success({ status: 'switched', populatedAt });
+  }
+
+  private async recomputeTeProjections(
+    collectiviteId: number,
+    user: ServiceSecondArg['user']
+  ): Promise<Result<void, SwitchToTeError>> {
+    // étape 4 : score-courant TE
+    const courant = await this.snapshotsService.computeAndUpsert(
+      { collectiviteId, referentielId: ReferentielIdEnum.TE },
+      { user }
+    );
+    if (!courant.success) {
+      return failure(SwitchToTeErrorEnum.POST_SWITCH_RECOMPUTE_FAILED, courant.cause);
+    }
+
+    // étape 5 : snapshot post-switch-te
+    // ref et nom déduits du jalon via getDefaultSnapshotMetadata (POST_SWITCH_TE)
+    // on ne passe pas nom pour éviter la restriction du scores service
+    const post = await this.snapshotsService.computeAndUpsert(
+      {
+        collectiviteId,
+        referentielId: ReferentielIdEnum.TE,
+        jalon: SnapshotJalonEnum.POST_SWITCH_TE,
+      },
+      { user }
+    );
+    if (!post.success) {
+      return failure(SwitchToTeErrorEnum.POST_SWITCH_RECOMPUTE_FAILED, post.cause);
+    }
+
+    return success(undefined);
   }
 }

--- a/apps/backend/src/referentiels/switch-to-te/switch-to-te.service.ts
+++ b/apps/backend/src/referentiels/switch-to-te/switch-to-te.service.ts
@@ -1,22 +1,29 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { CollectiviteReferentielModeService } from '@tet/backend/collectivites/collectivite-referentiel-mode/collectivite-referentiel-mode.service';
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
 import type { ServiceSecondArg } from '@tet/backend/utils/nest/service-second-arg.utils';
-import { failure, type Result } from '@tet/backend/utils/result.type';
+import { failure, success, type Result } from '@tet/backend/utils/result.type';
 import { TrackingService } from '@tet/backend/utils/tracking/tracking.service';
+import { TransactionManager } from '@tet/backend/utils/transaction/transaction-manager.service';
 import { type CollectiviteReferentielPreferences } from '@tet/domain/collectivites';
 import {
   getParcoursLabellisationStatus,
   ReferentielIdEnum,
+  SnapshotJalonEnum,
 } from '@tet/domain/referentiels';
 import { PermissionOperationEnum, ResourceType } from '@tet/domain/users';
 import { GetLabellisationService } from '../labellisations/get-labellisation.service';
+import { SNAPSHOTS } from '../snapshots/snapshots.constants';
+import { SnapshotsService } from '../snapshots/snapshots.service';
+import { CreatePreSwitchSnapshotsService } from './create-pre-switch-snapshots.service';
+import { MigrateCollectiviteDataService } from './migrate-collectivite-data/migrate-collectivite-data.service';
 import {
   SwitchToTeErrorEnum,
   type SwitchToTeError,
 } from './switch-to-te.errors';
-import type { SwitchToTeNotImplementedOutput } from './switch-to-te.output';
+import type { SwitchToTeOutput } from './switch-to-te.output';
 import {
+  buildPostSwitchPreferences,
   canSwitchToTe,
   getSwitchToTeBlockers,
   type SwitchToTeBlocker,
@@ -24,11 +31,17 @@ import {
 
 @Injectable()
 export class SwitchToTeService {
+  private readonly logger = new Logger(SwitchToTeService.name);
+
   constructor(
     private readonly trackingService: TrackingService,
     private readonly permissionService: PermissionService,
     private readonly collectiviteReferentielModeService: CollectiviteReferentielModeService,
-    private readonly getLabellisationService: GetLabellisationService
+    private readonly getLabellisationService: GetLabellisationService,
+    private readonly transactionManager: TransactionManager,
+    private readonly createPreSwitchSnapshotsService: CreatePreSwitchSnapshotsService,
+    private readonly migrateCollectiviteDataService: MigrateCollectiviteDataService,
+    private readonly snapshotsService: SnapshotsService
   ) {}
 
   // référentiels sources pouvant bloquer la bascule
@@ -81,7 +94,7 @@ export class SwitchToTeService {
   async switchToTe(
     collectiviteId: number,
     { user }: ServiceSecondArg
-  ): Promise<Result<SwitchToTeNotImplementedOutput, SwitchToTeError>> {
+  ): Promise<Result<SwitchToTeOutput, SwitchToTeError>> {
     const isReferentielTeEnabled = await this.trackingService.isFeatureEnabled(
       'is-referentiel-te-enabled',
       user.id,
@@ -132,7 +145,43 @@ export class SwitchToTeService {
     }
 
     if (prefs.te.populatedFromCaeEci) {
-      return failure(SwitchToTeErrorEnum.ALREADY_SWITCHED);
+      // déjà basculé : vérifie si le snapshot post-switch-te existe (get() sans
+      // effet de bord pour ce ref — pas de self-healing hors jalon COURANT).
+      // S'il manque (échec précédent du recompute best-effort), on répare au lieu
+      // de bloquer indéfiniment sur ALREADY_SWITCHED — cf. commentaire "réparable"
+      // plus bas : ceci le rend concrètement vrai.
+      const existingPostSwitch = await this.snapshotsService.get(
+        collectiviteId,
+        ReferentielIdEnum.TE,
+        SNAPSHOTS.POST_SWITCH_TE_REF,
+        { user }
+      );
+      if (existingPostSwitch.success) {
+        return failure(SwitchToTeErrorEnum.ALREADY_SWITCHED);
+      }
+
+      const repairResult = await this.recomputeSnapshotPostSwitchTe(
+        collectiviteId,
+        user
+      );
+      if (!repairResult.success) {
+        // contrairement au best-effort du premier appel, on renvoie l'échec ici :
+        // la bascule des données ne se reproduit pas, seul le recompute est
+        // retenté, pas de raison de masquer un 2e échec à l'appelant.
+        this.logger.error(
+          `Bascule TE collectivite=${collectiviteId} : réparation du snapshot post-switch-te échouée`,
+          repairResult.cause?.stack
+        );
+        return failure(
+          SwitchToTeErrorEnum.POST_SWITCH_RECOMPUTE_FAILED,
+          repairResult.cause
+        );
+      }
+
+      return success({
+        status: 'switched',
+        populatedAt: prefs.te.populatedFromCaeEci.populatedAt,
+      });
     }
 
     if (!canSwitchToTe(prefs)) {
@@ -144,6 +193,119 @@ export class SwitchToTeService {
       return failure(SwitchToTeService.BLOCKER_ERROR[blockers[0].type]);
     }
 
-    return failure(SwitchToTeErrorEnum.SWITCH_NOT_IMPLEMENTED);
+    // ── Transaction unique : données SOURCES (rollback total sur échec) ──────
+    const populatedAt = new Date().toISOString();
+
+    const txResult = await this.transactionManager.executeSingle<
+      void,
+      SwitchToTeError
+    >(async (tx) => {
+      // relit les préférences avec verrou (FOR UPDATE) pour sérialiser les bascules
+      // concurrentes, puis revalide l'éligibilité juste avant d'écrire
+      const lockedPrefsResult =
+        await this.collectiviteReferentielModeService.getReferentielPreferences(
+          collectiviteId,
+          { withLock: true, tx }
+        );
+      if (!lockedPrefsResult.success) return lockedPrefsResult;
+
+      const lockedPrefs = lockedPrefsResult.data;
+      if (lockedPrefs.te.populatedFromCaeEci) {
+        return failure(SwitchToTeErrorEnum.ALREADY_SWITCHED);
+      }
+      if (!canSwitchToTe(lockedPrefs)) {
+        return failure(SwitchToTeErrorEnum.NOT_ELIGIBLE);
+      }
+
+      // étape 1 : snapshots pre-switch-te (refs CAE/ECI en write)
+      const snapshotsResult =
+        await this.createPreSwitchSnapshotsService.createPreSwitchSnapshots(
+          collectiviteId,
+          lockedPrefs,
+          { user, tx }
+        );
+      if (!snapshotsResult.success) return snapshotsResult;
+
+      // étape 2 : migration données collectivité (te_*)
+      const migrateResult = await this.migrateCollectiviteDataService.migrate(
+        collectiviteId,
+        lockedPrefs,
+        snapshotsResult.data,
+        { user, tx }
+      );
+      if (!migrateResult.success) return migrateResult;
+
+      // étape 3 : prefs + populatedFromCaeEci (en dernier de la tx pour l'idempotence)
+      const prefsResult =
+        await this.collectiviteReferentielModeService.updateReferentielPreferences(
+          collectiviteId,
+          buildPostSwitchPreferences(lockedPrefs, {
+            populatedAt,
+            populatedBy: user.id,
+          }),
+          tx
+        );
+      if (!prefsResult.success) return prefsResult;
+
+      return success(undefined);
+    });
+
+    if (!txResult.success) return txResult;
+
+    // ── Après COMMIT : snapshot post-switch-te (hors tx, best-effort) ───────
+    // Historique figé au moment de la bascule (jalon POST_SWITCH_TE) : pas de
+    // self-healing équivalent ailleurs, contrairement au score-courant (voir
+    // SnapshotsService.get()) donc ce calcul doit rester explicite ici.
+    //
+    // Volontairement APRÈS le commit de la transaction principale et SANS lui
+    // passer `tx` : le calcul du score (ScoresService.computeScoreForCollectivite
+    // → ListActionStatutsRepository.listByActionIds) lit toujours via le pool
+    // par défaut, jamais via un `tx` fourni par l'appelant. Threader `tx` ici ne
+    // rendrait donc PAS ce calcul transaction-safe : il verrait les données te_*
+    // via une connexion séparée qui ne voit pas les écritures non committées de
+    // la transaction en cours (MVCC), et calculerait un score faux/vide. Même
+    // pattern que UpdateActionStatutService.upsertActionStatuts (écrit dans une
+    // tx interne, puis appelle computeAndUpsert SANS tx, après le commit).
+    const recomputeResult = await this.recomputeSnapshotPostSwitchTe(
+      collectiviteId,
+      user
+    );
+    if (!recomputeResult.success) {
+      // la bascule EST réussie (flag committé) ; snapshot régénérable — un
+      // nouvel appel à switchToTe retentera ce calcul (voir plus haut).
+      this.logger.error(
+        `Bascule TE collectivite=${collectiviteId} : recompute du snapshot post-switch-te échoué (réparable)`,
+        recomputeResult.cause?.stack
+      );
+    }
+
+    return success({ status: 'switched', populatedAt });
+  }
+
+  private async recomputeSnapshotPostSwitchTe(
+    collectiviteId: number,
+    user: ServiceSecondArg['user']
+  ): Promise<Result<void, SwitchToTeError>> {
+    // Snapshot post-switch-te : ref et nom déduits du jalon via
+    // getDefaultSnapshotMetadata (POST_SWITCH_TE). On ne passe pas `nom` pour
+    // éviter la restriction du scores service.
+    //
+    // NB : le score-courant TE n'est PAS recalculé ici — il est régénéré
+    // automatiquement au premier accès en lecture via le self-healing de
+    // SnapshotsService.get() (déjà utilisé ailleurs, ex. UpdateActionStatutService),
+    // ce qui rend un calcul explicite ici redondant.
+    const post = await this.snapshotsService.computeAndUpsert(
+      {
+        collectiviteId,
+        referentielId: ReferentielIdEnum.TE,
+        jalon: SnapshotJalonEnum.POST_SWITCH_TE,
+      },
+      { user }
+    );
+    if (!post.success) {
+      return failure(SwitchToTeErrorEnum.POST_SWITCH_RECOMPUTE_FAILED, post.cause);
+    }
+
+    return success(undefined);
   }
 }

--- a/apps/backend/src/utils/tracking/posthog-event-tracker.ts
+++ b/apps/backend/src/utils/tracking/posthog-event-tracker.ts
@@ -61,6 +61,7 @@ export class PostHogEventTracker
   ): Promise<boolean> {
     if (
       process.env.NODE_ENV === 'development' ||
+      process.env.NODE_ENV === 'test' ||
       process.env.ENV_NAME === 'dev' ||
       process.env.ENV_NAME === 'ci'
     ) {

--- a/doc/plans/2026-06-11-001-feat-bascule-referentiel-te-prd.md
+++ b/doc/plans/2026-06-11-001-feat-bascule-referentiel-te-prd.md
@@ -166,22 +166,33 @@ sequenceDiagram
 
   UI->>SwitchService: referentiels.switchToTe(collectiviteId)
   SwitchService->>SwitchService: guards (cf. Guards)
+  rect rgb(230, 240, 255)
+  note over SwitchService,Prefs: Transaction unique — données sources
   SwitchService->>Snapshots: pre-switch-te (refs CAE/ECI concernés)
   SwitchService->>Migrate: copie données (cf. Règles migration)
-  SwitchService->>Scores: recalcul TE + client_scores
-  SwitchService->>Snapshots: post-switch-te sur te
   SwitchService->>Prefs: referentiels + te.populatedFromCaeEci
+  end
+  note over SwitchService,Scores: Après commit — projections reconstructibles
+  SwitchService->>Scores: recalcul score-courant TE
+  SwitchService->>Snapshots: post-switch-te sur te
 ```
 
-**Ordre transactionnel** — une seule transaction DB, étapes strictes :
+**Ordre — transaction sur les données sources, puis recompute des projections hors transaction** :
+
+*Transaction unique (rollback total sur échec)* :
 
 1. Snapshots `pre-switch-te` (chaque ref. CAE/ECI concerné).
 2. Migration données collectivité.
-3. Recalcul scores TE + `client_scores`.
-4. Snapshot `post-switch-te` sur TE.
-5. **En dernier** : `preferences.referentiels` + `te.populatedFromCaeEci`.
+3. **En dernier de la transaction** : `preferences.referentiels` + `te.populatedFromCaeEci`.
 
-Guards **avant** la transaction. Échec ou timeout → **rollback total** ; `te.populatedFromCaeEci` ne doit **jamais** être écrit partiellement (seul garde-fou d'idempotence).
+*Après commit (projections reconstructibles, hors transaction)* :
+
+4. Recalcul `score-courant` TE.
+5. Snapshot `post-switch-te` sur TE.
+
+Guards **avant** la transaction. Échec des étapes 1–3 → **rollback total** ; `te.populatedFromCaeEci` ne doit **jamais** être écrit partiellement (seul garde-fou d'idempotence).
+
+> **Recompute hors transaction (décision PR18)** — `score-courant` TE et `post-switch-te` sont des **projections reconstructibles** (dérivées de `te_<id>` + personnalisation), pas des données sources. Elles sont recomputées **après le commit**, à l'identique du flux nominal `UpdateActionStatutService.upsertActionStatuts` (écriture des statuts en transaction, puis `SnapshotsService.computeAndUpsert` hors transaction). Motifs : `computeScoreForCollectivite` lit `action_statut` hors transaction (chemin de scoring partagé, non modifié) ; transaction plus courte (moindre risque de `statement_timeout`) ; cohérence avec l'existant. Échec du recompute post-commit → bascule considérée réussie (flag committé), projections régénérées à la 1re saisie TE ou via `forceRecompute` (ops). Détail : `doc/plans/2026-06-11-013-feat-bascule-referentiel-te-pr18-plan.md`.
 
 **Modèle de migration** : copie des données vers les actions `te_<id>` à la bascule (pas de projection origine en production).
 
@@ -215,7 +226,7 @@ Règle transversale : sources `concerne = false` (non concerné explicite ou dé
 | Snapshot | `ref` | `jalon` | `nom` | Comportement |
 |---|---|---|---|---|
 | Pré-bascule | `pre-switch-te` | `pre_switch_te` | État pré-bascule Climat Ressources | Figé à la bascule ; jalon système non éditable (comme `pre_audit`) |
-| Post-bascule TE | `post-switch-te` | `post_switch_te` | État initial TE | Figé à la bascule ; jalon système non éditable |
+| Post-bascule TE | `post-switch-te` | `post_switch_te` | État initial Climat Ressources | Figé à la bascule ; jalon système non éditable |
 | Score courant | `score-courant` | `score_courant` | Score courant | Vivant sur TE post-bascule ; **masqué** sur CAE/ECI archivés (ligne conservée en BDD) |
 
 > **Convention `ref` / `jalon`** — `ref` (kebab-case) pour API/UI/exports ; `jalon` (snake_case) pour enum BDD `SnapshotJalonEnum`. Ne pas unifier.
@@ -334,7 +345,7 @@ Objectif de découpage : **PRs reviewables en une session**. Règle générale ~
 | PR15 | `mergeServices` + correctif Drizzle PK + tests | PR12 | ~250 | Non (endpoint) |
 | PR16 | `mergeFicheActionLinks` + tests | PR12 | ~250 | Non (endpoint) |
 | PR17 | MigrateCollectiviteDataService (+ détection sources fusionnées pour snapshots archived si besoin) | PR13–PR16 | ~300 | Non (endpoint) |
-| PR18 | Recalcul scores + snapshot post-switch-te + transaction + prefs + **exposition prod** | PR9, PR10, PR17 | ~550 | **Oui (endpoint)** |
+| PR18 | Transaction sources (snapshots pre + migration + prefs) + recompute projections hors tx + **exposition prod** | PR9, PR10, PR17 | ~500 | **Oui (endpoint)** |
 | PR19 | UI bascule — CTA + états disabled (COT/demande/audit) | PR18 | ~350 | Oui |
 | PR20 | UI bascule — modale irréversible (migré / non migré) | PR19 | ~350 | Oui |
 | PR21 | Masquage questions / personnalisations legacy | PR18 | ~400 | Oui |
@@ -437,11 +448,10 @@ Feedback rapide possible après PR5–PR7 (lecture seule visible).
 
 ### PR18 — Bascule bout-en-bout
 
-- Recalcul scores TE : après migration des statuts, déclencher le recalcul et la persistance via `SnapshotsService.forceRecompute` (sur `score-courant` TE, puis snapshot `post-switch-te`) — pas d'écriture directe `client_scores` depuis `ScoresService`.
-- Snapshot `post-switch-te` sur TE.
-- Intégration transactionnelle complète : cf. [Flux de bascule](#flux-de-bascule).
-- Mise à jour prefs + `te.populatedFromCaeEci`.
+- Transaction unique sur les **données sources** : snapshots `pre-switch-te` → migration `te_<id>` → prefs + `te.populatedFromCaeEci` (en dernier). Rollback total sur échec.
+- **Après commit, hors transaction** : recalcul `score-courant` TE + snapshot `post-switch-te` via `SnapshotsService.computeAndUpsert` (pattern `upsertActionStatuts`) — pas d'écriture directe `client_scores` depuis `ScoresService` ; aucune modification du scoring. Cf. [Flux de bascule](#flux-de-bascule).
 - **Exposition prod** de `referentiels.switchToTe`.
+- Détail : `doc/plans/2026-06-11-013-feat-bascule-referentiel-te-pr18-plan.md`.
 
 ### PR19 — UI bascule (CTA)
 

--- a/doc/plans/2026-06-11-013-feat-bascule-referentiel-te-pr18-plan.md
+++ b/doc/plans/2026-06-11-013-feat-bascule-referentiel-te-pr18-plan.md
@@ -1,0 +1,334 @@
+---
+name: PR18 Bascule bout-en-bout
+overview: "Câbler switchToTe() de bout en bout : transaction atomique sur les données sources (createPreSwitchSnapshots → migrate → prefs + populatedFromCaeEci), puis recompute des projections hors tx (score-courant TE + post-switch-te), à la manière de upsertActionStatuts. Retirer SWITCH_NOT_IMPLEMENTED et exposer l'endpoint en prod."
+todos:
+  - id: post-switch-constants
+    content: "Constantes POST_SWITCH_TE_REF / POST_SWITCH_TE_NOM (snapshots.constants.ts) + case getDefaultSnapshotMetadata"
+    status: pending
+  - id: post-switch-prefs-rule
+    content: "buildPostSwitchPreferences(prefs, {populatedAt, populatedBy}) pure + tests unitaires"
+    status: pending
+  - id: switch-service-orchestration
+    content: "SwitchToTeService.switchToTe : transaction unique, ordre strict, retrait SWITCH_NOT_IMPLEMENTED"
+    status: pending
+  - id: success-output
+    content: "switch-to-te.output.ts : schéma succès + adaptation router"
+    status: pending
+  - id: errors
+    content: "Erreur typée POST_SWITCH_RECOMPUTE_FAILED (projections post-commit) + retrait SWITCH_NOT_IMPLEMENTED"
+    status: pending
+  - id: e2e-full-switch
+    content: "E2e bascule complète (snapshots pre/post, données migrées, scores, prefs, idempotence, rollback)"
+    status: pending
+  - id: e2e-existing-update
+    content: "Mettre à jour switch-to-te.router.e2e-spec.ts (tests SWITCH_NOT_IMPLEMENTED → succès)"
+    status: pending
+  - id: heavy-ct-bench
+    content: "E2e/bench CT max charge (1377 statuts CAE) — durée transaction < statement_timeout (risque D)"
+    status: pending
+isProject: false
+---
+
+# PR18 — Bascule bout-en-bout (`switchToTe`)
+
+**Parent** : [doc/plans/2026-06-11-001-feat-bascule-referentiel-te-prd.md](2026-06-11-001-feat-bascule-referentiel-te-prd.md)
+
+**Prérequis** : PR8 (squelette + guards permissions/idempotence), PR9 (guards COT/demande/audit), PR10 (`CreatePreSwitchSnapshotsService`), PR17b ([`MigrateCollectiviteDataService`](2026-06-11-012-feat-bascule-referentiel-te-pr17b-plan.md)) — tous mergés.
+
+**Branche** : `TE-7303/switch-te-PR18` depuis `main`
+
+**Estimation** : ~500 LOC (code + tests). *Orchestration (tx données sources + recompute hors tx) + prefs + output + e2e.* Tolérance ~650 LOC (PRD — bascule transactionnelle).
+
+**Prod** : **Oui (endpoint)** — première PR qui **expose `referentiels.switchToTe` en prod** et rend la bascule utilisateur possible.
+
+---
+
+## Contexte
+
+Jusqu'à PR17b, tous les blocs de la bascule existent isolément mais `switchToTe()` retourne `SWITCH_NOT_IMPLEMENTED` après les guards. PR18 est la PR d'**assemblage** : elle branche les services, puis retire le garde `SWITCH_NOT_IMPLEMENTED` et expose l'endpoint.
+
+**Décision d'architecture** (cf. § Point technique central) : la bascule sépare **écritures sources** (atomiques, en transaction) et **projections** (score-courant TE + `post-switch-te`, recomputées **hors tx** après commit). Ce découpage suit le **précédent établi** du codebase : `UpdateActionStatutService.upsertActionStatuts` écrit les statuts en tx, puis appelle `snapshotsService.computeAndUpsert` **hors tx** une fois committé.
+
+**Delta vs PR17b** : orchestration ; recalcul du `score-courant` TE + snapshot `post-switch-te` ; mise à jour `preferences.referentiels` + `te.populatedFromCaeEci` ; archivage des refs CAE/ECI en `write` ; exposition prod + output de succès.
+
+```mermaid
+sequenceDiagram
+  participant Svc as SwitchToTeService
+  participant TxM as TransactionManager
+  participant Snap as CreatePreSwitchSnapshotsService
+  participant Mig as MigrateCollectiviteDataService
+  participant Prefs as CollectiviteReferentielModeService
+  participant Sc as SnapshotsService
+
+  Svc->>Svc: guards (permissions, flag, idempotence, éligibilité, COT/audit) — HORS tx
+  rect rgba(200,230,255,0.4)
+    Note over TxM,Prefs: Transaction unique — données SOURCES (rollback total)
+    Svc->>TxM: executeSingle(async tx => …)
+    TxM->>Snap: createPreSwitchSnapshots(prefs, {user, tx})  1
+    Snap-->>TxM: ScoreSnapshot[] (refs CAE/ECI en write)
+    TxM->>Mig: migrate(collId, prefs, preSwitchSnapshots, {user, tx})  2
+    TxM->>Prefs: updateReferentielPreferences(buildPostSwitchPreferences(…), tx)  3
+  end
+  Note over Svc,Sc: Après COMMIT — projections reconstructibles (hors tx)
+  Svc->>Sc: computeAndUpsert(te, score-courant, {user})  4
+  Svc->>Sc: computeAndUpsert(te, post-switch-te, {user})  5
+  Sc-->>Svc: Result<SwitchToTeOutput>
+```
+
+Échec des étapes 1→3 → `throw` du `Result` → rollback total Drizzle → `te.populatedFromCaeEci` **jamais** écrit partiellement, données `te_*` non persistées. Échec des étapes 4/5 (post-commit) → CT basculée (sources cohérentes) mais projections manquantes → **best-effort** : log + reconstruction à la 1re saisie TE ou via `forceRecompute` ops (cf. § Projections hors transaction).
+
+---
+
+## Décisions actées
+
+**Hérite PR8–PR17b** : `Result<…, SwitchToTeError>` (ADR 0012) ; guards **avant** la transaction ; `preSwitchSnapshots` **injectés en mémoire** dans `migrate` (pas de re-read) ; garde TE vide dans `migrate` ; pas de suppression des données CAE/ECI (archivage via prefs).
+
+| Sujet | Décision |
+| --- | --- |
+| Orchestration | **Transaction unique sur les données sources** via `transactionManager.executeSingle(async (tx) => { … })` (étapes 1→3), **puis recompute des projections hors tx** (étapes 4→5). Guards inchangés, **avant** la tx (lectures read-only). |
+| Ordre | 1 `createPreSwitchSnapshots(tx)` → 2 `migrate(tx)` → 3 prefs + `populatedFromCaeEci` (`tx`, **en dernier de la tx**) → **commit** → 4 recalcul `score-courant` TE (hors tx) → 5 snapshot `post-switch-te` (hors tx). |
+| Découpage tx / hors-tx | Suit le précédent `UpdateActionStatutService.upsertActionStatuts` : les statuts s'écrivent en tx, `computeAndUpsert` recompute **après commit**. Les projections (`score-courant`, `post-switch-te`) sont **reconstructibles** depuis `te_*` + personnalisation → pas besoin d'atomicité stricte. |
+| Recalcul scores | `SnapshotsService.computeAndUpsert` **sans `tx`** (lit les données committées, comme le flux nominal). 4 `computeAndUpsert({ collectiviteId, referentielId: te }, { user })` (jalon `COURANT`) ; 5 `computeAndUpsert({ collectiviteId, referentielId: te, ref: POST_SWITCH_TE_REF, jalon: POST_SWITCH_TE, nom: POST_SWITCH_TE_NOM }, { user })`. **Aucune modification du scoring** (`computeScoreForCollectivite` inchangé). Pas d'écriture directe `client_scores` (PRD). |
+| `post-switch-te` | `ref: 'post-switch-te'`, `jalon: post_switch_te`, `nom: 'État initial Climat Ressources'` — ajouter `POST_SWITCH_TE_REF` / `POST_SWITCH_TE_NOM` dans `snapshots.constants.ts` + case dédié dans `getDefaultSnapshotMetadata` (jalon système non éditable, comme `pre_audit`). |
+| Archivage refs | `buildPostSwitchPreferences` (pure) : refs CAE/ECI en `mode: write` → `{ mode: archived, display: false }` ; refs déjà `archived` inchangées ; `te` → `{ mode: write, display: true, populatedFromCaeEci: { populatedAt, populatedBy: user.id } }`. Invariant Zod `archived ⇒ display: false` respecté. |
+| Persistance prefs | `CollectiviteReferentielModeService.updateReferentielPreferences(collectiviteId, referentiels, tx)` — étape 3, `tx` propagé. |
+| Idempotence | Garde `te.populatedFromCaeEci` (PR8) **avant** tx ; écrit **en dernier de la transaction source**. Un rollback des étapes 1→3 laisse la CT re-basculable. |
+| Retrait squelette | Supprimer `return failure(SWITCH_NOT_IMPLEMENTED)` ; **supprimer** l'erreur `SWITCH_NOT_IMPLEMENTED` de `switch-to-te.errors.ts` (plus référencée) une fois les tests migrés. |
+| Output | `switch-to-te.output.ts` : schéma succès `{ status: 'switched', populatedAt: string }` (remplace `not_implemented`). Router : passe le `Result` par `getResultDataOrThrowError` (inchangé). |
+| Erreurs | Ajouter `POST_SWITCH_RECOMPUTE_FAILED` (`INTERNAL_SERVER_ERROR`, projections post-commit) dans `switch-to-te.errors.ts`. Réutiliser `PRE_SWITCH_SNAPSHOT_FAILED` / `MIGRATION_FAILED` existants. Pas d'erreur `PREFERENCES_UPDATE_FAILED` dédiée : `updateReferentielPreferences` renvoie déjà un `Result` typé propagé tel quel. |
+| Timeout | **Réduit** vs « tout en tx » : la transaction ne contient que les écritures (pas le recompute). Risque **accepté** (PRD risque D) ; validé par e2e sur CT max charge (cf. Tests). |
+
+---
+
+## Point technique central — pourquoi le recompute est hors transaction
+
+**Contrainte** : `SnapshotsService.computeAndUpsert` **écrit** avec `tx`, mais délègue le **calcul** à `ScoresService.computeScoreForCollectivite`, qui lit `action_statut` via `ListActionStatutsRepository.listByActionIds` sur `this.databaseService.db` (**pool, hors transaction**). Un recompute exécuté *dans* la tx de bascule ne verrait donc **pas** les statuts `te_*` migrés non commités (isolation PostgreSQL).
+
+**Deux options envisagées :**
+
+| Option | Description | Verdict |
+| --- | --- | --- |
+| **A — tx-aware ciblé** | Threader `tx?` dans `computeScoreForCollectivite` + `listByActionIds` (+ explications) pour tout exécuter en une seule tx | **Écartée** : touche le **cœur du scoring** (chemin partagé) ; allonge la tx → **risque timeout** accru sur CT max charge ; nécessite aussi de rendre les explications `tx`-aware pour un `post-switch-te` complet ; va **à contre-courant du pattern codebase** |
+| **C — write atomique + projections hors tx** *(retenue)* | Écritures sources en tx ; `computeAndUpsert` (score-courant + post-switch) **après commit**, exactement comme `upsertActionStatuts` | **Retenue** : **zéro modification du scoring** ; **transaction courte** (timeout réduit) ; **cohérente** avec le précédent du codebase ; atomicité garantie sur les **données sources** |
+
+**Justification du choix C** : le point clé est que `score-courant` TE et `post-switch-te` sont des **projections reconstructibles** (dérivées de `te_*` + personnalisation), pas des données sources. Le seul périmètre nécessitant l'atomicité — snapshots `pre-switch-te`, données `te_*`, `prefs + populatedFromCaeEci` — est protégé par la transaction. Reproduire le pattern `upsertActionStatuts` (recompute post-commit) est plus sûr (aucune régression scoring), plus rapide (tx courte) et cohérent avec l'existant.
+
+**Compromis assumé** : si le recompute post-commit (4/5) échoue, la CT est **basculée** (données sources cohérentes) mais sans `score-courant`/`post-switch-te` — cf. § Projections hors transaction.
+
+> **Divergence PRD** : le PRD ([Flux de bascule](2026-06-11-001-feat-bascule-referentiel-te-prd.md#flux-de-bascule)) place le recompute (étape 3) et `post-switch-te` (étape 4) *dans* la transaction unique. La Stratégie C impose d'**amender le PRD** pour distinguer « transaction atomique sur les données sources » et « recompute des projections hors tx (pattern `upsertActionStatuts`) ». Amendement à porter dans la même PR.
+
+## Projections hors transaction — robustesse
+
+- **Ordre** : le flag `populatedFromCaeEci` est écrit **dans la tx source** (étape 3), donc cohérent avec les données `te_*`. La bascule est considérée réussie dès le commit.
+- **Échec 4/5** (post-commit) : renvoyer `failure(POST_SWITCH_RECOMPUTE_FAILED)` **n'annule pas** la bascule (le flag est déjà committé). Choix : logger l'erreur en `error` (Sentry) et **retourner tout de même un succès** à l'appelant, la projection étant reconstructible. *(À trancher : succès silencieux vs erreur explicite — cf. Questions ouvertes.)*
+- **Reconstruction** : `score-courant` TE est recalculé à la **1re saisie** TE (`upsertActionStatuts`) ; `post-switch-te` peut être régénéré via `forceRecompute` (capacité ops, déjà envisagée par le PRD).
+- **Micro-fenêtre** : entre le commit (TE devient `write`) et le figement de `post-switch-te`, une saisie TE concurrente pourrait polluer l'état figé. Fenêtre de l'ordre de la seconde, jugée **négligeable**. Si l'équipe la juge inacceptable → variante 3-phases (flag écrit *après* les projections, garde d'idempotence basée sur le flag) : cf. Questions ouvertes.
+
+---
+
+## Ordre d'implémentation
+
+1. **`snapshots.constants.ts`** — `POST_SWITCH_TE_REF` / `POST_SWITCH_TE_NOM` + case `getDefaultSnapshotMetadata`.
+2. **`switch-to-te.rules.ts`** — `buildPostSwitchPreferences` (pure) + tests `switch-to-te.rules.spec.ts`.
+3. **`switch-to-te.errors.ts`** — `POST_SWITCH_RECOMPUTE_FAILED` ; retrait `SWITCH_NOT_IMPLEMENTED` (après migration des tests).
+4. **`switch-to-te.output.ts`** — schéma succès.
+5. **`switch-to-te.service.ts`** — orchestration (tx sources + recompute hors tx).
+6. **`switch-to-te.router.ts`** — inchangé (vérifier type output).
+7. **PRD** — amender [Flux de bascule](2026-06-11-001-feat-bascule-referentiel-te-prd.md#flux-de-bascule) (tx sources + projections hors tx).
+8. **E2e** — bascule complète + mise à jour des tests squelette.
+
+*Aucune modification de `ScoresService` / `ListActionStatutsRepository` (Stratégie C).*
+
+---
+
+## Implémentation
+
+### 1) Constantes & métadonnées snapshot
+
+```ts
+// snapshots.constants.ts
+POST_SWITCH_TE_REF: 'post-switch-te',
+POST_SWITCH_TE_NOM: 'État initial Climat Ressources',
+```
+
+`getDefaultSnapshotMetadata` : ajouter le case `SnapshotJalonEnum.POST_SWITCH_TE` → `{ ref: POST_SWITCH_TE_REF, nom: POST_SWITCH_TE_NOM }` (miroir du case `PRE_SWITCH_TE` livré en PR10).
+
+### 2) `buildPostSwitchPreferences` (pure — `switch-to-te.rules.ts`)
+
+```ts
+export function buildPostSwitchPreferences(
+  prefs: CollectiviteReferentielPreferences,
+  populated: { populatedAt: string; populatedBy: string }
+): CollectiviteReferentielPreferences {
+  const archiveIfWrite = (p: ReferentielPreference): ReferentielPreference =>
+    p.mode === 'write' ? { mode: 'archived', display: false } : p;
+
+  return {
+    cae: archiveIfWrite(prefs.cae),
+    eci: archiveIfWrite(prefs.eci),
+    te: { mode: 'write', display: true, populatedFromCaeEci: populated },
+  };
+}
+```
+
+### 3) `SwitchToTeService.switchToTe` — orchestration
+
+Après les guards existants (permissions, flag, `ALREADY_SWITCHED`, `canSwitchToTe`, blockers), remplacer le `failure(SWITCH_NOT_IMPLEMENTED)` par une **transaction sources** puis un **recompute post-commit** :
+
+```ts
+const populatedAt = new Date().toISOString();
+
+// ── Transaction unique : données SOURCES (rollback total sur échec) ──
+const txResult = await this.transactionManager.executeSingle<
+  void,
+  SwitchToTeError
+>(async (tx) => {
+  // étape 1 : snapshots pre-switch-te (refs CAE/ECI en write)
+  const snapshotsResult =
+    await this.createPreSwitchSnapshotsService.createPreSwitchSnapshots(
+      collectiviteId, prefs, { user, tx });
+  if (!snapshotsResult.success) return snapshotsResult;
+
+  // étape 2 : migration données collectivité (te_*)
+  const migrateResult = await this.migrateCollectiviteDataService.migrate(
+    collectiviteId, prefs, snapshotsResult.data, { user, tx });
+  if (!migrateResult.success) return migrateResult;
+
+  // étape 3 : prefs + populatedFromCaeEci (en dernier de la tx)
+  const prefsResult = await this.collectiviteReferentielModeService
+    .updateReferentielPreferences(
+      collectiviteId,
+      buildPostSwitchPreferences(prefs, { populatedAt, populatedBy: user.id }),
+      tx);
+  if (!prefsResult.success) return prefsResult;
+
+  return success(undefined);
+});
+
+if (!txResult.success) return txResult; // rollback déjà effectué
+
+// ── Après COMMIT : projections reconstructibles (hors tx, best-effort) ──
+// Lit les données te_* committées, comme UpdateActionStatutService.upsertActionStatuts.
+const recomputeResult = await this.recomputeTeProjections(collectiviteId, user);
+if (!recomputeResult.success) {
+  // la bascule EST réussie (flag committé) ; projections régénérables → succès renvoyé
+  this.logger.error(
+    `Bascule TE ${collectiviteId} : recompute des projections échoué (réparable)`,
+    recomputeResult.cause?.stack
+  );
+}
+
+return success({ status: 'switched', populatedAt });
+```
+
+```ts
+private async recomputeTeProjections(collectiviteId: number, user: AuthUser) {
+  // étape 4 : score-courant TE
+  const courant = await this.snapshotsService.computeAndUpsert(
+    { collectiviteId, referentielId: ReferentielIdEnum.TE }, { user });
+  if (!courant.success) return failure(POST_SWITCH_RECOMPUTE_FAILED, courant.cause);
+
+  // étape 5 : snapshot post-switch-te
+  const post = await this.snapshotsService.computeAndUpsert(
+    { collectiviteId, referentielId: ReferentielIdEnum.TE,
+      ref: SNAPSHOTS.POST_SWITCH_TE_REF, jalon: SnapshotJalonEnum.POST_SWITCH_TE,
+      nom: SNAPSHOTS.POST_SWITCH_TE_NOM }, { user });
+  if (!post.success) return failure(POST_SWITCH_RECOMPUTE_FAILED, post.cause);
+
+  return success(undefined);
+}
+```
+
+Injecter dans le constructeur : `TransactionManager`, `CreatePreSwitchSnapshotsService`, `MigrateCollectiviteDataService`, `SnapshotsService`, `CollectiviteReferentielModeService` (tous déjà providers de `ReferentielsModule`).
+
+> **Note idempotence** : le recompute hors tx utilise `computeAndUpsert` **sans `tx`** → il lit l'état committé, comme le flux nominal. Aucun paramètre `tx` à ajouter au scoring.
+
+### 4) Output & router
+
+```ts
+// switch-to-te.output.ts
+export const switchToTeOutputSchema = z.object({
+  status: z.literal('switched'),
+  populatedAt: z.string(),
+});
+export type SwitchToTeOutput = z.infer<typeof switchToTeOutputSchema>;
+```
+
+Router inchangé (`getResultDataOrThrowError(result)`). Vérifier que le type de retour de `switchToTe` est bien `Result<SwitchToTeOutput, SwitchToTeError>`.
+
+---
+
+## Tests
+
+### E2e bascule complète — `switch-to-te.router.e2e-spec.ts` (+ éventuel `switch-to-te.service.e2e-spec.ts`)
+
+Réutiliser fixtures PR17b (`switch-to-te-context.test-fixture.ts` : `prefsEligibleCaeOnly`, `prefsEligibleCaeAndEci`, seeders statuts/commentaires/pilotes/services/liens fiches).
+
+| Scénario | Seed | Vérif DB |
+| --- | --- | --- |
+| Bascule nominale CAE seul | CT `prefsEligibleCaeOnly` + statuts/explications/pilotes/services/lien fiche sur `cae_*` | snapshot `pre-switch-te` sur `cae` ; données `te_*` migrées ; snapshot `score-courant` TE recalculé ; snapshot `post-switch-te` TE ; prefs → `cae: archived/display false`, `te: write/display true` + `populatedFromCaeEci` |
+| Fusion CAE+ECI | `prefsEligibleCaeAndEci` + statuts CAE+ECI sur mesure `teMesureCaeAndEci` | 2 snapshots `pre-switch-te` (cae+eci) ; statut TE fusionné N→1 ; `cae`+`eci` archivés |
+| Cohérence statut ↔ score | statuts mixtes source | `post-switch-te` cohérent avec `mergeStatuts` (arrondi 5 %) |
+| Idempotence | rejouer `switchToTe` après succès | `ALREADY_SWITCHED` ; aucune double écriture |
+| Rollback (migration) | forcer TE déjà peuplé (insert `te_*` avant) | `REFERENTIEL_TE_NOT_EMPTY` ; **aucun** snapshot `pre-switch-te` ; prefs **inchangées** ; `populatedFromCaeEci` absent |
+| Rollback (étape 3 prefs) | simuler échec `updateReferentielPreferences` | tout rollbacké (snapshots pre, données `te_*`) ; CT re-basculable |
+| Projections best-effort | simuler échec `computeAndUpsert` post-commit | **succès** renvoyé ; flag committé ; log `error` ; données `te_*` + prefs présentes ; `post-switch-te` absent (régénérable) |
+| Guards préservés | COT actif / audit en cours / lecture | erreurs PR8/PR9 inchangées, **hors** tx (aucun snapshot créé) |
+
+### Mise à jour tests existants
+
+Les 3 tests asseoyant `SWITCH_NOT_IMPLEMENTED` (« guards passent (squelette) », « audit validé et clos », « audit sur ref archived ») doivent désormais **asserter le succès** (`status: 'switched'` + effets DB), la bascule étant réellement exécutée.
+
+### Non-régression scoring
+
+Stratégie C = **aucune modification** de `ScoresService` / `ListActionStatutsRepository`. Le recompute réutilise `computeAndUpsert` tel quel (chemin déjà couvert par `upsertActionStatuts`). Pas de risque de régression scoring à couvrir spécifiquement.
+
+### Risque D — CT max charge
+
+E2e/bench sur la CT la plus chargée connue (1377 statuts CAE) : mesurer la durée `migrate` + recalculs + écritures ; **assert < `statement_timeout` (30 s)**. Documenter la durée observée dans la PR.
+
+```bash
+pnpm test:backend switch-to-te
+```
+
+---
+
+## Hors scope
+
+- UI bascule : CTA + états disabled (PR19), modale irréversible (PR20).
+- Masquage questions/personnalisations legacy (PR21).
+- UI snapshots post-bascule + masquage « Figer l'état des lieux » (PR22).
+- Export score-comparaison personnalisations (PR23).
+- Suppression des données CAE/ECI (hors périmètre PRD — archivage seul).
+- Chunking des inserts (réévalué seulement si le bench risque D dépasse le timeout).
+- Recalcul service-role de `pre-switch-te` (capacité ops, hors scope produit).
+
+---
+
+## Décisions tranchées (revue)
+
+- **Échec du recompute post-commit → succès silencieux** *(tranché)*. `switchToTe` renvoie `{ status: 'switched' }` même si le recompute des projections échoue ; l'erreur est loggée en `error` (Sentry). Motif : la bascule est réussie (flag + données committés), les projections sont régénérables (1re saisie TE ou `forceRecompute`). Un champ optionnel `projectionsPending` pourra être ajouté sans casser le contrat si l'UX PR19 le justifie.
+- **Micro-fenêtre `post-switch-te` → acceptée** *(tranché)*. Variante simple conservée (flag dans la tx, projections recomputées après commit). La fenêtre (~1 s, après une action de bascule volontaire) où une saisie TE pourrait précéder le figement de `post-switch-te` est jugée négligeable. Pas de variante 3-phases (éviterait la fenêtre au prix d'une double tx + garde d'idempotence basée sur le flag + chemin de reprise).
+- **Amendement PRD → dans la PR18** *(tranché)*. La mise à jour du PRD ([Flux de bascule](2026-06-11-001-feat-bascule-referentiel-te-prd.md#flux-de-bascule) + section/table PR18) voyage avec le code, pour une revue conjointe décision + implémentation. Pas de PR de doc séparée.
+
+## Critères de done
+
+- [ ] `switchToTe` : transaction unique sur les **données sources** (1→3, `populatedFromCaeEci` en dernier de la tx) ; recompute des projections **hors tx** (4→5). Rollback total des sources validé en e2e.
+- [ ] `score-courant` TE + `post-switch-te` créés post-commit ; échec best-effort validé en e2e (succès renvoyé, log).
+- [ ] Prefs post-bascule correctes (`buildPostSwitchPreferences` + tests unitaires) ; invariant `archived ⇒ display false`.
+- [ ] `SWITCH_NOT_IMPLEMENTED` retiré ; `POST_SWITCH_RECOMPUTE_FAILED` ajouté ; output succès ; endpoint **exposé prod**.
+- [ ] E2e bascule complète (nominale, fusion, idempotence, rollback, projection best-effort) verts ; tests squelette migrés.
+- [ ] **Aucune** modification de `ScoresService` / `ListActionStatutsRepository`.
+- [ ] Bench CT max charge documenté (tx < `statement_timeout`).
+- [ ] PRD amendé (Flux de bascule : tx sources + projections hors tx).
+
+---
+
+## Suite (PR19+)
+
+| PR | Suite |
+| --- | --- |
+| PR19–PR20 | UI bascule (CTA + états disabled ; modale irréversible) |
+| PR21 | Masquage questions / personnalisations legacy |
+| PR22 | UI snapshots post-bascule |
+| PR23 | Export score-comparaison : feuille personnalisations |

--- a/doc/plans/2026-06-11-013-feat-bascule-referentiel-te-pr18-plan.md
+++ b/doc/plans/2026-06-11-013-feat-bascule-referentiel-te-pr18-plan.md
@@ -1,0 +1,373 @@
+---
+name: PR18 Bascule bout-en-bout
+overview: "Câbler switchToTe() de bout en bout : transaction atomique sur les données sources (createPreSwitchSnapshots → migrate → prefs + populatedFromCaeEci), puis recompute du snapshot post-switch-te hors tx, à la manière de upsertActionStatuts. Le score-courant TE n'est pas recalculé ici : self-healing au premier SnapshotsService.get(). Un rappel de switchToTe sur une CT déjà basculée répare le snapshot post-switch-te s'il est manquant. Retirer SWITCH_NOT_IMPLEMENTED et exposer l'endpoint en prod."
+todos:
+  - id: post-switch-constants
+    content: "Constantes POST_SWITCH_TE_REF / POST_SWITCH_TE_NOM (snapshots.constants.ts) + case getDefaultSnapshotMetadata"
+    status: pending
+  - id: post-switch-prefs-rule
+    content: "buildPostSwitchPreferences(prefs, {populatedAt, populatedBy}) pure + tests unitaires"
+    status: pending
+  - id: switch-service-orchestration
+    content: "SwitchToTeService.switchToTe : transaction unique, ordre strict, retrait SWITCH_NOT_IMPLEMENTED"
+    status: pending
+  - id: success-output
+    content: "switch-to-te.output.ts : schéma succès + adaptation router"
+    status: pending
+  - id: errors
+    content: "Erreur typée POST_SWITCH_RECOMPUTE_FAILED (projections post-commit) + retrait SWITCH_NOT_IMPLEMENTED"
+    status: pending
+  - id: e2e-full-switch
+    content: "E2e bascule complète (snapshots pre/post, données migrées, scores, prefs, idempotence, rollback)"
+    status: pending
+  - id: e2e-existing-update
+    content: "Mettre à jour switch-to-te.router.e2e-spec.ts (tests SWITCH_NOT_IMPLEMENTED → succès)"
+    status: pending
+  - id: heavy-ct-bench
+    content: "E2e/bench CT max charge (1377 statuts CAE) — durée transaction < statement_timeout (risque D)"
+    status: pending
+isProject: false
+---
+
+# PR18 — Bascule bout-en-bout (`switchToTe`)
+
+**Parent** : [doc/plans/2026-06-11-001-feat-bascule-referentiel-te-prd.md](2026-06-11-001-feat-bascule-referentiel-te-prd.md)
+
+**Prérequis** : PR8 (squelette + guards permissions/idempotence), PR9 (guards COT/demande/audit), PR10 (`CreatePreSwitchSnapshotsService`), PR17b ([`MigrateCollectiviteDataService`](2026-06-11-012-feat-bascule-referentiel-te-pr17b-plan.md)) — tous mergés.
+
+**Branche** : `TE-7303/switch-te-PR18` depuis `main`
+
+**Estimation** : ~500 LOC (code + tests). *Orchestration (tx données sources + recompute hors tx) + prefs + output + e2e.* Tolérance ~650 LOC (PRD — bascule transactionnelle).
+
+**Prod** : **Oui (endpoint)** — première PR qui **expose `referentiels.switchToTe` en prod** et rend la bascule utilisateur possible.
+
+---
+
+## Contexte
+
+Jusqu'à PR17b, tous les blocs de la bascule existent isolément mais `switchToTe()` retourne `SWITCH_NOT_IMPLEMENTED` après les guards. PR18 est la PR d'**assemblage** : elle branche les services, puis retire le garde `SWITCH_NOT_IMPLEMENTED` et expose l'endpoint.
+
+**Décision d'architecture** (cf. § Point technique central) : la bascule sépare **écritures sources** (atomiques, en transaction) et **projection** (`post-switch-te`, recomputée **hors tx** après commit). Ce découpage suit le **précédent établi** du codebase : `UpdateActionStatutService.upsertActionStatuts` écrit les statuts en tx, puis appelle `snapshotsService.computeAndUpsert` **hors tx** une fois committé. Le score-courant TE n'entre pas dans ce recompute post-commit : il est régénéré par le **self-healing générique** de `SnapshotsService.get()` (déjà utilisé par `upsertActionStatuts` et `onPersonnalisationResponseSaved`) au premier accès en lecture, un calcul explicite ici serait redondant. *(Affiné post-implémentation — le plan initial prévoyait aussi un recalcul explicite du score-courant à cette étape ; cf. § Décisions tranchées.)*
+
+**Delta vs PR17b** : orchestration ; snapshot `post-switch-te` recomputé hors tx (+ réparation retentée si un rappel de `switchToTe` le trouve manquant) ; mise à jour `preferences.referentiels` + `te.populatedFromCaeEci` ; archivage des refs CAE/ECI en `write` ; exposition prod + output de succès.
+
+```mermaid
+sequenceDiagram
+  participant Svc as SwitchToTeService
+  participant TxM as TransactionManager
+  participant Snap as CreatePreSwitchSnapshotsService
+  participant Mig as MigrateCollectiviteDataService
+  participant Prefs as CollectiviteReferentielModeService
+  participant Sc as SnapshotsService
+
+  Svc->>Svc: guards (permissions, flag, idempotence, éligibilité, COT/audit) — HORS tx
+  rect rgba(200,230,255,0.4)
+    Note over TxM,Prefs: Transaction unique — données SOURCES (rollback total)
+    Svc->>TxM: executeSingle(async tx => …)
+    TxM->>Snap: createPreSwitchSnapshots(prefs, {user, tx})  1
+    Snap-->>TxM: ScoreSnapshot[] (refs CAE/ECI en write)
+    TxM->>Mig: migrate(collId, prefs, preSwitchSnapshots, {user, tx})  2
+    TxM->>Prefs: updateReferentielPreferences(buildPostSwitchPreferences(…), tx)  3
+  end
+  Note over Svc,Sc: Après COMMIT — snapshot post-switch-te reconstructible (hors tx)
+  Svc->>Svc: recomputeSnapshotPostSwitchTe(collectiviteId, user)
+  Svc->>Sc: computeAndUpsert(te, jalon: post-switch-te, {user})  4
+  Svc->>Svc: Result<void, SwitchToTeError>
+  Svc-->>Svc: success({status: 'switched', populatedAt})
+  Note over Svc,Sc: score-courant TE non recalculé ici : self-healing générique<br/>au 1er SnapshotsService.get() (comme upsertActionStatuts)
+```
+
+Si `switchToTe` est rappelé sur une CT où `populatedFromCaeEci` est déjà posé, le service ne renvoie pas `ALREADY_SWITCHED` à l'aveugle : il vérifie d'abord la présence du snapshot `post-switch-te` (`SnapshotsService.get(..., POST_SWITCH_TE_REF)`, sans effet de bord pour ce ref) — présent → `ALREADY_SWITCHED` ; absent (échec du recompute précédent) → **réparation** : retente `recomputeSnapshotPostSwitchTe` et renvoie `switched` si ça aboutit, ou `POST_SWITCH_RECOMPUTE_FAILED` (cette fois renvoyée à l'appelant) si ça échoue encore.
+
+Échec des étapes 1→3 → la transaction retourne un `Result` en échec, propagé tel quel par `SwitchToTeService.switchToTe` (`if (!txResult.success) return txResult`) ; le rollback lui-même est assuré par le mécanisme existant de `TransactionManager.executeTransaction` (rollback total Drizzle) → `te.populatedFromCaeEci` **jamais** écrit partiellement, données `te_*` non persistées. Échec de l'étape 4 (post-commit, capté par `recomputeSnapshotPostSwitchTe` qui renvoie `Result<void, SwitchToTeError>`) → CT basculée (sources cohérentes) mais snapshot manquant → **best-effort au 1er appel** : `switchToTe` logge l'erreur et renvoie tout de même un succès ; réparation via un nouvel appel à `switchToTe` (cf. § Projections hors transaction).
+
+---
+
+## Décisions actées
+
+**Hérite PR8–PR17b** : `Result<…, SwitchToTeError>` (ADR 0012) ; guards **avant** la transaction ; `preSwitchSnapshots` **injectés en mémoire** dans `migrate` (pas de re-read) ; garde TE vide dans `migrate` ; pas de suppression des données CAE/ECI (archivage via prefs).
+
+| Sujet | Décision |
+| --- | --- |
+| Orchestration | **Transaction unique sur les données sources** via `transactionManager.executeSingle(async (tx) => { … })` (étapes 1→3), **puis recompute du snapshot post-switch-te hors tx** (étape 4). Guards de permission inchangés, **avant** la tx (lectures read-only) ; le guard d'idempotence (`populatedFromCaeEci`) est affiné pour déclencher une réparation plutôt qu'un simple refus (cf. ligne « Réparation »). |
+| Ordre | 1 `createPreSwitchSnapshots(tx)` → 2 `migrate(tx)` → 3 prefs + `populatedFromCaeEci` (`tx`, **en dernier de la tx**) → **commit** → 4 snapshot `post-switch-te` (hors tx). Le score-courant TE n'est **pas** recalculé dans cette séquence — self-healing générique au 1er `SnapshotsService.get()`. |
+| Découpage tx / hors-tx | Suit le précédent `UpdateActionStatutService.upsertActionStatuts` : les statuts s'écrivent en tx, `computeAndUpsert` recompute **après commit**. Le snapshot `post-switch-te` est **reconstructible** depuis `te_*` + personnalisation → pas besoin d'atomicité stricte. |
+| Recalcul scores | `SnapshotsService.computeAndUpsert` **sans `tx`** (lit les données committées, comme le flux nominal), orchestré par `SwitchToTeService.recomputeSnapshotPostSwitchTe` qui renvoie `Result<void, SwitchToTeError>` : `computeAndUpsert({ collectiviteId, referentielId: te, jalon: POST_SWITCH_TE }, { user })` — **pas de `ref`/`nom`** : déduits du jalon par `getDefaultSnapshotMetadata`. **Aucune modification du scoring** (`computeScoreForCollectivite` inchangé). Pas d'écriture directe `client_scores` (PRD). Le score-courant TE (jalon `COURANT`) n'est **pas** recalculé ici : `SnapshotsService.get()` l'auto-crée au premier accès en lecture si absent — calcul explicite redondant, retiré post-implémentation (cf. § Décisions tranchées). |
+| Réparation | Si `switchToTe` est rappelé sur une CT déjà `populatedFromCaeEci` mais dont le snapshot `post-switch-te` est absent (échec du recompute best-effort précédent), le recompute est **retenté** (upsert idempotent sur la PK `(collectivite_id, referentiel_id, ref)`) au lieu de renvoyer directement `ALREADY_SWITCHED`. Contrairement au 1er appel, un échec de ce retry est renvoyé à l'appelant (`POST_SWITCH_RECOMPUTE_FAILED`) plutôt que loggué en silence — rend concret le caractère « réparable » du best-effort. *(Ajouté post-implémentation.)* |
+| `post-switch-te` | `ref: 'post-switch-te'`, `jalon: post_switch_te`, `nom: 'État initial Climat Ressources'` — ajouter `POST_SWITCH_TE_REF` / `POST_SWITCH_TE_NOM` dans `snapshots.constants.ts` + case dédié dans `getDefaultSnapshotMetadata` (jalon système non éditable, comme `pre_audit`). |
+| Archivage refs | `buildPostSwitchPreferences` (pure) : refs CAE/ECI en `mode: write` → `{ mode: archived, display: false }` ; refs déjà `archived` inchangées ; `te` → `{ mode: write, display: true, populatedFromCaeEci: { populatedAt, populatedBy: user.id } }`. Invariant Zod `archived ⇒ display: false` respecté. |
+| Persistance prefs | `CollectiviteReferentielModeService.updateReferentielPreferences(collectiviteId, referentiels, tx)` — étape 3, `tx` propagé. |
+| Idempotence | Garde `te.populatedFromCaeEci` (PR8) **avant** tx ; écrit **en dernier de la transaction source**. Un rollback des étapes 1→3 laisse la CT re-basculable. Affinée post-implémentation : ne se contente plus de refuser (`ALREADY_SWITCHED`), voir ligne « Réparation ». |
+| Retrait squelette | Supprimer `return failure(SWITCH_NOT_IMPLEMENTED)` ; **supprimer** l'erreur `SWITCH_NOT_IMPLEMENTED` de `switch-to-te.errors.ts` (plus référencée) une fois les tests migrés. |
+| Output | `switch-to-te.output.ts` : schéma succès `{ status: 'switched', populatedAt: string }` (remplace `not_implemented`). Router : passe le `Result` par `getResultDataOrThrowError` (inchangé). |
+| Erreurs | Ajouter `POST_SWITCH_RECOMPUTE_FAILED` (`INTERNAL_SERVER_ERROR`, échec du recompute post-commit — au 1er appel comme lors d'une réparation) dans `switch-to-te.errors.ts`. Réutiliser `PRE_SWITCH_SNAPSHOT_FAILED` / `MIGRATION_FAILED` existants. Pas d'erreur `PREFERENCES_UPDATE_FAILED` dédiée : `updateReferentielPreferences` renvoie déjà un `Result` typé propagé tel quel. |
+| Timeout | **Réduit** vs « tout en tx » : la transaction ne contient que les écritures (pas le recompute). Risque **accepté** (PRD risque D) ; validé par e2e sur CT max charge (cf. Tests). |
+
+---
+
+## Point technique central — pourquoi le recompute est hors transaction
+
+**Contrainte** : `SnapshotsService.computeAndUpsert` **écrit** avec `tx`, mais délègue le **calcul** à `ScoresService.computeScoreForCollectivite`, qui lit `action_statut` via `ListActionStatutsRepository.listByActionIds` sur `this.databaseService.db` (**pool, hors transaction**). Un recompute exécuté *dans* la tx de bascule ne verrait donc **pas** les statuts `te_*` migrés non commités (isolation PostgreSQL).
+
+**Deux options envisagées :**
+
+| Option | Description | Verdict |
+| --- | --- | --- |
+| **A — tx-aware ciblé** | Threader `tx?` dans `computeScoreForCollectivite` + `listByActionIds` (+ explications) pour tout exécuter en une seule tx | **Écartée** : touche le **cœur du scoring** (chemin partagé) ; allonge la tx → **risque timeout** accru sur CT max charge ; nécessite aussi de rendre les explications `tx`-aware pour un `post-switch-te` complet ; va **à contre-courant du pattern codebase** |
+| **C — write atomique + projection hors tx** *(retenue)* | Écritures sources en tx ; `computeAndUpsert` (post-switch-te) **après commit**, exactement comme `upsertActionStatuts` | **Retenue** : **zéro modification du scoring** ; **transaction courte** (timeout réduit) ; **cohérente** avec le précédent du codebase ; atomicité garantie sur les **données sources** |
+
+**Justification du choix C** : le point clé est que `post-switch-te` est une **projection reconstructible** (dérivée de `te_*` + personnalisation), pas une donnée source. Le seul périmètre nécessitant l'atomicité — snapshots `pre-switch-te`, données `te_*`, `prefs + populatedFromCaeEci` — est protégé par la transaction. Reproduire le pattern `upsertActionStatuts` (recompute post-commit) est plus sûr (aucune régression scoring), plus rapide (tx courte) et cohérent avec l'existant. Le score-courant TE, lui, n'est même plus recalculé à cette étape (self-healing, cf. plus haut) — il n'entre donc pas dans ce périmètre.
+
+**Compromis assumé** : si le recompute post-commit (étape 4) échoue, la CT est **basculée** (données sources cohérentes) mais sans `post-switch-te` — cf. § Projections hors transaction pour le mécanisme de réparation.
+
+> **Divergence PRD** : le PRD ([Flux de bascule](2026-06-11-001-feat-bascule-referentiel-te-prd.md#flux-de-bascule)) place le recompute (étape 3) et `post-switch-te` (étape 4) *dans* la transaction unique. La Stratégie C impose d'**amender le PRD** pour distinguer « transaction atomique sur les données sources » et « recompute du snapshot post-switch-te hors tx (pattern `upsertActionStatuts`) ». Amendement à porter dans la même PR.
+
+## Projections hors transaction — robustesse
+
+- **Ordre** : le flag `populatedFromCaeEci` est écrit **dans la tx source** (étape 3), donc cohérent avec les données `te_*`. La bascule est considérée réussie dès le commit.
+- **Échec étape 4** (post-commit, 1er appel) : renvoyer `failure(POST_SWITCH_RECOMPUTE_FAILED)` **n'annule pas** la bascule (le flag est déjà committé). Choix tranché : logger l'erreur en `error` (Sentry) et **retourner tout de même un succès** à l'appelant, le snapshot étant reconstructible.
+- **Reconstruction** :
+  - `score-courant` TE : self-healing **générique**, indépendant de la bascule — `SnapshotsService.get()` le recrée automatiquement au 1er accès en lecture si absent (dashboard, `upsertActionStatuts`, etc.), sans effet de bord destructeur.
+  - `post-switch-te` : pas d'équivalent self-healing (jalon historique figé, pas de branche dédiée dans `SnapshotsService.get()`). Sa réparation passe par un **nouvel appel à `switchToTe`** sur la même CT : le service détecte que `populatedFromCaeEci` est déjà posé, vérifie via `get(..., POST_SWITCH_TE_REF)` (sans effet de bord) que le snapshot manque, puis retente `recomputeSnapshotPostSwitchTe` — upsert idempotent, aucun risque de doublon. Si ce 2e essai échoue aussi, l'erreur est cette fois renvoyée à l'appelant. *(`forceRecompute` — capacité ops mentionnée dans une version antérieure de ce plan et dans le PRD — ne convient **pas** à ce cas : il exige que le snapshot existe déjà, `SNAPSHOT_NOT_FOUND` sinon ; il rafraîchit un snapshot existant, il n'en crée pas un manquant.)*
+- **Micro-fenêtre** : entre le commit (TE devient `write`) et le figement de `post-switch-te`, une saisie TE concurrente pourrait polluer l'état figé. Fenêtre de l'ordre de la seconde, jugée **négligeable**. Pas de variante 3-phases retenue (flag écrit *après* le recompute) — cf. § Décisions tranchées.
+
+---
+
+## Ordre d'implémentation
+
+1. **`snapshots.constants.ts`** — `POST_SWITCH_TE_REF` / `POST_SWITCH_TE_NOM` + case `getDefaultSnapshotMetadata`.
+2. **`switch-to-te.rules.ts`** — `buildPostSwitchPreferences` (pure) + tests `switch-to-te.rules.spec.ts`.
+3. **`switch-to-te.errors.ts`** — `POST_SWITCH_RECOMPUTE_FAILED` ; retrait `SWITCH_NOT_IMPLEMENTED` (après migration des tests).
+4. **`switch-to-te.output.ts`** — schéma succès.
+5. **`switch-to-te.service.ts`** — orchestration (tx sources + recompute hors tx).
+6. **`switch-to-te.router.ts`** — inchangé (vérifier type output).
+7. **PRD** — amender [Flux de bascule](2026-06-11-001-feat-bascule-referentiel-te-prd.md#flux-de-bascule) (tx sources + snapshot post-switch-te hors tx).
+8. **E2e** — bascule complète + mise à jour des tests squelette.
+
+*Aucune modification de `ScoresService` / `ListActionStatutsRepository` (Stratégie C).*
+
+---
+
+## Implémentation
+
+### 1) Constantes & métadonnées snapshot
+
+```ts
+// snapshots.constants.ts
+POST_SWITCH_TE_REF: 'post-switch-te',
+POST_SWITCH_TE_NOM: 'État initial Climat Ressources',
+```
+
+`getDefaultSnapshotMetadata` : ajouter le case `SnapshotJalonEnum.POST_SWITCH_TE` → `{ ref: POST_SWITCH_TE_REF, nom: POST_SWITCH_TE_NOM }` (miroir du case `PRE_SWITCH_TE` livré en PR10).
+
+### 2) `buildPostSwitchPreferences` (pure — `switch-to-te.rules.ts`)
+
+```ts
+export function buildPostSwitchPreferences(
+  prefs: CollectiviteReferentielPreferences,
+  populated: { populatedAt: string; populatedBy: string }
+): CollectiviteReferentielPreferences {
+  const archiveIfWrite = (p: ReferentielPreference): ReferentielPreference =>
+    p.mode === 'write' ? { mode: 'archived', display: false } : p;
+
+  return {
+    cae: archiveIfWrite(prefs.cae),
+    eci: archiveIfWrite(prefs.eci),
+    te: { mode: 'write', display: true, populatedFromCaeEci: populated },
+  };
+}
+```
+
+### 3) `SwitchToTeService.switchToTe` — orchestration
+
+*(Code ci-dessous conforme à l'implémentation finale — affiné post-implémentation, cf. § Décisions tranchées : suppression du recalcul explicite du score-courant, ajout de la réparation sur rappel.)*
+
+Après les guards de permission, remplacer le `failure(SWITCH_NOT_IMPLEMENTED)` par le guard `populatedFromCaeEci` (idempotence **et** réparation), puis, si non basculée : `canSwitchToTe`, blockers, **transaction sources**, **recompute post-commit** :
+
+```ts
+if (prefs.te.populatedFromCaeEci) {
+  // déjà basculé : le snapshot post-switch-te existe-t-il ? get() sans effet
+  // de bord pour ce ref (pas de self-healing hors jalon COURANT). S'il manque
+  // (échec précédent du recompute best-effort), on répare au lieu de bloquer
+  // indéfiniment sur ALREADY_SWITCHED.
+  const existingPostSwitch = await this.snapshotsService.get(
+    collectiviteId, ReferentielIdEnum.TE, SNAPSHOTS.POST_SWITCH_TE_REF, { user });
+  if (existingPostSwitch.success) {
+    return failure(SwitchToTeErrorEnum.ALREADY_SWITCHED);
+  }
+
+  const repairResult = await this.recomputeSnapshotPostSwitchTe(collectiviteId, user);
+  if (!repairResult.success) {
+    // contrairement au best-effort du premier appel, on renvoie l'échec ici :
+    // pas de raison de masquer un 2e échec à l'appelant.
+    this.logger.error(
+      `Bascule TE collectivite=${collectiviteId} : réparation du snapshot post-switch-te échouée`,
+      repairResult.cause?.stack
+    );
+    return failure(SwitchToTeErrorEnum.POST_SWITCH_RECOMPUTE_FAILED, repairResult.cause);
+  }
+
+  return success({
+    status: 'switched',
+    populatedAt: prefs.te.populatedFromCaeEci.populatedAt,
+  });
+}
+
+// … canSwitchToTe, blockers (inchangés) …
+
+const populatedAt = new Date().toISOString();
+
+// ── Transaction unique : données SOURCES (rollback total sur échec) ──
+const txResult = await this.transactionManager.executeSingle<
+  void,
+  SwitchToTeError
+>(async (tx) => {
+  // étape 1 : snapshots pre-switch-te (refs CAE/ECI en write)
+  const snapshotsResult =
+    await this.createPreSwitchSnapshotsService.createPreSwitchSnapshots(
+      collectiviteId, prefs, { user, tx });
+  if (!snapshotsResult.success) return snapshotsResult;
+
+  // étape 2 : migration données collectivité (te_*)
+  const migrateResult = await this.migrateCollectiviteDataService.migrate(
+    collectiviteId, prefs, snapshotsResult.data, { user, tx });
+  if (!migrateResult.success) return migrateResult;
+
+  // étape 3 : prefs + populatedFromCaeEci (en dernier de la tx)
+  const prefsResult = await this.collectiviteReferentielModeService
+    .updateReferentielPreferences(
+      collectiviteId,
+      buildPostSwitchPreferences(prefs, { populatedAt, populatedBy: user.id }),
+      tx);
+  if (!prefsResult.success) return prefsResult;
+
+  return success(undefined);
+});
+
+if (!txResult.success) return txResult; // rollback déjà effectué
+
+// ── Après COMMIT : snapshot post-switch-te (hors tx, best-effort) ──
+// Lit les données te_* committées, comme UpdateActionStatutService.upsertActionStatuts.
+const recomputeResult = await this.recomputeSnapshotPostSwitchTe(collectiviteId, user);
+if (!recomputeResult.success) {
+  // la bascule EST réussie (flag committé) ; snapshot régénérable — un nouvel
+  // appel à switchToTe retentera ce calcul (voir le guard plus haut).
+  this.logger.error(
+    `Bascule TE collectivite=${collectiviteId} : recompute du snapshot post-switch-te échoué (réparable)`,
+    recomputeResult.cause?.stack
+  );
+}
+
+return success({ status: 'switched', populatedAt });
+```
+
+```ts
+// étape 4 : snapshot post-switch-te — ref/nom déduits du jalon
+// (getDefaultSnapshotMetadata), pas transmis ici. Le score-courant TE n'est
+// PAS recalculé ici : self-healing au 1er accès en lecture via
+// SnapshotsService.get() (déjà utilisé ailleurs, ex. UpdateActionStatutService).
+private async recomputeSnapshotPostSwitchTe(collectiviteId: number, user: AuthUser) {
+  const post = await this.snapshotsService.computeAndUpsert(
+    { collectiviteId, referentielId: ReferentielIdEnum.TE,
+      jalon: SnapshotJalonEnum.POST_SWITCH_TE }, { user });
+  if (!post.success) return failure(POST_SWITCH_RECOMPUTE_FAILED, post.cause);
+
+  return success(undefined);
+}
+```
+
+Injecter dans le constructeur : `TransactionManager`, `CreatePreSwitchSnapshotsService`, `MigrateCollectiviteDataService`, `SnapshotsService`, `CollectiviteReferentielModeService` (tous déjà providers de `ReferentielsModule`).
+
+> **Note idempotence** : le recompute hors tx utilise `computeAndUpsert` **sans `tx`** → il lit l'état committé, comme le flux nominal. Aucun paramètre `tx` à ajouter au scoring.
+
+### 4) Output & router
+
+```ts
+// switch-to-te.output.ts
+export const switchToTeOutputSchema = z.object({
+  status: z.literal('switched'),
+  populatedAt: z.string(),
+});
+export type SwitchToTeOutput = z.infer<typeof switchToTeOutputSchema>;
+```
+
+Router inchangé (`getResultDataOrThrowError(result)`). Vérifier que le type de retour de `switchToTe` est bien `Result<SwitchToTeOutput, SwitchToTeError>`.
+
+---
+
+## Tests
+
+### E2e bascule complète — `switch-to-te.router.e2e-spec.ts` (+ éventuel `switch-to-te.service.e2e-spec.ts`)
+
+Réutiliser fixtures PR17b (`switch-to-te-context.test-fixture.ts` : `prefsEligibleCaeOnly`, `prefsEligibleCaeAndEci`, seeders statuts/commentaires/pilotes/services/liens fiches).
+
+| Scénario | Seed | Vérif DB |
+| --- | --- | --- |
+| Bascule nominale CAE seul | CT `prefsEligibleCaeOnly` + statuts/explications/pilotes/services/lien fiche sur `cae_*` | snapshot `pre-switch-te` sur `cae` ; données `te_*` migrées ; snapshot `post-switch-te` TE ; score-courant TE **absent** juste après (un `get()` le recrée par self-healing, vérifié directement) ; prefs → `cae: archived/display false`, `te: write/display true` + `populatedFromCaeEci` |
+| Fusion CAE+ECI | `prefsEligibleCaeAndEci` + statuts CAE+ECI sur mesure `teMesureCaeAndEci` | 2 snapshots `pre-switch-te` (cae+eci) ; statut TE fusionné N→1 ; `cae`+`eci` archivés |
+| Cohérence statut ↔ score | statuts mixtes source | `post-switch-te` cohérent avec `mergeStatuts` (arrondi 5 %) |
+| Idempotence (snapshot présent) | rejouer `switchToTe` après succès, snapshot post-switch-te présent | `ALREADY_SWITCHED` ; aucune double écriture |
+| Réparation (snapshot manquant) | CT déjà `populatedFromCaeEci` mais snapshot `post-switch-te` absent (échec best-effort simulé) | rappel de `switchToTe` retourne `switched` (pas `ALREADY_SWITCHED`) ; snapshot `post-switch-te` créé |
+| Rollback (migration) | forcer TE déjà peuplé (insert `te_*` avant) | `REFERENTIEL_TE_NOT_EMPTY` ; **aucun** snapshot `pre-switch-te` ; prefs **inchangées** ; `populatedFromCaeEci` absent |
+| Rollback (étape 3 prefs) | simuler échec `updateReferentielPreferences` | tout rollbacké (snapshots pre, données `te_*`) ; CT re-basculable |
+| Projection best-effort | simuler échec `computeAndUpsert` post-commit (1er appel) | **succès** renvoyé ; flag committé ; log `error` ; données `te_*` + prefs présentes ; `post-switch-te` absent (régénérable via un nouvel appel à `switchToTe`, cf. scénario Réparation) |
+| Guards préservés | COT actif / audit en cours / lecture | erreurs PR8/PR9 inchangées, **hors** tx (aucun snapshot créé) |
+
+### Mise à jour tests existants
+
+Les 3 tests asseoyant `SWITCH_NOT_IMPLEMENTED` (« guards passent (squelette) », « audit validé et clos », « audit sur ref archived ») doivent désormais **asserter le succès** (`status: 'switched'` + effets DB), la bascule étant réellement exécutée.
+
+### Non-régression scoring
+
+Stratégie C = **aucune modification** de `ScoresService` / `ListActionStatutsRepository`. Le recompute réutilise `computeAndUpsert` tel quel (chemin déjà couvert par `upsertActionStatuts`). Pas de risque de régression scoring à couvrir spécifiquement.
+
+### Risque D — CT max charge
+
+E2e/bench sur la CT la plus chargée connue (1377 statuts CAE) : mesurer la durée `migrate` + recalculs + écritures ; **assert < `statement_timeout` (30 s)**. Documenter la durée observée dans la PR.
+
+```bash
+pnpm test:backend switch-to-te
+```
+
+---
+
+## Hors scope
+
+- UI bascule : CTA + états disabled (PR19), modale irréversible (PR20).
+- Masquage questions/personnalisations legacy (PR21).
+- UI snapshots post-bascule + masquage « Figer l'état des lieux » (PR22).
+- Export score-comparaison personnalisations (PR23).
+- Suppression des données CAE/ECI (hors périmètre PRD — archivage seul).
+- Chunking des inserts (réévalué seulement si le bench risque D dépasse le timeout).
+- Recalcul service-role de `pre-switch-te` (capacité ops, hors scope produit).
+
+---
+
+## Décisions tranchées (revue)
+
+- **Échec du recompute post-commit → succès silencieux au 1er appel, erreur explicite en cas de nouvelle tentative** *(tranché, affiné post-implémentation)*. Au 1er appel, `switchToTe` renvoie `{ status: 'switched' }` même si le recompute du snapshot post-switch-te échoue ; l'erreur est loggée en `error` (Sentry). Motif : la bascule est réussie (flag + données committés), le snapshot est régénérable. **Affinement** : un rappel ultérieur de `switchToTe` sur cette CT ne renvoie plus `ALREADY_SWITCHED` à l'aveugle — il vérifie la présence du snapshot `post-switch-te` (`get()`, sans effet de bord) et, s'il manque, retente le recompute (upsert idempotent sur la PK `(collectivite_id, referentiel_id, ref)`, sans effet destructeur). Si ce 2e essai échoue aussi, l'échec est cette fois **renvoyé à l'appelant** (`POST_SWITCH_RECOMPUTE_FAILED`) plutôt que masqué — sans quoi la CT resterait indéfiniment bloquée sans aucun moyen de réparation. *(`forceRecompute`, envisagé initialement comme voie de régénération, ne convient pas : il exige un snapshot préexistant.)*
+- **Score-courant TE non recalculé en post-commit → suppression de l'étape dédiée** *(affiné post-implémentation)*. `SnapshotsService.get()` auto-crée le score-courant au premier accès s'il est absent (self-healing déjà utilisé ailleurs dans le codebase, ex. `UpdateActionStatutService.upsertActionStatuts`, `onPersonnalisationResponseSaved`). Le calcul explicite prévu initialement (étape 4 du plan d'origine) était donc redondant ; il a été retiré pour simplifier `recomputeTeProjections` (renommé `recomputeSnapshotPostSwitchTe`, qui ne gère plus que le snapshot `post-switch-te`). Trade-off assumé : un échec de calcul du score-courant remonte désormais au premier accès utilisateur plutôt que d'être absorbé en best-effort au moment de la bascule — jugé acceptable car c'est le comportement standard de `get()` pour toute collectivité, bascule ou non.
+- **Micro-fenêtre `post-switch-te` → acceptée** *(tranché)*. Variante simple conservée (flag dans la tx, projection recomputée après commit). La fenêtre (~1 s, après une action de bascule volontaire) où une saisie TE pourrait précéder le figement de `post-switch-te` est jugée négligeable. Pas de variante 3-phases (éviterait la fenêtre au prix d'une double tx + garde d'idempotence basée sur le flag + chemin de reprise).
+- **Amendement PRD → dans la PR18** *(tranché)*. La mise à jour du PRD ([Flux de bascule](2026-06-11-001-feat-bascule-referentiel-te-prd.md#flux-de-bascule) + section/table PR18) voyage avec le code, pour une revue conjointe décision + implémentation. Pas de PR de doc séparée.
+
+## Critères de done
+
+- [ ] `switchToTe` : transaction unique sur les **données sources** (1→3, `populatedFromCaeEci` en dernier de la tx) ; recompute du snapshot `post-switch-te` **hors tx** (étape 4). Rollback total des sources validé en e2e.
+- [ ] `post-switch-te` créé post-commit (best-effort au 1er appel) ; score-courant TE **non** recalculé ici (self-healing générique de `SnapshotsService.get()`) ; échec du recompute validé en e2e (1er appel : succès renvoyé + log ; rappel ultérieur : réparation retentée, erreur renvoyée si échec persistant).
+- [ ] Prefs post-bascule correctes (`buildPostSwitchPreferences` + tests unitaires) ; invariant `archived ⇒ display false`.
+- [ ] `SWITCH_NOT_IMPLEMENTED` retiré ; `POST_SWITCH_RECOMPUTE_FAILED` ajouté ; output succès ; endpoint **exposé prod**.
+- [ ] E2e bascule complète (nominale, fusion, idempotence, réparation, rollback, projection best-effort) verts ; tests squelette migrés.
+- [ ] **Aucune** modification de `ScoresService` / `ListActionStatutsRepository`.
+- [ ] Bench CT max charge documenté (tx < `statement_timeout`).
+- [ ] PRD amendé (Flux de bascule : tx sources + projection hors tx).
+
+---
+
+## Suite (PR19+)
+
+| PR | Suite |
+| --- | --- |
+| PR19–PR20 | UI bascule (CTA + états disabled ; modale irréversible) |
+| PR21 | Masquage questions / personnalisations legacy |
+| PR22 | UI snapshots post-bascule |
+| PR23 | Export score-comparaison : feuille personnalisations |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * La bascule vers le référentiel Climat Ressources est désormais opérationnelle de bout en bout.
  * Les données CAE et ECI sont migrées vers TE, avec archivage automatique des anciennes préférences.
  * Des snapshots avant et après bascule sont créés pour préserver l’historique.
  * Le résultat indique le statut de bascule et sa date de finalisation.

* **Améliorations**
  * La bascule est idempotente et sécurisée par rollback en cas d’échec.
  * Les snapshots post-bascule manquants peuvent être automatiquement réparés.
  * Les erreurs de recalcul post-bascule sont signalées distinctement, sans annuler la bascule réussie.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->