### PR TITLE
feat(historique): expose le scope référentiel au hook et à HistoriqueListe

### DIFF
--- a/apps/app/src/app/pages/collectivite/Historique/HistoriqueListe.tsx
+++ b/apps/app/src/app/pages/collectivite/Historique/HistoriqueListe.tsx
@@ -4,7 +4,10 @@ import { appLabels } from '@/app/labels/catalog';
 import HistoriqueItemActionPrecision from '@/app/app/pages/collectivite/Historique/actionPrecision/HistoriqueItemActionPrecision';
 import HistoriqueItemActionStatut from '@/app/app/pages/collectivite/Historique/actionStatut/HistoriqueItemActionStatut';
 import SpinnerLoader from '@/app/ui/shared/SpinnerLoader';
-import { NB_HISTORIQUE_ITEMS_PER_PAGE } from '@tet/domain/referentiels';
+import {
+  NB_HISTORIQUE_ITEMS_PER_PAGE,
+  ReferentielId,
+} from '@tet/domain/referentiels';
 import { Alert, Event, Pagination, useEventTracker } from '@tet/ui';
 import HistoriqueFiltres from './HistoriqueFiltres/HistoriqueFiltres';
 import HistoriqueItemJustification from './reponse/HistoriqueItemJustification';
@@ -12,16 +15,20 @@ import HistoriqueItemReponse from './reponse/HistoriqueItemReponse';
 import { HistoriqueItem } from './types';
 import { useHistoriqueItemListe } from './useHistoriqueItemListe';
 
+type HistoriqueListeProps = {
+  actionId?: string;
+  referentielId?: ReferentielId;
+  small?: boolean;
+};
+
 export const HistoriqueListe = ({
   actionId,
+  referentielId,
   small,
-}: {
-  actionId?: string;
-  small?: boolean;
-}) => {
+}: HistoriqueListeProps) => {
   const tracker = useEventTracker();
   const { items, total, filters, setFilters, isLoading, isError } =
-    useHistoriqueItemListe({ actionId });
+    useHistoriqueItemListe({ actionId, referentielId });
 
   return (
     <>

--- a/apps/app/src/app/pages/collectivite/Historique/useHistoriqueItemListe.ts
+++ b/apps/app/src/app/pages/collectivite/Historique/useHistoriqueItemListe.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { useTRPC } from '@tet/api';
 import { useCurrentCollectivite } from '@tet/api/collectivites';
+import { ReferentielId } from '@tet/domain/referentiels';
 import { ITEM_ALL } from '@tet/ui';
 import { useQueryStates } from 'nuqs';
 import { filtersParsers, filtersUrlKeys } from './filters';
@@ -16,8 +17,10 @@ const isValidFilter = (
  */
 export const useHistoriqueItemListe = ({
   actionId,
+  referentielId,
 }: {
   actionId?: string;
+  referentielId?: ReferentielId;
 } = {}): THistoriqueProps => {
   const { collectiviteId } = useCurrentCollectivite();
   const trpc = useTRPC();
@@ -33,6 +36,7 @@ export const useHistoriqueItemListe = ({
     trpc.referentiels.historique.list.queryOptions({
       collectiviteId,
       actionId,
+      referentielId,
       filters: {
         modifiedBy: isValidFilter(modifiedBy) ? modifiedBy : undefined,
         types: isValidFilter(types) ? types : undefined,


### PR DESCRIPTION
> **PR empilée.** Sa base est `feat/historique-api-scope-referentiel` (#4808), pas `main`. Le diff affiché ici ne contient que les 2 fichiers qui lui appartiennent. À retarger sur `main` quand #4808 sera mergée.

PR 2/2 de la stack « Filtre par référentiel sur l'historique ». #4808 livre le contrat d'API, celle-ci le rend appelable depuis le front.

## Plan validé

`compound-knowledge-db/docs/plans/2026-08-17-001-feat-historique-filtre-referentiel-plan.md` — section « PR 2 ».

## Ce que ça fait

```ts
useHistoriqueItemListe({ referentielId })
<HistoriqueListe referentielId={referentielId} />
```

Le référentiel est transmis à `referentiels.historique.list`. C'est un **argument d'appel, pas un état d'URL** : le contexte de page le fixe, exactement comme `actionId` que le side panel d'action passe déjà (`referentiel/[referentielId]/action/[actionId]/_components/side-panel/index.tsx:69`).

`referentielId` est typé `ReferentielId` (le type du domaine), pas `string`.

`HistoriqueListe` passe à trois props, donc ses props sortent de la signature inline vers un type nommé `HistoriqueListeProps` — c'est la seule raison des lignes supprimées dans ce fichier.

## Surface de review

| Fichier | Lignes |
|---|---|
| `HistoriqueListe.tsx` | +13 −6 |
| `useHistoriqueItemListe.ts` | +4 |

Logique nouvelle : ~10 lignes. Aucun fichier mécanique.

## Aucun appelant ne passe encore la prop

C'est l'écart déclaré de la stack, assumé et borné. Sur `main`, aucune surface d'historique par référentiel n'existe. Le consommateur arrive avec `TET-6818/refonte-main-nav`, où `referentiel/[referentielId]/(overview)/@tabs/historique/page.tsx` rend aujourd'hui `<HistoriqueListe />` **sans scope** — l'historique complet de la collectivité s'affiche donc sous chaque onglet référentiel. Le diff qui referme l'écart fera **une ligne**.

Alternative écartée : attendre la branche de nav pour livrer, ce qui laisserait #4808 seule et sans consommateur plus longtemps.

## ⚠️ Dépendance de déploiement, pas seulement de merge

Front et backend se déploient séparément (déploiement backend de staging manuel via `cd-backend.yml`). **Si cette PR arrive en prod avant #4808**, zod retire silencieusement la clé inconnue : le paramètre est accepté côté appelant et ne scope rien. L'échec est muet, pas bruyant. #4808 doit être déployée d'abord.

## Tests

**Aucun test automatisé, volontairement.** Le hook consomme tRPC/React-Query, et les conventions front excluent le test unitaire de ces composants (pas de MSW, pas de `renderWithProviders`). La couverture réelle du comportement est l'e2e backend de #4808.

**Le câblage est néanmoins prouvé.** J'ai retiré les 2 lignes de schéma de #4808 de la base et relancé le typecheck :

```
error TS2339: Property 'referentielId' does not exist on type
'{ collectiviteId: number; actionId?: string; filters: {...} }'
```

La chaîne casse. Le paramètre traverse donc réellement domaine → routeur → types du client tRPC ; ce n'est pas un prop décoratif. (L'erreur remonte d'abord côté backend, la chaîne de build s'arrêtant là avant d'atteindre l'appel front.)

Vérification manuelle attendue avant merge : `<HistoriqueListe referentielId="cae" />` monté temporairement sur la page Historique remonte moins d'items que sans la prop.

## Vérifications

- `nx run app:typecheck` ✅ · `nx run backend:typecheck` ✅
- `nx run app:lint` ✅ (0 erreur, 125 warnings = baseline préexistante) · prettier ✅
- `nx test app` → **540/540**

## Hors scope

- Un filtre utilisateur multi-sélection dans la barre de filtres (`filters.referentielIds` + sélecteur) → feature distincte, section « Différé » du plan. Elle devra **réutiliser** `ReferentielsDropdown`, qui porte déjà le flag `te` et les préférences d'affichage de la collectivité
- Câbler l'onglet par référentiel → hors stack, arrive avec `refonte-main-nav`
- Réinitialiser la pagination quand le scope change : sans objet, le scope n'est pas dans l'URL, donc en changer signifie changer de page

## ⚠️ À surveiller au merge

Contrairement à #4808, **cette PR est exposée au risque de merge sémantique**. `TET-6818/refonte-main-nav` déplace `apps/app/src/app/pages/collectivite/Historique/` vers `apps/app/src/referentiels/` — soit exactement les 2 fichiers touchés ici. Les deux branches sont vertes isolément et cassent ensemble. C'est `refonte-main-nav` qui doit rebaser sur `main` mergé, avant son merge et pas après.
