### PR TITLE
fix(fiches): stop erasing sous-thematiques et temps de mise en oeuvre

### DIFF
--- a/apps/app/src/shared/thematiques/use-get-thematique-and-sous-thematique-options.ts
+++ b/apps/app/src/shared/thematiques/use-get-thematique-and-sous-thematique-options.ts
@@ -36,11 +36,11 @@ export const useGetThematiqueAndSousThematiqueOptions = ({
   sousThematiqueListe: SousThematique[];
 } => {
   const { thematiqueListe, thematiqueOptions } = useGetThematiqueOptions();
-  const { data: sousThematiqueListe = [] } = useListSousThematiques();
+  const { data: sousThematiqueListe } = useListSousThematiques();
 
   const availableSousThematiques: SousThematique[] = useMemo(() => {
     const thematiqueIds = new Set(selectedThematiques.map(({ id }) => id));
-    return sousThematiqueListe.filter(({ thematiqueId }) =>
+    return (sousThematiqueListe ?? []).filter(({ thematiqueId }) =>
       thematiqueIds.has(thematiqueId)
     );
   }, [sousThematiqueListe, selectedThematiques]);
@@ -55,6 +55,13 @@ export const useGetThematiqueAndSousThematiqueOptions = ({
   );
 
   useEffect(() => {
+    // Tant que la liste de référence n'a pas fini de charger,
+    // `availableSousThematiques` est vide sans que ça signifie que les
+    // sous-thématiques sélectionnées sont invalides : ne rien purger.
+    if (sousThematiqueListe === undefined) {
+      return;
+    }
+
     const selectedIds = new Set(selectedSousThematiques.map(({ id }) => id));
     const updatedSousThematiques = availableSousThematiques.filter(({ id }) =>
       selectedIds.has(id)
@@ -63,12 +70,17 @@ export const useGetThematiqueAndSousThematiqueOptions = ({
     if (updatedSousThematiques.length !== selectedSousThematiques.length) {
       onThematiqueChange(updatedSousThematiques);
     }
-  }, [availableSousThematiques, onThematiqueChange, selectedSousThematiques]);
+  }, [
+    sousThematiqueListe,
+    availableSousThematiques,
+    onThematiqueChange,
+    selectedSousThematiques,
+  ]);
 
   return {
     sousThematiqueOptions,
     thematiqueOptions,
     thematiqueListe,
-    sousThematiqueListe,
+    sousThematiqueListe: sousThematiqueListe ?? [],
   };
 };

--- a/apps/backend/src/plans/fiches/fiche-action.repository.ts
+++ b/apps/backend/src/plans/fiches/fiche-action.repository.ts
@@ -173,7 +173,9 @@ export class FicheActionRepository {
             ...ficheAction,
             modifiedBy: user.id,
             modifiedAt: new Date().toISOString(),
-            tempsDeMiseEnOeuvre: tempsDeMiseEnOeuvre?.id ?? null,
+            ...(tempsDeMiseEnOeuvre !== undefined && {
+              tempsDeMiseEnOeuvre: tempsDeMiseEnOeuvre?.id ?? null,
+            }),
           })
           .where(eq(ficheActionTable.id, ficheId));
       }

--- a/apps/backend/src/plans/fiches/update-fiche/update-fiche.router.e2e-spec.ts
+++ b/apps/backend/src/plans/fiches/update-fiche/update-fiche.router.e2e-spec.ts
@@ -265,6 +265,28 @@ describe('UpdateFicheService', () => {
       expect(ficheWithNullData).toMatchObject(nullData);
     });
 
+    test('should not reset tempsDeMiseEnOeuvre when it is absent from a partial update', async () => {
+      // Renseigne tempsDeMiseEnOeuvre
+      const ficheWithTemps = await updateFiche({ tempsDeMiseEnOeuvre: { id: 1 } });
+      expect(ficheWithTemps.tempsDeMiseEnOeuvre).toMatchObject({ id: 1 });
+
+      // Une mise à jour partielle qui ne mentionne pas du tout ce champ
+      // (comme le fait l'autosave champ par champ du frontend) ne doit pas
+      // l'écraser.
+      const ficheAfterUnrelatedUpdate = await updateFiche({
+        sousThematiques: [{ id: 3 }],
+      });
+      expect(ficheAfterUnrelatedUpdate.tempsDeMiseEnOeuvre).toMatchObject({
+        id: 1,
+      });
+
+      // Un update explicite à null doit en revanche bien l'effacer.
+      const ficheAfterExplicitNull = await updateFiche({
+        tempsDeMiseEnOeuvre: null,
+      });
+      expect(ficheAfterExplicitNull.tempsDeMiseEnOeuvre).toBeNull();
+    });
+
     test('should update a sous-fiche (fiche with parentId referencing a parent fiche)', async () => {
       // Crée une fiche parente (parentId = null)
       const [parentFiche] = await db.db


### PR DESCRIPTION
## Résumé

Corrige TET-7618 : lorsqu'un utilisateur définissait une sous-thématique sur une fiche action, celle-ci (ainsi que le temps de mise en œuvre) disparaissait au rechargement de la page.

Deux causes distinctes, compoundées :

- **Backend** (`fiche-action.repository.ts`) : `tempsDeMiseEnOeuvre` était le seul champ écrit sans garde `!== undefined` dans `applyUpdate`, contrairement aux autres relations (`axes`, `thematiques`, `sousThematiques`, `pilotes`, ...). Toute mise à jour partielle qui ne mentionnait pas ce champ le remettait donc silencieusement à `null`.
- **Frontend** (`use-get-thematique-and-sous-thematique-options.ts`) : `useListSousThematiques` masquait son état de chargement avec une valeur par défaut `[]` (`data: sousThematiqueListe = []`). Au montage, avant que la liste de référence des sous-thématiques n'ait fini de charger, l'effet de purge des sous-thématiques invalides voyait une liste vide et déclenchait `onThematiqueChange([])`, vidant les sous-thématiques réellement sélectionnées. L'autosave champ-par-champ du formulaire persistait alors ce vidage côté serveur.

## Changements

- `fiche-action.repository.ts` : ajoute la garde `tempsDeMiseEnOeuvre !== undefined` avant d'écrire ce champ, comme pour les autres relations.
- `use-get-thematique-and-sous-thematique-options.ts` : ne masque plus l'état de chargement de `useListSousThematiques` derrière un défaut `[]` ; l'effet de purge attend que la liste ait fini de charger avant d'agir.
- `update-fiche.router.e2e-spec.ts` : ajoute un test couvrant une mise à jour partielle omettant `tempsDeMiseEnOeuvre`, qui ne le réinitialisait pas correctement avant ce correctif.

## Test plan

- [x] Nouveau test e2e `should not reset tempsDeMiseEnOeuvre when it is absent from a partial update` ajouté.
- [ ] Suite e2e complète du fichier à faire tourner (bloqué localement par un seed de DB obsolète, `sous_thematique` id 1 absent — sans lien avec ce correctif).
- [ ] Vérification manuelle en environnement de review recommandée : définir une sous-thématique sur une FA, recharger la page, vérifier qu'elle persiste ainsi que le temps de mise en œuvre.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Correctifs**
  - Les mises à jour partielles d’une fiche conservent désormais la valeur existante du délai de mise en œuvre lorsqu’aucune nouvelle valeur n’est fournie.
  - La suppression explicite de ce délai reste possible en renseignant une valeur vide.
  - Les sélections de sous-thématiques ne sont plus supprimées prématurément pendant le chargement des données.
  - Les options de sous-thématiques restent correctement disponibles même lorsque les données sont temporairement absentes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->