### PR TITLE
fix(graphique): place le bouton de téléchargement sous le graphe

### DIFF
--- a/apps/app/src/ui/charts/old/ChartCard.tsx
+++ b/apps/app/src/ui/charts/old/ChartCard.tsx
@@ -81,14 +81,12 @@ const ChartCardModalContent = ({
   // Référence utilisée pour le téléchargement du graphe
   const { chartWrapperRef, DownloadChartButton } = useDownloadChartButton(
     chartInfo?.downloadedFileName,
-    'absolute -mr-2 right-0 top-3 z-10',
+    'flex justify-end pr-3',
     onDownload
   );
 
   return (
-    <div className="relative">
-      <DownloadChartButton />
-
+    <div>
       <div ref={chartWrapperRef} className="p-3">
         <div className="pb-4">
           {/* Titre du graphe */}
@@ -131,6 +129,8 @@ const ChartCardModalContent = ({
           </div>
         )}
       </div>
+
+      <DownloadChartButton />
     </div>
   );
 };


### PR DESCRIPTION
## Problème

Dans la modale d'agrandissement d'un graphique du référentiel, le bouton « Télécharger le graphique » était positionné en `absolute` en haut à droite du contenu, exactement là où le design system place la croix de fermeture de la `Modal`. Le bouton passait devant et rendait la croix inutilisable : la modale ne pouvait être fermée qu'en cliquant à côté.

## Correction

Le bouton de téléchargement sort du positionnement absolu : il est désormais dans le flux, aligné à droite sous le graphe. La croix de fermeture est entièrement dégagée, et le bouton reste hors du bloc capturé par html2canvas, donc toujours absent du PNG téléchargé.

## Avant / Après

<img width="2000" height="768" alt="avant-apres" src="https://github.com/user-attachments/assets/ce1aa99a-e05e-418d-bc76-d20c2059471b" />
