### PR TITLE
fix(devx): Fix + amélioration lint hook et cmd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,7 +76,7 @@ docker-data
 # Every other .env files
 .env
 # Clé privée de déchiffrement dotenvx — ne JAMAIS committer
-.env.keys
+.env.keys*
 # Surcharges locales
 .env.local
 

--- a/Makefile
+++ b/Makefile
@@ -40,12 +40,14 @@ env_flags = $(foreach f,$(1),$(foreach g,$(wildcard $(f).local) $(wildcard $(f))
 # déchiffrée (clé .env.keys manquante), la commande n'est alors jamais lancée.
 decrypt_env = $(DOTENVX) run $(ENV_KEYS) --strict $(call env_flags,$(1))
 # Exécute une commande Node sur l'hôte (mode dev) ou dans nx-daemon (mode Docker).
+# -q : pas de bannière « injected env » — ces cibles sont appelées par le hook
+# de pre-commit, leur sortie doit ne contenir que le résultat du lint.
 run_node = $(compose_here); \
 	if $$C --profile '*' ps --status running --services 2>/dev/null | grep -qx 'nx-daemon'; then \
-		$$C exec -T nx-daemon sh -lc 'dotenvx run $(ENV_KEYS) --ignore=MISSING_ENV_FILE $(call env_flags,$(ENV_ROOT)) -- $(1)'; \
+		$$C exec -T nx-daemon sh -lc 'dotenvx run $(ENV_KEYS) --ignore=MISSING_ENV_FILE $(call env_flags,$(ENV_ROOT)) -q -- $(1)'; \
 	else \
 		$(MAKE) --no-print-directory ensure-deps || exit 1; \
-		$(call decrypt_env,$(ENV_ROOT)) -- $(1); \
+		$(call decrypt_env,$(ENV_ROOT)) -q -- $(1); \
 	fi
 
 colored = red()    { printf '\033[31m%s\033[0m\n' "$$*"; }; \

--- a/Makefile
+++ b/Makefile
@@ -343,7 +343,7 @@ install: preflight-env-keys ## Installe les dépendances (token Bryntum injecté
 
 lint: preflight-env-keys ## Reproduit le job CI lint sur l'ensemble des projets
 	@if [ -n "$(files)" ]; then \
-		$(call run_node,pnpm exec eslint --quiet $(files)); \
+		$(call run_node,node scripts/lint-files.mts $(files)); \
 	else \
 		$(call run_node,pnpm exec nx run-many -t lint -- --quiet); \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -352,8 +352,12 @@ test: preflight-env-keys ## Lance les tests : make test [project=<nx-project>]
 	@$(call run_node,pnpm exec nx $(if $(project),test "$(project)",run-many -t test))
 
 hooks: ## Active les hooks git du dépôt (.githooks)
+# PIÈGE : git config --get sort en 1 quand la clé est absente. Sous set -e, une
+# affectation par substitution prend le code de la substitution et tue le shell
+# avant la lecture de $?. On capture donc le code via la condition d'un if, seul
+# contexte où set -e tolère un échec.
 	@set -e; \
-	current=$$(git config --local --get core.hooksPath 2>/dev/null); ret=$$?; \
+	if current=$$(git config --local --get core.hooksPath 2>/dev/null); then ret=0; else ret=$$?; fi; \
 	case $$ret in \
 		0) ;; \
 		1) current='' ;; \
@@ -369,7 +373,7 @@ hooks: ## Active les hooks git du dépôt (.githooks)
 
 hooks-off: ## Désactive les hooks git du dépôt
 	@set -e; \
-	present=$$(git config --local --get $(hooks_path_backup_present_key) 2>/dev/null); ret=$$?; \
+	if present=$$(git config --local --get $(hooks_path_backup_present_key) 2>/dev/null); then ret=0; else ret=$$?; fi; \
 	case $$ret in \
 		0) ;; \
 		1) present='' ;; \
@@ -381,7 +385,7 @@ hooks-off: ## Désactive les hooks git du dépôt
 	elif [ "$$present" = false ]; then \
 		git config --local --unset core.hooksPath; \
 	else \
-		current=$$(git config --local --get core.hooksPath 2>/dev/null); current_ret=$$?; \
+		if current=$$(git config --local --get core.hooksPath 2>/dev/null); then current_ret=0; else current_ret=$$?; fi; \
 		case $$current_ret in \
 			0) if [ "$$current" = '.githooks' ]; then git config --local --unset core.hooksPath; fi ;; \
 			1) true ;; \

--- a/Makefile
+++ b/Makefile
@@ -56,9 +56,6 @@ colored = red()    { printf '\033[31m%s\033[0m\n' "$$*"; }; \
 env_keys_help = blue "  Récupérez le contenu de .env.keys dans Vaultwarden puis exécutez :"; \
 		        blue "    make env-keys"
 
-hooks_path_backup_key = tet.hooksPathBackup
-hooks_path_backup_present_key = tet.hooksPathBackupPresent
-
 # Fichier .env ciblé par env-set/env-get : celui de l'app si app= est fourni,
 # sinon choix interactif parmi les .env du monorepo (scripts/pick-env-file.mts).
 env_target = $(if $(app),apps/$(app)/.env,$$(node scripts/pick-env-file.mts))
@@ -352,49 +349,11 @@ test: preflight-env-keys ## Lance les tests : make test [project=<nx-project>]
 	@$(call run_node,pnpm exec nx $(if $(project),test "$(project)",run-many -t test))
 
 hooks: ## Active les hooks git du dépôt (.githooks)
-# PIÈGE : git config --get sort en 1 quand la clé est absente. Sous set -e, une
-# affectation par substitution prend le code de la substitution et tue le shell
-# avant la lecture de $?. On capture donc le code via la condition d'un if, seul
-# contexte où set -e tolère un échec.
-	@set -e; \
-	if current=$$(git config --local --get core.hooksPath 2>/dev/null); then ret=0; else ret=$$?; fi; \
-	case $$ret in \
-		0) ;; \
-		1) current='' ;; \
-		*) exit $$ret ;; \
-	esac; \
-	if [ "$$current" != '.githooks' ]; then \
-		git config --local $(hooks_path_backup_present_key) $$([ $$ret -eq 0 ] && printf true || printf false) && \
-		git config --local $(hooks_path_backup_key) "$$current"; \
-	fi
-	@chmod +x .githooks/pre-commit
-	@git config --local core.hooksPath .githooks
-	@echo "✓ hooks git activés (.githooks)"
+	@node scripts/toggle-hooks.mts on
 
 hooks-off: ## Désactive les hooks git du dépôt
-	@set -e; \
-	if present=$$(git config --local --get $(hooks_path_backup_present_key) 2>/dev/null); then ret=0; else ret=$$?; fi; \
-	case $$ret in \
-		0) ;; \
-		1) present='' ;; \
-		*) exit $$ret ;; \
-	esac; \
-	if [ "$$present" = true ]; then \
-		backup=$$(git config --local --get $(hooks_path_backup_key)); \
-		git config --local core.hooksPath "$$backup"; \
-	elif [ "$$present" = false ]; then \
-		git config --local --unset core.hooksPath; \
-	else \
-		if current=$$(git config --local --get core.hooksPath 2>/dev/null); then current_ret=0; else current_ret=$$?; fi; \
-		case $$current_ret in \
-			0) if [ "$$current" = '.githooks' ]; then git config --local --unset core.hooksPath; fi ;; \
-			1) true ;; \
-			*) exit $$current_ret ;; \
-		esac; \
-	fi; \
-	if git config --local --get $(hooks_path_backup_present_key) >/dev/null 2>&1; then git config --local --unset-all $(hooks_path_backup_present_key); fi; \
-	if git config --local --get $(hooks_path_backup_key) >/dev/null 2>&1; then git config --local --unset-all $(hooks_path_backup_key); fi
-	@echo "✓ hooks git du dépôt désactivés"
+	@node scripts/toggle-hooks.mts off
+
 
 dev: preflight-env-keys ensure-deps ## Lance les apps cochées sur l'hôte : make dev [apps=app,backend] [infra=skip]
 	@$(if $(IS_WORKTREE),node scripts/worktree-env.mts,true)

--- a/scripts/lint-files.mts
+++ b/scripts/lint-files.mts
@@ -1,0 +1,51 @@
+// Lint d'une liste de fichiers (hook de pre-commit, make lint files=…).
+//
+// PIÈGE : en flat config, ESLint résout sa configuration depuis le CWD et non
+// depuis le fichier linté. Lancé de la racine il ignore les eslint.config.mjs
+// par projet et laisse passer ce que `nx run-many -t lint` (la CI) refuse. On
+// reproduit donc le découpage de nx : un groupe par projet, projet en CWD.
+import { ESLint } from 'eslint';
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { dirname, relative, resolve } from 'node:path';
+
+const CONFIG_NAMES = ['eslint.config.mjs', 'eslint.config.mts'];
+
+const files = process.argv.slice(2).filter(Boolean);
+if (!files.length) process.exit(0);
+
+const repoRoot = resolve(
+  execFileSync('git', ['rev-parse', '--show-toplevel'], {
+    encoding: 'utf8',
+  }).trim()
+);
+
+const projectDirOf = (file: string): string => {
+  let dir = dirname(resolve(file));
+  for (;;) {
+    if (CONFIG_NAMES.some((name) => existsSync(resolve(dir, name)))) return dir;
+    if (dir === repoRoot || dir === dirname(dir)) return repoRoot;
+    dir = dirname(dir);
+  }
+};
+
+const groups = new Map<string, string[]>();
+for (const file of files) {
+  const dir = projectDirOf(file);
+  const group = groups.get(dir) ?? [];
+  group.push(relative(dir, resolve(file)));
+  groups.set(dir, group);
+}
+
+const formatter = await new ESLint({ cwd: repoRoot }).loadFormatter('stylish');
+let failed = false;
+
+for (const [dir, group] of groups) {
+  const results = await new ESLint({ cwd: dir }).lintFiles(group);
+  const errors = ESLint.getErrorResults(results);
+  if (!errors.length) continue;
+  failed = true;
+  process.stdout.write(await formatter.format(errors));
+}
+
+process.exit(failed ? 1 : 0);

--- a/scripts/lint-files.mts
+++ b/scripts/lint-files.mts
@@ -11,6 +11,21 @@ import { dirname, relative, resolve } from 'node:path';
 
 const CONFIG_NAMES = ['eslint.config.mjs', 'eslint.config.mts'];
 
+// baseline-browser-mapping (transitif de browserslist, tiré par les plugins
+// ESLint) avertit sur console.warn dès son import quand ses données ont plus de
+// deux mois : timestamp figé à la compilation, aucun opt-out. Le message ne dit
+// rien du code linté, on l'écarte pour garder la sortie du hook lisible.
+const warn = console.warn;
+console.warn = (...args: Parameters<typeof console.warn>): void => {
+  if (
+    typeof args[0] === 'string' &&
+    args[0].startsWith('[baseline-browser-mapping]')
+  ) {
+    return;
+  }
+  warn(...args);
+};
+
 const files = process.argv.slice(2).filter(Boolean);
 if (!files.length) process.exit(0);
 

--- a/scripts/toggle-hooks.mts
+++ b/scripts/toggle-hooks.mts
@@ -1,0 +1,74 @@
+// Active ou désactive les hooks git du dépôt (make hooks / make hooks-off).
+//
+// L'activation écrase core.hooksPath : la valeur précédente est mémorisée dans
+// tet.hooksPathBackup pour être restaurée à l'extinction. L'ABSENCE de cette
+// clé vaut « il n'y avait pas de valeur » — git config distingue absent (code 1)
+// de vide (code 0), un second drapeau serait redondant.
+// UI sur stderr, comme les autres scripts du dossier.
+import { execFileSync } from 'node:child_process';
+import { chmodSync, existsSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const HOOKS_DIR = '.githooks';
+const HOOKS_KEY = 'core.hooksPath';
+const BACKUP_KEY = 'tet.hooksPathBackup';
+
+const git = (...args: string[]): string =>
+  execFileSync('git', args, { encoding: 'utf8' }).trim();
+
+// git config --get sort en 1 quand la clé est absente : on renvoie undefined
+// pour la distinguer d'une valeur vide.
+const get = (key: string): string | undefined => {
+  try {
+    return git('config', '--local', '--get', key);
+  } catch {
+    return undefined;
+  }
+};
+
+const set = (key: string, value: string): string =>
+  git('config', '--local', key, value);
+
+const unset = (key: string): void => {
+  if (get(key) !== undefined) git('config', '--local', '--unset-all', key);
+};
+
+const enable = (): void => {
+  if (!existsSync(HOOKS_DIR)) {
+    console.error(`✗ dossier ${HOOKS_DIR} absent à la racine du dépôt.`);
+    process.exit(1);
+  }
+  const current = get(HOOKS_KEY);
+  // Deuxième activation : ne pas écraser la sauvegarde par .githooks lui-même.
+  if (current !== HOOKS_DIR) {
+    if (current === undefined) unset(BACKUP_KEY);
+    else set(BACKUP_KEY, current);
+  }
+  // git ignore un hook non exécutable, sans rien dire.
+  for (const entry of readdirSync(HOOKS_DIR)) {
+    const hook = join(HOOKS_DIR, entry);
+    if (statSync(hook).isFile()) chmodSync(hook, 0o755);
+  }
+  set(HOOKS_KEY, HOOKS_DIR);
+  console.error(`✓ hooks git activés (${HOOKS_DIR})`);
+};
+
+const disable = (): void => {
+  // Ne toucher à core.hooksPath que s'il pointe bien sur nos hooks : sinon il
+  // appartient à quelqu'un d'autre (husky…) et n'est pas à nous de l'effacer.
+  if (get(HOOKS_KEY) === HOOKS_DIR) {
+    const backup = get(BACKUP_KEY);
+    if (backup === undefined) unset(HOOKS_KEY);
+    else set(HOOKS_KEY, backup);
+  }
+  unset(BACKUP_KEY);
+  console.error('✓ hooks git du dépôt désactivés');
+};
+
+const mode = process.argv[2];
+if (mode === 'on') enable();
+else if (mode === 'off') disable();
+else {
+  console.error('✗ usage : node scripts/toggle-hooks.mts on|off');
+  process.exit(1);
+}


### PR DESCRIPTION
La précédente config lancait bien eslint sur la liste de fichiers mais sans charger automatiquement les configs adaptées aux projets. J'ai tenté en lançant les tests via nx affected mais c'était trop lent car ça analysait tout le projet inutilement, 28s pour 1 fichier lors de mon test (autant dire une éternité si c'est executé en pre-commit hook).
J'ai créé un script qui fait ça en mode flash :zap:

J'en ai également profité pour modifuier le gitignore afin d'éviter de commit un fichier .env.keys.temp en cas de crash inopiné ! 

Troisième commit de la PR de fix, make hooks ne fonctionnait pas chez moi car j'avais pas la clé de config, j'ai géré différents cas.

4ème proposition d'amélioration, j'ai proposé une réécriture des fonctions d'activation/désactivation des hooks en script mts pour une meilleure lisibilité et maintenabilité.