### PR TITLE
chore(agents): trim derivable content from AGENTS.md files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,16 +11,6 @@ For side-specific conventions, see:
 ## Commands
 
 ```bash
-# Development
-pnpm dev              # All apps in parallel
-pnpm dev:app          # app + backend
-pnpm dev:backend      # Backend only
-
-# Testing
-pnpm test:app         # Frontend tests (Vitest + jsdom)
-pnpm test:api         # API / domain tests
-pnpm test:backend     # Backend tests (Vitest + NestJS)
-
 # Single backend test file or name pattern
 nx test backend 'filename.spec.ts'
 nx test backend 'referentiels'
@@ -32,18 +22,7 @@ act -j db-restore     # Restore to seed state
 
 ## Architecture
 
-Nx monorepo with pnpm. Key workspaces:
-
-- **`apps/backend`** — NestJS API server. Exposes tRPC routers and REST controllers.
-- **`apps/app`** — Next.js 16 main frontend (admin dashboard).
-- **`apps/site`** — Public marketing site.
-- **`packages/api`** — Shared API types between frontend and backend.
-- **`packages/domain`** — Shared business entities and pure rules.
-- **`packages/ui`** — Shared React component library (DSFR design system).
-- **`data_layer/sqitch`** — PostgreSQL migrations via Sqitch.
-- **`data_layer/tests`** — pgTAP database unit tests.
-
-Data flow: Frontend (`useQuery`/`useMutation`) → tRPC Router → Application Service → Repository (Drizzle ORM) → PostgreSQL (Supabase).
+Nx monorepo with pnpm. Data flow: Frontend (`useQuery`/`useMutation`) → tRPC Router → Application Service → Repository (Drizzle ORM) → PostgreSQL (Supabase).
 
 ## Naming & File Conventions (ADR 0003)
 

--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -24,13 +24,7 @@ plans/fiches/mutate-fiche/
 
 ## Result pattern (ADR 0012)
 
-Public service methods return `Result<Data, E>` instead of throwing:
-
-```ts
-type Result<Data, ServiceError, Cause extends Error = Error> =
-  | { success: true; data: Data }
-  | { success: false; error: ServiceError; cause?: Cause };
-```
+Public service methods return `Result<Data, E>` instead of throwing (see `apps/backend/src/utils/result.type.ts` for the type).
 
 - Helpers: `success(data)`, `failure(error, cause?)`, `isSuccess`, `isFailure`, `combineResults` — from `apps/backend/src/utils/result.type.ts`.
 - Routers convert Result → TRPCError with `private readonly getResultDataOrThrowError = createTrpcErrorHandler(<feature>ErrorConfig)` (stored on the class, not invoked inline).


### PR DESCRIPTION
## Summary
- Remove pnpm/nx dev+test commands and workspace layout from the root `AGENTS.md` — both are verbatim/derivable from `package.json` scripts and `ls`, respectively.
- Remove the inline `Result<Data, ServiceError, Cause>` type copy from `apps/backend/AGENTS.md` — it duplicates `apps/backend/src/utils/result.type.ts`.
- Kept everything non-derivable: naming conventions, domain-structure rule, gotchas, security rules, DB/auth patterns.

Found via a `/doctor` context audit — neither file is anywhere near the large-CLAUDE.md warning threshold, this is just decluttering always-loaded content that a session can reconstruct with a couple of tool calls.

## Test plan
- [ ] Skim both files to confirm nothing load-bearing was cut

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplification de la documentation des commandes de développement et de test.
  * Mise à jour de la description de l’architecture et du flux de données.
  * Allègement des consignes backend concernant le format des résultats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->