### PR TITLE
fix(e2e): envoie le header apikey lors de l'authentification

### DIFF
--- a/e2e/tests/shared/supabase-client.utils.ts
+++ b/e2e/tests/shared/supabase-client.utils.ts
@@ -40,6 +40,14 @@ export class SupabaseClient {
     return supabaseUrl;
   }
 
+  getSupabaseAnonKey(): string {
+    const anonKey = process.env.SUPABASE_ANON_KEY;
+    if (!anonKey) {
+      throw new Error('SUPABASE_ANON_KEY environment variable is not set');
+    }
+    return anonKey;
+  }
+
   /**
    * Extrait la référence du projet Supabase depuis l'URL pour le nom du cookie
    * e.g., "http://127.0.0.1:54321" -> "127"
@@ -93,6 +101,7 @@ export class SupabaseClient {
       }),
       headers: {
         'Content-Type': 'application/json',
+        apikey: this.getSupabaseAnonKey(),
       },
     };
     const response = await fetch(authUrl, requestInit);


### PR DESCRIPTION
## Mode de défaillance

`SupabaseClient.authenticateUser` appelait `/auth/v1/token?grant_type=password` avec le seul header `Content-Type`. La passerelle Supabase rejette alors la requête en **401**, avant même d'évaluer les identifiants.

Vérifié en curl sur le même endpoint, avec des identifiants volontairement invalides :

```
sans apikey : 401     (rejeté par la passerelle)
avec apikey : 400     (identifiants invalides — la requête est acceptée)
```

L'échec survient dans `addCollectiviteAndUser`, donc dans le `beforeEach` de la quasi-totalité des suites e2e : aucune ne démarre localement.

## Surface de review

Un seul fichier, `e2e/tests/shared/supabase-client.utils.ts` (+9) : ajout de `getSupabaseAnonKey()` et du header `apikey` dans `authenticateUser`.

## Vérification

`checklist-acte-engagement.spec.ts` — 2 tests, en échec 401 avant, verts après (4.7s). Typecheck (`e2e/tsconfig.spec.json`) et lint du fichier touché : propres.

## Pas de commit de test rouge

La convention du repo veut un test rouge précédant tout `fix(...)`. Il n'y en a pas ici, et c'est délibéré : le défaut est dans l'outillage de test lui-même, et ce qu'il met en échec est la suite e2e entière — qui ne peut pas s'exécuter. Fabriquer un test unitaire autour de `authenticateUser` reviendrait à tester le mock plutôt que le défaut. La preuve est le curl ci-dessus et le passage rouge → vert d'une suite existante.

## Zone de moindre confiance

**La CI est verte sur `main` sans ce header.** Sa passerelle ne l'exige donc pas, là où l'instance locale si. Je n'ai pas identifié la cause de la divergence (pas de CLI supabase global, version épinglée à 2.69.0 dans `package.json`, GoTrue local en v2.193.1 derrière `tet-kong-1`).

Cela dit, envoyer `apikey` est le comportement normal de tout client Supabase : le correctif est correct en soi, débloque le développement local, et ne change rien en CI. Si un reviewer connaît l'origine de l'écart, ça vaut la peine de l'écrire quelque part.

## Recherche anti-duplication

`git grep 'SUPABASE_ANON_KEY|anonKey' -- 'e2e/**/*.ts'` remonte un helper existant : `getSupabaseCredentials()` dans `e2e/tests/shared/storage-download.utils.ts:5-9`, qui lit l'URL **et** la clé anon.

Le `getSupabaseAnonKey()` ajouté en duplique donc la moitié. Je ne l'ai pas factorisé, pour trois raisons : il est symétrique du `getSupabaseUrl()` déjà présent dans la même classe, la duplication de l'URL entre ces deux fichiers préexiste, et l'extraction d'un accesseur d'environnement commun est un refactor qui n'a pas sa place dans un correctif. À traiter séparément si l'équipe le souhaite.

## Plan

Pas de plan lié : correctif d'outillage isolé, découvert en essayant de faire tourner les e2e sur un autre sujet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Correctifs**
  * L’authentification aux services Supabase utilise désormais la clé anonyme configurée.
  * Une erreur explicite est affichée lorsque cette clé est absente.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->