### PR TITLE
fix(fiches): synchroniser la date de fin entre le tableau et la fiche action

### DIFF
--- a/apps/app/src/plans/fiches/list-all-fiches/components/fiches-list.table/generic-cells/action.date.generic-cell.spec.tsx
+++ b/apps/app/src/plans/fiches/list-all-fiches/components/fiches-list.table/generic-cells/action.date.generic-cell.spec.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import { FicheWithRelationsAndCollectivite } from '@tet/domain/plans';
+import { describe, expect, it, vi } from 'vitest';
+import { ActionDateGenericCell } from './action.date.generic-cell';
+
+// cast de mock : seuls les champs lus par le rendu de la cellule importent ici
+const buildAction = (overrides: Partial<FicheWithRelationsAndCollectivite>) =>
+  ({
+    id: 1,
+    statut: null,
+    dateFin: null,
+    ameliorationContinue: null,
+    ...overrides,
+  }) as unknown as FicheWithRelationsAndCollectivite;
+
+describe('ActionDateGenericCell', () => {
+  it('affiche la date de fin quand la fiche ne se répète pas', () => {
+    render(
+      <ActionDateGenericCell
+        action={buildAction({ dateFin: '2027-12-31' })}
+        canUpdate={true}
+        updateAction={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('31/12/2027')).toBeTruthy();
+  });
+
+  it("n'affiche pas une date de fin périmée quand l'action se répète tous les ans, même si dateFin est encore renseignée en base", () => {
+    render(
+      <ActionDateGenericCell
+        action={buildAction({
+          dateFin: '2027-12-31',
+          ameliorationContinue: true,
+        })}
+        canUpdate={true}
+        updateAction={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByText('31/12/2027')).toBeNull();
+    expect(screen.getByText("L'action se répète tous les ans")).toBeTruthy();
+  });
+});

--- a/apps/app/src/plans/fiches/list-all-fiches/components/fiches-list.table/generic-cells/action.date.generic-cell.tsx
+++ b/apps/app/src/plans/fiches/list-all-fiches/components/fiches-list.table/generic-cells/action.date.generic-cell.tsx
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import { format, isEqual, isValid } from 'date-fns';
 import { useState } from 'react';
 
@@ -11,7 +12,12 @@ export const ActionDateGenericCell = ({
   canUpdate,
   updateAction,
 }: ActionGenericCellProps) => {
-  const initialDate = action.dateFin ?? '';
+  // Une action qui se répète tous les ans n'a pas de date de fin : c'est la
+  // même règle que dans le détail de la fiche action (cf. `planning/index.tsx`).
+  const isAmeliorationContinue = action.ameliorationContinue === true;
+  const displayDateFin = isAmeliorationContinue ? null : action.dateFin;
+
+  const initialDate = displayDateFin ?? '';
 
   const [value, setValue] = useState(initialDate);
 
@@ -21,13 +27,13 @@ export const ActionDateGenericCell = ({
     value !== initialDate && !isEqual(new Date(value), new Date(initialDate));
 
   const isLate = !isFicheOnTime({
-    dateFin: action.dateFin,
+    dateFin: displayDateFin,
     statut: action.statut,
   });
 
   return (
     <TableCell
-      canEdit={canUpdate}
+      canEdit={canUpdate && !isAmeliorationContinue}
       edit={{
         onClose: () => {
           if (hasChanged)
@@ -52,14 +58,19 @@ export const ActionDateGenericCell = ({
         ),
       }}
     >
-      {action.dateFin ? (
+      {isAmeliorationContinue ? (
+        <span className="flex items-baseline gap-2 text-grey-6">
+          <Icon icon="loop-left-line" size="sm" />
+          {appLabels.actionRepeteTousLesAns}
+        </span>
+      ) : displayDateFin ? (
         <span
           className={cn('flex items-baseline gap-2 text-primary-9', {
             'text-error-1': isLate,
           })}
         >
           <Icon icon="calendar-line" size="sm" />
-          {format(new Date(action.dateFin), 'dd/MM/yyyy')}
+          {format(new Date(displayDateFin), 'dd/MM/yyyy')}
         </span>
       ) : (
         <div className="text-center text-grey-6">


### PR DESCRIPTION
## Résumé

- Ticket Notion [TET-7654](https://app.notion.com/p/3aa6523d57d7808e90dbee8f3a1df451) : dans une fiche action avec « l'action se répète tous les ans » activé, le détail de la fiche masque et désactive la date de fin (`ficheActionTable.dateFin` → colonne `date_fin_provisoire`, cf. `apps/app/src/plans/fiches/show-fiche/content/details/planning/index.tsx`), alors que la cellule « date de fin » du tableau (`ActionDateGenericCell`, partagée par les vues « mon suivi personnel » et « toutes les actions ») affichait et permettait d'éditer cette même colonne sans tenir compte du flag `ameliorationContinue`.
- Concrètement : une fiche récurrente ayant conservé une `dateFin` en base (import, édition groupée, ancien état...) affichait une date périmée dans le tableau, et la modifier depuis le tableau n'avait aucun effet visible dans la fiche (le détail force toujours l'affichage à vide dès que `ameliorationContinue` est vrai).
- La cellule applique désormais la même règle que le détail de la fiche et la modale d'édition groupée (`EditionPlanning.tsx`) : date de fin masquée, non éditable, et remplacée par le libellé de récurrence quand `ameliorationContinue` est vrai.

## Test plan

- [x] `nx test app 'action.date.generic-cell'` — nouveau test qui échoue sans le correctif (date périmée affichée) et passe avec
- [x] `nx run app:typecheck`
- [x] `eslint` sur les fichiers modifiés