### PR TITLE
feat(lint): Règle ESLint no-hardcoded-app-path

### DIFF
--- a/DISCOVERED.md
+++ b/DISCOVERED.md
@@ -24,11 +24,11 @@
 - **Découvert pendant** : audit-checklist-view-update (stabilisation des e2e labellisation)
 - **Découvert le** : 2026-05-21
 
-## [bug] L'ordre des topics du diagnostic PCAET n'est pas déterministe
-- **Symptôme** : deux tests rouges sur toutes les branches, avec la même empreinte. Backend : `get-diagnostic.router.e2e-spec.ts:84` attend `['profil_energie_climat', 'consommation_energetique', 'sequestration', 'polluants_atmospheriques', 'enr', 'vulnerabilite_territoire']` et reçoit `sequestration` et `consommation_energetique` **après** `polluants_atmospheriques`. E2E : `demarche-pcaet-workflow.spec.ts:97` attend `?topic=consommation_energetique` sur le bouton « suivant » de la barre d'étapes et obtient `?topic=polluants_atmospheriques`. Reproduit 3 fois sur 3 dans le même run (pas un flake transitoire), et à l'identique sur des branches sans rapport (`TET-6818/refonte-main-nav`, `chore/eslint-no-hardcoded-app-path`).
-- **Localisation** : `apps/backend/src/demarches/pcaet/get-diagnostic/` (requête des topics) ; se propage à la barre d'étapes via `apps/app/src/demarches/steps.ts`.
-- **Diagnostic suspecté** : `ORDER BY` absent ou non total sur la lecture des topics — l'ordre d'affichage repose sur l'ordre physique des lignes, qui varie selon l'état de la base de test. Les deux échecs ont une seule cause : le e2e ne fait que rendre visible l'ordre que le backend renvoie.
-- **Impact** : utilisateur — l'ordre des étapes du diagnostic PCAET peut varier d'une collectivité à l'autre ; dev — deux checks CI rouges en permanence, qui masquent les régressions réelles.
+## [improvement] Une migration de données de référence peut périmer des assertions TS sans que rien ne le signale
+- **Symptôme** : `demarche/pcaet_diagnostic_ordre_reglementaire` (commit `f43f017abb`) permute le `display_order` de deux topics PCAET et met à jour le test pgTAP voisin, mais laisse rouges deux specs TS qui figeaient l'ancien ordre (`get-diagnostic.router.e2e-spec.ts:84`, `demarche-pcaet-workflow.spec.ts:97`). Résultat : `test-backend` et `test-e2e` rouges sur toutes les branches, de façon déterministe, jusqu'à ce que quelqu'un remonte à la migration. Corrigé par la PR #4809.
+- **Localisation** : `data_layer/sqitch/deploy/demarche/` (migrations qui font des `UPDATE` sur des données de référence) vs les specs TS qui les assertent.
+- **Diagnostic suspecté** : rien ne relie une migration de données de référence aux tests applicatifs qui en dépendent. Les tests pgTAP colocalisés sont mis à jour parce qu'ils sont dans le même dossier ; les specs backend/e2e sont à deux dossiers de là et personne ne pense à les chercher. Piste : un test qui compare l'ordre servi par l'API à `SELECT code FROM demarche_pcaet_topic ORDER BY display_order` plutôt qu'à une liste littérale, ce qui déplacerait l'assertion vers « l'API respecte l'ordre de la base » — la propriété qu'on veut vraiment — au lieu de dupliquer la donnée.
+- **Impact** : dev — checks CI rouges de façon persistante, qui masquent les régressions réelles et coûtent un diagnostic complet à chaque personne qui les croise.
 - **Découvert pendant** : chore/eslint-no-hardcoded-app-path (qualification des rouges CI de la PR #4807)
 - **Découvert le** : 2026-08-17
 

--- a/DISCOVERED.md
+++ b/DISCOVERED.md
@@ -24,3 +24,11 @@
 - **Découvert pendant** : audit-checklist-view-update (stabilisation des e2e labellisation)
 - **Découvert le** : 2026-05-21
 
+## [bug] L'ordre des topics du diagnostic PCAET n'est pas déterministe
+- **Symptôme** : deux tests rouges sur toutes les branches, avec la même empreinte. Backend : `get-diagnostic.router.e2e-spec.ts:84` attend `['profil_energie_climat', 'consommation_energetique', 'sequestration', 'polluants_atmospheriques', 'enr', 'vulnerabilite_territoire']` et reçoit `sequestration` et `consommation_energetique` **après** `polluants_atmospheriques`. E2E : `demarche-pcaet-workflow.spec.ts:97` attend `?topic=consommation_energetique` sur le bouton « suivant » de la barre d'étapes et obtient `?topic=polluants_atmospheriques`. Reproduit 3 fois sur 3 dans le même run (pas un flake transitoire), et à l'identique sur des branches sans rapport (`TET-6818/refonte-main-nav`, `chore/eslint-no-hardcoded-app-path`).
+- **Localisation** : `apps/backend/src/demarches/pcaet/get-diagnostic/` (requête des topics) ; se propage à la barre d'étapes via `apps/app/src/demarches/steps.ts`.
+- **Diagnostic suspecté** : `ORDER BY` absent ou non total sur la lecture des topics — l'ordre d'affichage repose sur l'ordre physique des lignes, qui varie selon l'état de la base de test. Les deux échecs ont une seule cause : le e2e ne fait que rendre visible l'ordre que le backend renvoie.
+- **Impact** : utilisateur — l'ordre des étapes du diagnostic PCAET peut varier d'une collectivité à l'autre ; dev — deux checks CI rouges en permanence, qui masquent les régressions réelles.
+- **Découvert pendant** : chore/eslint-no-hardcoded-app-path (qualification des rouges CI de la PR #4807)
+- **Découvert le** : 2026-08-17
+

--- a/apps/app/AGENTS.md
+++ b/apps/app/AGENTS.md
@@ -62,7 +62,7 @@ useMutation(trpc.x.y.mutationOptions({
 - Root provider stack (`app/root-providers.tsx`): `SupabaseProvider` → `UserProvider` → `PostHogProvider` → `TrpcWithReactQueryProvider` → `NuqsAdapter` → `ToastProvider`. Order matters; new providers slot here.
 - Authed providers live in a separate client component `app/(authed)/authed-providers.tsx`, fed by the server `app/(authed)/layout.tsx` (which fetches `getUser()`). Mirror this server-layout + client-provider split for any new authed surface.
 - Collectivité param parsed with `z.coerce.number()` in the layout.
-- **Never hand-concatenate URLs** — use builders in `src/app/paths.ts` (`makeCollectiviteToutesLesFichesUrl(...)` etc.).
+- **Never hand-concatenate URLs** — use builders in `src/app/paths.ts` (`makeCollectiviteToutesLesFichesUrl(...)` etc.). Enforced by the local ESLint rule `tet/no-hardcoded-app-path` (`eslint-rules/no-hardcoded-app-path.mjs`); `paths.ts` and `next.config.ts` declare routes and are exempt.
 
 ## Auth & permissions
 

--- a/apps/app/app/(authed)/collectivite/plans/page.tsx
+++ b/apps/app/app/(authed)/collectivite/plans/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { makeCollectivitePlansActionsListUrl } from '@/app/app/paths';
 import SpinnerLoader from '@/app/ui/shared/SpinnerLoader';
 import { useCollectiviteId } from '@tet/api/collectivites';
 import { useRouter } from 'next/navigation';
@@ -10,7 +11,11 @@ export default function RedirectToPlansPage() {
   const router = useRouter();
 
   useEffect(() => {
-    router.replace(`/collectivite/${currentCollectiviteId}/plans`);
+    router.replace(
+      makeCollectivitePlansActionsListUrl({
+        collectiviteId: currentCollectiviteId,
+      })
+    );
   }, [currentCollectiviteId, router]);
 
   return <SpinnerLoader />;

--- a/apps/app/app/(public)/invitation/[invitationId]/route.ts
+++ b/apps/app/app/(public)/invitation/[invitationId]/route.ts
@@ -1,8 +1,14 @@
-import { signInPath, signUpPath } from '@/app/app/paths';
+import {
+  finaliserMonInscriptionUrl,
+  signInPath,
+  signUpPath,
+} from '@/app/app/paths';
 import { getRequestUrl } from '@tet/api';
 import { getAuthUser } from '@tet/api/utils/supabase/auth-user.server';
 import { trpcInServerFunction } from '@tet/api/utils/trpc/trpc-server-client';
 import { redirect, RedirectType } from 'next/navigation';
+
+const invitationErrorUrl = `${finaliserMonInscriptionUrl}?error=invitation`;
 
 export async function GET(
   request: Request,
@@ -20,10 +26,7 @@ export async function GET(
     );
 
   if (!invitation) {
-    redirect(
-      `/finaliser-mon-inscription?error=invitation`,
-      RedirectType.replace
-    );
+    redirect(invitationErrorUrl, RedirectType.replace);
   }
 
   const invitationEmail = invitation.email;
@@ -69,11 +72,7 @@ export async function GET(
       JSON.stringify(error)
     );
 
-    // Redirige vers la page de finalisation avec un message d'erreur
-    redirect(
-      `/finaliser-mon-inscription?error=invitation`,
-      RedirectType.replace
-    );
+    redirect(invitationErrorUrl, RedirectType.replace);
   }
 
   redirect('/', RedirectType.replace);

--- a/apps/app/eslint-rules/no-hardcoded-app-path.mjs
+++ b/apps/app/eslint-rules/no-hardcoded-app-path.mjs
@@ -1,0 +1,55 @@
+const routeRoots = [
+  'ajouter-collectivite',
+  'banniere',
+  'collectivite',
+  'error',
+  'finaliser-mon-inscription',
+  'invitation',
+  'login',
+  'plans',
+  'profil',
+  'recherches',
+  'recover',
+  'rejoindre-une-collectivite',
+  'signup',
+];
+
+const appPathPattern = new RegExp(`^/(?:${routeRoots.join('|')})(?=$|[/?#])`);
+
+const noHardcodedAppPath = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Build internal app URLs with a builder exported from src/app/paths.ts',
+    },
+    schema: [],
+    messages: {
+      hardcodedAppPath:
+        'Hardcoded internal app path. Use a URL builder from src/app/paths.ts (add one there if none fits).',
+    },
+  },
+  create(context) {
+    const reportIfAppPath = (node, pathStart) => {
+      if (!appPathPattern.test(pathStart)) {
+        return;
+      }
+      context.report({ node, messageId: 'hardcodedAppPath' });
+    };
+
+    return {
+      Literal(node) {
+        if (typeof node.value !== 'string') {
+          return;
+        }
+        reportIfAppPath(node, node.value);
+      },
+      TemplateLiteral(node) {
+        const [firstQuasi] = node.quasis;
+        reportIfAppPath(node, firstQuasi.value.raw);
+      },
+    };
+  },
+};
+
+export default noHardcodedAppPath;

--- a/apps/app/eslint-rules/no-hardcoded-app-path.spec.mts
+++ b/apps/app/eslint-rules/no-hardcoded-app-path.spec.mts
@@ -1,0 +1,67 @@
+import { RuleTester } from 'eslint';
+import tseslint from 'typescript-eslint';
+import noHardcodedAppPath from './no-hardcoded-app-path.mjs';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: tseslint.parser,
+    ecmaVersion: 2022,
+    sourceType: 'module',
+    parserOptions: { ecmaFeatures: { jsx: true } },
+  },
+});
+
+ruleTester.run('no-hardcoded-app-path', noHardcodedAppPath, {
+  valid: [
+    {
+      code: `const url = makeCollectivitePlansActionsListUrl({ collectiviteId });`,
+    },
+    { code: 'const url = `${finaliserMonInscriptionUrl}?error=invitation`;' },
+    { code: `const url = signInPath;` },
+    { code: `const externalUrl = 'https://www.ademe.fr/collectivite/1';` },
+    { code: `const mail = 'mailto:contact@ademe.fr';` },
+    { code: `const anchor = '#indicateurs';` },
+    { code: `const home = '/';` },
+    { code: `const logo = '/logo.svg';` },
+    { code: `const backendRoute = '/plan/export';` },
+    { code: `const backendRoute = '/collectivites/1/plans/import-ia';` },
+    {
+      code: 'const backendRoute = `/collectivites/${collectiviteId}/documents/${documentId}/download`;',
+    },
+    { code: `const storagePrefix = '/storage/v1/object/sign/';` },
+    { code: `const isActionPath = path.includes('/action/');` },
+  ],
+  invalid: [
+    {
+      code: 'router.replace(`/collectivite/${collectiviteId}/plans`);',
+      errors: [{ messageId: 'hardcodedAppPath' }],
+    },
+    {
+      code: `const link = <Button href="/login" />;`,
+      errors: [{ messageId: 'hardcodedAppPath' }],
+    },
+    {
+      code: 'redirect(`/finaliser-mon-inscription?error=invitation`);',
+      errors: [{ messageId: 'hardcodedAppPath' }],
+    },
+    {
+      code: `const url = '/collectivite/' + collectiviteId + '/plans';`,
+      errors: [
+        { messageId: 'hardcodedAppPath' },
+        { messageId: 'hardcodedAppPath' },
+      ],
+    },
+    {
+      code: `router.push('/profil');`,
+      errors: [{ messageId: 'hardcodedAppPath' }],
+    },
+    {
+      code: `const base = '/collectivite';`,
+      errors: [{ messageId: 'hardcodedAppPath' }],
+    },
+    {
+      code: `const withAnchor = '/recherches#collectivites';`,
+      errors: [{ messageId: 'hardcodedAppPath' }],
+    },
+  ],
+});

--- a/apps/app/eslint.config.mjs
+++ b/apps/app/eslint.config.mjs
@@ -2,6 +2,7 @@ import { defineConfig } from 'eslint/config';
 import { frontendEnforceModuleBoundaries } from '../../eslint-frontend.config.mjs';
 import nextjsConfig from '../../eslint-nextjs.config.mjs';
 import baseConfig from '../../eslint.config.mjs';
+import noHardcodedAppPath from './eslint-rules/no-hardcoded-app-path.mjs';
 
 const eslintConfig = defineConfig([
   ...nextjsConfig,
@@ -32,8 +33,23 @@ const eslintConfig = defineConfig([
       'react/jsx-no-literals': 'off',
     },
   },
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+    ignores: [
+      '**/src/app/paths.ts',
+      '**/next.config.ts',
+      '**/*.spec.ts',
+      '**/*.spec.tsx',
+      '**/*.stories.tsx',
+      '**/eslint-rules/**',
+    ],
+    plugins: {
+      tet: { rules: { 'no-hardcoded-app-path': noHardcodedAppPath } },
+    },
+    rules: {
+      'tet/no-hardcoded-app-path': 'error',
+    },
+  },
 ]);
 
 export default eslintConfig;
-
-

--- a/apps/app/src/users/authentications/signup-user/signup-step1.tsx
+++ b/apps/app/src/users/authentications/signup-user/signup-step1.tsx
@@ -1,3 +1,4 @@
+import { signInPath } from '@/app/app/paths';
 import { appLabels } from '@/app/labels/catalog';
 import { zodResolver } from '@hookform/resolvers/zod';
 import {
@@ -169,7 +170,12 @@ const SignupStep1Form = (
         <Input id="email" type="text" {...register('email')} />
       </Field>
       {isEmailAlreadyExists && (
-        <Button href="/login" prefetch={false} size="xs" variant="underlined">
+        <Button
+          href={signInPath}
+          prefetch={false}
+          size="xs"
+          variant="underlined"
+        >
           {appLabels.seConnecter}
         </Button>
       )}


### PR DESCRIPTION
## Contexte

Issue de l'inventaire « quelles règles ESLint custom écrire pour attraper au lint ce que la review attrape à la main » : cette PR implémente la première d'entre elles, la règle 11 de `te-en-t-style-enforcer` (« URL d'app hard-codée / hand-concaténée »), documentée dans `apps/app/AGENTS.md` § Routing (« Never hand-concatenate URLs ») mais jusqu'ici vérifiée uniquement à la relecture.

Pas de plan markdown dédié : le périmètre est exactement une règle de lint + les sites qu'elle révèle.

## Surface de review

**Attention humaine :**
- `apps/app/eslint-rules/no-hardcoded-app-path.mjs` — la règle (55 lignes). Le seul point de conception est le motif : `^/(?:<route racine>)(?=$|[/?#])`, testé sur la valeur d'un `Literal` string et sur le **premier quasi** d'un `TemplateLiteral`.
- `apps/app/eslint.config.mjs` — activation en `error` + liste des exemptions.

**Mécanique / dérivé :**
- `apps/app/eslint-rules/no-hardcoded-app-path.spec.mts` — 13 cas valides / 7 invalides (RuleTester).
- Les 3 fichiers corrigés (commit 1), tous des substitutions littéral → builder existant.
- `apps/app/AGENTS.md` — une phrase renvoyant vers la règle.

## Ce que la règle attrape / laisse passer

Ne matchent pas, par construction du motif — chaque cas est dans le spec :

| Cas | Pourquoi |
|---|---|
| `https://…`, `mailto:`, `#ancre` | ne commencent pas par `/` |
| `/` seul, `/logo.svg` | premier segment absent de la liste des routes |
| `/collectivites/1/plans/import-ia`, `/plan/export` | routes REST backend : `collectivites` au pluriel, `plan` au singulier — le lookahead `(?=$\|[/?#])` échoue |
| `` `${finaliserMonInscriptionUrl}?error=invitation` `` | premier quasi vide → query-param ajouté à une URL déjà construite, explicitement autorisé |
| `path.includes('/action/')` | `action` n'est pas une route racine |

Exemptions (fichiers, pas cas particuliers dans la règle — la règle reste sans option) :

- `src/app/paths.ts` : c'est la source des builders.
- `next.config.ts` : la table de redirections **déclare** des routes legacy (`/collectivite/:collectiviteId/plans/fiches/:ficheId*`) qui n'existent plus dans `paths.ts` et dont les wildcards `:path*` ne sont pas représentables par un builder. 22 des 26 signalements initiaux venaient de là.
- specs et stories : l'URL littérale y est l'assertion / la fixture (`steps.spec.ts` vérifie précisément la sortie des builders — l'écrire via le builder rendrait le test tautologique).

## Hypothèses prises

1. **La liste des routes racines vit dans la règle**, pas en option de config : les 13 entrées sont exactement les premiers segments exportés par `paths.ts`. Conséquence assumée : ajouter une route de premier niveau demande une entrée ici. L'inverse (motif générique « tout chemin `/x/y` ») produisait des faux positifs sur les routes REST backend et les chemins de storage — mesuré avant d'écrire la règle.
2. `/tests` (route de debug de `app/(authed)/tests/`) est volontairement **hors liste** : `paths.ts` ne l'expose pas, la règle exigerait donc un builder pour une route dev-only.
3. `invitationErrorUrl` extraite en constante de module plutôt qu'inlinée deux fois : les deux `redirect(...)` de `route.ts` construisaient la même URL à l'identique.

## Low-confidence zones

- **Le nom du plugin `tet`** est arbitraire (`tet/no-hardcoded-app-path`) et la règle est aujourd'hui locale à `apps/app`. Si d'autres règles suivent, l'endroit naturel devient un dossier partagé à la racine, à côté de `eslint-frontend.config.mjs`. Rien ici ne bloque ce déplacement.
- **La résolution des `ignores`** (relative au cwd vs au fichier de config) est traitée en préfixant tous les motifs par `**/`, ce qui les rend insensibles au cwd. Vérifié empiriquement : 0 signalement dans `paths.ts` / `next.config.ts` / specs / stories sur un lint complet de `apps/app`.

## Vérifications

- `vitest run apps/app eslint-rules` → **20/20**. Les specs paths existants (`demarches/steps.spec.ts`, `mesure-row-link.spec.tsx`) restent verts.
- `eslint .` sur `apps/app` → **0 erreur**, dont **0 `tet/no-hardcoded-app-path`** (26 avant corrections + exemption de `next.config.ts`). Les 125 warnings sont préexistants (`react-hooks/set-state-in-effect`).
- `tsc --noEmit -p tsconfig.project.json` → aucune erreur sur les fichiers touchés.
- Un `-2` de diff sur `apps/app/eslint.config.mjs` : prettier a supprimé deux lignes vides en fin de fichier, préexistantes.

## Anti-duplication

Cherché avant d'écrire : aucun plugin ESLint local dans le repo (pas de `tools/eslint-rules`, pas de workspace-rule Nx, pas de `packages/eslint-plugin`) ; les seules règles maison sont des configurations de règles amont (`no-restricted-imports` pour luxon, `@nx/enforce-module-boundaries`). Aucune règle publiée ne couvre « chemin interne en dur » — c'est spécifique à `paths.ts`.

## Checks rouges : cause identifiee, corrigee ailleurs

`test-backend` et `test-e2e` sont rouges sur **toutes** les branches, y compris `TET-6818/refonte-main-nav` qui ne contient pas cette regle. La cause : la migration `demarche/pcaet_diagnostic_ordre_reglementaire` (commit `f43f017abb`, merge aujourd'hui) permute deux topics PCAET et a mis a jour le test pgTAP, mais pas les deux specs TS qui figeaient l'ancien ordre. Determin*iste*, pas un flake.

**Corrige par la PR #4809** (deux fichiers de test, aucun code de production). Cette PR-ci est independante et n'a rien a voir avec ces deux checks.

Les lanes concernees par le present diff sont vertes : `test-syntax / lint`, `test-syntax / typecheck`, `test-app`, `test-package-api`, `test-db-deploy`, les 3 `test-build`.

## DISCOVERED.md

Un ajout, `[improvement]` : rien ne relie une migration de donnees de reference aux specs TS qui les assertent. Les tests pgTAP colocalises sont mis a jour parce qu'ils sont dans le meme dossier ; les specs backend/e2e sont a deux dossiers de la et personne ne pense a les chercher. Piste notee : asserter « l'API respecte l'ordre de la base » plutot que dupliquer l'ordre en litteral.
