### PR TITLE
fix(referentiel): colocalise ReferentielThematiqueViewProvider avec la table

### DIFF
--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/(overview)/@tabs/layout.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/(overview)/@tabs/layout.tsx
@@ -1,4 +1,3 @@
-import { ReferentielThematiqueViewProvider } from '@/app/referentiels/referentiel.table/use-referentiel-thematique-view';
 import { ReferentielViewModeProvider } from '@/app/referentiels/referentiel.table/use-referentiel-view-mode';
 import { referentielIdEnumSchema } from '@tet/domain/referentiels';
 import { ReactNode } from 'react';
@@ -17,11 +16,9 @@ export default async function Layout({
 
   return (
     <ReferentielViewModeProvider>
-      <ReferentielThematiqueViewProvider>
-        <Header referentielId={referentielId} />
+      <Header referentielId={referentielId} />
 
-        <TabsWrapper>{children}</TabsWrapper>
-      </ReferentielThematiqueViewProvider>
+      <TabsWrapper>{children}</TabsWrapper>
     </ReferentielViewModeProvider>
   );
 }

--- a/apps/app/src/referentiels/referentiel.table/referentiel-table.tsx
+++ b/apps/app/src/referentiels/referentiel.table/referentiel-table.tsx
@@ -59,7 +59,10 @@ import { useListReferentielTableColumns } from './use-list-referentiel-table-col
 import { useReferentielTableColumnVisibility } from './use-referentiel-table-column-visibility';
 import { useReferentielTableData } from './use-referentiel-table-data';
 import { useReferentielTableRowExpanded } from './use-referentiel-table-row-expanded';
-import { useReferentielThematiqueView } from './use-referentiel-thematique-view';
+import {
+  ReferentielThematiqueViewProvider,
+  useReferentielThematiqueView,
+} from './use-referentiel-thematique-view';
 import { ReferentielTableMeta, rowClassNameByActionType } from './utils';
 
 declare module '@tanstack/react-table' {
@@ -84,21 +87,23 @@ export function ReferentielTableWithData() {
   const actions = data.get(referentielId)?.actionsById ?? {};
 
   return (
-    <div className="flex flex-col gap-4">
-      <div className="flex items-center gap-4 justify-between w-full">
-        <ReferentielTableFiltersForm columnVisibility={columnVisibility} />
-        <ReferentielTableThematiquesViews />
-      </div>
+    <ReferentielThematiqueViewProvider>
+      <div className="flex flex-col gap-4">
+        <div className="flex items-center gap-4 justify-between w-full">
+          <ReferentielTableFiltersForm columnVisibility={columnVisibility} />
+          <ReferentielTableThematiquesViews />
+        </div>
 
-      <ReferentielTable
-        key={`${Object.keys(actions).length}-${isPending}`}
-        actions={actions}
-        referentielId={referentielId}
-        isPending={isPending}
-        filtersState={filtersState}
-        columnVisibility={columnVisibility.columnVisibility}
-      />
-    </div>
+        <ReferentielTable
+          key={`${Object.keys(actions).length}-${isPending}`}
+          actions={actions}
+          referentielId={referentielId}
+          isPending={isPending}
+          filtersState={filtersState}
+          columnVisibility={columnVisibility.columnVisibility}
+        />
+      </div>
+    </ReferentielThematiqueViewProvider>
   );
 }
 


### PR DESCRIPTION
## Mode de défaillance

`/collectivite/<id>/referentiel/new/<referentiel>/progression` crashait au rendu :

> Erreur : useReferentielThematiqueView doit être utilisé dans un ReferentielThematiqueViewProvider

La page de progression de la route `referentiel/new` importe `ReferentielViewSwitcher` de l'ancienne route ; celui-ci rend `ReferentielTableWithData`, dont la table appelle `useReferentielThematiqueView()`. Le provider correspondant n'a été monté que dans la layout `@tabs` de l'ancienne route (commit `9397c7d7b3`, vue SGPE), jamais dans celle de `referentiel/new`.

## Correctif

Plutôt que de dupliquer le montage dans la seconde layout — ce qui laisserait la 3e route régresser à l'identique — le provider est **colocalisé avec son unique sous-arbre consommateur**.

Tous les consommateurs du contexte vivent sous `ReferentielTableWithData` :

| Consommateur | Emplacement |
|---|---|
| `ReferentielTableThematiquesViews` | `referentiel-table.tsx` |
| `ReferentielTable` | `referentiel-table.tsx` |
| `ReferentielTableTitleCell` | `use-list-referentiel-table-columns.tsx`, importé seulement par `referentiel-table.tsx` |

Aucun consommateur au-dessus de la table. Le contexte devient donc un détail d'implémentation de la table : il est structurellement impossible de la rendre sans son provider, et le montage disparaît des layouts de route.

- `referentiel-table.tsx` : `ReferentielTableWithData` monte le provider.
- `referentiel/[referentielId]/(overview)/@tabs/layout.tsx` : montage retiré.
- `referentiel/new/…/@tabs/layout.tsx` : inchangé — il n'a jamais eu besoin d'être touché.

Contraste volontaire avec `ReferentielViewModeProvider`, qui **reste** en layout : `ReferentielViewSwitcher` et le `tabs-wrapper` de l'ancienne route le consomment au-dessus de la table. C'est ce qui rendait la duplication de `ThematiqueView` accidentelle plutôt que structurelle.

## Surface de review

- `referentiel-table.tsx` : +1 provider autour du JSX existant, le reste du diff est de la ré-indentation.
- `@tabs/layout.tsx` (ancienne route) : suppression du montage + de l'import.

## Hypothèses

- L'exhaustivité des consommateurs a été vérifiée par recherche sur `useReferentielThematiqueView`, `ReferentielTableThematiquesViews` et `use-list-referentiel-table-columns` (chaîne à consommateur unique).
- Le remontage du provider avec la table est sans effet observable : l'état est persisté en `localStorage`, et le sync de la person property PostHog est déjà idempotent via `lastSyncedReferentielThematiqueViewPersonProperty`.

## Test de régression

Absent, assumé. Le repo n'a ni `renderWithProviders` ni MSW ; le bug se situait dans le graphe de montage d'une layout serveur Next, non couvrable par les specs jsdom existantes. Le correctif retenu supprime la classe de bug par construction plutôt que d'ajouter un cas à tester — un garde-fou réaliste resterait un e2e sur la route, hors scope.

## Zones de moindre confiance

- Aucune sur le correctif (`nx run app:typecheck` vert, `nx run app:lint` sans erreur — les warnings sur `referentiel-table.tsx` sont préexistants et hors des lignes touchées).
- Smell préexistant non corrigé, hors scope : dans `use-referentiel-thematique-view.tsx`, `useReferentielId()` est appelé après le `throw` conditionnel — appel de hook conditionnel au sens des règles de React. Inoffensif tant que le throw est fatal.

## DISCOVERED.md

Aucun item ajouté.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Améliorations**
  * Amélioration de la cohérence d’affichage entre les onglets et les tableaux des référentiels.
  * Meilleure prise en compte du mode de vue thématique dans les tableaux.
  * Navigation et rendu des pages de référentiel simplifiés pour une expérience plus stable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->