### PR TITLE
feat(historique): scope l'historique par référentiel

### DIFF
--- a/apps/app/src/app/pages/collectivite/Historique/HistoriqueListe.tsx
+++ b/apps/app/src/app/pages/collectivite/Historique/HistoriqueListe.tsx
@@ -4,7 +4,10 @@ import { appLabels } from '@/app/labels/catalog';
 import HistoriqueItemActionPrecision from '@/app/app/pages/collectivite/Historique/actionPrecision/HistoriqueItemActionPrecision';
 import HistoriqueItemActionStatut from '@/app/app/pages/collectivite/Historique/actionStatut/HistoriqueItemActionStatut';
 import SpinnerLoader from '@/app/ui/shared/SpinnerLoader';
-import { NB_HISTORIQUE_ITEMS_PER_PAGE } from '@tet/domain/referentiels';
+import {
+  NB_HISTORIQUE_ITEMS_PER_PAGE,
+  ReferentielId,
+} from '@tet/domain/referentiels';
 import { Alert, Event, Pagination, useEventTracker } from '@tet/ui';
 import HistoriqueFiltres from './HistoriqueFiltres/HistoriqueFiltres';
 import HistoriqueItemJustification from './reponse/HistoriqueItemJustification';
@@ -12,16 +15,20 @@ import HistoriqueItemReponse from './reponse/HistoriqueItemReponse';
 import { HistoriqueItem } from './types';
 import { useHistoriqueItemListe } from './useHistoriqueItemListe';
 
+type HistoriqueListeProps = {
+  actionId?: string;
+  referentielId?: ReferentielId;
+  small?: boolean;
+};
+
 export const HistoriqueListe = ({
   actionId,
+  referentielId,
   small,
-}: {
-  actionId?: string;
-  small?: boolean;
-}) => {
+}: HistoriqueListeProps) => {
   const tracker = useEventTracker();
   const { items, total, filters, setFilters, isLoading, isError } =
-    useHistoriqueItemListe({ actionId });
+    useHistoriqueItemListe({ actionId, referentielId });
 
   return (
     <>

--- a/apps/app/src/app/pages/collectivite/Historique/useHistoriqueItemListe.ts
+++ b/apps/app/src/app/pages/collectivite/Historique/useHistoriqueItemListe.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { useTRPC } from '@tet/api';
 import { useCurrentCollectivite } from '@tet/api/collectivites';
+import { ReferentielId } from '@tet/domain/referentiels';
 import { ITEM_ALL } from '@tet/ui';
 import { useQueryStates } from 'nuqs';
 import { filtersParsers, filtersUrlKeys } from './filters';
@@ -16,8 +17,10 @@ const isValidFilter = (
  */
 export const useHistoriqueItemListe = ({
   actionId,
+  referentielId,
 }: {
   actionId?: string;
+  referentielId?: ReferentielId;
 } = {}): THistoriqueProps => {
   const { collectiviteId } = useCurrentCollectivite();
   const trpc = useTRPC();
@@ -33,6 +36,7 @@ export const useHistoriqueItemListe = ({
     trpc.referentiels.historique.list.queryOptions({
       collectiviteId,
       actionId,
+      referentielId,
       filters: {
         modifiedBy: isValidFilter(modifiedBy) ? modifiedBy : undefined,
         types: isValidFilter(types) ? types : undefined,

--- a/apps/backend/src/referentiels/historique/historique.router.e2e-spec.ts
+++ b/apps/backend/src/referentiels/historique/historique.router.e2e-spec.ts
@@ -6,6 +6,7 @@ import { actionCommentaireTable } from '@tet/backend/referentiels/models/action-
 import { actionDefinitionTable } from '@tet/backend/referentiels/models/action-definition.table';
 import { actionRelationTable } from '@tet/backend/referentiels/models/action-relation.table';
 import { historiqueActionStatutTable } from '@tet/backend/referentiels/models/historique-action-statut.table';
+import { questionActionTable } from '@tet/backend/referentiels/models/question-action.table';
 import { cleanupReferentielActionStatutsAndLabellisations } from '@tet/backend/referentiels/update-action-statut/referentiel-action-statut.test-fixture';
 import { getAuthUserFromUserCredentials } from '@tet/backend/test';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
@@ -17,10 +18,12 @@ import {
   HistoriqueActionStatutItem,
   HistoriqueItem,
   NB_HISTORIQUE_ITEMS_PER_PAGE,
+  ReferentielIdEnum,
 } from '@tet/domain/referentiels';
 import { CollectiviteRole } from '@tet/domain/users';
 import { inferProcedureInput } from '@trpc/server';
 import { eq } from 'drizzle-orm';
+import { onTestFinished } from 'vitest';
 import {
   getTestApp,
   getTestDatabase,
@@ -35,9 +38,9 @@ type ListUtilisateursInput = inferProcedureInput<
   AppRouter['referentiels']['historique']['listUtilisateurs']
 >;
 
-const TACHE_ACTION_ID = 'cae_1.1.1.1.2'; // profondeur 5 → tache
-const SOUS_ACTION_ID = 'cae_1.1.1.1'; // profondeur 4 → sous-action
-const ECI_SOUS_ACTION_ID = 'eci_1.1.1'; // ECI n'a pas de sous-axe, donc prof 3 → sous-action
+const TACHE_CAE = 'cae_1.1.1.1.2'; // profondeur 5 → tache
+const SOUS_ACTION_CAE = 'cae_1.1.1.1'; // profondeur 4 → sous-action
+const SOUS_ACTION_ECI = 'eci_1.1.1'; // ECI n'a pas de sous-axe, donc prof 3 → sous-action
 
 /**
  * Narrow un `HistoriqueItem` (union discriminée) sur son `type`. Les
@@ -286,7 +289,7 @@ describe('HistoriqueRouter', () => {
 
     test('un lecteur de la collectivité peut lire son historique', async () => {
       await seedHistoriqueActionStatuts(router, editorA, [
-        { collectiviteId: collectiviteA.id, actionId: TACHE_ACTION_ID },
+        { collectiviteId: collectiviteA.id, actionId: TACHE_CAE },
       ]);
 
       const readerCaller = router.createCaller({ user: readerA });
@@ -297,16 +300,16 @@ describe('HistoriqueRouter', () => {
       expect(total).toBe(1);
       expect(items).toHaveLength(1);
       assertHistoriqueType(items[0], 'action_statut');
-      expect(items[0].actionId).toBe(TACHE_ACTION_ID);
+      expect(items[0].actionId).toBe(TACHE_CAE);
     });
 
     test('union sur les 4 sources : action_statut, action_precision, reponse, justification', async () => {
       await seedHistoriqueActionStatuts(router, editorA, [
-        { collectiviteId: collectiviteA.id, actionId: TACHE_ACTION_ID },
+        { collectiviteId: collectiviteA.id, actionId: TACHE_CAE },
       ]);
       await seedHistoriqueActionCommentaire(router, editorA, {
         collectiviteId: collectiviteA.id,
-        actionId: SOUS_ACTION_ID,
+        actionId: SOUS_ACTION_CAE,
         commentaire: 'Précision test',
       });
       await seedHistoriqueReponse(router, editorA, {
@@ -326,11 +329,11 @@ describe('HistoriqueRouter', () => {
       );
 
       const statutItem = requireItemOfType(items, 'action_statut');
-      expect(statutItem.actionId).toBe(TACHE_ACTION_ID);
+      expect(statutItem.actionId).toBe(TACHE_CAE);
       expect(statutItem.actionType).toBe(ActionTypeEnum.TACHE);
 
       const precisionItem = requireItemOfType(items, 'action_precision');
-      expect(precisionItem.actionId).toBe(SOUS_ACTION_ID);
+      expect(precisionItem.actionId).toBe(SOUS_ACTION_CAE);
       expect(precisionItem.actionType).toBe(ActionTypeEnum.SOUS_ACTION);
       expect(precisionItem.precision).toBe('Précision test');
 
@@ -346,11 +349,11 @@ describe('HistoriqueRouter', () => {
       // updateStatuts exige que toutes les actions d'un batch soient dans le
       // même référentiel — on splitte donc en deux appels.
       await seedHistoriqueActionStatuts(router, editorA, [
-        { collectiviteId: collectiviteA.id, actionId: TACHE_ACTION_ID },
-        { collectiviteId: collectiviteA.id, actionId: SOUS_ACTION_ID },
+        { collectiviteId: collectiviteA.id, actionId: TACHE_CAE },
+        { collectiviteId: collectiviteA.id, actionId: SOUS_ACTION_CAE },
       ]);
       await seedHistoriqueActionStatuts(router, editorA, [
-        { collectiviteId: collectiviteA.id, actionId: ECI_SOUS_ACTION_ID },
+        { collectiviteId: collectiviteA.id, actionId: SOUS_ACTION_ECI },
       ]);
 
       const caller = router.createCaller({ user: readerA });
@@ -364,9 +367,11 @@ describe('HistoriqueRouter', () => {
       const byId = Object.fromEntries(
         actionStatutItems.map((i) => [i.actionId, i])
       );
-      expect(byId[TACHE_ACTION_ID]?.actionType).toBe(ActionTypeEnum.TACHE);
-      expect(byId[SOUS_ACTION_ID]?.actionType).toBe(ActionTypeEnum.SOUS_ACTION);
-      expect(byId[ECI_SOUS_ACTION_ID]?.actionType).toBe(
+      expect(byId[TACHE_CAE]?.actionType).toBe(ActionTypeEnum.TACHE);
+      expect(byId[SOUS_ACTION_CAE]?.actionType).toBe(
+        ActionTypeEnum.SOUS_ACTION
+      );
+      expect(byId[SOUS_ACTION_ECI]?.actionType).toBe(
         ActionTypeEnum.SOUS_ACTION
       );
     });
@@ -374,7 +379,7 @@ describe('HistoriqueRouter', () => {
     test("filtre par actionId inclut l'action et ses descendants", async () => {
       await seedHistoriqueActionStatuts(router, editorA, [
         // cae_1.1.1.1.2 → descendant de cae_1.1
-        { collectiviteId: collectiviteA.id, actionId: TACHE_ACTION_ID },
+        { collectiviteId: collectiviteA.id, actionId: TACHE_CAE },
         // hors du préfixe cae_1.1
         { collectiviteId: collectiviteA.id, actionId: 'cae_1.2.2.1.1' },
       ]);
@@ -388,7 +393,7 @@ describe('HistoriqueRouter', () => {
 
       expect(items).toHaveLength(1);
       assertHistoriqueType(items[0], 'action_statut');
-      expect(items[0].actionId).toBe(TACHE_ACTION_ID);
+      expect(items[0].actionId).toBe(TACHE_CAE);
     });
 
     test("filtre par actionId est ancré sur le séparateur '.' : 'cae_1.1' ne remonte pas 'cae_1.10'", async () => {
@@ -471,10 +476,10 @@ describe('HistoriqueRouter', () => {
 
     test('filtre par modifiedBy', async () => {
       await seedHistoriqueActionStatuts(router, editorA, [
-        { collectiviteId: collectiviteA.id, actionId: TACHE_ACTION_ID },
+        { collectiviteId: collectiviteA.id, actionId: TACHE_CAE },
       ]);
       await seedHistoriqueActionStatuts(router, adminA, [
-        { collectiviteId: collectiviteA.id, actionId: SOUS_ACTION_ID },
+        { collectiviteId: collectiviteA.id, actionId: SOUS_ACTION_CAE },
       ]);
 
       const caller = router.createCaller({ user: readerA });
@@ -489,10 +494,10 @@ describe('HistoriqueRouter', () => {
 
     test('isole les collectivités : seules les lignes de la collectivité demandée sont renvoyées', async () => {
       await seedHistoriqueActionStatuts(router, editorA, [
-        { collectiviteId: collectiviteA.id, actionId: TACHE_ACTION_ID },
+        { collectiviteId: collectiviteA.id, actionId: TACHE_CAE },
       ]);
       await seedHistoriqueActionStatuts(router, editorB, [
-        { collectiviteId: collectiviteB.id, actionId: SOUS_ACTION_ID },
+        { collectiviteId: collectiviteB.id, actionId: SOUS_ACTION_CAE },
       ]);
 
       const readerACaller = router.createCaller({ user: readerA });
@@ -505,7 +510,7 @@ describe('HistoriqueRouter', () => {
       expect(itemsA).toHaveLength(1);
       expect(itemsA[0].collectiviteId).toBe(collectiviteA.id);
       assertHistoriqueType(itemsA[0], 'action_statut');
-      expect(itemsA[0].actionId).toBe(TACHE_ACTION_ID);
+      expect(itemsA[0].actionId).toBe(TACHE_CAE);
 
       const readerBCaller = router.createCaller({ user: readerB });
       const { items: itemsB, total: totalB } =
@@ -515,7 +520,7 @@ describe('HistoriqueRouter', () => {
       expect(totalB).toBe(1);
       expect(itemsB[0].collectiviteId).toBe(collectiviteB.id);
       assertHistoriqueType(itemsB[0], 'action_statut');
-      expect(itemsB[0].actionId).toBe(SOUS_ACTION_ID);
+      expect(itemsB[0].actionId).toBe(SOUS_ACTION_CAE);
     });
 
     // #3 — Non-member rejection (P1)
@@ -606,7 +611,7 @@ describe('HistoriqueRouter', () => {
       await databaseService.db.insert(historiqueActionStatutTable).values([
         {
           collectiviteId: collectiviteA.id,
-          actionId: TACHE_ACTION_ID,
+          actionId: TACHE_CAE,
           avancement: 'fait',
           concerne: true,
           modifiedBy: editorA.id,
@@ -614,7 +619,7 @@ describe('HistoriqueRouter', () => {
         },
         {
           collectiviteId: collectiviteA.id,
-          actionId: SOUS_ACTION_ID,
+          actionId: SOUS_ACTION_CAE,
           avancement: 'fait',
           concerne: true,
           modifiedBy: editorA.id,
@@ -630,7 +635,7 @@ describe('HistoriqueRouter', () => {
 
       expect(items).toHaveLength(1);
       assertHistoriqueType(items[0], 'action_statut');
-      expect(items[0].actionId).toBe(TACHE_ACTION_ID);
+      expect(items[0].actionId).toBe(TACHE_CAE);
     });
 
     // #10 — Pagination + total (P2)
@@ -643,7 +648,7 @@ describe('HistoriqueRouter', () => {
       await databaseService.db.insert(historiqueActionStatutTable).values(
         Array.from({ length: totalRows }).map((_, i) => ({
           collectiviteId: collectiviteA.id,
-          actionId: TACHE_ACTION_ID,
+          actionId: TACHE_CAE,
           avancement: 'fait' as const,
           concerne: true,
           modifiedBy: editorA.id,
@@ -676,11 +681,11 @@ describe('HistoriqueRouter', () => {
     // #21 — types filter (P3)
     test('filtre par types : `action_statut` ne renvoie que les statuts', async () => {
       await seedHistoriqueActionStatuts(router, editorA, [
-        { collectiviteId: collectiviteA.id, actionId: TACHE_ACTION_ID },
+        { collectiviteId: collectiviteA.id, actionId: TACHE_CAE },
       ]);
       await seedHistoriqueActionCommentaire(router, editorA, {
         collectiviteId: collectiviteA.id,
-        actionId: SOUS_ACTION_ID,
+        actionId: SOUS_ACTION_CAE,
         commentaire: 'Précision test',
       });
       await seedHistoriqueReponse(router, editorA, {
@@ -704,12 +709,187 @@ describe('HistoriqueRouter', () => {
       assertHistoriqueType(items[0], 'action_statut');
     });
 
+    describe('scope par referentielId', () => {
+      test('isole les référentiels dans les deux sens', async () => {
+        await seedHistoriqueActionStatuts(router, editorA, [
+          { collectiviteId: collectiviteA.id, actionId: TACHE_CAE },
+        ]);
+        await seedHistoriqueActionStatuts(router, editorA, [
+          { collectiviteId: collectiviteA.id, actionId: SOUS_ACTION_ECI },
+        ]);
+
+        const caller = router.createCaller({ user: readerA });
+        const { total: totalSansScope } =
+          await caller.referentiels.historique.list(
+            baseInput(collectiviteA.id)
+          );
+
+        expect(totalSansScope).toBe(2);
+
+        const { items: itemsEci, total: totalEci } =
+          await caller.referentiels.historique.list({
+            collectiviteId: collectiviteA.id,
+            referentielId: ReferentielIdEnum.ECI,
+            filters: {},
+          });
+
+        expect(totalEci).toBe(1);
+        assertHistoriqueType(itemsEci[0], 'action_statut');
+        expect(itemsEci[0].actionId).toBe(SOUS_ACTION_ECI);
+
+        const { items: itemsCae, total: totalCae } =
+          await caller.referentiels.historique.list({
+            collectiviteId: collectiviteA.id,
+            referentielId: ReferentielIdEnum.CAE,
+            filters: {},
+          });
+
+        expect(totalCae).toBe(1);
+        assertHistoriqueType(itemsCae[0], 'action_statut');
+        expect(itemsCae[0].actionId).toBe(TACHE_CAE);
+      });
+
+      test('une réponse de personnalisation remonte via les actions liées à sa question', async () => {
+        await databaseService.db.insert(questionActionTable).values({
+          questionId: TEST_QUESTION_BINAIRE_ID,
+          actionId: SOUS_ACTION_CAE,
+        });
+        onTestFinished(async () => {
+          await databaseService.db
+            .delete(questionActionTable)
+            .where(
+              eq(questionActionTable.questionId, TEST_QUESTION_BINAIRE_ID)
+            );
+        });
+
+        await seedHistoriqueReponse(router, editorA, {
+          collectiviteId: collectiviteA.id,
+          questionId: TEST_QUESTION_BINAIRE_ID,
+          reponse: true,
+        });
+
+        const caller = router.createCaller({ user: readerA });
+        const { items: itemsCae } = await caller.referentiels.historique.list({
+          collectiviteId: collectiviteA.id,
+          referentielId: ReferentielIdEnum.CAE,
+          filters: {},
+        });
+
+        expect(requireItemOfType(itemsCae, 'reponse').questionId).toBe(
+          TEST_QUESTION_BINAIRE_ID
+        );
+
+        const { items: itemsEci, total: totalEci } =
+          await caller.referentiels.historique.list({
+            collectiviteId: collectiviteA.id,
+            referentielId: ReferentielIdEnum.ECI,
+            filters: {},
+          });
+
+        expect(totalEci).toBe(0);
+        expect(itemsEci).toHaveLength(0);
+      });
+
+      test('une question sans action liée ne remonte pour aucun référentiel', async () => {
+        const questionSansActionId = 'hist-test-question-sans-action';
+        await databaseService.db.insert(questionTable).values({
+          id: questionSansActionId,
+          type: 'binaire',
+          description: 'Question binaire sans action liée',
+          formulation: 'Question sans action liée ?',
+          version: '1.0.0',
+        });
+        onTestFinished(async () => {
+          await databaseService.db
+            .delete(reponseBinaireTable)
+            .where(eq(reponseBinaireTable.questionId, questionSansActionId));
+          await databaseService.db
+            .delete(questionTable)
+            .where(eq(questionTable.id, questionSansActionId));
+        });
+
+        await seedHistoriqueReponse(router, editorA, {
+          collectiviteId: collectiviteA.id,
+          questionId: questionSansActionId,
+          reponse: true,
+        });
+
+        const caller = router.createCaller({ user: readerA });
+        const { total: totalSansScope } =
+          await caller.referentiels.historique.list(
+            baseInput(collectiviteA.id)
+          );
+
+        expect(totalSansScope).toBe(1);
+
+        const { items, total } = await caller.referentiels.historique.list({
+          collectiviteId: collectiviteA.id,
+          referentielId: ReferentielIdEnum.CAE,
+          filters: {},
+        });
+
+        expect(total).toBe(0);
+        expect(items).toHaveLength(0);
+      });
+
+      test('une question liée à plusieurs référentiels remonte pour chacun', async () => {
+        await databaseService.db.insert(questionActionTable).values([
+          { questionId: TEST_QUESTION_BINAIRE_ID, actionId: SOUS_ACTION_CAE },
+          { questionId: TEST_QUESTION_BINAIRE_ID, actionId: SOUS_ACTION_ECI },
+        ]);
+        onTestFinished(async () => {
+          await databaseService.db
+            .delete(questionActionTable)
+            .where(
+              eq(questionActionTable.questionId, TEST_QUESTION_BINAIRE_ID)
+            );
+        });
+
+        await seedHistoriqueReponse(router, editorA, {
+          collectiviteId: collectiviteA.id,
+          questionId: TEST_QUESTION_BINAIRE_ID,
+          reponse: true,
+        });
+        await seedHistoriqueActionStatuts(router, editorA, [
+          { collectiviteId: collectiviteA.id, actionId: TACHE_CAE },
+        ]);
+
+        const caller = router.createCaller({ user: readerA });
+        const { items: itemsCae, total: totalCae } =
+          await caller.referentiels.historique.list({
+            collectiviteId: collectiviteA.id,
+            referentielId: ReferentielIdEnum.CAE,
+            filters: {},
+          });
+
+        expect(totalCae).toBe(2);
+        expect(requireItemOfType(itemsCae, 'reponse').questionId).toBe(
+          TEST_QUESTION_BINAIRE_ID
+        );
+        expect(requireItemOfType(itemsCae, 'action_statut').actionId).toBe(
+          TACHE_CAE
+        );
+
+        const { items: itemsEci, total: totalEci } =
+          await caller.referentiels.historique.list({
+            collectiviteId: collectiviteA.id,
+            referentielId: ReferentielIdEnum.ECI,
+            filters: {},
+          });
+
+        expect(totalEci).toBe(1);
+        expect(requireItemOfType(itemsEci, 'reponse').questionId).toBe(
+          TEST_QUESTION_BINAIRE_ID
+        );
+      });
+    });
+
     // #22 — modifiedAt desc ordering (P3)
     test('ordonne les items par modifiedAt décroissant', async () => {
       await databaseService.db.insert(historiqueActionStatutTable).values([
         {
           collectiviteId: collectiviteA.id,
-          actionId: TACHE_ACTION_ID,
+          actionId: TACHE_CAE,
           avancement: 'fait',
           concerne: true,
           modifiedBy: editorA.id,
@@ -717,7 +897,7 @@ describe('HistoriqueRouter', () => {
         },
         {
           collectiviteId: collectiviteA.id,
-          actionId: SOUS_ACTION_ID,
+          actionId: SOUS_ACTION_CAE,
           avancement: 'fait',
           concerne: true,
           modifiedBy: editorA.id,
@@ -739,8 +919,8 @@ describe('HistoriqueRouter', () => {
       }
       assertHistoriqueType(items[0], 'action_statut');
       assertHistoriqueType(items[1], 'action_statut');
-      expect(items[0].actionId).toBe(SOUS_ACTION_ID);
-      expect(items[1].actionId).toBe(TACHE_ACTION_ID);
+      expect(items[0].actionId).toBe(SOUS_ACTION_CAE);
+      expect(items[1].actionId).toBe(TACHE_CAE);
     });
   });
 
@@ -760,11 +940,11 @@ describe('HistoriqueRouter', () => {
 
     test('retourne les contributeurs distincts de la collectivité', async () => {
       await seedHistoriqueActionStatuts(router, editorA, [
-        { collectiviteId: collectiviteA.id, actionId: TACHE_ACTION_ID },
+        { collectiviteId: collectiviteA.id, actionId: TACHE_CAE },
       ]);
       // Contribution sur une autre collectivité : ne doit pas apparaître ici.
       await seedHistoriqueActionStatuts(router, editorB, [
-        { collectiviteId: collectiviteB.id, actionId: TACHE_ACTION_ID },
+        { collectiviteId: collectiviteB.id, actionId: TACHE_CAE },
       ]);
 
       const readerACaller = router.createCaller({ user: readerA });
@@ -790,11 +970,11 @@ describe('HistoriqueRouter', () => {
     // #23 — Dedup d'un utilisateur contribuant sur plusieurs sources
     test('dédoublonne un utilisateur contribuant sur plusieurs sources', async () => {
       await seedHistoriqueActionStatuts(router, editorA, [
-        { collectiviteId: collectiviteA.id, actionId: TACHE_ACTION_ID },
+        { collectiviteId: collectiviteA.id, actionId: TACHE_CAE },
       ]);
       await seedHistoriqueActionCommentaire(router, editorA, {
         collectiviteId: collectiviteA.id,
-        actionId: SOUS_ACTION_ID,
+        actionId: SOUS_ACTION_CAE,
         commentaire: 'Précision test dedup',
       });
 

--- a/apps/backend/src/referentiels/historique/list-historique/list-historique.repository.ts
+++ b/apps/backend/src/referentiels/historique/list-historique/list-historique.repository.ts
@@ -89,8 +89,8 @@ export class ListHistoriqueRepository {
    * Reconstitue le contenu de la vue `public.historique` via quatre selects
    * Drizzle unionnés (sans la clause `have_lecture_acces` qui dépend de
    * `auth.uid()` — la permission est vérifiée côté service). Applique les
-   * filtres conditionnels (actionId, modifiedBy, types, startDate, endDate),
-   * la pagination et le comptage en parallèle.
+   * filtres conditionnels (actionId, referentielId, modifiedBy, types,
+   * startDate, endDate), la pagination et le comptage en parallèle.
    *
    * Équivalence stricte au SQL pré-extraction : mêmes joins, mêmes
    * sentinelles `null::*`, même `unionAll`, mêmes `where`, mêmes
@@ -110,7 +110,7 @@ export class ListHistoriqueRepository {
     input: ListHistoriqueInput,
     tx?: Transaction
   ): Promise<{ rows: HistoriqueUnionRow[]; total: number }> {
-    const { collectiviteId, actionId, filters } = input;
+    const { collectiviteId, actionId, referentielId, filters } = input;
     const { page, modifiedBy, types, startDate, endDate } = filters;
 
     const historiqueUnion = unionAll(
@@ -141,6 +141,11 @@ export class ListHistoriqueRepository {
         like(historiqueUnion.actionId, `${escapedActionId}.%`)
       );
       if (actionIdFilter) conditions.push(actionIdFilter);
+    }
+    if (referentielId) {
+      conditions.push(
+        sql`exists (select 1 from unnest(${historiqueUnion.actionIds}) as linked_action_id where split_part(linked_action_id, '_', 1) = ${referentielId})`
+      );
     }
     if (modifiedBy && modifiedBy.length > 0) {
       conditions.push(inArray(historiqueUnion.modifiedById, modifiedBy));

--- a/packages/domain/src/referentiels/historique/list-historique.input.ts
+++ b/packages/domain/src/referentiels/historique/list-historique.input.ts
@@ -1,4 +1,5 @@
 import z from 'zod';
+import { referentielIdEnumSchema } from '../referentiel-id.enum';
 import { historiqueTypeSchema } from './historique-type.enum';
 
 /** Nombre d'éléments par page pour l'historique */
@@ -15,6 +16,7 @@ export const listHistoriqueInputFiltersSchema = z.object({
 export const listHistoriqueInputSchema = z.object({
   collectiviteId: z.number().int().positive(),
   actionId: z.string().optional(),
+  referentielId: z.optional(referentielIdEnumSchema),
   filters: listHistoriqueInputFiltersSchema.default({}),
 });
 


### PR DESCRIPTION
Rend l'historique d'une collectivité scopable par référentiel, du domaine jusqu'au hook front, en un commit.

Les deux moitiés — contrat d'API et transmission côté front — atterrissent ensemble, ce qui évite qu'on merge le front sans le back. Attention toutefois : elles se **déploient** séparément, voir l'avertissement sur l'ordre de déploiement plus bas.

## Ce que ça fait

`referentiels.historique.list` accepte un `referentielId` optionnel **à la racine** de son entrée, à côté de `actionId`, et le hook le transmet :

```ts
useHistoriqueItemListe({ referentielId })
<HistoriqueListe referentielId={referentielId} />
```

C'est un **scope de page**, pas un filtre utilisateur : le référentiel vient du contexte (une route), pas d'une case cochée. Exactement comme `actionId`, que le side panel d'action passe déjà (`referentiel/[referentielId]/action/[actionId]/_components/side-panel/index.tsx:69`). Champ optionnel, donc absent → comportement inchangé.

Le placement à la racine n'est pas cosmétique : `trpc.service.ts:63` passe le `rawInput` à `autoSetContextFromPayload`, qui lit la clé de premier niveau `referentielId` (`context.service.ts:53-61`) et l'injecte dans le scope AsyncLocalStorage. Toutes les lignes de log de la requête portent donc le `referentielId`. Sous `filters`, cet enrichissement n'aurait pas lieu — c'est la convention documentée dans `apps/backend/CLAUDE.md`, tenue par une correspondance de chaîne au runtime et non par le compilateur.

### Conception SQL

Tout le filtre tient en une condition, **sans toucher au `unionAll`** :

```sql
exists (
  select 1 from unnest(action_ids) as linked_action_id
  where split_part(linked_action_id, '_', 1) = $referentielId
)
```

La colonne `action_ids` est déjà projetée par les 4 branches et contient exactement les action ids pertinents :

- `action_statut` / `action_precision` : `array[action_id]`, un seul élément
- `reponse` / `justification` : les actions liées à la question via `question_action`

Une ligne appartient donc au référentiel demandé si l'un de ses action ids en porte le préfixe. Conséquences directes, toutes deux couvertes par un test :

- une question de personnalisation liée à des actions de **plusieurs** référentiels remonte pour chacun — c'est le cas normal, une question n'a pas de référentiel propre ;
- une question **sans** action liée ne remonte pour aucun référentiel : `action_ids` est `NULL`, `unnest(NULL)` ne produit aucune ligne, `exists` est faux.

Rien n'est évalué quand `referentielId` est absent.

## Surface de review

| Fichier | Nature | Lignes |
|---|---|---|
| `list-historique.repository.ts` | **Attention humaine — le SQL** | +8 −3 |
| `list-historique.input.ts` | **Attention humaine — le contrat** | +2 |
| `HistoriqueListe.tsx` | Front | +13 −6 |
| `useHistoriqueItemListe.ts` | Front | +4 |
| `historique.router.e2e-spec.ts` | Tests | +217 −37 |

Ni le routeur ni le service backend ne changent : le routeur est piloté par le schéma, et `ListHistoriqueService` passe `input` tel quel au repository.

Logique nouvelle : ~20 lignes. Les suppressions dans le spec viennent d'un renommage de constantes qui touche les 19 tests préexistants (voir « Lisibilité des tests ») ; celles de `HistoriqueListe.tsx` viennent du passage des props inline à un type nommé, `HistoriqueListe` atteignant trois props.

## Une passe de revue a simplifié l'implémentation

La première version ajoutait une colonne `referentiel_ids` (`text[]`) aux 4 branches du `unionAll`, via deux helpers privés et une **deuxième** sous-requête corrélée sur `question_action` pour les branches reponse et justification. Une relecture a montré que `action_ids`, déjà projetée, portait toute l'information nécessaire.

Retiré : les 2 helpers, les 4 ajouts de colonne, l'import de `SQLWrapper` et l'usage d'`arrayOverlapsPatched` — soit 33 lignes, et une sous-requête par ligne sur 2 des 4 branches qui aurait été payée par **toute** requête d'historique, y compris sans `referentielId` (Postgres n'aplatit pas les set-operations, donc les expressions de la liste de select des branches sont évaluées même si la colonne n'est pas utilisée en sortie — raisonné, non mesuré). Les 23 tests passent à l'identique avant et après cette simplification.

## Preuve de recherche anti-duplication

**Bilan : aucune utility créée, et aucune réutilisation nécessaire non plus** — la donnée existait déjà dans la requête.

| Élément envisagé | Recherche | Décision |
|---|---|---|
| Helper « littéral `text[]` + opérateur `&&` » (nommé `toTextArray` dans une version exploratoire) | `arrayOverlapsPatched` existe — `apps/backend/src/utils/drizzle.utils.ts:6`, précédent d'usage identique `list-indicateurs.service.ts:670` | **Supprimé** ; puis `arrayOverlapsPatched` lui-même est devenu inutile avec la simplification ci-dessus |
| Nouvelle colonne d'appartenance au référentiel | La colonne `action_ids` du `unionAll` porte déjà les action ids des 4 branches | **Réutilisée** plutôt que dupliquée |
| Paramètre de scope à la racine, et prop de scope sur `HistoriqueListe` | `actionId` (`list-historique.input.ts:17`), traitement `list-historique.repository.ts:128-146`, prop consommée par le side panel d'action | **Calqués** : même emplacement, même style de condition inline, aucun traitement dans le service |
| Dérivation du référentiel depuis un `action_id` | `getReferentielIdFromActionId` côté domaine (`referentiel.utils.ts:19`) ; colonnes `action_relation.referentiel` et `action_definition.referentiel_id` côté SQL | **Créé en connaissance de cause** — voir « Zones low-confidence » |

## Hypothèses prises

1. La visibilité des référentiels (feature flag `te`, préférences d'affichage de la collectivité) est une préoccupation de **vue**, pas d'API. Le backend accepte tout `ReferentielId` valide ; l'autorisation reste celle de la lecture de l'historique de la collectivité. Un backend qui filtrerait sur les préférences d'affichage rendrait l'API dépendante d'un réglage cosmétique.
2. `referentielId` et `actionId` se combinent en `AND`, et ce n'est **volontairement pas testé**. Les passer ensemble n'est jamais utile — redondant au mieux, contradictoire au pire (résultat vide, pas d'erreur). Un test l'épinglant figerait un détail d'assemblage de la clause `WHERE` et cimenterait une API que le plan considère perfectible : l'encodage idéal serait une union discriminée `{ actionId } | { referentielId } | {}`, écartée ici parce qu'elle casserait la signature actuelle de `actionId`.
3. `z.optional(referentielIdEnumSchema)` en forme fonction et non `.optional()` : le schéma du domaine est en `zod/mini`, qui n'expose pas cette méthode. Réutiliser le schéma canonique préserve ses métadonnées enregistrées (`description: 'Identifiant du référentiel'`) qu'une redéfinition en `z.enum(referentielIdEnumValues)` aurait perdues.

## Zones low-confidence

**`split_part` plutôt qu'une jointure sur `action_relation.referentiel`** — c'est le point de review à cibler.

`split_part` fait fuiter dans le SQL une règle de nommage déjà exprimée côté domaine par `getReferentielIdFromActionId`. La règle « le préfixe avant le premier `_` est l'id du référentiel » est désormais écrite à deux endroits ; si elle change, les deux bougent.

Retenu quand même parce que l'alternative ajoute des jointures sur un `unionAll` déjà large, et parce que l'égalité exacte du préfixe évite le piège `te` / `te-test` : un `LIKE 'te\_%'` — réflexe naturel, et c'est justement la technique du filtre `actionId` voisin — remonterait `te-test_1.1`, `_` étant un joker LIKE.

**Trou de couverture assumé sur ce point.** Aucun test ne garde cette frontière de préfixe. Le couple `te` / `te-test` est le seul du domaine où un id préfixe un autre, et `te-test` n'a pas d'action seedée : le couvrir imposait de fabriquer `action_relation` + `action_definition` de toutes pièces, le fixture le plus lourd du fichier. Arbitré en faveur de fixtures cae/eci uniquement. **Conséquence : si quelqu'un réécrit la condition en `LIKE`, aucun test ne l'attrape** — seule la review protège ce choix.

## Aucun appelant ne passe encore la prop

Écart assumé et borné. Sur `main`, aucune surface d'historique par référentiel n'existe. Le consommateur arrive avec `TET-6818/refonte-main-nav`, où `referentiel/[referentielId]/(overview)/@tabs/historique/page.tsx` rend aujourd'hui `<HistoriqueListe />` **sans scope** — l'historique complet de la collectivité s'affiche donc sous chaque onglet référentiel. Le diff qui referme l'écart fera **une ligne**.

## ⚠️ L'ordre de déploiement reste à surveiller

Consolider les deux moitiés dans une seule PR garantit qu'elles sont mergées ensemble, mais **front et backend se déploient séparément** (déploiement backend de staging manuel via `cd-backend.yml`). Si le front part avant le back, zod retire silencieusement la clé inconnue : le paramètre est accepté côté appelant et ne scope rien. L'échec est muet, pas bruyant. **Déployer le backend en premier.**

## Tests

4 tests e2e ajoutés (23 au total sur le fichier, 19 existants inchangés), tous sur cae/eci :

1. **isole les référentiels dans les deux sens** — deux lignes seedées, une CAE une ECI ; demander `eci` ne remonte que l'ECI, demander `cae` ne remonte que la CAE
2. **une réponse de personnalisation remonte via les actions liées à sa question** — question liée à une action CAE : présente en `cae`, absente en `eci`
3. **une question sans action liée ne remonte pour aucun référentiel** — le chemin `unnest(NULL)`
4. **une question liée à plusieurs référentiels remonte pour chacun** — la question apparaît en `cae` et en `eci`, tandis qu'un statut d'action CAE seul n'apparaît qu'en `cae`

**Aucun test sur la partie front**, volontairement : le hook consomme tRPC/React-Query et les conventions front excluent le test unitaire de ces composants (pas de MSW, pas de `renderWithProviders`). La couverture du comportement est l'e2e backend.

### Vérification que les tests sont porteurs

Ce n'est pas un `fix`, donc pas de commit de test rouge. J'ai néanmoins vérifié que les tests ne passent pas à vide, en neutralisant la condition (`if (referentielId && false)`) :

```
× isole les référentiels dans les deux sens
× une réponse de personnalisation remonte via les actions liées à sa question
× une question sans action liée ne remonte pour aucun référentiel
× une question liée à plusieurs référentiels remonte pour chacun
Tests  4 failed | 19 passed (23)
```

Exactement les 4 nouveaux tombent et les 19 existants passent — aucun ne passe à vide. Contrôle refait après la simplification de l'implémentation.

**Fuite constatée dans les deux sens**, sans le SQL : en demandant `eci`, `totalEci` reçoit `2` au lieu de `1` (la ligne CAE remonte) ; en relâchant cette première assertion pour atteindre la seconde, `totalCae` reçoit `2` au lieu de `1` (la ligne ECI remonte). L'isolation n'est donc pas asymétrique par accident.

**Câblage front prouvé** malgré l'absence de test : en retirant les 2 lignes de schéma du domaine, la chaîne casse avec `error TS2339: Property 'referentielId' does not exist on type '{ collectiviteId: number; actionId?: string; filters: {...} }'`. Le paramètre traverse donc réellement domaine → routeur → types du client tRPC ; ce n'est pas un prop décoratif.

Deux tests écrits puis retirés en cours de review, plutôt que gardés par habitude : celui qui vérifiait le `AND` entre `referentielId` et `actionId` (détail d'assemblage, cf. hypothèse 2) et celui sur `te` / `te-test` (fixture fabriquée, cf. « Zones low-confidence »).

## Lisibilité des tests

Deux corrections après relecture, qui touchent aussi les 19 tests préexistants :

- **Constantes renommées** en `TACHE_CAE`, `SOUS_ACTION_CAE`, `SOUS_ACTION_ECI`. Les précédentes (`TACHE_ACTION_ID`, `SOUS_ACTION_ID`, `ECI_SOUS_ACTION_ID`) ne disaient pas leur référentiel, alors que c'est précisément le sujet des nouvelles assertions ; les remplacer par des littéraux ne disait plus le type d'action. Le nom porte maintenant les deux, et aucun numéro d'action n'est écrit à la main dans les tests.
- **Le test « question sans action liée » crée sa propre question.** Sa prémisse n'était écrite nulle part : elle n'était vraie que parce que le `beforeAll` ne pose pas de `question_action` et que le test voisin nettoie le sien — un couplage silencieux entre deux tests, sensible à l'ordre `onTestFinished` / `afterEach`.

## Vérifications

- `nx run backend:typecheck` ✅ · `nx run app:typecheck` ✅
- `nx run backend:lint` ✅ · `nx run app:lint` ✅ (0 erreur, warnings = baseline préexistante) · prettier ✅
- `nx test backend 'historique.router'` → **23/23** · `nx test app` → **540/540**
- Branche rebasée sur `main` et revérifiée après rebase

## Hors scope

- Un filtre utilisateur multi-sélection (`filters.referentielIds` + sélecteur dans la barre de filtres) → feature distincte, décrite dans la section « Différé » du plan. Elle devra **réutiliser** `ReferentielsDropdown`, qui porte déjà le flag `te` et les préférences d'affichage
- Câbler l'onglet par référentiel → arrive avec `refonte-main-nav`
- Scoper `listUtilisateurs` : sur une page scopée par référentiel, le filtre « Membre » listera donc les contributeurs de tous les référentiels. À traiter quand le consommateur existera
- Exposer le référentiel en sortie (`HistoriqueItem`) : le front le dérive déjà via `getReferentielIdFromActionId` (`Modification.tsx:42`)
- Restreindre `referentielId` aux référentiels affichés par la collectivité côté backend (hypothèse 1)
- Le `total: 0` sur page hors bornes côté repository : comportement volontaire, documenté et épinglé par le test e2e existant sur la pagination
- Réinitialiser la pagination quand le scope change : sans objet, le scope n'est pas dans l'URL

## Items ajoutés à DISCOVERED.md

Aucun dans cette PR. Deux découvertes faites pendant la planification concernent des fichiers non touchés ici :

- **Changer un filtre ne réinitialise pas la pagination** → faux état vide sans échappatoire visible (`Pagination` ne rend rien quand `nbOfElements <= maxElementsPerPage`). Deux PRs de suite prévues dans le plan, sur un track indépendant.
- **La story `HistoriqueFiltres` passe des props qui n'existent plus** (`collectivite_id`, `initialFilters`), aucun test rouge écrivable — les `*.stories.tsx` sont exclus du typecheck et du CI.

## ⚠️ À surveiller au merge

`TET-6818/refonte-main-nav` **déplace** `apps/app/src/app/pages/collectivite/Historique/` vers `apps/app/src/referentiels/` — soit les 2 fichiers front touchés ici. Les deux branches sont vertes isolément et cassent ensemble. C'est `refonte-main-nav` qui doit rebaser sur `main` mergé, avant son merge et pas après. La partie backend, elle, est hors de la zone de conflit.
