### PR TITLE
refactor(historique): remonte la propriété des filtres d'URL aux hôtes

### DIFF
--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/action/[actionId]/_components/side-panel/historique.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/action/[actionId]/_components/side-panel/historique.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { HistoriqueListe } from '@/app/app/pages/collectivite/Historique/HistoriqueListe';
+import { useHistoriqueFilters } from '@/app/app/pages/collectivite/Historique/use-historique-filters';
+
+export function HistoriquePanelContent({ actionId }: { actionId: string }) {
+  const [filters, setFilters] = useHistoriqueFilters();
+
+  return (
+    <HistoriqueListe
+      actionId={actionId}
+      filters={filters}
+      onFiltersChange={setFilters}
+      small
+    />
+  );
+}

--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/action/[actionId]/_components/side-panel/index.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/action/[actionId]/_components/side-panel/index.tsx
@@ -1,4 +1,3 @@
-import { HistoriqueListe } from '@/app/app/pages/collectivite/Historique/HistoriqueListe';
 import { FichesActionLiees } from '@/app/referentiels/action.show/FichesActionLiees';
 import { ActionProvider } from '@/app/referentiels/actions/action-context';
 import { useGetAction } from '@/app/referentiels/actions/use-get-action';
@@ -8,6 +7,7 @@ import { ReferentielId } from '@tet/domain/referentiels';
 import { ReactNode } from 'react';
 import { CommentsPanelContent } from './comments';
 import { DocumentsPanelContent } from './documents';
+import { HistoriquePanelContent } from './historique';
 import { IndicateursPanelContent } from './indicateurs';
 import { InformationsPanelContent } from './informations';
 import { ActionPanelId, ActionPanelIdEnum } from './types';
@@ -66,7 +66,7 @@ export function SidePanelInnerContent({
     case ActionPanelIdEnum.FICHES:
       return <FichesActionLiees actionId={actionId} />;
     case ActionPanelIdEnum.HISTORIQUE:
-      return <HistoriqueListe actionId={actionId} small />;
+      return <HistoriquePanelContent actionId={actionId} />;
     case ActionPanelIdEnum.INFORMATIONS: {
       const infoAction = targetAction ?? action;
       return infoAction ? (

--- a/apps/app/src/app/pages/collectivite/Historique/HistoriqueListe.tsx
+++ b/apps/app/src/app/pages/collectivite/Historique/HistoriqueListe.tsx
@@ -9,6 +9,7 @@ import {
   ReferentielId,
 } from '@tet/domain/referentiels';
 import { Alert, Event, Pagination, useEventTracker } from '@tet/ui';
+import { Filters, SetFilters } from './filters';
 import HistoriqueFiltres from './HistoriqueFiltres/HistoriqueFiltres';
 import HistoriqueItemJustification from './reponse/HistoriqueItemJustification';
 import HistoriqueItemReponse from './reponse/HistoriqueItemReponse';
@@ -16,26 +17,33 @@ import { HistoriqueItem } from './types';
 import { useHistoriqueItemListe } from './useHistoriqueItemListe';
 
 type HistoriqueListeProps = {
+  filters: Filters;
+  onFiltersChange: SetFilters;
   actionId?: string;
   referentielId?: ReferentielId;
   small?: boolean;
 };
 
 export const HistoriqueListe = ({
+  filters,
+  onFiltersChange,
   actionId,
   referentielId,
   small,
 }: HistoriqueListeProps) => {
   const tracker = useEventTracker();
-  const { items, total, filters, setFilters, isLoading, isError } =
-    useHistoriqueItemListe({ actionId, referentielId });
+  const { items, total, isLoading, isError } = useHistoriqueItemListe({
+    filters,
+    actionId,
+    referentielId,
+  });
 
   return (
     <>
       <HistoriqueFiltres
         itemsNumber={total}
         filters={filters}
-        setFilters={setFilters}
+        setFilters={onFiltersChange}
       />
       <div className="grow flex flex-col gap-5" data-test="Historique">
         <Content
@@ -52,7 +60,7 @@ export const HistoriqueListe = ({
         maxElementsPerPage={NB_HISTORIQUE_ITEMS_PER_PAGE}
         selectedPage={filters.page ?? 1}
         onChange={(selected) => {
-          setFilters({ page: selected });
+          onFiltersChange({ page: selected });
           tracker(Event.paginationClick);
         }}
         idToScrollTo="filtres-historique"

--- a/apps/app/src/app/pages/collectivite/Historique/JournalActivite.tsx
+++ b/apps/app/src/app/pages/collectivite/Historique/JournalActivite.tsx
@@ -3,15 +3,18 @@
 import { appLabels } from '@/app/labels/catalog';
 import { PageHeader } from '@tet/ui';
 import { HistoriqueListe } from './HistoriqueListe';
+import { useHistoriqueFilters } from './use-historique-filters';
 
 export const JournalActivite = () => {
+  const [filters, setFilters] = useHistoriqueFilters();
+
   return (
     <div data-test="JournalActivite" className="grow flex flex-col">
       <PageHeader>
         <PageHeader.Title>{appLabels.journalActivite}</PageHeader.Title>
       </PageHeader>
       <p className="mb-6 font-bold">{appLabels.filtrerHistorique}</p>
-      <HistoriqueListe />
+      <HistoriqueListe filters={filters} onFiltersChange={setFilters} />
     </div>
   );
 };

--- a/apps/app/src/app/pages/collectivite/Historique/filters.tsx
+++ b/apps/app/src/app/pages/collectivite/Historique/filters.tsx
@@ -1,12 +1,5 @@
 import { appLabels } from '@/app/labels/catalog';
-import {
-  parseAsArrayOf,
-  parseAsInteger,
-  parseAsString,
-  parseAsStringLiteral,
-  UrlKeys,
-} from 'nuqs';
-import { HistoriqueType, historiqueTypeEnumValues } from './types';
+import { HistoriqueType } from './types';
 
 export type FilterType = HistoriqueType;
 
@@ -49,21 +42,3 @@ export type FiltreProps = {
   filters: Filters;
   setFilters: SetFilters;
 };
-
-/** Parsers nuqs pour les parametres de recherche URL de l'historique */
-export const filtersParsers = {
-  modifiedBy: parseAsArrayOf(parseAsString),
-  types: parseAsArrayOf(parseAsStringLiteral(historiqueTypeEnumValues)),
-  startDate: parseAsString,
-  endDate: parseAsString,
-  page: parseAsInteger,
-};
-
-/** Mapping noms -> cles URL courtes */
-export const filtersUrlKeys: UrlKeys<typeof filtersParsers> = {
-  modifiedBy: 'm',
-  types: 't',
-  startDate: 's',
-  endDate: 'e',
-  page: 'p',
-} as const;

--- a/apps/app/src/app/pages/collectivite/Historique/types.ts
+++ b/apps/app/src/app/pages/collectivite/Historique/types.ts
@@ -1,5 +1,4 @@
 import { HistoriqueItem, HistoriqueType } from '@tet/domain/referentiels';
-import { Filters, SetFilters } from './filters';
 
 export {
   historiqueTypeEnumValues,
@@ -23,8 +22,6 @@ export type HistoriqueItemPropsOf<T extends HistoriqueType> = {
 export type HistoriqueProps = {
   items: HistoriqueItem[];
   total: number;
-  filters: Filters;
-  setFilters: SetFilters;
   isLoading?: boolean;
   isError: boolean;
 };

--- a/apps/app/src/app/pages/collectivite/Historique/use-historique-filters.ts
+++ b/apps/app/src/app/pages/collectivite/Historique/use-historique-filters.ts
@@ -1,16 +1,38 @@
-import { useQueryStates } from 'nuqs';
 import {
-  Filters,
-  filtersParsers,
-  filtersUrlKeys,
-  SetFilters,
-  withPageReset,
-} from './filters';
+  parseAsArrayOf,
+  parseAsInteger,
+  parseAsString,
+  parseAsStringLiteral,
+  UrlKeys,
+  useQueryStates,
+} from 'nuqs';
+import { Filters, SetFilters, withPageReset } from './filters';
+import { historiqueTypeEnumValues } from './types';
+
+/** Parsers nuqs pour les parametres de recherche URL de l'historique */
+const filtersParsers = {
+  modifiedBy: parseAsArrayOf(parseAsString),
+  types: parseAsArrayOf(parseAsStringLiteral(historiqueTypeEnumValues)),
+  startDate: parseAsString,
+  endDate: parseAsString,
+  page: parseAsInteger,
+};
+
+/** Mapping noms -> cles URL courtes */
+const filtersUrlKeys: UrlKeys<typeof filtersParsers> = {
+  modifiedBy: 'm',
+  types: 't',
+  startDate: 's',
+  endDate: 'e',
+  page: 'p',
+} as const;
 
 /**
- * Les filtres de l'historique, synchronisés avec l'URL. Seul point
- * d'écriture : la réinitialisation de pagination y est appliquée pour tous
- * les appelants.
+ * Les filtres de l'historique, synchronisés avec l'URL. Seul point d'écriture :
+ * la réinitialisation de pagination y est appliquée pour tous les appelants.
+ *
+ * À appeler depuis le composant hôte le plus haut, jamais depuis les
+ * composants de filtre : ils reçoivent `filters` et `onFiltersChange`.
  */
 export const useHistoriqueFilters = (): [Filters, SetFilters] => {
   const [filters, setQueryStates] = useQueryStates(filtersParsers, {

--- a/apps/app/src/app/pages/collectivite/Historique/useHistoriqueItemListe.ts
+++ b/apps/app/src/app/pages/collectivite/Historique/useHistoriqueItemListe.ts
@@ -3,8 +3,8 @@ import { useTRPC } from '@tet/api';
 import { useCurrentCollectivite } from '@tet/api/collectivites';
 import { ReferentielId } from '@tet/domain/referentiels';
 import { ITEM_ALL } from '@tet/ui';
+import { Filters } from './filters';
 import { HistoriqueProps } from './types';
-import { useHistoriqueFilters } from './use-historique-filters';
 
 /** vérifie si ITEM_ALL n'est pas présent dans un filtre */
 const isValidFilter = (
@@ -15,16 +15,16 @@ const isValidFilter = (
  * Les dernières modifications d'une collectivité
  */
 export const useHistoriqueItemListe = ({
+  filters,
   actionId,
   referentielId,
 }: {
+  filters: Filters;
   actionId?: string;
   referentielId?: ReferentielId;
-} = {}): HistoriqueProps => {
+}): HistoriqueProps => {
   const { collectiviteId } = useCurrentCollectivite();
   const trpc = useTRPC();
-
-  const [filters, setFilters] = useHistoriqueFilters();
 
   const { modifiedBy, types, startDate, endDate, page } = filters;
 
@@ -45,8 +45,6 @@ export const useHistoriqueItemListe = ({
 
   return {
     ...(data ?? { items: [], total: 0 }),
-    filters,
-    setFilters,
     isLoading,
     isError,
   };


### PR DESCRIPTION
> **PR empilée.** Base : `refactor/historique-filters-hook` (#4814). À retarger quand les précédentes seront mergées.

Applique un principe d'architecture : **nuqs ne doit pas fuiter dans les composants, et l'état d'URL doit être détenu aussi haut que possible dans l'arbre React.**

## Ce qui n'allait pas

`useQueryStates` était appelé depuis `HistoriqueListe` — un composant de **liste réutilisable**, monté par trois hôtes différents :

- `JournalActivite` (page Historique)
- le side panel d'une action (`ActionPanelIdEnum.HISTORIQUE`)
- et bientôt l'onglet Historique par référentiel de `refonte-main-nav`

Chaque consommateur héritait donc du couplage à l'URL **sans l'avoir demandé**. Conséquence la plus parlante : deux `<HistoriqueListe>` sur une même page se disputeraient les mêmes `?m=&t=&s=&e=&p=`, sans que rien dans la signature du composant ne le laisse deviner.

À noter, l'import de nuqs, lui, ne fuitait pas : aucun composant ne l'importait. Le problème était la **hauteur de propriété**, pas la visibilité du module.

## Le changement

`HistoriqueListe` devient muet vis-à-vis de l'URL :

```tsx
type HistoriqueListeProps = {
  filters: Filters;
  onFiltersChange: SetFilters;
  actionId?: string;
  referentielId?: ReferentielId;
  small?: boolean;
};
```

Et `useHistoriqueItemListe` prend les filtres en argument au lieu de les lire :

```ts
useHistoriqueItemListe({ filters, actionId, referentielId })
```

Il ne renvoie plus que les données — `HistoriqueProps` perd `filters` et `setFilters`. Le nommage `onFiltersChange` suit la convention déjà en vigueur ici (`value` + `onXxxChange`).

Les deux hôtes prennent la propriété, explicitement :

```tsx
// JournalActivite — le plus haut client component de la page
const [filters, setFilters] = useHistoriqueFilters();
return <HistoriqueListe filters={filters} onFiltersChange={setFilters} />;
```

`page.tsx` étant un server component, `JournalActivite` **est** le point le plus haut atteignable pour cette surface.

Pour le side panel, un `HistoriquePanelContent` extrait dans `side-panel/historique.tsx`, conforme au découpage un fichier par panneau du dossier (`comments.tsx`, `documents.tsx`, `indicateurs.tsx`…). Il évite aussi d'appeler le hook dans le `switch`, ce qui l'aurait exécuté pour tous les panneaux.

## Le confinement de nuqs, complété

En vérifiant, le confinement était incomplet : `filters.tsx` importait nuqs pour les parsers **et** était importé par les quatre composants de filtre pour les types. Leur graphe de modules touchait donc nuqs.

Les parsers sont déplacés dans le fichier du hook, leur **seul** consommateur — un motif déjà présent dans le repo (`referentiel.table/use-get-referentiel-table-filters-state.ts` déclare les siens sur place).

Résultat : **un seul fichier importe nuqs** dans tout le dossier.

```
avant : filters.tsx (nuqs) ← 4 composants de filtre
        use-historique-filters.ts (nuqs)
après : use-historique-filters.ts (nuqs)   ← seul
```

## Surface de review

| Fichier | Lignes |
|---|---|
| `use-historique-filters.ts` | +32 −10 (accueille les parsers) |
| `HistoriqueListe.tsx` | +12 −4 |
| `useHistoriqueItemListe.ts` | +4 −6 |
| `filters.tsx` | +1 −26 (perd les parsers et l'import nuqs) |
| `types.ts` | −3 |
| `JournalActivite.tsx` | +4 −1 |
| `side-panel/historique.tsx` | +17 (nouveau) |
| `side-panel/index.tsx` | +2 −2 |

8 fichiers, +72 −52.

## Un point de conception laissé en l'état, volontairement

Les filtres du side panel continuent de **partager les clés d'URL** de la page Historique (`m`, `t`, `s`, `e`, `p`). C'était déjà le cas avant, et les deux surfaces vivent sur des routes distinctes, donc elles ne coexistent jamais — aucun changement de comportement.

Mais la question devient maintenant **visible et décidable par hôte** : `HistoriquePanelContent` pourrait passer à un `useState` local, si l'on juge que les filtres d'un panneau latéral n'ont pas à être dans l'URL. C'est exactement ce que cette PR rend possible sans toucher à `HistoriqueListe`. Je ne l'ai pas fait : ce serait un changement de comportement (les filtres du panneau ne seraient plus partageables par URL), donc un arbitrage produit.

## Tests

Aucun test nouveau. Le déplacement de propriété est vérifié par le compilateur — les props ajoutées font échouer tout appelant qui ne les fournit pas — et les tests de #4814 continuent de garder le comportement du hook, désormais appelé plus haut.

- `nx run app:typecheck` ✅ · `nx run app:lint` ✅ (0 erreur) · prettier ✅
- `nx test app` → **547/547**

## Anti-scope

- Passer le side panel en état local (arbitrage produit, ci-dessus)
- Les mêmes remontées de propriété dans les autres dossiers de filtres (`AuditSuivi`, `AidePriorisation`, `DetailTaches`, `CollectivitesEngagees`) : plusieurs appellent déjà `useQueryStates` depuis leur vue de plus haut niveau, d'autres non. Balayage repo-wide, hors scope.
- Le chemin résiduel du bug de pagination et les cas limites `undefined` de `FiltersPatch`, listés dans l'anti-scope de #4814.

## ⚠️ À surveiller au merge

Cette PR touche `apps/app/src/app/pages/collectivite/Historique/` que `TET-6818/refonte-main-nav` déplace vers `apps/app/src/referentiels/`, **et** un fichier de l'arbre App Router (`side-panel/`) que cette branche modifie aussi. C'est la PR de la stack la plus exposée au conflit sémantique. `refonte-main-nav` doit rebaser sur `main` mergé.
