### PR TITLE
[Batch/pcaet depot avis] Instruction : suivi des demandes d'avis et consultation du dossier

### DIFF
--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(instruction)/demandes-avis/[demandeAvisId]/page.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(instruction)/demandes-avis/[demandeAvisId]/page.tsx
@@ -1,0 +1,13 @@
+import { DossierInstructionPage } from '@/app/demarches/pcaet/instruction/dossier/dossier-instruction.page';
+import z from 'zod';
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ demandeAvisId: string }>;
+}) {
+  const { demandeAvisId: unsafeDemandeAvisId } = await params;
+  const demandeAvisId = z.coerce.number().parse(unsafeDemandeAvisId);
+
+  return <DossierInstructionPage demandeAvisId={demandeAvisId} />;
+}

--- a/apps/app/src/app/paths.ts
+++ b/apps/app/src/app/paths.ts
@@ -137,6 +137,20 @@ export const makeDemandesAvisUrl = ({
 }) =>
   demandesAvisPath.replace(`:${collectiviteParam}`, collectiviteId.toString());
 
+export const demandeAvisParam = 'demandeAvisId';
+const demandeAvisDossierPath = `${demandesAvisPath}/:${demandeAvisParam}`;
+
+export const makeDemandeAvisDossierUrl = ({
+  collectiviteId,
+  demandeAvisId,
+}: {
+  collectiviteId: number;
+  demandeAvisId: number;
+}) =>
+  demandeAvisDossierPath
+    .replace(`:${collectiviteParam}`, collectiviteId.toString())
+    .replace(`:${demandeAvisParam}`, demandeAvisId.toString());
+
 export type TDBViewId = 'synthetique' | 'personnel';
 
 export const makeCollectiviteRootUrl = ({

--- a/apps/app/src/demarches/pcaet/diagnostic/topic-tab.tsx
+++ b/apps/app/src/demarches/pcaet/diagnostic/topic-tab.tsx
@@ -1,16 +1,18 @@
 'use client';
 
+import type { DemarchePcaetTopic } from '@tet/domain/demarches';
 import { Icon } from '@tet/ui';
 import { cn } from '@tet/ui/utils/cn';
 import { JSX } from 'react';
-import type { DemarchePcaetTopic } from '@tet/domain/demarches';
-import type { DemarcheCompletionStatut } from '../../types';
 import { DemarcheCompletionBadge } from '../../components/completion.badge';
+import type { DemarcheCompletionStatut } from '../../types';
 
 type TopicTabProps = {
   topic: DemarchePcaetTopic;
   isActive: boolean;
   statut: DemarcheCompletionStatut;
+  /** Omis en consultation : l'avancement ne concerne que la collectivité. */
+  isComplete?: boolean;
   onSelect: () => void;
 };
 

--- a/apps/app/src/demarches/pcaet/instruction/data/use-list-demandes-avis.ts
+++ b/apps/app/src/demarches/pcaet/instruction/data/use-list-demandes-avis.ts
@@ -1,0 +1,57 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { useTRPC } from '@tet/api';
+import { useCurrentCollectivite } from '@tet/api/collectivites';
+import {
+  parseAsInteger,
+  parseAsStringLiteral,
+  useQueryStates,
+} from 'nuqs';
+
+const SORT_VALUES = ['echeance', 'collectivite'] as const;
+const DIRECTION_VALUES = ['asc', 'desc'] as const;
+
+const LIMIT = 10;
+
+export const useListDemandesAvis = () => {
+  const { collectiviteId } = useCurrentCollectivite();
+  const trpc = useTRPC();
+
+  const [{ page, sort, direction }, setParams] = useQueryStates(
+    {
+      page: parseAsInteger.withDefault(1),
+      sort: parseAsStringLiteral(SORT_VALUES).withDefault('echeance'),
+      direction: parseAsStringLiteral(DIRECTION_VALUES).withDefault('asc'),
+    },
+    { urlKeys: { page: '$p', sort: '$s', direction: '$d' } }
+  );
+
+  const { data, isLoading, isError, refetch } = useQuery(
+    trpc.demarches.pcaet.listDemandesAvis.queryOptions({
+      collectiviteId,
+      page,
+      limit: LIMIT,
+      sort,
+      direction,
+    })
+  );
+
+  const trierPar =(colonne: (typeof SORT_VALUES)[number]) =>
+    setParams({
+      sort: colonne,
+      direction: sort === colonne && direction === 'asc' ? 'desc' : 'asc',
+      page: 1,
+    });
+
+  return {
+    data,
+    isLoading,
+    isError,
+    refetch,
+    page,
+    limit: LIMIT,
+    setPage: (nouvellePage: number) => setParams({ page: nouvellePage }),
+    trierPar,
+  };
+};

--- a/apps/app/src/demarches/pcaet/instruction/demandes-avis.page.tsx
+++ b/apps/app/src/demarches/pcaet/instruction/demandes-avis.page.tsx
@@ -1,26 +1,101 @@
 'use client';
 
 import { appLabels } from '@/app/labels/catalog';
+import { MetricCard } from '@/app/tableaux-de-bord/metrics/metric.card';
 import PictoDashboard from '@/app/ui/pictogrammes/PictoDashboard';
+import SpinnerLoader from '@/app/ui/shared/SpinnerLoader';
+import { ErrorCard } from '@/app/utils/error/error.card';
 import { useCurrentCollectivite } from '@tet/api/collectivites';
-import { EmptyCard, PageHeader } from '@tet/ui';
+import { useUser } from '@tet/api/users';
+import { PcaetDemandeAvisEtatEnum } from '@tet/domain/demarches';
+import { EmptyCard, Pagination } from '@tet/ui';
+import { useListDemandesAvis } from './data/use-list-demandes-avis';
+import { DemandesAvisTable } from './demandes-avis.table';
 
 export const DemandesAvisPage = () => {
-  const collectivite = useCurrentCollectivite();
+  const { collectiviteId } = useCurrentCollectivite();
+  const user = useUser();
+  const { data, isLoading, isError, refetch, page, limit, setPage, trierPar } =
+    useListDemandesAvis();
+
+  const aInstruire = data
+    ? data.countByEtat[PcaetDemandeAvisEtatEnum.A_TRAITER] +
+      data.countByEtat[PcaetDemandeAvisEtatEnum.BROUILLON_EN_COURS]
+    : 0;
+  const instruits =
+    data?.countByEtat[PcaetDemandeAvisEtatEnum.AVIS_RENDU] ?? 0;
+  const delaiMoyenJours = data?.stats.delaiMoyenJours ?? 0;
+  const nbCollectivites = data?.stats.nbCollectivites ?? 0;
 
   return (
-    <div data-test="demarches.pcaet.demandes-avis">
-      <PageHeader>
-        <PageHeader.Title>{appLabels.instructionTitre}</PageHeader.Title>
-      </PageHeader>
-      <p className="text-grey-8">
-        {appLabels.instructionBienvenue({ nom: collectivite.nom })}
-      </p>
-      <EmptyCard
-        picto={(props) => <PictoDashboard {...props} />}
-        title={appLabels.instructionAVenirTitre}
-        description={appLabels.instructionAVenirDescription}
-      />
+    <div
+      data-test="demarches.pcaet.instruction.demandes-avis"
+      className="flex flex-col gap-6 pb-12"
+    >
+      <h1 className="text-2xl font-bold text-primary-9 m-0">
+        {appLabels.instructionBonjour({ prenom: user.prenom })}
+      </h1>
+
+      <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-4">
+        <MetricCard
+          title={appLabels.instructionStatATraiter}
+          count={aInstruire}
+        />
+        <MetricCard
+          title={appLabels.instructionStatInstruits({ count: instruits })}
+          count={instruits}
+        />
+        <MetricCard
+          title={appLabels.instructionStatDelaiMoyen({
+            count: delaiMoyenJours,
+          })}
+          count={delaiMoyenJours}
+        />
+        <MetricCard
+          title={appLabels.instructionStatCollectivites({
+            count: nbCollectivites,
+          })}
+          count={nbCollectivites}
+        />
+      </div>
+
+      <section className="flex flex-col gap-4 rounded-xl border border-grey-3 bg-white p-6">
+        <h2 className="text-lg font-bold text-primary-9 m-0">
+          {appLabels.instructionListeTitre}
+        </h2>
+
+        {isLoading ? (
+          <div className="flex py-12">
+            <SpinnerLoader className="m-auto" />
+          </div>
+        ) : isError || !data ? (
+          <ErrorCard
+            title={appLabels.uneErreurEstSurvenue}
+            retry={() => refetch()}
+          />
+        ) : data.items.length === 0 ? (
+          <EmptyCard
+            picto={(props) => <PictoDashboard {...props} />}
+            title={appLabels.instructionListeVide}
+          />
+        ) : (
+          <>
+            <DemandesAvisTable
+              demandes={data.items}
+              collectiviteId={collectiviteId}
+              onTrierParCollectivite={() => trierPar('collectivite')}
+              onTrierParEcheance={() => trierPar('echeance')}
+            />
+            <Pagination
+              selectedPage={page}
+              nbOfElements={data.total}
+              maxElementsPerPage={limit}
+              onChange={setPage}
+              className="mx-auto"
+            />
+          </>
+        )}
+      </section>
     </div>
   );
 };

--- a/apps/app/src/demarches/pcaet/instruction/demandes-avis.table.tsx
+++ b/apps/app/src/demarches/pcaet/instruction/demandes-avis.table.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import { makeDemandeAvisDossierUrl } from '@/app/app/paths';
+import { appLabels } from '@/app/labels/catalog';
+import { getTextFormattedDate } from '@/app/utils/formatUtils';
+import type { RouterOutput } from '@tet/api';
+import { PcaetDemandeAvisEtatEnum } from '@tet/domain/demarches';
+import {
+  Badge,
+  Button,
+  cn,
+  Icon,
+  Table,
+  TableCell,
+  TableHead,
+  TableHeaderCell,
+  TableRow,
+  Tooltip,
+} from '@tet/ui';
+import Link from 'next/link';
+import {
+  DEMANDE_AVIS_ETAT_LABELS,
+  DEMANDE_AVIS_ETAT_VARIANTS,
+} from './instruction.constants';
+
+type Demande =
+  RouterOutput['demarches']['pcaet']['listDemandesAvis']['items'][number];
+
+const JOURS_URGENCE = 30;
+
+const estUrgente = (avisDeadlineAt: string | null): boolean => {
+  if (!avisDeadlineAt) return false;
+  const restant = new Date(avisDeadlineAt).getTime() - Date.now();
+  return restant < JOURS_URGENCE * 24 * 60 * 60 * 1000;
+};
+
+const EcheanceCell = ({ demande }: { demande: Demande }) => {
+  if (!demande.avisDeadlineAt) {
+    return <span className="text-grey-6">—</span>;
+  }
+
+  const urgente = estUrgente(demande.avisDeadlineAt);
+
+  return (
+    <div
+      className={cn(
+        'flex items-center gap-2',
+        urgente ? 'text-error-1 font-medium' : 'text-primary-9'
+      )}
+    >
+      <Icon icon="calendar-line" size="sm" className="shrink-0" />
+      <span>{getTextFormattedDate({ date: demande.avisDeadlineAt })}</span>
+    </div>
+  );
+};
+
+const ContactCell = ({ demande }: { demande: Demande }) => {
+  const contact = demande.contacts[0];
+
+  if (!contact) {
+    return (
+      <span className="text-grey-6" title={appLabels.instructionListeSansContact}>
+        —
+      </span>
+    );
+  }
+
+  return (
+    <div className="flex flex-col">
+      <span className="text-primary-9">{`${contact.prenom} ${contact.nom}`}</span>
+      <a
+        href={`mailto:${contact.email}`}
+        className="text-primary-7 hover:underline truncate"
+      >
+        {contact.email}
+      </a>
+    </div>
+  );
+};
+
+const ActionsCell = ({
+  demande,
+  collectiviteId,
+}: {
+  demande: Demande;
+  collectiviteId: number;
+}) => {
+  const instructionOuverte =
+    demande.etat === PcaetDemandeAvisEtatEnum.A_TRAITER ||
+    demande.etat === PcaetDemandeAvisEtatEnum.BROUILLON_EN_COURS;
+
+  return (
+    <div className="flex items-center gap-2 justify-end">
+      <Link
+        href={makeDemandeAvisDossierUrl({
+          collectiviteId,
+          demandeAvisId: demande.demandeAvisId,
+        })}
+      >
+        <Button
+          variant="outlined"
+          size="xs"
+          icon={instructionOuverte ? 'draft-line' : 'eye-line'}
+        >
+          {instructionOuverte
+            ? appLabels.instructionListeConsulter
+            : appLabels.instructionListeVoirInstruction}
+        </Button>
+      </Link>
+      <Tooltip label={appLabels.instructionListeTelechargerIndisponible}>
+        <span tabIndex={0} className="inline-flex rounded outline-primary">
+          <Button
+            variant="outlined"
+            size="xs"
+            icon="download-line"
+            disabled
+            aria-label={appLabels.instructionListeTelecharger}
+          />
+        </span>
+      </Tooltip>
+    </div>
+  );
+};
+
+export const DemandesAvisTable = ({
+  demandes,
+  collectiviteId,
+  onTrierParCollectivite,
+  onTrierParEcheance,
+}: {
+  demandes: Demande[];
+  collectiviteId: number;
+  onTrierParCollectivite: () => void;
+  onTrierParEcheance: () => void;
+}) => (
+  <Table aria-label={appLabels.instructionListeIntitule}>
+    <TableHead>
+      <TableRow>
+        <TableHeaderCell
+          title={appLabels.instructionListeColonneCollectivite}
+          sortFn={onTrierParCollectivite}
+        />
+        <TableHeaderCell title={appLabels.instructionListeColonneContact} />
+        <TableHeaderCell title={appLabels.instructionListeColonneStatut} />
+        <TableHeaderCell
+          title={appLabels.instructionListeColonneEcheance}
+          sortFn={onTrierParEcheance}
+        />
+        <TableHeaderCell
+          title={appLabels.instructionListeColonneActions}
+          className="text-right"
+        />
+      </TableRow>
+    </TableHead>
+    <tbody>
+      {demandes.map((demande) => (
+        <TableRow
+          key={demande.demandeAvisId}
+          data-test={`demarches.pcaet.instruction.demande-${demande.demandeAvisId}`}
+        >
+          <TableCell>
+            <Link
+              href={makeDemandeAvisDossierUrl({
+                collectiviteId,
+                demandeAvisId: demande.demandeAvisId,
+              })}
+              className="font-bold text-primary-9 hover:underline"
+            >
+              {demande.collectivite.nom}
+            </Link>
+          </TableCell>
+          <TableCell>
+            <ContactCell demande={demande} />
+          </TableCell>
+          <TableCell>
+            <Badge
+              title={DEMANDE_AVIS_ETAT_LABELS[demande.etat]}
+              variant={DEMANDE_AVIS_ETAT_VARIANTS[demande.etat]}
+              size="sm"
+            />
+          </TableCell>
+          <TableCell>
+            <EcheanceCell demande={demande} />
+          </TableCell>
+          <TableCell>
+            <ActionsCell demande={demande} collectiviteId={collectiviteId} />
+          </TableCell>
+        </TableRow>
+      ))}
+    </tbody>
+  </Table>
+);

--- a/apps/app/src/demarches/pcaet/instruction/dossier/data/use-diagnostic-instruction.ts
+++ b/apps/app/src/demarches/pcaet/instruction/dossier/data/use-diagnostic-instruction.ts
@@ -1,0 +1,21 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { useTRPC } from '@tet/api';
+
+export const useDiagnosticInstruction = (demandeAvisId: number) => {
+  const trpc = useTRPC();
+
+  const {
+    data: diagnostic,
+    isLoading,
+    isError,
+    refetch,
+  } = useQuery(
+    trpc.demarches.pcaet.getDiagnosticInstruction.queryOptions({
+      demandeAvisId,
+    })
+  );
+
+  return { diagnostic, isLoading, isError, refetch };
+};

--- a/apps/app/src/demarches/pcaet/instruction/dossier/data/use-dossier-instruction.ts
+++ b/apps/app/src/demarches/pcaet/instruction/dossier/data/use-dossier-instruction.ts
@@ -1,0 +1,19 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { useTRPC } from '@tet/api';
+
+export const useDossierInstruction = (demandeAvisId: number) => {
+  const trpc = useTRPC();
+
+  const {
+    data: dossier,
+    isLoading,
+    isError,
+    refetch,
+  } = useQuery(
+    trpc.demarches.pcaet.getDossierInstruction.queryOptions({ demandeAvisId })
+  );
+
+  return { dossier, isLoading, isError, refetch };
+};

--- a/apps/app/src/demarches/pcaet/instruction/dossier/data/use-valider-partie-instruction.ts
+++ b/apps/app/src/demarches/pcaet/instruction/dossier/data/use-valider-partie-instruction.ts
@@ -1,0 +1,26 @@
+'use client';
+
+import { appLabels } from '@/app/labels/catalog';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useTRPC } from '@tet/api';
+
+export const useValiderPartieInstruction = (demandeAvisId: number) => {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+
+  return useMutation(
+    trpc.demarches.pcaet.validerPartieInstruction.mutationOptions({
+      onSuccess: () => {
+        queryClient.invalidateQueries({
+          queryKey: trpc.demarches.pcaet.getDossierInstruction.queryKey({
+            demandeAvisId,
+          }),
+        });
+      },
+      meta: {
+        success: appLabels.instructionDossierValidationEnregistree,
+        error: appLabels.instructionDossierValidationErreur,
+      },
+    })
+  );
+};

--- a/apps/app/src/demarches/pcaet/instruction/dossier/dossier-instruction.page.tsx
+++ b/apps/app/src/demarches/pcaet/instruction/dossier/dossier-instruction.page.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import { makeDemandesAvisUrl } from '@/app/app/paths';
+import { appLabels } from '@/app/labels/catalog';
+import SpinnerLoader from '@/app/ui/shared/SpinnerLoader';
+import { ErrorCard } from '@/app/utils/error/error.card';
+import { useCollectiviteId } from '@tet/api/collectivites';
+import {
+  PcaetInstructionPartieEnum,
+  pcaetInstructionPartieValues,
+  type PcaetInstructionPartie,
+} from '@tet/domain/demarches';
+import { Button, cn, Icon } from '@tet/ui';
+import Link from 'next/link';
+import { parseAsStringLiteral, useQueryState } from 'nuqs';
+import { useDossierInstruction } from './data/use-dossier-instruction';
+import { DossierInstructionHeader } from './dossier.header';
+import { EtapeDiagnosticSection } from './etape-diagnostic.section';
+import { EtapeDocumentsSection } from './etape-documents.section';
+import { EtapePlanSection } from './etape-plan.section';
+import type { EtapeInstruction } from './etapes-instruction.side-panel-content';
+import { useEtapesInstructionSidePanel } from './use-etapes-instruction-side-panel';
+import { ValiderPartieButton } from './valider-partie.button';
+
+const ETAPE_LABELS: Record<PcaetInstructionPartie, string> = {
+  documents: appLabels.instructionDossierEtapeDocuments,
+  diagnostic: appLabels.instructionDossierEtapeDiagnostic,
+  plan: appLabels.instructionDossierEtapePlan,
+};
+
+const ETAPE_DESCRIPTIONS: Record<PcaetInstructionPartie, string> = {
+  documents: appLabels.instructionDossierEtapeDocumentsDescription,
+  diagnostic: appLabels.instructionDossierEtapeDiagnosticDescription,
+  plan: appLabels.instructionDossierEtapePlanDescription,
+};
+
+export const DossierInstructionPage = ({
+  demandeAvisId,
+}: {
+  demandeAvisId: number;
+}) => {
+  const collectiviteId = useCollectiviteId();
+  const { dossier, isLoading, isError, refetch } =
+    useDossierInstruction(demandeAvisId);
+  const [etape, setEtape] = useQueryState(
+    'etape',
+    parseAsStringLiteral(pcaetInstructionPartieValues).withDefault(
+      PcaetInstructionPartieEnum.DOCUMENTS
+    )
+  );
+
+  const etapes: EtapeInstruction[] = pcaetInstructionPartieValues.map(
+    (key) => ({
+      key,
+      label: ETAPE_LABELS[key],
+      description: ETAPE_DESCRIPTIONS[key],
+      isValidee:
+        dossier?.partiesValidees.some(({ partie }) => partie === key) ?? false,
+    })
+  );
+
+  const { isOpen, toggle } = useEtapesInstructionSidePanel(
+    { etapes, activeEtape: etape, onSelect: setEtape },
+    { collectiviteId, demandeAvisId }
+  );
+
+  if (isLoading) {
+    return (
+      <div className="flex grow items-center justify-center">
+        <SpinnerLoader />
+      </div>
+    );
+  }
+
+  if (isError || !dossier) {
+    return (
+      <ErrorCard
+        title={appLabels.uneErreurEstSurvenue}
+        retry={() => refetch()}
+      />
+    );
+  }
+
+  const footer = <ValiderPartieButton dossier={dossier} partie={etape} />;
+
+  return (
+    <div
+      data-test="demarches.pcaet.instruction.dossier"
+      className="flex flex-col gap-6 pb-12"
+    >
+      <div className="flex flex-col gap-2">
+        <Link
+          href={makeDemandesAvisUrl({ collectiviteId })}
+          className="flex items-center gap-1 w-fit text-sm text-primary-8 hover:underline"
+        >
+          <Icon icon="arrow-left-line" size="sm" />
+          {appLabels.instructionDossierRetourListe}
+        </Link>
+
+        <DossierInstructionHeader
+          dossier={dossier}
+          action={
+            <Button
+              variant="grey"
+              size="xs"
+              icon="list-check"
+              onClick={toggle}
+              aria-pressed={isOpen}
+              data-test="demarches.pcaet.instruction.etapes-panneau-bouton"
+              className={cn(
+                isOpen
+                  ? 'bg-primary-9 hover:!bg-primary-9 text-white hover:!text-white'
+                  : 'text-grey-8 border-grey-4'
+              )}
+            >
+              {appLabels.instructionDossierPanneauBouton}
+            </Button>
+          }
+        />
+      </div>
+
+      {etape === PcaetInstructionPartieEnum.DOCUMENTS && (
+        <EtapeDocumentsSection
+          demandeAvisId={demandeAvisId}
+          documents={dossier.documents}
+          footer={footer}
+        />
+      )}
+      {etape === PcaetInstructionPartieEnum.DIAGNOSTIC && (
+        <EtapeDiagnosticSection footer={footer} />
+      )}
+      {etape === PcaetInstructionPartieEnum.PLAN && (
+        <EtapePlanSection footer={footer} />
+      )}
+    </div>
+  );
+};

--- a/apps/app/src/demarches/pcaet/instruction/dossier/dossier-instruction.page.tsx
+++ b/apps/app/src/demarches/pcaet/instruction/dossier/dossier-instruction.page.tsx
@@ -127,7 +127,11 @@ export const DossierInstructionPage = ({
         />
       )}
       {etape === PcaetInstructionPartieEnum.DIAGNOSTIC && (
-        <EtapeDiagnosticSection footer={footer} />
+        <EtapeDiagnosticSection
+          demandeAvisId={demandeAvisId}
+          demarcheId={dossier.demarcheId}
+          footer={footer}
+        />
       )}
       {etape === PcaetInstructionPartieEnum.PLAN && (
         <EtapePlanSection footer={footer} />

--- a/apps/app/src/demarches/pcaet/instruction/dossier/dossier.header.tsx
+++ b/apps/app/src/demarches/pcaet/instruction/dossier/dossier.header.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { DateModificationItem } from '@/app/demarches/pcaet/components/header/date-modification-item';
+import { DepotDateItem } from '@/app/demarches/pcaet/components/header/depot-date-item';
+import { Separator } from '@/app/demarches/pcaet/components/header/separator';
+import { appLabels } from '@/app/labels/catalog';
+import {
+  DEMANDE_AVIS_ETAT_LABELS,
+  DEMANDE_AVIS_ETAT_VARIANTS,
+} from '../instruction.constants';
+import { MetadataItem, MetadataLine } from '@/app/ui/metadata-line';
+import { getTextFormattedDate } from '@/app/utils/formatUtils';
+import type { RouterOutput } from '@tet/api';
+import { Badge, PageHeader } from '@tet/ui';
+import { ReactNode } from 'react';
+
+type Dossier = RouterOutput['demarches']['pcaet']['getDossierInstruction'];
+
+export const DossierInstructionHeader = ({
+  dossier,
+  action,
+}: {
+  dossier: Dossier;
+  action: ReactNode;
+}) => {
+  const isEcheancePassee =
+    dossier.avisDeadlineAt !== null &&
+    new Date(dossier.avisDeadlineAt).getTime() < Date.now();
+
+  return (
+    <PageHeader>
+      <PageHeader.Title>{dossier.titre}</PageHeader.Title>
+      <PageHeader.Actions>{action}</PageHeader.Actions>
+      <PageHeader.Metadata>
+        <MetadataLine>
+          <MetadataItem
+            icon="community-line"
+            label={appLabels.instructionDossierMetaCollectivite}
+            value={dossier.collectivite.nom}
+          />
+          {dossier.launchedAt && (
+            <MetadataItem
+              icon="calendar-event-line"
+              label={appLabels.demarcheHeaderDateDebut}
+              value={getTextFormattedDate({ date: dossier.launchedAt })}
+            />
+          )}
+          <DepotDateItem dateCreation={dossier.createdAt} />
+          <DateModificationItem dateModification={dossier.modifiedAt} />
+          {dossier.pilotes.length > 0 && (
+            <MetadataItem
+              icon="user-line"
+              label={
+                dossier.pilotes.length > 1
+                  ? appLabels.demarcheHeaderPilotePluriel
+                  : appLabels.demarcheHeaderPiloteSingulier
+              }
+              value={dossier.pilotes.join(', ')}
+            />
+          )}
+          {dossier.transmittedAt && (
+            <MetadataItem
+              icon="send-plane-line"
+              label={appLabels.instructionDossierMetaTransmis}
+              value={getTextFormattedDate({ date: dossier.transmittedAt })}
+            />
+          )}
+          {dossier.avisDeadlineAt && (
+            <MetadataItem
+              icon="time-line"
+              label={appLabels.instructionDossierMetaEcheance}
+              hideSeparator
+              value={
+                isEcheancePassee ? (
+                  <span className="text-error-1">
+                    {appLabels.instructionDossierMetaEcheanceDepassee({
+                      date: getTextFormattedDate({
+                        date: dossier.avisDeadlineAt,
+                      }),
+                    })}
+                  </span>
+                ) : (
+                  getTextFormattedDate({ date: dossier.avisDeadlineAt })
+                )
+              }
+            />
+          )}
+          <Separator />
+          <Badge
+            title={DEMANDE_AVIS_ETAT_LABELS[dossier.etat]}
+            variant={DEMANDE_AVIS_ETAT_VARIANTS[dossier.etat]}
+            size="sm"
+          />
+        </MetadataLine>
+      </PageHeader.Metadata>
+    </PageHeader>
+  );
+};

--- a/apps/app/src/demarches/pcaet/instruction/dossier/etape-diagnostic.section.tsx
+++ b/apps/app/src/demarches/pcaet/instruction/dossier/etape-diagnostic.section.tsx
@@ -1,20 +1,116 @@
 'use client';
 
+import { resolveActiveTopic } from '@/app/demarches/active-topic';
 import { DemarcheSection } from '@/app/demarches/components/section';
+import { TopicGridView } from '@/app/demarches/pcaet/diagnostic/indicateurs-grid/topic-grid.view';
+import { TopicTab } from '@/app/demarches/pcaet/diagnostic/topic-tab';
+import { VulnerabiliteTable } from '@/app/demarches/pcaet/diagnostic/vulnerabilite-table';
 import { appLabels } from '@/app/labels/catalog';
-import { PictoEtatDesLieux } from '@/app/ui/pictogrammes/PictoEtatDesLieux';
-import { EmptyCard } from '@tet/ui';
-import { ReactNode } from 'react';
+import SpinnerLoader from '@/app/ui/shared/SpinnerLoader';
+import { ErrorCard } from '@/app/utils/error/error.card';
+import { getTextFormattedDate } from '@/app/utils/formatUtils';
+import { DemarchePcaetTopicKindEnum } from '@tet/domain/demarches';
+import { Alert } from '@tet/ui';
+import { Tabs, TabsList, TabsPanel } from '@tet/ui/design-system/TabsNext/index';
+import { ReactNode, useState } from 'react';
+import { useDiagnosticInstruction } from './data/use-diagnostic-instruction';
 
-export const EtapeDiagnosticSection = ({ footer }: { footer: ReactNode }) => (
-  <DemarcheSection
-    title={appLabels.instructionDossierEtapeDiagnostic}
-    description={appLabels.instructionDossierEtapeDiagnosticDescription}
-  >
-    <EmptyCard
-      picto={({ className }) => <PictoEtatDesLieux className={className} />}
-      title={appLabels.instructionDossierDiagnosticAVenir}
-    />
-    {footer}
-  </DemarcheSection>
-);
+export const EtapeDiagnosticSection = ({
+  demandeAvisId,
+  demarcheId,
+  footer,
+}: {
+  demandeAvisId: number;
+  demarcheId: number;
+  footer: ReactNode;
+}) => {
+  const { diagnostic, isLoading, isError, refetch } =
+    useDiagnosticInstruction(demandeAvisId);
+  const [topicCode, setTopicCode] = useState<string | null>(null);
+
+  const topics = diagnostic?.topics ?? [];
+  const activeTopic = resolveActiveTopic(
+    topics,
+    topicCode,
+    (topic) => topic.code
+  );
+
+  return (
+    <DemarcheSection
+      title={appLabels.instructionDossierEtapeDiagnostic}
+      description={appLabels.instructionDossierEtapeDiagnosticDescription}
+    >
+      {isError ? (
+        <ErrorCard
+          title={appLabels.instructionDossierDiagnosticNonFige}
+          retry={() => refetch()}
+        />
+      ) : isLoading || !diagnostic || !activeTopic ? (
+        <SpinnerLoader className="m-auto" />
+      ) : (
+        <>
+          {diagnostic.snapshotDate && (
+            <Alert
+              className="mb-6"
+              state="info"
+              description={appLabels.instructionDossierDiagnosticPhoto({
+                date: getTextFormattedDate({ date: diagnostic.snapshotDate }),
+              })}
+            />
+          )}
+
+          <Tabs dataTest="demarches.pcaet.instruction.diagnostic-topics">
+            <TabsList className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-2 bg-transparent p-0 m-0 rounded-none w-full !list-none justify-stretch">
+              {topics.map((topic) => (
+                <TopicTab
+                  key={topic.code}
+                  topic={topic}
+                  isActive={activeTopic.code === topic.code}
+                  onSelect={() => setTopicCode(topic.code)}
+                />
+              ))}
+            </TabsList>
+
+            <TabsPanel className="mt-8">
+              <div
+                role="tabpanel"
+                id={`demarche-topic-panel-${activeTopic.code}`}
+                aria-labelledby={`demarche-topic-tab-${activeTopic.code}`}
+              >
+                {activeTopic.kind ===
+                DemarchePcaetTopicKindEnum.VULNERABILITE ? (
+                  <div className="flex flex-col gap-4">
+                    <p className="text-sm text-primary-9 m-0">
+                      {appLabels.demarcheVulnerabiliteDescription}
+                    </p>
+                    <div className="max-xl:overflow-x-auto p-4 pt-2 lg:p-8 lg:pt-4 bg-white rounded-xl border border-grey-3">
+                      <VulnerabiliteTable
+                        vulnerabilite={
+                          activeTopic.vulnerabilite ?? {
+                            domaines: [],
+                            lignes: [],
+                          }
+                        }
+                        demarcheId={demarcheId}
+                        isReadonly
+                      />
+                    </div>
+                  </div>
+                ) : (
+                  <TopicGridView
+                    key={activeTopic.code}
+                    demarcheId={demarcheId}
+                    topic={activeTopic}
+                    isReadonly
+                  />
+                )}
+              </div>
+            </TabsPanel>
+          </Tabs>
+
+          {footer}
+        </>
+      )}
+    </DemarcheSection>
+  );
+};

--- a/apps/app/src/demarches/pcaet/instruction/dossier/etape-diagnostic.section.tsx
+++ b/apps/app/src/demarches/pcaet/instruction/dossier/etape-diagnostic.section.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { DemarcheSection } from '@/app/demarches/components/section';
+import { appLabels } from '@/app/labels/catalog';
+import { PictoEtatDesLieux } from '@/app/ui/pictogrammes/PictoEtatDesLieux';
+import { EmptyCard } from '@tet/ui';
+import { ReactNode } from 'react';
+
+export const EtapeDiagnosticSection = ({ footer }: { footer: ReactNode }) => (
+  <DemarcheSection
+    title={appLabels.instructionDossierEtapeDiagnostic}
+    description={appLabels.instructionDossierEtapeDiagnosticDescription}
+  >
+    <EmptyCard
+      picto={({ className }) => <PictoEtatDesLieux className={className} />}
+      title={appLabels.instructionDossierDiagnosticAVenir}
+    />
+    {footer}
+  </DemarcheSection>
+);

--- a/apps/app/src/demarches/pcaet/instruction/dossier/etape-documents.section.tsx
+++ b/apps/app/src/demarches/pcaet/instruction/dossier/etape-documents.section.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { DemarcheDocumentsTable } from '@/app/demarches/components/documents.table';
+import { DemarcheSection } from '@/app/demarches/components/section';
+import { appLabels } from '@/app/labels/catalog';
+import { saveBlob } from '@/app/referentiels/preuves/Bibliotheque/saveBlob';
+import { useQueryClient } from '@tanstack/react-query';
+import { useTRPC } from '@tet/api';
+import {
+  computeDemarcheDocumentsCoverage,
+  DemarcheTypeEnum,
+  type DemarcheDocumentDepose,
+  type DemarcheDocumentsSnapshot,
+} from '@tet/domain/demarches';
+import { ReactNode, useMemo } from 'react';
+
+const noop = () => undefined;
+
+export const EtapeDocumentsSection = ({
+  demandeAvisId,
+  documents,
+  footer,
+}: {
+  demandeAvisId: number;
+  documents: DemarcheDocumentsSnapshot;
+  footer: ReactNode;
+}) => {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+
+  const coverage = useMemo(
+    () => computeDemarcheDocumentsCoverage(documents),
+    [documents]
+  );
+
+  const downloadDocument = async ({ documentId }: DemarcheDocumentDepose) => {
+    const { url, filename } = await queryClient.fetchQuery(
+      trpc.demarches.pcaet.getDossierDocumentUrl.queryOptions(
+        { demandeAvisId, documentId },
+        { staleTime: 0 }
+      )
+    );
+    const response = await fetch(url);
+    saveBlob(await response.blob(), filename);
+  };
+
+  return (
+    <DemarcheSection
+      title={appLabels.instructionDossierEtapeDocuments}
+      description={appLabels.instructionDossierEtapeDocumentsDescription}
+      className="gap-2"
+    >
+      <DemarcheDocumentsTable
+        demarcheType={DemarcheTypeEnum.PCAET}
+        etape="amont"
+        definitions={documents.definitions}
+        documents={documents.documents}
+        coverage={coverage}
+        isDocumentReadonly={() => true}
+        onAddFichier={noop}
+        onRemoveDocument={noop}
+        onToggleCouverture={noop}
+        onDownload={downloadDocument}
+      />
+      {footer}
+    </DemarcheSection>
+  );
+};

--- a/apps/app/src/demarches/pcaet/instruction/dossier/etape-plan.section.tsx
+++ b/apps/app/src/demarches/pcaet/instruction/dossier/etape-plan.section.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { DemarcheSection } from '@/app/demarches/components/section';
+import { appLabels } from '@/app/labels/catalog';
+import { PictoPlansAction } from '@/app/ui/pictogrammes/PictoPlansAction';
+import { EmptyCard } from '@tet/ui';
+import { ReactNode } from 'react';
+
+export const EtapePlanSection = ({ footer }: { footer: ReactNode }) => (
+  <DemarcheSection
+    title={appLabels.instructionDossierEtapePlan}
+    description={appLabels.instructionDossierEtapePlanDescription}
+  >
+    <EmptyCard
+      picto={({ className }) => <PictoPlansAction className={className} />}
+      title={appLabels.instructionDossierPlanAVenir}
+    />
+    {footer}
+  </DemarcheSection>
+);

--- a/apps/app/src/demarches/pcaet/instruction/dossier/etape-plan.section.tsx
+++ b/apps/app/src/demarches/pcaet/instruction/dossier/etape-plan.section.tsx
@@ -2,7 +2,7 @@
 
 import { DemarcheSection } from '@/app/demarches/components/section';
 import { appLabels } from '@/app/labels/catalog';
-import { PictoPlansAction } from '@/app/ui/pictogrammes/PictoPlansAction';
+import PictoAction from '@/app/ui/pictogrammes/PictoAction';
 import { EmptyCard } from '@tet/ui';
 import { ReactNode } from 'react';
 
@@ -12,7 +12,7 @@ export const EtapePlanSection = ({ footer }: { footer: ReactNode }) => (
     description={appLabels.instructionDossierEtapePlanDescription}
   >
     <EmptyCard
-      picto={({ className }) => <PictoPlansAction className={className} />}
+      picto={({ className }) => <PictoAction className={className} />}
       title={appLabels.instructionDossierPlanAVenir}
     />
     {footer}

--- a/apps/app/src/demarches/pcaet/instruction/dossier/etapes-instruction.side-panel-content.tsx
+++ b/apps/app/src/demarches/pcaet/instruction/dossier/etapes-instruction.side-panel-content.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { appLabels } from '@/app/labels/catalog';
+import type { PcaetInstructionPartie } from '@tet/domain/demarches';
+import { Badge, cn, Icon } from '@tet/ui';
+
+export type EtapeInstruction = {
+  key: PcaetInstructionPartie;
+  label: string;
+  description: string;
+  isValidee: boolean;
+};
+
+export type EtapesInstructionSidePanelContentProps = {
+  etapes: EtapeInstruction[];
+  activeEtape: PcaetInstructionPartie;
+  onSelect: (etape: PcaetInstructionPartie) => void;
+};
+
+export const EtapesInstructionSidePanelContent = ({
+  etapes,
+  activeEtape,
+  onSelect,
+}: EtapesInstructionSidePanelContentProps) => (
+  <div className="flex flex-col gap-3 p-4">
+    {etapes.map((etape) => {
+      const isActive = etape.key === activeEtape;
+
+      return (
+        <button
+          key={etape.key}
+          type="button"
+          onClick={() => onSelect(etape.key)}
+          aria-current={isActive ? 'step' : undefined}
+          data-test={`demarches.pcaet.instruction.etape-${etape.key}`}
+          className={cn(
+            'flex w-full gap-3 rounded-lg border p-3 text-left text-sm transition-colors',
+            isActive
+              ? 'border-primary-7 border-2 bg-primary-0 p-[calc(0.75rem-1px)]'
+              : 'border-grey-3 bg-white hover:border-primary-4 hover:bg-primary-0'
+          )}
+        >
+          <div
+            className={cn(
+              'flex items-center justify-center rounded-full w-8 h-8 shrink-0',
+              etape.isValidee
+                ? 'bg-success text-white'
+                : 'bg-warning-2 text-warning-1'
+            )}
+          >
+            <Icon icon={etape.isValidee ? 'check-line' : 'close-line'} size="sm" />
+          </div>
+          <div className="flex flex-col gap-1 min-w-0 flex-1">
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className="font-medium text-primary-9">{etape.label}</span>
+              <Badge
+                title={
+                  etape.isValidee
+                    ? appLabels.instructionDossierPartieValidee
+                    : appLabels.instructionDossierAValider
+                }
+                variant={etape.isValidee ? 'success' : 'warning'}
+                size="xs"
+              />
+            </div>
+            <span className="leading-relaxed text-grey-7">
+              {etape.description}
+            </span>
+          </div>
+        </button>
+      );
+    })}
+  </div>
+);

--- a/apps/app/src/demarches/pcaet/instruction/dossier/use-etapes-instruction-side-panel.tsx
+++ b/apps/app/src/demarches/pcaet/instruction/dossier/use-etapes-instruction-side-panel.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { makeDemandeAvisDossierUrl } from '@/app/app/paths';
+import { appLabels } from '@/app/labels/catalog';
+import { useSidePanel } from '@/app/ui/layout/side-panel/side-panel.context';
+import { useCallback, useEffect, useRef } from 'react';
+import {
+  EtapesInstructionSidePanelContent,
+  type EtapesInstructionSidePanelContentProps,
+} from './etapes-instruction.side-panel-content';
+
+const PANEL_TITLE = appLabels.instructionDossierEtapesTitre;
+
+type Options = {
+  collectiviteId: number;
+  demandeAvisId: number;
+};
+
+export function useEtapesInstructionSidePanel(
+  contentProps: EtapesInstructionSidePanelContentProps,
+  { collectiviteId, demandeAvisId }: Options
+): { isOpen: boolean; toggle: () => void } {
+  const { setPanel, panel } = useSidePanel();
+  const contentPropsRef = useRef(contentProps);
+
+  useEffect(() => {
+    contentPropsRef.current = contentProps;
+  });
+
+  const isOpen = panel.isOpen && panel.title === PANEL_TITLE;
+
+  const dossierPath = makeDemandeAvisDossierUrl({
+    collectiviteId,
+    demandeAvisId,
+  });
+
+  const openPanel = useCallback(() => {
+    setPanel({
+      type: 'open',
+      title: PANEL_TITLE,
+      isPersistentWithNextPath: (path) => path === dossierPath,
+      Title: ({ title }) => (
+        <h5 className="text-primary-9 font-bold leading-7 text-xl m-0">
+          {title}
+        </h5>
+      ),
+      content: (
+        <EtapesInstructionSidePanelContent {...contentPropsRef.current} />
+      ),
+    });
+  }, [setPanel, dossierPath]);
+
+  const hasAutoOpenedRef = useRef(false);
+  useEffect(() => {
+    if (hasAutoOpenedRef.current) return;
+    hasAutoOpenedRef.current = true;
+    openPanel();
+  }, [openPanel]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    openPanel();
+  }, [
+    isOpen,
+    openPanel,
+    contentProps.activeEtape,
+    contentProps.etapes.map(({ isValidee }) => isValidee).join(),
+  ]);
+
+  const toggle = useCallback(() => {
+    if (isOpen) {
+      setPanel({ type: 'close' });
+      return;
+    }
+    openPanel();
+  }, [isOpen, openPanel, setPanel]);
+
+  return { isOpen, toggle };
+}

--- a/apps/app/src/demarches/pcaet/instruction/dossier/valider-partie.button.tsx
+++ b/apps/app/src/demarches/pcaet/instruction/dossier/valider-partie.button.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { appLabels } from '@/app/labels/catalog';
+import { getTextFormattedDate } from '@/app/utils/formatUtils';
+import type { RouterOutput } from '@tet/api';
+import {
+  fenetreAvisOuverte,
+  type PcaetInstructionPartie,
+} from '@tet/domain/demarches';
+import { Button } from '@tet/ui';
+import { useValiderPartieInstruction } from './data/use-valider-partie-instruction';
+
+type Dossier = RouterOutput['demarches']['pcaet']['getDossierInstruction'];
+
+type Props = {
+  dossier: Dossier;
+  partie: PcaetInstructionPartie;
+};
+
+export const ValiderPartieButton = ({ dossier, partie }: Props) => {
+  const { mutate, isPending } = useValiderPartieInstruction(
+    dossier.demandeAvisId
+  );
+
+  const isFenetreOuverte = fenetreAvisOuverte(
+    { demarcheStatus: dossier.status, avisDeadlineAt: dossier.avisDeadlineAt },
+    new Date()
+  );
+
+  const validation = dossier.partiesValidees.find(
+    (validee) => validee.partie === partie
+  );
+
+  if (!isFenetreOuverte) {
+    return (
+      <p className="text-sm text-grey-7 m-0 text-right">
+        {appLabels.instructionDossierValidationsVerrouillees}
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex items-center justify-end gap-3">
+      {validation && (
+        <span className="text-sm text-grey-7">
+          {appLabels.instructionDossierPartieValideeLe({
+            date: getTextFormattedDate({ date: validation.valideLe }),
+          })}
+        </span>
+      )}
+      <Button
+        variant={validation ? 'grey' : 'primary'}
+        size="sm"
+        icon="check-line"
+        iconPosition="right"
+        disabled={isPending}
+        data-test="demarches.pcaet.instruction.valider-partie"
+        onClick={() =>
+          mutate({
+            demandeAvisId: dossier.demandeAvisId,
+            partie,
+            validee: !validation,
+          })
+        }
+      >
+        {validation
+          ? appLabels.instructionDossierDevaliderPartie
+          : appLabels.instructionDossierValiderPartie}
+      </Button>
+    </div>
+  );
+};

--- a/apps/app/src/demarches/pcaet/instruction/instruction.constants.ts
+++ b/apps/app/src/demarches/pcaet/instruction/instruction.constants.ts
@@ -1,0 +1,22 @@
+import { appLabels } from '@/app/labels/catalog';
+import type { ColorVariant } from '@tet/design-tokens';
+import type { PcaetDemandeAvisEtat } from '@tet/domain/demarches';
+
+export const DEMANDE_AVIS_ETAT_LABELS: Record<PcaetDemandeAvisEtat, string> = {
+  a_traiter: appLabels.instructionEtatATraiter,
+  brouillon_en_cours: appLabels.instructionEtatBrouillonEnCours,
+  avis_rendu: appLabels.instructionEtatAvisRendu,
+  delai_ecoule: appLabels.instructionEtatDelaiEcoule,
+  clos: appLabels.instructionEtatClos,
+};
+
+export const DEMANDE_AVIS_ETAT_VARIANTS: Record<
+  PcaetDemandeAvisEtat,
+  ColorVariant
+> = {
+  a_traiter: 'warning',
+  brouillon_en_cours: 'info',
+  avis_rendu: 'success',
+  delai_ecoule: 'error',
+  clos: 'grey',
+};

--- a/apps/app/src/labels/catalog.ts
+++ b/apps/app/src/labels/catalog.ts
@@ -2080,6 +2080,43 @@ export const appLabels = {
   instructionAVenirTitre: 'Votre tableau de bord arrive bientôt',
   instructionAVenirDescription:
     'Vous y suivrez les demandes d’avis des collectivités de votre région, consulterez les dossiers transmis et déposerez vos avis.',
+  instructionEtatATraiter: 'À instruire',
+  instructionEtatBrouillonEnCours: 'Brouillon en cours',
+  instructionEtatAvisRendu: 'Instruit',
+  instructionEtatDelaiEcoule: 'Délai écoulé',
+  instructionEtatClos: 'Archivé',
+  instructionDossierRetourListe: 'Retour aux demandes d’avis',
+  instructionDossierMetaCollectivite: 'Collectivité',
+  instructionDossierMetaTransmis: 'Transmis le',
+  instructionDossierMetaEcheance: 'Échéance des avis',
+  instructionDossierMetaEcheanceDepassee: ({ date }: { date: string }) =>
+    `${date} (délai écoulé)`,
+  instructionDossierEtapesTitre: 'Les étapes de l’instruction',
+  instructionDossierPanneauBouton: 'Étapes',
+  instructionDossierEtapeDocuments: 'Documents déposés',
+  instructionDossierEtapeDocumentsDescription:
+    'Consultez les pièces déposées par la collectivité pour ce dépôt de PCAET.',
+  instructionDossierEtapeDiagnostic: 'Diagnostic',
+  instructionDossierEtapeDiagnosticDescription:
+    'Consultez les indicateurs par volet du PCAET : tableau des valeurs et données par secteur.',
+  instructionDossierEtapePlan: 'Programme d’actions',
+  instructionDossierEtapePlanDescription:
+    'Consultez le programme d’actions rattaché à ce PCAET.',
+  instructionDossierDiagnosticAVenir:
+    'Le diagnostic renseigné par la collectivité n’est pas encore consultable ici.',
+  instructionDossierPlanAVenir:
+    'Le programme d’actions de la collectivité n’est pas encore consultable ici.',
+  instructionDossierValiderPartie: 'Valider cette partie',
+  instructionDossierDevaliderPartie: 'Annuler la validation',
+  instructionDossierAValider: 'À valider',
+  instructionDossierPartieValidee: 'Validée',
+  instructionDossierPartieValideeLe: ({ date }: { date: string }) =>
+    `Validée le ${date}`,
+  instructionDossierValidationsVerrouillees:
+    'La fenêtre d’avis est fermée : les validations ne sont plus modifiables.',
+  instructionDossierValidationEnregistree: 'Avancement enregistré',
+  instructionDossierValidationErreur:
+    'L’enregistrement de l’avancement a échoué',
   uneErreurEstSurvenue: 'Une erreur est survenue',
   indicateurValeurEnregistree: 'Enregistré',
   indicateurValeursGrille: 'Valeurs des indicateurs',

--- a/apps/app/src/labels/catalog.ts
+++ b/apps/app/src/labels/catalog.ts
@@ -2126,8 +2126,13 @@ export const appLabels = {
   instructionDossierEtapePlan: 'Programme d’actions',
   instructionDossierEtapePlanDescription:
     'Consultez le programme d’actions rattaché à ce PCAET.',
-  instructionDossierDiagnosticAVenir:
-    'Le diagnostic renseigné par la collectivité n’est pas encore consultable ici.',
+  instructionDossierDiagnosticVulnerabiliteAVenir:
+    'Le tableau de vulnérabilité du territoire n’est pas encore consultable ici.',
+  instructionDossierDiagnosticPhoto: ({ date }: { date: string }) =>
+    `Diagnostic tel que déposé le ${date}.`,
+  instructionDossierDiagnosticNonFige:
+    'Le diagnostic de ce dépôt n’a pas été figé à la transmission : il n’est pas consultable en instruction.',
+  instructionDossierDiagnosticOnglets: 'Volets du diagnostic',
   instructionDossierPlanAVenir:
     'Le programme d’actions de la collectivité n’est pas encore consultable ici.',
   instructionDossierValiderPartie: 'Valider cette partie',

--- a/apps/app/src/labels/catalog.ts
+++ b/apps/app/src/labels/catalog.ts
@@ -2075,11 +2075,35 @@ export const appLabels = {
   retourPagePrecedente: 'Revenir à la page précédente',
 
   instructionTitre: 'Suivi des demandes d’avis',
-  instructionBienvenue: ({ nom }: { nom: string }) =>
-    `Bienvenue sur l’espace instructeur de ${nom}.`,
-  instructionAVenirTitre: 'Votre tableau de bord arrive bientôt',
-  instructionAVenirDescription:
-    'Vous y suivrez les demandes d’avis des collectivités de votre région, consulterez les dossiers transmis et déposerez vos avis.',
+  instructionBonjour: ({ prenom }: { prenom: string }) => `Bonjour ${prenom} !`,
+  instructionStatATraiter: 'PCAET à instruire',
+  instructionStatInstruits: plural({
+    one: 'PCAET instruit',
+    other: 'PCAET instruits',
+  }),
+  instructionStatDelaiMoyen: plural({
+    one: 'Jour de délai d’instruction',
+    other: 'Jours de délai d’instruction',
+  }),
+  instructionStatCollectivites: plural({
+    one: 'Collectivité accompagnée',
+    other: 'Collectivités accompagnées',
+  }),
+  instructionListeTitre: 'Instructions dont je suis en charge',
+  instructionListeVide:
+    'Les dépôts PCAET transmis par les collectivités de votre région apparaîtront ici.',
+  instructionListeIntitule: 'Demandes d’avis des collectivités de la région',
+  instructionListeColonneCollectivite: 'Collectivité',
+  instructionListeColonneContact: 'Contact',
+  instructionListeColonneStatut: 'Statut',
+  instructionListeColonneEcheance: 'Échéance avis',
+  instructionListeColonneActions: 'Actions',
+  instructionListeConsulter: 'Consulter le PCAET',
+  instructionListeVoirInstruction: 'Voir l’instruction',
+  instructionListeTelecharger: 'Télécharger le dossier',
+  instructionListeTelechargerIndisponible:
+    'Le téléchargement du dossier complet arrive prochainement.',
+  instructionListeSansContact: 'Aucun référent renseigné',
   instructionEtatATraiter: 'À instruire',
   instructionEtatBrouillonEnCours: 'Brouillon en cours',
   instructionEtatAvisRendu: 'Instruit',

--- a/apps/app/src/ui/layout/header/header.tsx
+++ b/apps/app/src/ui/layout/header/header.tsx
@@ -6,10 +6,7 @@ import { useReferentielTeEnabled } from '@/app/referentiels/use-referentiel-te-e
 import { makeUserTdbUrl } from '@/app/tableaux-de-bord/make-user-tdb-url';
 import { useCollectiviteContext } from '@tet/api/collectivites';
 import { useUser } from '@tet/api/users';
-import {
-  isServiceDeconcentre,
-  REFERENTIEL_TE_DISABLED_REFERENTIELS_DISPLAY,
-} from '@tet/domain/collectivites';
+import { REFERENTIEL_TE_DISABLED_REFERENTIELS_DISPLAY } from '@tet/domain/collectivites';
 import { Header as HeaderTet } from '@tet/ui';
 import { makeMainNav } from './main-nav/make-main-nav';
 import { makeSecondaryNav } from './make-secondary-nav';

--- a/apps/backend/src/demarches/pcaet/get-diagnostic-instruction/get-diagnostic-instruction.errors.ts
+++ b/apps/backend/src/demarches/pcaet/get-diagnostic-instruction/get-diagnostic-instruction.errors.ts
@@ -1,0 +1,30 @@
+import {
+  createErrorsEnum,
+  TrpcErrorHandlerConfig,
+} from '@tet/backend/utils/trpc/trpc-error-handler';
+
+const specificErrors = [
+  'DEMANDE_AVIS_NOT_FOUND',
+  'DIAGNOSTIC_NON_FIGE',
+] as const;
+type SpecificError = (typeof specificErrors)[number];
+
+export const getDiagnosticInstructionErrorConfig: TrpcErrorHandlerConfig<SpecificError> =
+  {
+    specificErrors: {
+      DEMANDE_AVIS_NOT_FOUND: {
+        code: 'NOT_FOUND',
+        message: "La demande d'avis n'a pas été trouvée",
+      },
+      DIAGNOSTIC_NON_FIGE: {
+        code: 'CONFLICT',
+        message:
+          "Le diagnostic de ce dépôt n'a pas été figé à la transmission : il n'est pas consultable en instruction",
+      },
+    },
+  };
+
+export const GetDiagnosticInstructionErrorEnum =
+  createErrorsEnum(specificErrors);
+export type GetDiagnosticInstructionError =
+  keyof typeof GetDiagnosticInstructionErrorEnum;

--- a/apps/backend/src/demarches/pcaet/get-diagnostic-instruction/get-diagnostic-instruction.input.ts
+++ b/apps/backend/src/demarches/pcaet/get-diagnostic-instruction/get-diagnostic-instruction.input.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const getDiagnosticInstructionInputSchema = z.object({
+  demandeAvisId: z.number().int().positive(),
+});
+
+export type GetDiagnosticInstructionInput = z.infer<
+  typeof getDiagnosticInstructionInputSchema
+>;

--- a/apps/backend/src/demarches/pcaet/get-diagnostic-instruction/get-diagnostic-instruction.router.e2e-spec.ts
+++ b/apps/backend/src/demarches/pcaet/get-diagnostic-instruction/get-diagnostic-instruction.router.e2e-spec.ts
@@ -1,0 +1,179 @@
+import { INestApplication } from '@nestjs/common';
+import { addTestCollectiviteAndUser } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { demarcheTable } from '@tet/backend/demarches/shared/models/demarche.table';
+import {
+  getAuthUserFromUserCredentials,
+  getTestApp,
+  getTestDatabase,
+  getTestRouter,
+} from '@tet/backend/test';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { CollectiviteRole } from '@tet/domain/users';
+import { eq } from 'drizzle-orm';
+import { onTestFinished } from 'vitest';
+import { demarchePcaetDiagnosticSnapshotTable } from '../shared/models/demarche-pcaet-diagnostic-snapshot.table';
+import { pcaetDemandeAvisTable } from '../shared/models/pcaet-demande-avis.table';
+
+describe('getDiagnosticInstruction', () => {
+  let app: INestApplication;
+  let db: DatabaseService;
+  let router: Awaited<ReturnType<typeof getTestRouter>>;
+  let camille: AuthenticatedUser;
+  let marie: AuthenticatedUser;
+  let demarcheId: number;
+  let demandeAvisId: number;
+
+  const REGION = '52';
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    db = await getTestDatabase(app);
+    router = await getTestRouter(app);
+
+    const deposante = await addTestCollectiviteAndUser(db, {
+      user: { role: CollectiviteRole.ADMIN },
+      collectivite: { regionCode: REGION, nom: 'Agglo test diagnostic' },
+    });
+    marie = getAuthUserFromUserCredentials(deposante.user);
+
+    const dreal = await addTestCollectiviteAndUser(db, {
+      user: { role: CollectiviteRole.ADMIN },
+      collectivite: {
+        type: 'dreal',
+        regionCode: REGION,
+        nom: 'DREAL test diagnostic',
+      },
+    });
+    camille = getAuthUserFromUserCredentials(dreal.user);
+
+    const [demarche] = await db.db
+      .insert(demarcheTable)
+      .values({
+        collectiviteId: deposante.collectivite.id,
+        type: 'pcaet',
+        titre: 'PCAET test diagnostic',
+        status: 'transmis_pour_avis',
+        transmittedAt: new Date().toISOString(),
+        avisDeadlineAt: new Date(
+          Date.now() + 30 * 24 * 3600 * 1000
+        ).toISOString(),
+      })
+      .returning({ id: demarcheTable.id });
+    demarcheId = demarche.id;
+
+    const [demande] = await db.db
+      .insert(pcaetDemandeAvisTable)
+      .values({
+        demarcheId,
+        instructeurCollectiviteId: dreal.collectivite.id,
+        source: 'seed',
+      })
+      .returning({ id: pcaetDemandeAvisTable.id });
+    demandeAvisId = demande.id;
+
+    return async () => {
+      await db.db
+        .delete(pcaetDemandeAvisTable)
+        .where(eq(pcaetDemandeAvisTable.id, demandeAvisId));
+      await db.db.delete(demarcheTable).where(eq(demarcheTable.id, demarcheId));
+      await dreal.cleanup();
+      await deposante.cleanup();
+      await app.close();
+    };
+  });
+
+  const poserPhoto = async () => {
+    const [photo] = await db.db
+      .insert(demarchePcaetDiagnosticSnapshotTable)
+      .values({
+        demarcheId,
+        jalon: 'transmission',
+        payload: {
+          topics: [
+            {
+              code: 'profil_energie_climat',
+              label: 'Profil énergie climat',
+              icon: 'fire-line',
+              kind: 'indicateurs',
+              groupLabel: 'Secteur',
+              rowLabel: null,
+              unit: 'kteq CO2',
+              referentielId: 'cae_1.a',
+              referenceYear: 2018,
+              horizons: [2030, 2036, 2050],
+              extraYears: [],
+              years: [2018, 2030, 2036, 2050],
+              rows: [],
+              valeurs: [],
+            },
+          ],
+        },
+      })
+      .returning({ id: demarchePcaetDiagnosticSnapshotTable.id });
+
+    onTestFinished(async () => {
+      await db.db
+        .delete(demarchePcaetDiagnosticSnapshotTable)
+        .where(eq(demarchePcaetDiagnosticSnapshotTable.id, photo.id));
+    });
+  };
+
+  it("l'instructrice lit la photo du diagnostic transmis", async () => {
+    await poserPhoto();
+
+    const diagnostic = await router
+      .createCaller({ user: camille })
+      .demarches.pcaet.getDiagnosticInstruction({ demandeAvisId });
+
+    expect(diagnostic.snapshotDate).not.toBeNull();
+    expect(diagnostic.topics.map((topic) => topic.code)).toContain(
+      'profil_energie_climat'
+    );
+  });
+
+  it('sert la photo même pendant une reprise d’élaboration', async () => {
+    await poserPhoto();
+    await db.db
+      .update(demarcheTable)
+      .set({ status: 'en_elaboration' })
+      .where(eq(demarcheTable.id, demarcheId));
+
+    onTestFinished(async () => {
+      await db.db
+        .update(demarcheTable)
+        .set({ status: 'transmis_pour_avis' })
+        .where(eq(demarcheTable.id, demarcheId));
+    });
+
+    const diagnostic = await router
+      .createCaller({ user: camille })
+      .demarches.pcaet.getDiagnosticInstruction({ demandeAvisId });
+
+    expect(diagnostic.snapshotDate).not.toBeNull();
+  });
+
+  it("refuse un dépôt dont le diagnostic n'a pas été figé", async () => {
+    await expect(
+      router
+        .createCaller({ user: camille })
+        .demarches.pcaet.getDiagnosticInstruction({ demandeAvisId })
+    ).rejects.toThrow("n'a pas été figé à la transmission");
+  });
+
+  it("refuse l'agente de la collectivité déposante", async () => {
+    await expect(
+      router
+        .createCaller({ user: marie })
+        .demarches.pcaet.getDiagnosticInstruction({ demandeAvisId })
+    ).rejects.toThrow();
+  });
+
+  it('refuse une demande inconnue', async () => {
+    await expect(
+      router
+        .createCaller({ user: camille })
+        .demarches.pcaet.getDiagnosticInstruction({ demandeAvisId: 999999999 })
+    ).rejects.toThrow();
+  });
+});

--- a/apps/backend/src/demarches/pcaet/get-diagnostic-instruction/get-diagnostic-instruction.router.ts
+++ b/apps/backend/src/demarches/pcaet/get-diagnostic-instruction/get-diagnostic-instruction.router.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@nestjs/common';
+import { createTrpcErrorHandler } from '@tet/backend/utils/trpc/trpc-error-handler';
+import { TrpcService } from '@tet/backend/utils/trpc/trpc.service';
+import { getDiagnosticInstructionErrorConfig } from './get-diagnostic-instruction.errors';
+import { getDiagnosticInstructionInputSchema } from './get-diagnostic-instruction.input';
+import { GetDiagnosticInstructionService } from './get-diagnostic-instruction.service';
+
+@Injectable()
+export class GetDiagnosticInstructionRouter {
+  constructor(
+    private readonly trpc: TrpcService,
+    private readonly getDiagnosticInstructionService: GetDiagnosticInstructionService
+  ) {}
+
+  private readonly getResultDataOrThrowError = createTrpcErrorHandler(
+    getDiagnosticInstructionErrorConfig
+  );
+
+  router = this.trpc.router({
+    getDiagnosticInstruction: this.trpc.authedProcedure
+      .input(getDiagnosticInstructionInputSchema)
+      .query(async ({ input, ctx }) => {
+        const result =
+          await this.getDiagnosticInstructionService.getDiagnosticInstruction(
+            input,
+            { user: ctx.user }
+          );
+        return this.getResultDataOrThrowError(result);
+      }),
+  });
+}

--- a/apps/backend/src/demarches/pcaet/get-diagnostic-instruction/get-diagnostic-instruction.service.ts
+++ b/apps/backend/src/demarches/pcaet/get-diagnostic-instruction/get-diagnostic-instruction.service.ts
@@ -1,0 +1,63 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { ServiceSecondArg } from '@tet/backend/utils/nest/service-second-arg.utils';
+import { failure, Result, success } from '@tet/backend/utils/result.type';
+import { type DemarchePcaetDiagnostic } from '@tet/domain/demarches';
+import { eq } from 'drizzle-orm';
+import { DemarchePcaetDiagnosticRepository } from '../shared/demarche-pcaet-diagnostic.repository';
+import { DepotPermissionsService } from '../shared/depot-permissions.service';
+import { pcaetDemandeAvisTable } from '../shared/models/pcaet-demande-avis.table';
+import {
+  GetDiagnosticInstructionError,
+  GetDiagnosticInstructionErrorEnum,
+} from './get-diagnostic-instruction.errors';
+import { GetDiagnosticInstructionInput } from './get-diagnostic-instruction.input';
+
+@Injectable()
+export class GetDiagnosticInstructionService {
+  private readonly logger = new Logger(GetDiagnosticInstructionService.name);
+
+  constructor(
+    private readonly databaseService: DatabaseService,
+    private readonly depotPermissionsService: DepotPermissionsService,
+    private readonly diagnosticRepository: DemarchePcaetDiagnosticRepository
+  ) {}
+
+  async getDiagnosticInstruction(
+    { demandeAvisId }: GetDiagnosticInstructionInput,
+    { user, tx }: ServiceSecondArg
+  ): Promise<Result<DemarchePcaetDiagnostic, GetDiagnosticInstructionError>> {
+    const permissionResult =
+      await this.depotPermissionsService.canConsulterDepot(demandeAvisId, {
+        user,
+        tx,
+      });
+    if (!permissionResult.success) {
+      return failure(GetDiagnosticInstructionErrorEnum.UNAUTHORIZED);
+    }
+
+    const rows = await (tx ?? this.databaseService.db)
+      .select({ demarcheId: pcaetDemandeAvisTable.demarcheId })
+      .from(pcaetDemandeAvisTable)
+      .where(eq(pcaetDemandeAvisTable.id, demandeAvisId))
+      .limit(1);
+
+    const demande = rows[0];
+    if (!demande) {
+      return failure(GetDiagnosticInstructionErrorEnum.DEMANDE_AVIS_NOT_FOUND);
+    }
+
+    const snapshot = await this.diagnosticRepository.findLatestSnapshot(
+      { demarcheId: demande.demarcheId, jalon: 'transmission' },
+      tx
+    );
+    if (!snapshot) {
+      this.logger.warn(
+        `Aucune photo de diagnostic pour la démarche ${demande.demarcheId} (demande d'avis ${demandeAvisId})`
+      );
+      return failure(GetDiagnosticInstructionErrorEnum.DIAGNOSTIC_NON_FIGE);
+    }
+
+    return success({ ...snapshot.payload, snapshotDate: snapshot.date });
+  }
+}

--- a/apps/backend/src/demarches/pcaet/get-dossier-document-url/get-dossier-document-url.errors.ts
+++ b/apps/backend/src/demarches/pcaet/get-dossier-document-url/get-dossier-document-url.errors.ts
@@ -1,0 +1,33 @@
+import {
+  createErrorsEnum,
+  TrpcErrorHandlerConfig,
+} from '@tet/backend/utils/trpc/trpc-error-handler';
+
+const specificErrors = [
+  'DEMANDE_AVIS_NOT_FOUND',
+  'DOCUMENT_NOT_FOUND',
+  'DOCUMENT_URL_ERROR',
+] as const;
+type SpecificError = (typeof specificErrors)[number];
+
+export const getDossierDocumentUrlErrorConfig: TrpcErrorHandlerConfig<SpecificError> =
+  {
+    specificErrors: {
+      DEMANDE_AVIS_NOT_FOUND: {
+        code: 'NOT_FOUND',
+        message: "La demande d'avis n'a pas été trouvée",
+      },
+      DOCUMENT_NOT_FOUND: {
+        code: 'NOT_FOUND',
+        message: "Le document n'a pas été trouvé dans ce dossier",
+      },
+      DOCUMENT_URL_ERROR: {
+        code: 'INTERNAL_SERVER_ERROR',
+        message: "Le lien de téléchargement n'a pas pu être généré",
+      },
+    },
+  };
+
+export const GetDossierDocumentUrlErrorEnum = createErrorsEnum(specificErrors);
+export type GetDossierDocumentUrlError =
+  keyof typeof GetDossierDocumentUrlErrorEnum;

--- a/apps/backend/src/demarches/pcaet/get-dossier-document-url/get-dossier-document-url.input.ts
+++ b/apps/backend/src/demarches/pcaet/get-dossier-document-url/get-dossier-document-url.input.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const getDossierDocumentUrlInputSchema = z.object({
+  demandeAvisId: z.number().int().positive(),
+  documentId: z.string().min(1),
+});
+
+export type GetDossierDocumentUrlInput = z.infer<
+  typeof getDossierDocumentUrlInputSchema
+>;

--- a/apps/backend/src/demarches/pcaet/get-dossier-document-url/get-dossier-document-url.output.ts
+++ b/apps/backend/src/demarches/pcaet/get-dossier-document-url/get-dossier-document-url.output.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const dossierDocumentUrlSchema = z.object({
+  url: z.string(),
+  filename: z.string(),
+});
+
+export type DossierDocumentUrl = z.infer<typeof dossierDocumentUrlSchema>;

--- a/apps/backend/src/demarches/pcaet/get-dossier-document-url/get-dossier-document-url.router.e2e-spec.ts
+++ b/apps/backend/src/demarches/pcaet/get-dossier-document-url/get-dossier-document-url.router.e2e-spec.ts
@@ -1,0 +1,155 @@
+import { INestApplication } from '@nestjs/common';
+import { addTestCollectiviteAndUser } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { demarcheTable } from '@tet/backend/demarches/shared/models/demarche.table';
+import {
+  getAuthUserFromUserCredentials,
+  getTestApp,
+  getTestDatabase,
+  getTestRouter,
+} from '@tet/backend/test';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { DocumentStorageService } from '@tet/backend/utils/supabase/document-storage.service';
+import { CollectiviteRole } from '@tet/domain/users';
+import { eq } from 'drizzle-orm';
+import {
+  addTestBibliothequeFichier,
+  PCAET_DOCUMENT_GLOBAL_ID,
+} from '../demarches-pcaet.test-fixture';
+import { pcaetDemandeAvisTable } from '../shared/models/pcaet-demande-avis.table';
+
+describe('getDossierDocumentUrl', () => {
+  let app: INestApplication;
+  let db: DatabaseService;
+  let router: Awaited<ReturnType<typeof getTestRouter>>;
+  let camille: AuthenticatedUser;
+  let marie: AuthenticatedUser;
+  let demarcheId: number;
+  let demandeAvisId: number;
+  let filename: string;
+
+  const REGION = '76';
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    db = await getTestDatabase(app);
+    router = await getTestRouter(app);
+
+    const deposante = await addTestCollectiviteAndUser(db, {
+      user: { role: CollectiviteRole.ADMIN },
+      collectivite: { regionCode: REGION, nom: 'Agglo test document url' },
+    });
+    marie = getAuthUserFromUserCredentials(deposante.user);
+
+    const dreal = await addTestCollectiviteAndUser(db, {
+      user: { role: CollectiviteRole.ADMIN },
+      collectivite: {
+        type: 'dreal',
+        regionCode: REGION,
+        nom: 'DREAL test document url',
+      },
+    });
+    camille = getAuthUserFromUserCredentials(dreal.user);
+
+    const [demarche] = await db.db
+      .insert(demarcheTable)
+      .values({
+        collectiviteId: deposante.collectivite.id,
+        type: 'pcaet',
+        titre: 'PCAET test document url',
+        status: 'en_elaboration',
+      })
+      .returning({ id: demarcheTable.id });
+    demarcheId = demarche.id;
+
+    const fichier = await addTestBibliothequeFichier(db, {
+      collectiviteId: deposante.collectivite.id,
+      filename: 'dossier-complet.pdf',
+    });
+    filename = fichier.filename;
+
+    const depose = await router
+      .createCaller({ user: marie })
+      .demarches.pcaet.documents.add({
+        collectiviteId: deposante.collectivite.id,
+        demarcheId,
+        documentId: PCAET_DOCUMENT_GLOBAL_ID,
+        fichierId: fichier.id,
+      });
+
+    const documentStorage = app.get(DocumentStorageService);
+    const storeResult = await documentStorage.storeDocument({
+      bucketId: depose.fichier?.bucketId ?? '',
+      key: depose.fichier?.hash ?? '',
+      contentType: 'application/pdf',
+      content: Buffer.from('%PDF-1.4 test'),
+    });
+    expect(storeResult.success).toBe(true);
+
+    await db.db
+      .update(demarcheTable)
+      .set({
+        status: 'transmis_pour_avis',
+        transmittedAt: new Date().toISOString(),
+        avisDeadlineAt: new Date(
+          Date.now() + 30 * 24 * 3600 * 1000
+        ).toISOString(),
+      })
+      .where(eq(demarcheTable.id, demarcheId));
+
+    const [demande] = await db.db
+      .insert(pcaetDemandeAvisTable)
+      .values({
+        demarcheId,
+        instructeurCollectiviteId: dreal.collectivite.id,
+        source: 'seed',
+      })
+      .returning({ id: pcaetDemandeAvisTable.id });
+    demandeAvisId = demande.id;
+
+    return async () => {
+      await db.db
+        .delete(pcaetDemandeAvisTable)
+        .where(eq(pcaetDemandeAvisTable.id, demandeAvisId));
+      await db.db.delete(demarcheTable).where(eq(demarcheTable.id, demarcheId));
+      await dreal.cleanup();
+      await deposante.cleanup();
+      await app.close();
+    };
+  });
+
+  it("l'instructrice obtient une URL signée et le nom du fichier", async () => {
+    const result = await router
+      .createCaller({ user: camille })
+      .demarches.pcaet.getDossierDocumentUrl({
+        demandeAvisId,
+        documentId: PCAET_DOCUMENT_GLOBAL_ID,
+      });
+
+    expect(result.filename).toBe(filename);
+    expect(result.url).toContain('/sign/');
+
+    const response = await fetch(result.url);
+    expect(response.status).toBe(200);
+  });
+
+  it("refuse l'agente de la collectivité déposante", async () => {
+    await expect(
+      router.createCaller({ user: marie }).demarches.pcaet.getDossierDocumentUrl({
+        demandeAvisId,
+        documentId: PCAET_DOCUMENT_GLOBAL_ID,
+      })
+    ).rejects.toThrow();
+  });
+
+  it('refuse un document absent du dossier', async () => {
+    await expect(
+      router
+        .createCaller({ user: camille })
+        .demarches.pcaet.getDossierDocumentUrl({
+          demandeAvisId,
+          documentId: 'pcaet_diagnostic',
+        })
+    ).rejects.toThrow("Le document n'a pas été trouvé dans ce dossier");
+  });
+});

--- a/apps/backend/src/demarches/pcaet/get-dossier-document-url/get-dossier-document-url.router.ts
+++ b/apps/backend/src/demarches/pcaet/get-dossier-document-url/get-dossier-document-url.router.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@nestjs/common';
+import { createTrpcErrorHandler } from '@tet/backend/utils/trpc/trpc-error-handler';
+import { TrpcService } from '@tet/backend/utils/trpc/trpc.service';
+import { getDossierDocumentUrlErrorConfig } from './get-dossier-document-url.errors';
+import { getDossierDocumentUrlInputSchema } from './get-dossier-document-url.input';
+import { GetDossierDocumentUrlService } from './get-dossier-document-url.service';
+
+@Injectable()
+export class GetDossierDocumentUrlRouter {
+  constructor(
+    private readonly trpc: TrpcService,
+    private readonly getDossierDocumentUrlService: GetDossierDocumentUrlService
+  ) {}
+
+  private readonly getResultDataOrThrowError = createTrpcErrorHandler(
+    getDossierDocumentUrlErrorConfig
+  );
+
+  router = this.trpc.router({
+    getDossierDocumentUrl: this.trpc.authedProcedure
+      .input(getDossierDocumentUrlInputSchema)
+      .query(async ({ input, ctx }) => {
+        const result =
+          await this.getDossierDocumentUrlService.getDossierDocumentUrl(
+            input,
+            { user: ctx.user }
+          );
+        return this.getResultDataOrThrowError(result);
+      }),
+  });
+}

--- a/apps/backend/src/demarches/pcaet/get-dossier-document-url/get-dossier-document-url.service.ts
+++ b/apps/backend/src/demarches/pcaet/get-dossier-document-url/get-dossier-document-url.service.ts
@@ -1,0 +1,84 @@
+import { Injectable } from '@nestjs/common';
+import { DemarcheDocumentsRepository } from '@tet/backend/demarches/shared/demarche-documents.repository';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { ServiceSecondArg } from '@tet/backend/utils/nest/service-second-arg.utils';
+import { failure, Result, success } from '@tet/backend/utils/result.type';
+import { DocumentStorageService } from '@tet/backend/utils/supabase/document-storage.service';
+import { DemarcheTypeEnum } from '@tet/domain/demarches';
+import { eq } from 'drizzle-orm';
+import { DepotPermissionsService } from '../shared/depot-permissions.service';
+import { pcaetDemandeAvisTable } from '../shared/models/pcaet-demande-avis.table';
+import {
+  GetDossierDocumentUrlError,
+  GetDossierDocumentUrlErrorEnum,
+} from './get-dossier-document-url.errors';
+import { GetDossierDocumentUrlInput } from './get-dossier-document-url.input';
+import { DossierDocumentUrl } from './get-dossier-document-url.output';
+
+const DOWNLOAD_URL_TTL_SECONDS = 60;
+
+@Injectable()
+export class GetDossierDocumentUrlService {
+  constructor(
+    private readonly databaseService: DatabaseService,
+    private readonly depotPermissionsService: DepotPermissionsService,
+    private readonly demarcheDocumentsRepository: DemarcheDocumentsRepository,
+    private readonly documentStorageService: DocumentStorageService
+  ) {}
+
+  async getDossierDocumentUrl(
+    { demandeAvisId, documentId }: GetDossierDocumentUrlInput,
+    { user, tx }: ServiceSecondArg
+  ): Promise<Result<DossierDocumentUrl, GetDossierDocumentUrlError>> {
+    const permissionResult =
+      await this.depotPermissionsService.canConsulterDepot(demandeAvisId, {
+        user,
+        tx,
+      });
+    if (!permissionResult.success) {
+      return failure(GetDossierDocumentUrlErrorEnum.UNAUTHORIZED);
+    }
+
+    const rows = await (tx ?? this.databaseService.db)
+      .select({ demarcheId: pcaetDemandeAvisTable.demarcheId })
+      .from(pcaetDemandeAvisTable)
+      .where(eq(pcaetDemandeAvisTable.id, demandeAvisId))
+      .limit(1);
+
+    const demande = rows[0];
+    if (!demande) {
+      return failure(GetDossierDocumentUrlErrorEnum.DEMANDE_AVIS_NOT_FOUND);
+    }
+
+    const snapshot = await this.demarcheDocumentsRepository.loadSnapshot(
+      {
+        demarcheId: demande.demarcheId,
+        demarcheType: DemarcheTypeEnum.PCAET,
+      },
+      tx
+    );
+
+    const document = snapshot.documents.find(
+      (depose) => depose.documentId === documentId
+    );
+    const fichier = document?.fichier;
+    if (!fichier?.bucketId) {
+      return failure(GetDossierDocumentUrlErrorEnum.DOCUMENT_NOT_FOUND);
+    }
+
+    const signedUrlResult =
+      await this.documentStorageService.createDocumentSignedUrl({
+        bucketId: fichier.bucketId,
+        key: fichier.hash,
+        expiresInSeconds: DOWNLOAD_URL_TTL_SECONDS,
+      });
+    if (!signedUrlResult.success) {
+      return failure(GetDossierDocumentUrlErrorEnum.DOCUMENT_URL_ERROR);
+    }
+
+    return success({
+      url: signedUrlResult.data.signedUrl,
+      filename: fichier.filename,
+    });
+  }
+}

--- a/apps/backend/src/demarches/pcaet/get-dossier-instruction/get-dossier-instruction.errors.ts
+++ b/apps/backend/src/demarches/pcaet/get-dossier-instruction/get-dossier-instruction.errors.ts
@@ -1,0 +1,21 @@
+import {
+  createErrorsEnum,
+  TrpcErrorHandlerConfig,
+} from '@tet/backend/utils/trpc/trpc-error-handler';
+
+const specificErrors = ['DEMANDE_AVIS_NOT_FOUND'] as const;
+type SpecificError = (typeof specificErrors)[number];
+
+export const getDossierInstructionErrorConfig: TrpcErrorHandlerConfig<SpecificError> =
+  {
+    specificErrors: {
+      DEMANDE_AVIS_NOT_FOUND: {
+        code: 'NOT_FOUND',
+        message: "La demande d'avis n'a pas été trouvée",
+      },
+    },
+  };
+
+export const GetDossierInstructionErrorEnum = createErrorsEnum(specificErrors);
+export type GetDossierInstructionError =
+  keyof typeof GetDossierInstructionErrorEnum;

--- a/apps/backend/src/demarches/pcaet/get-dossier-instruction/get-dossier-instruction.input.ts
+++ b/apps/backend/src/demarches/pcaet/get-dossier-instruction/get-dossier-instruction.input.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const getDossierInstructionInputSchema = z.object({
+  demandeAvisId: z.number().int().positive(),
+});
+
+export type GetDossierInstructionInput = z.infer<
+  typeof getDossierInstructionInputSchema
+>;

--- a/apps/backend/src/demarches/pcaet/get-dossier-instruction/get-dossier-instruction.output.ts
+++ b/apps/backend/src/demarches/pcaet/get-dossier-instruction/get-dossier-instruction.output.ts
@@ -1,0 +1,29 @@
+import {
+  demarcheDocumentsSnapshotSchema,
+  demarchePcaetStatusSchema,
+  pcaetDemandeAvisEtatSchema,
+} from '@tet/domain/demarches';
+import { z } from 'zod';
+import { partieValideeSchema } from '../valider-partie-instruction/valider-partie-instruction.output';
+
+export const dossierInstructionSchema = z.object({
+  demandeAvisId: z.number().int(),
+  demarcheId: z.number().int(),
+  titre: z.string(),
+  status: demarchePcaetStatusSchema,
+  etat: pcaetDemandeAvisEtatSchema,
+  transmittedAt: z.string().nullable(),
+  avisDeadlineAt: z.string().nullable(),
+  launchedAt: z.string().nullable(),
+  createdAt: z.string(),
+  modifiedAt: z.string(),
+  pilotes: z.string().array(),
+  collectivite: z.object({
+    id: z.number().int(),
+    nom: z.string(),
+  }),
+  documents: demarcheDocumentsSnapshotSchema,
+  partiesValidees: partieValideeSchema.array(),
+});
+
+export type DossierInstruction = z.infer<typeof dossierInstructionSchema>;

--- a/apps/backend/src/demarches/pcaet/get-dossier-instruction/get-dossier-instruction.router.e2e-spec.ts
+++ b/apps/backend/src/demarches/pcaet/get-dossier-instruction/get-dossier-instruction.router.e2e-spec.ts
@@ -1,0 +1,137 @@
+import { INestApplication } from '@nestjs/common';
+import { addTestCollectiviteAndUser } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { demarcheTable } from '@tet/backend/demarches/shared/models/demarche.table';
+import {
+  getAuthUserFromUserCredentials,
+  getTestApp,
+  getTestDatabase,
+  getTestRouter,
+} from '@tet/backend/test';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { PcaetDemandeAvisEtatEnum } from '@tet/domain/demarches';
+import { CollectiviteRole } from '@tet/domain/users';
+import { eq } from 'drizzle-orm';
+import { pcaetDemandeAvisTable } from '../shared/models/pcaet-demande-avis.table';
+
+describe('getDossierInstruction', () => {
+  let app: INestApplication;
+  let db: DatabaseService;
+  let router: Awaited<ReturnType<typeof getTestRouter>>;
+  let camille: AuthenticatedUser;
+  let marie: AuthenticatedUser;
+  let demarcheId: number;
+  let demandeAvisId: number;
+
+  const REGION = '32';
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    db = await getTestDatabase(app);
+    router = await getTestRouter(app);
+
+    const deposante = await addTestCollectiviteAndUser(db, {
+      user: { role: CollectiviteRole.ADMIN },
+      collectivite: { regionCode: REGION, nom: 'Agglo test consultation' },
+    });
+    marie = getAuthUserFromUserCredentials(deposante.user);
+
+    const dreal = await addTestCollectiviteAndUser(db, {
+      user: { role: CollectiviteRole.ADMIN },
+      collectivite: {
+        type: 'dreal',
+        regionCode: REGION,
+        nom: 'DREAL test consultation',
+      },
+    });
+    camille = getAuthUserFromUserCredentials(dreal.user);
+
+    const [demarche] = await db.db
+      .insert(demarcheTable)
+      .values({
+        collectiviteId: deposante.collectivite.id,
+        type: 'pcaet',
+        titre: 'PCAET test consultation',
+        status: 'transmis_pour_avis',
+        transmittedAt: new Date().toISOString(),
+        avisDeadlineAt: new Date(
+          Date.now() + 30 * 24 * 3600 * 1000
+        ).toISOString(),
+      })
+      .returning({ id: demarcheTable.id });
+    demarcheId = demarche.id;
+
+    const [demande] = await db.db
+      .insert(pcaetDemandeAvisTable)
+      .values({
+        demarcheId,
+        instructeurCollectiviteId: dreal.collectivite.id,
+        source: 'seed',
+      })
+      .returning({ id: pcaetDemandeAvisTable.id });
+    demandeAvisId = demande.id;
+
+    return async () => {
+      await db.db
+        .delete(pcaetDemandeAvisTable)
+        .where(eq(pcaetDemandeAvisTable.id, demandeAvisId));
+      await db.db.delete(demarcheTable).where(eq(demarcheTable.id, demarcheId));
+      await dreal.cleanup();
+      await deposante.cleanup();
+      await app.close();
+    };
+  });
+
+  it("l'instructeur lit l'en-tête du dossier de la collectivité", async () => {
+    const dossier = await router
+      .createCaller({ user: camille })
+      .demarches.pcaet.getDossierInstruction({ demandeAvisId });
+
+    expect(dossier.demarcheId).toBe(demarcheId);
+    expect(dossier.titre).toBe('PCAET test consultation');
+    expect(dossier.status).toBe('transmis_pour_avis');
+    expect(dossier.collectivite.nom).toBe('Agglo test consultation');
+    expect(dossier.avisDeadlineAt).not.toBeNull();
+    expect(dossier.createdAt).not.toBeNull();
+    expect(dossier.modifiedAt).not.toBeNull();
+    expect(dossier.launchedAt).toBeNull();
+    expect(dossier.pilotes).toEqual([]);
+  });
+
+  it("expose l'état de l'instruction, pas seulement le statut du dossier", async () => {
+    const dossier = await router
+      .createCaller({ user: camille })
+      .demarches.pcaet.getDossierInstruction({ demandeAvisId });
+
+    expect(dossier.status).toBe('transmis_pour_avis');
+    expect(dossier.etat).toBe(PcaetDemandeAvisEtatEnum.A_TRAITER);
+  });
+
+  it('et le modèle documentaire servi par la base, dossier vide', async () => {
+    const dossier = await router
+      .createCaller({ user: camille })
+      .demarches.pcaet.getDossierInstruction({ demandeAvisId });
+
+    expect(dossier.documents.definitions.length).toBeGreaterThan(0);
+    expect(dossier.documents.definitions.map((d) => d.id)).toContain(
+      'pcaet_diagnostic'
+    );
+    expect(dossier.documents.documents).toEqual([]);
+  });
+
+  it("refuse l'agente de la collectivité déposante", async () => {
+    await expect(
+      router
+        .createCaller({ user: marie })
+        .demarches.pcaet.getDossierInstruction({ demandeAvisId })
+    ).rejects.toThrow();
+  });
+
+  it('refuse une demande inconnue', async () => {
+    await expect(
+      router
+        .createCaller({ user: camille })
+        .demarches.pcaet.getDossierInstruction({ demandeAvisId: 999999999 })
+    ).rejects.toThrow();
+  });
+});

--- a/apps/backend/src/demarches/pcaet/get-dossier-instruction/get-dossier-instruction.router.ts
+++ b/apps/backend/src/demarches/pcaet/get-dossier-instruction/get-dossier-instruction.router.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+import { createTrpcErrorHandler } from '@tet/backend/utils/trpc/trpc-error-handler';
+import { TrpcService } from '@tet/backend/utils/trpc/trpc.service';
+import { getDossierInstructionErrorConfig } from './get-dossier-instruction.errors';
+import { getDossierInstructionInputSchema } from './get-dossier-instruction.input';
+import { GetDossierInstructionService } from './get-dossier-instruction.service';
+
+@Injectable()
+export class GetDossierInstructionRouter {
+  constructor(
+    private readonly trpc: TrpcService,
+    private readonly getDossierInstructionService: GetDossierInstructionService
+  ) {}
+
+  private readonly getResultDataOrThrowError = createTrpcErrorHandler(
+    getDossierInstructionErrorConfig
+  );
+
+  router = this.trpc.router({
+    getDossierInstruction: this.trpc.authedProcedure
+      .input(getDossierInstructionInputSchema)
+      .query(async ({ input, ctx }) => {
+        const result =
+          await this.getDossierInstructionService.getDossierInstruction(input, {
+            user: ctx.user,
+          });
+        return this.getResultDataOrThrowError(result);
+      }),
+  });
+}

--- a/apps/backend/src/demarches/pcaet/get-dossier-instruction/get-dossier-instruction.service.ts
+++ b/apps/backend/src/demarches/pcaet/get-dossier-instruction/get-dossier-instruction.service.ts
@@ -1,0 +1,138 @@
+import { Injectable } from '@nestjs/common';
+import { collectiviteTable } from '@tet/backend/collectivites/shared/models/collectivite.table';
+import { DemarcheDocumentsRepository } from '@tet/backend/demarches/shared/demarche-documents.repository';
+import { demarcheTable } from '@tet/backend/demarches/shared/models/demarche.table';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { ServiceSecondArg } from '@tet/backend/utils/nest/service-second-arg.utils';
+import { failure, Result, success } from '@tet/backend/utils/result.type';
+import { DemarcheTypeEnum, getDemandeAvisEtat } from '@tet/domain/demarches';
+import { eq, sql } from 'drizzle-orm';
+import { GetDemarchePcaetRepository } from '../get-demarche-pcaet/get-demarche-pcaet.repository';
+import { DepotPermissionsService } from '../shared/depot-permissions.service';
+import { pcaetAvisTable } from '../shared/models/pcaet-avis.table';
+import { pcaetDemandeAvisTable } from '../shared/models/pcaet-demande-avis.table';
+import { pcaetInstructionValidationTable } from '../shared/models/pcaet-instruction-validation.table';
+import {
+  GetDossierInstructionError,
+  GetDossierInstructionErrorEnum,
+} from './get-dossier-instruction.errors';
+import { GetDossierInstructionInput } from './get-dossier-instruction.input';
+import { DossierInstruction } from './get-dossier-instruction.output';
+
+@Injectable()
+export class GetDossierInstructionService {
+  constructor(
+    private readonly databaseService: DatabaseService,
+    private readonly depotPermissionsService: DepotPermissionsService,
+    private readonly demarcheDocumentsRepository: DemarcheDocumentsRepository,
+    private readonly getDemarchePcaetRepository: GetDemarchePcaetRepository
+  ) {}
+
+  async getDossierInstruction(
+    { demandeAvisId }: GetDossierInstructionInput,
+    { user, tx }: ServiceSecondArg
+  ): Promise<Result<DossierInstruction, GetDossierInstructionError>> {
+    const permissionResult =
+      await this.depotPermissionsService.canConsulterDepot(demandeAvisId, {
+        user,
+        tx,
+      });
+    if (!permissionResult.success) {
+      return failure(GetDossierInstructionErrorEnum.UNAUTHORIZED);
+    }
+
+    const rows = await (tx ?? this.databaseService.db)
+      .select({
+        demarcheId: demarcheTable.id,
+        titre: demarcheTable.titre,
+        status: demarcheTable.status,
+        transmittedAt: demarcheTable.transmittedAt,
+        avisDeadlineAt: demarcheTable.avisDeadlineAt,
+        launchedAt: demarcheTable.launchedAt,
+        createdAt: demarcheTable.createdAt,
+        modifiedAt: demarcheTable.modifiedAt,
+        collectiviteId: collectiviteTable.id,
+        collectiviteNom: collectiviteTable.nom,
+        nbAvisValides: sql<number>`(
+          select count(*)::int from ${pcaetAvisTable}
+          where ${pcaetAvisTable.demandeAvisId} = ${pcaetDemandeAvisTable.id}
+            and ${pcaetAvisTable.valideLe} is not null
+        )`,
+        nbAvisBrouillons: sql<number>`(
+          select count(*)::int from ${pcaetAvisTable}
+          where ${pcaetAvisTable.demandeAvisId} = ${pcaetDemandeAvisTable.id}
+            and ${pcaetAvisTable.valideLe} is null
+        )`,
+      })
+      .from(pcaetDemandeAvisTable)
+      .innerJoin(
+        demarcheTable,
+        eq(demarcheTable.id, pcaetDemandeAvisTable.demarcheId)
+      )
+      .innerJoin(
+        collectiviteTable,
+        eq(collectiviteTable.id, demarcheTable.collectiviteId)
+      )
+      .where(eq(pcaetDemandeAvisTable.id, demandeAvisId))
+      .limit(1);
+
+    const dossier = rows[0];
+    if (!dossier) {
+      return failure(GetDossierInstructionErrorEnum.DEMANDE_AVIS_NOT_FOUND);
+    }
+
+    const documents = await this.demarcheDocumentsRepository.loadSnapshot(
+      {
+        demarcheId: dossier.demarcheId,
+        demarcheType: DemarcheTypeEnum.PCAET,
+      },
+      tx
+    );
+
+    const partiesValidees = await (tx ?? this.databaseService.db)
+      .select({
+        partie: pcaetInstructionValidationTable.partie,
+        valideLe: pcaetInstructionValidationTable.valideLe,
+        validePar: pcaetInstructionValidationTable.validePar,
+      })
+      .from(pcaetInstructionValidationTable)
+      .where(eq(pcaetInstructionValidationTable.demandeAvisId, demandeAvisId));
+
+    const pilotesByDemarcheId =
+      await this.getDemarchePcaetRepository.listPilotes(
+        [dossier.demarcheId],
+        tx
+      );
+    const pilotes = (pilotesByDemarcheId.get(dossier.demarcheId) ?? []).map(
+      ({ nom }) => nom
+    );
+
+    return success({
+      demandeAvisId,
+      demarcheId: dossier.demarcheId,
+      titre: dossier.titre,
+      status: dossier.status,
+      etat: getDemandeAvisEtat(
+        {
+          demarcheStatus: dossier.status,
+          avisDeadlineAt: dossier.avisDeadlineAt,
+          nbAvisValides: dossier.nbAvisValides,
+          nbAvisBrouillons: dossier.nbAvisBrouillons,
+        },
+        new Date()
+      ),
+      transmittedAt: dossier.transmittedAt,
+      avisDeadlineAt: dossier.avisDeadlineAt,
+      launchedAt: dossier.launchedAt,
+      createdAt: dossier.createdAt,
+      modifiedAt: dossier.modifiedAt,
+      pilotes,
+      collectivite: {
+        id: dossier.collectiviteId,
+        nom: dossier.collectiviteNom,
+      },
+      documents,
+      partiesValidees,
+    });
+  }
+}

--- a/apps/backend/src/demarches/pcaet/list-demandes-avis/list-demandes-avis.errors.ts
+++ b/apps/backend/src/demarches/pcaet/list-demandes-avis/list-demandes-avis.errors.ts
@@ -1,0 +1,20 @@
+import {
+  createErrorsEnum,
+  TrpcErrorHandlerConfig,
+} from '@tet/backend/utils/trpc/trpc-error-handler';
+
+const specificErrors = ['LIST_DEMANDES_AVIS_ERROR'] as const;
+type SpecificError = (typeof specificErrors)[number];
+
+export const listDemandesAvisErrorConfig: TrpcErrorHandlerConfig<SpecificError> =
+  {
+    specificErrors: {
+      LIST_DEMANDES_AVIS_ERROR: {
+        code: 'INTERNAL_SERVER_ERROR',
+        message: "Erreur de lecture des demandes d'avis",
+      },
+    },
+  };
+
+export const ListDemandesAvisErrorEnum = createErrorsEnum(specificErrors);
+export type ListDemandesAvisError = keyof typeof ListDemandesAvisErrorEnum;

--- a/apps/backend/src/demarches/pcaet/list-demandes-avis/list-demandes-avis.input.ts
+++ b/apps/backend/src/demarches/pcaet/list-demandes-avis/list-demandes-avis.input.ts
@@ -1,0 +1,17 @@
+import { pcaetDemandeAvisEtatValues } from '@tet/domain/demarches';
+import { z } from 'zod';
+
+export const listDemandesAvisSortValues = ['echeance', 'collectivite'] as const;
+
+export const listDemandesAvisInputSchema = z.object({
+  collectiviteId: z.number().int().positive(),
+  etats: z.enum(pcaetDemandeAvisEtatValues).array().optional(),
+  departementCodes: z.string().array().optional(),
+  recherche: z.string().trim().min(1).optional(),
+  sort: z.enum(listDemandesAvisSortValues).prefault('echeance'),
+  direction: z.enum(['asc', 'desc']).prefault('asc'),
+  page: z.coerce.number().int().min(1).prefault(1),
+  limit: z.coerce.number().int().min(1).max(200).prefault(25),
+});
+
+export type ListDemandesAvisInput = z.infer<typeof listDemandesAvisInputSchema>;

--- a/apps/backend/src/demarches/pcaet/list-demandes-avis/list-demandes-avis.output.ts
+++ b/apps/backend/src/demarches/pcaet/list-demandes-avis/list-demandes-avis.output.ts
@@ -33,12 +33,20 @@ export const demandeAvisLigneSchema = z.object({
 
 export type DemandeAvisLigne = z.infer<typeof demandeAvisLigneSchema>;
 
+export const demandesAvisStatsSchema = z.object({
+  nbCollectivites: z.number().int(),
+  delaiMoyenJours: z.number().int().nullable(),
+});
+
+export type DemandesAvisStats = z.infer<typeof demandesAvisStatsSchema>;
+
 export const listDemandesAvisOutputSchema = z.object({
   items: demandeAvisLigneSchema.array(),
   total: z.number().int(),
   page: z.number().int(),
   limit: z.number().int(),
   countByEtat: z.record(pcaetDemandeAvisEtatSchema, z.number().int()),
+  stats: demandesAvisStatsSchema,
 });
 
 export type ListDemandesAvisOutput = z.infer<

--- a/apps/backend/src/demarches/pcaet/list-demandes-avis/list-demandes-avis.output.ts
+++ b/apps/backend/src/demarches/pcaet/list-demandes-avis/list-demandes-avis.output.ts
@@ -1,0 +1,57 @@
+import {
+  demarchePcaetStatusSchema,
+  pcaetDemandeAvisEtatSchema,
+  pcaetDemandeAvisEtatValues,
+} from '@tet/domain/demarches';
+import { z } from 'zod';
+
+export const demandeAvisContactSchema = z.object({
+  prenom: z.string(),
+  nom: z.string(),
+  email: z.string(),
+});
+
+export type DemandeAvisContact = z.infer<typeof demandeAvisContactSchema>;
+
+export const demandeAvisLigneSchema = z.object({
+  demandeAvisId: z.number().int(),
+  demarcheId: z.number().int(),
+  demarcheTitre: z.string(),
+  demarcheStatus: demarchePcaetStatusSchema,
+  avisDeadlineAt: z.string().nullable(),
+  transmittedAt: z.string().nullable(),
+  collectivite: z.object({
+    id: z.number().int(),
+    nom: z.string(),
+    departementCode: z.string().nullable(),
+  }),
+  contacts: demandeAvisContactSchema.array(),
+  etat: pcaetDemandeAvisEtatSchema,
+  nbAvisValides: z.number().int(),
+  nbAvisBrouillons: z.number().int(),
+});
+
+export type DemandeAvisLigne = z.infer<typeof demandeAvisLigneSchema>;
+
+export const listDemandesAvisOutputSchema = z.object({
+  items: demandeAvisLigneSchema.array(),
+  total: z.number().int(),
+  page: z.number().int(),
+  limit: z.number().int(),
+  countByEtat: z.record(pcaetDemandeAvisEtatSchema, z.number().int()),
+});
+
+export type ListDemandesAvisOutput = z.infer<
+  typeof listDemandesAvisOutputSchema
+>;
+
+export const emptyCountByEtat = (): Record<
+  (typeof pcaetDemandeAvisEtatValues)[number],
+  number
+> => ({
+  a_traiter: 0,
+  brouillon_en_cours: 0,
+  avis_rendu: 0,
+  delai_ecoule: 0,
+  clos: 0,
+});

--- a/apps/backend/src/demarches/pcaet/list-demandes-avis/list-demandes-avis.repository.ts
+++ b/apps/backend/src/demarches/pcaet/list-demandes-avis/list-demandes-avis.repository.ts
@@ -1,0 +1,174 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { collectiviteTable } from '@tet/backend/collectivites/shared/models/collectivite.table';
+import { demarcheTable } from '@tet/backend/demarches/shared/models/demarche.table';
+import { dcpTable } from '@tet/backend/users/models/dcp.table';
+import { utilisateurCollectiviteAccessTable } from '@tet/backend/users/authorizations/utilisateur-collectivite-access.table';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { failure, Result, success } from '@tet/backend/utils/result.type';
+import { getCleGeoInstructeur } from '@tet/domain/demarches';
+import { CollectiviteRole } from '@tet/domain/users';
+import { and, eq, inArray, sql } from 'drizzle-orm';
+import { pcaetAvisTable } from '../shared/models/pcaet-avis.table';
+import { pcaetDemandeAvisTable } from '../shared/models/pcaet-demande-avis.table';
+import type { DemarchePcaetStatus } from '@tet/domain/demarches';
+import {
+  ListDemandesAvisError,
+  ListDemandesAvisErrorEnum,
+} from './list-demandes-avis.errors';
+import type { DemandeAvisContact } from './list-demandes-avis.output';
+
+export type DemandeAvisRow = {
+  demandeAvisId: number;
+  demarcheId: number;
+  demarcheTitre: string;
+  demarcheStatus: DemarchePcaetStatus;
+  avisDeadlineAt: string | null;
+  transmittedAt: string | null;
+  collectiviteId: number;
+  collectiviteNom: string;
+  collectiviteDepartementCode: string | null;
+  nbAvisValides: number;
+  nbAvisBrouillons: number;
+};
+
+@Injectable()
+export class ListDemandesAvisRepository {
+  private readonly logger = new Logger(ListDemandesAvisRepository.name);
+
+  constructor(private readonly databaseService: DatabaseService) {}
+
+  async listDemandesCouvertes(
+    instructeurCollectiviteId: number,
+    tx?: Transaction
+  ): Promise<Result<DemandeAvisRow[], ListDemandesAvisError>> {
+    const db = tx ?? this.databaseService.db;
+
+    try {
+      const instructrices = await db
+        .select({
+          type: collectiviteTable.type,
+          regionCode: collectiviteTable.regionCode,
+          departementCode: collectiviteTable.departementCode,
+        })
+        .from(collectiviteTable)
+        .where(eq(collectiviteTable.id, instructeurCollectiviteId))
+        .limit(1);
+
+      const instructrice = instructrices[0];
+      if (!instructrice) {
+        return success([]);
+      }
+
+      const cleGeo = getCleGeoInstructeur(instructrice.type);
+      if (!cleGeo) {
+        return success([]);
+      }
+
+      const codeInstructrice =
+        cleGeo === 'regionCode'
+          ? instructrice.regionCode
+          : instructrice.departementCode;
+
+      if (!codeInstructrice) {
+        return success([]);
+      }
+
+      const colonneDeposante =
+        cleGeo === 'regionCode'
+          ? collectiviteTable.regionCode
+          : collectiviteTable.departementCode;
+
+      const rows = await db
+        .select({
+          demandeAvisId: pcaetDemandeAvisTable.id,
+          demarcheId: demarcheTable.id,
+          demarcheTitre: demarcheTable.titre,
+          demarcheStatus: demarcheTable.status,
+          avisDeadlineAt: demarcheTable.avisDeadlineAt,
+          transmittedAt: demarcheTable.transmittedAt,
+          collectiviteId: collectiviteTable.id,
+          collectiviteNom: collectiviteTable.nom,
+          collectiviteDepartementCode: collectiviteTable.departementCode,
+          nbAvisValides: sql<number>`(
+            select count(*)::int from ${pcaetAvisTable}
+            where ${pcaetAvisTable.demandeAvisId} = ${pcaetDemandeAvisTable.id}
+              and ${pcaetAvisTable.valideLe} is not null
+          )`,
+          nbAvisBrouillons: sql<number>`(
+            select count(*)::int from ${pcaetAvisTable}
+            where ${pcaetAvisTable.demandeAvisId} = ${pcaetDemandeAvisTable.id}
+              and ${pcaetAvisTable.valideLe} is null
+          )`,
+        })
+        .from(pcaetDemandeAvisTable)
+        .innerJoin(
+          demarcheTable,
+          eq(demarcheTable.id, pcaetDemandeAvisTable.demarcheId)
+        )
+        .innerJoin(
+          collectiviteTable,
+          eq(collectiviteTable.id, demarcheTable.collectiviteId)
+        )
+        .where(
+          and(
+            eq(
+              pcaetDemandeAvisTable.instructeurCollectiviteId,
+              instructeurCollectiviteId
+            ),
+            eq(colonneDeposante, codeInstructrice)
+          )
+        );
+
+      return success(rows);
+    } catch (error) {
+      this.logger.error(
+        `Error listing demandes avis for collectivite ${instructeurCollectiviteId}: ${error}`
+      );
+      return failure(ListDemandesAvisErrorEnum.LIST_DEMANDES_AVIS_ERROR);
+    }
+  }
+
+  async listContactsParCollectivite(
+    collectiviteIds: number[],
+    tx?: Transaction
+  ): Promise<Map<number, DemandeAvisContact[]>> {
+    if (collectiviteIds.length === 0) {
+      return new Map();
+    }
+
+    const db = tx ?? this.databaseService.db;
+
+    const rows = await db
+      .select({
+        collectiviteId: utilisateurCollectiviteAccessTable.collectiviteId,
+        prenom: dcpTable.prenom,
+        nom: dcpTable.nom,
+        email: dcpTable.email,
+      })
+      .from(utilisateurCollectiviteAccessTable)
+      .innerJoin(
+        dcpTable,
+        eq(dcpTable.id, utilisateurCollectiviteAccessTable.userId)
+      )
+      .where(
+        and(
+          inArray(
+            utilisateurCollectiviteAccessTable.collectiviteId,
+            collectiviteIds
+          ),
+          eq(utilisateurCollectiviteAccessTable.isActive, true),
+          eq(utilisateurCollectiviteAccessTable.role, CollectiviteRole.ADMIN),
+          eq(dcpTable.deleted, false)
+        )
+      );
+
+    const parCollectivite = new Map<number, DemandeAvisContact[]>();
+    for (const { collectiviteId, ...contact } of rows) {
+      const contacts = parCollectivite.get(collectiviteId) ?? [];
+      contacts.push(contact);
+      parCollectivite.set(collectiviteId, contacts);
+    }
+    return parCollectivite;
+  }
+}

--- a/apps/backend/src/demarches/pcaet/list-demandes-avis/list-demandes-avis.router.e2e-spec.ts
+++ b/apps/backend/src/demarches/pcaet/list-demandes-avis/list-demandes-avis.router.e2e-spec.ts
@@ -1,0 +1,235 @@
+import { INestApplication } from '@nestjs/common';
+import { addTestCollectiviteAndUser } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { demarcheTable } from '@tet/backend/demarches/shared/models/demarche.table';
+import {
+  getAuthUserFromUserCredentials,
+  getTestApp,
+  getTestDatabase,
+  getTestRouter,
+} from '@tet/backend/test';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { PcaetDemandeAvisEtatEnum } from '@tet/domain/demarches';
+import { CollectiviteRole } from '@tet/domain/users';
+import { eq, inArray } from 'drizzle-orm';
+import { pcaetAvisTable } from '../shared/models/pcaet-avis.table';
+import { pcaetDemandeAvisTable } from '../shared/models/pcaet-demande-avis.table';
+
+describe('listDemandesAvis', () => {
+  let app: INestApplication;
+  let db: DatabaseService;
+  let router: Awaited<ReturnType<typeof getTestRouter>>;
+  let camille: AuthenticatedUser;
+  let marie: AuthenticatedUser;
+  let marieEmail: string;
+  let drealId: number;
+  const demarcheIds: number[] = [];
+
+  const REGION = '44';
+  const AUTRE_REGION = '75';
+
+  const dansNJours = (n: number) =>
+    new Date(Date.now() + n * 24 * 3600 * 1000).toISOString();
+
+  const appeler = (user: AuthenticatedUser, input: Record<string, unknown>) =>
+    router
+      .createCaller({ user })
+      .demarches.pcaet.listDemandesAvis({
+        collectiviteId: drealId,
+        ...input,
+      });
+
+  const creerDossier = async ({
+    collectiviteId,
+    status,
+    avisDeadlineAt,
+    avis,
+  }: {
+    collectiviteId: number;
+    status: 'transmis_pour_avis' | 'adopte';
+    avisDeadlineAt: string;
+    avis?: { valide: boolean };
+  }) => {
+    const [demarche] = await db.db
+      .insert(demarcheTable)
+      .values({
+        collectiviteId,
+        type: 'pcaet',
+        titre: 'PCAET test liste',
+        status,
+        transmittedAt: dansNJours(-30),
+        avisDeadlineAt,
+      })
+      .returning({ id: demarcheTable.id });
+    demarcheIds.push(demarche.id);
+
+    const [demande] = await db.db
+      .insert(pcaetDemandeAvisTable)
+      .values({
+        demarcheId: demarche.id,
+        instructeurCollectiviteId: drealId,
+        source: 'seed',
+      })
+      .returning({ id: pcaetDemandeAvisTable.id });
+
+    if (avis) {
+      await db.db.insert(pcaetAvisTable).values({
+        demandeAvisId: demande.id,
+        emetteurCollectiviteId: drealId,
+        auTitreDe: 'prefet_region',
+        sens: 'favorable',
+        fichierRef: avis.valide ? 'avis/test.pdf' : null,
+        valideLe: avis.valide ? new Date().toISOString() : null,
+      });
+    }
+
+    return demande.id;
+  };
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    db = await getTestDatabase(app);
+    router = await getTestRouter(app);
+
+    const dreal = await addTestCollectiviteAndUser(db, {
+      user: { role: CollectiviteRole.ADMIN },
+      collectivite: {
+        type: 'dreal',
+        regionCode: REGION,
+        nom: 'DREAL test liste demandes',
+      },
+    });
+    camille = getAuthUserFromUserCredentials(dreal.user);
+    drealId = dreal.collectivite.id;
+
+    const aTraiter = await addTestCollectiviteAndUser(db, {
+      user: { role: CollectiviteRole.ADMIN },
+      collectivite: {
+        regionCode: REGION,
+        departementCode: '54',
+        nom: 'Zitrone Agglo',
+      },
+    });
+    marie = getAuthUserFromUserCredentials(aTraiter.user);
+    marieEmail = aTraiter.user.email;
+
+    const avisRendu = await addTestCollectiviteAndUser(db, {
+      user: { role: CollectiviteRole.ADMIN },
+      collectivite: {
+        regionCode: REGION,
+        departementCode: '67',
+        nom: 'Abricot Communaute',
+      },
+    });
+
+    const horsPerimetre = await addTestCollectiviteAndUser(db, {
+      user: { role: CollectiviteRole.ADMIN },
+      collectivite: { regionCode: AUTRE_REGION, nom: 'Melon Metropole' },
+    });
+
+    await creerDossier({
+      collectiviteId: aTraiter.collectivite.id,
+      status: 'transmis_pour_avis',
+      avisDeadlineAt: dansNJours(60),
+    });
+    await creerDossier({
+      collectiviteId: avisRendu.collectivite.id,
+      status: 'transmis_pour_avis',
+      avisDeadlineAt: dansNJours(10),
+      avis: { valide: true },
+    });
+    await creerDossier({
+      collectiviteId: horsPerimetre.collectivite.id,
+      status: 'transmis_pour_avis',
+      avisDeadlineAt: dansNJours(20),
+    });
+
+    return async () => {
+      await db.db
+        .delete(pcaetDemandeAvisTable)
+        .where(inArray(pcaetDemandeAvisTable.demarcheId, demarcheIds));
+      await db.db
+        .delete(demarcheTable)
+        .where(inArray(demarcheTable.id, demarcheIds));
+      await horsPerimetre.cleanup();
+      await avisRendu.cleanup();
+      await aTraiter.cleanup();
+      await dreal.cleanup();
+      await app.close();
+    };
+  });
+
+  it('ne liste que les dossiers couverts par le périmètre de la DREAL', async () => {
+    const result = await appeler(camille, {});
+
+    expect(result.total).toBe(2);
+    expect(result.items.map((item) => item.collectivite.nom)).not.toContain(
+      'Melon Metropole'
+    );
+  });
+
+  it('trie par échéance croissante par défaut', async () => {
+    const result = await appeler(camille, {});
+
+    expect(result.items.map((item) => item.collectivite.nom)).toEqual([
+      'Abricot Communaute',
+      'Zitrone Agglo',
+    ]);
+  });
+
+  it('déduit les états et les compte', async () => {
+    const result = await appeler(camille, {});
+
+    const parNom = new Map(
+      result.items.map((item) => [item.collectivite.nom, item.etat])
+    );
+    expect(parNom.get('Zitrone Agglo')).toBe(PcaetDemandeAvisEtatEnum.A_TRAITER);
+    expect(parNom.get('Abricot Communaute')).toBe(
+      PcaetDemandeAvisEtatEnum.AVIS_RENDU
+    );
+    expect(result.countByEtat.a_traiter).toBe(1);
+    expect(result.countByEtat.avis_rendu).toBe(1);
+    expect(result.countByEtat.clos).toBe(0);
+  });
+
+  it('filtre par état', async () => {
+    const result = await appeler(camille, {
+      etats: [PcaetDemandeAvisEtatEnum.A_TRAITER],
+    });
+
+    expect(result.total).toBe(1);
+    expect(result.items[0].collectivite.nom).toBe('Zitrone Agglo');
+  });
+
+  it('filtre par département', async () => {
+    const result = await appeler(camille, { departementCodes: ['67'] });
+
+    expect(result.total).toBe(1);
+    expect(result.items[0].collectivite.nom).toBe('Abricot Communaute');
+  });
+
+  it('recherche par nom de collectivité, insensible à la casse', async () => {
+    const result = await appeler(camille, { recherche: 'zitrone' });
+
+    expect(result.total).toBe(1);
+    expect(result.items[0].collectivite.nom).toBe('Zitrone Agglo');
+  });
+
+  it('pagine sans perdre le total', async () => {
+    const result = await appeler(camille, { limit: 1, page: 2 });
+
+    expect(result.total).toBe(2);
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].collectivite.nom).toBe('Zitrone Agglo');
+  });
+
+  it('expose le référent de la collectivité comme contact', async () => {
+    const result = await appeler(camille, { recherche: 'zitrone' });
+
+    expect(result.items[0].contacts.map((c) => c.email)).toContain(marieEmail);
+  });
+
+  it("refuse l'agente d'une collectivité déposante", async () => {
+    await expect(appeler(marie, {})).rejects.toThrow();
+  });
+});

--- a/apps/backend/src/demarches/pcaet/list-demandes-avis/list-demandes-avis.router.e2e-spec.ts
+++ b/apps/backend/src/demarches/pcaet/list-demandes-avis/list-demandes-avis.router.e2e-spec.ts
@@ -192,6 +192,16 @@ describe('listDemandesAvis', () => {
     expect(result.countByEtat.clos).toBe(0);
   });
 
+  it('agrège les statistiques du tableau de bord sur tout le périmètre', async () => {
+    const result = await appeler(camille, {});
+    const premierePage = await appeler(camille, { limit: 1, page: 1 });
+
+    expect(result.stats.nbCollectivites).toBe(2);
+    expect(result.stats.delaiMoyenJours).not.toBeNull();
+    expect(premierePage.items).toHaveLength(1);
+    expect(premierePage.stats).toEqual(result.stats);
+  });
+
   it('filtre par état', async () => {
     const result = await appeler(camille, {
       etats: [PcaetDemandeAvisEtatEnum.A_TRAITER],

--- a/apps/backend/src/demarches/pcaet/list-demandes-avis/list-demandes-avis.router.ts
+++ b/apps/backend/src/demarches/pcaet/list-demandes-avis/list-demandes-avis.router.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+import { createTrpcErrorHandler } from '@tet/backend/utils/trpc/trpc-error-handler';
+import { TrpcService } from '@tet/backend/utils/trpc/trpc.service';
+import { listDemandesAvisErrorConfig } from './list-demandes-avis.errors';
+import { listDemandesAvisInputSchema } from './list-demandes-avis.input';
+import { ListDemandesAvisService } from './list-demandes-avis.service';
+
+@Injectable()
+export class ListDemandesAvisRouter {
+  constructor(
+    private readonly trpc: TrpcService,
+    private readonly listDemandesAvisService: ListDemandesAvisService
+  ) {}
+
+  private readonly getResultDataOrThrowError = createTrpcErrorHandler(
+    listDemandesAvisErrorConfig
+  );
+
+  router = this.trpc.router({
+    listDemandesAvis: this.trpc.authedProcedure
+      .input(listDemandesAvisInputSchema)
+      .query(async ({ input, ctx }) => {
+        const result = await this.listDemandesAvisService.listDemandesAvis(
+          input,
+          { user: ctx.user }
+        );
+        return this.getResultDataOrThrowError(result);
+      }),
+  });
+}

--- a/apps/backend/src/demarches/pcaet/list-demandes-avis/list-demandes-avis.service.ts
+++ b/apps/backend/src/demarches/pcaet/list-demandes-avis/list-demandes-avis.service.ts
@@ -10,10 +10,13 @@ import {
 import { ListDemandesAvisInput } from './list-demandes-avis.input';
 import {
   DemandeAvisLigne,
+  DemandesAvisStats,
   emptyCountByEtat,
   ListDemandesAvisOutput,
 } from './list-demandes-avis.output';
 import { ListDemandesAvisRepository } from './list-demandes-avis.repository';
+
+const MILLISECONDES_PAR_JOUR = 24 * 60 * 60 * 1000;
 
 @Injectable()
 export class ListDemandesAvisService {
@@ -73,6 +76,7 @@ export class ListDemandesAvisService {
     for (const ligne of lignes) {
       countByEtat[ligne.etat] += 1;
     }
+    const stats = this.calculerStats(lignes, now);
 
     const filtrees = lignes.filter((ligne) => {
       if (input.etats && !input.etats.includes(ligne.etat)) {
@@ -105,7 +109,38 @@ export class ListDemandesAvisService {
       page: input.page,
       limit: input.limit,
       countByEtat,
+      stats,
     });
+  }
+
+  private calculerStats(
+    lignes: DemandeAvisLigne[],
+    now: Date
+  ): DemandesAvisStats {
+    const joursRestants = lignes
+      .filter(
+        (ligne) =>
+          ligne.avisDeadlineAt !== null &&
+          new Date(ligne.avisDeadlineAt).getTime() > now.getTime() &&
+          ligne.nbAvisValides === 0
+      )
+      .map((ligne) =>
+        Math.ceil(
+          (new Date(ligne.avisDeadlineAt as string).getTime() - now.getTime()) /
+            MILLISECONDES_PAR_JOUR
+        )
+      );
+
+    return {
+      nbCollectivites: new Set(lignes.map((ligne) => ligne.collectivite.id))
+        .size,
+      delaiMoyenJours: joursRestants.length
+        ? Math.round(
+            joursRestants.reduce((total, jours) => total + jours, 0) /
+              joursRestants.length
+          )
+        : null,
+    };
   }
 
   private trier(

--- a/apps/backend/src/demarches/pcaet/list-demandes-avis/list-demandes-avis.service.ts
+++ b/apps/backend/src/demarches/pcaet/list-demandes-avis/list-demandes-avis.service.ts
@@ -1,0 +1,138 @@
+import { Injectable } from '@nestjs/common';
+import { ServiceSecondArg } from '@tet/backend/utils/nest/service-second-arg.utils';
+import { failure, Result, success } from '@tet/backend/utils/result.type';
+import { getDemandeAvisEtat } from '@tet/domain/demarches';
+import { DepotPermissionsService } from '../shared/depot-permissions.service';
+import {
+  ListDemandesAvisError,
+  ListDemandesAvisErrorEnum,
+} from './list-demandes-avis.errors';
+import { ListDemandesAvisInput } from './list-demandes-avis.input';
+import {
+  DemandeAvisLigne,
+  emptyCountByEtat,
+  ListDemandesAvisOutput,
+} from './list-demandes-avis.output';
+import { ListDemandesAvisRepository } from './list-demandes-avis.repository';
+
+@Injectable()
+export class ListDemandesAvisService {
+  constructor(
+    private readonly depotPermissionsService: DepotPermissionsService,
+    private readonly listDemandesAvisRepository: ListDemandesAvisRepository
+  ) {}
+
+  async listDemandesAvis(
+    input: ListDemandesAvisInput,
+    { user, tx }: ServiceSecondArg
+  ): Promise<Result<ListDemandesAvisOutput, ListDemandesAvisError>> {
+    const permissionResult =
+      await this.depotPermissionsService.canListerDemandes(
+        input.collectiviteId,
+        { user, tx }
+      );
+    if (!permissionResult.success) {
+      return failure(ListDemandesAvisErrorEnum.UNAUTHORIZED);
+    }
+
+    const rowsResult =
+      await this.listDemandesAvisRepository.listDemandesCouvertes(
+        input.collectiviteId,
+        tx
+      );
+    if (!rowsResult.success) {
+      return rowsResult;
+    }
+
+    const contactsParCollectivite =
+      await this.listDemandesAvisRepository.listContactsParCollectivite(
+        [...new Set(rowsResult.data.map((row) => row.collectiviteId))],
+        tx
+      );
+
+    const now = new Date();
+    const lignes: DemandeAvisLigne[] = rowsResult.data.map((row) => ({
+      demandeAvisId: row.demandeAvisId,
+      demarcheId: row.demarcheId,
+      demarcheTitre: row.demarcheTitre,
+      demarcheStatus: row.demarcheStatus,
+      avisDeadlineAt: row.avisDeadlineAt,
+      transmittedAt: row.transmittedAt,
+      collectivite: {
+        id: row.collectiviteId,
+        nom: row.collectiviteNom,
+        departementCode: row.collectiviteDepartementCode,
+      },
+      contacts: contactsParCollectivite.get(row.collectiviteId) ?? [],
+      etat: getDemandeAvisEtat(row, now),
+      nbAvisValides: row.nbAvisValides,
+      nbAvisBrouillons: row.nbAvisBrouillons,
+    }));
+
+    const countByEtat = emptyCountByEtat();
+    for (const ligne of lignes) {
+      countByEtat[ligne.etat] += 1;
+    }
+
+    const filtrees = lignes.filter((ligne) => {
+      if (input.etats && !input.etats.includes(ligne.etat)) {
+        return false;
+      }
+      if (
+        input.departementCodes &&
+        (ligne.collectivite.departementCode === null ||
+          !input.departementCodes.includes(ligne.collectivite.departementCode))
+      ) {
+        return false;
+      }
+      if (
+        input.recherche &&
+        !ligne.collectivite.nom
+          .toLocaleLowerCase('fr')
+          .includes(input.recherche.toLocaleLowerCase('fr'))
+      ) {
+        return false;
+      }
+      return true;
+    });
+
+    const triees = this.trier(filtrees, input.sort, input.direction);
+    const debut = (input.page - 1) * input.limit;
+
+    return success({
+      items: triees.slice(debut, debut + input.limit),
+      total: triees.length,
+      page: input.page,
+      limit: input.limit,
+      countByEtat,
+    });
+  }
+
+  private trier(
+    lignes: DemandeAvisLigne[],
+    sort: ListDemandesAvisInput['sort'],
+    direction: ListDemandesAvisInput['direction']
+  ): DemandeAvisLigne[] {
+    const sens = direction === 'asc' ? 1 : -1;
+
+    return [...lignes].sort((a, b) => {
+      if (sort === 'collectivite') {
+        return sens * a.collectivite.nom.localeCompare(b.collectivite.nom, 'fr');
+      }
+      if (a.avisDeadlineAt === b.avisDeadlineAt) {
+        return a.collectivite.nom.localeCompare(b.collectivite.nom, 'fr');
+      }
+      if (a.avisDeadlineAt === null) {
+        return 1;
+      }
+      if (b.avisDeadlineAt === null) {
+        return -1;
+      }
+      return (
+        sens *
+        (new Date(a.avisDeadlineAt).getTime() -
+          new Date(b.avisDeadlineAt).getTime())
+      );
+    });
+  }
+}

--- a/apps/backend/src/demarches/pcaet/pcaet.module.ts
+++ b/apps/backend/src/demarches/pcaet/pcaet.module.ts
@@ -40,6 +40,8 @@ import { UpdateDemarchePcaetDocumentAdditionalService } from './documents/update
 import { GetDemarchePcaetRepository } from './get-demarche-pcaet/get-demarche-pcaet.repository';
 import { GetDemarchePcaetRouter } from './get-demarche-pcaet/get-demarche-pcaet.router';
 import { GetDemarchePcaetService } from './get-demarche-pcaet/get-demarche-pcaet.service';
+import { GetDiagnosticInstructionRouter } from './get-diagnostic-instruction/get-diagnostic-instruction.router';
+import { GetDiagnosticInstructionService } from './get-diagnostic-instruction/get-diagnostic-instruction.service';
 import { GetDiagnosticRouter } from './get-diagnostic/get-diagnostic.router';
 import { GetDiagnosticService } from './get-diagnostic/get-diagnostic.service';
 import { GetDossierDocumentUrlRouter } from './get-dossier-document-url/get-dossier-document-url.router';
@@ -136,6 +138,8 @@ import { ValiderPartieInstructionService } from './valider-partie-instruction/va
     ListDemandesAvisRouter,
     GetDossierInstructionService,
     GetDossierInstructionRouter,
+    GetDiagnosticInstructionService,
+    GetDiagnosticInstructionRouter,
     GetDossierDocumentUrlService,
     GetDossierDocumentUrlRouter,
     ValiderPartieInstructionService,

--- a/apps/backend/src/demarches/pcaet/pcaet.module.ts
+++ b/apps/backend/src/demarches/pcaet/pcaet.module.ts
@@ -33,6 +33,9 @@ import { GetDemarchePcaetRouter } from './get-demarche-pcaet/get-demarche-pcaet.
 import { GetDemarchePcaetService } from './get-demarche-pcaet/get-demarche-pcaet.service';
 import { GetDiagnosticRouter } from './get-diagnostic/get-diagnostic.router';
 import { GetDiagnosticService } from './get-diagnostic/get-diagnostic.service';
+import { ListDemandesAvisRepository } from './list-demandes-avis/list-demandes-avis.repository';
+import { ListDemandesAvisRouter } from './list-demandes-avis/list-demandes-avis.router';
+import { ListDemandesAvisService } from './list-demandes-avis/list-demandes-avis.service';
 import { ListDemarchesPcaetRepository } from './list-demarches-pcaet/list-demarches-pcaet.repository';
 import { ListDemarchesPcaetRouter } from './list-demarches-pcaet/list-demarches-pcaet.router';
 import { ListDemarchesPcaetService } from './list-demarches-pcaet/list-demarches-pcaet.service';
@@ -122,6 +125,9 @@ import { UpdateDemarchePcaetService } from './update-demarche-pcaet/update-demar
     ListDemarchesPcaetRepository,
     ListDemarchesPcaetService,
     ListDemarchesPcaetRouter,
+    ListDemandesAvisRepository,
+    ListDemandesAvisService,
+    ListDemandesAvisRouter,
     CreateDemarchePcaetRepository,
     CreateDemarchePcaetService,
     CreateDemarchePcaetRouter,

--- a/apps/backend/src/demarches/pcaet/pcaet.module.ts
+++ b/apps/backend/src/demarches/pcaet/pcaet.module.ts
@@ -42,6 +42,8 @@ import { GetDemarchePcaetRouter } from './get-demarche-pcaet/get-demarche-pcaet.
 import { GetDemarchePcaetService } from './get-demarche-pcaet/get-demarche-pcaet.service';
 import { GetDiagnosticRouter } from './get-diagnostic/get-diagnostic.router';
 import { GetDiagnosticService } from './get-diagnostic/get-diagnostic.service';
+import { GetDossierDocumentUrlRouter } from './get-dossier-document-url/get-dossier-document-url.router';
+import { GetDossierDocumentUrlService } from './get-dossier-document-url/get-dossier-document-url.service';
 import { GetDossierInstructionRouter } from './get-dossier-instruction/get-dossier-instruction.router';
 import { GetDossierInstructionService } from './get-dossier-instruction/get-dossier-instruction.service';
 import { ListDemandesAvisRepository } from './list-demandes-avis/list-demandes-avis.repository';
@@ -134,6 +136,8 @@ import { ValiderPartieInstructionService } from './valider-partie-instruction/va
     ListDemandesAvisRouter,
     GetDossierInstructionService,
     GetDossierInstructionRouter,
+    GetDossierDocumentUrlService,
+    GetDossierDocumentUrlRouter,
     ValiderPartieInstructionService,
     ValiderPartieInstructionRouter,
     CreateDemarchePcaetRepository,

--- a/apps/backend/src/demarches/pcaet/pcaet.module.ts
+++ b/apps/backend/src/demarches/pcaet/pcaet.module.ts
@@ -1,16 +1,27 @@
 import { Module } from '@nestjs/common';
+import { DemarcheDocumentsRepository } from '@tet/backend/demarches/shared/demarche-documents.repository';
+import { DemarchePlanActionsRepository } from '@tet/backend/demarches/shared/demarche-plan-actions.repository';
 import { IndicateursModule } from '@tet/backend/indicateurs/indicateurs.module';
 import { PlanModule } from '@tet/backend/plans/plans/plans.module';
 import { UsersModule } from '@tet/backend/users/users.module';
 import { TransactionModule } from '@tet/backend/utils/transaction/transaction.module';
+import { AddVulnerabiliteThematiqueRouter } from './add-vulnerabilite-thematique/add-vulnerabilite-thematique.router';
+import { AddVulnerabiliteThematiqueService } from './add-vulnerabilite-thematique/add-vulnerabilite-thematique.service';
+import { AdopterDemarchePcaetRouter } from './adopter-demarche/adopter-demarche.router';
+import { AdopterDemarchePcaetService } from './adopter-demarche/adopter-demarche.service';
+import { ArchiverDemarchePcaetRouter } from './archiver-demarche/archiver-demarche.router';
+import { ArchiverDemarchePcaetService } from './archiver-demarche/archiver-demarche.service';
 import { CreateAndLinkPlanRouter } from './create-and-link-plan/create-and-link-plan.router';
 import { CreateAndLinkPlanService } from './create-and-link-plan/create-and-link-plan.service';
 import { CreateDemarchePcaetRepository } from './create-demarche-pcaet/create-demarche-pcaet.repository';
 import { CreateDemarchePcaetRouter } from './create-demarche-pcaet/create-demarche-pcaet.router';
+import { CreateDemarchePcaetService } from './create-demarche-pcaet/create-demarche-pcaet.service';
 import { DeleteDemarchePcaetRepository } from './delete-demarche-pcaet/delete-demarche-pcaet.repository';
 import { DeleteDemarchePcaetRouter } from './delete-demarche-pcaet/delete-demarche-pcaet.router';
 import { DeleteDemarchePcaetService } from './delete-demarche-pcaet/delete-demarche-pcaet.service';
-import { CreateDemarchePcaetService } from './create-demarche-pcaet/create-demarche-pcaet.service';
+import { DepublierDemarchePcaetRouter } from './depublier-demarche/depublier-demarche.router';
+import { DepublierDemarchePcaetService } from './depublier-demarche/depublier-demarche.service';
+import { PcaetDiagnosticRouter } from './diagnostic/pcaet-diagnostic.router';
 import { AddDemarchePcaetDocumentRouter } from './documents/add-document/add-document.router';
 import { AddDemarchePcaetDocumentService } from './documents/add-document/add-document.service';
 import { CreateDemarchePcaetDocumentAdditionalRouter } from './documents/create-document-additional/create-document-additional.router';
@@ -26,8 +37,6 @@ import { SetDemarchePcaetDocumentCouvertureRouter } from './documents/set-docume
 import { SetDemarchePcaetDocumentCouvertureService } from './documents/set-document-couverture/set-document-couverture.service';
 import { UpdateDemarchePcaetDocumentAdditionalRouter } from './documents/update-document-additional/update-document-additional.router';
 import { UpdateDemarchePcaetDocumentAdditionalService } from './documents/update-document-additional/update-document-additional.service';
-import { DemarcheDocumentsRepository } from '@tet/backend/demarches/shared/demarche-documents.repository';
-import { DemarchePlanActionsRepository } from '@tet/backend/demarches/shared/demarche-plan-actions.repository';
 import { GetDemarchePcaetRepository } from './get-demarche-pcaet/get-demarche-pcaet.repository';
 import { GetDemarchePcaetRouter } from './get-demarche-pcaet/get-demarche-pcaet.router';
 import { GetDemarchePcaetService } from './get-demarche-pcaet/get-demarche-pcaet.service';
@@ -40,43 +49,36 @@ import { ListDemarchesPcaetRepository } from './list-demarches-pcaet/list-demarc
 import { ListDemarchesPcaetRouter } from './list-demarches-pcaet/list-demarches-pcaet.router';
 import { ListDemarchesPcaetService } from './list-demarches-pcaet/list-demarches-pcaet.service';
 import { PcaetRouter } from './pcaet.router';
-import { PcaetDiagnosticRouter } from './diagnostic/pcaet-diagnostic.router';
-import { DemarchePcaetDiagnosticRepository } from './shared/demarche-pcaet-diagnostic.repository';
-import { DemarchePcaetDiagnosticService } from './shared/demarche-pcaet-diagnostic.service';
-import { SetDiagnosticYearsRouter } from './set-diagnostic-years/set-diagnostic-years.router';
-import { SetDiagnosticYearsService } from './set-diagnostic-years/set-diagnostic-years.service';
-import { TransmettrePourAvisDemarchePcaetRouter } from './transmettre-pour-avis/transmettre-pour-avis.router';
-import { TransmettrePourAvisDemarchePcaetService } from './transmettre-pour-avis/transmettre-pour-avis.service';
-import { ReprendreElaborationDemarchePcaetRouter } from './reprendre-elaboration/reprendre-elaboration.router';
-import { ReprendreElaborationDemarchePcaetService } from './reprendre-elaboration/reprendre-elaboration.service';
-import { AdopterDemarchePcaetRouter } from './adopter-demarche/adopter-demarche.router';
-import { AdopterDemarchePcaetService } from './adopter-demarche/adopter-demarche.service';
 import { PublierDemarchePcaetRouter } from './publier-demarche/publier-demarche.router';
 import { PublierDemarchePcaetService } from './publier-demarche/publier-demarche.service';
-import { DepublierDemarchePcaetRouter } from './depublier-demarche/depublier-demarche.router';
-import { DepublierDemarchePcaetService } from './depublier-demarche/depublier-demarche.service';
-import { ArchiverDemarchePcaetRouter } from './archiver-demarche/archiver-demarche.router';
-import { ArchiverDemarchePcaetService } from './archiver-demarche/archiver-demarche.service';
-import { DemarchePcaetGuardsService } from './shared/demarche-pcaet-guards.service';
-import { DemarchePcaetTransitionRepository } from './shared/demarche-pcaet-transition.repository';
-import { DemarchePcaetTransitionService } from './shared/demarche-pcaet-transition.service';
-import { DepotPermissionsService } from './shared/depot-permissions.service';
-import { DemarchePcaetPilotesRepository } from './shared/demarche-pcaet-pilotes.repository';
-import { DemarchePcaetRefRepository } from './shared/demarche-pcaet-ref.repository';
-import { DemarchePcaetAccessService } from './shared/demarche-pcaet-access.service';
-import { DemarchePcaetVulnerabiliteReadService } from './shared/demarche-pcaet-vulnerabilite-read.service';
-import { DemarchePcaetVulnerabiliteRepository } from './shared/demarche-pcaet-vulnerabilite.repository';
-import { AddVulnerabiliteThematiqueRouter } from './add-vulnerabilite-thematique/add-vulnerabilite-thematique.router';
-import { AddVulnerabiliteThematiqueService } from './add-vulnerabilite-thematique/add-vulnerabilite-thematique.service';
 import { RemoveVulnerabiliteThematiqueRouter } from './remove-vulnerabilite-thematique/remove-vulnerabilite-thematique.router';
 import { RemoveVulnerabiliteThematiqueService } from './remove-vulnerabilite-thematique/remove-vulnerabilite-thematique.service';
+import { ReprendreElaborationDemarchePcaetRouter } from './reprendre-elaboration/reprendre-elaboration.router';
+import { ReprendreElaborationDemarchePcaetService } from './reprendre-elaboration/reprendre-elaboration.service';
+import { SetDiagnosticYearsRouter } from './set-diagnostic-years/set-diagnostic-years.router';
+import { SetDiagnosticYearsService } from './set-diagnostic-years/set-diagnostic-years.service';
 import { SetVulnerabiliteLigneRouter } from './set-vulnerabilite-ligne/set-vulnerabilite-ligne.router';
 import { SetVulnerabiliteLigneService } from './set-vulnerabilite-ligne/set-vulnerabilite-ligne.service';
+import { DemarchePcaetAccessService } from './shared/demarche-pcaet-access.service';
+import { DemarchePcaetDiagnosticRepository } from './shared/demarche-pcaet-diagnostic.repository';
+import { DemarchePcaetDiagnosticService } from './shared/demarche-pcaet-diagnostic.service';
+import { DemarchePcaetGuardsService } from './shared/demarche-pcaet-guards.service';
+import { DemarchePcaetPilotesRepository } from './shared/demarche-pcaet-pilotes.repository';
+import { DemarchePcaetRefRepository } from './shared/demarche-pcaet-ref.repository';
+import { DemarchePcaetTransitionRepository } from './shared/demarche-pcaet-transition.repository';
+import { DemarchePcaetTransitionService } from './shared/demarche-pcaet-transition.service';
+import { DemarchePcaetVulnerabiliteReadService } from './shared/demarche-pcaet-vulnerabilite-read.service';
+import { DemarchePcaetVulnerabiliteRepository } from './shared/demarche-pcaet-vulnerabilite.repository';
+import { DepotPermissionsService } from './shared/depot-permissions.service';
+import { TransmettrePourAvisDemarchePcaetRouter } from './transmettre-pour-avis/transmettre-pour-avis.router';
+import { TransmettrePourAvisDemarchePcaetService } from './transmettre-pour-avis/transmettre-pour-avis.service';
+import { UpdateDemarchePcaetRepository } from './update-demarche-pcaet/update-demarche-pcaet.repository';
+import { UpdateDemarchePcaetRouter } from './update-demarche-pcaet/update-demarche-pcaet.router';
+import { UpdateDemarchePcaetService } from './update-demarche-pcaet/update-demarche-pcaet.service';
 import { UpdateVulnerabiliteThematiqueRouter } from './update-vulnerabilite-thematique/update-vulnerabilite-thematique.router';
 import { UpdateVulnerabiliteThematiqueService } from './update-vulnerabilite-thematique/update-vulnerabilite-thematique.service';
-import { UpdateDemarchePcaetRouter } from './update-demarche-pcaet/update-demarche-pcaet.router';
-import { UpdateDemarchePcaetRepository } from './update-demarche-pcaet/update-demarche-pcaet.repository';
-import { UpdateDemarchePcaetService } from './update-demarche-pcaet/update-demarche-pcaet.service';
+import { ValiderPartieInstructionRouter } from './valider-partie-instruction/valider-partie-instruction.router';
+import { ValiderPartieInstructionService } from './valider-partie-instruction/valider-partie-instruction.service';
 
 @Module({
   imports: [UsersModule, TransactionModule, IndicateursModule, PlanModule],
@@ -128,6 +130,8 @@ import { UpdateDemarchePcaetService } from './update-demarche-pcaet/update-demar
     ListDemandesAvisRepository,
     ListDemandesAvisService,
     ListDemandesAvisRouter,
+    ValiderPartieInstructionService,
+    ValiderPartieInstructionRouter,
     CreateDemarchePcaetRepository,
     CreateDemarchePcaetService,
     CreateDemarchePcaetRouter,

--- a/apps/backend/src/demarches/pcaet/pcaet.module.ts
+++ b/apps/backend/src/demarches/pcaet/pcaet.module.ts
@@ -42,6 +42,8 @@ import { GetDemarchePcaetRouter } from './get-demarche-pcaet/get-demarche-pcaet.
 import { GetDemarchePcaetService } from './get-demarche-pcaet/get-demarche-pcaet.service';
 import { GetDiagnosticRouter } from './get-diagnostic/get-diagnostic.router';
 import { GetDiagnosticService } from './get-diagnostic/get-diagnostic.service';
+import { GetDossierInstructionRouter } from './get-dossier-instruction/get-dossier-instruction.router';
+import { GetDossierInstructionService } from './get-dossier-instruction/get-dossier-instruction.service';
 import { ListDemandesAvisRepository } from './list-demandes-avis/list-demandes-avis.repository';
 import { ListDemandesAvisRouter } from './list-demandes-avis/list-demandes-avis.router';
 import { ListDemandesAvisService } from './list-demandes-avis/list-demandes-avis.service';
@@ -130,6 +132,8 @@ import { ValiderPartieInstructionService } from './valider-partie-instruction/va
     ListDemandesAvisRepository,
     ListDemandesAvisService,
     ListDemandesAvisRouter,
+    GetDossierInstructionService,
+    GetDossierInstructionRouter,
     ValiderPartieInstructionService,
     ValiderPartieInstructionRouter,
     CreateDemarchePcaetRepository,

--- a/apps/backend/src/demarches/pcaet/pcaet.router.ts
+++ b/apps/backend/src/demarches/pcaet/pcaet.router.ts
@@ -12,6 +12,7 @@ import { DeleteDemarchePcaetRouter } from './delete-demarche-pcaet/delete-demarc
 import { PcaetDiagnosticRouter } from './diagnostic/pcaet-diagnostic.router';
 import { PcaetDocumentsRouter } from './documents/pcaet-documents.router';
 import { GetDemarchePcaetRouter } from './get-demarche-pcaet/get-demarche-pcaet.router';
+import { GetDossierInstructionRouter } from './get-dossier-instruction/get-dossier-instruction.router';
 import { ListDemandesAvisRouter } from './list-demandes-avis/list-demandes-avis.router';
 import { ListDemarchesPcaetRouter } from './list-demarches-pcaet/list-demarches-pcaet.router';
 import { ValiderPartieInstructionRouter } from './valider-partie-instruction/valider-partie-instruction.router';
@@ -23,6 +24,7 @@ export class PcaetRouter {
     private readonly trpc: TrpcService,
     private readonly listDemarchesPcaetRouter: ListDemarchesPcaetRouter,
     private readonly listDemandesAvisRouter: ListDemandesAvisRouter,
+    private readonly getDossierInstructionRouter: GetDossierInstructionRouter,
     private readonly validerPartieInstructionRouter: ValiderPartieInstructionRouter,
     private readonly getDemarchePcaetRouter: GetDemarchePcaetRouter,
     private readonly createDemarchePcaetRouter: CreateDemarchePcaetRouter,
@@ -42,6 +44,7 @@ export class PcaetRouter {
   router = this.trpc.mergeRouters(
     this.listDemarchesPcaetRouter.router,
     this.listDemandesAvisRouter.router,
+    this.getDossierInstructionRouter.router,
     this.validerPartieInstructionRouter.router,
     this.getDemarchePcaetRouter.router,
     this.createDemarchePcaetRouter.router,

--- a/apps/backend/src/demarches/pcaet/pcaet.router.ts
+++ b/apps/backend/src/demarches/pcaet/pcaet.router.ts
@@ -12,6 +12,7 @@ import { DeleteDemarchePcaetRouter } from './delete-demarche-pcaet/delete-demarc
 import { PcaetDiagnosticRouter } from './diagnostic/pcaet-diagnostic.router';
 import { PcaetDocumentsRouter } from './documents/pcaet-documents.router';
 import { GetDemarchePcaetRouter } from './get-demarche-pcaet/get-demarche-pcaet.router';
+import { ListDemandesAvisRouter } from './list-demandes-avis/list-demandes-avis.router';
 import { ListDemarchesPcaetRouter } from './list-demarches-pcaet/list-demarches-pcaet.router';
 import { UpdateDemarchePcaetRouter } from './update-demarche-pcaet/update-demarche-pcaet.router';
 
@@ -20,6 +21,7 @@ export class PcaetRouter {
   constructor(
     private readonly trpc: TrpcService,
     private readonly listDemarchesPcaetRouter: ListDemarchesPcaetRouter,
+    private readonly listDemandesAvisRouter: ListDemandesAvisRouter,
     private readonly getDemarchePcaetRouter: GetDemarchePcaetRouter,
     private readonly createDemarchePcaetRouter: CreateDemarchePcaetRouter,
     private readonly createAndLinkPlanRouter: CreateAndLinkPlanRouter,
@@ -37,6 +39,7 @@ export class PcaetRouter {
 
   router = this.trpc.mergeRouters(
     this.listDemarchesPcaetRouter.router,
+    this.listDemandesAvisRouter.router,
     this.getDemarchePcaetRouter.router,
     this.createDemarchePcaetRouter.router,
     this.createAndLinkPlanRouter.router,

--- a/apps/backend/src/demarches/pcaet/pcaet.router.ts
+++ b/apps/backend/src/demarches/pcaet/pcaet.router.ts
@@ -12,6 +12,7 @@ import { DeleteDemarchePcaetRouter } from './delete-demarche-pcaet/delete-demarc
 import { PcaetDiagnosticRouter } from './diagnostic/pcaet-diagnostic.router';
 import { PcaetDocumentsRouter } from './documents/pcaet-documents.router';
 import { GetDemarchePcaetRouter } from './get-demarche-pcaet/get-demarche-pcaet.router';
+import { GetDossierDocumentUrlRouter } from './get-dossier-document-url/get-dossier-document-url.router';
 import { GetDossierInstructionRouter } from './get-dossier-instruction/get-dossier-instruction.router';
 import { ListDemandesAvisRouter } from './list-demandes-avis/list-demandes-avis.router';
 import { ListDemarchesPcaetRouter } from './list-demarches-pcaet/list-demarches-pcaet.router';
@@ -25,6 +26,7 @@ export class PcaetRouter {
     private readonly listDemarchesPcaetRouter: ListDemarchesPcaetRouter,
     private readonly listDemandesAvisRouter: ListDemandesAvisRouter,
     private readonly getDossierInstructionRouter: GetDossierInstructionRouter,
+    private readonly getDossierDocumentUrlRouter: GetDossierDocumentUrlRouter,
     private readonly validerPartieInstructionRouter: ValiderPartieInstructionRouter,
     private readonly getDemarchePcaetRouter: GetDemarchePcaetRouter,
     private readonly createDemarchePcaetRouter: CreateDemarchePcaetRouter,
@@ -45,6 +47,7 @@ export class PcaetRouter {
     this.listDemarchesPcaetRouter.router,
     this.listDemandesAvisRouter.router,
     this.getDossierInstructionRouter.router,
+    this.getDossierDocumentUrlRouter.router,
     this.validerPartieInstructionRouter.router,
     this.getDemarchePcaetRouter.router,
     this.createDemarchePcaetRouter.router,

--- a/apps/backend/src/demarches/pcaet/pcaet.router.ts
+++ b/apps/backend/src/demarches/pcaet/pcaet.router.ts
@@ -13,6 +13,7 @@ import { PcaetDiagnosticRouter } from './diagnostic/pcaet-diagnostic.router';
 import { PcaetDocumentsRouter } from './documents/pcaet-documents.router';
 import { GetDemarchePcaetRouter } from './get-demarche-pcaet/get-demarche-pcaet.router';
 import { GetDossierDocumentUrlRouter } from './get-dossier-document-url/get-dossier-document-url.router';
+import { GetDiagnosticInstructionRouter } from './get-diagnostic-instruction/get-diagnostic-instruction.router';
 import { GetDossierInstructionRouter } from './get-dossier-instruction/get-dossier-instruction.router';
 import { ListDemandesAvisRouter } from './list-demandes-avis/list-demandes-avis.router';
 import { ListDemarchesPcaetRouter } from './list-demarches-pcaet/list-demarches-pcaet.router';
@@ -27,6 +28,7 @@ export class PcaetRouter {
     private readonly listDemandesAvisRouter: ListDemandesAvisRouter,
     private readonly getDossierInstructionRouter: GetDossierInstructionRouter,
     private readonly getDossierDocumentUrlRouter: GetDossierDocumentUrlRouter,
+    private readonly getDiagnosticInstructionRouter: GetDiagnosticInstructionRouter,
     private readonly validerPartieInstructionRouter: ValiderPartieInstructionRouter,
     private readonly getDemarchePcaetRouter: GetDemarchePcaetRouter,
     private readonly createDemarchePcaetRouter: CreateDemarchePcaetRouter,
@@ -48,6 +50,7 @@ export class PcaetRouter {
     this.listDemandesAvisRouter.router,
     this.getDossierInstructionRouter.router,
     this.getDossierDocumentUrlRouter.router,
+    this.getDiagnosticInstructionRouter.router,
     this.validerPartieInstructionRouter.router,
     this.getDemarchePcaetRouter.router,
     this.createDemarchePcaetRouter.router,

--- a/apps/backend/src/demarches/pcaet/pcaet.router.ts
+++ b/apps/backend/src/demarches/pcaet/pcaet.router.ts
@@ -14,6 +14,7 @@ import { PcaetDocumentsRouter } from './documents/pcaet-documents.router';
 import { GetDemarchePcaetRouter } from './get-demarche-pcaet/get-demarche-pcaet.router';
 import { ListDemandesAvisRouter } from './list-demandes-avis/list-demandes-avis.router';
 import { ListDemarchesPcaetRouter } from './list-demarches-pcaet/list-demarches-pcaet.router';
+import { ValiderPartieInstructionRouter } from './valider-partie-instruction/valider-partie-instruction.router';
 import { UpdateDemarchePcaetRouter } from './update-demarche-pcaet/update-demarche-pcaet.router';
 
 @Injectable()
@@ -22,6 +23,7 @@ export class PcaetRouter {
     private readonly trpc: TrpcService,
     private readonly listDemarchesPcaetRouter: ListDemarchesPcaetRouter,
     private readonly listDemandesAvisRouter: ListDemandesAvisRouter,
+    private readonly validerPartieInstructionRouter: ValiderPartieInstructionRouter,
     private readonly getDemarchePcaetRouter: GetDemarchePcaetRouter,
     private readonly createDemarchePcaetRouter: CreateDemarchePcaetRouter,
     private readonly createAndLinkPlanRouter: CreateAndLinkPlanRouter,
@@ -40,6 +42,7 @@ export class PcaetRouter {
   router = this.trpc.mergeRouters(
     this.listDemarchesPcaetRouter.router,
     this.listDemandesAvisRouter.router,
+    this.validerPartieInstructionRouter.router,
     this.getDemarchePcaetRouter.router,
     this.createDemarchePcaetRouter.router,
     this.createAndLinkPlanRouter.router,

--- a/apps/backend/src/demarches/pcaet/shared/depot-permissions.service.ts
+++ b/apps/backend/src/demarches/pcaet/shared/depot-permissions.service.ts
@@ -10,6 +10,7 @@ import { failure, Result, success } from '@tet/backend/utils/result.type';
 import {
   fenetreAvisOuverte,
   instructeurCouvreCollectivite,
+  isTypeInstructeur,
   type FenetreAvisEntree,
   type PerimetreInstructeurEntree,
 } from '@tet/domain/demarches';
@@ -31,6 +32,28 @@ export class DepotPermissionsService {
     private readonly databaseService: DatabaseService,
     private readonly permissionService: PermissionService
   ) {}
+
+  async canListerDemandes(
+    instructeurCollectiviteId: number,
+    { user, tx }: ServiceSecondArg
+  ): Promise<Result<void, DepotPermissionsError>> {
+    const rows = await (tx ?? this.databaseService.db)
+      .select({ type: collectiviteTable.type })
+      .from(collectiviteTable)
+      .where(eq(collectiviteTable.id, instructeurCollectiviteId))
+      .limit(1);
+
+    const collectivite = rows[0];
+    if (!collectivite || !isTypeInstructeur(collectivite.type)) {
+      return failure(DepotPermissionsErrorEnum.UNAUTHORIZED);
+    }
+
+    if (!(await this.isMembreActif(user.id, instructeurCollectiviteId, tx))) {
+      return failure(DepotPermissionsErrorEnum.UNAUTHORIZED);
+    }
+
+    return success(undefined);
+  }
 
   async canConsulterDepot(
     demandeAvisId: number,

--- a/apps/backend/src/demarches/pcaet/shared/models/pcaet-instruction-validation.table.ts
+++ b/apps/backend/src/demarches/pcaet/shared/models/pcaet-instruction-validation.table.ts
@@ -1,0 +1,33 @@
+import { authUsersTable } from '@tet/backend/users/models/auth-users.table';
+import { TIMESTAMP_OPTIONS } from '@tet/backend/utils/column.utils';
+import type { PcaetInstructionPartie } from '@tet/domain/demarches';
+import {
+  integer,
+  pgTable,
+  text,
+  timestamp,
+  unique,
+  uuid,
+} from 'drizzle-orm/pg-core';
+import { pcaetDemandeAvisTable } from './pcaet-demande-avis.table';
+
+export const pcaetInstructionValidationTable = pgTable(
+  'pcaet_instruction_validation',
+  {
+    id: integer('id').primaryKey().generatedAlwaysAsIdentity(),
+    demandeAvisId: integer('demande_avis_id')
+      .notNull()
+      .references(() => pcaetDemandeAvisTable.id, { onDelete: 'cascade' }),
+    partie: text('partie').notNull().$type<PcaetInstructionPartie>(),
+    validePar: uuid('valide_par').references(() => authUsersTable.id, {
+      onDelete: 'set null',
+    }),
+    valideLe: timestamp('valide_le', TIMESTAMP_OPTIONS).defaultNow().notNull(),
+  },
+  (table) => [
+    unique('pcaet_instruction_validation_unique_partie').on(
+      table.demandeAvisId,
+      table.partie
+    ),
+  ]
+);

--- a/apps/backend/src/demarches/pcaet/valider-partie-instruction/valider-partie-instruction.errors.ts
+++ b/apps/backend/src/demarches/pcaet/valider-partie-instruction/valider-partie-instruction.errors.ts
@@ -1,0 +1,22 @@
+import {
+  createErrorsEnum,
+  TrpcErrorHandlerConfig,
+} from '@tet/backend/utils/trpc/trpc-error-handler';
+
+const specificErrors = ['DEMANDE_AVIS_NOT_FOUND'] as const;
+type SpecificError = (typeof specificErrors)[number];
+
+export const validerPartieInstructionErrorConfig: TrpcErrorHandlerConfig<SpecificError> =
+  {
+    specificErrors: {
+      DEMANDE_AVIS_NOT_FOUND: {
+        code: 'NOT_FOUND',
+        message: "La demande d'avis n'a pas été trouvée",
+      },
+    },
+  };
+
+export const ValiderPartieInstructionErrorEnum =
+  createErrorsEnum(specificErrors);
+export type ValiderPartieInstructionError =
+  keyof typeof ValiderPartieInstructionErrorEnum;

--- a/apps/backend/src/demarches/pcaet/valider-partie-instruction/valider-partie-instruction.input.ts
+++ b/apps/backend/src/demarches/pcaet/valider-partie-instruction/valider-partie-instruction.input.ts
@@ -1,0 +1,12 @@
+import { pcaetInstructionPartieValues } from '@tet/domain/demarches';
+import { z } from 'zod';
+
+export const validerPartieInstructionInputSchema = z.object({
+  demandeAvisId: z.number().int().positive(),
+  partie: z.enum(pcaetInstructionPartieValues),
+  validee: z.boolean(),
+});
+
+export type ValiderPartieInstructionInput = z.infer<
+  typeof validerPartieInstructionInputSchema
+>;

--- a/apps/backend/src/demarches/pcaet/valider-partie-instruction/valider-partie-instruction.output.ts
+++ b/apps/backend/src/demarches/pcaet/valider-partie-instruction/valider-partie-instruction.output.ts
@@ -1,0 +1,10 @@
+import { pcaetInstructionPartieSchema } from '@tet/domain/demarches';
+import { z } from 'zod';
+
+export const partieValideeSchema = z.object({
+  partie: pcaetInstructionPartieSchema,
+  valideLe: z.string(),
+  validePar: z.string().nullable(),
+});
+
+export type PartieValidee = z.infer<typeof partieValideeSchema>;

--- a/apps/backend/src/demarches/pcaet/valider-partie-instruction/valider-partie-instruction.router.e2e-spec.ts
+++ b/apps/backend/src/demarches/pcaet/valider-partie-instruction/valider-partie-instruction.router.e2e-spec.ts
@@ -1,0 +1,135 @@
+import { INestApplication } from '@nestjs/common';
+import { addTestCollectiviteAndUser } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { demarcheTable } from '@tet/backend/demarches/shared/models/demarche.table';
+import {
+  getAuthUserFromUserCredentials,
+  getTestApp,
+  getTestDatabase,
+  getTestRouter,
+} from '@tet/backend/test';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { CollectiviteRole } from '@tet/domain/users';
+import { eq } from 'drizzle-orm';
+import { pcaetDemandeAvisTable } from '../shared/models/pcaet-demande-avis.table';
+
+describe('validerPartieInstruction', () => {
+  let app: INestApplication;
+  let db: DatabaseService;
+  let router: Awaited<ReturnType<typeof getTestRouter>>;
+  let camille: AuthenticatedUser;
+  let marie: AuthenticatedUser;
+  let demarcheId: number;
+  let demandeAvisId: number;
+
+  const REGION = '53';
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    db = await getTestDatabase(app);
+    router = await getTestRouter(app);
+
+    const deposante = await addTestCollectiviteAndUser(db, {
+      user: { role: CollectiviteRole.ADMIN },
+      collectivite: { regionCode: REGION, nom: 'Agglo test validation' },
+    });
+    marie = getAuthUserFromUserCredentials(deposante.user);
+
+    const dreal = await addTestCollectiviteAndUser(db, {
+      user: { role: CollectiviteRole.ADMIN },
+      collectivite: {
+        type: 'dreal',
+        regionCode: REGION,
+        nom: 'DREAL test validation',
+      },
+    });
+    camille = getAuthUserFromUserCredentials(dreal.user);
+
+    const [demarche] = await db.db
+      .insert(demarcheTable)
+      .values({
+        collectiviteId: deposante.collectivite.id,
+        type: 'pcaet',
+        titre: 'PCAET test validation',
+        status: 'transmis_pour_avis',
+        transmittedAt: new Date().toISOString(),
+        avisDeadlineAt: new Date(
+          Date.now() + 30 * 24 * 3600 * 1000
+        ).toISOString(),
+      })
+      .returning({ id: demarcheTable.id });
+    demarcheId = demarche.id;
+
+    const [demande] = await db.db
+      .insert(pcaetDemandeAvisTable)
+      .values({
+        demarcheId,
+        instructeurCollectiviteId: dreal.collectivite.id,
+        source: 'seed',
+      })
+      .returning({ id: pcaetDemandeAvisTable.id });
+    demandeAvisId = demande.id;
+
+    return async () => {
+      await db.db
+        .delete(pcaetDemandeAvisTable)
+        .where(eq(pcaetDemandeAvisTable.id, demandeAvisId));
+      await db.db.delete(demarcheTable).where(eq(demarcheTable.id, demarcheId));
+      await dreal.cleanup();
+      await deposante.cleanup();
+      await app.close();
+    };
+  });
+
+  const valider = (
+    user: AuthenticatedUser,
+    partie: 'documents' | 'diagnostic' | 'plan',
+    validee: boolean
+  ) =>
+    router.createCaller({ user }).demarches.pcaet.validerPartieInstruction({
+      demandeAvisId,
+      partie,
+      validee,
+    });
+
+  it('valide une partie et la retrouve dans le dossier', async () => {
+    const validations = await valider(camille, 'documents', true);
+
+    expect(validations.map((v) => v.partie)).toEqual(['documents']);
+    expect(validations[0].validePar).toBe(camille.id);
+
+    const dossier = await router
+      .createCaller({ user: camille })
+      .demarches.pcaet.getDossierInstruction({ demandeAvisId });
+    expect(dossier.partiesValidees.map((v) => v.partie)).toEqual(['documents']);
+  });
+
+  it('revalider la même partie ne crée pas de doublon et garde le premier auteur', async () => {
+    const validations = await valider(camille, 'documents', true);
+
+    expect(validations).toHaveLength(1);
+    expect(validations[0].validePar).toBe(camille.id);
+  });
+
+  it('dévalide en supprimant la ligne', async () => {
+    await valider(camille, 'diagnostic', true);
+    const validations = await valider(camille, 'diagnostic', false);
+
+    expect(validations.map((v) => v.partie)).toEqual(['documents']);
+  });
+
+  it("refuse l'agente de la collectivité déposante", async () => {
+    await expect(valider(marie, 'plan', true)).rejects.toThrow();
+  });
+
+  it("refuse quand la fenêtre d'avis est fermée", async () => {
+    await db.db
+      .update(demarcheTable)
+      .set({
+        avisDeadlineAt: new Date(Date.now() - 24 * 3600 * 1000).toISOString(),
+      })
+      .where(eq(demarcheTable.id, demarcheId));
+
+    await expect(valider(camille, 'plan', true)).rejects.toThrow();
+  });
+});

--- a/apps/backend/src/demarches/pcaet/valider-partie-instruction/valider-partie-instruction.router.ts
+++ b/apps/backend/src/demarches/pcaet/valider-partie-instruction/valider-partie-instruction.router.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@nestjs/common';
+import { createTrpcErrorHandler } from '@tet/backend/utils/trpc/trpc-error-handler';
+import { TrpcService } from '@tet/backend/utils/trpc/trpc.service';
+import { validerPartieInstructionErrorConfig } from './valider-partie-instruction.errors';
+import { validerPartieInstructionInputSchema } from './valider-partie-instruction.input';
+import { ValiderPartieInstructionService } from './valider-partie-instruction.service';
+
+@Injectable()
+export class ValiderPartieInstructionRouter {
+  constructor(
+    private readonly trpc: TrpcService,
+    private readonly validerPartieInstructionService: ValiderPartieInstructionService
+  ) {}
+
+  private readonly getResultDataOrThrowError = createTrpcErrorHandler(
+    validerPartieInstructionErrorConfig
+  );
+
+  router = this.trpc.router({
+    validerPartieInstruction: this.trpc.authedProcedure
+      .input(validerPartieInstructionInputSchema)
+      .mutation(async ({ input, ctx }) => {
+        const result =
+          await this.validerPartieInstructionService.validerPartieInstruction(
+            input,
+            { user: ctx.user }
+          );
+        return this.getResultDataOrThrowError(result);
+      }),
+  });
+}

--- a/apps/backend/src/demarches/pcaet/valider-partie-instruction/valider-partie-instruction.service.ts
+++ b/apps/backend/src/demarches/pcaet/valider-partie-instruction/valider-partie-instruction.service.ts
@@ -1,0 +1,64 @@
+import { Injectable } from '@nestjs/common';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { ServiceSecondArg } from '@tet/backend/utils/nest/service-second-arg.utils';
+import { failure, Result, success } from '@tet/backend/utils/result.type';
+import { and, eq } from 'drizzle-orm';
+import { DepotPermissionsService } from '../shared/depot-permissions.service';
+import { pcaetInstructionValidationTable } from '../shared/models/pcaet-instruction-validation.table';
+import { PartieValidee } from './valider-partie-instruction.output';
+import {
+  ValiderPartieInstructionError,
+  ValiderPartieInstructionErrorEnum,
+} from './valider-partie-instruction.errors';
+import { ValiderPartieInstructionInput } from './valider-partie-instruction.input';
+
+@Injectable()
+export class ValiderPartieInstructionService {
+  constructor(
+    private readonly databaseService: DatabaseService,
+    private readonly depotPermissionsService: DepotPermissionsService
+  ) {}
+
+  async validerPartieInstruction(
+    { demandeAvisId, partie, validee }: ValiderPartieInstructionInput,
+    { user, tx }: ServiceSecondArg
+  ): Promise<Result<PartieValidee[], ValiderPartieInstructionError>> {
+    const permissionResult =
+      await this.depotPermissionsService.canDeposerAvis(demandeAvisId, {
+        user,
+        tx,
+      });
+    if (!permissionResult.success) {
+      return failure(permissionResult.error);
+    }
+
+    const db = tx ?? this.databaseService.db;
+
+    if (validee) {
+      await db
+        .insert(pcaetInstructionValidationTable)
+        .values({ demandeAvisId, partie, validePar: user.id })
+        .onConflictDoNothing();
+    } else {
+      await db
+        .delete(pcaetInstructionValidationTable)
+        .where(
+          and(
+            eq(pcaetInstructionValidationTable.demandeAvisId, demandeAvisId),
+            eq(pcaetInstructionValidationTable.partie, partie)
+          )
+        );
+    }
+
+    const rows = await db
+      .select({
+        partie: pcaetInstructionValidationTable.partie,
+        valideLe: pcaetInstructionValidationTable.valideLe,
+        validePar: pcaetInstructionValidationTable.validePar,
+      })
+      .from(pcaetInstructionValidationTable)
+      .where(eq(pcaetInstructionValidationTable.demandeAvisId, demandeAvisId));
+
+    return success(rows);
+  }
+}

--- a/data_layer/seed/fakes/26-insert_fake_pcaet_avis.sql
+++ b/data_layer/seed/fakes/26-insert_fake_pcaet_avis.sql
@@ -1,0 +1,151 @@
+set search_path to public;
+
+CREATE TEMP TABLE pcaet_seed_deposantes AS
+SELECT id FROM collectivite
+WHERE siren IN ('200065647', '200010650', '245804406', '200069052', '200067114');
+
+DELETE FROM pcaet_demande_avis
+WHERE demarche_id IN (
+    SELECT id FROM demarche
+    WHERE type = 'pcaet' AND collectivite_id IN (SELECT id FROM pcaet_seed_deposantes)
+);
+
+DELETE FROM demarche
+WHERE type = 'pcaet' AND collectivite_id IN (SELECT id FROM pcaet_seed_deposantes);
+
+DROP TABLE pcaet_seed_deposantes;
+
+INSERT INTO auth.users (instance_id, id, aud, role, email, encrypted_password, email_confirmed_at, invited_at, confirmation_token, confirmation_sent_at, recovery_token, recovery_sent_at, email_change_token_new, email_change, email_change_sent_at, last_sign_in_at, raw_app_meta_data, raw_user_meta_data, is_super_admin, created_at, updated_at, phone, phone_confirmed_at, phone_change, phone_change_token, phone_change_sent_at, email_change_token_current, email_change_confirm_status, banned_until, reauthentication_token, reauthentication_sent_at) VALUES ('00000000-0000-0000-0000-000000000000', '22222222-0cae-4bfc-a000-000000000001', 'authenticated', 'authenticated', 'marie@montbeliard.fr', '$2a$10$zHta6/ak2n7cONYwYodHJOJ0cmnhyXKUomwX0D4X0j3sQqWfXNs0C', now(), null, '', null, '', null, '', '', null, now(), '{"provider": "email", "providers": ["email"]}', '{}', null, now(), now(), null, null, '', '', null, '', 0, null, '', null) ON CONFLICT (id) DO NOTHING;
+UPDATE dcp SET prenom = 'Marie', nom = 'Dupont', cgu_acceptees_le = current_timestamp WHERE user_id = '22222222-0cae-4bfc-a000-000000000001';
+UPDATE utilisateur_verifie SET verifie = true WHERE user_id = '22222222-0cae-4bfc-a000-000000000001';
+INSERT INTO private_utilisateur_droit (user_id, collectivite_id, niveau_acces, active)
+SELECT '22222222-0cae-4bfc-a000-000000000001', id, 'admin', TRUE FROM collectivite WHERE siren = '200065647'
+ON CONFLICT (user_id, collectivite_id) DO NOTHING;
+
+INSERT INTO auth.users (instance_id, id, aud, role, email, encrypted_password, email_confirmed_at, invited_at, confirmation_token, confirmation_sent_at, recovery_token, recovery_sent_at, email_change_token_new, email_change, email_change_sent_at, last_sign_in_at, raw_app_meta_data, raw_user_meta_data, is_super_admin, created_at, updated_at, phone, phone_confirmed_at, phone_change, phone_change_token, phone_change_sent_at, email_change_token_current, email_change_confirm_status, banned_until, reauthentication_token, reauthentication_sent_at) VALUES ('00000000-0000-0000-0000-000000000000', '22222222-0cae-4bfc-a000-000000000002', 'authenticated', 'authenticated', 'karim@nevers.fr', '$2a$10$zHta6/ak2n7cONYwYodHJOJ0cmnhyXKUomwX0D4X0j3sQqWfXNs0C', now(), null, '', null, '', null, '', '', null, now(), '{"provider": "email", "providers": ["email"]}', '{}', null, now(), now(), null, null, '', '', null, '', 0, null, '', null) ON CONFLICT (id) DO NOTHING;
+UPDATE dcp SET prenom = 'Karim', nom = 'Benali', cgu_acceptees_le = current_timestamp WHERE user_id = '22222222-0cae-4bfc-a000-000000000002';
+UPDATE utilisateur_verifie SET verifie = true WHERE user_id = '22222222-0cae-4bfc-a000-000000000002';
+INSERT INTO private_utilisateur_droit (user_id, collectivite_id, niveau_acces, active)
+SELECT '22222222-0cae-4bfc-a000-000000000002', id, 'admin', TRUE FROM collectivite WHERE siren = '245804406'
+ON CONFLICT (user_id, collectivite_id) DO NOTHING;
+
+INSERT INTO auth.users (instance_id, id, aud, role, email, encrypted_password, email_confirmed_at, invited_at, confirmation_token, confirmation_sent_at, recovery_token, recovery_sent_at, email_change_token_new, email_change, email_change_sent_at, last_sign_in_at, raw_app_meta_data, raw_user_meta_data, is_super_admin, created_at, updated_at, phone, phone_confirmed_at, phone_change, phone_change_token, phone_change_sent_at, email_change_token_current, email_change_confirm_status, banned_until, reauthentication_token, reauthentication_sent_at) VALUES ('00000000-0000-0000-0000-000000000000', '22222222-0cae-4bfc-a000-000000000003', 'authenticated', 'authenticated', 'sophie@auxerrois.fr', '$2a$10$zHta6/ak2n7cONYwYodHJOJ0cmnhyXKUomwX0D4X0j3sQqWfXNs0C', now(), null, '', null, '', null, '', '', null, now(), '{"provider": "email", "providers": ["email"]}', '{}', null, now(), now(), null, null, '', '', null, '', 0, null, '', null) ON CONFLICT (id) DO NOTHING;
+UPDATE dcp SET prenom = 'Sophie', nom = 'Renard', cgu_acceptees_le = current_timestamp WHERE user_id = '22222222-0cae-4bfc-a000-000000000003';
+UPDATE utilisateur_verifie SET verifie = true WHERE user_id = '22222222-0cae-4bfc-a000-000000000003';
+INSERT INTO private_utilisateur_droit (user_id, collectivite_id, niveau_acces, active)
+SELECT '22222222-0cae-4bfc-a000-000000000003', id, 'admin', TRUE FROM collectivite WHERE siren = '200067114'
+ON CONFLICT (user_id, collectivite_id) DO NOTHING;
+
+WITH demarche_creee AS (
+    INSERT INTO demarche (collectivite_id, type, titre, description, status, publication_status, obligation, launched_at, transmitted_at, avis_deadline_at, created_by)
+    SELECT c.id, 'pcaet', 'PCAET 2026-2032', 'Deuxième génération de PCAET du Pays de Montbéliard.', 'transmis_pour_avis', 'published', 'obligatoire',
+           now() - interval '18 months', now() - interval '15 days', now() + interval '75 days',
+           '22222222-0cae-4bfc-a000-000000000001'
+    FROM collectivite c WHERE c.siren = '200065647'
+    RETURNING id
+),
+journal AS (
+    INSERT INTO demarche_status_history (demarche_id, from_status, to_status, transition, created_at, created_by)
+    SELECT id, 'en_elaboration', 'transmis_pour_avis', 'transmettre_pour_avis', now() - interval '15 days',
+           '22222222-0cae-4bfc-a000-000000000001'
+    FROM demarche_creee
+)
+INSERT INTO pcaet_demande_avis (demarche_id, instructeur_collectivite_id, source, created_at)
+SELECT id, (SELECT id FROM collectivite WHERE type = 'dreal' AND region_code = '27'), 'seed', now() - interval '15 days'
+FROM demarche_creee;
+
+WITH demarche_creee AS (
+    INSERT INTO demarche (collectivite_id, type, titre, description, status, publication_status, obligation, launched_at, transmitted_at, avis_deadline_at)
+    SELECT c.id, 'pcaet', 'PCAET du Grand Dole', 'Révision du plan climat air énergie territorial.', 'transmis_pour_avis', 'published', 'obligatoire',
+           now() - interval '2 years', now() - interval '60 days', now() + interval '30 days'
+    FROM collectivite c WHERE c.siren = '200010650'
+    RETURNING id
+),
+journal AS (
+    INSERT INTO demarche_status_history (demarche_id, from_status, to_status, transition, created_at)
+    SELECT id, 'en_elaboration', 'transmis_pour_avis', 'transmettre_pour_avis', now() - interval '60 days'
+    FROM demarche_creee
+),
+demande_creee AS (
+    INSERT INTO pcaet_demande_avis (demarche_id, instructeur_collectivite_id, source, created_at)
+    SELECT id, (SELECT id FROM collectivite WHERE type = 'dreal' AND region_code = '27'), 'seed', now() - interval '60 days'
+    FROM demarche_creee
+    RETURNING id
+)
+INSERT INTO pcaet_avis (demande_avis_id, emetteur_collectivite_id, au_titre_de, sens, fichier_ref, valide_le, depose_par, depose_le)
+SELECT demande_creee.id, (SELECT id FROM collectivite WHERE type = 'dreal' AND region_code = '27'),
+       'prefet_region', 'avec_reserves', NULL, NULL,
+       '11111111-dea1-4bfc-a000-000000000002', now() - interval '3 days'
+FROM demande_creee;
+
+WITH demarche_creee AS (
+    INSERT INTO demarche (collectivite_id, type, titre, description, status, publication_status, obligation, launched_at, transmitted_at, avis_deadline_at, created_by)
+    SELECT c.id, 'pcaet', 'PCAET de l''agglomération de Nevers', 'Plan climat air énergie territorial 2026-2032.', 'transmis_pour_avis', 'published', 'obligatoire',
+           now() - interval '30 months', now() - interval '75 days', now() + interval '15 days',
+           '22222222-0cae-4bfc-a000-000000000002'
+    FROM collectivite c WHERE c.siren = '245804406'
+    RETURNING id
+),
+journal AS (
+    INSERT INTO demarche_status_history (demarche_id, from_status, to_status, transition, created_at, created_by)
+    SELECT id, 'en_elaboration', 'transmis_pour_avis', 'transmettre_pour_avis', now() - interval '75 days',
+           '22222222-0cae-4bfc-a000-000000000002'
+    FROM demarche_creee
+),
+demande_creee AS (
+    INSERT INTO pcaet_demande_avis (demarche_id, instructeur_collectivite_id, source, created_at)
+    SELECT id, (SELECT id FROM collectivite WHERE type = 'dreal' AND region_code = '27'), 'seed', now() - interval '75 days'
+    FROM demarche_creee
+    RETURNING id
+)
+INSERT INTO pcaet_avis (demande_avis_id, emetteur_collectivite_id, au_titre_de, sens, fichier_ref, valide_le, depose_par, depose_le, envoye_le)
+SELECT demande_creee.id, (SELECT id FROM collectivite WHERE type = 'dreal' AND region_code = '27'),
+       avis_titre.au_titre_de, 'favorable', 'avis/avis-dreal-bfc-nevers.pdf', now() - interval '10 days',
+       '11111111-dea1-4bfc-a000-000000000001', now() - interval '12 days', avis_titre.envoye_le
+FROM demande_creee,
+     (VALUES ('prefet_region', now() - interval '10 days'),
+             ('autorite_environnementale', NULL::timestamptz)) AS avis_titre(au_titre_de, envoye_le);
+
+WITH demarche_creee AS (
+    INSERT INTO demarche (collectivite_id, type, titre, description, status, publication_status, obligation, launched_at, transmitted_at, avis_deadline_at)
+    SELECT c.id, 'pcaet', 'PCAET du Grand Belfort', 'Plan climat air énergie territorial.', 'transmis_pour_avis', 'published', 'obligatoire',
+           now() - interval '3 years', now() - interval '120 days', now() - interval '30 days'
+    FROM collectivite c WHERE c.siren = '200069052'
+    RETURNING id
+),
+journal AS (
+    INSERT INTO demarche_status_history (demarche_id, from_status, to_status, transition, created_at)
+    SELECT id, 'en_elaboration', 'transmis_pour_avis', 'transmettre_pour_avis', now() - interval '120 days'
+    FROM demarche_creee
+),
+demande_creee AS (
+    INSERT INTO pcaet_demande_avis (demarche_id, instructeur_collectivite_id, source, created_at)
+    SELECT id, (SELECT id FROM collectivite WHERE type = 'dreal' AND region_code = '27'), 'seed', now() - interval '120 days'
+    FROM demarche_creee
+    RETURNING id
+)
+INSERT INTO pcaet_avis (demande_avis_id, emetteur_collectivite_id, au_titre_de, sens, fichier_ref, valide_le, depose_par, depose_le, modifie_le)
+SELECT demande_creee.id, (SELECT id FROM collectivite WHERE type = 'dreal' AND region_code = '27'),
+       'prefet_region', 'defavorable', NULL, NULL,
+       '11111111-dea1-4bfc-a000-000000000001', now() - interval '95 days', now() - interval '80 days'
+FROM demande_creee;
+
+WITH demarche_creee AS (
+    INSERT INTO demarche (collectivite_id, type, titre, description, status, publication_status, obligation, launched_at, transmitted_at, avis_deadline_at, created_by)
+    SELECT c.id, 'pcaet', 'PCAET de l''Auxerrois', 'Plan climat air énergie territorial adopté en conseil communautaire.', 'adopte', 'published', 'obligatoire',
+           now() - interval '4 years', now() - interval '200 days', now() - interval '110 days',
+           '22222222-0cae-4bfc-a000-000000000003'
+    FROM collectivite c WHERE c.siren = '200067114'
+    RETURNING id
+),
+journal AS (
+    INSERT INTO demarche_status_history (demarche_id, from_status, to_status, transition, created_at, created_by)
+    SELECT d.id, etape.from_status, etape.to_status, etape.transition, etape.created_at,
+           '22222222-0cae-4bfc-a000-000000000003'
+    FROM demarche_creee d,
+         (VALUES ('en_elaboration', 'transmis_pour_avis', 'transmettre_pour_avis', now() - interval '200 days'),
+                 ('transmis_pour_avis', 'adopte', 'adopter', now() - interval '100 days')) AS etape(from_status, to_status, transition, created_at)
+)
+INSERT INTO pcaet_demande_avis (demarche_id, instructeur_collectivite_id, source, created_at)
+SELECT id, (SELECT id FROM collectivite WHERE type = 'dreal' AND region_code = '27'), 'seed', now() - interval '200 days'
+FROM demarche_creee;

--- a/data_layer/sqitch/deploy/demarches/pcaet_instruction_validation.sql
+++ b/data_layer/sqitch/deploy/demarches/pcaet_instruction_validation.sql
@@ -1,0 +1,21 @@
+-- Deploy tet:demarches/pcaet_instruction_validation to pg
+-- requires: demarches/pcaet_avis
+
+BEGIN;
+
+CREATE TABLE public.pcaet_instruction_validation (
+    id              integer     PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    demande_avis_id integer     NOT NULL REFERENCES public.pcaet_demande_avis(id) ON DELETE CASCADE,
+    partie          text        NOT NULL CHECK (partie IN ('documents', 'diagnostic', 'plan')),
+    valide_par      uuid        NULL REFERENCES auth.users(id) ON DELETE SET NULL,
+    valide_le       timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT pcaet_instruction_validation_unique_partie UNIQUE (demande_avis_id, partie)
+);
+
+COMMENT ON TABLE public.pcaet_instruction_validation IS 'Avancement de l''instruction d''une demande d''avis : une ligne = une partie du dossier validée par l''instructeur (parcours en trois étapes des maquettes). Dévalider = supprimer la ligne. Les validations restent acquises quand la collectivité retransmet le dossier.';
+COMMENT ON COLUMN public.pcaet_instruction_validation.partie IS 'documents | diagnostic | plan — les clés du parcours d''instruction, alignées sur les sections du stepper.';
+COMMENT ON COLUMN public.pcaet_instruction_validation.valide_par IS 'Auteur de la validation ; SET NULL à la suppression du compte.';
+
+ALTER TABLE public.pcaet_instruction_validation ENABLE ROW LEVEL SECURITY;
+
+COMMIT;

--- a/data_layer/sqitch/revert/demarches/pcaet_instruction_validation.sql
+++ b/data_layer/sqitch/revert/demarches/pcaet_instruction_validation.sql
@@ -1,0 +1,7 @@
+-- Revert tet:demarches/pcaet_instruction_validation from pg
+
+BEGIN;
+
+DROP TABLE IF EXISTS public.pcaet_instruction_validation;
+
+COMMIT;

--- a/data_layer/sqitch/sqitch.plan
+++ b/data_layer/sqitch/sqitch.plan
@@ -1029,3 +1029,4 @@ demarche/plan_actions_multiples [demarche/plan_action_exclusif] 2026-08-24T09:00
 collectivite/type_add_dreal [collectivite/type_add_structure_sans_statut_juridique] 2026-08-05T09:41:41Z mehdilouraoui <med.louraoui@gmail.com> # Ajoute le type dreal
 collectivite/dreal_unique_region_code [collectivite/type_add_dreal] 2026-08-05T09:41:41Z mehdilouraoui <med.louraoui@gmail.com> # Ajoute un index unique partiel garantissant une seule DREAL par region
 demarches/pcaet_avis [collectivite/type_add_dreal demarche/demarche] 2026-08-05T13:48:10Z mehdilouraoui <med.louraoui@gmail.com> # Cree le modele des avis PCAET : pcaet_demande_avis (ancree sur demarche), pcaet_avis, invariant instructeur (fonction + 2 triggers), non-exposition REST
+demarches/pcaet_instruction_validation [demarches/pcaet_avis] 2026-08-12T09:00:00Z mehdilouraoui <med.louraoui@gmail.com> # Avancement de l'instruction : validation par partie (documents, diagnostic, plan), non-exposition REST

--- a/data_layer/sqitch/verify/demarches/pcaet_instruction_validation.sql
+++ b/data_layer/sqitch/verify/demarches/pcaet_instruction_validation.sql
@@ -1,0 +1,44 @@
+-- Verify tet:demarches/pcaet_instruction_validation on pg
+
+BEGIN;
+
+DO $$
+BEGIN
+  ASSERT (
+    SELECT COUNT(*) = 1
+    FROM pg_tables
+    WHERE schemaname = 'public'
+      AND tablename = 'pcaet_instruction_validation'
+  ), 'La table pcaet_instruction_validation doit exister';
+
+  ASSERT (
+    SELECT relrowsecurity
+    FROM pg_class
+    WHERE oid = 'public.pcaet_instruction_validation'::regclass
+  ), 'Le RLS doit être activé (non-exposition REST)';
+
+  ASSERT (
+    SELECT COUNT(*) = 0
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'pcaet_instruction_validation'
+  ), 'Aucune policy ne doit exposer la table';
+
+  ASSERT (
+    SELECT COUNT(*) = 1
+    FROM pg_constraint
+    WHERE conrelid = 'public.pcaet_instruction_validation'::regclass
+      AND contype = 'u'
+      AND conname = 'pcaet_instruction_validation_unique_partie'
+  ), 'L''unicité « une validation par (demande, partie) » doit exister';
+
+  ASSERT (
+    SELECT confdeltype = 'c'
+    FROM pg_constraint
+    WHERE conrelid = 'public.pcaet_instruction_validation'::regclass
+      AND contype = 'f'
+      AND confrelid = 'public.pcaet_demande_avis'::regclass
+  ), 'La FK validation → demande doit exister, en ON DELETE CASCADE';
+END $$;
+
+ROLLBACK;

--- a/data_layer/tests/demarches/pcaet_instruction_validation.sql
+++ b/data_layer/tests/demarches/pcaet_instruction_validation.sql
@@ -1,0 +1,91 @@
+begin;
+select plan(7);
+
+create temp table ctx (
+    dreal_id integer,
+    epci_id integer,
+    demarche_id integer,
+    demande_id integer
+) on commit drop;
+
+with d as (
+    insert into collectivite (nom, type, region_code)
+    values ('DREAL test validation pgTAP', 'dreal', '94')
+    returning id
+)
+insert into ctx (dreal_id) select id from d;
+
+update ctx set epci_id = (
+    select id from collectivite
+    where type = 'epci'
+      and id not in (
+        select collectivite_id from demarche
+        where type = 'pcaet'
+          and status in ('en_elaboration', 'transmis_pour_avis')
+      )
+    limit 1
+);
+
+with dem as (
+    insert into demarche (collectivite_id, type, titre)
+    select epci_id, 'pcaet', 'Démarche PCAET test validation' from ctx
+    returning id
+)
+update ctx set demarche_id = (select id from dem);
+
+with da as (
+    insert into pcaet_demande_avis (demarche_id, instructeur_collectivite_id, source)
+    select demarche_id, dreal_id, 'seed' from ctx
+    returning id
+)
+update ctx set demande_id = (select id from da);
+
+select lives_ok(
+    $$ insert into pcaet_instruction_validation (demande_avis_id, partie)
+       select demande_id, 'documents' from ctx $$,
+    'valider la partie documents est accepté'
+);
+
+select throws_ok(
+    $$ insert into pcaet_instruction_validation (demande_avis_id, partie)
+       select demande_id, 'documents' from ctx $$,
+    '23505',
+    null,
+    'valider deux fois la même partie est refusé'
+);
+
+select throws_ok(
+    $$ insert into pcaet_instruction_validation (demande_avis_id, partie)
+       select demande_id, 'contenu_libre' from ctx $$,
+    '23514',
+    null,
+    'une partie hors des trois du parcours est refusée'
+);
+
+select lives_ok(
+    $$ insert into pcaet_instruction_validation (demande_avis_id, partie)
+       select demande_id, 'diagnostic' from ctx $$,
+    'valider une autre partie de la même demande est accepté'
+);
+
+select is(
+    (select count(*)::int from pcaet_instruction_validation
+     where demande_avis_id = (select demande_id from ctx)),
+    2,
+    'la demande porte deux validations'
+);
+
+select lives_ok(
+    $$ delete from pcaet_demande_avis where id = (select demande_id from ctx) $$,
+    'supprimer la demande emporte ses validations (cascade)'
+);
+
+select is(
+    (select count(*)::int from pcaet_instruction_validation
+     where demande_avis_id = (select demande_id from ctx)),
+    0,
+    'les validations ont suivi la demande'
+);
+
+select * from finish();
+rollback;

--- a/packages/domain/src/demarches/index.ts
+++ b/packages/domain/src/demarches/index.ts
@@ -16,6 +16,7 @@ export * from './pcaet/diagnostic/demarche-pcaet-vulnerabilite.rules';
 export * from './pcaet/diagnostic/demarche-pcaet-vulnerabilite.schema';
 export * from './pcaet/pcaet-avis-au-titre-de.enum.schema';
 export * from './pcaet/pcaet-avis-sens.enum.schema';
+export * from './pcaet/pcaet-demande-avis-etat.rules';
 export * from './pcaet/pcaet-depot-permissions.rules';
 export * from './pcaet/pcaet-instructeur.rules';
 export * from './pcaet/workflow/demarche-pcaet-state';

--- a/packages/domain/src/demarches/index.ts
+++ b/packages/domain/src/demarches/index.ts
@@ -19,6 +19,7 @@ export * from './pcaet/pcaet-avis-sens.enum.schema';
 export * from './pcaet/pcaet-demande-avis-etat.rules';
 export * from './pcaet/pcaet-depot-permissions.rules';
 export * from './pcaet/pcaet-instructeur.rules';
+export * from './pcaet/pcaet-instruction-partie.enum.schema';
 export * from './pcaet/workflow/demarche-pcaet-state';
 export * from './pcaet/workflow/demarche-pcaet-workflow.facade';
 export * from './pcaet/workflow/demarche-pcaet.workflow';

--- a/packages/domain/src/demarches/pcaet/pcaet-demande-avis-etat.rules.spec.ts
+++ b/packages/domain/src/demarches/pcaet/pcaet-demande-avis-etat.rules.spec.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import { DemarchePcaetStatusEnum } from './demarche-pcaet-status.enum.schema';
+import {
+  getDemandeAvisEtat,
+  PcaetDemandeAvisEtatEnum,
+} from './pcaet-demande-avis-etat.rules';
+
+const now = new Date('2026-08-11T10:00:00.000Z');
+const echeanceAVenir = '2026-10-25T00:00:00.000Z';
+const echeancePassee = '2026-07-12T00:00:00.000Z';
+
+const demandeTransmise = {
+  demarcheStatus: DemarchePcaetStatusEnum.TRANSMIS_POUR_AVIS,
+  avisDeadlineAt: echeanceAVenir,
+  nbAvisValides: 0,
+  nbAvisBrouillons: 0,
+};
+
+describe('getDemandeAvisEtat', () => {
+  it('sans avis, fenêtre ouverte : à traiter', () => {
+    expect(getDemandeAvisEtat(demandeTransmise, now)).toBe(
+      PcaetDemandeAvisEtatEnum.A_TRAITER
+    );
+  });
+
+  it('un brouillon, fenêtre ouverte : brouillon en cours', () => {
+    expect(
+      getDemandeAvisEtat({ ...demandeTransmise, nbAvisBrouillons: 1 }, now)
+    ).toBe(PcaetDemandeAvisEtatEnum.BROUILLON_EN_COURS);
+  });
+
+  it('un avis validé : avis rendu', () => {
+    expect(
+      getDemandeAvisEtat({ ...demandeTransmise, nbAvisValides: 1 }, now)
+    ).toBe(PcaetDemandeAvisEtatEnum.AVIS_RENDU);
+  });
+
+  it('échéance passée, aucun avis validé : délai écoulé', () => {
+    expect(
+      getDemandeAvisEtat(
+        { ...demandeTransmise, avisDeadlineAt: echeancePassee },
+        now
+      )
+    ).toBe(PcaetDemandeAvisEtatEnum.DELAI_ECOULE);
+  });
+
+  it('échéance passée avec un brouillon jamais validé : délai écoulé', () => {
+    expect(
+      getDemandeAvisEtat(
+        {
+          ...demandeTransmise,
+          avisDeadlineAt: echeancePassee,
+          nbAvisBrouillons: 1,
+        },
+        now
+      )
+    ).toBe(PcaetDemandeAvisEtatEnum.DELAI_ECOULE);
+  });
+
+  it('démarche adoptée sans avis : clos', () => {
+    expect(
+      getDemandeAvisEtat(
+        {
+          ...demandeTransmise,
+          demarcheStatus: DemarchePcaetStatusEnum.ADOPTE,
+          avisDeadlineAt: echeancePassee,
+        },
+        now
+      )
+    ).toBe(PcaetDemandeAvisEtatEnum.CLOS);
+  });
+
+  it('démarche archivée sans avis : clos', () => {
+    expect(
+      getDemandeAvisEtat(
+        {
+          ...demandeTransmise,
+          demarcheStatus: DemarchePcaetStatusEnum.ARCHIVE,
+          avisDeadlineAt: echeancePassee,
+        },
+        now
+      )
+    ).toBe(PcaetDemandeAvisEtatEnum.CLOS);
+  });
+
+  it('avis rendu prime sur clos', () => {
+    expect(
+      getDemandeAvisEtat(
+        {
+          ...demandeTransmise,
+          demarcheStatus: DemarchePcaetStatusEnum.ADOPTE,
+          avisDeadlineAt: echeancePassee,
+          nbAvisValides: 1,
+        },
+        now
+      )
+    ).toBe(PcaetDemandeAvisEtatEnum.AVIS_RENDU);
+  });
+
+  it('reprise d’élaboration : la fenêtre reste ouverte', () => {
+    expect(
+      getDemandeAvisEtat(
+        {
+          ...demandeTransmise,
+          demarcheStatus: DemarchePcaetStatusEnum.EN_ELABORATION,
+        },
+        now
+      )
+    ).toBe(PcaetDemandeAvisEtatEnum.A_TRAITER);
+  });
+
+  it('échéance absente : délai écoulé, jamais à traiter', () => {
+    expect(
+      getDemandeAvisEtat({ ...demandeTransmise, avisDeadlineAt: null }, now)
+    ).toBe(PcaetDemandeAvisEtatEnum.DELAI_ECOULE);
+  });
+
+  it('le jour de l’échéance atteint ferme la fenêtre', () => {
+    expect(
+      getDemandeAvisEtat(
+        { ...demandeTransmise, avisDeadlineAt: now.toISOString() },
+        now
+      )
+    ).toBe(PcaetDemandeAvisEtatEnum.DELAI_ECOULE);
+  });
+});

--- a/packages/domain/src/demarches/pcaet/pcaet-demande-avis-etat.rules.ts
+++ b/packages/domain/src/demarches/pcaet/pcaet-demande-avis-etat.rules.ts
@@ -1,0 +1,55 @@
+import * as z from 'zod/mini';
+import { type DemarchePcaetStatus } from './demarche-pcaet-status.enum.schema';
+import { isActiveDemarchePcaetStatus } from './workflow/demarche-pcaet-state';
+import { fenetreAvisOuverte } from './pcaet-depot-permissions.rules';
+
+export const PcaetDemandeAvisEtatEnum = {
+  A_TRAITER: 'a_traiter',
+  BROUILLON_EN_COURS: 'brouillon_en_cours',
+  AVIS_RENDU: 'avis_rendu',
+  DELAI_ECOULE: 'delai_ecoule',
+  CLOS: 'clos',
+} as const;
+
+export const pcaetDemandeAvisEtatValues = [
+  PcaetDemandeAvisEtatEnum.A_TRAITER,
+  PcaetDemandeAvisEtatEnum.BROUILLON_EN_COURS,
+  PcaetDemandeAvisEtatEnum.AVIS_RENDU,
+  PcaetDemandeAvisEtatEnum.DELAI_ECOULE,
+  PcaetDemandeAvisEtatEnum.CLOS,
+] as const;
+
+export const pcaetDemandeAvisEtatSchema = z.enum(pcaetDemandeAvisEtatValues);
+
+export type PcaetDemandeAvisEtat = z.infer<typeof pcaetDemandeAvisEtatSchema>;
+
+export type DemandeAvisEtatEntree = {
+  demarcheStatus: DemarchePcaetStatus;
+  avisDeadlineAt: string | null;
+  nbAvisValides: number;
+  nbAvisBrouillons: number;
+};
+
+export const getDemandeAvisEtat = (
+  {
+    demarcheStatus,
+    avisDeadlineAt,
+    nbAvisValides,
+    nbAvisBrouillons,
+  }: DemandeAvisEtatEntree,
+  now: Date
+): PcaetDemandeAvisEtat => {
+  if (nbAvisValides > 0) {
+    return PcaetDemandeAvisEtatEnum.AVIS_RENDU;
+  }
+  if (!isActiveDemarchePcaetStatus(demarcheStatus)) {
+    return PcaetDemandeAvisEtatEnum.CLOS;
+  }
+  if (!fenetreAvisOuverte({ demarcheStatus, avisDeadlineAt }, now)) {
+    return PcaetDemandeAvisEtatEnum.DELAI_ECOULE;
+  }
+  if (nbAvisBrouillons > 0) {
+    return PcaetDemandeAvisEtatEnum.BROUILLON_EN_COURS;
+  }
+  return PcaetDemandeAvisEtatEnum.A_TRAITER;
+};

--- a/packages/domain/src/demarches/pcaet/pcaet-instruction-partie.enum.schema.ts
+++ b/packages/domain/src/demarches/pcaet/pcaet-instruction-partie.enum.schema.ts
@@ -1,0 +1,21 @@
+import * as z from 'zod/mini';
+
+export const PcaetInstructionPartieEnum = {
+  DOCUMENTS: 'documents',
+  DIAGNOSTIC: 'diagnostic',
+  PLAN: 'plan',
+} as const;
+
+export const pcaetInstructionPartieValues = [
+  PcaetInstructionPartieEnum.DOCUMENTS,
+  PcaetInstructionPartieEnum.DIAGNOSTIC,
+  PcaetInstructionPartieEnum.PLAN,
+] as const;
+
+export const pcaetInstructionPartieSchema = z.enum(
+  pcaetInstructionPartieValues
+);
+
+export type PcaetInstructionPartie = z.infer<
+  typeof pcaetInstructionPartieSchema
+>;


### PR DESCRIPTION
L'instructeur DREAL peut désormais suivre les demandes d'avis de sa région et ouvrir chaque dossier : un tableau de bord (tuiles, tri, pagination), puis un parcours en 3 étapes avec les documents déposés, le diagnostic figé à la transmission et la validation partie par partie, les pièces se téléchargeant par URL signée. Lecture seule : l'écriture arrive au batch suivant.

Démo : Camille (DREAL BFC) se connecte → tableau de bord avec ses 5 dossiers seedés (tuiles, tri sur les 4 colonnes, pagination). Elle ouvre le dossier de Montbéliard → trois étapes : les documents déposés (lecture seule, téléchargement par URL signée), le diagnostic figé à la transmission, le programme d'actions (à venir). Elle valide chaque partie ; la validation est persistée et partagée entre collègues.

## Les états d'une demande

Cinq états déduits, jamais stockés : à traiter, brouillon en cours, avis rendu, délai écoulé, clos. La règle vit dans le domaine, partagée entre la liste, le détail et les tuiles.

## Les gardes

Chaque port appelle `DepotPermissionsService` en première ligne (`canListerDemandes`, `canConsulterDepot`). Les pièces se téléchargent par une URL signée de 60 s résolue côté serveur : le client ne fournit jamais de bucket ni de hash. Le diagnostic sert toujours la dernière photo figée, et refuse (fail-closed) s'il n'en existe pas.

## Ce que contient la PR

**Base** : 1 changement Sqitch (`pcaet_instruction_validation`) et le seed des 5 dossiers de démonstration, idempotent.
**Backend** : les ports de lecture (liste + stats, dossier, document, diagnostic) et la validation par partie.
**Front** : les écrans Suivre et Consulter (volet d'étapes, header du dossier, composants existants réutilisés).

## Déploiement

1 migration Sqitch à jouer. Le seed ne concerne que le dev.

