### PR TITLE
ci: relance automatique du job test-e2e en cas de faux négatif

### DIFF
--- a/.github/workflows/retry-e2e.yml
+++ b/.github/workflows/retry-e2e.yml
@@ -1,0 +1,43 @@
+# Relance automatiquement (une seule fois) le job test-e2e quand il est
+# le seul en échec dans le run CI — les tests e2e produisent parfois des
+# faux négatifs (flakiness infra) malgré les retries Playwright.
+name: Retry e2e
+
+permissions:
+  actions: write
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+
+jobs:
+  retry-e2e:
+    # run_attempt == 1 : on ne relance qu'une seule fois
+    if: >
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.run_attempt == 1
+    runs-on: ubuntu-latest
+    steps:
+      - name: Relance les jobs échoués si seul test-e2e a échoué
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          REPO: ${{ github.repository }}
+        run: |
+          failed_jobs=$(gh api "repos/$REPO/actions/runs/$RUN_ID/jobs?per_page=100" --paginate \
+            --jq '.jobs[] | select(.conclusion == "failure") | .name')
+
+          if [ -z "$failed_jobs" ]; then
+            echo "Aucun job en échec, rien à relancer."
+            exit 0
+          fi
+
+          if echo "$failed_jobs" | grep -vq '^test-e2e'; then
+            echo "Échec en dehors de test-e2e, pas de retry automatique :"
+            echo "$failed_jobs"
+            exit 0
+          fi
+
+          echo "Seul test-e2e a échoué, relance des jobs échoués du run $RUN_ID."
+          gh run rerun "$RUN_ID" --failed --repo "$REPO"


### PR DESCRIPTION
### Problème

Le job `test-e2e` échoue parfois en faux négatif (flakiness d'infra : démarrage de la stack, timeouts…), alors que le code est sain. Il faut relancer le job à la main pour débloquer la PR.


### Solution

GitHub Actions n'a pas d'équivalent du `retry:` de GitLab CI au niveau job. On ajoute donc un petit workflow (`retry-e2e.yml`) qui, à la fin d'un run CI en échec, relance automatiquement le job **une seule fois** — et uniquement si `test-e2e` est le seul job en échec (sinon l'échec est probablement réel).

Le re-run remplace le résultat initial : si le retry passe, les checks de la PR repassent au vert.
Typiquement, dans cette même PR, on a eu le soucis:

<img width="496" height="265" alt="image" src="https://github.com/user-attachments/assets/030b49e1-318c-4b09-affb-1b668ddc1438" />

> ⚠️ Le déclencheur `workflow_run` ne s'active qu'une fois le fichier présent sur `main` — le retry ne sera donc effectif qu'après merge de cette PR.
