### PR TITLE
chore(app): typecheck réellement les fichiers de test

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -17,7 +17,7 @@
       },
       "typecheck": {
         "dependsOn": ["^typecheck"],
-        "command": "tsc --noEmit -p tsconfig.project.json",
+        "command": "tsc --noEmit -p tsconfig.project.json && tsc --noEmit -p tsconfig.spec.json",
         "options": {
           "cwd": "apps/app"
         },

--- a/apps/app/src/app/pages/collectivite/Indicateurs/data/prepare-data.spec.ts
+++ b/apps/app/src/app/pages/collectivite/Indicateurs/data/prepare-data.spec.ts
@@ -1,5 +1,10 @@
 import { prepareData } from './prepare-data';
-import fixture from './test/fixture.json';
+import fixtureJson from './test/fixture.json';
+
+type IndicateurSources = NonNullable<Parameters<typeof prepareData>[0]>;
+
+// La fixture JSON ne porte qu'un sous-ensemble des champs du type source.
+const fixture = fixtureJson as unknown as { indicateurs: IndicateurSources[] };
 
 describe('prepareData', () => {
   test('Extrait les données "objectifs"', () => {

--- a/apps/app/src/demarches/completion.spec.ts
+++ b/apps/app/src/demarches/completion.spec.ts
@@ -72,6 +72,7 @@ const completeSnapshot = documentsSnapshot({
 const completeDemarche: DemarchePcaet = {
   id: 1,
   collectiviteId: 1,
+  type: 'pcaet',
   titre: 'PCAET',
   description: 'Présentation du PCAET',
   statutPublication: 'draft',
@@ -81,6 +82,9 @@ const completeDemarche: DemarchePcaet = {
   dateModification: '2026-01-01T00:00:00.000Z',
   dateLancement: null,
   datePublication: null,
+  dateTransmission: null,
+  dateEcheanceAvis: null,
+  availableTransitions: [],
   pilotes: [],
   planActionId: 42,
   topics: {

--- a/apps/app/src/plans/fiches/list-all-fiches/filters/__tests__/count-active-fiche-filters.test.ts
+++ b/apps/app/src/plans/fiches/list-all-fiches/filters/__tests__/count-active-fiche-filters.test.ts
@@ -66,7 +66,8 @@ describe('countActiveFicheFilters', () => {
         ficheIds: [],
         thematiqueIds: [5],
         noPilote: true,
-      } as FormFilters;
+        sort: 'created_at',
+      };
       expect(countActiveFicheFilters(filters)).toBe(2);
     });
   });

--- a/apps/app/src/plans/fiches/list-all-fiches/filters/__tests__/fiche-action-filters.context.test.ts
+++ b/apps/app/src/plans/fiches/list-all-fiches/filters/__tests__/fiche-action-filters.context.test.ts
@@ -11,7 +11,6 @@ describe('deleteFilterValueForSingleKey', () => {
     thematiqueIds: [1, 2, 3],
     planActionIds: [10, 20],
     hasIndicateurLies: WITH,
-    notesDeSuivi: WITHOUT,
     hasMesuresLiees: WITH,
     hasDateDeFinPrevisionnelle: WITHOUT,
     sort: 'created_at',

--- a/apps/app/src/plans/fiches/list-all-fiches/hooks/use-select-fiches.test.ts
+++ b/apps/app/src/plans/fiches/list-all-fiches/hooks/use-select-fiches.test.ts
@@ -13,8 +13,11 @@ const mockCollectivite: CollectiviteCurrent = {
   isRoleAuditeur: false,
   isSimplifiedView: false,
   hasCollectivitePermission: () => false,
+  hasReferentielPermission: () => false,
   permissions: [],
   audits: [],
+  user: {} as CollectiviteCurrent['user'],
+  collectivitePreferences: {} as CollectiviteCurrent['collectivitePreferences'],
 };
 
 describe('useFicheActionSelection', () => {

--- a/apps/app/src/plans/plans/show-plan/plan-arborescence.view/get-children-axe-ids.test.ts
+++ b/apps/app/src/plans/plans/show-plan/plan-arborescence.view/get-children-axe-ids.test.ts
@@ -13,7 +13,6 @@ describe('getAllChildrenAxeIds', () => {
     fiches,
     parent,
     depth: 0,
-    collectiviteId: 1,
   });
 
   describe('simple cases', () => {

--- a/apps/app/src/plans/plans/show-plan/plan-arborescence.view/use-toggle-axe.test.ts
+++ b/apps/app/src/plans/plans/show-plan/plan-arborescence.view/use-toggle-axe.test.ts
@@ -12,7 +12,6 @@ const createAxe = (args: {
   fiches: args.fiches ?? [],
   parent: args.parent || null,
   depth: args.depth,
-  collectiviteId: 1,
 });
 describe('scroll to axe management', () => {
   describe('basic cases', () => {

--- a/apps/app/tsconfig.spec.json
+++ b/apps/app/tsconfig.spec.json
@@ -3,29 +3,25 @@
   "compilerOptions": {
     "outDir": "out-tsc/spec",
     "types": [
+      "node",
       "vitest/globals",
       "vitest/importMeta",
-      "vite/client",
-      "node",
-      "vitest"
-    ],
-    "paths": {
-      "@/app/*": [
-        "./src/*"
-      ]
-    }
+      "vite/client"
+    ]
   },
   "include": [
-    "vitest.config.mts",
-    "vitest.config.ts",
-    "src/**/*.test.ts",
-    "src/**/*.spec.ts",
-    "src/**/*.test.tsx",
-    "src/**/*.spec.tsx",
-    "src/**/*.test.js",
-    "src/**/*.spec.js",
-    "src/**/*.test.jsx",
-    "src/**/*.spec.jsx",
+    "*.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
     "**/fixture.json"
+  ],
+  "exclude": [
+    "out-tsc/**/*",
+    "vitest.config.mts",
+    "**/*.stories.ts",
+    "**/*.stories.tsx",
+    "**/*.stories.js",
+    "**/*.stories.jsx"
   ]
 }


### PR DESCRIPTION
## Problème

Les fichiers de test de `apps/app` **ne sont typecheckés nulle part**.

`tsconfig.spec.json` inclut bien `src/**/*.spec.ts`, mais il `extends` `tsconfig.project.json` sans redéfinir `exclude` — et le parent exclut précisément `**/*.spec.ts`, `**/*.test.ts`, etc. L'`exclude` filtrant ce que l'`include` a capté, la configuration s'annulait elle-même : `tsc --listFiles` compilait **0 fichier de test**.

Constaté plutôt que déduit : en injectant `const x: number = 'pas un nombre'` dans un spec, `tsc -p apps/app/tsconfig.spec.json` renvoyait **0 erreur**.

Conséquence : `app:typecheck` exclut les tests, cette config croit les couvrir sans le faire, et Vitest transpile sans vérifier les types. Une fixture pouvait donc affirmer une valeur impossible — un champ absent du type, ou `null` là où le schéma zod dit `.optional()`, donc `undefined` — et le test validait un cas qui n'existe pas en production, sans qu'aucun outil ne bronche.

## Correction

- `tsconfig.spec.json` reprend l'`include` de l'app et un `exclude` qui ne réintroduit pas les tests (les stories restent exclues), avec les types `vitest` ajoutés à ceux du parent.
- `app:typecheck` enchaîne les deux projets : `tsc -p tsconfig.project.json && tsc -p tsconfig.spec.json`. Le contrôle passe donc par la CI existante, sans nouveau job.

## Les erreurs révélées

La config réparée a fait apparaître 269 diagnostics, dont l'essentiel n'était pas des erreurs de type : 184 `TS6307` (fichiers importés non listés dans le projet) venaient de l'`include` initial trop étroit. Une fois la config alignée sur celle de l'app, il restait **13 vraies erreurs, toutes dans des fixtures de test**, toutes corrigées :

| Fichier | Nature |
|---|---|
| `prepare-data.spec.ts` | fixture JSON typée au point d'import, sa forme ayant divergé du paramètre attendu |
| `completion.spec.ts` | `DemarchePcaet` amputé de `type`, `dateTransmission`, `dateEcheanceAvis`, `availableTransitions` |
| `use-select-fiches.test.ts` | `CollectiviteCurrent` amputé de `hasReferentielPermission`, `user`, `collectivitePreferences` |
| `count-active-fiche-filters.test.ts` | `sort` manquant, et un `as FormFilters` qui masquait l'absence |
| `fiche-action-filters.context.test.ts` | `notesDeSuivi`, clé de filtre qui n'existe plus |
| `get-children-axe-ids.test.ts`, `use-toggle-axe.test.ts` | `collectiviteId` absent de `PlanNode` |

Ce sont exactement les dérives que la PR rend désormais impossibles.

## Surface de review

Attention humaine :

- `apps/app/tsconfig.spec.json` — le cœur. Vérifier que l'`exclude` ne réintroduit aucun motif de test.
- `completion.spec.ts`, `use-select-fiches.test.ts` — j'ai complété les fixtures avec des valeurs neutres (`null`, `[]`, casts de mock pour `user` et `collectivitePreferences`, non lus par les tests). À valider si une valeur réaliste est préférable.

Mécanique : les cinq autres specs (suppression d'un champ disparu, ajout d'un champ requis).

## Vérifications

- `nx run app:typecheck` : vert, et **exit code 1** dès qu'on injecte une erreur de type dans un spec — le garde-fou est prouvé, pas supposé.
- Suite unitaire `apps/app` : **75/75 fichiers, 498/498 tests**.

## Zone de moindre confiance

Les stories (`**/*.stories.tsx`) restent exclues, comme dans la config de l'app. Les inclure ferait apparaître d'autres erreurs ; c'est un chantier distinct.
