### PR TITLE
fix(referentiel): Cache les onglets aide à la priorisation et détail …

### DIFF
--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/(overview)/@tabs/tabs-wrapper.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/(overview)/@tabs/tabs-wrapper.tsx
@@ -1,7 +1,9 @@
 'use client';
 
+import { useReferentielId } from '@/app/referentiels/referentiel-context';
 import { useReferentielViewMode } from '@/app/referentiels/referentiel.table/use-referentiel-view-mode';
 import { useCurrentCollectivite } from '@tet/api/collectivites';
+import { isNewReferentiel as isNewReferentielUtils } from '@tet/domain/referentiels';
 import {
   Tabs,
   TabsList,
@@ -11,6 +13,7 @@ import {
 import { PropsWithChildren } from 'react';
 
 export const TabsWrapper = ({ children }: PropsWithChildren) => {
+  const referentielId = useReferentielId();
   const { hasCollectivitePermission } = useCurrentCollectivite();
   const canReadComments = hasCollectivitePermission(
     'referentiels.discussions.read'
@@ -18,12 +21,13 @@ export const TabsWrapper = ({ children }: PropsWithChildren) => {
 
   const { mode } = useReferentielViewMode();
   const isTableView = mode === 'table';
+  const isNewReferentiel = isNewReferentielUtils(referentielId);
 
   return (
     <Tabs className="grow flex flex-col">
       <TabsList className="!justify-start pl-0 flex-nowrap bg-transparent overflow-x-auto">
         <TabsTab href="progression" label="Mesures" />
-        {!isTableView && (
+        {!isNewReferentiel && !isTableView && (
           <>
             <TabsTab href="priorisation" label="Aide à la priorisation" />
             <TabsTab href="detail" label="Détail des statuts" />


### PR DESCRIPTION
…des statuts pour le référentiel CR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Améliorations**
  - Les référentiels nouvellement créés affichent désormais une interface simplifiée.
  - Les onglets de priorisation et de détail des statuts sont masqués pour les nouveaux référentiels et en mode tableau.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->