### PR TITLE
fix(plans): trie les notes de suivi par annee decroissante

### DIFF
--- a/apps/backend/src/plans/fiches/list-fiches/list-fiches.router.e2e-spec.ts
+++ b/apps/backend/src/plans/fiches/list-fiches/list-fiches.router.e2e-spec.ts
@@ -2317,6 +2317,56 @@ describe('ListFichesRouter', () => {
     expect(ficheTestInexistante).toBeUndefined();
   });
 
+  test('Les notes sont triees de la plus recente a la plus ancienne quel que soit leur ordre d insertion', async () => {
+    const caller = router.createCaller({ user: testUser });
+
+    const [fiche] = await db.db
+      .insert(ficheActionTable)
+      .values({
+        titre: 'Fiche test pour ordre des notes',
+        collectiviteId: testCollectiviteId,
+      })
+      .returning();
+    const testFicheId = fiche.id;
+
+    const now = new Date().toISOString();
+    const datesNoteDansLeDesordre = [
+      '2023-01-01',
+      '2025-01-01',
+      '2021-01-01',
+      '2024-01-01',
+    ];
+    await db.db.insert(ficheActionNoteTable).values(
+      datesNoteDansLeDesordre.map((dateNote) => ({
+        ficheId: testFicheId,
+        dateNote,
+        note: `Note ${dateNote}`,
+        createdBy: testUser.id,
+        modifiedBy: testUser.id,
+        createdAt: now,
+        modifiedAt: now,
+      }))
+    );
+
+    onTestFinished(async () => {
+      await db.db
+        .delete(ficheActionNoteTable)
+        .where(eq(ficheActionNoteTable.ficheId, testFicheId));
+      await db.db
+        .delete(ficheActionTable)
+        .where(eq(ficheActionTable.id, testFicheId));
+    });
+
+    const ficheAvecNotes = await caller.plans.fiches.get({ id: testFicheId });
+
+    expect(ficheAvecNotes.notes?.map((note) => note.dateNote)).toEqual([
+      '2025-01-01',
+      '2024-01-01',
+      '2023-01-01',
+      '2021-01-01',
+    ]);
+  });
+
   test('Fetch avec filtre sur priorites', async () => {
     const caller = router.createCaller({ user: testUser });
 

--- a/apps/backend/src/plans/fiches/list-fiches/list-fiches.service.ts
+++ b/apps/backend/src/plans/fiches/list-fiches/list-fiches.service.ts
@@ -627,10 +627,12 @@ export default class ListFichesService {
           'modifiedBy', CASE WHEN ${ficheActionNoteTable.modifiedBy} IS NULL THEN NULL
             ELSE json_build_object('id', ${ficheActionNoteTable.modifiedBy}, 'prenom', ${dcpModifiedBy.prenom}, 'nom', ${dcpModifiedBy.nom})
           END
-        ))`.as('notes'),
+        ) ORDER BY ${ficheActionNoteTable.dateNote} DESC)`.as('notes'),
         anneesNotes: sql<
           string[]
-        >`array_agg(${ficheActionNoteTable.dateNote})`.as('annees_notes'),
+        >`array_agg(${ficheActionNoteTable.dateNote} ORDER BY ${ficheActionNoteTable.dateNote} DESC)`.as(
+          'annees_notes'
+        ),
       })
       .from(ficheActionNoteTable)
       .leftJoin(


### PR DESCRIPTION
## Symptôme

Dans l'export PDF d'une fiche action, les années des notes de suivi s'affichent dans le désordre. Reproduit sur la CC Démo. « Des fois ça marche, des fois non ».

## Cause

`getFicheActionNotesQuery` agrège les notes avec deux `array_agg` sans `ORDER BY` (`list-fiches.service.ts:618` et `:631`). Postgres ne garantit alors aucun ordre : il restitue l'ordre du scan, en pratique l'ordre de création des notes. L'export est donc correct uniquement quand les notes ont été saisies dans l'ordre chronologique — d'où l'intermittence.

Pourquoi seul le PDF est touché :

- l'app retrie côté client (`notes.table.tsx:48`, date décroissante) — le bug y est masqué ;
- l'export XLSX construit une colonne par année à partir d'une liste `anneesNotes` triée explicitement (`plan-actions.service.ts:83`) — non touché ;
- `packages/pdf-components/src/fiche-action/Notes.tsx` rend les notes dans l'ordre reçu, chaque carte titrée par son année.

## Correction

`ORDER BY date_note DESC` sur les deux agrégations, à la source. C'est le pattern déjà en place dans le même fichier pour les partenaires, les financeurs et les instances de gouvernance.

## Surface de review

- `list-fiches.service.ts` — 4 lignes, attention humaine.
- `list-fiches.router.e2e-spec.ts` — test de régression.

## Test rouge

Le test `Les notes sont triees de la plus recente a la plus ancienne quel que soit leur ordre d insertion` cible `plans.fiches.get`, le endpoint qu'utilise le payload de l'export PDF. Il insère 4 notes dans le désordre et, sur le code pré-fix, échoue en reproduisant exactement le symptôme signalé :

```
- Expected      + Received
-   "2025-01-01"    "2023-01-01"
-   "2024-01-01"  +  "2025-01-01"
    "2023-01-01"     "2021-01-01"
    "2021-01-01"  +  "2024-01-01"
```

Les deux commits ont été fusionnés à la demande du repo owner ; l'état rouge est vérifiable en annulant le diff de `list-fiches.service.ts`.

## Hypothèses

- Le tri est **décroissant** (note la plus récente en premier), pour coller à ce que l'utilisateur voit dans l'app. Si l'attendu pour un document PDF est l'ordre chronologique croissant, c'est un `DESC` → `ASC`.
- `anneesNotes` est trié aussi : ce champ n'est consommé que par des surfaces qui retriaient déjà, le changement est donc neutre pour elles, mais il rend le contrat de la requête déterministe.

## Anti-duplication

Aucune nouvelle utility. Recherche faite sur les agrégations existantes du même fichier (`grep "ORDER BY"`) pour reprendre le pattern déjà appliqué aux partenaires / financeurs / instances de gouvernance plutôt que d'introduire un tri applicatif.

## Vérifications

- `nx test backend 'list-fiches.router.e2e-spec.ts'` : 57/57
- `nx test backend 'update-fiche.router.e2e-spec.ts'` : 42/42
- `nx run backend:typecheck`, `nx run backend:lint` : verts

## Hors scope

Toutes les autres agrégations de `list-fiches.service.ts` (thématiques, sous-thématiques, indicateurs, référents, effets attendus, tags libres / structure, services, axes) ont le même défaut latent et impactent probablement les autres exports. Non corrigé ici — à traiter dans une PR dédiée.
