### PR TITLE
fix(banner): aligne l'icône sur la première ligne et régularise le spacing

### DIFF
--- a/apps/app/src/utils/banner/banner-info.box.tsx
+++ b/apps/app/src/utils/banner/banner-info.box.tsx
@@ -40,37 +40,40 @@ type BannerInfoBoxProps = {
 
 /**
  * Presentational banner component used by the global widget and by the live
- * preview on the support edit page. Centered text, icon on the left of the
- * text run (not the side of the banner), and the wrapper enforces
- * `font-normal` so inline `<strong>` / `<b>` keep their semantics without
- * making the entire content bold.
+ * preview on the support edit page. The icon sits on the left of the text run
+ * (not the side of the banner) and is optically centred on its first line, so
+ * a message wrapping over several lines keeps the icon anchored to the top
+ * instead of drifting to the middle. The wrapper enforces `font-normal` so
+ * inline `<strong>` / `<b>` keep their semantics without making the entire
+ * content bold.
  */
 export function BannerInfoBox({ type, html, className }: BannerInfoBoxProps) {
   const styles = TYPE_STYLES[type];
 
   return (
-    <div
-      className={cn(
-        'flex items-center justify-center gap-3 px-6 py-3',
-        styles.bg,
-        styles.text,
-        className
-      )}
-    >
-      <Icon icon={styles.icon} className={cn('shrink-0', styles.text)} />
-      <div
-        className={cn(
-          'text-sm font-normal text-center',
-          // tighter vertical rhythm — banner is a single short message
-          '[&>*]:my-0',
-          // Tailwind preflight resets <a> to inherit color + no underline,
-          // so links emitted by BlockNote (with href + target=_blank) would
-          // render as plain text. Explicit underline + hover gives them
-          // affordance while keeping the type palette colour.
-          '[&_a]:underline [&_a:hover]:no-underline'
-        )}
-        dangerouslySetInnerHTML={{ __html: html }}
-      />
+    <div className={cn('px-6 py-3', styles.bg, styles.text, className)}>
+      {/* même largeur de contenu que app-layout, pour ne pas tasser le texte */}
+      <div className="mx-auto flex max-w-[90rem] items-start justify-center gap-3">
+        {/* h-5 matches the text-sm line height, centring the icon on the first line */}
+        <span className="flex h-5 shrink-0 items-center">
+          <Icon icon={styles.icon} className={styles.text} />
+        </span>
+        <div
+          className={cn(
+            'min-w-0 text-sm font-normal',
+            // BlockNote nests the paragraph four wrappers deep, so only a
+            // descendant selector reaches it — a child one leaves the inner
+            // margins in place and the banner grows an uneven gap
+            '[&_*]:my-0',
+            // Tailwind preflight resets <a> to inherit color + no underline,
+            // so links emitted by BlockNote (with href + target=_blank) would
+            // render as plain text. Explicit underline + hover gives them
+            // affordance while keeping the type palette colour.
+            '[&_a]:underline [&_a:hover]:no-underline'
+          )}
+          dangerouslySetInnerHTML={{ __html: html }}
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Surface de review

Un seul fichier de logique : `apps/app/src/utils/banner/banner-info.box.tsx`.

## Ce qui change

- **Icône alignée sur la première ligne** au lieu d'être centrée sur tout le bloc. Elle dérivait vers le milieu du paragraphe dès que le message passait sur plusieurs lignes. Le conteneur de l'icône a la hauteur du `line-height` de `text-sm`, ce qui la centre optiquement sur la première ligne quel que soit le nombre de lignes.
- **Largeur de contenu alignée sur `app-layout`** (`max-w-[90rem]`) : un message long s'affichait sur quatre lignes alors que la largeur d'écran était disponible.
- **Spacing vertical symétrique** : seul le `py-3` du bandeau détermine désormais l'espace, identique en haut et en bas.

## Hypothèses

- L'alignement haut suit ce que fait déjà le composant `Alert` du DS (`mt-0.5` sur son icône, jamais de centrage vertical), ainsi que DSFR / GOV.UK / Material. Le centrage n'est équivalent que sur une ligne et se dégrade au-delà — or le contenu est saisi librement depuis `/banniere`, donc sa longueur n'est pas maîtrisable.
- Le texte est aligné à gauche dès qu'il dépasse une ligne ; sur une ligne, le bloc reste centré comme avant.

## Zone de moindre confiance

`max-w-[90rem]` est repris en dur de `app-layout.tsx:37`. Les deux valeurs peuvent dériver ; un token partagé serait préférable, hors périmètre ici.

## Découvert au passage, non corrigé

BlockNote enregistre le paragraphe avec `!text-base !text-grey-8` en `!important` : le texte de la bannière ignore donc le `text-sm` et la couleur du niveau définis par `BannerInfoBox`, et s'affiche en gris quel que soit le type (info / warning / error). À traiter séparément si la couleur doit suivre le niveau.

## Tests

Aucun test automatisé ajouté : le changement est purement visuel (classes utilitaires). Vérifié à la main sur `/banniere` en une et plusieurs lignes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Amélioration de la mise en page des bannières d’information sur les écrans larges.
  - Icône mieux alignée avec la première ligne du texte.
  - Contenu textuel désormais capable de s’adapter aux retours à la ligne.
  - Espacements internes harmonisés pour une présentation plus cohérente.
  - Texte affiché avec un poids normal et liens clairement soulignés.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->