### PR TITLE
test(demarches): Aligne l'ordre attendu des topics PCAET sur la migration réglementaire

### DIFF
--- a/apps/backend/src/demarches/pcaet/get-diagnostic/get-diagnostic.router.e2e-spec.ts
+++ b/apps/backend/src/demarches/pcaet/get-diagnostic/get-diagnostic.router.e2e-spec.ts
@@ -83,9 +83,9 @@ describe('Récupérer le diagnostic PCAET', () => {
 
     expect(diagnostic.topics.map((topic) => topic.code)).toEqual([
       'profil_energie_climat',
-      'consommation_energetique',
-      'sequestration',
       'polluants_atmospheriques',
+      'sequestration',
+      'consommation_energetique',
       'enr',
       'vulnerabilite_territoire',
     ]);

--- a/e2e/tests/demarches/pcaet/demarche-pcaet-workflow.spec.ts
+++ b/e2e/tests/demarches/pcaet/demarche-pcaet-workflow.spec.ts
@@ -115,17 +115,17 @@ test.describe('Démarche PCAET - workflow plan actions', () => {
     // Naviguer entre topics ne touche pas au panneau. Le parcours suit l'ordre
     // d'affichage du référentiel : aucun volet ne s'y saute.
     await demarchePcaetPom.closeProgressPanel();
-    await clickNextTo(/topic=consommation_energetique$/);
-    await expect(page).toHaveURL(/\?topic=consommation_energetique$/);
-    await demarchePcaetPom.expectActiveTopic('consommation_energetique');
+    await clickNextTo(/topic=polluants_atmospheriques$/);
+    await expect(page).toHaveURL(/\?topic=polluants_atmospheriques$/);
+    await demarchePcaetPom.expectActiveTopic('polluants_atmospheriques');
     await clickNextTo(/topic=sequestration$/);
     await expect(page).toHaveURL(/\?topic=sequestration$/);
     await demarchePcaetPom.expectActiveTopic('sequestration');
     await demarchePcaetPom.expectProgressPanelOpen(false);
 
-    await clickNextTo(/topic=polluants_atmospheriques$/);
-    await expect(page).toHaveURL(/\?topic=polluants_atmospheriques$/);
-    await demarchePcaetPom.expectActiveTopic('polluants_atmospheriques');
+    await clickNextTo(/topic=consommation_energetique$/);
+    await expect(page).toHaveURL(/\?topic=consommation_energetique$/);
+    await demarchePcaetPom.expectActiveTopic('consommation_energetique');
     await clickNextTo(/topic=enr$/);
     await expect(page).toHaveURL(/\?topic=enr$/);
     await demarchePcaetPom.expectActiveTopic('enr');


### PR DESCRIPTION
## Mode de défaillance

`test-backend` et `test-e2e` sont rouges **sur toutes les branches** depuis aujourd'hui, sur deux specs :

- `apps/backend/src/demarches/pcaet/get-diagnostic/get-diagnostic.router.e2e-spec.ts:84` — attend `consommation_energetique` en 2e position, reçoit `polluants_atmospheriques` ;
- `e2e/tests/demarches/pcaet/demarche-pcaet-workflow.spec.ts:97` — le bouton « suivant » de la barre d'étapes pointe `?topic=polluants_atmospheriques` là où le test attend `?topic=consommation_energetique`.

**Ce n'est pas un flake, et pas un `ORDER BY` manquant.** `demarche/pcaet_diagnostic_ordre_reglementaire` (commit `f43f017abb`, « fix(demarches): apply recette fixes on the pcaet diagnostic and documents », mergé le 2026-08-17) permute délibérément deux topics pour appliquer l'ordre de présentation demandé par le ministère :

```sql
UPDATE public.demarche_pcaet_topic SET display_order = 2 WHERE code = 'polluants_atmospheriques';
UPDATE public.demarche_pcaet_topic SET display_order = 4 WHERE code = 'consommation_energetique';
```

Cette PR a mis à jour le test pgTAP (`data_layer/tests/demarche/pcaet_diagnostic.sql`) mais pas les deux specs TS du 2026-08-13, qui figeaient l'ordre d'avant.

## Ordre attendu, dérivé des migrations

Sans avoir besoin d'une base : le seed `pcaet_diagnostic.sql:148` pose `profil=1, consommation=2, sequestration=3, polluants=4, enr=5, vulnerabilite=6`, puis la migration met `polluants→2` et `consommation→4`. Ordre final :

| # | code |
|---|---|
| 1 | `profil_energie_climat` |
| 2 | `polluants_atmospheriques` |
| 3 | `sequestration` |
| 4 | `consommation_energetique` |
| 5 | `enr` |
| 6 | `vulnerabilite_territoire` |

Ce qui correspond exactement au « Received » de la CI, et à l'ordre énoncé en commentaire de la migration (émissions de GES, polluants, séquestration, consommation énergétique finale, ENR, vulnérabilité).

## Surface de review

Deux fichiers de test, **aucun code de production** — le backend renvoyait déjà le bon ordre.

- backend : les deux entrées permutées dans le tableau attendu.
- e2e : les codes de topic permutés dans deux des blocs de navigation. Les assertions de panneau d'avancée (`expectProgressPanelOpen`) restent à leur place : elles vérifient que naviguer entre topics ne touche pas au panneau, indépendamment du topic visité.

## Discipline test-first

L'ordre habituel (commit du test rouge, puis le fix) ne s'applique pas ici : le test rouge **existe déjà sur `main`** et c'est précisément lui que cette PR corrige. Le défaut est dans l'assertion, pas dans le code.

## Vérification

- L'ordre attendu est dérivé des migrations, pas d'une observation : seed + `UPDATE` ⇒ la table ci-dessus, sans ambiguïté.
- Je n'ai **pas** pu exécuter les deux specs en local : la base de dev de ma machine est antérieure aux tables du diagnostic PCAET (`relation "public.demarche_pcaet_topic" does not exist`), et je n'ai pas voulu lancer `act -j db-init` sur une base de travail. La vérification est donc la CI de cette PR, qui déploie toutes les migrations via `init-db`.
- Vérifié qu'aucune autre assertion ne dépend de cet ordre : `apps/app/src/demarches/steps.spec.ts` utilise sa propre liste de codes en fixture et ne teste que la préservation de l'ordre d'entrée.

## Hors scope, signalé

La même migration renomme le libellé du topic `profil_energie_climat` en « Émissions GES ». Trois fixtures de specs purs portent encore « Profil énergie climat » (`apps/app/src/demarches/completion.spec.ts:95`, `packages/domain/src/demarches/pcaet/diagnostic/demarche-pcaet-diagnostic.rules.spec.ts:37`, et un commentaire dans `topic-grid.adapter.spec.ts:42`). Ce sont des valeurs de fixture arbitraires dans des tests de logique pure, qui ne lisent pas la base : elles sont vertes et le resteront. Je ne les touche pas.

Egalement laisse tel quel : `demarche-pcaet.pom.ts:126-135` (`expectDiagnosticTopicsFromApi`) liste les six codes dans l'ancien ordre, mais la boucle ne fait qu'un `toBeVisible()` par onglet — l'assertion est insensible a l'ordre, elle passe. La liste *ressemble* a un ordre d'affichage sans en etre un ; a rebaptiser ou reordonner si on veut lever l'ambiguite, hors scope de ce correctif.
