### PR TITLE
fix(users): badge de rôle audit toujours bleu dans le sélecteur de collectivité

### DIFF
--- a/apps/app/src/users/BadgeNiveauAcces.tsx
+++ b/apps/app/src/users/BadgeNiveauAcces.tsx
@@ -16,7 +16,11 @@ export const BadgeNiveauAcces = ({
     <Badge
       title={getLabel(collectivite)}
       size="xs"
-      variant={collectivite.role === null ? 'new' : 'info'}
+      variant={
+        collectivite.role === null && !collectivite.isRoleAuditeur
+          ? 'new'
+          : 'info'
+      }
       className={cn('pointer-events-none', className)}
     />
   );


### PR DESCRIPTION
## Summary
- Le badge "audit" dans le sélecteur de collectivité changeait de couleur (bleu/jaune) selon que l'utilisateur soit membre ou non de la collectivité, sans raison métier.
- Il est désormais toujours bleu (`info`), comme les autres badges de rôle. Le badge "visite" (aucun rôle, non-auditeur) reste jaune.
- Réf. TET-7583

## Test plan
- [x] `tsc --noEmit` sur `apps/app` sans erreur sur le fichier modifié
- [ ] Vérifier visuellement le badge "audit" pour un auditeur membre et non-membre de la collectivité

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Correctifs**
  * Correction de l’affichage du badge de niveau d’accès pour les collectivités dont le rôle est « auditeur ».
  * Ces collectivités affichent désormais le badge informatif approprié, même lorsqu’aucun rôle n’est défini.
  * Les collectivités sans rôle et sans statut d’auditeur continuent d’afficher le badge signalant un nouveau niveau d’accès.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->