### PR TITLE
fix(plans): trier les actions/sous-actions du rapport PPT comme dans l'app

### DIFF
--- a/apps/backend/src/plans/reports/generate-plan-report-pptx/ppt-builder.service.spec.ts
+++ b/apps/backend/src/plans/reports/generate-plan-report-pptx/ppt-builder.service.spec.ts
@@ -1,0 +1,78 @@
+import { Test } from '@nestjs/testing';
+import { FicheWithRelations } from '@tet/domain/plans';
+import { PptBuilderService } from './ppt-builder.service';
+
+describe('PptBuilderService', () => {
+  let pptBuilderService: PptBuilderService;
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [PptBuilderService],
+    })
+      .useMocker(() => ({}))
+      .compile();
+
+    pptBuilderService = moduleRef.get(PptBuilderService);
+  });
+
+  describe('sortFichesForReport', () => {
+    const fiche = (
+      overrides: Partial<FicheWithRelations>
+    ): FicheWithRelations =>
+      ({
+        titre: null,
+        parentId: null,
+        createdAt: '2024-01-01T00:00:00.000Z',
+        ...overrides,
+      } as FicheWithRelations);
+
+    it('trie les actions de premier niveau par titre, alphabétiquement', () => {
+      const fiches = [
+        fiche({ id: 1, titre: 'Action C' }),
+        fiche({ id: 2, titre: 'Action A' }),
+        fiche({ id: 3, titre: 'Action B' }),
+      ];
+
+      const result = (pptBuilderService as any).sortFichesForReport(fiches);
+
+      expect(result.map((f: FicheWithRelations) => f.id)).toEqual([2, 3, 1]);
+    });
+
+    it("place chaque sous-action juste après sa fiche parente, triées par date de création (pas par titre)", () => {
+      const fiches = [
+        fiche({ id: 1, titre: 'Action A' }),
+        fiche({ id: 2, titre: 'Action B' }),
+        // Sous-actions de l'action B, volontairement pas dans l'ordre alphabétique ni d'insertion
+        fiche({
+          id: 21,
+          titre: 'Z sous-action',
+          parentId: 2,
+          createdAt: '2024-01-02T00:00:00.000Z',
+        }),
+        fiche({
+          id: 22,
+          titre: 'A sous-action',
+          parentId: 2,
+          createdAt: '2024-01-01T00:00:00.000Z',
+        }),
+      ];
+
+      const result = (pptBuilderService as any).sortFichesForReport(fiches);
+
+      expect(result.map((f: FicheWithRelations) => f.id)).toEqual([
+        1, 2, 22, 21,
+      ]);
+    });
+
+    it('inclut les sous-actions orphelines (dont la fiche parente est absente de la liste)', () => {
+      const fiches = [
+        fiche({ id: 1, titre: 'Action A' }),
+        fiche({ id: 99, titre: 'Sous-action orpheline', parentId: 999 }),
+      ];
+
+      const result = (pptBuilderService as any).sortFichesForReport(fiches);
+
+      expect(result.map((f: FicheWithRelations) => f.id)).toEqual([1, 99]);
+    });
+  });
+});

--- a/apps/backend/src/plans/reports/generate-plan-report-pptx/ppt-builder.service.ts
+++ b/apps/backend/src/plans/reports/generate-plan-report-pptx/ppt-builder.service.ts
@@ -413,18 +413,12 @@ export class PptBuilderService {
           logo,
         });
 
-        const axeFilteredFiches = filteredFiches
-          .filter((fiche) =>
-            axe.id === this.countByService.NO_AXE_ID
-              ? !fiche.axes?.some((a) => a.parentId === plan.id)
-              : fiche.axes?.some((a) => a.id === axe.id)
-          )
-          .sort((a, b) =>
-            (a.titre ?? '').localeCompare(b.titre ?? '', this.LOCALE, {
-              sensitivity: 'base',
-              numeric: true,
-            })
-          );
+        const axeFiches = filteredFiches.filter((fiche) =>
+          axe.id === this.countByService.NO_AXE_ID
+            ? !fiche.axes?.some((a) => a.parentId === plan.id)
+            : fiche.axes?.some((a) => a.id === axe.id)
+        );
+        const axeFilteredFiches = this.sortFichesForReport(axeFiches);
         for (const fiche of axeFilteredFiches) {
           const ficheTextReplacementsInfo = this.getFicheTextReplacementsInfos(
             fiche,
@@ -1231,6 +1225,58 @@ export class PptBuilderService {
         { selector: 'img', format: 'skip' },
       ],
     }).trim();
+  }
+
+  /**
+   * Trie les fiches d'un axe comme dans l'app : les actions de premier
+   * niveau par ordre alphabétique de titre, chacune suivie de ses
+   * sous-actions triées par date de création.
+   */
+  private sortFichesForReport(
+    fiches: FicheWithRelations[]
+  ): FicheWithRelations[] {
+    const topLevelFiches = fiches
+      .filter((fiche) => !fiche.parentId)
+      .sort((a, b) =>
+        (a.titre ?? '').localeCompare(b.titre ?? '', this.LOCALE, {
+          sensitivity: 'base',
+          numeric: true,
+        })
+      );
+
+    const childrenByParentId = new Map<number, FicheWithRelations[]>();
+    for (const fiche of fiches) {
+      if (fiche.parentId) {
+        const siblings = childrenByParentId.get(fiche.parentId) ?? [];
+        siblings.push(fiche);
+        childrenByParentId.set(fiche.parentId, siblings);
+      }
+    }
+    for (const siblings of childrenByParentId.values()) {
+      siblings.sort(
+        (a, b) =>
+          new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+      );
+    }
+
+    const orderedFiches: FicheWithRelations[] = [];
+    const consumedChildIds = new Set<number>();
+    for (const fiche of topLevelFiches) {
+      orderedFiches.push(fiche);
+      for (const child of childrenByParentId.get(fiche.id) ?? []) {
+        orderedFiches.push(child);
+        consumedChildIds.add(child.id);
+      }
+    }
+
+    // Sous-actions dont la fiche parente n'apparait pas dans cette liste
+    // (ex. parent rattaché à un autre axe) : on les inclut quand même.
+    const orphanChildren = fiches.filter(
+      (fiche) => fiche.parentId && !consumedChildIds.has(fiche.id)
+    );
+    orderedFiches.push(...orphanChildren);
+
+    return orderedFiches;
   }
 
   private getAxeGeneralInfo(


### PR DESCRIPTION
## Contexte

Ticket Notion [TET-6834](https://app.notion.com/p/3176523d57d7813f83b0df88c3a8f864) : dans le rapport PPT généré depuis un plan d'action, les axes sont bien ordonnés mais les actions et sous-actions à l'intérieur d'un axe apparaissent mélangées, contrairement à l'app où elles s'affichent correctement (actions triées par titre, sous-actions imbriquées sous leur action parente et triées par date de création).

## Cause

Dans `PptBuilderService.buildPresentation`, la liste des fiches d'un axe (actions de premier niveau + sous-actions, récupérées à plat via `withChildren: true`) était triée globalement par `titre`, sans distinguer parent/enfant — une sous-action pouvait donc apparaître entre deux actions parentes différentes selon son titre.

## Correctif

Ajout de `PptBuilderService.sortFichesForReport` qui reproduit l'ordre de l'app : les actions de premier niveau triées par titre, chacune suivie immédiatement de ses sous-actions triées par date de création (`createdAt`). Les éventuelles sous-actions orphelines (parent hors de l'axe) restent incluses en fin de liste par sécurité.

## Test plan

- [x] Nouveau test unitaire `ppt-builder.service.spec.ts` (tri des actions, imbrication des sous-actions, cas orphelin) — `pnpm nx test backend ppt-builder.service.spec.ts` ✅
- [x] `pnpm nx run backend:typecheck` ✅
- [x] `pnpm nx run backend:lint` sur les fichiers modifiés (0 erreur) ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Améliorations**
  * Les présentations générées organisent désormais les fiches par titre, dans l’ordre alphabétique.
  * Les sous-actions apparaissent immédiatement après leur fiche parente et sont triées par date de création.
  * Les sous-actions sans fiche parente sont conservées en fin de présentation.

* **Tests**
  * Ajout de tests couvrant les différents scénarios de tri des fiches et sous-actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->