### PR TITLE
fix(referentiels): arrondit les points au survol du donut de score

### DIFF
--- a/apps/app/src/referentiels/tableau-de-bord/labellisation/Scores.tsx
+++ b/apps/app/src/referentiels/tableau-de-bord/labellisation/Scores.tsx
@@ -17,6 +17,7 @@ import Link from 'next/link';
 import { JSX } from 'react';
 import { AccueilCard } from '../AccueilCard';
 import { getAggregatedScore } from '../utils';
+import { buildScoreDonutTooltip } from './build-score-donut-tooltip';
 import LabellisationInfo from './LabellisationInfo';
 
 type ScoreRempliProps = {
@@ -46,7 +47,15 @@ export const ScoreRempli = ({
       trigger: 'item',
       formatter: (params) => {
         if (Array.isArray(params)) return '';
-        return `${params.marker} ${params.name}: <b>${params.value} points (${params.percent}%)</b>`;
+        const { marker, name, value, percent } = params;
+        if (
+          typeof marker !== 'string' ||
+          typeof value !== 'number' ||
+          percent === undefined
+        ) {
+          return '';
+        }
+        return buildScoreDonutTooltip({ marker, name, points: value, percent });
       },
       textStyle: {
         color: '#222',

--- a/apps/app/src/referentiels/tableau-de-bord/labellisation/build-score-donut-tooltip.spec.ts
+++ b/apps/app/src/referentiels/tableau-de-bord/labellisation/build-score-donut-tooltip.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { buildScoreDonutTooltip } from './build-score-donut-tooltip';
+
+const MARKER = '<span></span>';
+
+describe('buildScoreDonutTooltip', () => {
+  it('affiche 128 points pour une somme de 128.00000000000003', () => {
+    expect(
+      buildScoreDonutTooltip({
+        marker: MARKER,
+        name: 'Non renseigné',
+        points: 128.00000000000003,
+        percent: 42,
+      })
+    ).toEqual(`${MARKER} Non renseigné: <b>128 points (42%)</b>`);
+  });
+
+  it('affiche 213,8 points pour une somme de 213.79999999999998', () => {
+    expect(
+      buildScoreDonutTooltip({
+        marker: MARKER,
+        name: 'Fait',
+        points: 213.79999999999998,
+        percent: 58,
+      })
+    ).toMatch(/^<span><\/span> Fait: <b>213[.,]8 points \(58%\)<\/b>$/);
+  });
+
+  it('accorde le libellé au singulier pour une somme de 1.0000000000000002', () => {
+    expect(
+      buildScoreDonutTooltip({
+        marker: MARKER,
+        name: 'Programmé',
+        points: 1.0000000000000002,
+        percent: 1,
+      })
+    ).toEqual(`${MARKER} Programmé: <b>1 point (1%)</b>`);
+  });
+
+  it('accorde le libellé au singulier pour une somme de 0', () => {
+    expect(
+      buildScoreDonutTooltip({
+        marker: MARKER,
+        name: 'Pas fait',
+        points: 0,
+        percent: 0,
+      })
+    ).toEqual(`${MARKER} Pas fait: <b>0 point (0%)</b>`);
+  });
+});

--- a/apps/app/src/referentiels/tableau-de-bord/labellisation/build-score-donut-tooltip.ts
+++ b/apps/app/src/referentiels/tableau-de-bord/labellisation/build-score-donut-tooltip.ts
@@ -1,0 +1,14 @@
+type ScoreDonutTooltipParams = {
+  marker: string;
+  name: string;
+  points: number;
+  percent: number;
+};
+
+export const buildScoreDonutTooltip = ({
+  marker,
+  name,
+  points,
+  percent,
+}: ScoreDonutTooltipParams): string =>
+  `${marker} ${name}: <b>${points} points (${percent}%)</b>`;

--- a/apps/app/src/referentiels/tableau-de-bord/labellisation/build-score-donut-tooltip.ts
+++ b/apps/app/src/referentiels/tableau-de-bord/labellisation/build-score-donut-tooltip.ts
@@ -1,3 +1,9 @@
+import { appLabels } from '@/app/labels/catalog';
+import { toLocaleFixed } from '@/app/utils/to-locale-fixed';
+import { round } from 'es-toolkit';
+
+const POINTS_PRECISION = 1;
+
 type ScoreDonutTooltipParams = {
   marker: string;
   name: string;
@@ -10,5 +16,11 @@ export const buildScoreDonutTooltip = ({
   name,
   points,
   percent,
-}: ScoreDonutTooltipParams): string =>
-  `${marker} ${name}: <b>${points} points (${percent}%)</b>`;
+}: ScoreDonutTooltipParams): string => {
+  const roundedPoints = round(points, POINTS_PRECISION);
+
+  return `${marker} ${name}: <b>${appLabels.pointsFormates({
+    formattedValue: toLocaleFixed(roundedPoints, POINTS_PRECISION),
+    count: roundedPoints,
+  })} (${percent}%)</b>`;
+};


### PR DESCRIPTION
## Symptôme

Sur `/collectivite/:id/referentiel/:referentielId/synthese`, le survol du donut de la carte « état des lieux » affiche la somme flottante brute :

> Non renseigné: **128.00000000000003 points** (42%)
> Fait: **213.79999999999998 points** (58%)

## Diagnostic

Le formatter ECharts interpolait `params.value` sans mise en forme (`Scores.tsx:49` avant fix). `getAggregatedScore` (`referentiels/tableau-de-bord/utils.ts:113-118`) construit cette valeur par accumulation de flottants (`+= score.pointFait`), d'où l'artefact IEEE-754.

« Fait » et « Non renseigné » sont les deux tranches visées parce que ce sont les seules qui somment réellement des points fractionnaires — `Programmé` / `Pas fait` sont le plus souvent à 0.

Le `percent`, lui, était déjà correct : la série porte `percentPrecision: 0`.

## Surface de review

| Fichier | Attention |
|---|---|
| `build-score-donut-tooltip.ts` | **humaine** — 12 lignes, le fix |
| `build-score-donut-tooltip.spec.ts` | **humaine** — les 4 cas de régression |
| `Scores.tsx` | mécanique — narrowing des params ECharts + délégation |
| `DISCOVERED.md` | mécanique — une entrée |

## Test rouge

Commit 1 (`test(referentiels): verrouille l'arrondi du tooltip du donut de score`) extrait le formatter **tel quel**, comportement buggé préservé, et ajoute la spec. Les 4 cas y sont rouges, avec exactement le défaut rapporté. Commit 2 les passe au vert.

## Hypothèses prises

- **Précision d'affichage : 1 décimale.** Aligné sur le « Potentiel » affiché au centre du même donut (`toLocaleFixed(potentiel, 1)`) et sur `score.ratio-badge.tsx`.
- **`round` d'es-toolkit plutôt que `roundTo` de `@tet/domain/utils`.** #4800 migre les 60 appels `roundTo` vers `round` ; ajouter un appel `roundTo` ici aurait créé un site orphelin quel que soit l'ordre de merge. Aucune dépendance sur #4800 : `es-toolkit` est déjà une dépendance racine et est déjà importé dans `apps/app`.

## Zone de confiance basse

**Le libellé passe au singulier** : « 1 point » / « 0 point » là où le formatter écrivait « 1 points » / « 0 points ». `appLabels.pointsFormates` est la seule entrée du catalogue couvrant ce concept, et la règle « aucune chaîne user-facing inline » interdisait de recopier `' points'`. C'est une correction en soi, mais elle dépasse la demande initiale — à arbitrer.

## Recherche anti-duplication

- **Arrondi** : `rg roundTo` → helper du repo, ~60 appels. Utilisé (via son remplaçant `round`, cf. hypothèses). Pas de réimplémentation.
- **Formatage « N point(s) »** : `rg pointsFormates`, `rg "points'"`, revue de `apps/app/src/utils/` → `appLabels.pointsFormates` existait déjà dans le catalogue mais n'était référencé nulle part. Réutilisé plutôt que dupliqué.
- **Formatage locale** : `toLocaleFixed` (`apps/app/src/utils/to-locale-fixed.ts`), déjà importé par `Scores.tsx`.

## Items ajoutés à `DISCOVERED.md`

- `[refactor]` Arrondi décimal réimplémenté à la main sur 5 sites de graphes, hors du périmètre de la migration `roundTo` → `round` de #4800.

## Plan

Pas de plan formel : correction ponctuelle sur signalement direct.

## Vérifications

- `vitest run` (`apps/app`) : **547 passed / 76 fichiers**, dont les 4 nouveaux cas
- `nx run app:typecheck` ✅
- `nx run app:lint` : 0 erreur, aucun warning sur les fichiers touchés
- Prettier ✅
