### PR TITLE
chore(devx): add missing documented Make targets and add env-keys command

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+staged_paths=$(git diff --cached --name-only --diff-filter=ACMR)
+staged_files=$(printf '%s\n' "$staged_paths" | awk '/\.(cjs|cts|js|jsx|mjs|mts|ts|tsx)$/')
+
+if [[ -z "$staged_files" ]]; then
+	exit 0
+fi
+
+unstaged_paths=$(git diff --name-only --diff-filter=ACMR)
+unstaged_files=$(printf '%s\n' "$unstaged_paths" | awk '/\.(cjs|cts|js|jsx|mjs|mts|ts|tsx)$/')
+mixed_files=$(grep -Fxf <(printf '%s\n' "$staged_files") <(printf '%s\n' "$unstaged_files") || true)
+
+if [[ -n "$mixed_files" ]]; then
+	echo "Les fichiers suivants ont des changements indexés et non indexés :"
+	printf '%s\n' "$mixed_files"
+	echo "Le hook lint analyse le contenu du disque. Finalisez ou désindexez ces fichiers avant de commit."
+	exit 1
+fi
+
+echo "Lint sur les fichiers indexés..."
+make --no-print-directory lint files="$(printf '%s' "$staged_files" | tr '\n' ' ')"

--- a/Makefile
+++ b/Makefile
@@ -39,19 +39,35 @@ env_flags = $(foreach f,$(1),$(foreach g,$(wildcard $(f).local) $(wildcard $(f))
 # --strict : dotenvx sort en erreur (code 1) si une variable ne peut pas être
 # déchiffrée (clé .env.keys manquante), la commande n'est alors jamais lancée.
 decrypt_env = $(DOTENVX) run $(ENV_KEYS) --strict $(call env_flags,$(1))
+# Exécute une commande Node sur l'hôte (mode dev) ou dans nx-daemon (mode Docker).
+run_node = $(compose_here); \
+	if $$C --profile '*' ps --status running --services 2>/dev/null | grep -qx 'nx-daemon'; then \
+		$$C exec -T nx-daemon sh -lc 'dotenvx run $(ENV_KEYS) --ignore=MISSING_ENV_FILE $(call env_flags,$(ENV_ROOT)) -- $(1)'; \
+	else \
+		$(MAKE) --no-print-directory ensure-deps || exit 1; \
+		$(call decrypt_env,$(ENV_ROOT)) -- $(1); \
+	fi
 
 colored = red()    { printf '\033[31m%s\033[0m\n' "$$*"; }; \
           green()  { printf '\033[32m%s\033[0m\n' "$$*"; }; \
           yellow() { printf '\033[33m%s\033[0m\n' "$$*"; }; \
           blue()   { printf '\033[34m%s\033[0m\n' "$$*"; }
 
+env_keys_help = blue "  Récupérez le contenu de .env.keys dans Vaultwarden puis exécutez :"; \
+		        blue "    make env-keys"
+
+hooks_path_backup_key = tet.hooksPathBackup
+hooks_path_backup_present_key = tet.hooksPathBackupPresent
+
 # Fichier .env ciblé par env-set/env-get : celui de l'app si app= est fourni,
 # sinon choix interactif parmi les .env du monorepo (scripts/pick-env-file.mts).
 env_target = $(if $(app),apps/$(app)/.env,$$(node scripts/pick-env-file.mts))
 
 .DEFAULT_GOAL = help
-.PHONY: help env-set env-get \
+.PHONY: help env-set env-get env-keys \
+	lint test \
         install dev graph \
+	hooks hooks-off \
         infra-up services-scoped-up worktree worktree-env worktree-prune guard-main warn-shared-db \
         up services-up node-base stop down cache-clean workflow-graph logs ps tui \
         preflight-inotify preflight-env-keys ensure-deps inotify-persist \
@@ -70,6 +86,31 @@ env-set: ## Définit une valeur chiffrée : make env-set e=CLE=valeur [app=backe
 env-get: ## Lit une valeur déchiffrée : make env-get k=CLE [app=backend]
 	@f=$(env_target) && test -n "$$f" && $(DOTENVX) get $(k) -f $$f $(ENV_KEYS)
 
+env-keys: ## Crée .env.keys par collage dans le terminal
+	@$(colored); \
+	if [ -f .env.keys ]; then \
+		yellow "ℹ fichier .env.keys déjà présent — aucune modification"; \
+		exit 0; \
+	fi; \
+	if [ ! -t 0 ]; then \
+		red "✗ make env-keys requiert un terminal interactif."; \
+		blue "  Lancez la commande dans un terminal puis collez le contenu de .env.keys."; \
+		exit 1; \
+	fi; \
+	tmp_file=$$(mktemp .env.keys.tmp.XXXXXX) || { red "✗ impossible de préparer .env.keys."; exit 1; }; \
+	cleanup() { stty echo >/dev/null 2>&1 || true; rm -f "$$tmp_file"; }; \
+	trap cleanup EXIT INT TERM; \
+	stty -echo || { red "✗ impossible de masquer la saisie."; exit 1; }; \
+	yellow "Collez le contenu complet de .env.keys puis terminez par Ctrl-D (saisie masquée)."; \
+	cat > "$$tmp_file"; ret=$$?; \
+	stty echo || { red "✗ impossible de restaurer l'affichage du terminal."; exit 1; }; \
+	trap - EXIT INT TERM; \
+	printf '\n'; \
+	[ "$$ret" -eq 0 ] || { rm -f "$$tmp_file"; red "✗ lecture annulée."; exit 1; }; \
+	tr -d '[:space:]' < "$$tmp_file" | grep -q . || { rm -f "$$tmp_file"; red "✗ aucun contenu fourni."; $(env_keys_help); exit 1; }; \
+	mv "$$tmp_file" .env.keys || { rm -f "$$tmp_file"; red "✗ impossible d'écrire .env.keys."; exit 1; }; \
+	green "✓ fichier .env.keys créé à la racine du projet"
+
 ## —— 🐳 Stack locale (services + apps) ———————————————————————————————————————
 # internes (absents du help) :
 # - services-up : tous les services, sans prompt (db-init)
@@ -86,8 +127,7 @@ preflight-env-keys:
 	@$(colored); \
 	if [ -z "$(IS_WORKTREE)" ] && [ ! -f .env.keys ]; then \
 		red "✗ fichier .env.keys manquant à la racine du projet."; \
-		blue "  Pour lancer le projet, vous devez récupérer le fichier .env.keys"; \
-		blue "  (versionné dans Vaultwarden) et le placer à la racine du projet."; \
+		$(env_keys_help); \
 		exit 1; \
 	fi
 
@@ -300,6 +340,57 @@ install: preflight-env-keys ## Installe les dépendances (token Bryntum injecté
 	@$(call decrypt_env,$(ENV_ROOT)) -- sh -c '\
 		case "$$BRYNTUM_ACCESS_TOKEN" in ""|encrypted:*) echo "✗ BRYNTUM_ACCESS_TOKEN vide ou indéchiffrable dans $(ENV_ROOT) (clé .env.keys manquante ?)"; exit 1;; esac; \
 		pnpm install && pnpm rebuild canvas supabase'
+
+lint: preflight-env-keys ## Reproduit le job CI lint sur l'ensemble des projets
+	@if [ -n "$(files)" ]; then \
+		$(call run_node,pnpm exec eslint --quiet $(files)); \
+	else \
+		$(call run_node,pnpm exec nx run-many -t lint -- --quiet); \
+	fi
+
+test: preflight-env-keys ## Lance les tests : make test [project=<nx-project>]
+	@$(call run_node,pnpm exec nx $(if $(project),test "$(project)",run-many -t test))
+
+hooks: ## Active les hooks git du dépôt (.githooks)
+	@set -e; \
+	current=$$(git config --local --get core.hooksPath 2>/dev/null); ret=$$?; \
+	case $$ret in \
+		0) ;; \
+		1) current='' ;; \
+		*) exit $$ret ;; \
+	esac; \
+	if [ "$$current" != '.githooks' ]; then \
+		git config --local $(hooks_path_backup_present_key) $$([ $$ret -eq 0 ] && printf true || printf false) && \
+		git config --local $(hooks_path_backup_key) "$$current"; \
+	fi
+	@chmod +x .githooks/pre-commit
+	@git config --local core.hooksPath .githooks
+	@echo "✓ hooks git activés (.githooks)"
+
+hooks-off: ## Désactive les hooks git du dépôt
+	@set -e; \
+	present=$$(git config --local --get $(hooks_path_backup_present_key) 2>/dev/null); ret=$$?; \
+	case $$ret in \
+		0) ;; \
+		1) present='' ;; \
+		*) exit $$ret ;; \
+	esac; \
+	if [ "$$present" = true ]; then \
+		backup=$$(git config --local --get $(hooks_path_backup_key)); \
+		git config --local core.hooksPath "$$backup"; \
+	elif [ "$$present" = false ]; then \
+		git config --local --unset core.hooksPath; \
+	else \
+		current=$$(git config --local --get core.hooksPath 2>/dev/null); current_ret=$$?; \
+		case $$current_ret in \
+			0) if [ "$$current" = '.githooks' ]; then git config --local --unset core.hooksPath; fi ;; \
+			1) true ;; \
+			*) exit $$current_ret ;; \
+		esac; \
+	fi; \
+	if git config --local --get $(hooks_path_backup_present_key) >/dev/null 2>&1; then git config --local --unset-all $(hooks_path_backup_present_key); fi; \
+	if git config --local --get $(hooks_path_backup_key) >/dev/null 2>&1; then git config --local --unset-all $(hooks_path_backup_key); fi
+	@echo "✓ hooks git du dépôt désactivés"
 
 dev: preflight-env-keys ensure-deps ## Lance les apps cochées sur l'hôte : make dev [apps=app,backend] [infra=skip]
 	@$(if $(IS_WORKTREE),node scripts/worktree-env.mts,true)

--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ Chaque dossier à la racine contient son propre `README.md` et peut a priori fon
 
 Vous pouvez contribuer à notre projet [en suivant cette documentation](docs/workflows/contribuer-au-projet.md).
 
-# Conception
+## Conception
 
 La conception, des données au choix de la stack.
 
-## Données
+### Données
 
-### Les données métier
+#### Les données métier
 
 Les données métier suivantes sont stockées sur des spreadsheets partagés:
 
@@ -61,7 +61,7 @@ Cela permet de bénéficier des avantages suivants par rapport aux markdown empl
   - Validation directement dans le spreadsheet lorsque cela est faisable à travers des listes déroulantes par exemple.
   - Fonctionnalité de validitation du contenu faisant appel au backend intégrée sous forme de bouton.
 
-## Stack
+### Stack
 
 - Le `client` utilise React ce qui nous permet de bénéficier d'un écosystème riche. Il est développé en TypeScript.
 
@@ -82,7 +82,7 @@ Cela permet de bénéficier des avantages suivants par rapport aux markdown empl
 - `make`, point d'entrée de toutes les commandes du projet (`make help` pour la liste).
 - Node.js 24 et [pnpm](https://pnpm.io/) pour lancer les apps sur la machine hôte.
 
-Pour la première installation, une fois `.env.keys` en place (voir « Variables d'environnement »), lancez :
+Pour la première installation, une fois `.env.keys` en place (voir [Variables d'environnement](#variables-denvironnement)), lancez :
 
 ```sh
 make install    # dépendances node
@@ -95,7 +95,7 @@ make db-init    # services docker + migrations + référentiels + données de te
 - 🧑‍💻 **Mode hybride** (par défaut) : les services tournent en docker mais les apps tournent sur la machine hôte (`make dev`) — Node 24 local requis, TUI nx.
 
 > 🍏 Sur mac, le mode Docker nécessite Docker Desktop ≥ 4.34 avec *host networking* activé ; à défaut, utilisez le mode host. Si le HMR ne réagit pas (montages VirtioFS), exportez `WATCHPACK_POLLING=true` via `Makefile.local`.
-
+>
 > 🐧 **Linux** : les limites inotify du noyau sont partagées entre l'hôte (IDE, nx…) et les conteneurs. Avec les valeurs par défaut (`max_user_instances=128`, `max_user_watches=65536`), Turbopack plante au démarrage des apps (`OS file watch limit reached` → `Next.js app exited with code 1`) : le conteneur sort avant d'être *healthy* et `make up` replie alors toute la stack (échec obscur). `make up` refuse de démarrer les apps sous ces limites et affiche la marche à suivre ; pour les relever et les persister une fois pour toutes :
 >
 > ```sh
@@ -110,7 +110,7 @@ make db-init    # services docker + migrations + référentiels + données de te
 - **Sécurité**: résolution stricte des dépendances et `node_modules` non-plat
 - **Performance**: installation plus rapide et meilleure prise en charge des monorepos
 
-L'installation passe par le registre npm privé Bryntum. Le token (`BRYNTUM_ACCESS_TOKEN`) est chiffré dans le `.env` racine et le `.npmrc` du projet le référence par variable d'environnement : avec `.env.keys` en place (voir « Variables d'environnement »), il suffit de lancer :
+L'installation passe par le registre npm privé Bryntum. Le token (`BRYNTUM_ACCESS_TOKEN`) est chiffré dans le `.env` racine et le `.npmrc` du projet le référence par variable d'environnement : avec `.env.keys` en place (voir [Variables d'environnement](#variables-denvironnement)), il suffit de lancer :
 
 ```sh
 make install
@@ -133,6 +133,8 @@ Les fichiers `.env` du projet (racine **et** apps) sont **versionnés** et gér�
 
 - les secrets sont **chiffrés** dans les fichiers (valeurs préfixées par `encrypted:`) ; la config locale non confidentielle (ports, URLs localhost, variables `NEXT_PUBLIC_*` exposées au navigateur) peuvent rester en clair ;
 - **une seule paire de clés pour tout le monorepo** : la clé publique (`DOTENV_PUBLIC_KEY`) est en tête de chaque fichier, la clé privée est dans `.env.keys` (**non versionné**, à récupérer auprès de l'équipe et à placer à la racine).
+
+Pour créer `.env.keys` une fois son contenu récupéré auprès de l'équipe, lancez `make env-keys` à la racine du dépôt puis collez le contenu complet dans le terminal.
 
 Les fichiers ne se déchiffrent jamais à la main : `make dev` injecte les valeurs déchiffrées à la volée (via `dotenvx run`) avant de lancer nx. Les apps lisent leurs `.env` sans savoir les déchiffrer, mais n'écrasent jamais une variable déjà présente dans l'environnement — aucune modification du code des apps n'est nécessaire.
 
@@ -223,7 +225,7 @@ Celle-ci supprime le volume docker de la base puis relance `make db-init`.
 
 ### Lint et hook de pre-commit
 
-`make lint` reproduit le job CI `lint` sur l'ensemble des projets.
+`make lint` reproduit le job CI `lint` sur l'ensemble des projets. En mode hôte (`make dev`), la commande s'exécute localement ; en mode Docker (`make up`), elle passe par le conteneur `nx-daemon` déjà démarré.
 
 Pour éviter de découvrir une erreur de lint après le push, on peut activer le hook git
 livré dans le dépôt — il lance ESLint sur les seuls fichiers indexés (≈ 2 s) :
@@ -239,10 +241,17 @@ passer outre ponctuellement : `git commit --no-verify`.
 
 ### Lancer les tests
 
-Les trois services sont des projets indépendants qui peuvent-être testés en local sous reserve que les dépendances de
-développement soient installées.
+Depuis la racine du dépôt, le point d'entrée recommandé est la target `make test` :
 
-Néanmoins, on peut lancer les tests avec `earthly` en utilisant des conteneurs :
+```sh
+make test                  # lance tous les tests Nx du monorepo
+make test project=backend  # lance un seul projet Nx
+make test project=app
+```
+
+Comme `make lint`, la commande fonctionne dans les deux modes de développement : localement en mode hôte, ou via `nx-daemon` quand les apps tournent en conteneurs. Elle réutilise le même chargement d'environnement que les autres cibles de développement, puis exécute `nx test <project>` si `project=` est fourni, sinon `nx run-many -t test`.
+
+Pour exécuter les tests en conteneurs, on peut aussi utiliser `earthly` :
 
 ```shell
 # Lance le projet suivi de tout les tests.

--- a/scripts/worktree-env.mts
+++ b/scripts/worktree-env.mts
@@ -43,6 +43,7 @@ if (resolve(gitDir) === resolve(gitCommonDir)) {
 process.chdir(git('rev-parse', '--show-toplevel'));
 const cwd = process.cwd();
 const mainRoot = dirname(gitCommonDir);
+const shellQuote = (value: string): string => `'${value.replace(/'/g, `'"'"'`)}'`;
 
 // .env.keys (gitignoré) : COPIE depuis le checkout principal — surtout pas un
 // symlink : sa cible, hors du bind mount `.:/repo`, n'existe pas dans le
@@ -70,12 +71,8 @@ if (!keysInfo) {
     // stack échoue de façon obscure. On échoue tôt avec la marche à suivre,
     // en pointant le checkout principal (là où la clé doit vraiment vivre).
     console.error('✗ fichier .env.keys manquant dans le checkout principal.');
-    console.error(
-      '  Pour lancer le projet, vous devez récupérer le fichier .env.keys'
-    );
-    console.error(
-      `  (versionné dans Vaultwarden) et le placer à la racine : ${mainRoot}`
-    );
+    console.error("  Récupérez le contenu de .env.keys dans Vaultwarden puis créez-le avec :");
+    console.error(`    cd ${shellQuote(mainRoot)} && make env-keys`);
     process.exit(1);
   }
 }


### PR DESCRIPTION
## Summary

This PR improves local developer onboarding and repository tooling.

## Why

A few documented commands and workflows were either missing or not working as described:

- `make hooks` / `make hooks-off` were mentioned in the README but did not exist.
- The pre-commit hook could fail because `pnpm` read `.npmrc` before `dotenvx` injected `BRYNTUM_ACCESS_TOKEN`.
- `make lint` was documented but missing.
- Setting up `.env.keys` was not guided enough for a first local setup.

## Changes

- add `make hooks` and `make hooks-off`
- add a repository pre-commit hook for staged JS/TS files
- route hook linting through `make lint files=...`
- add `make lint` to match the CI lint job
- add `make env-keys` to help create `.env.keys` interactively
- improve missing `.env.keys` messages in `Makefile` and worktree setup
- update README so the documented commands and setup steps match the actual behavior

## Result

Local setup is more consistent with the README, linting is easier to run manually, and the pre-commit hook now uses the same env/bootstrap path as the rest of the repo.

## Validation

- `make hooks` / `make hooks-off`
- `make lint`
- `make --no-print-directory lint files='scripts/worktree-env.mts'`
- pre-commit path no longer shows the `.npmrc` / `BRYNTUM_ACCESS_TOKEN` warning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Ajout de commandes pour créer `.env.keys`, lancer le lint et les tests, et activer ou désactiver les hooks Git.
  * Vérification automatique des fichiers JavaScript et TypeScript avant chaque commit.
  * Blocage des commits mêlant modifications indexées et non indexées.

* **Documentation**
  * Documentation des commandes `.env.keys`, lint et tests.
  * Amélioration de la structure des sections et des liens vers les variables d’environnement.

* **Messages d’erreur**
  * Instructions mises à jour pour récupérer et recréer `.env.keys` lorsqu’il est absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->