### PR TITLE
fix(referentiel): masque les onglets priorisation et détail en vue tableau sur referentiel/new

### DIFF
--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/new/[referentielId]/(overview)/@tabs/tabs-wrapper.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/new/[referentielId]/(overview)/@tabs/tabs-wrapper.tsx
@@ -2,6 +2,7 @@
 
 import { useGetAuditBadge } from '@/app/referentiels/audit-labellisation/audit-badge-status/use-get-audit-badge';
 import { useChecklist } from '@/app/referentiels/audit-labellisation/checklist.context';
+import { useReferentielViewMode } from '@/app/referentiels/referentiel.table/use-referentiel-view-mode';
 import { useIsVisitor } from '@/app/users/authorizations/use-is-visitor';
 import { Spacer, VisibleWhen } from '@tet/ui';
 import {
@@ -17,13 +18,17 @@ export const TabsWrapper = ({ children }: PropsWithChildren) => {
   const auditBadge = useGetAuditBadge();
   const { cycle } = useChecklist();
   const showAuditConductTabs = cycle.isConductingAudit;
+  const { mode } = useReferentielViewMode();
+  const isTableView = mode === 'table';
 
   return (
     <Tabs className="grow flex flex-col" size="sm">
       <TabsList className="!justify-start pl-0 flex-nowrap bg-transparent overflow-x-auto">
         <TabsTab href="progression" label="Mesures" />
-        <TabsTab href="priorisation" label="Aide à la priorisation" />
-        <TabsTab href="detail" label="Détail des statuts" />
+        <VisibleWhen condition={!isTableView}>
+          <TabsTab href="priorisation" label="Aide à la priorisation" />
+          <TabsTab href="detail" label="Détail des statuts" />
+        </VisibleWhen>
         <TabsTab href="evolutions" label="Évolutions du score" />
         {!isVisitor && <TabsTab href="commentaires" label="Commentaires" />}
         <TabsTab


### PR DESCRIPTION
## Mode de défaillance

Les deux `tabs-wrapper` de la vue référentiel traitaient différemment le même invariant de visibilité.

| | *Aide à la priorisation* / *Détail des statuts* |
|---|---|
| `referentiel/[referentielId]/…/tabs-wrapper.tsx` | `{!isNewReferentiel && !isTableView && (…)}` |
| `referentiel/new/[referentielId]/…/tabs-wrapper.tsx` | rendus sans condition |

En vue tableau, la vue tabulaire porte déjà la priorisation et le détail des statuts — c'est la raison du garde `!isTableView` sur l'ancienne route. Sur `referentiel/new`, les deux onglets restaient accessibles en vue tableau, donc redondants.

Repéré en instruisant la duplication de providers de #4781 ; arbitré avec Gaël : **l'ancienne route a raison**, on aligne `new` dessus.

## Correctif

`referentiel/new/…/@tabs/tabs-wrapper.tsx` : les deux onglets passent sous `<VisibleWhen condition={!isTableView}>`.

Seul `!isTableView` est repris, délibérément. `isNewReferentiel` ne couvre que `te` / `te-test` (`referentiel.utils.ts`), or la layout de `referentiel/new` fait `notFound()` sur tout ce qui n'est pas `cae` / `eci` (`isAuditLabellisationReferentiel`) : le répliquer aurait introduit un garde mort.

`VisibleWhen` plutôt que le `{cond && <>…</>}` de l'ancienne route : c'est l'idiome déjà en place dans ce fichier pour l'onglet *Cycles et comparaison*. Convergence du comportement, pas de la syntaxe.

## Surface de review

- 1 fichier, +7/-2. La seule décision à challenger est le choix de ne pas répliquer `isNewReferentiel`.

## Hypothèses

- L'intention du garde de l'ancienne route est bien « la vue tableau remplace ces deux onglets » : `!isTableView` préexiste à `908f52c898`, qui n'a fait qu'ajouter le volet `!isNewReferentiel`.
- `TabsList` n'introspecte pas ses enfants (aucun `React.Children` / `cloneElement` dans `TabsNext`), donc envelopper deux `TabsTab` dans `VisibleWhen` est sans effet sur le rendu de la liste.

## Test de régression

Absent, assumé. `TabsWrapper` dépend de `useGetAuditBadge` et `useChecklist` (tRPC / React-Query) ; la convention du repo est de ne pas tester unitairement ces composants, et il n'existe ni MSW ni `renderWithProviders`.

## Zones de moindre confiance

- Le comportement au changement de vue depuis l'onglet `/priorisation` ou `/detail` (l'onglet disparaît, la route reste) est identique à celui de l'ancienne route — convergence assumée, pas corrigée ici.

## Lien

Découvert pendant #4781, mais indépendant : fichiers disjoints, mergeable seul, dans n'importe quel ordre.

## DISCOVERED.md

Aucun item ajouté — la divergence est corrigée par cette PR plutôt que consignée.
