### PR TITLE
:technologist: add staging db mcp (with encrypted database_url) to ease operations on staging

### DIFF
--- a/.env.staging
+++ b/.env.staging
@@ -1,0 +1,10 @@
+#/-------------------[DOTENV_PUBLIC_KEY]--------------------/
+#/            public-key encryption for .env files          /
+#/       [how it works](https://dotenvx.com/encryption)     /
+#/----------------------------------------------------------/
+DOTENV_PUBLIC_KEY_STAGING="02027c84a9a9be633345a3c763ab29103f78d57303222eeadf54fb2d444bab84d9"
+
+# .env.staging
+# Secrets de la base de données de STAGING (chiffrés via dotenvx).
+# Consommé par le serveur MCP "staging-db" déclaré dans .mcp.json.
+DATABASE_URI="encrypted:BDANpd2FhPiyIffpcPmDgLjqM7h5p57l/ACjNBTxdKRr+a2IuRSFf2O96rYImlaghoIQQtreOlEoPfHFOfquhnX1w8+T7TuIpY3wtjiNGMNtX/icW9MqY0noJPyUngyaGXBXsYdSZ2wVDhlRDCERW+SBoR4tAlrSG1VNV9lCdtZQYKYStf/E2Ca1GJHgbo84cAoJJOB2nSjNHcrRme4ArekbdkTazq1ypv4Np+HGgChZ6bAuN/xk2Nk="

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,21 @@
+{
+    "mcpServers": {
+        "staging-db": {
+            "command": "npx",
+            "args": [
+                "-y",
+                "@dotenvx/dotenvx",
+                "run",
+                "--env-keys-file=.env.keys",
+                "--strict",
+                "-f",
+                ".env.staging",
+                "--",
+                "uvx",
+                "postgres-mcp",
+                "--access-mode",
+                "unrestricted"
+            ]
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
  - Ajout de la configuration de l’environnement de staging avec gestion sécurisée des paramètres sensibles.
  - Activation de l’accès contrôlé à la base de données de staging via un serveur MCP dédié.
  - Les informations sensibles sont chiffrées et chargées uniquement lors de l’exécution, renforçant la sécurité des connexions de test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->