### PR TITLE
fix(trajectoires): la courbe "Émissions nettes" pointe vers le total net (TET-7651)

### DIFF
--- a/packages/domain/src/indicateurs/trajectoires/ges-emissions-properties.ts
+++ b/packages/domain/src/indicateurs/trajectoires/ges-emissions-properties.ts
@@ -4,9 +4,11 @@ import { TrajectoirePropertiesType } from './types';
 
 const EMISSIONS_GES_UNITE = 'kteq CO2';
 const EMISSIONS_GES_IDENTIFIANT = 'cae_1.a';
+// cae_1.aa = Total net = émissions brutes (cae_1.a) moins la séquestration UTCATF
+const EMISSIONS_NETTES_IDENTIFIANT = 'cae_1.aa';
 
 export const EMISSIONS_NETTES = {
-  id: EMISSIONS_GES_IDENTIFIANT,
+  id: EMISSIONS_NETTES_IDENTIFIANT,
   nom: 'Émissions nettes',
 };
 


### PR DESCRIPTION
## Summary
- La courbe "Émissions nettes" du graphe de comparaison des trajectoires GES pointait vers l'identifiant `cae_1.a` (Total brut), au lieu de `cae_1.aa` (Total net, qui soustrait la séquestration UTCATF).
- Régression introduite lors du refactor du calcul de trajectoire (commit `ff1e16430`, oct. 2025) : la constante `EMISSIONS_NETTES` avait initialement `id: 'cae_1.aa'` avant d'être déplacée vers `packages/domain` avec `id: 'cae_1.a'` par erreur.
- Le calcul du total net (brut − séquestration UTCATF) existe déjà côté backend (`trajectoires-spreadsheet.service.ts`) et est déjà calculé/stocké pour les collectivités sous `cae_1.aa` — seul le frontend pointait vers le mauvais identifiant.

Remonté par une utilisatrice via ce ticket Notion : https://app.notion.com/p/1576523d57d78077a6c5c5f00cc63874

## Test plan
- [x] `pnpm nx build domain` passe
- [x] `pnpm nx run app:typecheck` passe (app + backend + domain)
- [x] Vérifier visuellement le graphe "Comparaison des trajectoires d'émissions de GES" sur une collectivité avec données `cae_1.aa` en base

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Corrections**
  * L’identifiant des émissions nettes est désormais correctement distingué de celui des émissions de gaz à effet de serre.
  * Les données et affichages associés aux émissions nettes utilisent ainsi la référence appropriée.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->