### PR TITLE
refactor(historique): passe les setters de filtres en patch partiel

### DIFF
--- a/apps/app/src/app/pages/collectivite/Historique/HistoriqueFiltres/FiltreDate.tsx
+++ b/apps/app/src/app/pages/collectivite/Historique/HistoriqueFiltres/FiltreDate.tsx
@@ -1,9 +1,9 @@
 import { appLabels } from '@/app/labels/catalog';
 import { Field, Input } from '@tet/ui';
 import { useRef } from 'react';
-import { TFiltreProps } from '../filters';
+import { FiltreProps } from '../filters';
 
-export const FiltreDateDebut = ({ filters, setFilters }: TFiltreProps) => {
+export const FiltreDateDebut = ({ filters, setFilters }: FiltreProps) => {
   const ref = useRef<HTMLInputElement>(null);
   return (
     <Field title={appLabels.dateDebut} small>
@@ -13,13 +13,13 @@ export const FiltreDateDebut = ({ filters, setFilters }: TFiltreProps) => {
         type="date"
         data-test="filtre-start-date"
         value={filters.startDate || ''}
-        onChange={(e) => setFilters({ ...filters, startDate: e.target.value })}
+        onChange={(e) => setFilters({ startDate: e.target.value })}
       />
     </Field>
   );
 };
 
-export const FiltreDateFin = ({ filters, setFilters }: TFiltreProps) => {
+export const FiltreDateFin = ({ filters, setFilters }: FiltreProps) => {
   const ref = useRef<HTMLInputElement>(null);
   return (
     <Field title={appLabels.dateFin} small>
@@ -29,7 +29,7 @@ export const FiltreDateFin = ({ filters, setFilters }: TFiltreProps) => {
         type="date"
         data-test="filtre-end-date"
         value={filters.endDate || ''}
-        onChange={(e) => setFilters({ ...filters, endDate: e.target.value })}
+        onChange={(e) => setFilters({ endDate: e.target.value })}
       />
     </Field>
   );

--- a/apps/app/src/app/pages/collectivite/Historique/HistoriqueFiltres/FiltreMembre.tsx
+++ b/apps/app/src/app/pages/collectivite/Historique/HistoriqueFiltres/FiltreMembre.tsx
@@ -1,10 +1,10 @@
 import { appLabels } from '@/app/labels/catalog';
 import { useCollectiviteId } from '@tet/api/collectivites';
 import { Field, SelectFilter } from '@tet/ui';
-import { TFiltreProps } from '../filters';
+import { FiltreProps } from '../filters';
 import { useHistoriqueUtilisateurListe } from '../useHistoriqueUtilisateurListe';
 
-const FiltreMembre = ({ filters, setFilters }: TFiltreProps) => {
+const FiltreMembre = ({ filters, setFilters }: FiltreProps) => {
   const collectiviteId = useCollectiviteId();
   const utilisateurs = useHistoriqueUtilisateurListe(collectiviteId);
 
@@ -27,14 +27,14 @@ const FiltreMembre = ({ filters, setFilters }: TFiltreProps) => {
         options={memberList}
         onChange={({ values }) => {
           if (values === undefined) {
-            const { modifiedBy, ...rest } = filters;
-            return setFilters({ modifiedBy: null, ...rest });
-          } else {
-            return setFilters({
-              ...filters,
-              modifiedBy: values as string[],
-            });
+            setFilters({ modifiedBy: null });
+            return;
           }
+          setFilters({
+            modifiedBy: memberList
+              .map((membre) => membre.value)
+              .filter((id) => values.includes(id)),
+          });
         }}
         disabled={memberList.length === 0}
       />

--- a/apps/app/src/app/pages/collectivite/Historique/HistoriqueFiltres/FiltreType.tsx
+++ b/apps/app/src/app/pages/collectivite/Historique/HistoriqueFiltres/FiltreType.tsx
@@ -1,8 +1,9 @@
 import { appLabels } from '@/app/labels/catalog';
 import { Field, SelectFilter } from '@tet/ui';
-import { filtresTypeOptions, TFilterType, TFiltreProps } from '../filters';
+import { historiqueTypeEnumValues } from '@tet/domain/referentiels';
+import { filtresTypeOptions, FiltreProps } from '../filters';
 
-const FiltreType = ({ filters, setFilters }: TFiltreProps) => {
+const FiltreType = ({ filters, setFilters }: FiltreProps) => {
   return (
     <Field title={appLabels.typeElementModifie} small>
       <SelectFilter
@@ -12,11 +13,14 @@ const FiltreType = ({ filters, setFilters }: TFiltreProps) => {
         options={filtresTypeOptions}
         onChange={({ values }) => {
           if (values === undefined) {
-            const { types, ...rest } = filters;
-            return setFilters({ types: null, ...rest });
-          } else {
-            return setFilters({ ...filters, types: values as TFilterType[] });
+            setFilters({ types: null });
+            return;
           }
+          setFilters({
+            types: historiqueTypeEnumValues.filter((type) =>
+              values.includes(type)
+            ),
+          });
         }}
       />
     </Field>

--- a/apps/app/src/app/pages/collectivite/Historique/HistoriqueFiltres/HistoriqueFiltres.stories.tsx
+++ b/apps/app/src/app/pages/collectivite/Historique/HistoriqueFiltres/HistoriqueFiltres.stories.tsx
@@ -2,14 +2,14 @@ import {Meta} from '@storybook/nextjs-vite';
 import {action} from 'storybook/actions';
 
 import HistoriqueFiltres from './HistoriqueFiltres';
-import {TSetFilters} from '../filters';
+import {SetFilters} from '../filters';
 
 export default {
   component: HistoriqueFiltres,
 } as Meta;
 
 const handlers = {
-  setFilters: action('setFilters') as TSetFilters,
+  setFilters: action('setFilters') as SetFilters,
 };
 
 const filtresArgs = {

--- a/apps/app/src/app/pages/collectivite/Historique/HistoriqueFiltres/HistoriqueFiltres.tsx
+++ b/apps/app/src/app/pages/collectivite/Historique/HistoriqueFiltres/HistoriqueFiltres.tsx
@@ -3,13 +3,13 @@ import FiltreMembre from './FiltreMembre';
 import FiltreType from './FiltreType';
 
 import { ClearAllFiltersButton } from '@tet/ui';
-import { TFilters } from '../filters';
+import { Filters, SetFilters } from '../filters';
 import { FiltreDateDebut, FiltreDateFin } from './FiltreDate';
 
 export type HistoriqueFiltresProps = {
   itemsNumber: number;
-  filters: TFilters;
-  setFilters: (filters: TFilters | null) => void;
+  filters: Filters;
+  setFilters: SetFilters;
 };
 
 const HistoriqueFiltres = ({

--- a/apps/app/src/app/pages/collectivite/Historique/HistoriqueListe.tsx
+++ b/apps/app/src/app/pages/collectivite/Historique/HistoriqueListe.tsx
@@ -52,7 +52,7 @@ export const HistoriqueListe = ({
         maxElementsPerPage={NB_HISTORIQUE_ITEMS_PER_PAGE}
         selectedPage={filters.page ?? 1}
         onChange={(selected) => {
-          setFilters({ ...filters, page: selected });
+          setFilters({ page: selected });
           tracker(Event.paginationClick);
         }}
         idToScrollTo="filtres-historique"

--- a/apps/app/src/app/pages/collectivite/Historique/filters.tsx
+++ b/apps/app/src/app/pages/collectivite/Historique/filters.tsx
@@ -8,9 +8,7 @@ import {
 } from 'nuqs';
 import { HistoriqueType, historiqueTypeEnumValues } from './types';
 
-export type TFilterType = HistoriqueType;
-
-export const filtresTypeOptions: { value: TFilterType; label: string }[] = [
+export const filtresTypeOptions: { value: HistoriqueType; label: string }[] = [
   { value: 'action_statut', label: appLabels.historiqueActionStatut },
   { value: 'action_precision', label: appLabels.historiqueActionPrecision },
   { value: 'reponse', label: appLabels.historiqueReponse },
@@ -20,11 +18,11 @@ export const filtresTypeOptions: { value: TFilterType; label: string }[] = [
   },
 ];
 
-export type TFilters = {
+export type Filters = {
   /** par membres de la collectivite */
   modifiedBy: string[] | null;
   /** Par type d'historique */
-  types: TFilterType[] | null;
+  types: HistoriqueType[] | null;
   /** par plage de dates */
   startDate: string | null;
   endDate: string | null;
@@ -32,11 +30,13 @@ export type TFilters = {
   page: number | null;
 };
 
-export type TSetFilters = (newFilter: TFilters) => void;
+export type FiltersPatch = Partial<Filters>;
 
-export type TFiltreProps = {
-  filters: TFilters;
-  setFilters: TSetFilters;
+export type SetFilters = (patch: FiltersPatch | null) => void;
+
+export type FiltreProps = {
+  filters: Filters;
+  setFilters: SetFilters;
 };
 
 /** Parsers nuqs pour les parametres de recherche URL de l'historique */

--- a/apps/app/src/app/pages/collectivite/Historique/types.ts
+++ b/apps/app/src/app/pages/collectivite/Historique/types.ts
@@ -1,5 +1,5 @@
 import { HistoriqueItem, HistoriqueType } from '@tet/domain/referentiels';
-import { TFilters } from './filters';
+import { Filters, SetFilters } from './filters';
 
 export {
   historiqueTypeEnumValues,
@@ -20,11 +20,11 @@ export type HistoriqueItemPropsOf<T extends HistoriqueType> = {
   item: Extract<HistoriqueItem, { type: T }>;
 };
 
-export type THistoriqueProps = {
+export type HistoriqueProps = {
   items: HistoriqueItem[];
   total: number;
-  filters: TFilters;
-  setFilters: (filters: TFilters | null) => void;
+  filters: Filters;
+  setFilters: SetFilters;
   isLoading?: boolean;
   isError: boolean;
 };

--- a/apps/app/src/app/pages/collectivite/Historique/useHistoriqueItemListe.ts
+++ b/apps/app/src/app/pages/collectivite/Historique/useHistoriqueItemListe.ts
@@ -4,8 +4,8 @@ import { useCurrentCollectivite } from '@tet/api/collectivites';
 import { ReferentielId } from '@tet/domain/referentiels';
 import { ITEM_ALL } from '@tet/ui';
 import { useQueryStates } from 'nuqs';
-import { filtersParsers, filtersUrlKeys } from './filters';
-import { THistoriqueProps } from './types';
+import { filtersParsers, filtersUrlKeys, SetFilters } from './filters';
+import { HistoriqueProps } from './types';
 
 /** vérifie si ITEM_ALL n'est pas présent dans un filtre */
 const isValidFilter = (
@@ -21,14 +21,18 @@ export const useHistoriqueItemListe = ({
 }: {
   actionId?: string;
   referentielId?: ReferentielId;
-} = {}): THistoriqueProps => {
+} = {}): HistoriqueProps => {
   const { collectiviteId } = useCurrentCollectivite();
   const trpc = useTRPC();
 
   // Filtres URL gérés par nuqs
-  const [filters, setFilters] = useQueryStates(filtersParsers, {
+  const [filters, setQueryStates] = useQueryStates(filtersParsers, {
     urlKeys: filtersUrlKeys,
   });
+
+  const setFilters: SetFilters = (patch) => {
+    void setQueryStates(patch);
+  };
 
   const { modifiedBy, types, startDate, endDate, page } = filters;
 


### PR DESCRIPTION
> **PR empilée.** Base : `main` — #4808 est mergée. Suivie de #4813 puis #4814.

Refactor préparatoire, **sans changement de comportement observable**. Il crée le point d'écriture unique dont le fix de pagination (#4813) a besoin.

Track B du plan de refonte, indépendant de la ligne référentiel ; empilé ici uniquement parce que #4808 touche déjà `useHistoriqueItemListe.ts` et `HistoriqueListe.tsx`, ce qui éviterait un conflit.

## Le problème

Chaque filtre reconstruisait l'objet complet :

```ts
// FiltreType, avant
if (values === undefined) {
  const { types, ...rest } = filters;
  return setFilters({ types: null, ...rest });   // = { ...filters, types: null }
} else {
  return setFilters({ ...filters, types: values as FilterType[] });
}
```

Deux conséquences :

1. **Aucun point d'interception.** Impossible d'imposer un invariant transverse sur l'écriture des filtres — chaque enfant décide seul de ce qu'il écrit.
2. **`filters` est capturé au render.** Deux changements de filtre dans le même tick s'écrasent mutuellement, chacun repartant de la même copie.

## Le changement

```ts
export type FiltersPatch = Partial<Filters>;
export type SetFilters = (patch: FiltersPatch | null) => void;
```

Le hook transmet le patch tel quel à nuqs :

```ts
const setFilters: SetFilters = (patch) => {
  void setQueryStates(patch);
};
```

**nuqs fusionne nativement un partiel** dans l'état de l'URL — sa signature est `(values: Partial<Nullable<Values<T>>> | UpdaterFn<T> | null, options?) => Promise<URLSearchParams>` (`node_modules/nuqs/dist/index.d.ts:495`). La fusion se fait donc sur l'état courant de l'URL, plus sur une copie de render : le risque de *stale closure* disparaît au lieu d'être centralisé.

Les cinq appelants deviennent :

```ts
setFilters({ startDate: e.target.value })
setFilters({ page: selected })
```

`void` sur la promesse de nuqs est délibéré et suit la convention du repo (« pas de promesse non attendue : `await fn()` ou `void fn()` »). Aucun appelant n'attendait cette promesse auparavant.

## Plus aucune assertion de type dans les filtres

Le `onChange` du design system rend un `OptionValue[]`, soit `(number | string)[]`, volontairement large. Les deux filtres à choix multiples s'en sortaient par une assertion :

```ts
types: values === undefined ? null : (values as FilterType[]),
modifiedBy: values === undefined ? null : (values as string[]),
```

Un type predicate maison n'aurait pas mieux fait : il devrait lui-même caster en interne pour appeler `includes` sur un tuple `readonly` de littéraux — le cast changerait juste de place. Chaque filtre **garde les valeurs connues que la sélection contient**, en early return plutôt qu'en ternaire :

```tsx
onChange={({ values }) => {
  if (values === undefined) {
    setFilters({ types: null });
    return;
  }
  setFilters({
    types: historiqueTypeEnumValues.filter((type) => values.includes(type)),
  });
}}
```

Et symétriquement pour `modifiedBy`, à partir de `memberList`.

`historiqueTypeEnumValues` étant un tuple `readonly` de littéraux, `.filter()` rend directement `HistoriqueType[]`. Bénéfice au-delà du type : la sélection est **validée contre un ensemble fermé** au lieu d'être supposée conforme. Même motif que `ReferentielsDropdown` ailleurs dans le repo.

## Suppression du préfixe `T`

Les types locaux du dossier perdent leur préfixe : `Filters`, `FiltersPatch`, `SetFilters`, `FiltreProps`, `HistoriqueProps`. `TFilterType` disparaît carrément : ce n'était qu'un alias de `HistoriqueType`, que les deux sites concernés importent désormais directement. Il n'apportait rien, et `types.ts` **mélangeait déjà les deux styles** — `THistoriqueProps` cohabitait avec `HistoriqueItemProps` et `HistoriqueItemPropsOf`.

Contenu au dossier `Historique/`. `AuditSuivi`, `AidePriorisation`, `DetailTaches` et `preuves/AddPreuveModal` définissent chacun leurs propres `TFilters` / `TSetFilters` — des types **locaux distincts**, pas des imports partagés. Les renommer serait un balayage repo-wide sans rapport avec cette PR.

## Surface de review

| Fichier | Lignes |
|---|---|
| `filters.tsx` | le cœur : 2 types |
| `types.ts` | suit la signature |
| `useHistoriqueItemListe.ts` | enveloppe le setter de nuqs |
| `HistoriqueFiltres/FiltreType.tsx` | patch + retrait du cast |
| `HistoriqueFiltres/FiltreMembre.tsx` | patch + retrait du cast |
| `HistoriqueFiltres/FiltreDate.tsx` | 2 appels |
| `HistoriqueFiltres/HistoriqueFiltres.tsx` | suit la signature |
| `HistoriqueListe.tsx` | 1 appel |
| `HistoriqueFiltres.stories.tsx` | le renommage uniquement |

9 fichiers, +51 −43. Aucun fichier mécanique.

## Invariant établi

**Toute écriture de filtre passe par le setter du hook.** Encodage **type-level** : `SetFilters` n'accepte plus un `Filters` complet, donc un enfant ne *peut plus* reconstruire l'objet et contourner le point de passage. C'est l'intérêt de cette PR par rapport à un helper que les enfants seraient libres d'oublier.

Sites concernés : les 4 composants de filtre, le bouton « effacer tous les filtres » (`setFilters(null)`, inchangé) et la pagination de `HistoriqueListe`.

## Tests

**Aucun test nouveau dans cette PR.** Le refactor est vérifié par le compilateur — le changement de signature fait remonter chaque call site — et par les 540 tests existants. Il n'introduit aucune fonction pure à tester : la fusion est déléguée à nuqs.

Le hook lui-même devient testable en #4814, qui l'isole de tRPC pour le monter avec `withNuqsTestingAdapter`.

- `nx run app:typecheck` ✅
- `nx run app:lint` ✅ (0 erreur, 125 warnings = baseline préexistante) · prettier ✅
- `nx test app` → **540/540**

## Passage du style enforcer

L'agent `te-en-t-style-enforcer` a été passé sur les 9 fichiers. Sur ses 37 constats, **un seul portait sur du code introduit par cette PR** : le ternaire multi-lignes dans les deux `onChange` (règle 62), corrigé en early return ci-dessus. L'alias vide `FilterType` a été supprimé dans la foulée, puisque cette PR le renommait de toute façon.

Le reste est de la **dette préexistante** que le scan remonte parce qu'il lit les fichiers entiers et non le diff : JSDoc tautologiques dans `filters.tsx` et `types.ts`, string user-facing en dur dans `HistoriqueListe`, `as SetFilters` et `collectivite_id` dans la story périmée, deux `useRef` jamais lus dans `FiltreDate`, `gray-200`/`gray-400` au lieu des tokens DS. Rien de tout cela n'est introduit ici, et le corriger ferait exploser le diff d'un refactor à comportement constant.

## Anti-scope

- La réinitialisation de `page` → #4813, parce que c'est un `fix` et que mélanger refactor et fix empêcherait de démontrer le test rouge
- Isoler le hook de tRPC pour le rendre testable → #4814
- Renommer les `TFilters` des 4 autres dossiers de filtres
- Reformater les fichiers non touchés du dossier : mon premier passage `prettier --write` sur un glob avait reformaté 8 fichiers voisins (stories, `formatReponseValue`), c'est revenu en arrière

## ⚠️ À surveiller au merge

`TET-6818/refonte-main-nav` déplace `apps/app/src/app/pages/collectivite/Historique/` vers `apps/app/src/referentiels/` — soit les 9 fichiers touchés ici. Les deux branches sont vertes isolément et cassent ensemble. C'est `refonte-main-nav` qui doit rebaser sur `main` mergé.
