### PR TITLE
fix(referentiels): préserve la complétude lors de l'assignation d'un rôle

### DIFF
--- a/apps/app/src/referentiels/actions/action-statut/use-action-statut.ts
+++ b/apps/app/src/referentiels/actions/action-statut/use-action-statut.ts
@@ -11,48 +11,47 @@ import { useLabellisationParcours } from '../../labellisations/useLabellisationP
 import { useReferentielId } from '../../referentiel-context';
 import { useGetAction } from '../use-get-action';
 
-export const useSaveActionStatut = () => {
+export const useSaveActionStatuts = () => {
   const collectiviteId = useCollectiviteId();
   const referentielId = useReferentielId();
   const queryClient = useQueryClient();
   const trpc = useTRPC();
 
-  const { isPending, mutate: saveActionStatut } = useMutation(
-    trpc.referentiels.actions.updateStatut.mutationOptions({
-      onSuccess: () => {
-        // Invalidate cache for all action statuts
-        queryClient.invalidateQueries({
-          queryKey: ['action_statut', collectiviteId],
-        });
-
-        queryClient.invalidateQueries({
-          queryKey: trpc.referentiels.actions.listActionsGroupedById.queryKey({
-            collectiviteId,
-            referentielId,
+  const { isPending, mutateAsync: saveActionStatuts } = useMutation(
+    trpc.referentiels.actions.updateStatuts.mutationOptions({
+      // Awaitées pour que la promesse de mutation ne se résolve qu'une fois les
+      // caches dérivés rafraîchis : un caller qui enchaîne sur `mutateAsync`
+      // lirait sinon l'état d'avant l'écriture.
+      onSuccess: async () => {
+        await Promise.all([
+          queryClient.invalidateQueries({
+            queryKey: ['action_statut', collectiviteId],
           }),
-        });
-
-        queryClient.invalidateQueries({
-          queryKey: trpc.referentiels.snapshots.getCurrent.queryKey({
-            collectiviteId,
-            referentielId,
+          queryClient.invalidateQueries({
+            queryKey: trpc.referentiels.actions.listActionsGroupedById.queryKey(
+              {
+                collectiviteId,
+                referentielId,
+              }
+            ),
           }),
-        });
-
-        queryClient.invalidateQueries({
-          queryKey: trpc.referentiels.labellisations.getParcours.queryKey({
-            collectiviteId,
-            referentielId,
+          queryClient.invalidateQueries({
+            queryKey: trpc.referentiels.snapshots.getCurrent.queryKey({
+              collectiviteId,
+              referentielId,
+            }),
           }),
-        });
+          queryClient.invalidateQueries({
+            queryKey: trpc.referentiels.labellisations.getParcours.queryKey({
+              collectiviteId,
+              referentielId,
+            }),
+          }),
+        ]);
       },
-      // Les invalidations de l'historique sont placées dans `onSettled` et
-      // awaitées, alignées sur le pattern de
-      // `useSetPersonnalisationJustification` : on veut rafraîchir
-      // l'historique même si la mutation a échoué (cas optimistique avec
-      // rollback) et garantir que la promesse de mutation ne se résout
-      // qu'une fois le cache à jour, pour éviter qu'un caller chaîné voie
-      // l'ancien état.
+      // L'historique est dans `onSettled`, et non `onSuccess`, pour être
+      // rafraîchi même quand la mutation a échoué — cas optimistique avec
+      // rollback. Aligné sur `useSetPersonnalisationJustification`.
       onSettled: async () => {
         await queryClient.invalidateQueries({
           queryKey: trpc.referentiels.historique.list.queryKey(),
@@ -66,7 +65,7 @@ export const useSaveActionStatut = () => {
 
   return {
     isLoading: isPending,
-    saveActionStatut,
+    saveActionStatuts,
   };
 };
 /**
@@ -75,8 +74,7 @@ export const useSaveActionStatut = () => {
  * per row with the action's `score.desactive` value.
  */
 export const useActionStatutEditContext = () => {
-  const { hasReferentielPermission, collectiviteId } =
-    useCurrentCollectivite();
+  const { hasReferentielPermission, collectiviteId } = useCurrentCollectivite();
   const referentielId = useReferentielId();
   const { parcours } = useLabellisationParcours({
     collectiviteId,

--- a/apps/app/src/referentiels/audit-labellisation/checklist-page-header/checklist-page-header.tsx
+++ b/apps/app/src/referentiels/audit-labellisation/checklist-page-header/checklist-page-header.tsx
@@ -51,7 +51,9 @@ const ChecklistPageHeaderView = ({
     </PageHeader.Actions>
     <PageHeader.Metadata>
       <ReferentsLine roleMesures={roleMesures} />
-      {referentiel !== undefined && <ReferentielScoreLine action={referentiel} />}
+      {referentiel !== undefined && (
+        <ReferentielScoreLine action={referentiel} />
+      )}
     </PageHeader.Metadata>
   </PageHeader>
 );

--- a/apps/app/src/referentiels/audit-labellisation/checklist-page-header/conseiller-referent.item.tsx
+++ b/apps/app/src/referentiels/audit-labellisation/checklist-page-header/conseiller-referent.item.tsx
@@ -38,9 +38,7 @@ export const ConseillerReferentItem = ({
         <ReferentsDropdown
           buttonClassName="border-none"
           membres={conseillers}
-          onChange={({ values }) =>
-            saveConseillers((values ?? []).map(String))
-          }
+          onChange={({ values }) => saveConseillers((values ?? []).map(String))}
           openState={openState}
         />
       )}

--- a/apps/app/src/referentiels/audit-labellisation/checklist-page-header/propagate-statut-to-taches.spec.ts
+++ b/apps/app/src/referentiels/audit-labellisation/checklist-page-header/propagate-statut-to-taches.spec.ts
@@ -1,0 +1,307 @@
+import { ActionId, StatutAvancementEnum } from '@tet/domain/referentiels';
+import { describe, expect, it } from 'vitest';
+import {
+  propagateStatutToTaches,
+  SousAction,
+} from './propagate-statut-to-taches';
+
+const collectiviteId = 42;
+
+const sousActionId: ActionId = 'eci_1.1.1';
+const referentTechniqueId: ActionId = 'eci_1.1.1.3';
+const eluReferentId: ActionId = 'eci_1.1.1.1';
+const visionPolitiqueId: ActionId = 'eci_1.1.1.2';
+
+const aRenseigner = { concerne: true, desactive: false };
+
+const toSousAction = ({
+  avancement,
+  avancementDetaille = null,
+  tachesWithoutStatut = [eluReferentId, visionPolitiqueId],
+  tachesWithStatut = [],
+  tachesNonConcernees = [],
+  tachesDesactivees = [],
+}: {
+  avancement: SousAction['score']['avancement'];
+  avancementDetaille?: SousAction['score']['avancementDetaille'];
+  tachesWithoutStatut?: ActionId[];
+  tachesWithStatut?: ActionId[];
+  tachesNonConcernees?: ActionId[];
+  tachesDesactivees?: ActionId[];
+}): SousAction => ({
+  actionId: sousActionId,
+  score: { avancement, avancementDetaille, ...aRenseigner },
+  actionsEnfant: [
+    { actionId: referentTechniqueId, score: { ...aRenseigner } },
+    ...tachesWithoutStatut.map((actionId) => ({
+      actionId,
+      score: { ...aRenseigner },
+    })),
+    ...tachesWithStatut.map((actionId) => ({
+      actionId,
+      score: { avancement: StatutAvancementEnum.FAIT, ...aRenseigner },
+    })),
+    ...tachesNonConcernees.map((actionId) => ({
+      actionId,
+      score: { concerne: false, desactive: false },
+    })),
+    ...tachesDesactivees.map((actionId) => ({
+      actionId,
+      score: { concerne: false, desactive: true },
+    })),
+  ],
+});
+
+describe('propagateStatutToTaches', () => {
+  it('met la mesure du rôle à fait', () => {
+    const statuts = propagateStatutToTaches({
+      collectiviteId,
+      tacheId: referentTechniqueId,
+      sousAction: toSousAction({ avancement: undefined }),
+      statut: StatutAvancementEnum.FAIT,
+    });
+
+    expect(statuts).toEqual([
+      {
+        collectiviteId,
+        actionId: referentTechniqueId,
+        statut: StatutAvancementEnum.FAIT,
+        statutDetailleAuPourcentage: null,
+      },
+    ]);
+  });
+
+  it('recopie le statut direct de la sous-action sur les tâches sœurs qui en sont dépourvues', () => {
+    const statuts = propagateStatutToTaches({
+      collectiviteId,
+      tacheId: referentTechniqueId,
+      sousAction: toSousAction({
+        avancement: StatutAvancementEnum.PAS_FAIT,
+      }),
+      statut: StatutAvancementEnum.FAIT,
+    });
+
+    expect(statuts).toEqual([
+      {
+        collectiviteId,
+        actionId: referentTechniqueId,
+        statut: StatutAvancementEnum.FAIT,
+        statutDetailleAuPourcentage: null,
+      },
+      {
+        collectiviteId,
+        actionId: eluReferentId,
+        statut: StatutAvancementEnum.PAS_FAIT,
+        statutDetailleAuPourcentage: null,
+      },
+      {
+        collectiviteId,
+        actionId: visionPolitiqueId,
+        statut: StatutAvancementEnum.PAS_FAIT,
+        statutDetailleAuPourcentage: null,
+      },
+      {
+        collectiviteId,
+        actionId: sousActionId,
+        statut: StatutAvancementEnum.DETAILLE_A_LA_TACHE,
+        statutDetailleAuPourcentage: null,
+      },
+    ]);
+  });
+
+  it('bascule explicitement la sous-action en détaillé à la tâche, pour que le backend ne génère pas un reset par tâche du lot', () => {
+    const statuts = propagateStatutToTaches({
+      collectiviteId,
+      tacheId: referentTechniqueId,
+      sousAction: toSousAction({
+        avancement: StatutAvancementEnum.PAS_FAIT,
+      }),
+      statut: StatutAvancementEnum.FAIT,
+    });
+
+    expect(statuts.filter(({ actionId }) => actionId === sousActionId)).toEqual(
+      [
+        {
+          collectiviteId,
+          actionId: sousActionId,
+          statut: StatutAvancementEnum.DETAILLE_A_LA_TACHE,
+          statutDetailleAuPourcentage: null,
+        },
+      ]
+    );
+  });
+
+  it("assigner le référent technique n'écrase pas le statut déjà saisi sur l'élu référent", () => {
+    const statuts = propagateStatutToTaches({
+      collectiviteId,
+      tacheId: referentTechniqueId,
+      sousAction: toSousAction({
+        avancement: StatutAvancementEnum.PAS_FAIT,
+        tachesWithoutStatut: [visionPolitiqueId],
+        tachesWithStatut: [eluReferentId],
+      }),
+      statut: StatutAvancementEnum.FAIT,
+    });
+
+    expect(statuts).toEqual([
+      {
+        collectiviteId,
+        actionId: referentTechniqueId,
+        statut: StatutAvancementEnum.FAIT,
+        statutDetailleAuPourcentage: null,
+      },
+      {
+        collectiviteId,
+        actionId: visionPolitiqueId,
+        statut: StatutAvancementEnum.PAS_FAIT,
+        statutDetailleAuPourcentage: null,
+      },
+      {
+        collectiviteId,
+        actionId: sousActionId,
+        statut: StatutAvancementEnum.DETAILLE_A_LA_TACHE,
+        statutDetailleAuPourcentage: null,
+      },
+    ]);
+  });
+
+  it('recopie le détail au pourcentage de la sous-action tel quel', () => {
+    const statuts = propagateStatutToTaches({
+      collectiviteId,
+      tacheId: referentTechniqueId,
+      sousAction: toSousAction({
+        avancement: StatutAvancementEnum.DETAILLE_AU_POURCENTAGE,
+        avancementDetaille: [0.5, 0.25, 0.25],
+        tachesWithoutStatut: [eluReferentId],
+      }),
+      statut: StatutAvancementEnum.FAIT,
+    });
+
+    expect(statuts).toContainEqual({
+      collectiviteId,
+      actionId: eluReferentId,
+      statut: StatutAvancementEnum.DETAILLE_AU_POURCENTAGE,
+      statutDetailleAuPourcentage: [0.5, 0.25, 0.25],
+    });
+  });
+
+  it('ne recopie rien quand la sous-action est détaillée au pourcentage sans détail exploitable', () => {
+    const statuts = propagateStatutToTaches({
+      collectiviteId,
+      tacheId: referentTechniqueId,
+      sousAction: toSousAction({
+        avancement: StatutAvancementEnum.DETAILLE_AU_POURCENTAGE,
+        avancementDetaille: null,
+      }),
+      statut: StatutAvancementEnum.FAIT,
+    });
+
+    expect(statuts.map(({ actionId }) => actionId)).toEqual([
+      referentTechniqueId,
+      sousActionId,
+    ]);
+  });
+
+  it('recopie aussi lors du retrait du rôle, qui remet la mesure à non renseigné', () => {
+    const statuts = propagateStatutToTaches({
+      collectiviteId,
+      tacheId: referentTechniqueId,
+      sousAction: toSousAction({
+        avancement: StatutAvancementEnum.PAS_FAIT,
+        tachesWithoutStatut: [eluReferentId],
+      }),
+      statut: StatutAvancementEnum.NON_RENSEIGNE,
+    });
+
+    expect(statuts).toEqual([
+      {
+        collectiviteId,
+        actionId: referentTechniqueId,
+        statut: StatutAvancementEnum.NON_RENSEIGNE,
+        statutDetailleAuPourcentage: null,
+      },
+      {
+        collectiviteId,
+        actionId: eluReferentId,
+        statut: StatutAvancementEnum.PAS_FAIT,
+        statutDetailleAuPourcentage: null,
+      },
+      {
+        collectiviteId,
+        actionId: sousActionId,
+        statut: StatutAvancementEnum.DETAILLE_A_LA_TACHE,
+        statutDetailleAuPourcentage: null,
+      },
+    ]);
+  });
+
+  it('ne recopie rien sur une tâche sœur déclarée non concernée, dont la déclaration serait effacée', () => {
+    const statuts = propagateStatutToTaches({
+      collectiviteId,
+      tacheId: referentTechniqueId,
+      sousAction: toSousAction({
+        avancement: StatutAvancementEnum.PAS_FAIT,
+        tachesWithoutStatut: [],
+        tachesNonConcernees: [visionPolitiqueId],
+      }),
+      statut: StatutAvancementEnum.FAIT,
+    });
+
+    expect(statuts.map(({ actionId }) => actionId)).toEqual([
+      referentTechniqueId,
+      sousActionId,
+    ]);
+  });
+
+  it('exclut du lot une tâche sœur désactivée, que le backend rejetterait en entier', () => {
+    const statuts = propagateStatutToTaches({
+      collectiviteId,
+      tacheId: referentTechniqueId,
+      sousAction: toSousAction({
+        avancement: StatutAvancementEnum.PAS_FAIT,
+        tachesWithoutStatut: [],
+        tachesDesactivees: [visionPolitiqueId],
+      }),
+      statut: StatutAvancementEnum.FAIT,
+    });
+
+    expect(statuts.map(({ actionId }) => actionId)).toEqual([
+      referentTechniqueId,
+      sousActionId,
+    ]);
+  });
+
+  it("retirer le référent technique n'écrase pas le statut déjà saisi sur l'élu référent", () => {
+    const statuts = propagateStatutToTaches({
+      collectiviteId,
+      tacheId: referentTechniqueId,
+      sousAction: toSousAction({
+        avancement: StatutAvancementEnum.PAS_FAIT,
+        tachesWithoutStatut: [visionPolitiqueId],
+        tachesWithStatut: [eluReferentId],
+      }),
+      statut: StatutAvancementEnum.NON_RENSEIGNE,
+    });
+
+    expect(statuts).toEqual([
+      {
+        collectiviteId,
+        actionId: referentTechniqueId,
+        statut: StatutAvancementEnum.NON_RENSEIGNE,
+        statutDetailleAuPourcentage: null,
+      },
+      {
+        collectiviteId,
+        actionId: visionPolitiqueId,
+        statut: StatutAvancementEnum.PAS_FAIT,
+        statutDetailleAuPourcentage: null,
+      },
+      {
+        collectiviteId,
+        actionId: sousActionId,
+        statut: StatutAvancementEnum.DETAILLE_A_LA_TACHE,
+        statutDetailleAuPourcentage: null,
+      },
+    ]);
+  });
+});

--- a/apps/app/src/referentiels/audit-labellisation/checklist-page-header/propagate-statut-to-taches.ts
+++ b/apps/app/src/referentiels/audit-labellisation/checklist-page-header/propagate-statut-to-taches.ts
@@ -1,0 +1,169 @@
+import {
+  ActionId,
+  ActionScore,
+  ActionStatutCreate,
+  StatutAvancementCreate,
+  StatutAvancementEnum,
+  StatutDetailleAuPourcentage,
+} from '@tet/domain/referentiels';
+import { match } from 'ts-pattern';
+
+type ActionWithAvancement = {
+  actionId: ActionId;
+  score: Pick<
+    ActionScore,
+    'avancement' | 'avancementDetaille' | 'concerne' | 'desactive'
+  >;
+};
+
+export type SousAction = ActionWithAvancement & {
+  actionsEnfant: ActionWithAvancement[];
+};
+
+type StatutRenseigne = Exclude<
+  NonNullable<ActionScore['avancement']>,
+  typeof StatutAvancementEnum.NON_RENSEIGNE
+>;
+
+type StatutTache = Exclude<
+  StatutAvancementCreate,
+  typeof StatutAvancementEnum.DETAILLE_AU_POURCENTAGE
+>;
+
+const isStatutRenseigne = (
+  avancement: ActionWithAvancement['score']['avancement']
+): avancement is StatutRenseigne =>
+  avancement != null && avancement !== StatutAvancementEnum.NON_RENSEIGNE;
+
+/**
+ * Une tâche déclarée non concernée, ou désactivée par la personnalisation, est
+ * déjà comptée comme renseignée par le moteur de score et ne doit rien recevoir :
+ * lui écrire un statut simple rétablirait `concerne` à vrai et effacerait la
+ * déclaration. Le backend refuse par ailleurs tout lot contenant une action
+ * désactivée, et rejetterait alors l'assignation entière.
+ */
+const mustInheritStatut = ({ score }: ActionWithAvancement): boolean =>
+  !isStatutRenseigne(score.avancement) && score.concerne && !score.desactive;
+
+const toPropagatedStatut = ({
+  collectiviteId,
+  actionId,
+  avancement,
+  avancementDetaille,
+}: {
+  collectiviteId: number;
+  actionId: ActionId;
+  avancement: StatutRenseigne;
+  avancementDetaille: StatutDetailleAuPourcentage | null;
+}): ActionStatutCreate | null =>
+  match<StatutRenseigne, ActionStatutCreate | null>(avancement)
+    .with(
+      StatutAvancementEnum.FAIT,
+      StatutAvancementEnum.PAS_FAIT,
+      StatutAvancementEnum.PROGRAMME,
+      (statut) => ({
+        collectiviteId,
+        actionId,
+        statut,
+        statutDetailleAuPourcentage: null,
+      })
+    )
+    .with(StatutAvancementEnum.DETAILLE_AU_POURCENTAGE, (statut) => {
+      if (!avancementDetaille) {
+        return null;
+      }
+      return {
+        collectiviteId,
+        actionId,
+        statut,
+        statutDetailleAuPourcentage: avancementDetaille,
+      };
+    })
+    .exhaustive();
+
+const toSiblingTachesStatuts = ({
+  collectiviteId,
+  tacheId,
+  sousAction,
+  avancement,
+  avancementDetaille,
+}: {
+  collectiviteId: number;
+  tacheId: ActionId;
+  sousAction: SousAction;
+  avancement: StatutRenseigne;
+  avancementDetaille: StatutDetailleAuPourcentage | null;
+}): ActionStatutCreate[] =>
+  sousAction.actionsEnfant
+    .filter((tache) => tache.actionId !== tacheId)
+    .filter(mustInheritStatut)
+    .map((tache) =>
+      toPropagatedStatut({
+        collectiviteId,
+        actionId: tache.actionId,
+        avancement,
+        avancementDetaille,
+      })
+    )
+    .filter(
+      (propagated): propagated is ActionStatutCreate => propagated !== null
+    );
+
+/**
+ * Compose le lot de statuts à écrire pour renseigner une tâche sans faire
+ * chuter la complétude du référentiel.
+ *
+ * Écrire le statut d'une tâche fait remettre à `non_renseigne`, côté backend,
+ * le statut direct de sa sous-action parente — voir
+ * `compute-cascading-statuts.rules.ts`. Les tâches sœurs que ce statut
+ * couvrait deviendraient alors non renseignées, et le critère « Renseigner les
+ * statuts de toutes les mesures » retomberait à non atteint. Le lot recopie
+ * donc au préalable le statut de la sous-action sur ces tâches sœurs.
+ *
+ * La sous-action est incluse explicitement, en `detaille_a_la_tache` : c'est
+ * la traduction exacte du reset attendu, et sa présence dans le lot empêche la
+ * cascade d'en générer un par tâche envoyée, ce que l'upsert rejette.
+ */
+export const propagateStatutToTaches = ({
+  collectiviteId,
+  tacheId,
+  statut,
+  sousAction,
+}: {
+  collectiviteId: number;
+  tacheId: ActionId;
+  statut: StatutTache;
+  sousAction: SousAction;
+}): ActionStatutCreate[] => {
+  const tacheStatut: ActionStatutCreate = {
+    collectiviteId,
+    actionId: tacheId,
+    statut,
+    statutDetailleAuPourcentage: null,
+  };
+
+  const { avancement, avancementDetaille } = sousAction.score;
+
+  if (!isStatutRenseigne(avancement) || sousAction.score.desactive) {
+    return [tacheStatut];
+  }
+
+  const sousActionDetaillee: ActionStatutCreate = {
+    collectiviteId,
+    actionId: sousAction.actionId,
+    statut: StatutAvancementEnum.DETAILLE_A_LA_TACHE,
+    statutDetailleAuPourcentage: null,
+  };
+
+  return [
+    tacheStatut,
+    ...toSiblingTachesStatuts({
+      collectiviteId,
+      tacheId,
+      sousAction,
+      avancement,
+      avancementDetaille: avancementDetaille ?? null,
+    }),
+    sousActionDetaillee,
+  ];
+};

--- a/apps/app/src/referentiels/audit-labellisation/checklist-page-header/role-mesure.item.tsx
+++ b/apps/app/src/referentiels/audit-labellisation/checklist-page-header/role-mesure.item.tsx
@@ -21,13 +21,15 @@ export const RoleMesureItem = ({
   label: (params: { count: number }) => string;
   hideSeparator?: boolean;
 }): ReactElement => {
-  const { pilotes, arePilotesLoading, isReadOnly, isMutating, saveRoleMesure } =
+  const { pilotes, isLoading, isReadOnly, isMutating, saveRoleMesure } =
     useRoleMesure(actionId);
 
   const { activeActionId, openDropdown, closeDropdown } = useRoleDropdown();
   const isOpen = activeActionId === actionId;
   const setIsOpen = (open: boolean): void =>
     open ? openDropdown(actionId) : closeDropdown();
+
+  const canEdit = !isReadOnly && !isLoading;
 
   const pilotesNoms = pilotes
     .map((p) => p.nom)
@@ -36,23 +38,28 @@ export const RoleMesureItem = ({
 
   return (
     <InlineEditWrapper
-      disabled={isReadOnly || isMutating}
+      disabled={!canEdit}
       openState={{ isOpen, setIsOpen }}
       renderOnEdit={({ openState }) => (
         <PersonneTagDropdown
           buttonClassName="border-none"
           values={pilotes.map(getPersonneStringId)}
-          onChange={({ personnes }) => saveRoleMesure(personnes)}
+          onChange={({ personnes }) => {
+            if (isMutating) {
+              return;
+            }
+            void saveRoleMesure(personnes);
+          }}
           openState={openState}
         />
       )}
     >
       <MetadataItem
-        interactive={!isReadOnly}
+        interactive={canEdit}
         hideSeparator={hideSeparator}
         icon={icon}
         label={label({ count: pilotes.length })}
-        value={arePilotesLoading ? appLabels.chargement : pilotesNoms || null}
+        value={isLoading ? appLabels.chargement : pilotesNoms || null}
       />
     </InlineEditWrapper>
   );

--- a/apps/app/src/referentiels/audit-labellisation/checklist-page-header/use-conseiller-referent.ts
+++ b/apps/app/src/referentiels/audit-labellisation/checklist-page-header/use-conseiller-referent.ts
@@ -29,7 +29,9 @@ export const useConseillerReferent = (): {
 
   const saveConseillers = (userIds: string[]): void => {
     const toUpdate = conseillers
-      .filter((membre) => membre.estReferent !== userIds.includes(membre.userId))
+      .filter(
+        (membre) => membre.estReferent !== userIds.includes(membre.userId)
+      )
       .map((membre) => ({
         userId: membre.userId,
         estReferent: userIds.includes(membre.userId),

--- a/apps/app/src/referentiels/audit-labellisation/checklist-page-header/use-get-sous-action-of-tache.ts
+++ b/apps/app/src/referentiels/audit-labellisation/checklist-page-header/use-get-sous-action-of-tache.ts
@@ -1,0 +1,35 @@
+import { useGetAction } from '@/app/referentiels/actions/use-get-action';
+import { useGetActionChildren } from '@/app/referentiels/actions/use-get-action-children';
+import { useListActionsGroupedById } from '@/app/referentiels/actions/use-list-actions-grouped-by-id';
+import {
+  ActionId,
+  getParentId,
+  getReferentielIdFromActionId,
+} from '@tet/domain/referentiels';
+import { SousAction } from './propagate-statut-to-taches';
+
+export const useGetSousActionOfTache = (
+  tacheId: ActionId
+): { sousAction: SousAction | undefined; isPending: boolean } => {
+  const sousActionId = getParentId({ actionId: tacheId });
+  const lookupId = sousActionId ?? tacheId;
+
+  const { isPending } = useListActionsGroupedById({
+    referentielIds: [getReferentielIdFromActionId(tacheId)],
+  });
+  const sousActionItem = useGetAction({ actionId: lookupId });
+  const taches = useGetActionChildren({ actionId: lookupId });
+
+  if (sousActionId === null || !sousActionItem) {
+    return { sousAction: undefined, isPending };
+  }
+
+  return {
+    sousAction: {
+      actionId: sousActionItem.actionId,
+      score: sousActionItem.score,
+      actionsEnfant: taches,
+    },
+    isPending,
+  };
+};

--- a/apps/app/src/referentiels/audit-labellisation/checklist-page-header/use-role-mesure.ts
+++ b/apps/app/src/referentiels/audit-labellisation/checklist-page-header/use-role-mesure.ts
@@ -1,20 +1,21 @@
 import { appLabels } from '@/app/labels/catalog';
-import { useSaveActionStatut } from '@/app/referentiels/actions/action-statut/use-action-statut';
+import { useSaveActionStatuts } from '@/app/referentiels/actions/action-statut/use-action-statut';
 import {
   useDeleteMesurePilotes,
   useListMesurePilotes,
   useUpsertMesurePilotes,
 } from '@/app/referentiels/actions/use-mesure-pilotes';
+import { useReferentielId } from '@/app/referentiels/referentiel-context';
+import { captureException } from '@/app/utils/sentry/sentry-client.lazy';
 import { useToastContext } from '@/app/utils/toast/toast-context';
-import { useQueryClient } from '@tanstack/react-query';
-import { useTRPC } from '@tet/api';
 import {
   useCollectiviteId,
   useCurrentCollectivite,
 } from '@tet/api/collectivites';
 import { PersonneTagOrUser } from '@tet/domain/collectivites';
-import { ActionId } from '@tet/domain/referentiels';
-import { useReferentielId } from '@/app/referentiels/referentiel-context';
+import { ActionId, StatutAvancementEnum } from '@tet/domain/referentiels';
+import { propagateStatutToTaches } from './propagate-statut-to-taches';
+import { useGetSousActionOfTache } from './use-get-sous-action-of-tache';
 
 type MesurePilotes = ReturnType<typeof useListMesurePilotes>['data'];
 
@@ -22,10 +23,10 @@ export const useRoleMesure = (
   actionId: ActionId
 ): {
   pilotes: MesurePilotes;
-  arePilotesLoading: boolean;
+  isLoading: boolean;
   isReadOnly: boolean;
   isMutating: boolean;
-  saveRoleMesure: (personnes: PersonneTagOrUser[]) => void;
+  saveRoleMesure: (personnes: PersonneTagOrUser[]) => Promise<void>;
 } => {
   const collectiviteId = useCollectiviteId();
   const referentielId = useReferentielId();
@@ -37,62 +38,62 @@ export const useRoleMesure = (
 
   const { data: pilotes, isLoading: arePilotesLoading } =
     useListMesurePilotes(actionId);
-  const { mutate: upsertPilotes, isPending: isUpsertPending } =
+  const { sousAction, isPending: isSousActionPending } =
+    useGetSousActionOfTache(actionId);
+
+  const { mutateAsync: upsertPilotes, isPending: isUpsertPending } =
     useUpsertMesurePilotes();
-  const { mutate: deletePilotes, isPending: isDeletePending } =
+  const { mutateAsync: deletePilotes, isPending: isDeletePending } =
     useDeleteMesurePilotes();
-  const { saveActionStatut, isLoading: isStatutPending } =
-    useSaveActionStatut();
+  const { saveActionStatuts, isLoading: isStatutPending } =
+    useSaveActionStatuts();
   const { setToast } = useToastContext();
 
+  const isLoading = arePilotesLoading || isSousActionPending;
   const isMutating = isUpsertPending || isDeletePending || isStatutPending;
 
-  const trpc = useTRPC();
-  const queryClient = useQueryClient();
+  const savePilotes = (personnes: PersonneTagOrUser[]): Promise<unknown> => {
+    if (personnes.length === 0) {
+      return deletePilotes({ collectiviteId, mesureId: actionId });
+    }
 
-  const invalidateParcours = (): void => {
-    queryClient.invalidateQueries({
-      queryKey: trpc.referentiels.labellisations.getParcours.queryKey({
-        collectiviteId,
-      }),
+    return upsertPilotes({
+      collectiviteId,
+      mesureId: actionId,
+      pilotes: personnes.map((personne) => ({
+        userId: personne.userId ?? null,
+        tagId: personne.tagId ?? null,
+      })),
     });
   };
 
-  const onMutationError = (): void =>
-    setToast('error', appLabels.mutationError);
-
-  const saveStatut = (avancement: 'fait' | 'non_renseigne'): void =>
-    saveActionStatut(
-      { collectiviteId, actionId, statut: avancement },
-      { onSuccess: invalidateParcours, onError: onMutationError }
-    );
-
-  const saveRoleMesure = (personnes: PersonneTagOrUser[]): void => {
-    if (personnes.length === 0) {
-      deletePilotes(
-        { collectiviteId, mesureId: actionId },
-        {
-          onSuccess: () => saveStatut('non_renseigne'),
-          onError: onMutationError,
-        }
-      );
+  const saveRoleMesure = async (
+    personnes: PersonneTagOrUser[]
+  ): Promise<void> => {
+    if (!sousAction) {
+      setToast('error', appLabels.mutationError);
       return;
     }
-    upsertPilotes(
-      {
-        collectiviteId,
-        mesureId: actionId,
-        pilotes: personnes.map((p) => ({
-          userId: p.userId ?? null,
-          tagId: p.tagId ?? null,
-        })),
-      },
-      {
-        onSuccess: () => saveStatut('fait'),
-        onError: onMutationError,
-      }
-    );
+
+    const statut =
+      personnes.length === 0
+        ? StatutAvancementEnum.NON_RENSEIGNE
+        : StatutAvancementEnum.FAIT;
+
+    try {
+      await savePilotes(personnes);
+      await saveActionStatuts({
+        actionStatuts: propagateStatutToTaches({
+          collectiviteId,
+          tacheId: actionId,
+          statut,
+          sousAction,
+        }),
+      });
+    } catch (error) {
+      captureException({ error });
+    }
   };
 
-  return { pilotes, arePilotesLoading, isReadOnly, isMutating, saveRoleMesure };
+  return { pilotes, isLoading, isReadOnly, isMutating, saveRoleMesure };
 };

--- a/e2e/tests/referentiels/labellisations/checklist-completude-role-mesure.spec.ts
+++ b/e2e/tests/referentiels/labellisations/checklist-completude-role-mesure.spec.ts
@@ -1,0 +1,169 @@
+import { expect, Page } from '@playwright/test';
+import { ActionId, ReferentielId } from '@tet/domain/referentiels';
+import { NewAuditLabellisationPom } from './new-audit-labellisation.pom';
+import { testWithReferentiels as test } from '../referentiels.fixture';
+
+type Scenario = {
+  referentiel: ReferentielId;
+  sousActionId: ActionId;
+  tacheIds: ActionId[];
+};
+
+const scenarios: Scenario[] = [
+  {
+    referentiel: 'eci',
+    sousActionId: 'eci_1.1.1',
+    tacheIds: [
+      'eci_1.1.1.1',
+      'eci_1.1.1.2',
+      'eci_1.1.1.3',
+      'eci_1.1.1.4',
+      'eci_1.1.1.5',
+    ],
+  },
+  {
+    referentiel: 'cae',
+    sousActionId: 'cae_5.1.1.1',
+    tacheIds: ['cae_5.1.1.1.1', 'cae_5.1.1.1.2', 'cae_5.1.1.1.3'],
+  },
+];
+
+const COMPLETUDE_ROW_PATTERN =
+  /Renseigner les statuts de toutes les mesures du référentiel/;
+
+const REFERENT_TECHNIQUE_ROW_PATTERN = /Identifier une personne technique/i;
+
+const ASSIGNATION_REFRESH_TIMEOUT = 15_000;
+
+const assignReferentTechnique = async ({
+  page,
+  newAuditLabellisationPom,
+  userFullName,
+}: {
+  page: Page;
+  newAuditLabellisationPom: NewAuditLabellisationPom;
+  userFullName: string;
+}): Promise<void> => {
+  await newAuditLabellisationPom.roleHeaderItem('referentTechnique').click();
+
+  const statutSaved = page.waitForResponse((response) =>
+    response.url().includes('updateStatut')
+  );
+  const parcoursReloaded = page.waitForResponse((response) =>
+    response.url().includes('getParcours')
+  );
+
+  await page.getByRole('button', { name: userFullName }).click();
+  await statutSaved;
+  await parcoursReloaded;
+  await page.keyboard.press('Escape');
+};
+
+test.describe('Checklist audit-labellisation — complétude vs assignation de rôle', () => {
+  test.beforeEach(async ({ page, collectivites }) => {
+    const { collectivite, user } = await collectivites.addCollectiviteAndUser({
+      userArgs: { autoLogin: true },
+    });
+    for (const { referentiel } of scenarios) {
+      await user.precomputeReferentielSnapshot(
+        collectivite.data.id,
+        referentiel
+      );
+    }
+    await page.goto('/');
+  });
+
+  for (const { referentiel, sousActionId, tacheIds } of scenarios) {
+    test(`${referentiel.toUpperCase()} — assigner un référent technique laisse « Renseigner les statuts » atteint quand la mesure du rôle est renseignée tâche par tâche`, async ({
+      page,
+      newAuditLabellisationPom,
+      collectivites,
+      referentiels,
+    }) => {
+      const collectivite = collectivites.getCollectivite();
+      const user = collectivite.getUser(0);
+      const userFullName = `${user.data.prenom} ${user.data.nom}`;
+
+      await referentiels.updateAllNeedReferentielStatutsToCompleteReferentiel(
+        user,
+        collectivite.data.id,
+        referentiel
+      );
+
+      await newAuditLabellisationPom.goto(collectivite.data.id, referentiel);
+
+      const completudeRow = newAuditLabellisationPom.checklistRow(
+        COMPLETUDE_ROW_PATTERN
+      );
+      await expect(completudeRow.getByLabel('Critère atteint')).toBeVisible();
+
+      await assignReferentTechnique({
+        page,
+        newAuditLabellisationPom,
+        userFullName,
+      });
+
+      await expect(completudeRow.getByLabel('Critère atteint')).toBeVisible({
+        timeout: ASSIGNATION_REFRESH_TIMEOUT,
+      });
+    });
+
+    test(`${referentiel.toUpperCase()} — assigner un référent technique laisse « Renseigner les statuts » atteint quand la mesure du rôle est renseignée au niveau sous-action`, async ({
+      page,
+      newAuditLabellisationPom,
+      collectivites,
+      referentiels,
+    }) => {
+      const collectivite = collectivites.getCollectivite();
+      const user = collectivite.getUser(0);
+      const userFullName = `${user.data.prenom} ${user.data.nom}`;
+
+      await referentiels.updateAllNeedReferentielStatutsToCompleteReferentiel(
+        user,
+        collectivite.data.id,
+        referentiel
+      );
+
+      for (const actionId of tacheIds) {
+        await referentiels.updateActionStatut(user, {
+          collectiviteId: collectivite.data.id,
+          actionId,
+          statut: 'non_renseigne',
+        });
+      }
+      await referentiels.updateActionStatut(user, {
+        collectiviteId: collectivite.data.id,
+        actionId: sousActionId,
+        statut: 'pas_fait',
+      });
+
+      await newAuditLabellisationPom.goto(collectivite.data.id, referentiel);
+
+      const completudeRow = newAuditLabellisationPom.checklistRow(
+        COMPLETUDE_ROW_PATTERN
+      );
+      await expect(completudeRow.getByLabel('Critère atteint')).toBeVisible();
+
+      const referentTechniqueRow = newAuditLabellisationPom.checklistRow(
+        REFERENT_TECHNIQUE_ROW_PATTERN
+      );
+      await expect(
+        referentTechniqueRow.getByLabel('Critère non atteint')
+      ).toBeVisible();
+
+      await assignReferentTechnique({
+        page,
+        newAuditLabellisationPom,
+        userFullName,
+      });
+
+      await expect(
+        referentTechniqueRow.getByLabel('Critère atteint')
+      ).toBeVisible({ timeout: ASSIGNATION_REFRESH_TIMEOUT });
+
+      await expect(completudeRow.getByLabel('Critère atteint')).toBeVisible({
+        timeout: ASSIGNATION_REFRESH_TIMEOUT,
+      });
+    });
+  }
+});


### PR DESCRIPTION
## Problème

Sur `/collectivite/:id/referentiel/new/:referentiel/audit-labellisation`, renseigner un référent technique faisait basculer le critère « Renseigner les statuts de toutes les mesures du référentiel » en non atteint.

Le critère de rôle est une **tâche** (`eci_1.1.1.3`, `cae_5.1.1.1.3`) dont le parent est une **sous-action**. L'assignation écrivait le seul statut de cette tâche ; le backend en déduisait un reset du statut direct de la sous-action (`compute-cascading-statuts.rules.ts`). Quand la mesure était renseignée « en simple » — statut porté par la sous-action — ses autres tâches, jusque-là couvertes par ce statut, devenaient non renseignées et faisaient chuter la complétude.

Le cas touche CAE et ECI, référent technique comme élu référent (sous `cae_5.1.2.1`, 6 tâches).

## Correction

L'assignation envoie désormais un lot plutôt qu'un statut isolé :

- le statut de la tâche ;
- le statut de la sous-action recopié sur les tâches sœurs qui en sont dépourvues ;
- la sous-action basculée en `detaille_a_la_tache`.

L'héritage est à l'identique — `fait` → `fait`, `programmé` → `programmé`, `pas fait` → `pas fait`, détail au pourcentage recopié tel quel. Forcer les sœurs à `pas fait` aurait fait chuter le score réalisé d'une collectivité ayant déclaré la mesure à `fait`, donc cassé le critère de score affiché juste au-dessus dans la même checklist.

Si la sous-action est **déjà détaillée à la tâche**, rien n'est propagé : seul le statut de la tâche est écrit, et les statuts déjà saisis sur les sœurs ne sont jamais écrasés.

La bascule explicite de la sous-action n'est pas cosmétique : sans elle, la cascade backend génère un reset du parent **par tâche du lot**, et `ON CONFLICT DO UPDATE` rejette l'upsert (500). Voir « Découvert en route ».

Le fix est volontairement **ad hoc au point d'appel** : aucune ligne backend modifiée, pour ne pas généraliser cet edge case dans une règle partagée par tous les appelants.

## Surface de review

Attention humaine :

- `propagate-statut-to-taches.ts` — la composition du lot. Fonction pure, 10 tests, documentée en tête par le couplage backend qu'elle compense. Le prédicat `mustInheritStatut` porte les trois conditions d'éligibilité d'une tâche sœur. Le mapping du statut hérité passe par un `match` `ts-pattern` terminé par `.exhaustive()` : ajouter une valeur à `StatutAvancement` casse la compilation ici plutôt que de tomber dans un cas non géré.
- `use-role-mesure.ts` — la séquence pilotes → statuts → invalidation du parcours, en `async/await`. L'échec est capturé une seule fois et remonté à Sentry ; le toast utilisateur vient du subscriber global de mutations, pas d'un `setToast` local qui l'aurait affiché en double.

Mécanique :

- `use-get-sous-action-of-tache.ts` — récupération de la sous-action d'une tâche, qui encombrait le hook. S'appuie sur `useGetAction` / `useGetActionChildren` existants (lookup O(1), un seul référentiel) plutôt que de refaire leurs recherches.
- `use-action-statut.ts` — 8 lignes. Le hook unitaire n'avait qu'un seul appelant, celui-ci ; il bascule sur la mutation par lot plutôt que de coexister avec une version morte. Aucun changement de politique d'invalidation.
- `role-mesure.item.tsx` — renommage `arePilotesLoading` → `isLoading`, et garde de ré-entrance sur `onChange` (voir « Concurrence » ci-dessous).

## Tests

`checklist-completude-role-mesure.spec.ts` oppose deux configurations sur CAE et ECI :

| | avant fix | après fix |
|---|---|---|
| mesure du rôle renseignée tâche par tâche | vert | vert |
| mesure du rôle renseignée au niveau sous-action | **rouge** | vert |

Deux des huit tests unitaires couvrent la crainte la plus concrète — renseigner un rôle ne doit pas effacer la saisie de l'autre :

```
assigner le référent technique n'écrase pas le statut déjà saisi sur l'élu référent
retirer  le référent technique n'écrase pas le statut déjà saisi sur l'élu référent
```

Ils ont été contrôlés par mutation : en retirant le filtre qui protège les tâches sœurs, ce sont bien ces deux-là qui virent au rouge.

Deux tests couvrent les cas trouvés en revue de code, et ont été contrôlés par mutation (avec l'ancien prédicat, ce sont eux qui virent au rouge) :

```
ne recopie rien sur une tâche sœur déclarée non concernée, dont la déclaration serait effacée
exclut du lot une tâche sœur désactivée, que le backend rejetterait en entier
```

Vérifications locales : 10/10 sur ce spec, **508/508** sur toute la suite unitaire de `apps/app`, `app:typecheck` et lint propres.

**74/74 e2e** sur le dossier `labellisations` en conditions CI (`--workers=2`), rejoué sur l'état actuel de la branche, corrections de revue incluses.

Le correctif a par ailleurs été vérifié à la main sur la base locale, dans la configuration qui déclenche le bug (mesure des rôles renseignée au niveau sous-action, référentiel complet). En assignant les deux rôles, les trois tâches sœurs restées sans pilote héritent bien du « pas fait » que la sous-action portait pour elles, et `completude_ok` reste vrai.

## Hypothèses

- Un statut porté par la sous-action *signifiait déjà* ce statut pour ses tâches : le recopier ne fabrique pas d'information. Vérifié dans le moteur — en mode simple, les tâches reçoivent le statut d'affichage `non_renseignable`, et `completedTachesCount = totalTachesCount`. Le score est donc inchangé par la propagation.
- Effet visible assumé : les tâches sœurs passent de « non renseignable » à un statut propre et deviennent éditables ; la mesure passe de son statut simple à « Détaillé à la tâche ».

## Corrections issues de la revue de code

Une revue multi-agents a fait apparaître deux défauts que la première version introduisait, de même racine — le `Pick<ActionScore, …>` initial écartait les deux champs qui décident :

- **Une tâche déclarée « non concernée » était écrasée.** `NON_CONCERNE` n'est pas une valeur d'`avancement` : l'adaptateur la stocke en `{ avancement: 'non_renseigne', concerne: false }`. Le prédicat ne lisant que `avancement`, la sœur passait pour dépourvue de statut et recevait celui du parent, ce qui rétablissait `concerne: true` — déclaration utilisateur effacée, et points réintégrés au potentiel donc score réalisé en baisse.
- **Un lot contenant une action désactivée était rejeté en entier.** `can-update-action-statut.rules.ts` refuse tout le lot dès qu'une action porte `desactive`. Comme les pilotes sont écrits avant, l'échec laissait une assignation à moitié appliquée.

Le `Pick` inclut désormais `concerne` et `desactive`, et la sous-action elle-même est vérifiée avant toute composition de lot.

### Invalidations de cache

Les quatre invalidations du `onSuccess` de `useSaveActionStatuts` étaient des promesses flottantes : `await saveActionStatuts(...)` reprenait la main avant que les caches dérivés soient rafraîchis, alors que le commentaire du hook promettait l'inverse. Elles sont désormais awaitées dans un `Promise.all`. Conséquence utile : `isMutating` reste vrai jusqu'à la fin des refetch, ce qui prolonge le garde de ré-entrance ci-dessous.

L'`invalidateParcours` local de `use-role-mesure.ts` disparaît : il n'existait que pour compenser ces promesses flottantes, et utilisait une clé partielle plus large que les autres call sites du repo.

### Concurrence

Le contenu du floater restait interactif pendant l'écriture — `disabled` d'`InlineEditWrapper` ne garde que l'ouverture (`inline-edit.wrapper.tsx:49`), pas le contenu monté. Un second clic pouvait donc partir avec un instantané périmé. Le garde est porté par `onChange`. Au passage, `isMutating` sort du `disabled` du wrapper : il empêchait aussi la *fermeture*, laissant le panneau bloqué et le scroll verrouillé pendant l'écriture.

## Zones de moindre confiance

- **Le croisement entre les deux rôles reste ouvert, en connaissance de cause.** Chaque `RoleMesureItem` a son propre `isMutating` : en ECI, où les deux rôles sont frères sous `eci_1.1.1`, ouvrir l'un pendant que l'autre écrit reste possible et les deux lots se recouvrent. Le croisement préexiste ; ce que la PR change, c'est que les lots se recouvrent désormais. Le fermer demande un état partagé entre les deux items (contexte, ou `useIsMutating` filtré) — écarté du périmètre de ce fix.
- **Un clic pendant l'écriture est silencieusement ignoré.** Moins destructeur que la perte de pilote qu'il évite, mais pas satisfaisant : le vrai remède est une mise à jour optimiste pour que `values` ne soit plus périmé.
- Les statuts propagés sont attribués dans l'historique à l'utilisateur qui assigne le rôle. C'est déjà le cas aujourd'hui pour le reset du parent (`update-action-statut.service.ts` applique `modifiedBy: user.id` aux statuts en cascade) ; la PR en ajoute N au lieu d'1.
- Si la sous-action est en `detaille` sans `avancementDetaille` exploitable, rien n'est propagé. État incohérent supposé impossible, couvert par un test explicite plutôt que par un chemin silencieux.

## Découvert en route (hors scope, non corrigé)

`computeCascadingParentStatuts` produit un reset du parent par tâche du lot, sans dédoublonnage — un `updateStatuts` portant plusieurs tâches d'une même sous-action à statut direct échoue en 500. Non atteignable depuis l'UI actuelle, qui écrit les statuts un par un. Contourné ici en incluant explicitement la sous-action dans le lot. À traiter séparément par un dédoublonnage par `actionId`.

Le même symptôme de perte de complétude existe aussi en détaillant une tâche depuis la page mesure. C'est le comportement d'édition existant et délibéré (le front fait déjà ce reset dans `DetailTaches/CellStatut.tsx`), donc laissé tel quel.

## Anti-duplication

Recherche faite avant d'ajouter quoi que ce soit : `useSaveActionStatut`, `useUpdateActionStatut`, `useListActions` / `useListActionsGroupedById`, `useAction` / `use-snapshot`, `getParentId`. La mutation par lot réutilise les callbacks de la mutation unitaire existante plutôt que de les redéclarer. Les données de la sous-action viennent de `listActionsGroupedById`, déjà souscrit par la page via `use-referent-roles-defined` — une première version passait par `useAction`/snapshot et ajoutait une requête sur le chemin d'assignation, ce qui dégradait mesurablement la stabilité des e2e voisins (22/22 sans, 1 échec par passe avec).

## Note

Pas de plan validé en amont : PR issue d'un signalement de bug, diagnostiquée puis reproduite par test avant correction.

Le spec e2e a été écrit et vérifié **rouge avant le correctif** — les deux configurations « au niveau sous-action » échouaient, les deux « tâche par tâche » passaient déjà. L'historique ayant été aplati en un commit, cette séquence n'est plus lisible dans les commits : elle est reproductible en retirant le filtre de propagation dans `propagate-statut-to-taches.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Améliorations**
  * L’assignation d’un référent technique préserve désormais la complétude des mesures.
  * Les statuts des sous-actions sont propagés aux tâches concernées sans remplacer les statuts existants.
  * Les indicateurs de chargement sont harmonisés et l’édition est désactivée pendant l’enregistrement.
  * Les erreurs d’enregistrement sont mieux signalées.

* **Tests**
  * Ajout de tests couvrant la propagation des statuts et la complétude des référentiels ECI et CAE.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




