### PR TITLE
refactor(historique): remonte l'état d'URL des filtres et garde son comportement

### DIFF
--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/action/[actionId]/_components/side-panel/historique.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/action/[actionId]/_components/side-panel/historique.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { HistoriqueListe } from '@/app/app/pages/collectivite/Historique/HistoriqueListe';
+import { useHistoriqueFilters } from '@/app/app/pages/collectivite/Historique/use-historique-filters';
+
+export function HistoriquePanelContent({ actionId }: { actionId: string }) {
+  const [filters, setFilters] = useHistoriqueFilters();
+
+  return (
+    <HistoriqueListe
+      actionId={actionId}
+      filters={filters}
+      onFiltersChange={setFilters}
+      small
+    />
+  );
+}

--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/action/[actionId]/_components/side-panel/index.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/action/[actionId]/_components/side-panel/index.tsx
@@ -1,4 +1,3 @@
-import { HistoriqueListe } from '@/app/app/pages/collectivite/Historique/HistoriqueListe';
 import { FichesActionLiees } from '@/app/referentiels/action.show/FichesActionLiees';
 import { ActionProvider } from '@/app/referentiels/actions/action-context';
 import { useGetAction } from '@/app/referentiels/actions/use-get-action';
@@ -8,6 +7,7 @@ import { ReferentielId } from '@tet/domain/referentiels';
 import { ReactNode } from 'react';
 import { CommentsPanelContent } from './comments';
 import { DocumentsPanelContent } from './documents';
+import { HistoriquePanelContent } from './historique';
 import { IndicateursPanelContent } from './indicateurs';
 import { InformationsPanelContent } from './informations';
 import { ActionPanelId, ActionPanelIdEnum } from './types';
@@ -66,7 +66,7 @@ export function SidePanelInnerContent({
     case ActionPanelIdEnum.FICHES:
       return <FichesActionLiees actionId={actionId} />;
     case ActionPanelIdEnum.HISTORIQUE:
-      return <HistoriqueListe actionId={actionId} small />;
+      return <HistoriquePanelContent actionId={actionId} />;
     case ActionPanelIdEnum.INFORMATIONS: {
       const infoAction = targetAction ?? action;
       return infoAction ? (

--- a/apps/app/src/app/pages/collectivite/Historique/HistoriqueListe.tsx
+++ b/apps/app/src/app/pages/collectivite/Historique/HistoriqueListe.tsx
@@ -7,35 +7,43 @@ import SpinnerLoader from '@/app/ui/shared/SpinnerLoader';
 import {
   NB_HISTORIQUE_ITEMS_PER_PAGE,
   ReferentielId,
+  HistoriqueItem,
 } from '@tet/domain/referentiels';
 import { Alert, Event, Pagination, useEventTracker } from '@tet/ui';
+import { Filters, SetFilters } from './filters';
 import HistoriqueFiltres from './HistoriqueFiltres/HistoriqueFiltres';
 import HistoriqueItemJustification from './reponse/HistoriqueItemJustification';
 import HistoriqueItemReponse from './reponse/HistoriqueItemReponse';
-import { HistoriqueItem } from './types';
 import { useHistoriqueItemListe } from './useHistoriqueItemListe';
 
 type HistoriqueListeProps = {
+  filters: Filters;
+  onFiltersChange: SetFilters;
   actionId?: string;
   referentielId?: ReferentielId;
   small?: boolean;
 };
 
 export const HistoriqueListe = ({
+  filters,
+  onFiltersChange,
   actionId,
   referentielId,
   small,
 }: HistoriqueListeProps) => {
   const tracker = useEventTracker();
-  const { items, total, filters, setFilters, isLoading, isError } =
-    useHistoriqueItemListe({ actionId, referentielId });
+  const { items, total, isLoading, isError } = useHistoriqueItemListe({
+    filters,
+    actionId,
+    referentielId,
+  });
 
   return (
     <>
       <HistoriqueFiltres
         itemsNumber={total}
         filters={filters}
-        setFilters={setFilters}
+        setFilters={onFiltersChange}
       />
       <div className="grow flex flex-col gap-5" data-test="Historique">
         <Content
@@ -52,7 +60,7 @@ export const HistoriqueListe = ({
         maxElementsPerPage={NB_HISTORIQUE_ITEMS_PER_PAGE}
         selectedPage={filters.page ?? 1}
         onChange={(selected) => {
-          setFilters({ page: selected });
+          onFiltersChange({ page: selected });
           tracker(Event.paginationClick);
         }}
         idToScrollTo="filtres-historique"

--- a/apps/app/src/app/pages/collectivite/Historique/JournalActivite.tsx
+++ b/apps/app/src/app/pages/collectivite/Historique/JournalActivite.tsx
@@ -3,15 +3,18 @@
 import { appLabels } from '@/app/labels/catalog';
 import { PageHeader } from '@tet/ui';
 import { HistoriqueListe } from './HistoriqueListe';
+import { useHistoriqueFilters } from './use-historique-filters';
 
 export const JournalActivite = () => {
+  const [filters, setFilters] = useHistoriqueFilters();
+
   return (
     <div data-test="JournalActivite" className="grow flex flex-col">
       <PageHeader>
         <PageHeader.Title>{appLabels.journalActivite}</PageHeader.Title>
       </PageHeader>
       <p className="mb-6 font-bold">{appLabels.filtrerHistorique}</p>
-      <HistoriqueListe />
+      <HistoriqueListe filters={filters} onFiltersChange={setFilters} />
     </div>
   );
 };

--- a/apps/app/src/app/pages/collectivite/Historique/Modification.tsx
+++ b/apps/app/src/app/pages/collectivite/Historique/Modification.tsx
@@ -6,9 +6,11 @@ import { useSearchParams } from 'next/navigation';
 import { JSX, useState } from 'react';
 
 import { referentielToName } from '@/app/app/labels';
-import { getReferentielIdFromActionId } from '@tet/domain/referentiels';
+import {
+  getReferentielIdFromActionId,
+  HistoriqueItem,
+} from '@tet/domain/referentiels';
 import { Badge, Button, Icon, Spacer } from '@tet/ui';
-import { HistoriqueItem } from './types';
 
 export type HistoriqueDescription = {
   titre: string;

--- a/apps/app/src/app/pages/collectivite/Historique/actionStatut/getItemActionProps.tsx
+++ b/apps/app/src/app/pages/collectivite/Historique/actionStatut/getItemActionProps.tsx
@@ -3,11 +3,9 @@ import { ACTION_TYPE_LABELS } from '@/app/referentiels/actions/action-label.cons
 import {
   ActionTypeEnum,
   getReferentielIdFromActionId,
-} from '@tet/domain/referentiels';
-import {
   HistoriqueActionPrecisionItem,
   HistoriqueActionStatutItem,
-} from '../types';
+} from '@tet/domain/referentiels';
 
 /** Retourne le label avec première lettre en majuscule. */
 const capitalize = (s: string): string =>

--- a/apps/app/src/app/pages/collectivite/Historique/filters.tsx
+++ b/apps/app/src/app/pages/collectivite/Historique/filters.tsx
@@ -1,12 +1,5 @@
 import { appLabels } from '@/app/labels/catalog';
-import {
-  parseAsArrayOf,
-  parseAsInteger,
-  parseAsString,
-  parseAsStringLiteral,
-  UrlKeys,
-} from 'nuqs';
-import { HistoriqueType, historiqueTypeEnumValues } from './types';
+import { HistoriqueType } from '@tet/domain/referentiels';
 
 export const filtresTypeOptions: { value: HistoriqueType; label: string }[] = [
   { value: 'action_statut', label: appLabels.historiqueActionStatut },
@@ -49,21 +42,3 @@ export type FiltreProps = {
   filters: Filters;
   setFilters: SetFilters;
 };
-
-/** Parsers nuqs pour les parametres de recherche URL de l'historique */
-export const filtersParsers = {
-  modifiedBy: parseAsArrayOf(parseAsString),
-  types: parseAsArrayOf(parseAsStringLiteral(historiqueTypeEnumValues)),
-  startDate: parseAsString,
-  endDate: parseAsString,
-  page: parseAsInteger,
-};
-
-/** Mapping noms -> cles URL courtes */
-export const filtersUrlKeys: UrlKeys<typeof filtersParsers> = {
-  modifiedBy: 'm',
-  types: 't',
-  startDate: 's',
-  endDate: 'e',
-  page: 'p',
-} as const;

--- a/apps/app/src/app/pages/collectivite/Historique/fixture.ts
+++ b/apps/app/src/app/pages/collectivite/Historique/fixture.ts
@@ -1,8 +1,8 @@
-import { ActionTypeEnum } from '@tet/domain/referentiels';
 import {
+  ActionTypeEnum,
   HistoriqueActionPrecisionItem,
   HistoriqueActionStatutItem,
-} from './types';
+} from '@tet/domain/referentiels';
 
 const baseStatutFields: Omit<
   HistoriqueActionStatutItem,

--- a/apps/app/src/app/pages/collectivite/Historique/reponse/fixture.ts
+++ b/apps/app/src/app/pages/collectivite/Historique/reponse/fixture.ts
@@ -1,4 +1,4 @@
-import { HistoriqueReponseItem } from '../types';
+import { HistoriqueReponseItem } from '@tet/domain/referentiels';
 
 export const fakeReponseChoix: HistoriqueReponseItem = {
   type: 'reponse',

--- a/apps/app/src/app/pages/collectivite/Historique/types.ts
+++ b/apps/app/src/app/pages/collectivite/Historique/types.ts
@@ -1,15 +1,4 @@
 import { HistoriqueItem, HistoriqueType } from '@tet/domain/referentiels';
-import { Filters, SetFilters } from './filters';
-
-export {
-  historiqueTypeEnumValues,
-  type HistoriqueActionPrecisionItem,
-  type HistoriqueActionStatutItem,
-  type HistoriqueItem,
-  type HistoriqueJustificationItem,
-  type HistoriqueReponseItem,
-  type HistoriqueType,
-} from '@tet/domain/referentiels';
 
 export type HistoriqueItemProps = {
   item: HistoriqueItem;
@@ -18,13 +7,4 @@ export type HistoriqueItemProps = {
 /** Props d'un composant qui ne consomme qu'une variante de l'union. */
 export type HistoriqueItemPropsOf<T extends HistoriqueType> = {
   item: Extract<HistoriqueItem, { type: T }>;
-};
-
-export type HistoriqueProps = {
-  items: HistoriqueItem[];
-  total: number;
-  filters: Filters;
-  setFilters: SetFilters;
-  isLoading?: boolean;
-  isError: boolean;
 };

--- a/apps/app/src/app/pages/collectivite/Historique/use-historique-filters.spec.ts
+++ b/apps/app/src/app/pages/collectivite/Historique/use-historique-filters.spec.ts
@@ -1,0 +1,56 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { withNuqsTestingAdapter } from 'nuqs/adapters/testing';
+import { describe, expect, test, vi } from 'vitest';
+import { FiltersPatch } from './filters';
+import { useHistoriqueFilters } from './use-historique-filters';
+
+const monterAvecUrl = (searchParams: string) => {
+  const onUrlUpdate = vi.fn();
+  const { result } = renderHook(() => useHistoriqueFilters(), {
+    wrapper: withNuqsTestingAdapter({ searchParams, onUrlUpdate }),
+  });
+
+  // Le hook ne renvoie pas la promesse de nuqs : on attend que la file de
+  // mise à jour de l'URL se vide plutôt que de l'attendre directement.
+  const setFilters = async (patch: FiltersPatch | null) => {
+    act(() => {
+      result.current[1](patch);
+    });
+    await waitFor(() => expect(onUrlUpdate).toHaveBeenCalled());
+  };
+
+  const derniereUrl = () => onUrlUpdate.mock.calls.at(-1)?.[0].searchParams;
+
+  return { setFilters, derniereUrl };
+};
+
+describe('useHistoriqueFilters', () => {
+  test("retire la page de l'URL quand un filtre change", async () => {
+    const { setFilters, derniereUrl } = monterAvecUrl('?p=3');
+
+    await setFilters({ types: ['reponse'] });
+
+    expect(derniereUrl()?.get('t')).toBe('reponse');
+    expect(derniereUrl()?.get('p')).toBeNull();
+  });
+
+  test('conserve la page quand seule la page change', async () => {
+    const { setFilters, derniereUrl } = monterAvecUrl('?t=reponse');
+
+    await setFilters({ page: 2 });
+
+    expect(derniereUrl()?.get('p')).toBe('2');
+  });
+
+  test('efface tous les paramètres sur un patch null', async () => {
+    const { setFilters, derniereUrl } = monterAvecUrl(
+      '?p=3&t=reponse&m=membre'
+    );
+
+    await setFilters(null);
+
+    expect(derniereUrl()?.get('p')).toBeNull();
+    expect(derniereUrl()?.get('t')).toBeNull();
+    expect(derniereUrl()?.get('m')).toBeNull();
+  });
+});

--- a/apps/app/src/app/pages/collectivite/Historique/use-historique-filters.ts
+++ b/apps/app/src/app/pages/collectivite/Historique/use-historique-filters.ts
@@ -1,0 +1,48 @@
+import {
+  parseAsArrayOf,
+  parseAsInteger,
+  parseAsString,
+  parseAsStringLiteral,
+  UrlKeys,
+  useQueryStates,
+} from 'nuqs';
+import { Filters, SetFilters, withPageReset } from './filters';
+import { historiqueTypeEnumValues } from '@tet/domain/referentiels';
+
+/** Parsers nuqs pour les parametres de recherche URL de l'historique */
+const filtersParsers = {
+  modifiedBy: parseAsArrayOf(parseAsString),
+  types: parseAsArrayOf(parseAsStringLiteral(historiqueTypeEnumValues)),
+  startDate: parseAsString,
+  endDate: parseAsString,
+  page: parseAsInteger,
+};
+
+/** Mapping noms -> cles URL courtes */
+const filtersUrlKeys: UrlKeys<typeof filtersParsers> = {
+  modifiedBy: 'm',
+  types: 't',
+  startDate: 's',
+  endDate: 'e',
+  page: 'p',
+} as const;
+
+/**
+ * Les filtres de l'historique, synchronisés avec l'URL. Seul point d'écriture :
+ * la réinitialisation de pagination y est appliquée pour tous les appelants.
+ *
+ * À appeler depuis le composant hôte le plus haut, jamais depuis les
+ * composants de filtre : ils reçoivent `filters` et `onFiltersChange`.
+ */
+export const useHistoriqueFilters = (): [Filters, SetFilters] => {
+  const [filters, setQueryStates] = useQueryStates(filtersParsers, {
+    urlKeys: filtersUrlKeys,
+  });
+
+  const setFilters: SetFilters = (patch) => {
+    const nextPatch = patch === null ? null : withPageReset(patch);
+    void setQueryStates(nextPatch);
+  };
+
+  return [filters, setFilters];
+};

--- a/apps/app/src/app/pages/collectivite/Historique/useHistoriqueItemListe.ts
+++ b/apps/app/src/app/pages/collectivite/Historique/useHistoriqueItemListe.ts
@@ -1,16 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
 import { useTRPC } from '@tet/api';
 import { useCurrentCollectivite } from '@tet/api/collectivites';
-import { ReferentielId } from '@tet/domain/referentiels';
+import { HistoriqueItem, ReferentielId } from '@tet/domain/referentiels';
 import { ITEM_ALL } from '@tet/ui';
-import { useQueryStates } from 'nuqs';
-import {
-  filtersParsers,
-  filtersUrlKeys,
-  SetFilters,
-  withPageReset,
-} from './filters';
-import { HistoriqueProps } from './types';
+import { Filters } from './filters';
 
 /** vérifie si ITEM_ALL n'est pas présent dans un filtre */
 const isValidFilter = (
@@ -20,25 +13,24 @@ const isValidFilter = (
 /**
  * Les dernières modifications d'une collectivité
  */
+type HistoriqueItemListe = {
+  items: HistoriqueItem[];
+  total: number;
+  isLoading?: boolean;
+  isError: boolean;
+};
+
 export const useHistoriqueItemListe = ({
+  filters,
   actionId,
   referentielId,
 }: {
+  filters: Filters;
   actionId?: string;
   referentielId?: ReferentielId;
-} = {}): HistoriqueProps => {
+}): HistoriqueItemListe => {
   const { collectiviteId } = useCurrentCollectivite();
   const trpc = useTRPC();
-
-  // Filtres URL gérés par nuqs
-  const [filters, setQueryStates] = useQueryStates(filtersParsers, {
-    urlKeys: filtersUrlKeys,
-  });
-
-  const setFilters: SetFilters = (patch) => {
-    const nextPatch = patch === null ? null : withPageReset(patch);
-    void setQueryStates(nextPatch);
-  };
 
   const { modifiedBy, types, startDate, endDate, page } = filters;
 
@@ -59,8 +51,6 @@ export const useHistoriqueItemListe = ({
 
   return {
     ...(data ?? { items: [], total: 0 }),
-    filters,
-    setFilters,
     isLoading,
     isError,
   };


### PR DESCRIPTION
> Base : `main`. Dernière PR de la série sur les filtres d'historique.

Remet l'état d'URL des filtres d'historique à sa place, et le rend testable.

## Le problème

`useQueryStates` était appelé depuis `HistoriqueListe` — un composant de **liste réutilisable**, monté par trois hôtes :

- `JournalActivite` (page Historique)
- le side panel d'une action (`ActionPanelIdEnum.HISTORIQUE`)
- et bientôt l'onglet Historique par référentiel de `refonte-main-nav`

Chaque consommateur héritait donc du couplage à l'URL sans l'avoir demandé. Deux `<HistoriqueListe>` sur une même page se disputeraient les mêmes `?m=&t=&s=&e=&p=`, sans que rien dans la signature du composant ne le laisse deviner.

Effet de bord de ce placement : le hook mêlait état d'URL et requête tRPC, donc le seul point d'écriture des filtres était intestable — le monter imposait un provider tRPC.

## Le changement

`HistoriqueListe` devient muet vis-à-vis de l'URL :

```tsx
type HistoriqueListeProps = {
  filters: Filters;
  onFiltersChange: SetFilters;
  actionId?: string;
  referentielId?: ReferentielId;
  small?: boolean;
};
```

`useHistoriqueItemListe` prend les filtres en argument au lieu de les lire, et ne renvoie plus que les données — `HistoriqueProps` perd `filters` et `setFilters`.

Les deux hôtes prennent la propriété explicitement :

```tsx
const [filters, setFilters] = useHistoriqueFilters();
return <HistoriqueListe filters={filters} onFiltersChange={setFilters} />;
```

`page.tsx` étant un server component, `JournalActivite` est le point le plus haut atteignable pour cette surface. Pour le side panel, un `HistoriquePanelContent` dans `side-panel/historique.tsx`, conforme au découpage un fichier par panneau du dossier — il évite aussi d'appeler le hook dans le `switch`, ce qui l'aurait exécuté pour tous les panneaux.

### nuqs confiné à un fichier

`filters.tsx` importait nuqs pour les parsers **et** était importé par les quatre composants de filtre pour les types : leur graphe de modules touchait nuqs. Les parsers rejoignent le fichier du hook, leur seul consommateur.

```
avant : filters.tsx (nuqs) ← 4 composants de filtre
        use-historique-filters.ts (nuqs)
après : use-historique-filters.ts (nuqs)   ← seul fichier du dossier
```

### `types.ts` ne réexporte plus le domaine

Le fichier ouvrait sur une façade de re-export :

```ts
export {
  historiqueTypeEnumValues,
  type HistoriqueActionStatutItem,
  …
} from '@tet/domain/referentiels';
```

Neuf sites passaient par elle pour atteindre des types du domaine, ce qui masquait leur provenance. Ils importent maintenant `@tet/domain/referentiels` directement, en fusionnant avec l'import domaine déjà présent là où il y en avait un.

`HistoriqueProps`, que cette PR réduit à des données et que seul le hook qui le retourne consommait, rejoint ce hook sous le nom `HistoriqueItemListe` — « Props » ne décrivait plus rien.

Il reste deux types réellement locaux, dont celui qui justifie le fichier :

```ts
export type HistoriqueItemPropsOf<T extends HistoriqueType> = {
  item: Extract<HistoriqueItem, { type: T }>;
};
```

`HistoriqueItem` est une union discriminée sur `type` ; `HistoriqueListe` fait un `switch` dessus et rend un composant par variante. Ce type donne à chacun **la variante exacte qu'il consomme** (`HistoriqueItemPropsOf<'action_statut'>`), donc `item.avancement` est accessible sans garde et passer un item d'un autre type ne compile pas.

## Le branchement du reset de pagination est désormais gardé

`withPageReset` — dans `main` depuis #4813 — ajoute `page: null` à tout patch qui touche un autre filtre, ce qui évite de rester sur une page hors bornes. Elle était couverte comme fonction pure, mais rien ne vérifiait que le hook l'applique : retirer l'appel laissait les tests verts **et** le typecheck muet, les deux formes étant des `FiltersPatch`.

`useHistoriqueFilters` ne dépendant plus que de nuqs, trois tests le montent avec `withNuqsTestingAdapter` et assertent sur l'URL produite : un filtre change → `p` retiré ; seule la page change → `p` conservé ; patch `null` → tout effacé.

Sans l'appel à `withPageReset`, le premier échoue sur `expected '3' to be null`.

## Surface de review

| Fichier | Rôle |
|---|---|
| `use-historique-filters.ts` | **le cœur** : hook + parsers nuqs (nouveau) |
| `use-historique-filters.spec.ts` | le garde-fou (nouveau) |
| `HistoriqueListe.tsx` | devient muet, props `filters` + `onFiltersChange` |
| `useHistoriqueItemListe.ts` | perd la lecture d'URL, ne renvoie que les données |
| `filters.tsx` | perd les parsers et l'import nuqs |
| `types.ts` | perd la façade de re-export |
| `Modification.tsx`, `fixture.ts`, `reponse/fixture.ts`, `getItemActionProps.tsx` | imports redirigés vers le domaine |
| `JournalActivite.tsx` | prend la propriété |
| `side-panel/historique.tsx` | prend la propriété (nouveau) |
| `side-panel/index.tsx` | 2 lignes de câblage |

13 fichiers, +161 −84.

Les quatre fichiers de la ligne « imports redirigés » n'ont rien à voir avec l'état d'URL : ils ne changent que la provenance de leurs imports de types, suite au retrait de la façade. Mécanique et entièrement vérifié par le compilateur, mais facilement isolable en PR séparée si vous préférez.

- `nx run app:typecheck` ✅ · `nx run app:lint` ✅ (0 erreur) · prettier ✅
- `nx test app` → **547/547**

## Un arbitrage laissé ouvert

Les filtres du side panel continuent de **partager les clés d'URL** de la page Historique. C'était déjà le cas, et les deux surfaces vivent sur des routes distinctes donc ne coexistent jamais — aucun changement de comportement.

La question devient en revanche décidable par hôte : `HistoriquePanelContent` peut passer à un `useState` local si l'on juge que les filtres d'un panneau latéral n'ont pas à être dans l'URL, sans toucher à `HistoriqueListe`. Non fait ici : ce serait un changement de comportement, donc un arbitrage produit.

## Hors scope

- Les mêmes remontées de propriété dans les autres dossiers de filtres (`AuditSuivi`, `AidePriorisation`, `DetailTaches`, `CollectivitesEngagees`) : certains appellent déjà `useQueryStates` depuis leur vue de plus haut niveau, d'autres non.
- Le chemin résiduel du bug de pagination — si l'ensemble de résultats rétrécit sans changement de filtre, la page reste hors bornes — et les cas limites `undefined` de `FiltersPatch`. Décrits dans #4813.

## ⚠️ À surveiller au merge

Cette PR touche `apps/app/src/app/pages/collectivite/Historique/`, que `TET-6818/refonte-main-nav` déplace vers `apps/app/src/referentiels/`, **et** un fichier de l'arbre App Router (`side-panel/`) que cette branche modifie aussi. C'est la PR la plus exposée au conflit sémantique. `refonte-main-nav` doit rebaser sur `main` mergé.
