### PR TITLE
fix(referentiels): rattache chaque snapshot d'audit à son audit

### DIFF
--- a/apps/backend/src/referentiels/labellisations/validate-audit/validate-audit.router.e2e-spec.ts
+++ b/apps/backend/src/referentiels/labellisations/validate-audit/validate-audit.router.e2e-spec.ts
@@ -14,7 +14,7 @@ import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
 import { Collectivite } from '@tet/domain/collectivites';
 import { ReferentielIdEnum, SnapshotJalonEnum } from '@tet/domain/referentiels';
 import { CollectiviteRole } from '@tet/domain/users';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { snapshotTable } from '../../snapshots/snapshot.table';
 import { addAuditeurPermission } from '../labellisations.test-fixture';
 
@@ -78,6 +78,53 @@ describe('ValidateAuditRouter', () => {
     expect(snapshot).toBeDefined();
     expect(snapshot.jalon).toBe(SnapshotJalonEnum.POST_AUDIT);
     expect(snapshot.date).toBe(validatedAudit.dateFin);
+  });
+
+  test('deux audits validés la même année conservent chacun leur snapshot post-audit', async () => {
+    const { collectivite: auditedCollectivite, user } =
+      await addTestCollectiviteAndUser(db, {
+        user: { role: CollectiviteRole.ADMIN },
+      });
+    const auditeur = getAuthUserFromUserCredentials(user);
+    const caller = router.createCaller({ user: auditeur });
+
+    const validateNewAudit = async () => {
+      const { audit } = await createAuditWithOnTestFinished({
+        databaseService: db,
+        collectiviteId: auditedCollectivite.id,
+        referentielId: ReferentielIdEnum.CAE,
+        withDemande: true,
+      });
+
+      await addAuditeurPermission({
+        databaseService: db,
+        auditId: audit.id,
+        userId: auditeur.id,
+      });
+
+      return caller.referentiels.labellisations.validateAudit({
+        auditId: audit.id,
+      });
+    };
+
+    const firstAudit = await validateNewAudit();
+    const secondAudit = await validateNewAudit();
+
+    const postAuditSnapshots = await db.db
+      .select({ auditId: snapshotTable.auditId })
+      .from(snapshotTable)
+      .where(
+        and(
+          eq(snapshotTable.collectiviteId, auditedCollectivite.id),
+          eq(snapshotTable.jalon, SnapshotJalonEnum.POST_AUDIT)
+        )
+      )
+      .orderBy(snapshotTable.auditId);
+
+    expect(postAuditSnapshots).toEqual([
+      { auditId: firstAudit.id },
+      { auditId: secondAudit.id },
+    ]);
   });
 
   test('un non auditeur ne peut pas valider un audit', async () => {

--- a/apps/backend/src/referentiels/snapshots/snapshots.service.ts
+++ b/apps/backend/src/referentiels/snapshots/snapshots.service.ts
@@ -123,10 +123,12 @@ export class SnapshotsService {
     nom: snapshotNom,
     jalon,
     anneeAudit,
+    auditId,
   }: {
     nom?: string;
     jalon?: SnapshotJalon;
     anneeAudit?: number;
+    auditId?: number;
   }): Result<{ ref: string; nom: string }, SnapshotsError> {
     let ref = '';
     let nom = snapshotNom || '';
@@ -134,22 +136,22 @@ export class SnapshotsService {
     if (
       (jalon === SnapshotJalonEnum.PRE_AUDIT ||
         jalon === SnapshotJalonEnum.POST_AUDIT) &&
-      !anneeAudit
+      (!anneeAudit || !auditId)
     ) {
       this.logger.warn(
-        `L'année de l'audit doit être définie pour le jalon ${jalon}`
+        `L'année et l'identifiant de l'audit doivent être définis pour le jalon ${jalon}`
       );
       return failure(SnapshotsErrorEnum.SNAPSHOT_INVALID_METADATA);
     }
 
     switch (jalon) {
       case SnapshotJalonEnum.PRE_AUDIT:
-        ref = `${SNAPSHOTS.PRE_AUDIT_REF_PREFIX}${anneeAudit}`;
+        ref = `${SNAPSHOTS.PRE_AUDIT_REF_PREFIX}${anneeAudit}-${auditId}`;
         nom = `${anneeAudit}${SNAPSHOTS.PRE_AUDIT_NOM_SUFFIX}`;
         break;
 
       case SnapshotJalonEnum.POST_AUDIT:
-        ref = `${SNAPSHOTS.POST_AUDIT_REF_PREFIX}${anneeAudit}`;
+        ref = `${SNAPSHOTS.POST_AUDIT_REF_PREFIX}${anneeAudit}-${auditId}`;
         nom = `${anneeAudit}${SNAPSHOTS.POST_AUDIT_NOM_SUFFIX}`;
         break;
 
@@ -207,6 +209,8 @@ export class SnapshotsService {
           snapshotTable.ref,
         ],
         set: {
+          auditId: sql.raw(`excluded.${snapshotTable.auditId.name}`),
+          etoiles: sql.raw(`excluded.${snapshotTable.etoiles.name}`),
           date: sql.raw(`excluded.${snapshotTable.date.name}`),
           pointFait: sql.raw(`excluded.${snapshotTable.pointFait.name}`),
           pointPotentiel: sql.raw(
@@ -391,6 +395,7 @@ export class SnapshotsService {
         nom: snapshotNom,
         jalon: scoresPayload.jalon,
         anneeAudit: scoresPayload.anneeAudit,
+        auditId: scoresPayload.auditId,
       });
 
       if (!metadataResult.success) {


### PR DESCRIPTION
## Mode de défaillance

La ref d'un snapshot d'audit était `post-audit-<année de date_fin>` (`snapshots.service.ts:150`), or la clé primaire de `score_snapshot` est `(collectivite_id, referentiel_id, ref)` (`snapshot.table.ts:60`). Deux audits d'une même collectivité clos la même année civile visaient donc la même ligne.

Le `set` de l'`onConflictDoUpdate` de `upsertScoreSnapshot` n'incluant ni `audit_id` ni `etoiles`, le second audit écrasait les scores du premier **tout en héritant de son `audit_id`**.

Observé en production, collectivité 3878 / référentiel `cae` :

| audit | sujet demande | clos le | effet sur `post-audit-2026` |
|---|---|---|---|
| 7923 | `cot` | 2026-04-21 | crée la ligne, `audit_id = 7923` |
| 14988 | `labellisation_cot` | 2026-05-04 | écrase les scores, `audit_id` reste 7923 |

Le trigger `update_labellisation_before_audit_update` cherche son snapshot par `audit_id` + `type_jalon = 'post_audit'`. Ne le trouvant pas pour 14988, il sort sur un `raise log` **avant** d'évaluer les conditions métier — aucune ligne dans `public.labellisation` malgré un audit clos, validé, `valide_labellisation = true` et `date_cnl` au 2026-06-02. Échec totalement silencieux, ni erreur utilisateur ni Sentry.

Second symptôme du même défaut : `list-labellisations.service.ts` reconstruit les labellisations depuis `score_snapshot` en joignant `audit_id → audit → demande` et en filtrant sur `valide_labellisation`. Le join tombait sur 7923, dont ce champ est `null` — la labellisation disparaissait aussi de cette surface.

## Le correctif

La ref porte désormais l'année **et** l'identifiant de l'audit — `post-audit-2026-14988` — sur `pre_audit` comme sur `post_audit`. L'unicité vient de l'identifiant, l'année reste un préfixe lisible pour l'inspection en base. 21 caractères au maximum observé, contre 30 autorisés par la colonne.

Le point qui compte : ref et `audit_id` deviennent structurellement incapables de diverger, puisque l'une est calculée depuis l'autre. C'est exactement la contradiction qui a produit le bug — une ligne dont la ref disait « 2026 », le `audit_id` disait « 7923 », et le contenu était celui de 14988.

`audit_id` et `etoiles` rejoignent par ailleurs le `set`, de sorte qu'un recalcul rafraîchisse aussi ces colonnes.

**Pas de migration.** Les lignes existantes gardent leur ref annuelle, qui reste une clé de lookup valide : rien ne la parse, aucun SQL ne la filtre, et le front la traite comme opaque — elle sert de `value` aux options de `SelectMultiple`, le libellé affiché étant `nom` (`evolutions-snapshots.dropdown.tsx:81-83`). Aucune ref n'apparaît dans une URL.

## Commits

1. `2f3a2f33de` — test de régression, **rouge sur main**
2. `a39fc1f9b6` — le fix, qui le verdit
3. `05ea225f6e` — l'année réintroduite dans la ref, pour la lisibilité en base

## Surface de review

- `validate-audit.router.e2e-spec.ts` (+48) — le test : deux audits validés successivement, un snapshot post-audit attendu par audit.
- `snapshots.service.ts` (+9/-4 puis +2/-2) — `getDefaultSnapshotMetadata` et le `set` de `upsertScoreSnapshot`.

## Vérifications

- `nx test backend 'validate-audit.router.e2e-spec.ts'` : 3/3 verts (rouge avant le commit 2).
- `nx test backend 'snapshot'` : 26/29, soit `snapshots.router.e2e-spec` 20/20, `list-snapshots.service.e2e-spec` 2/2, `create-pre-switch-snapshots.service.e2e-spec` 4/4.
- `list-snapshots.controller.spec.ts` échoue (3 tests, `401` au lieu de `400`) — **préexistant**, vérifié en rejouant la spec sur l'arbre sans le fix.
- `nx run backend:typecheck` OK, `nx run backend:lint` 0 erreur (150 warnings, inchangé).

## Hypothèses

- **L'invariant asserté est « un snapshot post-audit par audit validé »**, pas « le dernier gagne » : le score post-audit de chaque audit est un fait historique distinct, et `public.labellisation` en dépend audit par audit.
- **La collision se reproduit sans manipuler les dates** : `labellisation.update_audit()` (`labellisation/audit@v2.101.0.sql:31-42`) pose `date_fin = now()` quand `valide` bascule, donc deux audits validés dans le même run partagent l'année civile.
- **Deux audits successifs sont créables** malgré l'index unique partiel `audit_existant` (`WHERE NOT clos`) parce que la validation d'une demande `cot` pose `clos = true`. C'est l'enchaînement de prod.

## Zones de faible confiance

- Le `nom` reste `${année} - audit` : deux audits de la même année produiront deux entrées de dropdown au libellé identique. Problème d'affichage distinct, volontairement hors de cette PR — la donnée nécessaire (`date` par snapshot) est déjà côté client.
- Le chemin `COURANT` (`insertSnapshotOrUpsertIfCurrentJalon`) porte un `set` incomplet comparable. Laissé en l'état, hors périmètre.
- Coexistence temporaire de deux schémas de ref (annuel pour l'existant, année + audit pour les nouveaux). Sans danger vu l'usage de la ref, mais à savoir en débug.

## Correction de données

La collectivité 3878 a été réparée manuellement hors PR (réaffectation d'`audit_id`, re-déclenchement du trigger, `refresh materialized view site_labellisation`). Un balayage de l'ensemble des audits clos, validés et passés en CNL ne remonte **aucune autre labellisation manquante** — ce correctif est donc préventif.


