### PR TITLE
refactor(ds/ui): extraction des changements design-system et ui depuis TET-7178

### DIFF
--- a/apps/app/src/ui/layout/app-layout.tsx
+++ b/apps/app/src/ui/layout/app-layout.tsx
@@ -34,7 +34,7 @@ const ContentWrapper = ({
           'max-lg:hidden': panel.isOpen,
         })}
       >
-        <div className="grow flex flex-col w-full max-w-[90rem] mx-auto px-2 md:px-4 lg:px-6 py-6">
+        <div className="grow flex flex-col w-full max-w-[90rem] mx-auto px-2 md:px-4 lg:px-6 pb-12 pt-6">
           {children}
         </div>
         <FooterTeT />

--- a/apps/app/src/ui/metadata-line/metadata-item-personne.tsx
+++ b/apps/app/src/ui/metadata-line/metadata-item-personne.tsx
@@ -6,19 +6,23 @@ import { MetadataItem } from './metadata-item';
 export const MetadataItemPersonne = ({
   dataTest,
   icon,
+  hideSeparator,
   isReadOnly,
   label,
   personnes,
   onChange,
   openState,
+  tooltip,
 }: {
   dataTest?: string;
   icon: IconValue;
+  hideSeparator?: boolean;
   isReadOnly: boolean;
   label: { one: string; many: string };
   personnes: Personne[];
   onChange: (personnes: Personne[]) => void;
   openState?: { isOpen: boolean; setIsOpen: (v: boolean) => void };
+  tooltip?: ReactNode;
 }) => {
   return (
     <InlineEditWrapper
@@ -31,7 +35,16 @@ export const MetadataItemPersonne = ({
             values={personnes
               ?.map((p) => p.userId || p.tagId?.toString() || '')
               .filter(Boolean)}
-            onChange={({ personnes }) => onChange(personnes)}
+            onChange={({ personnes: selected }) =>
+              onChange(
+                selected.map((p) => ({
+                  tagId: p.tagId,
+                  userId: p.userId,
+                  tagName: p.tagId ? p.nom : null,
+                  userName: p.userId ? p.nom : null,
+                }))
+              )
+            }
             openState={openState ?? internalOpenState}
           />
         );
@@ -40,12 +53,14 @@ export const MetadataItemPersonne = ({
       <MetadataItem
         dataTest={dataTest}
         interactive={!isReadOnly}
+        hideSeparator={hideSeparator}
+        tooltip={tooltip}
         icon={icon}
         label={personnes.length > 1 ? label.many : label.one}
         value={
           personnes.length
             ? personnes
-                .map((p) => p.userName || p.tagName || '')
+                .map((p) => p.nom || p.userName || p.tagName || '')
                 .filter(Boolean)
                 .join(', ')
             : null

--- a/apps/app/src/ui/metadata-line/metadata-item-personne.tsx
+++ b/apps/app/src/ui/metadata-line/metadata-item-personne.tsx
@@ -1,6 +1,7 @@
 import PersonneTagDropdown from '@/app/collectivites/tags/personne-tag.dropdown';
 import { Personne } from '@tet/domain/collectivites';
 import { IconValue, InlineEditWrapper } from '@tet/ui';
+import { ReactNode } from 'react';
 import { MetadataItem } from './metadata-item';
 
 export const MetadataItemPersonne = ({
@@ -60,7 +61,7 @@ export const MetadataItemPersonne = ({
         value={
           personnes.length
             ? personnes
-                .map((p) => p.nom || p.userName || p.tagName || '')
+                .map((p) => p.userName || p.tagName || '')
                 .filter(Boolean)
                 .join(', ')
             : null

--- a/apps/app/src/ui/metadata-line/metadata-item.tsx
+++ b/apps/app/src/ui/metadata-line/metadata-item.tsx
@@ -1,8 +1,7 @@
+import { appLabels } from '@/app/labels/catalog';
 import { cn, Icon, IconValue } from '@tet/ui';
 import { isNil } from 'es-toolkit';
 import { HTMLAttributes, ReactNode } from 'react';
-import { appLabels } from '@/app/labels/catalog';
-import { Colon } from '@/app/ui/colon';
 
 export type MetadataItemProps = {
   dataTest?: string;
@@ -11,6 +10,7 @@ export type MetadataItemProps = {
   icon: IconValue;
   label: string;
   value: ReactNode;
+  tooltip?: ReactNode;
 } & HTMLAttributes<HTMLDivElement>;
 
 export const MetadataItem = ({
@@ -20,6 +20,7 @@ export const MetadataItem = ({
   icon,
   label,
   value,
+  tooltip,
   ...props
 }: MetadataItemProps) => {
   return (
@@ -34,15 +35,13 @@ export const MetadataItem = ({
         })}
       >
         <Icon icon={icon} />
-        <span className="font-normal">
-          {label}
-          <Colon />
-        </span>
+        <span className="font-normal">{`${label} : `}</span>
         {isNil(value) || value === '' ? (
           <span className="text-warning-1">{appLabels.aCompleterMaj}</span>
         ) : (
           <span className="font-medium">{value}</span>
         )}
+        {tooltip}
       </div>
       {!hideSeparator && <div className="ml-4 w-[1px] h-4 bg-primary-3" />}
     </div>

--- a/packages/ui/src/design-system/ChecklistTable/ChecklistTable.tsx
+++ b/packages/ui/src/design-system/ChecklistTable/ChecklistTable.tsx
@@ -27,10 +27,10 @@ const CriterionCell = ({
   action?: ReactElement;
 }) => (
   <td className="py-3 px-4 border-r border-grey-4 align-middle">
-    <div className="flex items-start justify-between gap-4">
+    <div className="flex items-center justify-between gap-4">
       <div className="grow">{label}</div>
       {action && (
-        <div className="shrink-0 self-start opacity-0 group-hover:opacity-100 group-focus-within:opacity-100">
+        <div className="shrink-0 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100">
           {action}
         </div>
       )}

--- a/packages/ui/src/design-system/ChecklistTable/ChecklistTable.tsx
+++ b/packages/ui/src/design-system/ChecklistTable/ChecklistTable.tsx
@@ -103,7 +103,7 @@ const Head = ({
             {tagHeader ? (
               <span className="uppercase">{tagHeader}</span>
             ) : (
-              <span className="sr-only">{uiLabels.statutDuCritere}</span>
+              <span className="sr-only">{uiLabels.etiquette}</span>
             )}
           </HeaderCell>
         )}

--- a/packages/ui/src/design-system/ChecklistTable/ChecklistTable.tsx
+++ b/packages/ui/src/design-system/ChecklistTable/ChecklistTable.tsx
@@ -1,9 +1,18 @@
 'use client';
 
-import { ReactElement, ReactNode } from 'react';
+import { ReactElement, ReactNode, createContext, useContext } from 'react';
 import { uiLabels } from '../../labels/catalog';
 import { cn } from '../../utils/cn';
 import { Icon } from '../Icon';
+
+type ChecklistTableContextValue = {
+  /** Active une colonne dédiée (ex. badge/étiquette) après la colonne statut. */
+  hasTagColumn: boolean;
+};
+
+const ChecklistTableContext = createContext<ChecklistTableContextValue>({
+  hasTagColumn: false,
+});
 
 const StatusCell = ({ done }: { done: boolean }) => (
   <td className="w-12 py-3 px-4 border-r border-grey-4 align-middle">
@@ -16,6 +25,12 @@ const StatusCell = ({ done }: { done: boolean }) => (
         className={done ? 'text-success' : 'text-warning-1'}
       />
     </div>
+  </td>
+);
+
+const TagCell = ({ children }: { children: ReactNode }) => (
+  <td className="w-40 py-3 px-4 border-r border-grey-4 align-middle">
+    {children}
   </td>
 );
 
@@ -45,6 +60,11 @@ const AnswerCell = ({ children }: { children: ReactNode }) => (
 export type ChecklistTableHeadProps = {
   labelHeader: string;
   answerHeader: string;
+  /**
+   * Libellé de la colonne d’étiquette optionnelle. Requis (au moins pour
+   * l’accessibilité) lorsque la table est configurée avec `hasTagColumn`.
+   */
+  tagHeader?: string;
 };
 
 const HeaderCell = ({
@@ -65,21 +85,38 @@ const HeaderCell = ({
   </th>
 );
 
-const Head = ({ labelHeader, answerHeader }: ChecklistTableHeadProps) => (
-  <thead>
-    <tr>
-      <HeaderCell className="w-12">
-        <span className="sr-only">{uiLabels.statutDuCritere}</span>
-      </HeaderCell>
-      <HeaderCell>
-        <span className="uppercase">{labelHeader}</span>
-      </HeaderCell>
-      <HeaderCell className="w-1/3 border-r-0">
-        <span className="uppercase">{answerHeader}</span>
-      </HeaderCell>
-    </tr>
-  </thead>
-);
+const Head = ({
+  labelHeader,
+  answerHeader,
+  tagHeader,
+}: ChecklistTableHeadProps) => {
+  const { hasTagColumn } = useContext(ChecklistTableContext);
+
+  return (
+    <thead>
+      <tr>
+        <HeaderCell className="w-12">
+          <span className="sr-only">{uiLabels.statutDuCritere}</span>
+        </HeaderCell>
+        {hasTagColumn && (
+          <HeaderCell className="w-40">
+            {tagHeader ? (
+              <span className="uppercase">{tagHeader}</span>
+            ) : (
+              <span className="sr-only">{uiLabels.statutDuCritere}</span>
+            )}
+          </HeaderCell>
+        )}
+        <HeaderCell>
+          <span className="uppercase">{labelHeader}</span>
+        </HeaderCell>
+        <HeaderCell className="w-1/3 border-r-0">
+          <span className="uppercase">{answerHeader}</span>
+        </HeaderCell>
+      </tr>
+    </thead>
+  );
+};
 
 export type ChecklistTableRowProps = {
   done: boolean;
@@ -88,41 +125,57 @@ export type ChecklistTableRowProps = {
     action?: ReactElement;
   };
   answer: ReactNode;
+  /** Contenu de la colonne d’étiquette optionnelle (si `hasTagColumn`). */
+  tag?: ReactNode;
 };
 
-const Row = ({ done, criterion, answer }: ChecklistTableRowProps) => (
-  <tbody>
-    <tr className="group text-sm text-primary-9 hover:bg-primary-1 border-t border-grey-3">
-      <StatusCell done={done} />
-      <CriterionCell {...criterion} />
-      <AnswerCell>{answer}</AnswerCell>
-    </tr>
-  </tbody>
-);
+const Row = ({ done, criterion, answer, tag }: ChecklistTableRowProps) => {
+  const { hasTagColumn } = useContext(ChecklistTableContext);
+
+  return (
+    <tbody>
+      <tr className="group text-sm text-primary-9 hover:bg-primary-1 border-t border-grey-3">
+        <StatusCell done={done} />
+        {hasTagColumn && <TagCell>{tag}</TagCell>}
+        <CriterionCell {...criterion} />
+        <AnswerCell>{answer}</AnswerCell>
+      </tr>
+    </tbody>
+  );
+};
 
 export type ChecklistTableProps = {
   caption?: string;
   children: ReactNode;
   className?: string;
+  /**
+   * Ajoute une colonne d’étiquette dédiée juste après la colonne de statut.
+   * Alimentée par `tagHeader` sur `ChecklistTable.Head` et `tag` sur
+   * `ChecklistTable.Row`.
+   */
+  hasTagColumn?: boolean;
 };
 
 export function ChecklistTable({
   caption,
   children,
   className,
+  hasTagColumn = false,
 }: ChecklistTableProps) {
   return (
-    <div
-      className={cn(
-        'border border-grey-4 rounded-md overflow-x-auto',
-        className
-      )}
-    >
-      <table className="min-w-[640px] w-full bg-white table-fixed">
-        {caption && <caption className="sr-only">{caption}</caption>}
-        {children}
-      </table>
-    </div>
+    <ChecklistTableContext.Provider value={{ hasTagColumn }}>
+      <div
+        className={cn(
+          'border border-grey-4 rounded-md overflow-x-auto',
+          className
+        )}
+      >
+        <table className="min-w-[640px] w-full bg-white table-fixed">
+          {caption && <caption className="sr-only">{caption}</caption>}
+          {children}
+        </table>
+      </div>
+    </ChecklistTableContext.Provider>
   );
 }
 

--- a/packages/ui/src/design-system/table/table.cell.tsx
+++ b/packages/ui/src/design-system/table/table.cell.tsx
@@ -77,6 +77,7 @@ const Cell = ({
 }: TableCellProps) => {
   return (
     <td
+      role="gridcell"
       {...props}
       className={cn(
         'px-4 py-3 text-left',

--- a/packages/ui/src/design-system/table/table.cell.tsx
+++ b/packages/ui/src/design-system/table/table.cell.tsx
@@ -77,7 +77,6 @@ const Cell = ({
 }: TableCellProps) => {
   return (
     <td
-      role="gridcell"
       {...props}
       className={cn(
         'px-4 py-3 text-left',

--- a/packages/ui/src/design-system/table/table.header-cell.tsx
+++ b/packages/ui/src/design-system/table/table.header-cell.tsx
@@ -37,6 +37,7 @@ export const TableHeaderCell = ({
       className={cn(
         'px-4 py-3 text-sm text-grey-9 font-medium leading-none align-top',
         { [pinnedLeftClassName]: pinnedLeft },
+        pinnedLeft && 'bg-white',
         className
       )}
     >

--- a/packages/ui/src/design-system/table/table.header-cell.tsx
+++ b/packages/ui/src/design-system/table/table.header-cell.tsx
@@ -37,8 +37,8 @@ export const TableHeaderCell = ({
       className={cn(
         'px-4 py-3 text-sm text-grey-9 font-medium leading-none align-top',
         { [pinnedLeftClassName]: pinnedLeft },
-        pinnedLeft && 'bg-white',
-        className
+        className,
+        pinnedLeft && 'bg-white'
       )}
     >
       <div className={cn('flex flex-col', filter && 'gap-2')}>

--- a/packages/ui/src/design-system/table/table.row.tsx
+++ b/packages/ui/src/design-system/table/table.row.tsx
@@ -4,6 +4,7 @@ type Props = React.HTMLAttributes<HTMLTableRowElement>;
 
 export const TableRow = ({ className, ...props }: Props) => (
   <tr
+    role="row"
     className={cn(
       'group relative border-b border-grey-3 last:border-b-0 bg-white even:bg-grey-1',
       // Cache le span inséré par FloatingFocusManager

--- a/packages/ui/src/design-system/table/table.row.tsx
+++ b/packages/ui/src/design-system/table/table.row.tsx
@@ -5,7 +5,7 @@ type Props = React.HTMLAttributes<HTMLTableRowElement>;
 export const TableRow = ({ className, ...props }: Props) => (
   <tr
     className={cn(
-      'group relative border-b border-grey-3 last:border-b-0 even:bg-grey-1',
+      'group relative border-b border-grey-3 last:border-b-0 bg-white even:bg-grey-1',
       // Cache le span inséré par FloatingFocusManager
       // qui est ajouté pour récupérer le focus lorsque qu'une cellule
       // qui est ouverte (portal) en inline editing est refermée

--- a/packages/ui/src/labels/catalog.ts
+++ b/packages/ui/src/labels/catalog.ts
@@ -35,6 +35,7 @@ const uiLabels = {
   critereAtteint: "Critère atteint",
   critereNonAtteint: "Critère non atteint",
   statutDuCritere: "Statut du critère",
+  etiquette: "Étiquette",
   saisirUnTitre: "Saisir un titre",
   sansTitre: "Sans titre",
   modifierLeTitre: "Modifier le titre",


### PR DESCRIPTION
## Résumé

Isole dans une PR à part les changements de design system et de composants UI génériques qui étaient mélangés dans la PR #4455 (`TET-7178/pcaet-spec-tech`), afin de pouvoir les reviewer/merger indépendamment de la feature PCAET.

Commits extraits (cherry-pick à l'identique, ou hunk isolé quand le commit d'origine mélangeait plusieurs sujets) :

- `refact(ui): centre verticalement le contenu de ChecklistTable`
- `ui(metadata-item)`
- `feat(ui): réduire le padding-top du layout global à 1.5rem`
- `fix bg-color du tableau en mode sticky`
- `ui(table): DS better accessibility`
- `feat(ds): ajoute le support d'une colonne d'étiquette optionnelle à ChecklistTable` — hunk extrait du commit `bfd4c37ea` ("Update") qui mélangeait ce changement de `packages/ui/src/design-system/ChecklistTable` avec des évolutions métier PCAET (documents-table, stepper, labels)

### Exclu volontairement

`apps/app/src/ui/layout/header/main-nav/collectivite/generate-parametres-dropdown.ts` a aussi été modifié dans `TET-7178` (commit `24e774d84`) pour ajouter les entrées de nav PCAET, mais ce changement dépend d'URLs/labels ajoutés dans le même commit feature (`paths.ts`, `labels/catalog.ts`) — ce n'est pas un changement de design system, donc il reste dans la PR #4455.

## Captures avant / après

Générées via Storybook (`nx run ui:storybook` / `nx run app:storybook`), avec des stories temporaires jetables (non commitées) pour les composants sans story existante (`MetadataItem`, padding du layout).

### `fix bg-color du tableau en mode sticky` + `ui(table): DS better accessibility`

Table avec colonne épinglée (`pinnedLeft`) et scroll horizontal — avant le fix, le contenu des colonnes défilées transparaissait à travers la colonne figée.

| Avant | Après |
| --- | --- |
| ![before](https://gist.githubusercontent.com/farnoux/7ee3cd2c14a2f173f0375dc4fa2e1960/raw/92bc159f5c7a8e5beabb5b2d375cfadb22521d8f/table-pinned-before-scrolled.png) | ![after](https://gist.githubusercontent.com/farnoux/7ee3cd2c14a2f173f0375dc4fa2e1960/raw/92bc159f5c7a8e5beabb5b2d375cfadb22521d8f/table-pinned-after-scrolled.png) |

### `refact(ui): centre verticalement le contenu de ChecklistTable`

Le bouton d'action est maintenant centré verticalement par rapport au critère (au lieu d'être aligné en haut), notamment visible quand le libellé passe sur plusieurs lignes.

| Avant | Après |
| --- | --- |
| ![before](https://gist.githubusercontent.com/farnoux/7ee3cd2c14a2f173f0375dc4fa2e1960/raw/92bc159f5c7a8e5beabb5b2d375cfadb22521d8f/checklist-align-before.png) | ![after](https://gist.githubusercontent.com/farnoux/7ee3cd2c14a2f173f0375dc4fa2e1960/raw/92bc159f5c7a8e5beabb5b2d375cfadb22521d8f/checklist-align-after.png) |

### `feat(ds): ajoute le support d'une colonne d'étiquette optionnelle à ChecklistTable`

Nouvelle colonne optionnelle (`hasTagColumn` / `tagHeader` / `tag`) pour afficher une étiquette par ligne. Ci-dessous, un `ChecklistTable` classique (sans la nouvelle colonne) comparé au même tableau avec `hasTagColumn`.

| Avant (sans colonne) | Après (`hasTagColumn`) |
| --- | --- |
| ![before](https://gist.githubusercontent.com/farnoux/7ee3cd2c14a2f173f0375dc4fa2e1960/raw/92bc159f5c7a8e5beabb5b2d375cfadb22521d8f/checklist-tagcolumn-before.png) | ![after](https://gist.githubusercontent.com/farnoux/7ee3cd2c14a2f173f0375dc4fa2e1960/raw/92bc159f5c7a8e5beabb5b2d375cfadb22521d8f/checklist-tagcolumn-after.png) |

### `ui(metadata-item)`

Nouvelles props `tooltip` et `hideSeparator`. Ci-dessous, le même `MetadataItem` sans puis avec une tooltip d'info et le séparateur masqué.

| Avant | Après |
| --- | --- |
| ![before](https://gist.githubusercontent.com/farnoux/7ee3cd2c14a2f173f0375dc4fa2e1960/raw/92bc159f5c7a8e5beabb5b2d375cfadb22521d8f/metadata-item-before.png) | ![after](https://gist.githubusercontent.com/farnoux/7ee3cd2c14a2f173f0375dc4fa2e1960/raw/92bc159f5c7a8e5beabb5b2d375cfadb22521d8f/metadata-item-after.png) |

### `feat(ui): réduire le padding-top du layout global à 1.5rem`

Malgré son nom, ce commit augmente en réalité le padding-bottom du contenu (`py-6` → `pb-12 pt-6`), ce qui élargit l'espace entre le contenu de la page et le footer.

| Avant | Après |
| --- | --- |
| ![before](https://gist.githubusercontent.com/farnoux/7ee3cd2c14a2f173f0375dc4fa2e1960/raw/92bc159f5c7a8e5beabb5b2d375cfadb22521d8f/layout-padding-before.png) | ![after](https://gist.githubusercontent.com/farnoux/7ee3cd2c14a2f173f0375dc4fa2e1960/raw/92bc159f5c7a8e5beabb5b2d375cfadb22521d8f/layout-padding-after.png) |

### Non visuel (pas de capture)

- Ajout de `role="gridcell"` / `role="row"` sur les cellules et lignes du tableau DS — purement sémantique/accessibilité, aucun changement visuel.

## Test plan

- [ ] Vérifier visuellement `ChecklistTable` (colonne d'étiquette optionnelle) et le tableau DS (accessibilité, bg sticky)
- [ ] Vérifier `metadata-item` / `metadata-item-personne` et le padding du layout global

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Les tableaux de checklist peuvent désormais afficher une colonne dédiée aux étiquettes.
  * Les éléments de métadonnées prennent en charge les infobulles et un affichage plus complet des personnes.

* **Améliorations de l'interface**
  * L'espacement inférieur du contenu principal a été augmenté.
  * L'alignement et la lisibilité des actions dans les tableaux ont été améliorés.
  * Les colonnes fixes bénéficient d'un arrière-plan plus lisible.

* **Accessibilité**
  * Les lignes et cellules des tableaux disposent désormais d'une sémantique améliorée pour les technologies d'assistance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
