### PR TITLE
chore(deps): upgrade chromatic to 18.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -227,7 +227,7 @@
     "@types/zxcvbn": "4.4.5",
     "@vitest/browser-playwright": "4.1.7",
     "autoprefixer": "10.4.21",
-    "chromatic": "13.3.4",
+    "chromatic": "18.1.0",
     "css-loader": "7.1.2",
     "drizzle-kit": "0.24.2",
     "eslint": "9.39.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -655,8 +655,8 @@ importers:
         specifier: 10.4.21
         version: 10.4.21(postcss@8.5.6)
       chromatic:
-        specifier: 13.3.4
-        version: 13.3.4
+        specifier: 18.1.0
+        version: 18.1.0
       css-loader:
         specifier: 7.1.2
         version: 7.1.2(@rspack/core@1.6.8(@swc/helpers@0.5.23))(webpack@5.105.2(@swc/core@1.15.43(@swc/helpers@0.5.23))(esbuild@0.19.12)(postcss@8.5.6))
@@ -1493,7 +1493,6 @@ packages:
 
   '@bryntum/scheduler-lib@1.0.0':
     resolution: {integrity: sha512-3Bd95kUaPsEJL+M7X2G5iV+7eNeSEPiFDX/U6Aucy5VeZDIuFFW+YTq4NVCVrzfs2wxeh5IRwW7fJC2mKv/hFw==}
-    engines: {node: '>=0.10.0'}
 
   '@bryntum/scheduler-react@6.3.1':
     resolution: {integrity: sha512-tqdu0Zz2wk7ou7vmM4g1m6xSNYrrtiMaBxd8v/DInVRsVGM2ZO9F6X6jisjF29CzUGAak+nI6H+GH02AkXBPYw==}
@@ -7983,16 +7982,20 @@ packages:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
 
-  chromatic@13.3.4:
-    resolution: {integrity: sha512-TR5rvyH0ESXobBB3bV8jc87AEAFQC7/n+Eb4XWhJz6hW3YNxIQPVjcbgLv+a4oKHEl1dUBueWSoIQsOVGTd+RQ==}
+  chromatic@18.1.0:
+    resolution: {integrity: sha512-I9av8lUc5CQRlYzwKpmOG9cwYvZ4AFmTvtHeNrzOMC1353F9xYw45CHpSNIsNKuOiqqmzci9esXQd5akl0fi6w==}
+    engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
       '@chromatic-com/cypress': ^0.*.* || ^1.0.0
       '@chromatic-com/playwright': ^0.*.* || ^1.0.0
+      '@chromatic-com/vitest': ^0.*.* || ^1.0.0
     peerDependenciesMeta:
       '@chromatic-com/cypress':
         optional: true
       '@chromatic-com/playwright':
+        optional: true
+      '@chromatic-com/vitest':
         optional: true
 
   chrome-trace-event@1.0.4:
@@ -23844,7 +23847,9 @@ snapshots:
 
   chownr@3.0.0: {}
 
-  chromatic@13.3.4: {}
+  chromatic@18.1.0:
+    dependencies:
+      semver: 7.7.2
 
   chrome-trace-event@1.0.4: {}
 


### PR DESCRIPTION
## Summary
- Bump `chromatic` from 13.3.4 to 18.1.0

## Test plan
- [ ] Verify Chromatic CI job runs successfully with the new version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Mise à jour de l’outil de vérification visuelle vers une version plus récente.
  * Aucun changement fonctionnel visible pour les utilisateurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->