### PR TITLE
[Batch/pcaet depot avis] add the step-by-step navigation across the elaboration

### DIFF
--- a/apps/app/src/demarches/components/shell.tsx
+++ b/apps/app/src/demarches/components/shell.tsx
@@ -14,6 +14,7 @@ import { DemarchePcaetHeader } from '../pcaet/components/header';
 import type { DemarcheSectionKey } from '../steps';
 import { DemarcheAvanceSidePanelButton } from './avance.side-panel-button';
 import { DemarcheDetailLayout } from './detail.layout';
+import { DemarcheStepsNav } from './steps-nav';
 import { useDemarcheAvanceSidePanel } from './use-avance-side-panel';
 
 type Props = PropsWithChildren<{
@@ -56,7 +57,7 @@ export const DemarcheShell = ({
       DemarchePcaetTransitionEnum.TRANSMETTRE_POUR_AVIS
     );
 
-  const { isOpen, toggle } = useDemarcheAvanceSidePanel({
+  const { isOpen, toggle, open } = useDemarcheAvanceSidePanel({
     demarcheType: demarche.type,
     collectiviteId,
     demarcheId: demarche.id,
@@ -91,6 +92,15 @@ export const DemarcheShell = ({
 
       <DemarcheDetailLayout.Container>
         <DemarcheDetailLayout.Main>{children}</DemarcheDetailLayout.Main>
+        <DemarcheStepsNav
+          demarche={demarche}
+          collectiviteId={collectiviteId}
+          completion={completion}
+          activeSection={activeSection}
+          canTransmettre={canTransmettre}
+          onTransmettre={onTransmettre}
+          onOpenProgressPanel={open}
+        />
       </DemarcheDetailLayout.Container>
     </DemarcheDetailLayout.Root>
   );

--- a/apps/app/src/demarches/components/steps-nav.tsx
+++ b/apps/app/src/demarches/components/steps-nav.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import { appLabels } from '@/app/labels/catalog';
+import { DemarchePcaetStatusEnum } from '@tet/domain/demarches';
+import { Button, Tooltip } from '@tet/ui';
+import { useSearchParams } from 'next/navigation';
+import type { DemarchePcaetCompletion } from '../completion';
+import { useDemarchePcaetDiagnostic } from '../pcaet/diagnostic/data/use-diagnostic';
+import {
+  serializeTopicParam,
+  useDemarcheTopicParam,
+} from '../pcaet/diagnostic/use-topic-param';
+import { DREAL_INSTRUCTEUR_PARAM } from '../pcaet/vue-dreal/components/dreal-context-banner';
+import {
+  getStepsNavModel,
+  makeDemarcheSectionUrl,
+  type DemarcheSectionKey,
+  type DemarcheStepItem,
+} from '../steps';
+import type { DemarchePcaet } from '../types';
+
+type Props = {
+  demarche: DemarchePcaet;
+  collectiviteId: number;
+  completion: DemarchePcaetCompletion;
+  activeSection: DemarcheSectionKey;
+  canTransmettre: boolean;
+  onTransmettre: () => void;
+  /** Ouvre le panneau « Étapes » quand on franchit une sous-étape. */
+  onOpenProgressPanel: () => void;
+};
+
+/**
+ * Barre « Étape précédente | Étape suivante » du parcours d'élaboration :
+ * traverse documents → topics du diagnostic → plan, puis propose la
+ * transmission pour avis sur le dernier item.
+ */
+export const DemarcheStepsNav = ({
+  demarche,
+  collectiviteId,
+  completion,
+  activeSection,
+  canTransmettre,
+  onTransmettre,
+  onOpenProgressPanel,
+}: Props) => {
+  const searchParams = useSearchParams();
+  const { topics } = useDemarchePcaetDiagnostic(demarche.id);
+  const [topicParam] = useDemarcheTopicParam();
+
+  // Le parcours n'existe que pendant l'élaboration ; l'instructeur DREAL
+  // consulte en lecture seule, sans navigation d'édition.
+  if (demarche.statut !== DemarchePcaetStatusEnum.EN_ELABORATION) return null;
+  if (searchParams.get(DREAL_INSTRUCTEUR_PARAM) === '1') return null;
+
+  const { prev, next, isLastStep } = getStepsNavModel({
+    activeSection,
+    hasDocuments: completion.documents !== null,
+    topicCodes: topics.map((topic) => topic.code),
+    currentTopicCode: topicParam,
+  });
+
+  if (!prev && !next && !isLastStep) return null;
+
+  const ids = { collectiviteId, demarcheId: demarche.id };
+  const hrefOf = (item: DemarcheStepItem) =>
+    item.section === 'diagnostic' && item.topicCode
+      ? serializeTopicParam(makeDemarcheSectionUrl('diagnostic', ids), {
+          topic: item.topicCode,
+        })
+      : makeDemarcheSectionUrl(item.section, ids);
+  const crossesSection = (item: DemarcheStepItem) =>
+    item.section !== activeSection;
+
+  return (
+    <nav
+      aria-label={appLabels.demarcheStepsNavAriaLabel}
+      data-test="demarches.steps-nav"
+      // Sticky bottom : flotte au bas du viewport par-dessus le contenu tant
+      // que sa position naturelle est sous la ligne de flottaison, puis
+      // reprend sa place dans le flux en fin de page.
+      className="sticky bottom-0 z-10 flex w-full items-center gap-4 border-t border-primary-3 bg-grey-2 py-4 shadow-t-sm"
+    >
+      {prev && (
+        <Button
+          dataTest="demarches.steps-nav.previous"
+          variant="outlined"
+          size="sm"
+          icon="arrow-left-line"
+          iconPosition="left"
+          href={hrefOf(prev)}
+          onClick={crossesSection(prev) ? onOpenProgressPanel : undefined}
+        >
+          {appLabels.demarcheStepsNavPrevious}
+        </Button>
+      )}
+
+      {isLastStep ? (
+        <Tooltip
+          label={
+            !canTransmettre ? appLabels.demarcheAvanceValiderTooltip : undefined
+          }
+          activatedBy="hover"
+        >
+          <span className="block ml-auto">
+            <Button
+              dataTest="demarches.steps-nav.transmettre"
+              variant={canTransmettre ? 'primary' : 'grey'}
+              size="sm"
+              icon="arrow-right-line"
+              iconPosition="right"
+              disabled={!canTransmettre}
+              onClick={() => {
+                onOpenProgressPanel();
+                onTransmettre();
+              }}
+            >
+              {appLabels.demarcheAvanceValiderDepot}
+            </Button>
+          </span>
+        </Tooltip>
+      ) : (
+        next && (
+          <Button
+            dataTest="demarches.steps-nav.next"
+            className="ml-auto"
+            variant="primary"
+            size="sm"
+            icon="arrow-right-line"
+            iconPosition="right"
+            href={hrefOf(next)}
+            onClick={crossesSection(next) ? onOpenProgressPanel : undefined}
+          >
+            {appLabels.demarcheStepsNavNext}
+          </Button>
+        )
+      )}
+    </nav>
+  );
+};

--- a/apps/app/src/demarches/steps.spec.ts
+++ b/apps/app/src/demarches/steps.spec.ts
@@ -1,5 +1,165 @@
 import { describe, expect, it } from 'vitest';
-import { makeDemarcheSectionUrl } from './steps';
+import { flattenSteps, getStepsNavModel, makeDemarcheSectionUrl } from './steps';
+
+const TOPIC_CODES = [
+  'profil_energie_climat',
+  'sequestration',
+  'polluants_atmospheriques',
+  'enr',
+  'vulnerabilite_territoire',
+] as const;
+
+describe('flattenSteps', () => {
+  it('déroule documents, un item par topic, puis plan', () => {
+    const items = flattenSteps({ hasDocuments: true, topicCodes: TOPIC_CODES });
+
+    expect(items).toEqual([
+      { section: 'documents', topicCode: null },
+      { section: 'diagnostic', topicCode: 'profil_energie_climat' },
+      { section: 'diagnostic', topicCode: 'sequestration' },
+      { section: 'diagnostic', topicCode: 'polluants_atmospheriques' },
+      { section: 'diagnostic', topicCode: 'enr' },
+      { section: 'diagnostic', topicCode: 'vulnerabilite_territoire' },
+      { section: 'plan', topicCode: null },
+    ]);
+  });
+
+  it('replie le diagnostic en un seul item quand les topics ne sont pas chargés', () => {
+    expect(flattenSteps({ hasDocuments: true, topicCodes: [] })).toEqual([
+      { section: 'documents', topicCode: null },
+      { section: 'diagnostic', topicCode: null },
+      { section: 'plan', topicCode: null },
+    ]);
+  });
+
+  it('omet la sous-étape documents quand le modèle ne demande aucune pièce amont', () => {
+    const items = flattenSteps({ hasDocuments: false, topicCodes: TOPIC_CODES });
+
+    expect(items[0]).toEqual({
+      section: 'diagnostic',
+      topicCode: 'profil_energie_climat',
+    });
+    expect(items).toHaveLength(TOPIC_CODES.length + 1);
+  });
+});
+
+describe('getStepsNavModel', () => {
+  const base = { hasDocuments: true, topicCodes: TOPIC_CODES };
+
+  it('sur documents : pas de précédent, suivant = premier topic', () => {
+    const nav = getStepsNavModel({
+      ...base,
+      activeSection: 'documents',
+      currentTopicCode: null,
+    });
+
+    expect(nav.prev).toBeNull();
+    expect(nav.next).toEqual({
+      section: 'diagnostic',
+      topicCode: 'profil_energie_climat',
+    });
+    expect(nav.isLastStep).toBe(false);
+  });
+
+  it('sur un topic médian : les voisins sont des topics', () => {
+    const nav = getStepsNavModel({
+      ...base,
+      activeSection: 'diagnostic',
+      currentTopicCode: 'polluants_atmospheriques',
+    });
+
+    expect(nav.prev).toEqual({
+      section: 'diagnostic',
+      topicCode: 'sequestration',
+    });
+    expect(nav.next).toEqual({ section: 'diagnostic', topicCode: 'enr' });
+  });
+
+  it('sur le premier topic : précédent = documents', () => {
+    const nav = getStepsNavModel({
+      ...base,
+      activeSection: 'diagnostic',
+      currentTopicCode: 'profil_energie_climat',
+    });
+
+    expect(nav.prev).toEqual({ section: 'documents', topicCode: null });
+  });
+
+  it('sur le dernier topic : suivant = plan', () => {
+    const nav = getStepsNavModel({
+      ...base,
+      activeSection: 'diagnostic',
+      currentTopicCode: 'vulnerabilite_territoire',
+    });
+
+    expect(nav.next).toEqual({ section: 'plan', topicCode: null });
+    expect(nav.isLastStep).toBe(false);
+  });
+
+  it('sur le diagnostic sans ?topic= : se résout comme le premier topic', () => {
+    const nav = getStepsNavModel({
+      ...base,
+      activeSection: 'diagnostic',
+      currentTopicCode: null,
+    });
+
+    expect(nav.prev).toEqual({ section: 'documents', topicCode: null });
+    expect(nav.next).toEqual({
+      section: 'diagnostic',
+      topicCode: 'sequestration',
+    });
+  });
+
+  it('sur le diagnostic avec un ?topic= inconnu : se résout comme le premier topic', () => {
+    const nav = getStepsNavModel({
+      ...base,
+      activeSection: 'diagnostic',
+      currentTopicCode: 'topic_inconnu',
+    });
+
+    expect(nav.next).toEqual({
+      section: 'diagnostic',
+      topicCode: 'sequestration',
+    });
+  });
+
+  it('sur plan : précédent = dernier topic, et c’est la dernière étape', () => {
+    const nav = getStepsNavModel({
+      ...base,
+      activeSection: 'plan',
+      currentTopicCode: null,
+    });
+
+    expect(nav.prev).toEqual({
+      section: 'diagnostic',
+      topicCode: 'vulnerabilite_territoire',
+    });
+    expect(nav.next).toBeNull();
+    expect(nav.isLastStep).toBe(true);
+  });
+
+  it('sur plan avec topics non chargés : précédent = diagnostic sans topic', () => {
+    const nav = getStepsNavModel({
+      hasDocuments: true,
+      topicCodes: [],
+      activeSection: 'plan',
+      currentTopicCode: null,
+    });
+
+    expect(nav.prev).toEqual({ section: 'diagnostic', topicCode: null });
+  });
+
+  it('sans sous-étape documents : pas de précédent sur le premier topic', () => {
+    const nav = getStepsNavModel({
+      hasDocuments: false,
+      topicCodes: TOPIC_CODES,
+      activeSection: 'diagnostic',
+      currentTopicCode: 'profil_energie_climat',
+    });
+
+    expect(nav.prev).toBeNull();
+  });
+});
 
 describe('makeDemarcheSectionUrl', () => {
   const ids = { collectiviteId: 1, demarcheId: 42 };

--- a/apps/app/src/demarches/steps.ts
+++ b/apps/app/src/demarches/steps.ts
@@ -3,6 +3,7 @@ import {
   makeCollectiviteDemarchePcaetDocumentsUrl,
   makeCollectiviteDemarchePcaetPlanActionsUrl,
 } from '@/app/app/paths';
+import { resolveActiveTopic } from './active-topic';
 
 export const DEMARCHE_SECTION_KEYS = [
   'documents',
@@ -11,6 +12,38 @@ export const DEMARCHE_SECTION_KEYS = [
 ] as const;
 
 export type DemarcheSectionKey = (typeof DEMARCHE_SECTION_KEYS)[number];
+
+/**
+ * Un item du parcours aplati de l'élaboration. `topicCode` n'existe que pour
+ * le diagnostic ; il vaut `null` tant que la liste des topics n'est pas chargée.
+ */
+export type DemarcheStepItem = {
+  section: DemarcheSectionKey;
+  topicCode: string | null;
+};
+
+/**
+ * Déroule le parcours de l'élaboration : documents (si le modèle demande des
+ * pièces amont), puis un item par topic du diagnostic, puis le plan.
+ */
+export const flattenSteps = ({
+  hasDocuments,
+  topicCodes,
+}: {
+  hasDocuments: boolean;
+  topicCodes: readonly string[];
+}): DemarcheStepItem[] => [
+  ...(hasDocuments
+    ? [{ section: 'documents' as const, topicCode: null }]
+    : []),
+  ...(topicCodes.length > 0
+    ? topicCodes.map((topicCode) => ({
+        section: 'diagnostic' as const,
+        topicCode,
+      }))
+    : [{ section: 'diagnostic' as const, topicCode: null }]),
+  { section: 'plan' as const, topicCode: null },
+];
 
 export const makeDemarcheSectionUrl = (
   section: DemarcheSectionKey,
@@ -24,4 +57,42 @@ export const makeDemarcheSectionUrl = (
     case 'plan':
       return makeCollectiviteDemarchePcaetPlanActionsUrl(ids);
   }
+};
+
+export type StepsNavModel = {
+  prev: DemarcheStepItem | null;
+  next: DemarcheStepItem | null;
+  /** Sur le dernier item, « suivant » devient l'action de transmission. */
+  isLastStep: boolean;
+};
+
+/**
+ * Résout la position courante puis calcule les items adjacents.
+ */
+export const getStepsNavModel = ({
+  activeSection,
+  hasDocuments,
+  topicCodes,
+  currentTopicCode,
+}: {
+  activeSection: DemarcheSectionKey;
+  hasDocuments: boolean;
+  topicCodes: readonly string[];
+  currentTopicCode: string | null;
+}): StepsNavModel => {
+  const items = flattenSteps({ hasDocuments, topicCodes });
+  const resolvedTopicCode =
+    activeSection !== 'diagnostic'
+      ? null
+      : resolveActiveTopic(topicCodes, currentTopicCode, (code) => code);
+  const index = items.findIndex(
+    (item) =>
+      item.section === activeSection && item.topicCode === resolvedTopicCode
+  );
+
+  return {
+    prev: (index > 0 && items[index - 1]) || null,
+    next: (index >= 0 && items[index + 1]) || null,
+    isLastStep: index >= 0 && index === items.length - 1,
+  };
 };

--- a/apps/app/src/labels/catalog.ts
+++ b/apps/app/src/labels/catalog.ts
@@ -823,7 +823,10 @@ export const appLabels = {
     'Complétez les documents attendus pour publier votre démarche.',
   demarcheAvanceTransmisEcheance: 'Échéance remise des avis :',
   demarcheAvanceTransmisDepasse: 'Délai dépassé',
+  demarcheStepsNavPrevious: 'Étape précédente',
+  demarcheStepsNavNext: 'Étape suivante',
   /** Étiquette du `<nav>` de la barre d'étapes, lue par les lecteurs d'écran. */
+  demarcheStepsNavAriaLabel: 'Navigation entre les étapes du dépôt',
   demarcheVulnerabiliteTitre: 'Vulnérabilité du territoire',
   /** Étiquette du `<nav>` du fil d'Ariane, lue par les lecteurs d'écran. */
   demarcheVulnerabiliteFilAriane: 'Fil d’Ariane',

--- a/e2e/tests/demarches/pcaet/demarche-pcaet-workflow.spec.ts
+++ b/e2e/tests/demarches/pcaet/demarche-pcaet-workflow.spec.ts
@@ -112,8 +112,12 @@ test.describe('Démarche PCAET - workflow plan actions', () => {
     await demarchePcaetPom.expectActiveTopic('profil_energie_climat');
     await demarchePcaetPom.expectProgressPanelOpen(true);
 
-    // Naviguer entre topics ne touche pas au panneau.
+    // Naviguer entre topics ne touche pas au panneau. Le parcours suit l'ordre
+    // d'affichage du référentiel : aucun volet ne s'y saute.
     await demarchePcaetPom.closeProgressPanel();
+    await clickNextTo(/topic=consommation_energetique$/);
+    await expect(page).toHaveURL(/\?topic=consommation_energetique$/);
+    await demarchePcaetPom.expectActiveTopic('consommation_energetique');
     await clickNextTo(/topic=sequestration$/);
     await expect(page).toHaveURL(/\?topic=sequestration$/);
     await demarchePcaetPom.expectActiveTopic('sequestration');

--- a/e2e/tests/demarches/pcaet/demarche-pcaet-workflow.spec.ts
+++ b/e2e/tests/demarches/pcaet/demarche-pcaet-workflow.spec.ts
@@ -1,3 +1,4 @@
+import { expect } from '@playwright/test';
 import { test } from 'tests/main.fixture';
 import { DemarchePcaetPom } from './demarche-pcaet.pom';
 
@@ -74,5 +75,75 @@ test.describe('Démarche PCAET - workflow plan actions', () => {
     }
     await demarchePcaetPom.expectNoTopicGridRow('Chauffage / Logement collectif');
     await demarchePcaetPom.expectNoTopicGridRow('Autres industries');
+  });
+
+  test('la barre d’étapes traverse documents, topics du diagnostic et plan', async ({
+    collectivites,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    plans, // requis pour cleanup auto
+    page,
+  }) => {
+    const { collectivite } = await collectivites.addCollectiviteAndUser({
+      userArgs: { autoLogin: true },
+    });
+    const demarchePcaetPom = new DemarchePcaetPom(page);
+
+    await demarchePcaetPom.gotoCreatePage(collectivite.data.id);
+    await demarchePcaetPom.createDemarche(collectivite.data.id);
+
+    // Attend que la cible du bouton « suivante » soit recalculée avant de
+    // cliquer : le href se met à jour après le changement de ?topic=.
+    const clickNextTo = async (hrefPattern: RegExp) => {
+      await expect(demarchePcaetPom.stepsNavNext).toHaveAttribute(
+        'href',
+        hrefPattern
+      );
+      await demarchePcaetPom.stepsNavNext.click();
+    };
+
+    // Premier item du parcours : pas de « précédente », le panneau est fermé.
+    await expect(page).toHaveURL(/\/documents\/?$/);
+    await demarchePcaetPom.closeProgressPanel();
+    await expect(demarchePcaetPom.stepsNavPrevious).toBeHidden();
+
+    // Franchir une sous-étape ouvre le panneau d'avancée automatiquement.
+    await clickNextTo(/topic=profil_energie_climat$/);
+    await expect(page).toHaveURL(/\/indicateurs\?topic=profil_energie_climat$/);
+    await demarchePcaetPom.expectActiveTopic('profil_energie_climat');
+    await demarchePcaetPom.expectProgressPanelOpen(true);
+
+    // Naviguer entre topics ne touche pas au panneau.
+    await demarchePcaetPom.closeProgressPanel();
+    await clickNextTo(/topic=sequestration$/);
+    await expect(page).toHaveURL(/\?topic=sequestration$/);
+    await demarchePcaetPom.expectActiveTopic('sequestration');
+    await demarchePcaetPom.expectProgressPanelOpen(false);
+
+    await clickNextTo(/topic=polluants_atmospheriques$/);
+    await expect(page).toHaveURL(/\?topic=polluants_atmospheriques$/);
+    await demarchePcaetPom.expectActiveTopic('polluants_atmospheriques');
+    await clickNextTo(/topic=enr$/);
+    await expect(page).toHaveURL(/\?topic=enr$/);
+    await demarchePcaetPom.expectActiveTopic('enr');
+    await clickNextTo(/topic=vulnerabilite_territoire$/);
+    await expect(page).toHaveURL(/\?topic=vulnerabilite_territoire$/);
+    await demarchePcaetPom.expectActiveTopic('vulnerabilite_territoire');
+    await demarchePcaetPom.expectProgressPanelOpen(false);
+
+    // Dernier topic → plan : nouveau franchissement, le panneau se rouvre.
+    await clickNextTo(/\/plan$/);
+    await expect(page).toHaveURL(/\/plan\/?$/);
+    await demarchePcaetPom.expectProgressPanelOpen(true);
+
+    // Dernier item : « suivante » devient la transmission, bloquée tant que le
+    // dossier est incomplet (règle workflow évaluée côté serveur).
+    await expect(demarchePcaetPom.stepsNavNext).toBeHidden();
+    await expect(demarchePcaetPom.stepsNavTransmettre).toBeVisible();
+    await expect(demarchePcaetPom.stepsNavTransmettre).toBeDisabled();
+
+    // « Précédente » depuis le plan revient sur le dernier topic du diagnostic.
+    await demarchePcaetPom.stepsNavPrevious.click();
+    await expect(page).toHaveURL(/\?topic=vulnerabilite_territoire$/);
+    await demarchePcaetPom.expectActiveTopic('vulnerabilite_territoire');
   });
 });

--- a/e2e/tests/demarches/pcaet/demarche-pcaet.pom.ts
+++ b/e2e/tests/demarches/pcaet/demarche-pcaet.pom.ts
@@ -10,6 +10,9 @@ export class DemarchePcaetPom {
   readonly linkedPlanRow: Locator;
   readonly diagnosticTopics: Locator;
   readonly progressSidePanelButton: Locator;
+  readonly stepsNavPrevious: Locator;
+  readonly stepsNavNext: Locator;
+  readonly stepsNavTransmettre: Locator;
 
   constructor(readonly page: Page) {
     this.startDepotButton = page.getByRole('button', {
@@ -30,6 +33,11 @@ export class DemarchePcaetPom {
     this.diagnosticTopics = page.getByTestId('demarches.pcaet.diagnostic.topics');
     this.progressSidePanelButton = page.getByTestId(
       'demarches.pcaet.avance-side-panel-button'
+    );
+    this.stepsNavPrevious = page.getByTestId('demarches.steps-nav.previous');
+    this.stepsNavNext = page.getByTestId('demarches.steps-nav.next');
+    this.stepsNavTransmettre = page.getByTestId(
+      'demarches.steps-nav.transmettre'
     );
   }
 


### PR DESCRIPTION
Un chantier d'amélioration de la navigation avec des boutons Prev / Next a également été lancé ce qui améliore grandement l'UX :

https://github.com/user-attachments/assets/6146b201-44d1-43d4-8293-99aa1f75bfb4

On navigue entre les étapes mais également entre les sous-étapes et les sections au sein d'une étape, techniquement, le parcours est aplati en une liste d'étapes (flattenSteps) dans le fichier, ce qui permet à la navigation de traverser facilement les volets du diagnostic.

Sur le dernier item, « suivant » devient l'action de transmission prévue par le workflow et ne devient active que si les conditions sont réunies.