### PR TITLE
fix(labellisation): pointe "Suivre la labellisation" vers audit-labellisation

### DIFF
--- a/apps/app/src/app/paths.ts
+++ b/apps/app/src/app/paths.ts
@@ -57,7 +57,6 @@ export const indicateurViewParam = 'vue';
 export const indicateurIdParam = 'indicateurId';
 
 const actionParam = 'actionId';
-const labellisationVueParam = 'labellisationVue';
 
 export type IndicateurViewParamOption =
   | 'cae'
@@ -76,8 +75,6 @@ export type IndicateursListParamOption =
 export const referentielTabs = ['progression', 'evolutions'] as const;
 export type ReferentielTab = (typeof referentielTabs)[number];
 
-type LabellisationTab = 'cycles' | 'criteres';
-
 export const collectiviteBasePath = '/collectivite';
 export const collectivitePath = `${collectiviteBasePath}/:${collectiviteParam}`;
 
@@ -95,8 +92,7 @@ const referentielVueParam = 'referentielVue';
 const referentielRootPath = `${collectivitePath}/referentiel`;
 const referentielPath = `${referentielRootPath}/:${referentielIdParam}/:${referentielVueParam}`;
 const referentielActionPath = `${referentielRootPath}/:${referentielIdParam}/action/:${actionParam}`;
-const referentielLabellisationRootPath = `${referentielRootPath}/:${referentielIdParam}/labellisation`;
-const referentielLabellisationPath = `${referentielLabellisationRootPath}/:${labellisationVueParam}?`;
+const referentielAuditLabellisationPath = `${referentielRootPath}/:${referentielIdParam}/audit-labellisation`;
 
 export const collectiviteUsersPath = `${collectivitePath}/users`;
 export const collectiviteUsersTagsPath = `${collectiviteUsersPath}/tags`;
@@ -299,19 +295,16 @@ export const makeReferentielTacheUrl = ({
   return pathname + hash;
 };
 
-export const makeReferentielLabellisationUrl = ({
+export const makeReferentielAuditLabellisationUrl = ({
   collectiviteId,
   referentielId,
-  labellisationTab,
 }: {
   collectiviteId: number;
   referentielId: ReferentielId;
-  labellisationTab?: LabellisationTab;
 }) =>
-  referentielLabellisationPath
+  referentielAuditLabellisationPath
     .replace(`:${collectiviteParam}`, collectiviteId.toString())
-    .replace(`:${referentielIdParam}`, referentielId)
-    .replace(`:${labellisationVueParam}`, labellisationTab || 'criteres');
+    .replace(`:${referentielIdParam}`, referentielId);
 
 export const makeCollectivitePlansActionsNouveauUrl = ({
   collectiviteId,

--- a/apps/app/src/labels/catalog.ts
+++ b/apps/app/src/labels/catalog.ts
@@ -287,7 +287,7 @@ export const appLabels = {
   editerReferentiel: 'Éditer le référentiel',
   enregistrer: 'Enregistrer',
 
-  preuvesTelechargementVoir: 'Voir les téléchargements',
+  telechargerTousLesDocuments: 'Télécharger tous les documents',
   preuvesTelechargementDemarrer: 'Télécharger tous les documents',
   preuvesTelechargementAucun: 'Aucun téléchargement préparé pour le moment.',
   preuvesTelechargementPanelTitre: 'Téléchargement des documents',

--- a/apps/app/src/referentiels/audit-labellisation/checklist-page-header/referentiel-menu.button.tsx
+++ b/apps/app/src/referentiels/audit-labellisation/checklist-page-header/referentiel-menu.button.tsx
@@ -43,8 +43,8 @@ export const ReferentielMenuButton = ({
     icon: 'camera-line',
     onClick: () => setIsSaveOpen(true),
   };
-  const voirArchivesAction: MenuAction = {
-    label: appLabels.preuvesTelechargementVoir,
+  const telechargerDocumentsAction: MenuAction = {
+    label: appLabels.telechargerTousLesDocuments,
     icon: 'folder-zip-line',
     onClick: () =>
       openPanel({
@@ -57,7 +57,7 @@ export const ReferentielMenuButton = ({
   const menuActions: MenuAction[] = [
     telechargerAction,
     ...(canMutate ? [figerAction] : []),
-    ...(canAccessArchives ? [voirArchivesAction] : []),
+    ...(canAccessArchives ? [telechargerDocumentsAction] : []),
   ];
 
   return (

--- a/apps/app/src/referentiels/tableau-de-bord/labellisation/Scores.tsx
+++ b/apps/app/src/referentiels/tableau-de-bord/labellisation/Scores.tsx
@@ -1,7 +1,7 @@
 import { actionIdToLabel } from '@/app/app/labels';
 import {
   makeMaCollectiviteUrl,
-  makeReferentielLabellisationUrl,
+  makeReferentielAuditLabellisationUrl,
   makeReferentielUrl,
 } from '@/app/app/paths';
 import { appLabels } from '@/app/labels/catalog';
@@ -118,10 +118,9 @@ export const ScoreRempli = ({
         {/* Call to action */}
         <Button
           onClick={() => tracker(Event.referentiels.viewLabellisation)}
-          href={makeReferentielLabellisationUrl({
+          href={makeReferentielAuditLabellisationUrl({
             collectiviteId,
             referentielId: referentiel,
-            labellisationTab: 'criteres',
           })}
           disabled={status === 'audit_en_cours' || status === 'demande_envoyee'}
           size="sm"


### PR DESCRIPTION
## Contexte

Sur staging, le bouton « Suivre la labellisation » de la carte état des lieux (`/collectivite/4322/referentiel/cae/synthese`) menait à la page labellisation historique `/referentiel/cae/labellisation/criteres` au lieu de l'onglet vivant `/referentiel/cae/audit-labellisation`.

**Pas de plan validé à lier** : la PR part d'un bug constaté sur staging, pas d'une planification. À arbitrer si ça bloque la review approfondie.

## Pas de test de régression — décision assumée

La convention du repo demande un test rouge avant tout commit `fix`. Il a été écrit (rendu de `ScoreRempli`, assertion sur le `href`) et vérifié rouge sur le code pré-fix, puis **retiré sur décision** : verrouiller une destination de navigation ne justifiait pas les mocks nécessaires (`useCycleLabellisation`, `next/image`) pour un rendu de composant qui embarque ECharts. Le correctif se relit directement dans le diff.

## Surface de review

**Attention humaine :**
- `apps/app/src/app/paths.ts` — `makeReferentielLabellisationUrl` → `makeReferentielAuditLabellisationUrl`, plus la suppression des constantes de chemin historiques devenues orphelines (`labellisationVueParam`, `LabellisationTab`, `referentielLabellisationPath` / `RootPath`).
- `apps/app/src/referentiels/tableau-de-bord/labellisation/Scores.tsx` — le call-site.

**Mécanique :**
- `apps/app/src/labels/catalog.ts` et `referentiel-menu.button.tsx` — renommage de l'entrée de menu « Voir les téléchargements » → « Télécharger tous les documents » (clé `preuvesTelechargementVoir` → `telechargerTousLesDocuments`, variable `voirArchivesAction` → `telechargerDocumentsAction`).

## Hypothèses prises

- **`referentielTabs` n'est pas étendu** avec `audit-labellisation`. Ce tableau alimente `generate-edl-dropdown.ts` : y ajouter l'onglet aurait ajouté une entrée au menu de navigation. D'où un builder dédié plutôt qu'un nouveau membre de `ReferentielTab`.
- `makeReferentielLabellisationUrl` est **supprimé** et non déprécié : il n'avait aucun autre appelant dans le repo.

## Zones à faible confiance

- Le renommage du libellé fait que l'entrée de menu et `preuvesTelechargementDemarrer` (le bouton à l'intérieur du panneau) portent désormais **la même chaîne** pour deux concepts distincts — ouvrir le panneau vs lancer la préparation. Je ne les ai pas fusionnés : à trancher si ça gêne.

## Recherche anti-duplication

Cherché dans `paths.ts` et dans le repo : `makeReferentiel*Url`, `audit-labellisation`, `referentielTabs`. Aucun builder ne visait déjà cet onglet ; `referentielTabs` a été écarté pour la raison ci-dessus.

## Items ajoutés à DISCOVERED.md

Aucun sur cette PR.

## Vérifications

`nx run app:typecheck` OK · `nx run app:lint` 0 erreur, 102 warnings (identique à `main`) · `nx run app:test` 75 fichiers / 543 tests verts.
