### PR TITLE
fix(historique): remet la pagination en page 1 quand un filtre change

### DIFF
--- a/apps/app/src/app/pages/collectivite/Historique/filters.spec.ts
+++ b/apps/app/src/app/pages/collectivite/Historique/filters.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'vitest';
+import { withPageReset } from './filters';
+
+describe('withPageReset', () => {
+  test('remet la pagination à la première page quand un filtre change', () => {
+    expect(withPageReset({ types: ['reponse'] })).toEqual({
+      types: ['reponse'],
+      page: null,
+    });
+  });
+
+  test('ne touche pas la pagination quand seule la page change', () => {
+    expect(withPageReset({ page: 3 })).toEqual({ page: 3 });
+  });
+
+  test('laisse gagner la page explicite du patch', () => {
+    expect(withPageReset({ page: 2, types: ['justification'] })).toEqual({
+      page: 2,
+      types: ['justification'],
+    });
+  });
+
+  test('ne réinitialise rien sur un patch vide', () => {
+    expect(withPageReset({})).toEqual({});
+  });
+});

--- a/apps/app/src/app/pages/collectivite/Historique/filters.tsx
+++ b/apps/app/src/app/pages/collectivite/Historique/filters.tsx
@@ -32,6 +32,17 @@ export type Filters = {
 
 export type FiltersPatch = Partial<Filters>;
 
+export const withPageReset = (patch: FiltersPatch): FiltersPatch => {
+  const hasNonPageChange = Object.keys(patch).some((key) => key !== 'page');
+  const hasExplicitPage = 'page' in patch;
+
+  if (!hasNonPageChange || hasExplicitPage) {
+    return patch;
+  }
+
+  return { ...patch, page: null };
+};
+
 export type SetFilters = (patch: FiltersPatch | null) => void;
 
 export type FiltreProps = {

--- a/apps/app/src/app/pages/collectivite/Historique/useHistoriqueItemListe.ts
+++ b/apps/app/src/app/pages/collectivite/Historique/useHistoriqueItemListe.ts
@@ -4,7 +4,12 @@ import { useCurrentCollectivite } from '@tet/api/collectivites';
 import { ReferentielId } from '@tet/domain/referentiels';
 import { ITEM_ALL } from '@tet/ui';
 import { useQueryStates } from 'nuqs';
-import { filtersParsers, filtersUrlKeys, SetFilters } from './filters';
+import {
+  filtersParsers,
+  filtersUrlKeys,
+  SetFilters,
+  withPageReset,
+} from './filters';
 import { HistoriqueProps } from './types';
 
 /** vérifie si ITEM_ALL n'est pas présent dans un filtre */
@@ -31,7 +36,8 @@ export const useHistoriqueItemListe = ({
   });
 
   const setFilters: SetFilters = (patch) => {
-    void setQueryStates(patch);
+    const nextPatch = patch === null ? null : withPageReset(patch);
+    void setQueryStates(nextPatch);
   };
 
   const { modifiedBy, types, startDate, endDate, page } = filters;


### PR DESCRIPTION
> Base : `main`. Suivie de #4814, empilée dessus.

Corrige un faux état vide sur la page Historique.

## Le bug

Collectivité avec plus de 10 entrées → aller en page 2 → appliquer un filtre qui laisse 10 résultats ou moins.

1. L'URL conserve `?p=2`, le repository calcule `offset = 10`
2. La page est vide, donc `count(*) OVER ()` n'agrège rien et renvoie `total: 0` — comportement volontaire du repository, documenté et épinglé par un test e2e
3. Le front affiche « aucun historique »
4. `Pagination` reçoit `nbOfElements={0}` → `0 > 10` est faux → **le composant ne rend rien** (`packages/ui/src/design-system/Pagination/Pagination.tsx:76`)

L'utilisateur voit « aucun historique » alors que des résultats existent, sans contrôle pour revenir en arrière. La seule sortie visible est « effacer tous les filtres », qui efface aussi le filtre qu'il voulait.

Aucun des cinq filtres ne réinitialisait `page` : tous préservaient la valeur courante.

## Le correctif

```ts
export const withPageReset = (patch: FiltersPatch): FiltersPatch => {
  const hasNonPageChange = Object.keys(patch).some((key) => key !== 'page');
  const hasExplicitPage = 'page' in patch;

  if (!hasNonPageChange || hasExplicitPage) {
    return patch;
  }

  return { ...patch, page: null };
};
```

Appliqué dans le seul point d'écriture des filtres :

```ts
const setFilters: SetFilters = (patch) => {
  const nextPatch = patch === null ? null : withPageReset(patch);
  void setQueryStates(nextPatch);
};
```

**Avant** : `setFilters({ types: [...] })` depuis `?p=2` donne `?p=2&t=…` — page hors bornes.
**Après** : donne `?t=…`, la page disparaît de l'URL.

## Deux décisions à valider

- **`page: null` plutôt que `page: 1`** — le paramètre disparaît de l'URL, et `HistoriqueListe` lit déjà `filters.page ?? 1`. Cohérent avec la sémantique du bouton « effacer tous les filtres ».
- **Une page explicite dans le patch gagne** — sinon `setFilters({ page: 2, types: [...] })` deviendrait inexprimable.

## Invariant établi

**Toute mutation de filtre autre que `page` réinitialise `page`.** Site unique : `withPageReset`. Le type du setter n'acceptant qu'un patch partiel, aucun composant de filtre ne peut y déroger, et tout filtre ajouté plus tard en hérite sans ligne de code.

Préservé : changer de page ne se réinitialise pas soi-même — `HistoriqueListe` passe un patch mono-clé `page`.

## Tests

4 cas purs dans `filters.spec.ts` : un filtre change → `page: null` ; seule la page change → page conservée ; patch multi-clés dont `page` → la page explicite gagne ; patch vide → rien n'est réinitialisé.

⚠️ **Ces tests couvrent la fonction, pas son branchement.** Retirer l'appel à `withPageReset` du hook les laisserait verts, et le typecheck muet — les deux formes étant des `FiltersPatch`. #4814 referme ce trou en montant le hook avec `withNuqsTestingAdapter` : sans l'appel, son premier test échoue sur `expected '3' to be null`.

## Surface de review

| Fichier | Lignes |
|---|---|
| `filters.tsx` | +12 |
| `useHistoriqueItemListe.ts` | +8 −2 |
| `filters.spec.ts` | +26 (nouveau) |

Logique nouvelle : ~12 lignes.

- `nx run app:typecheck` ✅ · `nx run app:lint` ✅ (0 erreur) · prettier ✅
- `nx test app` → **544/544**

## Hors scope

- **Le `total: 0` sur page hors bornes côté backend** — comportement délibéré, documenté et épinglé par un test e2e. Le bug est côté front.
- **Faire clamper `page` par `Pagination`** quand `selectedPage > nbOfPages` — changement de design system affectant toutes les listes paginées du produit. C'est pourtant la seule correction qui fermerait aussi le **chemin résiduel** : si l'ensemble de résultats rétrécit sans changement de filtre (purge d'historique, changement de contexte), la page reste hors bornes et le faux état vide revient.

## ⚠️ À surveiller au merge

`TET-6818/refonte-main-nav` déplace `apps/app/src/app/pages/collectivite/Historique/` vers `apps/app/src/referentiels/` — soit les fichiers touchés ici. C'est `refonte-main-nav` qui doit rebaser sur `main` mergé.
