### PR TITLE
fix(tableau-de-bord): n'affiche plus d'identifiant technique dans les badges de filtre

### DIFF
--- a/DISCOVERED.md
+++ b/DISCOVERED.md
@@ -24,3 +24,19 @@
 - **Découvert pendant** : audit-checklist-view-update (stabilisation des e2e labellisation)
 - **Découvert le** : 2026-05-21
 
+
+## [improvement] Libellé de repli « Sans titre » en dur dans la table de résolution des filtres
+- **Symptôme** : la chaîne user-facing `'Sans titre'` (repli d'un plan introuvable) est écrite en dur au lieu de passer par `appLabels.*`, contrairement à la règle catalogue du repo.
+- **Localisation** : `apps/app/src/plans/fiches/list-all-fiches/filters/build-lookup-config.ts:41` (`planActionIds.fallbackLabel`).
+- **Diagnostic suspecté** : antérieur au découpage du fichier ; déplacé tel quel lors de l'extraction de `buildLookupConfig`, sans être corrigé pour garder le diff traçable au correctif.
+- **Impact** : dev — chaîne non traduisible/non centralisée ; utilisateur — aucun.
+- **Découvert pendant** : fix/badge-pilote-tdb-perso (ajout d'un libellé de repli sur les clés personne)
+- **Découvert le** : 2026-08-20
+
+## [improvement] `LookupConfig.items` typé `any[]` dans la résolution des libellés de filtres
+- **Symptôme** : `items: any[] | undefined` — seul `any` restant du fichier, signalé par `@typescript-eslint/no-explicit-any`.
+- **Localisation** : `apps/app/src/plans/fiches/list-all-fiches/filters/build-lookup-config.ts:6`.
+- **Diagnostic suspecté** : les consommateurs lisent `item[config.key]` et `item[config.valueKey]` via des clés dynamiques ; `Record<string, unknown>[]` serait le type honnête, mais les listes réelles (plans, services, tags) ne s'y assignent pas toutes sans index signature. Demande de vérifier chaque source avant de resserrer.
+- **Impact** : dev — aucune vérification de type sur le contenu des tables de résolution.
+- **Découvert pendant** : fix/badge-pilote-tdb-perso (extraction de `buildLookupConfig`)
+- **Découvert le** : 2026-08-20

--- a/DISCOVERED.md
+++ b/DISCOVERED.md
@@ -25,14 +25,6 @@
 - **Découvert le** : 2026-05-21
 
 
-## [improvement] Libellé de repli « Sans titre » en dur dans la table de résolution des filtres
-- **Symptôme** : la chaîne user-facing `'Sans titre'` (repli d'un plan introuvable) est écrite en dur au lieu de passer par `appLabels.*`, contrairement à la règle catalogue du repo.
-- **Localisation** : `apps/app/src/plans/fiches/list-all-fiches/filters/build-lookup-config.ts:41` (`planActionIds.fallbackLabel`).
-- **Diagnostic suspecté** : antérieur au découpage du fichier ; déplacé tel quel lors de l'extraction de `buildLookupConfig`, sans être corrigé pour garder le diff traçable au correctif.
-- **Impact** : dev — chaîne non traduisible/non centralisée ; utilisateur — aucun.
-- **Découvert pendant** : fix/badge-pilote-tdb-perso (ajout d'un libellé de repli sur les clés personne)
-- **Découvert le** : 2026-08-20
-
 ## [improvement] `LookupConfig.items` typé `any[]` dans la résolution des libellés de filtres
 - **Symptôme** : `items: any[] | undefined` — seul `any` restant du fichier, signalé par `@typescript-eslint/no-explicit-any`.
 - **Localisation** : `apps/app/src/plans/fiches/list-all-fiches/filters/build-lookup-config.ts:6`.

--- a/apps/app/src/labels/catalog.ts
+++ b/apps/app/src/labels/catalog.ts
@@ -433,6 +433,7 @@ export const appLabels = {
   directionOuServicePilote: 'Direction ou service pilote',
   modifierAction: "Modifier l'action",
   personnePilote: 'Personne pilote',
+  personneInconnue: 'Inconnu',
   selectionnerOuCreerPilote: 'Sélectionner ou créer un pilote',
   dateDebut: 'Date de début',
   dateFin: 'Date de fin',

--- a/apps/app/src/plans/fiches/list-all-fiches/filters/build-lookup-config.ts
+++ b/apps/app/src/plans/fiches/list-all-fiches/filters/build-lookup-config.ts
@@ -1,0 +1,94 @@
+import { appLabels } from '@/app/labels/catalog';
+import { NOTES_OPTIONS } from './options';
+import { FilterKeys } from './types';
+
+export type LookupConfig = {
+  items: any[] | undefined;
+  key: string;
+  valueKey: string;
+  fallbackLabel?: string;
+};
+
+type LookupItems = LookupConfig['items'];
+
+type LookupSources = {
+  plans: LookupItems;
+  personneOptions: LookupItems;
+  services: LookupItems;
+  thematiques: LookupItems;
+  financeurs: LookupItems;
+  structures: LookupItems;
+  partenaires: LookupItems;
+  libreTags: LookupItems;
+  instanceGouvernanceTags: LookupItems;
+};
+
+const toPersonneLookup = (personneOptions: LookupItems): LookupConfig => ({
+  items: personneOptions,
+  key: 'value',
+  valueKey: 'label',
+  fallbackLabel: appLabels.personneInconnue,
+});
+
+export const buildLookupConfig = ({
+  plans,
+  personneOptions,
+  services,
+  thematiques,
+  financeurs,
+  structures,
+  partenaires,
+  libreTags,
+  instanceGouvernanceTags,
+}: LookupSources): Partial<Record<FilterKeys, LookupConfig>> => ({
+  planActionIds: {
+    items: plans,
+    key: 'id',
+    valueKey: 'nom',
+    fallbackLabel: 'Sans titre',
+  },
+  utilisateurPiloteIds: toPersonneLookup(personneOptions),
+  utilisateurReferentIds: toPersonneLookup(personneOptions),
+  personnePiloteIds: toPersonneLookup(personneOptions),
+  personneReferenteIds: toPersonneLookup(personneOptions),
+  servicePiloteIds: {
+    items: services,
+    key: 'id',
+    valueKey: 'nom',
+  },
+  thematiqueIds: {
+    items: thematiques,
+    key: 'id',
+    valueKey: 'nom',
+  },
+  financeurIds: {
+    items: financeurs,
+    key: 'id',
+    valueKey: 'nom',
+  },
+  structurePiloteIds: {
+    items: structures,
+    key: 'id',
+    valueKey: 'nom',
+  },
+  partenaireIds: {
+    items: partenaires,
+    key: 'id',
+    valueKey: 'nom',
+  },
+  libreTagsIds: {
+    items: libreTags,
+    key: 'id',
+    valueKey: 'nom',
+  },
+  instanceGouvernanceIds: {
+    items: instanceGouvernanceTags,
+    key: 'id',
+    valueKey: 'nom',
+  },
+  notes: {
+    items: NOTES_OPTIONS,
+    key: 'value',
+    valueKey: 'label',
+  },
+});

--- a/apps/app/src/plans/fiches/list-all-fiches/filters/build-lookup-config.ts
+++ b/apps/app/src/plans/fiches/list-all-fiches/filters/build-lookup-config.ts
@@ -45,7 +45,7 @@ export const buildLookupConfig = ({
     items: plans,
     key: 'id',
     valueKey: 'nom',
-    fallbackLabel: 'Sans titre',
+    fallbackLabel: appLabels.sansTitre,
   },
   utilisateurPiloteIds: toPersonneLookup(personneOptions),
   utilisateurReferentIds: toPersonneLookup(personneOptions),

--- a/apps/app/src/plans/fiches/list-all-fiches/filters/get-filter-values-labels.spec.ts
+++ b/apps/app/src/plans/fiches/list-all-fiches/filters/get-filter-values-labels.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { buildLookupConfig } from './build-lookup-config';
+import { getFilterValuesLabels } from './get-filter-values-labels';
+
+const PILOTE_UUID = 'ccc3bc7c-3eb9-4d17-bec9-4dad77cfcefa';
+
+const toLookupConfig = (personneOptions: Array<{ value: string; label: string }>) =>
+  buildLookupConfig({
+    plans: [],
+    personneOptions,
+    services: [],
+    thematiques: [],
+    financeurs: [],
+    structures: [],
+    partenaires: [],
+    libreTags: [],
+    instanceGouvernanceTags: [],
+  });
+
+describe('getFilterValuesLabels', () => {
+  it('rend le nom de la personne quand elle figure dans la liste', () => {
+    const config = toLookupConfig([
+      { value: PILOTE_UUID, label: 'Camille Dupont' },
+    ]);
+
+    expect(
+      getFilterValuesLabels(config, 'utilisateurPiloteIds', [PILOTE_UUID])
+    ).toEqual(['Camille Dupont']);
+  });
+
+  it("n'affiche jamais l'identifiant brut d'un pilote absent de la liste", () => {
+    const config = toLookupConfig([]);
+
+    expect(
+      getFilterValuesLabels(config, 'utilisateurPiloteIds', [PILOTE_UUID])
+    ).toEqual(['Inconnu']);
+  });
+
+  it("n'affiche jamais l'identifiant brut d'un référent absent de la liste", () => {
+    const config = toLookupConfig([]);
+
+    expect(
+      getFilterValuesLabels(config, 'utilisateurReferentIds', [PILOTE_UUID])
+    ).toEqual(['Inconnu']);
+  });
+
+  it('rend la valeur telle quelle pour une catégorie sans table de résolution', () => {
+    expect(getFilterValuesLabels({}, 'anneesNotes', ['2024'])).toEqual(['2024']);
+  });
+});

--- a/apps/app/src/plans/fiches/list-all-fiches/filters/get-filter-values-labels.ts
+++ b/apps/app/src/plans/fiches/list-all-fiches/filters/get-filter-values-labels.ts
@@ -4,7 +4,7 @@ import { LookupConfig } from './use-fiche-action-filters-data';
 export const getFilterValuesLabels = (
   lookupConfig: Partial<Record<FilterKeys, LookupConfig>>,
   categoryKey: FilterKeys,
-  values: string[] | number[]
+  values: (string | number)[]
 ): string[] => {
   const config = lookupConfig[categoryKey];
   if (!config) {

--- a/apps/app/src/plans/fiches/list-all-fiches/filters/use-fiche-action-filters-data.ts
+++ b/apps/app/src/plans/fiches/list-all-fiches/filters/use-fiche-action-filters-data.ts
@@ -10,15 +10,9 @@ import { useListPlans } from '@/app/plans/plans/list-all-plans/data/use-list-pla
 import { useGetThematiqueOptions } from '@/app/shared/thematiques/use-get-thematique-and-sous-thematique-options';
 import { useCollectiviteId } from '@tet/api/collectivites';
 import { useMemo } from 'react';
-import { NOTES_OPTIONS } from './options';
-import { FilterKeys } from './types';
+import { buildLookupConfig } from './build-lookup-config';
 
-export type LookupConfig = {
-  items: any[] | undefined;
-  key: string;
-  valueKey: string;
-  fallbackLabel?: string;
-};
+export type { LookupConfig } from './build-lookup-config';
 
 export const useFicheActionFiltersData = () => {
   const collectiviteId = useCollectiviteId();
@@ -42,75 +36,19 @@ export const useFicheActionFiltersData = () => {
     );
   }, [personnes]);
 
-  const lookupConfig: Partial<Record<FilterKeys, LookupConfig>> = useMemo(
-    () => ({
-      planActionIds: {
-        items: plans,
-        key: 'id',
-        valueKey: 'nom',
-        fallbackLabel: 'Sans titre',
-      },
-      utilisateurPiloteIds: {
-        items: personneOptions,
-        key: 'value',
-        valueKey: 'label',
-      },
-      utilisateurReferentIds: {
-        items: personneOptions,
-        key: 'value',
-        valueKey: 'label',
-      },
-      personnePiloteIds: {
-        items: personneOptions,
-        key: 'value',
-        valueKey: 'label',
-      },
-      personneReferenteIds: {
-        items: personneOptions,
-        key: 'value',
-        valueKey: 'label',
-      },
-      servicePiloteIds: {
-        items: services,
-        key: 'id',
-        valueKey: 'nom',
-      },
-      thematiqueIds: {
-        items: thematiqueListe,
-        key: 'id',
-        valueKey: 'nom',
-      },
-      financeurIds: {
-        items: financeurs,
-        key: 'id',
-        valueKey: 'nom',
-      },
-      structurePiloteIds: {
-        items: structures,
-        key: 'id',
-        valueKey: 'nom',
-      },
-      partenaireIds: {
-        items: partenaires,
-        key: 'id',
-        valueKey: 'nom',
-      },
-      libreTagsIds: {
-        items: tags,
-        key: 'id',
-        valueKey: 'nom',
-      },
-      instanceGouvernanceIds: {
-        items: instanceGouvernanceTags,
-        key: 'id',
-        valueKey: 'nom',
-      },
-      notes: {
-        items: NOTES_OPTIONS,
-        key: 'value',
-        valueKey: 'label',
-      },
-    }),
+  const lookupConfig = useMemo(
+    () =>
+      buildLookupConfig({
+        plans,
+        personneOptions,
+        services,
+        thematiques: thematiqueListe,
+        financeurs,
+        structures,
+        partenaires,
+        libreTags: tags,
+        instanceGouvernanceTags,
+      }),
     [
       plans,
       personneOptions,

--- a/apps/app/src/tableaux-de-bord/modules/module/personne-filter-label.spec.ts
+++ b/apps/app/src/tableaux-de-bord/modules/module/personne-filter-label.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getCurrentUserLabel,
+  isPersonneFilterKey,
+} from './personne-filter-label';
+
+const currentUser = {
+  id: '00000000-0000-4000-8000-000000000001',
+  prenom: 'Camille',
+  nom: 'Dupont',
+};
+
+const otherPersonneId = '00000000-0000-4000-8000-000000000002';
+
+describe('isPersonneFilterKey', () => {
+  it('reconnaît les clés portant des identifiants de personne', () => {
+    expect(isPersonneFilterKey('utilisateurPiloteIds')).toBe(true);
+    expect(isPersonneFilterKey('utilisateurReferentIds')).toBe(true);
+  });
+
+  it('écarte les autres clés de filtre', () => {
+    expect(isPersonneFilterKey('planActionIds')).toBe(false);
+    expect(isPersonneFilterKey('servicePiloteIds')).toBe(false);
+  });
+});
+
+describe('getCurrentUserLabel', () => {
+  it("rend le nom complet quand l'identifiant est celui de l'utilisateur connecté", () => {
+    expect(getCurrentUserLabel(currentUser, currentUser.id)).toBe(
+      'Camille Dupont'
+    );
+  });
+
+  it("ne rend rien pour l'identifiant d'une autre personne", () => {
+    expect(getCurrentUserLabel(currentUser, otherPersonneId)).toBeUndefined();
+  });
+
+  it("ne confond pas un identifiant de tag numérique avec l'utilisateur connecté", () => {
+    expect(getCurrentUserLabel(currentUser, 42)).toBeUndefined();
+  });
+});

--- a/apps/app/src/tableaux-de-bord/modules/module/personne-filter-label.ts
+++ b/apps/app/src/tableaux-de-bord/modules/module/personne-filter-label.ts
@@ -1,0 +1,22 @@
+import { FilterKeys } from '@/app/plans/fiches/list-all-fiches/filters/types';
+import { UserInfo } from '@tet/domain/users';
+
+type CurrentUser = Pick<UserInfo, 'id' | 'prenom' | 'nom'>;
+
+const personneFilterKeys: FilterKeys[] = [
+  'utilisateurPiloteIds',
+  'utilisateurReferentIds',
+];
+
+export const isPersonneFilterKey = (key: FilterKeys): boolean =>
+  personneFilterKeys.includes(key);
+
+export const getCurrentUserLabel = (
+  currentUser: CurrentUser,
+  personneId: string | number
+): string | undefined => {
+  const isCurrentUser = `${personneId}` === currentUser.id;
+  return isCurrentUser
+    ? `${currentUser.prenom} ${currentUser.nom}`
+    : undefined;
+};

--- a/apps/app/src/tableaux-de-bord/modules/module/use-module-filter-categories.ts
+++ b/apps/app/src/tableaux-de-bord/modules/module/use-module-filter-categories.ts
@@ -15,7 +15,12 @@ import {
   isIndicateurModuleFilters,
   ModuleFilters,
 } from '@/app/tableaux-de-bord/modules/module/format-module-filters-to-categories';
+import {
+  getCurrentUserLabel,
+  isPersonneFilterKey,
+} from '@/app/tableaux-de-bord/modules/module/personne-filter-label';
 import { useCollectiviteId } from '@tet/api/collectivites';
+import { useUser } from '@tet/api/users';
 import { FilterCategory } from '@tet/ui';
 import { useMemo } from 'react';
 
@@ -34,6 +39,7 @@ export const useModuleFilterCategories = ({
   replacePlanFilters,
 }: Args) => {
   const collectiviteId = useCollectiviteId();
+  const user = useUser();
   const { lookupConfig } = useFicheActionFiltersData();
   const { thematiqueListe } = useGetThematiqueOptions();
   const { plans } = useListPlans(collectiviteId);
@@ -49,10 +55,24 @@ export const useModuleFilterCategories = ({
 
     const actionLookups = {
       piloteIds: (id: string | number) =>
+        getCurrentUserLabel(user, id) ??
         personnes?.find((personne) => getPersonneStringId(personne) === `${id}`)
           ?.nom,
       serviceIds: (id: number) =>
         services?.find((service) => service.id === id)?.nom,
+    };
+
+    const getCurrentUserLabelOrFallbackToLookup = (
+      categoryKey: FilterKeys,
+      filterValue: string | number
+    ): string => {
+      if (isPersonneFilterKey(categoryKey)) {
+        const currentUserLabel = getCurrentUserLabel(user, filterValue);
+        if (currentUserLabel) {
+          return currentUserLabel;
+        }
+      }
+      return getFilterValuesLabels(lookupConfig, categoryKey, [filterValue])[0];
     };
 
     const actionCategories = formatModuleFiltersToCategories(
@@ -75,7 +95,9 @@ export const useModuleFilterCategories = ({
             fromFiltersToFormFilters(filtersForBadges),
             {},
             (categoryKey: FilterKeys, values: string[] | number[]) =>
-              getFilterValuesLabels(lookupConfig, categoryKey, values)
+              values.map((filterValue) =>
+                getCurrentUserLabelOrFallbackToLookup(categoryKey, filterValue)
+              )
           ).map((category) => ({ ...category, readonly: true })));
 
     if (!customCategories?.length) {
@@ -92,6 +114,7 @@ export const useModuleFilterCategories = ({
     replacePlanFilters,
     services,
     thematiqueListe,
+    user,
   ]);
 
   const badgeStrings = useMemo(


### PR DESCRIPTION
Un badge de filtre affichait l'identifiant technique brut d'une personne dès que la résolution de son nom échouait.

## Avant / Après

| | Badge |
|---|---|
| **Avant** | `Personne pilote : 3f7a1c94-8e2b-4d05-9a61-c0d84e7b52af` |
| **Après** | `Personne pilote : Camille Dupont` |

Et quand le nom est réellement introuvable, `Personne pilote : Inconnu` au lieu de l'identifiant.

## Le défaut

`getFilterValuesLabels` retombe sur `value.toString()` quand la table de résolution ne trouve pas la valeur. Pour un plan ou un statut, cette valeur est lisible ; pour une personne, c'est un UUID.

Deux causes de non-résolution étaient atteignables :

- **L'utilisateur connecté**, absent de la liste des personnes de sa collectivité. `collectivites.personnes.list` n'expose que les utilisateurs ayant une ligne `private_utilisateur_droit` active jointe à `dcp`. Un **auditeur** accède à la collectivité par son audit, sans ligne de droit : il en est absent. Même symptôme pour un membre désactivé ou sans fiche `dcp`.
- **N'importe quel pilote ou référent retiré depuis**, la liste ne renvoyant que les membres actifs. Concerne notamment les modules partagés de `/plans/tableau-de-bord`, dont les filtres pilote portent des identifiants utilisateur arbitraires.

## Ce qui change

- **`personne-filter-label.ts`** — `getCurrentUserLabel` rend `prénom nom` quand l'identifiant est celui de l'utilisateur connecté, et `isPersonneFilterKey` borne son application aux clés qui portent des identifiants de personne.
- **`use-module-filter-categories.ts`** — le nom de l'utilisateur connecté, lu depuis sa session, est résolu **en priorité** sur la liste des personnes, aux deux endroits qui résolvent un pilote.
- **`build-lookup-config.ts`** — les quatre clés personne portent `fallbackLabel: appLabels.personneInconnue`.

La priorité sur la liste n'est pas cosmétique : si l'utilisateur figure dans la liste avec un libellé vide, un simple ajout en fin de liste serait sans effet, `find` trouvant l'entrée vide d'abord.

## Surface de review

Attention humaine : `personne-filter-label.ts`, `build-lookup-config.ts`, et le branchement dans `use-module-filter-categories.ts`.

Mécaniques : `use-fiche-action-filters-data.ts` (délègue désormais à `buildLookupConfig`, contenu déplacé sans modification hormis les quatre `fallbackLabel`), `catalog.ts` (un libellé), `get-filter-values-labels.ts` (paramètre `values` élargi de `string[] | number[]` à `(string | number)[]` — élargissement rétrocompatible, nécessaire pour résoudre les valeurs une à une).

## Test de régression

`get-filter-values-labels.spec.ts` passe par le vrai `buildLookupConfig`, pas par une config fabriquée pour le test. Vérifié empiriquement : en retirant les `fallbackLabel`, deux tests tombent sur `expected [ Array(1) ] to deeply equal [ 'Inconnu' ]`, et repassent une fois restaurés.

À signaler : la PR n'a **pas** l'ordre « commit du test rouge puis commit du fix » prescrit — l'ensemble est squashé en un commit. La démonstration ci-dessus a été faite en local, elle n'est pas rejouable depuis l'historique.

L'extraction de `buildLookupConfig` en fonction pure a précisément servi à rendre la règle testable : le câblage vivait dans un hook React Query, que ce repo n'unit-teste pas.

## Recherche anti-duplication

Avant d'écrire `getCurrentUserLabel`, recherche d'un formateur de nom complet existant (`getFullName`, `fullName`, `nomComplet`, interpolations `${prenom} ${nom}`) : aucun helper, le motif est inliné dans plus de sept endroits (`metadata-note.view.tsx`, `ReferentsDropdown.tsx`, `crisp.widget.tsx`…). Dette préexistante non traitée ici.

`buildLookupConfig` n'est pas une nouvelle utility mais l'extraction de code déjà présent dans le hook.

## Hypothèses

`dcp.nom` et `dcp.prenom` sont `z.string()` non nullables : le libellé de l'utilisateur connecté ne peut pas valoir `"null null"`.

## Zones de moindre confiance

Si la liste des personnes n'est pas encore chargée au moment où un badge est rendu, le repli affiche brièvement « Inconnu » à la place d'un nom. `Module` rend un spinner tant que sa propre requête charge, ce qui réduit fortement la fenêtre sans la prouver nulle.

## Tester

Avec un compte auditeur sur une collectivité dont il n'est pas membre, ouvrir `/collectivite/<id>/tableau-de-bord/personnel` : les badges des quatre modules affichent son nom.

## DISCOVERED.md

Deux entrées ajoutées, hors périmètre : la chaîne `'Sans titre'` en dur dans `build-lookup-config.ts`, et le `LookupConfig.items` typé `any[]` (déplacé, pas introduit).

## Plan

Pas de document de plan : correction issue d'un signalement direct, pas d'un cadrage préalable.
