### PR TITLE
refactor(utils): remplace roundTo par round d'es-toolkit

### DIFF
--- a/apps/app/src/app/pages/collectivite/Trajectoire/graphes/GrapheSecteur.stories.tsx
+++ b/apps/app/src/app/pages/collectivite/Trajectoire/graphes/GrapheSecteur.stories.tsx
@@ -1,6 +1,6 @@
+import { round } from 'es-toolkit';
 import { Dataset } from '@/app/ui/charts/echarts';
 import { Meta, StoryObj } from '@storybook/nextjs-vite';
-import { roundTo } from '@tet/domain/utils';
 import { GrapheSecteur } from './GrapheSecteur';
 
 const meta: Meta<typeof GrapheSecteur> = {
@@ -25,7 +25,7 @@ const genRandomDataset = (id: string, name: string, offset = 0): Dataset => ({
   dimensions: ['x', 'y'],
   source: ANNEES.map((annee) => ({
     x: annee,
-    y: roundTo(Math.random() * 100 + offset, 2),
+    y: round(Math.random() * 100 + offset, 2),
   })),
 });
 

--- a/apps/app/src/app/pages/collectivite/Trajectoire/graphes/GrapheTousSecteurs.stories.tsx
+++ b/apps/app/src/app/pages/collectivite/Trajectoire/graphes/GrapheTousSecteurs.stories.tsx
@@ -1,5 +1,5 @@
+import { round } from 'es-toolkit';
 import { Meta, StoryObj } from '@storybook/nextjs-vite';
-import { roundTo } from '@tet/domain/utils';
 import { INDICATEURS_TRAJECTOIRE } from '../../../../../indicateurs/trajectoires/trajectoire-constants';
 import { GrapheTousSecteurs } from './GrapheTousSecteurs';
 
@@ -26,7 +26,7 @@ const genRandomDataset = (id: string, name: string, offset = 0) => ({
   dimensions: ['x', 'y'],
   source: ANNEES.map((annee) => ({
     x: new Date(`${annee}-01-01`),
-    y: roundTo(Math.random() * 100 + offset, 2),
+    y: round(Math.random() * 100 + offset, 2),
   })),
 });
 

--- a/apps/app/src/collectivites/personnalisations/data/transform-reponse.ts
+++ b/apps/app/src/collectivites/personnalisations/data/transform-reponse.ts
@@ -1,9 +1,9 @@
+import { round } from 'es-toolkit';
 import {
   PersonnalisationReponse,
   PersonnalisationReponseValue,
   QuestionType,
 } from '@tet/domain/collectivites';
-import { roundTo } from '@tet/domain/utils';
 
 export const transformReponseToWrite = (
   questionType: QuestionType,
@@ -31,8 +31,7 @@ export const transformLoadedReponse = (
   const { questionType, reponse } = row;
 
   if (questionType === 'proportion') {
-    const value =
-      typeof reponse === 'number' ? roundTo(reponse * 100, 0) : null;
+    const value = typeof reponse === 'number' ? round(reponse * 100, 0) : null;
     return { ...row, reponse: value };
   }
 

--- a/apps/app/src/referentiels/audits/AuditComparaison/AuditComparaisonTable.tsx
+++ b/apps/app/src/referentiels/audits/AuditComparaison/AuditComparaisonTable.tsx
@@ -1,4 +1,5 @@
-import { divisionOrZero, roundTo } from '@tet/domain/utils';
+import { round } from 'es-toolkit';
+import { divisionOrZero } from '@tet/domain/utils';
 import { useMemo } from 'react';
 import {
   CellProps,
@@ -47,8 +48,8 @@ const getDifference = (
       ? divisionOrZero(courant.pointFait, courant.pointPotentiel)
       : courant[field];
 
-  const previous = roundTo(preAuditValue as number, 3);
-  const current = roundTo(currentValue as number, 3);
+  const previous = round(preAuditValue as number, 3);
+  const current = round(currentValue as number, 3);
 
   if (previous === current) {
     return undefined;

--- a/apps/app/src/referentiels/comparisons/evolutions-score-total.chart.tsx
+++ b/apps/app/src/referentiels/comparisons/evolutions-score-total.chart.tsx
@@ -1,3 +1,4 @@
+import { round } from 'es-toolkit';
 import { actionAvancementColors } from '@/app/app/theme';
 import {
   EChartsOption,
@@ -9,7 +10,6 @@ import {
   SnapshotJalon,
   SnapshotJalonEnum,
 } from '@tet/domain/referentiels';
-import { roundTo } from '@tet/domain/utils';
 import type { BarSeriesOption } from 'echarts/charts';
 import { theme as importedTheme } from '../../ui/charts/chartsTheme';
 import { SnapshotListItem } from '../use-snapshot';
@@ -186,7 +186,7 @@ export const ScoreTotalEvolutionsChart = ({
             break;
         }
 
-        return `${circle}${params.seriesName}: ${params.value}% (${roundTo(
+        return `${circle}${params.seriesName}: ${params.value}% (${round(
           points,
           1
         )} pts)`;
@@ -272,12 +272,12 @@ export const ScoreTotalEvolutionsChart = ({
 };
 
 const computePercentage = (point: number, pointPotentiel: number) => {
-  return roundTo((point / pointPotentiel) * 100, 1);
+  return round((point / pointPotentiel) * 100, 1);
 };
 
 const makeScoreSnapshotLabel = (pointFait: number, pointPotentiel: number) => {
   const percentage = computePercentage(pointFait, pointPotentiel);
-  return `{percent|${percentage}%}\n${roundTo(pointFait, 1)}/${roundTo(
+  return `{percent|${percentage}%}\n${round(pointFait, 1)}/${round(
     pointPotentiel,
     1
   )} pts`;

--- a/apps/app/src/referentiels/scores/progress-bar-with-tooltip.tsx
+++ b/apps/app/src/referentiels/scores/progress-bar-with-tooltip.tsx
@@ -1,4 +1,4 @@
-import { roundTo } from '@tet/domain/utils';
+import { round } from 'es-toolkit';
 import { Tooltip } from '@tet/ui';
 import ProgressBar, { ProgressBarType } from './progress-bar';
 import { JSX } from 'react';
@@ -113,4 +113,4 @@ const ProgressBarTooltipElement = ({
 const formatAvancementScore = (
   avancementPoint: number,
   maxPoint: number
-): number => (maxPoint ? roundTo((avancementPoint / maxPoint) * 100, 1) : 0);
+): number => (maxPoint ? round((avancementPoint / maxPoint) * 100, 1) : 0);

--- a/apps/app/src/referentiels/scores/progress-bar.tsx
+++ b/apps/app/src/referentiels/scores/progress-bar.tsx
@@ -1,4 +1,4 @@
-import { roundTo } from '@tet/domain/utils';
+import { round } from 'es-toolkit';
 import { Badge } from '@tet/ui';
 import classNames from 'classnames';
 import { JSX } from 'react';
@@ -53,7 +53,7 @@ const ProgressBar = ({
       {/* Légende à gauche de la barre de progression */}
       {!!displayedValue && (
         <Badge
-          title={`${roundTo(displayedValue, 1)} %`}
+          title={`${round(displayedValue, 1)} %`}
           variant="success"
           size="sm"
           trim={false}

--- a/apps/app/src/referentiels/scores/score.ratio-badge.tsx
+++ b/apps/app/src/referentiels/scores/score.ratio-badge.tsx
@@ -1,5 +1,5 @@
+import { round } from 'es-toolkit';
 import { SizeVariant } from '@tet/design-tokens';
-import { roundTo } from '@tet/domain/utils';
 import { Badge, BadgeDouble } from '@tet/ui';
 import classNames from 'classnames';
 import { forwardRef } from 'react';
@@ -19,8 +19,8 @@ export const ScoreRatioBadge = forwardRef<HTMLDivElement, Props>(
 
     const { pointFait, pointPotentiel } = action.score;
 
-    const roundPointFait = roundTo(pointFait, 1);
-    const roundPointPotentiel = roundTo(pointPotentiel, 1);
+    const roundPointFait = round(pointFait, 1);
+    const roundPointPotentiel = round(pointPotentiel, 1);
 
     return (
       <div
@@ -42,7 +42,7 @@ export const ScoreRatioBadge = forwardRef<HTMLDivElement, Props>(
             type="solid"
             size={size}
             badgeLeft={{
-              title: `${roundTo((pointFait / pointPotentiel) * 100, 1)} %`,
+              title: `${round((pointFait / pointPotentiel) * 100, 1)} %`,
               uppercase: false,
               trim: false,
             }}

--- a/apps/app/src/tableaux-de-bord/plans-action/fiches-action-count-by/utils/get-chart-option.ts
+++ b/apps/app/src/tableaux-de-bord/plans-action/fiches-action-count-by/utils/get-chart-option.ts
@@ -9,10 +9,9 @@ import {
   Priorite,
   Statut,
 } from '@tet/domain/plans';
-import { roundTo } from '@tet/domain/utils';
 import { preset } from '@tet/ui';
 import type { PieSeriesOption } from 'echarts/charts';
-import { cloneDeep } from 'es-toolkit';
+import { cloneDeep, round } from 'es-toolkit';
 
 const getItemColor = (
   countByProperty: CountByPropertyEnumType,
@@ -142,7 +141,7 @@ export const getChartOption = ({
       trigger: 'item',
       valueFormatter: (value) => {
         if (typeof value === 'number') {
-          return `${value} (${roundTo((value / countByTotal) * 100, 0)}%)`;
+          return `${value} (${round((value / countByTotal) * 100, 0)}%)`;
         }
         return '';
       },

--- a/apps/app/src/utils/file.ts
+++ b/apps/app/src/utils/file.ts
@@ -1,10 +1,10 @@
-import { roundTo } from '@tet/domain/utils';
+import { round } from 'es-toolkit';
 
 /** Renvoi une taille de fichier (en octet) formatée pour l'affichage */
 export const formatFileSize = (size: number) => {
   const i = Math.floor(Math.log(size) / Math.log(1024));
   return (
-    Number(roundTo(size / Math.pow(1024, i), 2)) +
+    Number(round(size / Math.pow(1024, i), 2)) +
     ' ' +
     ['o', 'Ko', 'Mo', 'Go', 'To'][i]
   );

--- a/apps/backend/src/indicateurs/trajectoire-leviers/trajectoire-leviers.service.ts
+++ b/apps/backend/src/indicateurs/trajectoire-leviers/trajectoire-leviers.service.ts
@@ -25,8 +25,7 @@ import { GetIndicateursValeursResponse } from '@tet/backend/indicateurs/valeurs/
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
 import { AuthUser } from '@tet/backend/users/models/auth.models';
 import { ResourceType } from '@tet/domain/users';
-import { roundTo } from '@tet/domain/utils';
-import { isNil, sum, sumBy } from 'es-toolkit';
+import { isNil, round, sum, sumBy } from 'es-toolkit';
 
 @Injectable()
 export class TrajectoireLeviersService {
@@ -397,7 +396,7 @@ export class TrajectoireLeviersService {
       (data) => data.objectif2030 ?? 0
     );
 
-    return roundTo(
+    return round(
       ((objectifTotal2030 - valeurTotal2019) * pourcentageRegional) / 100,
       2
     );

--- a/apps/backend/src/indicateurs/valeurs/compute-valeurs.service.ts
+++ b/apps/backend/src/indicateurs/valeurs/compute-valeurs.service.ts
@@ -15,7 +15,6 @@ import {
   IndicateurValeurCreate,
   IndicateurValeurWithIdentifiant,
 } from '@tet/domain/indicateurs';
-import { roundTo } from '@tet/domain/utils';
 import {
   and,
   eq,
@@ -26,7 +25,7 @@ import {
   sql,
   SQLWrapper,
 } from 'drizzle-orm';
-import { isNil } from 'es-toolkit';
+import { isNil, round } from 'es-toolkit';
 import { ListPlatformDefinitionsRepository } from '../definitions/list-platform-definitions/list-platform-definitions.repository';
 
 type IndicateurValeurInsert = IndicateurValeurCreate;
@@ -483,11 +482,11 @@ export default class ComputeValeursService {
               dateValeur: relatedSourceIndicateurInfo.date,
               resultat:
                 computedResultat !== null
-                  ? roundTo(computedResultat, indicateurPrecision)
+                  ? round(computedResultat, indicateurPrecision)
                   : null,
               objectif:
                 computedObjectif !== null
-                  ? roundTo(computedObjectif, indicateurPrecision)
+                  ? round(computedObjectif, indicateurPrecision)
                   : null,
               metadonneeId: relatedSourceIndicateurInfo.metadonneeId,
               calculAuto: true,

--- a/apps/backend/src/indicateurs/valeurs/crud-valeurs.service.ts
+++ b/apps/backend/src/indicateurs/valeurs/crud-valeurs.service.ts
@@ -30,7 +30,7 @@ import {
   PermissionOperationEnum,
   ResourceType,
 } from '@tet/domain/users';
-import { getErrorMessage, roundTo } from '@tet/domain/utils';
+import { getErrorMessage } from '@tet/domain/utils';
 import {
   and,
   eq,
@@ -54,6 +54,7 @@ import {
   omit,
   omitBy,
   partition,
+  round,
 } from 'es-toolkit';
 import { GetUserRolesAndPermissionsService } from '../../users/authorizations/get-user-roles-and-permissions/get-user-roles-and-permissions.service';
 import {
@@ -506,10 +507,10 @@ export default class CrudValeursService {
 
     if (user.role === AuthRole.AUTHENTICATED && user.id) {
       if (!isNil(data.resultat)) {
-        data.resultat = roundTo(data.resultat, indicateur.precision);
+        data.resultat = round(data.resultat, indicateur.precision);
       }
       if (!isNil(data.objectif)) {
-        data.objectif = roundTo(data.objectif, indicateur.precision);
+        data.objectif = round(data.objectif, indicateur.precision);
       }
 
       const now = new Date().toISOString();
@@ -695,10 +696,10 @@ export default class CrudValeursService {
       const definition = indicateurDefinitionsById[v.indicateurId];
       if (definition) {
         v.resultat = isNotNil(v.resultat)
-          ? roundTo(v.resultat, definition.precision)
+          ? round(v.resultat, definition.precision)
           : null;
         v.objectif = isNotNil(v.objectif)
-          ? roundTo(v.objectif, definition.precision)
+          ? round(v.objectif, definition.precision)
           : null;
       } else {
         throw new BadRequestException(

--- a/apps/backend/src/plans/plans/compute-budget/compute-budget.rules.ts
+++ b/apps/backend/src/plans/plans/compute-budget/compute-budget.rules.ts
@@ -1,3 +1,4 @@
+import { round } from 'es-toolkit';
 import { Injectable } from '@nestjs/common';
 import {
   AggregatedBudget,
@@ -6,7 +7,6 @@ import {
   BudgetWithTotal,
   FicheWithRelations,
 } from '@tet/domain/plans';
-import { roundTo } from '@tet/domain/utils';
 
 @Injectable()
 export class ComputeBudgetRules {
@@ -31,7 +31,7 @@ export class ComputeBudgetRules {
       }
       return acc + budget;
     }, 0);
-    return { total: roundTo(budget || 0, 2), nbFiches };
+    return { total: round(budget || 0, 2), nbFiches };
   }
 
   /**

--- a/apps/backend/src/plans/plans/progress/plan-progress.rules.ts
+++ b/apps/backend/src/plans/plans/progress/plan-progress.rules.ts
@@ -1,6 +1,6 @@
+import { round } from 'es-toolkit';
 import { Injectable, Logger } from '@nestjs/common';
 import { FicheWithRelations, StatutEnum } from '@tet/domain/plans';
-import { roundTo } from '@tet/domain/utils';
 
 @Injectable()
 export class PlanProgressRules {
@@ -15,6 +15,6 @@ export class PlanProgressRules {
     const fichesCompleted = fiches.filter(
       (fiche) => !fiche.parentId && fiche.statut === StatutEnum.REALISE
     ).length;
-    return roundTo((fichesCompleted * 100) / totalFiches, 1);
+    return round((fichesCompleted * 100) / totalFiches, 1);
   }
 }

--- a/apps/backend/src/referentiels/compute-score/score-from-origines.rules.ts
+++ b/apps/backend/src/referentiels/compute-score/score-from-origines.rules.ts
@@ -1,7 +1,6 @@
 import { type CorrelatedActionWithScore } from '@tet/backend/referentiels/correlated-actions/referentiel-action-origine-with-score.dto';
 import { type ActionScoreWithOnlyPoints } from '@tet/domain/referentiels';
-import { roundTo } from '@tet/domain/utils';
-import { isNil } from 'es-toolkit';
+import { isNil, round } from 'es-toolkit';
 
 export const getRatioFromOrigineActions = (
   origineActions: CorrelatedActionWithScore[] | undefined,
@@ -38,7 +37,7 @@ export const getScoreFromOrigineActionsAndRatio = (
     pointPasFait: 0,
     pointNonRenseigne: 0,
   };
-  initialScore.pointFait = roundTo(
+  initialScore.pointFait = round(
     ratio *
       (origineActions?.reduce(
         (acc, origineAction) =>
@@ -52,7 +51,7 @@ export const getScoreFromOrigineActionsAndRatio = (
     roundingDigits
   );
 
-  initialScore.pointProgramme = roundTo(
+  initialScore.pointProgramme = round(
     ratio *
       (origineActions?.reduce(
         (acc, origineAction) =>
@@ -65,7 +64,7 @@ export const getScoreFromOrigineActionsAndRatio = (
       ) || 0),
     roundingDigits
   );
-  initialScore.pointPasFait = roundTo(
+  initialScore.pointPasFait = round(
     ratio *
       (origineActions?.reduce(
         (acc, origineAction) =>
@@ -81,7 +80,7 @@ export const getScoreFromOrigineActionsAndRatio = (
 
   if (isNil(referentielPointsPotentiels)) {
     referentielPointsPotentiels =
-      roundTo(
+      round(
         ratio *
           (origineActions?.reduce(
             (acc, origineAction) =>
@@ -97,7 +96,7 @@ export const getScoreFromOrigineActionsAndRatio = (
     initialScore.pointPotentiel = referentielPointsPotentiels;
   }
 
-  initialScore.pointNonRenseigne = roundTo(
+  initialScore.pointNonRenseigne = round(
     (referentielPointsPotentiels || 0) -
       (initialScore.pointFait || 0) -
       (initialScore.pointProgramme || 0) -

--- a/apps/backend/src/referentiels/compute-score/scores.service.spec.ts
+++ b/apps/backend/src/referentiels/compute-score/scores.service.spec.ts
@@ -1,3 +1,4 @@
+import { round } from 'es-toolkit';
 import { Test } from '@nestjs/testing';
 import DocumentService from '@tet/backend/collectivites/documents/document.service';
 import { ScoreIndicatifService } from '@tet/backend/referentiels/score-indicatif/score-indicatif.service';
@@ -14,7 +15,6 @@ import {
   ActionTypeEnum,
   ScoreFields,
 } from '@tet/domain/referentiels';
-import { roundTo } from '@tet/domain/utils';
 import { CollectiviteReferentielModeService } from '../../collectivites/collectivite-referentiel-mode/collectivite-referentiel-mode.service';
 import ListPersonnalisationQuestionsService from '../../collectivites/personnalisations/list-personnalisation-questions/list-personnalisation-questions.service';
 import { ListPersonnalisationReponsesRepository } from '../../collectivites/personnalisations/list-personnalisation-reponses/list-personnalisation-reponses.repository';
@@ -1788,8 +1788,8 @@ describe('ReferentielsScoringService', () => {
         pointFait: 0,
         pointProgramme: 0,
         pointPasFait: 0,
-        pointNonRenseigne: roundTo((40 / 65) * 70, 3),
-        pointPotentiel: roundTo((40 / 65) * 70, 3),
+        pointNonRenseigne: round((40 / 65) * 70, 3),
+        pointPotentiel: round((40 / 65) * 70, 3),
         pointReferentiel: 40,
         completedTachesCount: 0,
         totalTachesCount: 1,
@@ -1809,8 +1809,8 @@ describe('ReferentielsScoringService', () => {
         pointFait: 0,
         pointProgramme: 0,
         pointPasFait: 0,
-        pointNonRenseigne: roundTo((25 / 65) * 70, 3),
-        pointPotentiel: roundTo((25 / 65) * 70, 3),
+        pointNonRenseigne: round((25 / 65) * 70, 3),
+        pointPotentiel: round((25 / 65) * 70, 3),
         pointReferentiel: 25,
         completedTachesCount: 0,
         totalTachesCount: 1,
@@ -2199,13 +2199,13 @@ describe('ReferentielsScoringService', () => {
       });
 
       expect(
-        roundTo(
+        round(
           (scoresMap['eci_1'].pointFait as number) /
             (scoresMap['eci_1'].pointPotentiel as number),
           5
         )
       ).toEqual(
-        roundTo(
+        round(
           (scoresMap['eci_2'].pointFait as number) /
             (scoresMap['eci_2'].pointPotentiel as number),
           5

--- a/apps/backend/src/referentiels/compute-score/scores.service.ts
+++ b/apps/backend/src/referentiels/compute-score/scores.service.ts
@@ -39,9 +39,8 @@ import {
   PermissionOperationEnum,
   ResourceType,
 } from '@tet/domain/users';
-import { roundTo } from '@tet/domain/utils';
 import { and, desc, eq, gte, sql } from 'drizzle-orm';
-import { chunk, isEqual, isNil, pick } from 'es-toolkit';
+import { chunk, isEqual, isNil, pick, round } from 'es-toolkit';
 import { DateTime } from 'luxon';
 import { PersonnalisationConsequencesByActionId } from '../../collectivites/personnalisations/models/personnalisation-consequence.dto';
 import PersonnalisationsExpressionService from '../../collectivites/personnalisations/services/personnalisations-expression.service';
@@ -634,7 +633,7 @@ export default class ScoresService {
     );
     scoreParent.pointPasFait =
       roundingDigits !== undefined
-        ? roundTo(pointPasFait, roundingDigits)
+        ? round(pointPasFait, roundingDigits)
         : pointPasFait;
 
     const pointFait = scoreEnfants.reduce(
@@ -643,7 +642,7 @@ export default class ScoresService {
     );
     scoreParent.pointFait =
       roundingDigits !== undefined
-        ? roundTo(pointFait, roundingDigits)
+        ? round(pointFait, roundingDigits)
         : pointFait;
 
     const pointProgramme = scoreEnfants.reduce(
@@ -652,7 +651,7 @@ export default class ScoresService {
     );
     scoreParent.pointProgramme =
       roundingDigits !== undefined
-        ? roundTo(pointProgramme, roundingDigits)
+        ? round(pointProgramme, roundingDigits)
         : pointProgramme;
 
     const pointNonRenseigne = scoreEnfants.reduce(
@@ -661,7 +660,7 @@ export default class ScoresService {
     );
     scoreParent.pointNonRenseigne =
       roundingDigits !== undefined
-        ? roundTo(pointNonRenseigne, roundingDigits)
+        ? round(pointNonRenseigne, roundingDigits)
         : pointNonRenseigne;
 
     if (includePointPotentielAndReferentiel) {
@@ -671,7 +670,7 @@ export default class ScoresService {
       );
       scoreParent.pointPotentiel =
         roundingDigits !== undefined
-          ? roundTo(pointPotentiel, roundingDigits)
+          ? round(pointPotentiel, roundingDigits)
           : pointPotentiel;
 
       const pointReferentiel = scoreEnfants.reduce(
@@ -680,7 +679,7 @@ export default class ScoresService {
       );
       scoreParent.pointReferentiel =
         roundingDigits !== undefined
-          ? roundTo(pointReferentiel, roundingDigits)
+          ? round(pointReferentiel, roundingDigits)
           : pointReferentiel;
     }
   }
@@ -821,59 +820,54 @@ export default class ScoresService {
 
     referentielActionAvecScore.score.pointPotentiel =
       referentielActionAvecScore.score.pointPotentiel !== null
-        ? roundTo(referentielActionAvecScore.score.pointPotentiel, ndigits)
+        ? round(referentielActionAvecScore.score.pointPotentiel, ndigits)
         : null;
     referentielActionAvecScore.score.pointFait =
       referentielActionAvecScore.score.pointFait !== null
-        ? roundTo(referentielActionAvecScore.score.pointFait, ndigits)
+        ? round(referentielActionAvecScore.score.pointFait, ndigits)
         : null;
     referentielActionAvecScore.score.pointProgramme =
       referentielActionAvecScore.score.pointProgramme !== null
-        ? roundTo(referentielActionAvecScore.score.pointProgramme, ndigits)
+        ? round(referentielActionAvecScore.score.pointProgramme, ndigits)
         : null;
     referentielActionAvecScore.score.pointNonRenseigne =
       referentielActionAvecScore.score.pointNonRenseigne !== null
-        ? roundTo(referentielActionAvecScore.score.pointNonRenseigne, ndigits)
+        ? round(referentielActionAvecScore.score.pointNonRenseigne, ndigits)
         : null;
     referentielActionAvecScore.score.pointPasFait =
       referentielActionAvecScore.score.pointPasFait !== null
-        ? roundTo(referentielActionAvecScore.score.pointPasFait, ndigits)
+        ? round(referentielActionAvecScore.score.pointPasFait, ndigits)
         : null;
     referentielActionAvecScore.score.pointReferentiel =
       referentielActionAvecScore.score.pointReferentiel !== null
-        ? roundTo(referentielActionAvecScore.score.pointReferentiel, ndigits)
+        ? round(referentielActionAvecScore.score.pointReferentiel, ndigits)
         : null;
     if (referentielActionAvecScore.score.pointPotentielPerso) {
       referentielActionAvecScore.score.pointPotentielPerso =
-        roundTo(
-          referentielActionAvecScore.score.pointPotentielPerso,
-          ndigits
-        ) || null;
+        round(referentielActionAvecScore.score.pointPotentielPerso, ndigits) ||
+        null;
     }
     referentielActionAvecScore.score.faitTachesAvancement =
       referentielActionAvecScore.score.faitTachesAvancement !== null
-        ? roundTo(
-            referentielActionAvecScore.score.faitTachesAvancement,
-            ndigits
-          )
+        ? round(referentielActionAvecScore.score.faitTachesAvancement, ndigits)
         : null;
     referentielActionAvecScore.score.pasFaitTachesAvancement =
       referentielActionAvecScore.score.pasFaitTachesAvancement !== null
-        ? roundTo(
+        ? round(
             referentielActionAvecScore.score.pasFaitTachesAvancement,
             ndigits
           )
         : null;
     referentielActionAvecScore.score.programmeTachesAvancement =
       referentielActionAvecScore.score.programmeTachesAvancement !== null
-        ? roundTo(
+        ? round(
             referentielActionAvecScore.score.programmeTachesAvancement,
             ndigits
           )
         : null;
     referentielActionAvecScore.score.pasConcerneTachesAvancement =
       referentielActionAvecScore.score.pasConcerneTachesAvancement !== null
-        ? roundTo(
+        ? round(
             referentielActionAvecScore.score.pasConcerneTachesAvancement,
             ndigits
           )
@@ -1316,12 +1310,12 @@ export default class ScoresService {
       );
       if (action.scoresOrigine) {
         action.scoresOrigine[referentielid] = {
-          pointFait: roundTo(pointFait, roundingDigits),
-          pointProgramme: roundTo(pointProgramme, roundingDigits),
-          pointPasFait: roundTo(pointPasFait, roundingDigits),
-          pointNonRenseigne: roundTo(pointNonRenseigne, roundingDigits),
-          pointPotentiel: roundTo(pointPotentiel, roundingDigits),
-          pointReferentiel: roundTo(pointReferentiel, roundingDigits),
+          pointFait: round(pointFait, roundingDigits),
+          pointProgramme: round(pointProgramme, roundingDigits),
+          pointPasFait: round(pointPasFait, roundingDigits),
+          pointNonRenseigne: round(pointNonRenseigne, roundingDigits),
+          pointPotentiel: round(pointPotentiel, roundingDigits),
+          pointReferentiel: round(pointReferentiel, roundingDigits),
         };
       }
     });

--- a/apps/backend/src/referentiels/export-score/build-columns.ts
+++ b/apps/backend/src/referentiels/export-score/build-columns.ts
@@ -13,8 +13,8 @@ import {
   StatutAvancementCreate,
   StatutAvancementEnum,
 } from '@tet/domain/referentiels';
-import { htmlToText, roundTo } from '@tet/domain/utils';
-import { toMerged } from 'es-toolkit';
+import { htmlToText } from '@tet/domain/utils';
+import { round, toMerged } from 'es-toolkit';
 import { CellFormulaValue, Style } from 'exceljs';
 import * as Utils from '../../utils/excel/export-excel.utils';
 
@@ -391,7 +391,7 @@ function buildScoreRowUtils(
     const point = score?.[`point${type}`];
     let value =
       point && score.pointPotentiel
-        ? roundTo(point / score.pointPotentiel, 3)
+        ? round(point / score.pointPotentiel, 3)
         : undefined;
 
     // dans certains cas (sous-mesures 5.2.1 et 5.3.1 de ECi) la somme des scores
@@ -424,7 +424,7 @@ function buildScoreRowUtils(
       score?.avancement === StatutAvancementEnum.DETAILLE_AU_POURCENTAGE &&
       value !== undefined
     ) {
-      return roundTo(value, 2);
+      return round(value, 2);
     }
     return value;
   }

--- a/apps/backend/src/referentiels/labellisations/list-labellisations.service.ts
+++ b/apps/backend/src/referentiels/labellisations/list-labellisations.service.ts
@@ -1,3 +1,4 @@
+import { round } from 'es-toolkit';
 import { Injectable, Logger } from '@nestjs/common';
 import { ListCollectiviteInput } from '@tet/backend/collectivites/list-collectivites/list-collectivites.input';
 import ListCollectivitesService from '@tet/backend/collectivites/list-collectivites/list-collectivites.service';
@@ -12,7 +13,6 @@ import { snapshotTable } from '@tet/backend/referentiels/snapshots/snapshot.tabl
 import { sqlToDateTimeISO } from '@tet/backend/utils/column.utils';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { SnapshotJalonEnum } from '@tet/domain/referentiels';
-import { roundTo } from '@tet/domain/utils';
 import { desc, getTableColumns, inArray, isNotNull } from 'drizzle-orm';
 import { and, eq, or } from 'drizzle-orm/sql';
 import { DateTime } from 'luxon';
@@ -94,14 +94,14 @@ export class ListLabellisationsService {
           etoiles: labellisation.etoiles,
           annee: annee,
           scoreRealise: labellisation.pointPotentiel
-            ? roundTo(
+            ? round(
                 (labellisation.pointFait * 100.0) /
                   labellisation.pointPotentiel,
                 1
               )
             : 0,
           scoreProgramme: labellisation.pointProgramme
-            ? roundTo(
+            ? round(
                 (labellisation.pointProgramme * 100.0) /
                   labellisation.pointPotentiel,
                 1

--- a/apps/backend/src/referentiels/snapshots/list-snapshots/list-snapshots.service.e2e-spec.ts
+++ b/apps/backend/src/referentiels/snapshots/list-snapshots/list-snapshots.service.e2e-spec.ts
@@ -1,3 +1,4 @@
+import { round } from 'es-toolkit';
 import { INestApplication } from '@nestjs/common';
 import { addTestCollectiviteAndUser } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
 import { collectiviteTable } from '@tet/backend/collectivites/shared/models/collectivite.table';
@@ -14,7 +15,6 @@ import {
 } from '@tet/domain/collectivites';
 import { ReferentielIdEnum, SnapshotJalonEnum } from '@tet/domain/referentiels';
 import { CollectiviteRole } from '@tet/domain/users';
-import { roundTo } from '@tet/domain/utils';
 import { eq } from 'drizzle-orm';
 import { ReferentielsRouter } from '../../referentiels.router';
 
@@ -101,7 +101,7 @@ describe('ListSnapshotsService', () => {
       pointFait: snapshot.pointFait,
       pointPasFait: snapshot.pointPasFait,
       pointNonRenseigne:
-        roundTo(
+        round(
           snapshot.pointPotentiel -
             (snapshot.pointFait +
               snapshot.pointPasFait +

--- a/apps/backend/src/referentiels/snapshots/list-snapshots/list-snapshots.service.ts
+++ b/apps/backend/src/referentiels/snapshots/list-snapshots/list-snapshots.service.ts
@@ -1,3 +1,4 @@
+import { round } from 'es-toolkit';
 import { Injectable } from '@nestjs/common';
 import { CollectiviteReferentielModeService } from '@tet/backend/collectivites/collectivite-referentiel-mode/collectivite-referentiel-mode.service';
 import { LIST_DEFAULT_JALONS } from '@tet/backend/referentiels/snapshots/list-snapshots/list-snapshots.api-query';
@@ -9,7 +10,6 @@ import {
   SnapshotJalonEnum,
   snapshotJalonEnumSchema,
 } from '@tet/domain/referentiels';
-import { roundTo } from '@tet/domain/utils';
 import { and, desc, eq, inArray } from 'drizzle-orm';
 import z from 'zod';
 import { snapshotTable } from '../snapshot.table';
@@ -122,7 +122,7 @@ export class ListSnapshotsService {
         const baseSnapshot = {
           ...snapshot,
           pointNonRenseigne:
-            roundTo(
+            round(
               snapshot.pointPotentiel -
                 (snapshot.pointFait +
                   snapshot.pointPasFait +

--- a/apps/backend/src/referentiels/snapshots/snapshots.service.ts
+++ b/apps/backend/src/referentiels/snapshots/snapshots.service.ts
@@ -25,9 +25,8 @@ import {
   SnapshotJalonEnum,
   SnapshotWithoutPayloads,
 } from '@tet/domain/referentiels';
-import { roundTo } from '@tet/domain/utils';
 import { and, eq, getTableColumns, sql } from 'drizzle-orm';
-import { omit } from 'es-toolkit';
+import { omit, round } from 'es-toolkit';
 import { DateTime } from 'luxon';
 import { z } from 'zod';
 import { CollectiviteReferentielModeService } from '../../collectivites/collectivite-referentiel-mode/collectivite-referentiel-mode.service';
@@ -699,7 +698,7 @@ export class SnapshotsService {
     this.logger.log(
       `ScoreSnapshot ${snapshotRef} modified at ${
         snapshot.modifiedAt
-      }, score: ${snapshot.pointFait}/${snapshot.pointPotentiel} = ${roundTo(
+      }, score: ${snapshot.pointFait}/${snapshot.pointPotentiel} = ${round(
         (snapshot.pointFait * 100) / snapshot.pointPotentiel,
         2
       )}%`
@@ -753,7 +752,7 @@ export class SnapshotsService {
         updatedSnapshot.modifiedAt
       }, score: ${updatedSnapshot.pointFait}/${
         updatedSnapshot.pointPotentiel
-      } = ${roundTo(
+      } = ${round(
         (updatedSnapshot.pointFait * 100) / updatedSnapshot.pointPotentiel,
         2
       )}%`

--- a/e2e/tests/referentiels/scores/referentiel-scores.pom.ts
+++ b/e2e/tests/referentiels/scores/referentiel-scores.pom.ts
@@ -1,9 +1,9 @@
+import { round } from 'es-toolkit';
 import { expect, Locator, Page } from '@playwright/test';
 import {
   ReferentielId,
   StatutAvancementCreate,
 } from '@tet/domain/referentiels';
-import { roundTo } from '@tet/domain/utils';
 import { DocumentsPom } from 'tests/collectivite/documents/documents.pom';
 
 export class ReferentielScoresPom {
@@ -251,7 +251,7 @@ export class ReferentielScoresPom {
     await expect(
       this.getScoreRatioLocator(referentielId, actionIdentifiant)
     ).toContainText(
-      `${roundTo(pointFait, 1)} / ${roundTo(pointPotentiel, 1)} points`
+      `${round(pointFait, 1)} / ${round(pointPotentiel, 1)} points`
     );
   }
 

--- a/packages/domain/src/utils/number.utils.spec.ts
+++ b/packages/domain/src/utils/number.utils.spec.ts
@@ -1,4 +1,4 @@
-import { getFormattedNumber, roundTo, sumRoundedTo } from './number.utils';
+import { getFormattedNumber, sumRoundedTo } from './number.utils';
 
 describe('number helper', () => {
   describe('getFormattedNumber', () => {
@@ -27,33 +27,31 @@ describe('number helper', () => {
     });
   });
 
-  describe('roundTo', () => {
-    it('roundTo for 1.5625', async () => {
-      expect(roundTo(1.5625, 3)).toBe(1.563);
-    });
-
-    it('roundTo for 0.3375', async () => {
-      expect(roundTo(0.3375, 3)).toBe(0.338);
-    });
-
-    it('roundTo for 0', async () => {
-      expect(roundTo(0, 3)).toBe(0);
-    });
-
-    it('roundTo for 2.0', async () => {
-      expect(roundTo(2.0, 3)).toBe(2);
-    });
-
-    it('roundTo for 2.35', async () => {
-      expect(roundTo(2.35, 1)).toBe(2.4);
-    });
-
-    it('roundTo for 2.55', async () => {
-      expect(roundTo(2.55, 1)).toBe(2.6);
-    });
-  });
-
   describe('sumRoundedTo', () => {
+    it('arrondit 1,5625 à 1,563', () => {
+      expect(sumRoundedTo([1.5625], 3)).toBe(1.563);
+    });
+
+    it('arrondit 0,3375 à 0,338', () => {
+      expect(sumRoundedTo([0.3375], 3)).toBe(0.338);
+    });
+
+    it('laisse 0 à 0', () => {
+      expect(sumRoundedTo([0], 3)).toBe(0);
+    });
+
+    it('laisse 2 à 2', () => {
+      expect(sumRoundedTo([2.0], 3)).toBe(2);
+    });
+
+    it('arrondit 2,35 au supérieur à 2,4', () => {
+      expect(sumRoundedTo([2.35], 1)).toBe(2.4);
+    });
+
+    it('arrondit 2,55 au supérieur à 2,6', () => {
+      expect(sumRoundedTo([2.55], 1)).toBe(2.6);
+    });
+
     it('renvoie 0 sans valeur', () => {
       expect(sumRoundedTo([])).toBe(0);
     });

--- a/packages/domain/src/utils/number.utils.ts
+++ b/packages/domain/src/utils/number.utils.ts
@@ -1,4 +1,4 @@
-import { isNil, sumBy } from 'es-toolkit';
+import { isNil, round, sumBy } from 'es-toolkit';
 
 export function divisionOrZero(a: number | null, b: number | null) {
   return division(a, b, 0);
@@ -27,16 +27,11 @@ export function getFormattedNumber(nb: number): string {
     : `${groupThousands(integerPart)},${decimalPart}`;
 }
 
-export function roundTo(num: number, precision: number): number {
-  const factor = Math.pow(10, precision);
-  return Math.round(num * factor + Number.EPSILON) / factor;
-}
-
 export function sumRoundedTo(
   values: readonly (number | null | undefined)[],
   precision = 2
 ): number {
-  return roundTo(
+  return round(
     sumBy(values, (value) => value ?? 0),
     precision
   );
@@ -65,5 +60,3 @@ export function pythonRoundTo(
     return Math.round(shiftedValue) / factor;
   }
 }
-
-

--- a/packages/pdf-components/src/fiche-action/scores/score-ratio-badge.tsx
+++ b/packages/pdf-components/src/fiche-action/scores/score-ratio-badge.tsx
@@ -1,6 +1,6 @@
+import { round } from 'es-toolkit';
 import { SizeVariant } from '@tet/design-tokens';
 import { ActionScoreFinal } from '@tet/domain/referentiels';
-import { roundTo } from '@tet/domain/utils';
 import { Badge } from '../../primitives/Badge';
 import { Stack } from '../../primitives/Stack';
 
@@ -19,15 +19,15 @@ export const ScoreRatioBadge = ({
 
   const { pointFait, pointPotentiel } = score;
 
-  const roundPointFait = roundTo(pointFait, 1);
-  const roundPointPotentiel = roundTo(pointPotentiel, 1);
+  const roundPointFait = round(pointFait, 1);
+  const roundPointPotentiel = round(pointPotentiel, 1);
 
   return pointPotentiel === 0 ? (
     <Badge title="0 point" variant="grey" type="outlined" size={size} />
   ) : (
     <Stack direction="row" gap={0}>
       <Badge
-        title={`${roundTo((pointFait / pointPotentiel) * 100, 1)} %`}
+        title={`${round((pointFait / pointPotentiel) * 100, 1)} %`}
         variant="success"
         size={size}
         className="rounded-r-none border-[0.5px] border-success-3 border-r-0"


### PR DESCRIPTION
## Pourquoi

`roundTo` de `@tet/domain/utils` est un équivalent maison de `round` d'es-toolkit, déjà dépendance du monorepo :

```ts
roundTo(num, p) → Math.round(num * 10**p + Number.EPSILON) / 10**p
round(value, p) → Math.round(value * 10**p) / 10**p   // + garde sur precision entière
```

Repéré en écrivant #4789, où la phrase « réutilisé `roundTo` plutôt que `round` » présentait un doublon comme un arbitrage.

## Équivalence vérifiée avant de migrer

Le `+ Number.EPSILON` est inerte :

- **0 divergence sur 3 000 000 de tirages aléatoires** (valeurs dans `[-10, 10]`, précisions 0 à 3) ;
- **0 divergence sur les valeurs-pivot** classiques du demi-arrondi : `0.05`, `0.15`, …, `0.95`, `1.005`, `1.015`, `1.025`, `0.125`, `0.135`, `2.675`, `1.45`, `-2.5` ;
- les **6 cas du spec de `roundTo`** (`1.5625`/3, `0.3375`/3, `0`/3, `2.0`/3, `2.35`/1, `2.55`/1) donnent le même résultat avec `round`.

C'est attendu : `Number.EPSILON` vaut l'ULP à 1.0. Au-dessus de 1 il déplace d'au plus 1 ULP sans jamais franchir une frontière `.5` ; en-dessous il est trop petit pour être représentable dans l'addition.

Seule différence de comportement, en faveur d'es-toolkit : `round` **lève** sur une précision non entière, là où `roundTo` renvoyait silencieusement une valeur fausse (`roundTo(1.234, 1.5)` → `1.2332882874656679`).

Vérifié qu'aucun site d'appel ne peut passer une précision non entière : littéraux, colonne `integer` (`indicateur_definition.precision`), constantes (`DEFAULT_ROUNDING_DIGITS`, `DEFAULT_ROUNDING_PRECISION`), ou argument gardé par `!== undefined` (`mergePointScoresEnfants`).

## Surface de review

**Attention humaine :**
- `packages/domain/src/utils/number.utils.ts` — suppression de `roundTo`, `sumRoundedTo` bascule sur `round`.
- `packages/domain/src/utils/number.utils.spec.ts` — les 6 cas de `roundTo` sont conservés, portés sur `sumRoundedTo` (son seul appelant restant dans le domaine) avec une valeur unique par tableau : même chemin d'arrondi, mais à travers notre API et non celle de la lib. C'est ce qui reste comme filet si es-toolkit changeait sa règle d'arrondi.
- `apps/backend/src/referentiels/compute-score/scores.service.ts` et `score-from-origines.rules.ts` — moteur de score, c'est là que le risque se concentre.

**Mécanique :** les ~60 autres appels, remplacement `roundTo(` → `round(` et bascule de l'import vers `es-toolkit` (fusionné dans l'import es-toolkit existant quand il y en avait un). Quelques hunks se reformatent parce que le nom raccourci de 2 caractères fait tenir l'appel sur moins de lignes.

## Périmètre

5 projets : `apps/app`, `apps/backend`, `packages/domain`, `packages/pdf-components`, `e2e`.

`pythonRoundTo` **reste** : son arrondi au pair (banker's rounding) n'a pas d'équivalent es-toolkit.

## Dépendance

Empilée sur `fix/total-budget-flottant` (#4789), qui introduit `sumRoundedTo`. **À merger après #4789** — sinon `sumRoundedTo` arrive sur `main` en appelant un `roundTo` supprimé ici. GitHub rebasera automatiquement la base sur `main` au merge de #4789.

## Vérifications

- `nx test backend 'scores.service.spec.ts'` : 32 tests ✅ (moteur de calcul des scores)
- `nx test backend 'rules.spec.ts'` : 16 fichiers, 153 tests ✅
- `nx test backend 'build-columns.spec.ts'` : 22 tests ✅
- `vitest` domain (18 tests `number.utils`) ✅, app ✅, pdf-components ✅
- `tsc --noEmit` : app, backend, domain, pdf-components, e2e ✅
- `lint` : app, backend, domain, pdf-components — 0 erreur ✅

Les `*.e2e-spec.ts` backend n'ont pas été exécutés localement (base de données requise) ; c'est la CI qui les couvre.

## Zones low-confidence

- Le moteur de score est couvert par ses specs unitaires, mais l'égalité stricte des scores en base n'a pas été rejouée sur un jeu de données réel. L'équivalence numérique démontrée plus haut est l'argument principal.

## Pas de plan linké

Nettoyage identifié pendant la review de #4789.
