### PR TITLE
fix(plans): corrige le total des budgets en virgule flottante

### DIFF
--- a/apps/app/src/plans/fiches/show-fiche/content/moyens/budget/per-year-table/budget-per-year.cells.tsx
+++ b/apps/app/src/plans/fiches/show-fiche/content/moyens/budget/per-year-table/budget-per-year.cells.tsx
@@ -1,4 +1,4 @@
-import { getFormattedFloat, getFormattedNumber } from '@/app/utils/formatUtils';
+import { getFormattedNumber } from '@tet/domain/utils';
 import { FicheWithRelations } from '@tet/domain/plans';
 import { SelectOption, TableCell, VisibleWhen } from '@tet/ui';
 import { isNil } from 'es-toolkit';
@@ -64,7 +64,7 @@ const BudgetPerYearNumberCell = ({
     if (name === 'montant' || name === 'depense') {
       return `${getFormattedNumber(currentValue)} €`;
     }
-    return `${getFormattedFloat(currentValue)} ETP`;
+    return `${getFormattedNumber(currentValue)} ETP`;
   }, [currentValue, name]);
 
   return (

--- a/apps/app/src/plans/fiches/show-fiche/content/moyens/budget/per-year-table/compute-budget-totals.spec.ts
+++ b/apps/app/src/plans/fiches/show-fiche/content/moyens/budget/per-year-table/compute-budget-totals.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { BudgetPerYear } from '../../../../context/types';
+import { computeBudgetTotals } from './compute-budget-totals';
+
+const toBudgetPerYear = (budget: Partial<BudgetPerYear>): BudgetPerYear => ({
+  year: 2025,
+  ...budget,
+});
+
+describe('computeBudgetTotals', () => {
+  it('renvoie des totaux nuls sans budget', () => {
+    expect(computeBudgetTotals([])).toEqual({
+      montant: 0,
+      depense: 0,
+      etpPrevisionnel: 0,
+      etpReel: 0,
+    });
+  });
+
+  it('ignore les valeurs non renseignées', () => {
+    const totals = computeBudgetTotals([
+      toBudgetPerYear({ year: 2024, montant: 1000 }),
+      toBudgetPerYear({ year: 2025, depense: 500, etpReel: 1 }),
+    ]);
+
+    expect(totals).toEqual({
+      montant: 1000,
+      depense: 500,
+      etpPrevisionnel: 0,
+      etpReel: 1,
+    });
+  });
+
+  it('additionne 0,1 et 0,2 ETP en 0,3', () => {
+    const totals = computeBudgetTotals([
+      toBudgetPerYear({ year: 2024, etpPrevisionnel: 0.1, etpReel: 0.1 }),
+      toBudgetPerYear({ year: 2025, etpPrevisionnel: 0.2, etpReel: 0.2 }),
+    ]);
+
+    expect(totals).toEqual({
+      montant: 0,
+      depense: 0,
+      etpPrevisionnel: 0.3,
+      etpReel: 0.3,
+    });
+  });
+
+  it('additionne 100,10 et 200,20 euros en 300,30', () => {
+    const totals = computeBudgetTotals([
+      toBudgetPerYear({ year: 2024, montant: 100.1, depense: 100.1 }),
+      toBudgetPerYear({ year: 2025, montant: 200.2, depense: 200.2 }),
+    ]);
+
+    expect(totals).toEqual({
+      montant: 300.3,
+      depense: 300.3,
+      etpPrevisionnel: 0,
+      etpReel: 0,
+    });
+  });
+});

--- a/apps/app/src/plans/fiches/show-fiche/content/moyens/budget/per-year-table/compute-budget-totals.ts
+++ b/apps/app/src/plans/fiches/show-fiche/content/moyens/budget/per-year-table/compute-budget-totals.ts
@@ -1,0 +1,23 @@
+import { sumRoundedTo } from '@tet/domain/utils';
+import { BudgetPerYear } from '../../../../context/types';
+
+export type BudgetTotals = {
+  montant: number;
+  depense: number;
+  etpPrevisionnel: number;
+  etpReel: number;
+};
+
+const sumField = (
+  budgets: BudgetPerYear[],
+  field: keyof BudgetTotals
+): number => sumRoundedTo(budgets.map((budget) => budget[field]));
+
+export const computeBudgetTotals = (
+  budgets: BudgetPerYear[]
+): BudgetTotals => ({
+  montant: sumField(budgets, 'montant'),
+  depense: sumField(budgets, 'depense'),
+  etpPrevisionnel: sumField(budgets, 'etpPrevisionnel'),
+  etpReel: sumField(budgets, 'etpReel'),
+});

--- a/apps/app/src/plans/fiches/show-fiche/content/moyens/budget/per-year-table/index.tsx
+++ b/apps/app/src/plans/fiches/show-fiche/content/moyens/budget/per-year-table/index.tsx
@@ -1,4 +1,4 @@
-import { getFormattedFloat, getFormattedNumber } from '@/app/utils/formatUtils';
+import { getFormattedNumber } from '@tet/domain/utils';
 import { appLabels } from '@/app/labels/catalog';
 import {
   createColumnHelper,
@@ -19,6 +19,7 @@ import { BudgetPerYear } from '../../../../context/types';
 import { getYearsOptions } from '@/app/utils/get-years-options';
 import { emptyViewsProps } from '../../empty-view';
 import { BudgetPerYearFormProvider } from './budget-per-year-form.context';
+import { computeBudgetTotals } from './compute-budget-totals';
 import {
   BudgetPerYearActionsCell,
   BudgetPerYearDepenseCell,
@@ -85,21 +86,7 @@ export const BudgetPerYearTable = ({
     return rows;
   }, [budgets.perYear]);
   const totals = useMemo(
-    () =>
-      budgets.perYear.reduce(
-        (acc, row) => ({
-          montant: acc.montant + (row.montant ?? 0),
-          depense: acc.depense + (row.depense ?? 0),
-          etpPrevisionnel: acc.etpPrevisionnel + (row.etpPrevisionnel ?? 0),
-          etpReel: acc.etpReel + (row.etpReel ?? 0),
-        }),
-        {
-          montant: 0,
-          depense: 0,
-          etpPrevisionnel: 0,
-          etpReel: 0,
-        }
-      ),
+    () => computeBudgetTotals(budgets.perYear),
     [budgets.perYear]
   );
 
@@ -165,7 +152,7 @@ export const BudgetPerYearTable = ({
           if (row.original.type === 'total') {
             return (
               <TotalTableCell>
-                {getFormattedFloat(totals.etpPrevisionnel)} {appLabels.uniteEtp}
+                {`${getFormattedNumber(totals.etpPrevisionnel)} ${appLabels.uniteEtp}`}
               </TotalTableCell>
             );
           }
@@ -179,7 +166,7 @@ export const BudgetPerYearTable = ({
           if (row.original.type === 'total') {
             return (
               <TotalTableCell>
-                {getFormattedFloat(totals.etpReel) ?? '-'} {appLabels.uniteEtp}
+                {`${getFormattedNumber(totals.etpReel)} ${appLabels.uniteEtp}`}
               </TotalTableCell>
             );
           }

--- a/apps/app/src/plans/fiches/show-fiche/content/moyens/budget/summary-table/index.tsx
+++ b/apps/app/src/plans/fiches/show-fiche/content/moyens/budget/summary-table/index.tsx
@@ -1,4 +1,4 @@
-import { getFormattedFloat, getFormattedNumber } from '@/app/utils/formatUtils';
+import { getFormattedNumber } from '@tet/domain/utils';
 import {
   createColumnHelper,
   getCoreRowModel,
@@ -75,7 +75,6 @@ export const BudgetSummaryTable = ({ type }: BudgetSummaryTableProps) => {
   const summaryItems: {
     label: string;
     fieldName: SummaryField;
-    getValue: (value: number | null | undefined) => string | null;
     unit: string;
     icon?: string;
   }[] = useMemo(
@@ -83,27 +82,23 @@ export const BudgetSummaryTable = ({ type }: BudgetSummaryTableProps) => {
       {
         label: 'Prévisionnel HT',
         fieldName: 'montant',
-        getValue: (value) => (!isNil(value) ? getFormattedNumber(value) : null),
         unit: '€',
         icon: '€',
       },
       {
         label: 'Dépensé',
         fieldName: 'depense',
-        getValue: (value) => (!isNil(value) ? getFormattedNumber(value) : null),
         unit: '€',
         icon: '€',
       },
       {
         label: 'ETP prévisionnel',
         fieldName: 'etpPrevisionnel',
-        getValue: (value) => (!isNil(value) ? getFormattedFloat(value) : null),
         unit: 'ETP',
       },
       {
         label: 'ETP réel',
         fieldName: 'etpReel',
-        getValue: (value) => (!isNil(value) ? getFormattedFloat(value) : null),
         unit: 'ETP',
       },
     ],
@@ -119,7 +114,10 @@ export const BudgetSummaryTable = ({ type }: BudgetSummaryTableProps) => {
             <TableHeaderCell title={item.label} className="w-1/4" />
           ),
           cell: ({ row }) => {
-            const value = item.getValue(row.original[item.fieldName]);
+            const fieldValue = row.original[item.fieldName];
+            const formattedValue = isNil(fieldValue)
+              ? null
+              : getFormattedNumber(fieldValue);
 
             return (
               <TableCell
@@ -155,7 +153,7 @@ export const BudgetSummaryTable = ({ type }: BudgetSummaryTableProps) => {
                   ),
                 }}
               >
-                <CellValue value={value} item={item} />
+                <CellValue value={formattedValue} item={item} />
               </TableCell>
             );
           },

--- a/apps/app/src/plans/fiches/show-fiche/content/moyens/financeurs/financeur-montant.cell.tsx
+++ b/apps/app/src/plans/fiches/show-fiche/content/moyens/financeurs/financeur-montant.cell.tsx
@@ -1,4 +1,4 @@
-import { getFormattedNumber } from '@/app/utils/formatUtils';
+import { getFormattedNumber } from '@tet/domain/utils';
 import { appLabels } from '@/app/labels/catalog';
 import { Input, TableCell } from '@tet/ui';
 import { isNil } from 'es-toolkit';

--- a/apps/app/src/plans/fiches/show-fiche/context/hooks/use-fiche-budgets.ts
+++ b/apps/app/src/plans/fiches/show-fiche/context/hooks/use-fiche-budgets.ts
@@ -52,7 +52,6 @@ export const useFicheBudgets = (fiche: FicheWithRelations): BudgetsState => {
           type
         );
 
-        console.log('budgetsToUpsert', budget, budgetsToUpsert);
         await upsertBudgetsMutation.mutateAsync(budgetsToUpsert);
         return;
       }

--- a/apps/app/src/utils/formatUtils.ts
+++ b/apps/app/src/utils/formatUtils.ts
@@ -60,21 +60,6 @@ export const getModifiedSince = (date: string) => {
   return `le ${format(modifiedDate, 'dd/MM/yyyy')}`;
 };
 
-// Renvoie un number formatté sous forme de string, avec un espace tous les 3 digits et un point virgule pour la virgule
-export const getFormattedNumber = (nb: number) => {
-  return nb
-    .toString()
-    .replace(/\B(?=(\d{3})+(?!\d))/g, ' ')
-    .replace('.', ',');
-};
-
-export const getFormattedFloat = (nb: number) => {
-  return nb
-    .toString()
-    .replace(/\B(?=(\d{3})+(?!\d))/g, ' ')
-    .replace('.', ',');
-};
-
 // Renvoie un texte tronqué
 export const getTruncatedText = (text: string | null, limit: number) => {
   let truncatedText: string | null = null;

--- a/apps/site/app/budget/TableauBudget.tsx
+++ b/apps/site/app/budget/TableauBudget.tsx
@@ -1,4 +1,4 @@
-import { getFormattedNumber } from '@/site/src/utils/getFormattedNumber';
+import { getFormattedNumber } from '@tet/domain/utils';
 import classNames from 'classnames';
 import { TTableauBudget } from './utils';
 

--- a/apps/site/app/collectivites/[code]/[name]/CollectiviteHeader.tsx
+++ b/apps/site/app/collectivites/[code]/[name]/CollectiviteHeader.tsx
@@ -2,7 +2,7 @@
 
 import { DEPRECATED_StrapiImage } from '@/site/components/strapiImage/StrapiImage';
 import { StrapiItem } from '@/site/src/strapi/StrapiItem';
-import { getFormattedNumber } from '@/site/src/utils/getFormattedNumber';
+import { getFormattedNumber } from '@tet/domain/utils';
 import { Badge, Icon } from '@tet/ui';
 import classNames from 'classnames';
 import Image from 'next/image';

--- a/apps/site/app/collectivites/[code]/[name]/IndicateurArtificialisationSols.tsx
+++ b/apps/site/app/collectivites/[code]/[name]/IndicateurArtificialisationSols.tsx
@@ -1,5 +1,5 @@
 import { IndicateurArtificialisation } from '@/site/app/collectivites/utils';
-import { getFormattedNumber } from '@/site/src/utils/getFormattedNumber';
+import { getFormattedNumber } from '@tet/domain/utils';
 import { fluxToLabel } from '@/site/src/utils/labels';
 import IndicateurCard from './IndicateurCard';
 import { IndicateurDefaultData } from './IndicateursCollectivite';

--- a/apps/site/app/collectivites/[code]/[name]/IndicateurGazEffetSerre.tsx
+++ b/apps/site/app/collectivites/[code]/[name]/IndicateurGazEffetSerre.tsx
@@ -1,5 +1,5 @@
 import { Indicateurs } from '@/site/app/collectivites/utils';
-import { getFormattedNumber } from '@/site/src/utils/getFormattedNumber';
+import { getFormattedNumber } from '@tet/domain/utils';
 import { secteurIdToLabel } from '@/site/src/utils/labels';
 import IndicateurCard from './IndicateurCard';
 import { IndicateurDefaultData } from './IndicateursCollectivite';

--- a/apps/site/components/charts/DonutChart.tsx
+++ b/apps/site/components/charts/DonutChart.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { getFormattedNumber } from '@/site/src/utils/getFormattedNumber';
+import { getFormattedNumber } from '@tet/domain/utils';
 import { PieTooltipProps, ResponsivePie } from '@nivo/pie';
 import { defaultColors, theme as localTheme } from './chartsTheme';
 

--- a/apps/site/src/utils/getFormattedNumber.ts
+++ b/apps/site/src/utils/getFormattedNumber.ts
@@ -1,3 +1,0 @@
-export const getFormattedNumber = (value: number | string): string => {
-  return value.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ');
-};

--- a/apps/site/tsconfig.json
+++ b/apps/site/tsconfig.json
@@ -40,6 +40,9 @@
       "path": "../../packages/api"
     },
     {
+      "path": "../../packages/domain"
+    },
+    {
       "path": "../../packages/ui"
     }
   ]

--- a/packages/domain/src/utils/number.utils.spec.ts
+++ b/packages/domain/src/utils/number.utils.spec.ts
@@ -1,6 +1,32 @@
-import { roundTo } from './number.utils';
+import { getFormattedNumber, roundTo, sumRoundedTo } from './number.utils';
 
 describe('number helper', () => {
+  describe('getFormattedNumber', () => {
+    it('sépare les milliers par un espace', () => {
+      expect(getFormattedNumber(1234567)).toBe('1 234 567');
+    });
+
+    it('laisse les nombres à 3 chiffres intacts', () => {
+      expect(getFormattedNumber(999)).toBe('999');
+    });
+
+    it('sépare les milliers des nombres négatifs sans détacher le signe', () => {
+      expect(getFormattedNumber(-1234)).toBe('-1 234');
+    });
+
+    it('affiche les décimales avec une virgule', () => {
+      expect(getFormattedNumber(1234.56)).toBe('1 234,56');
+    });
+
+    it('ne groupe pas les décimales au-delà de 3 chiffres', () => {
+      expect(getFormattedNumber(1234.56789)).toBe('1 234,56789');
+    });
+
+    it('rend 0,30000000000000004 sans groupage des décimales', () => {
+      expect(getFormattedNumber(0.1 + 0.2)).toBe('0,30000000000000004');
+    });
+  });
+
   describe('roundTo', () => {
     it('roundTo for 1.5625', async () => {
       expect(roundTo(1.5625, 3)).toBe(1.563);
@@ -24,6 +50,32 @@ describe('number helper', () => {
 
     it('roundTo for 2.55', async () => {
       expect(roundTo(2.55, 1)).toBe(2.6);
+    });
+  });
+
+  describe('sumRoundedTo', () => {
+    it('renvoie 0 sans valeur', () => {
+      expect(sumRoundedTo([])).toBe(0);
+    });
+
+    it('ignore les valeurs absentes', () => {
+      expect(sumRoundedTo([1000, null, undefined, 500])).toBe(1500);
+    });
+
+    it('additionne 0,1 et 0,2 en 0,3', () => {
+      expect(sumRoundedTo([0.1, 0.2])).toBe(0.3);
+    });
+
+    it('additionne 100,10 et 200,20 en 300,30', () => {
+      expect(sumRoundedTo([100.1, 200.2])).toBe(300.3);
+    });
+
+    it('arrondit au centime sans précision donnée', () => {
+      expect(sumRoundedTo([0.004, 0.004])).toBe(0.01);
+    });
+
+    it('arrondit à la précision donnée', () => {
+      expect(sumRoundedTo([0.1, 0.2], 0)).toBe(0);
     });
   });
 });

--- a/packages/domain/src/utils/number.utils.ts
+++ b/packages/domain/src/utils/number.utils.ts
@@ -1,4 +1,4 @@
-import { isNil } from 'es-toolkit';
+import { isNil, sumBy } from 'es-toolkit';
 
 export function divisionOrZero(a: number | null, b: number | null) {
   return division(a, b, 0);
@@ -16,9 +16,30 @@ export function division<T extends number | null>(
   return a / b;
 }
 
+function groupThousands(integerPart: string): string {
+  return integerPart.replace(/\B(?=(\d{3})+(?!\d))/g, ' ');
+}
+
+export function getFormattedNumber(nb: number): string {
+  const [integerPart, decimalPart] = nb.toString().split('.');
+  return decimalPart === undefined
+    ? groupThousands(integerPart)
+    : `${groupThousands(integerPart)},${decimalPart}`;
+}
+
 export function roundTo(num: number, precision: number): number {
   const factor = Math.pow(10, precision);
   return Math.round(num * factor + Number.EPSILON) / factor;
+}
+
+export function sumRoundedTo(
+  values: readonly (number | null | undefined)[],
+  precision = 2
+): number {
+  return roundTo(
+    sumBy(values, (value) => value ?? 0),
+    precision
+  );
 }
 
 export function pythonRoundTo(

--- a/packages/pdf-components/src/fiche-action/BudgetTable.tsx
+++ b/packages/pdf-components/src/fiche-action/BudgetTable.tsx
@@ -1,19 +1,14 @@
 import { Paragraph, TCell, TRow, Table } from '../primitives';
-import { getFormattedNumber } from './external-helpers';
 import { FicheBudget } from '@tet/domain/plans';
+import { getFormattedNumber } from '@tet/domain/utils';
 import { groupBy } from 'es-toolkit';
+import { BudgetRow, computeBudgetTotals } from './compute-budget-totals';
 
 type FicheBudgetWithYear = FicheBudget & {
   annee: number;
 };
 
-type FormattedBudgetType = {
-  annee: number | undefined | null;
-  eurosPrevisionnel: number | undefined | null;
-  eurosReel: number | undefined | null;
-  etpPrevisionnel: number | undefined | null;
-  etpReel: number | undefined | null;
-}[];
+type FormattedBudgetType = (BudgetRow & { annee: number })[];
 
 const getBudgetForTable = (
   budgets: Array<FicheBudget>
@@ -46,6 +41,7 @@ const getBudgetForTable = (
 
 const BudgetTable = ({ budgets }: { budgets: FicheBudget[] }) => {
   const formattedBudget = getBudgetForTable(budgets);
+  const totals = computeBudgetTotals(formattedBudget);
   return (
     <Table wrap={false}>
       {/* En-tête */}
@@ -113,50 +109,22 @@ const BudgetTable = ({ budgets }: { budgets: FicheBudget[] }) => {
           Total
         </TCell>
         <TCell colsNumber={5} contentClassName="text-primary-8">
-          {getFormattedNumber(
-            formattedBudget.reduce(
-              (sum, currVal) =>
-                sum +
-                (currVal.eurosPrevisionnel ? currVal.eurosPrevisionnel : 0),
-              0
-            )
-          )}{' '}
-          €{' '}
+          {getFormattedNumber(totals.eurosPrevisionnel)} €{' '}
           <Paragraph className="text-[0.5rem] leading-[0.6rem] font-bold text-primary-8">
             HT
           </Paragraph>
         </TCell>
         <TCell colsNumber={5} contentClassName="text-primary-8">
-          {getFormattedNumber(
-            formattedBudget.reduce(
-              (sum, currVal) =>
-                sum + (currVal.eurosReel ? currVal.eurosReel : 0),
-              0
-            )
-          )}{' '}
-          €{' '}
+          {getFormattedNumber(totals.eurosReel)} €{' '}
           <Paragraph className="text-[0.5rem] leading-[0.6rem] font-bold text-primary-8">
             HT
           </Paragraph>
         </TCell>
         <TCell colsNumber={5} contentClassName="text-primary-8">
-          {getFormattedNumber(
-            formattedBudget.reduce(
-              (sum, currVal) =>
-                sum + (currVal.etpPrevisionnel ? currVal.etpPrevisionnel : 0),
-              0
-            )
-          )}{' '}
-          ETP
+          {`${getFormattedNumber(totals.etpPrevisionnel)} ETP`}
         </TCell>
         <TCell colsNumber={5} contentClassName="text-primary-8">
-          {getFormattedNumber(
-            formattedBudget.reduce(
-              (sum, currVal) => sum + (currVal.etpReel ? currVal.etpReel : 0),
-              0
-            )
-          )}{' '}
-          ETP
+          {`${getFormattedNumber(totals.etpReel)} ETP`}
         </TCell>
       </TRow>
     </Table>

--- a/packages/pdf-components/src/fiche-action/compute-budget-totals.spec.ts
+++ b/packages/pdf-components/src/fiche-action/compute-budget-totals.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { BudgetRow, computeBudgetTotals } from './compute-budget-totals';
+
+const toBudgetRow = (budget: Partial<BudgetRow>): BudgetRow => ({
+  eurosPrevisionnel: null,
+  eurosReel: null,
+  etpPrevisionnel: null,
+  etpReel: null,
+  ...budget,
+});
+
+describe('computeBudgetTotals', () => {
+  it('renvoie des totaux nuls sans budget', () => {
+    expect(computeBudgetTotals([])).toEqual({
+      eurosPrevisionnel: 0,
+      eurosReel: 0,
+      etpPrevisionnel: 0,
+      etpReel: 0,
+    });
+  });
+
+  it('ignore les valeurs non renseignées', () => {
+    const totals = computeBudgetTotals([
+      toBudgetRow({ eurosPrevisionnel: 1000 }),
+      toBudgetRow({ eurosReel: 500, etpReel: 1 }),
+    ]);
+
+    expect(totals).toEqual({
+      eurosPrevisionnel: 1000,
+      eurosReel: 500,
+      etpPrevisionnel: 0,
+      etpReel: 1,
+    });
+  });
+
+  it('additionne 0,1 et 0,2 ETP en 0,3', () => {
+    const totals = computeBudgetTotals([
+      toBudgetRow({ etpPrevisionnel: 0.1, etpReel: 0.1 }),
+      toBudgetRow({ etpPrevisionnel: 0.2, etpReel: 0.2 }),
+    ]);
+
+    expect(totals).toEqual({
+      eurosPrevisionnel: 0,
+      eurosReel: 0,
+      etpPrevisionnel: 0.3,
+      etpReel: 0.3,
+    });
+  });
+
+  it('additionne 100,10 et 200,20 euros en 300,30', () => {
+    const totals = computeBudgetTotals([
+      toBudgetRow({ eurosPrevisionnel: 100.1, eurosReel: 100.1 }),
+      toBudgetRow({ eurosPrevisionnel: 200.2, eurosReel: 200.2 }),
+    ]);
+
+    expect(totals).toEqual({
+      eurosPrevisionnel: 300.3,
+      eurosReel: 300.3,
+      etpPrevisionnel: 0,
+      etpReel: 0,
+    });
+  });
+});

--- a/packages/pdf-components/src/fiche-action/compute-budget-totals.ts
+++ b/packages/pdf-components/src/fiche-action/compute-budget-totals.ts
@@ -1,0 +1,20 @@
+import { sumRoundedTo } from '@tet/domain/utils';
+
+export type BudgetRow = {
+  eurosPrevisionnel: number | undefined | null;
+  eurosReel: number | undefined | null;
+  etpPrevisionnel: number | undefined | null;
+  etpReel: number | undefined | null;
+};
+
+export type BudgetTotals = Record<keyof BudgetRow, number>;
+
+const sumField = (budgets: BudgetRow[], field: keyof BudgetRow): number =>
+  sumRoundedTo(budgets.map((budget) => budget[field]));
+
+export const computeBudgetTotals = (budgets: BudgetRow[]): BudgetTotals => ({
+  eurosPrevisionnel: sumField(budgets, 'eurosPrevisionnel'),
+  eurosReel: sumField(budgets, 'eurosReel'),
+  etpPrevisionnel: sumField(budgets, 'etpPrevisionnel'),
+  etpReel: sumField(budgets, 'etpReel'),
+});

--- a/packages/pdf-components/src/fiche-action/external-helpers.ts
+++ b/packages/pdf-components/src/fiche-action/external-helpers.ts
@@ -2,13 +2,6 @@ import { ParticipationCitoyenne } from '@tet/domain/plans';
 import { format } from 'date-fns';
 import { fr } from 'date-fns/locale';
 
-export const getFormattedNumber = (nb: number): string => {
-  return nb
-    .toString()
-    .replace(/\B(?=(\d{3})+(?!\d))/g, ' ')
-    .replace('.', ',');
-};
-
 export const generateTitle = (title?: string | null): string =>
   title || 'Sans titre';
 

--- a/packages/pdf-components/src/primitives/Badge/BadgeBudget.tsx
+++ b/packages/pdf-components/src/primitives/Badge/BadgeBudget.tsx
@@ -1,7 +1,7 @@
 import { Text } from '@react-pdf/renderer';
 import { SizeVariant } from '@tet/design-tokens';
 import classNames from 'classnames';
-import { getFormattedNumber } from '../../fiche-action/external-helpers';
+import { getFormattedNumber } from '@tet/domain/utils';
 import { tw } from '../utils';
 import { Badge } from './Badge';
 


### PR DESCRIPTION
## Bug

Signalé par Sophie : « Le total des budgets est infiniiiiii. » Sur l'onglet Moyens d'une fiche action, la ligne Total affichait par exemple `0,3 000 000 000 000 000 4 ETP`.

Deux défauts cumulés :

1. **Accumulation en virgule flottante brute** — le total des 4 colonnes était calculé par `+` successifs : `0,1 + 0,2 = 0.30000000000000004`.
2. **Formateur cassé** — `getFormattedNumber` appliquait la regex de séparateur de milliers à toute la chaîne, décimales comprises : au-delà de 3 décimales, la partie décimale était elle aussi découpée par groupes de 3, d'où l'effet « nombre infini ».

Le second défaut existait en **trois copies** (`apps/app`, `packages/pdf-components`, `apps/site`), et l'export PDF de la fiche portait aussi le premier.

## Test-first

La branche a été écrasée en un commit unique à la demande du mainteneur. Les paires test rouge → fix restent consultables dans l'historique de force-push de la PR (onglet *Commits* → *force-pushed*) :

| Test rouge | Fix |
|---|---|
| `24cb252` total budget vue fiche | `028c456` somme arrondie à 2 décimales |
| `ae27cf3` groupage des décimales | `9f5d26a` groupage limité à la partie entière |
| `50f6e19` même défaut dans l'export PDF | `bb29b06` total PDF arrondi + formateur corrigé |

Chaque commit de test échouait sur le commit précédent et passait sur son commit de fix. Les 3 specs correspondantes sont dans le diff final :
- `apps/app/.../per-year-table/compute-budget-totals.spec.ts`
- `packages/domain/src/utils/number.utils.spec.ts` (`getFormattedNumber`, `sumRoundedTo`)
- `packages/pdf-components/src/fiche-action/compute-budget-totals.spec.ts`

## Surface de review

**Attention humaine :**
- `packages/domain/src/utils/number.utils.ts` — l'implémentation unique de `getFormattedNumber` et de `sumRoundedTo`, à côté de `roundTo`.
- `apps/app/.../budget/per-year-table/compute-budget-totals.ts` et `packages/pdf-components/src/fiche-action/compute-budget-totals.ts` — les deux calculs de total. Ils ne portent plus que le mapping de champs de leur view-model ; l'accumulation et l'arrondi viennent de `sumRoundedTo`, la précision de `budgetDecimals` (exportée par `fiche-budget.schema`, c'est la précision de stockage des colonnes `budget_previsionnel` / `budget_reel`).
- `apps/site/tsconfig.json` — nouvelle project reference vers `packages/domain` (apps/site ne dépendait pas encore du domaine).

**Mécanique :** les 11 sites d'appel qui passent de leur import local à `@tet/domain/utils`, et les suppressions des 3 copies.

## Hypothèses

- L'arrondi à **2 décimales** est le bon niveau : c'est la précision de stockage (`numeric(14,2)`) et c'est déjà ce que fait `ComputeBudgetRules` côté backend pour l'agrégation par plan.
- Le total doit rester une somme des valeurs affichées, pas une somme des valeurs arrondies individuellement — l'arrondi est appliqué une fois, sur le total.

## Effet visible hors du bug

Sur **apps/site**, la copie locale ne convertissait pas le point décimal en virgule. Après unification, les valeurs décimales (hectares artificialisés, tooltips du donut) s'affichent `1 234,56` au lieu de `1 234.56`. C'est cohérent avec le reste du produit, mais c'est un changement visible sur le site public.

## Zones low-confidence

- L'export PDF n'a pas de test de rendu sur le total : seuls le formateur et le calcul sont couverts unitairement. Le rendu réel n'a pas été inspecté visuellement.
- `apps/site` n'a pas de cible `typecheck` ; vérifié via `tsc -b apps/site` (project references construites) et `nx run site:lint`.

## Anti-duplication

Recherche effectuée avant d'écrire quoi que ce soit :

- `getFormattedFloat` était une copie stricte de `getFormattedNumber` (et mal nommée : elle ne traitait pas les floats) — supprimée, ses 5 appels migrés.
- Les 3 copies de `getFormattedNumber` (`apps/app`, `packages/pdf-components`, `apps/site`) sont fusionnées en une seule.
- L'arrondi passe par `roundTo` de `@tet/domain/utils`, déjà utilisé par ~60 sites d'appel (scores référentiel, indicateurs, budget backend). À noter pour un futur nettoyage, hors périmètre ici : `roundTo` est lui-même un équivalent maison de `round` d'es-toolkit — `Math.round(x * 10**p + Number.EPSILON) / 10**p` contre `Math.round(x * 10**p) / 10**p`. L'epsilon est inerte (0 divergence sur 3M de tirages et sur les valeurs-pivot classiques) ; la seule différence de comportement est qu'es-toolkit lève sur une précision non entière là où `roundTo` renvoie silencieusement une valeur fausse. Le remplacer touche le moteur de calcul des scores, donc PR dédiée.

## Hors périmètre

Les fichiers seulement traversés par la migration d'import portent des écarts préexistants (libellés inline hors `appLabels`, `classnames` au lieu de `cn`, ternaires imbriqués et couleurs en dur côté `apps/site`) : laissés en place, chaque ligne changée doit tracer au signalement.

Un point préexistant mérite une PR à part : `packages/pdf-components/src/fiche-action/BudgetTable.tsx:79` garde en `&&` sur un `number`, une valeur à 0 rend le littéral `0` au lieu de la cellule formatée.

## DISCOVERED.md

Aucune entrée ajoutée : le défaut de formatage identifié hors scope initial a été corrigé directement dans cette PR plutôt que reporté.

## Vérifications

- `vitest` : app (4 specs budget) ✅, domain (12 tests `number.utils`) ✅, pdf-components (suite complète, 10 tests) ✅
- `tsc --noEmit` : app ✅, pdf-components ✅ — `tsc -b apps/site` ✅
- `nx run app:lint` : 0 erreur (125 warnings pré-existants) — `site`, `domain`, `pdf-components` ✅

## Pas de plan linké

Correction issue d'un signalement support, pas d'un plan d'implémentation.
