### PR TITLE
fix(tableau-de-bord): n'envoie plus les auditeurs sur le suivi personnel

### DIFF
--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/tableau-de-bord/page.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/tableau-de-bord/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { makeTdbCollectiviteUrl } from '@/app/app/paths';
+import { makeUserTdbUrl } from '@/app/tableaux-de-bord/make-user-tdb-url';
 import SpinnerLoader from '@/app/ui/shared/SpinnerLoader';
 import { useCurrentCollectivite } from '@tet/api/collectivites';
 import { useUser } from '@tet/api/users';
@@ -8,22 +8,13 @@ import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 
 export default function RedirectToTdbPage() {
-  const currentCollectivite = useCurrentCollectivite();
+  const { collectiviteId } = useCurrentCollectivite();
   const user = useUser();
   const router = useRouter();
 
-  const isUserCollectivite = user.collectivites.some(
-    (c) => c.collectiviteId === currentCollectivite.collectiviteId
-  );
-
   useEffect(() => {
-    router.replace(
-      makeTdbCollectiviteUrl({
-        collectiviteId: currentCollectivite.collectiviteId,
-        view: isUserCollectivite ? 'personnel' : 'synthetique',
-      })
-    );
-  }, [currentCollectivite.collectiviteId, isUserCollectivite, router]);
+    router.replace(makeUserTdbUrl({ user, collectiviteId }));
+  }, [collectiviteId, router, user]);
 
   return <SpinnerLoader className="m-auto" />;
 }

--- a/apps/app/app/(authed)/collectivite/tableau-de-bord/page.tsx
+++ b/apps/app/app/(authed)/collectivite/tableau-de-bord/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { makeTdbCollectiviteUrl } from '@/app/app/paths';
+import { makeUserTdbUrl } from '@/app/tableaux-de-bord/make-user-tdb-url';
 import SpinnerLoader from '@/app/ui/shared/SpinnerLoader';
 import { useCollectiviteContext } from '@tet/api/collectivites';
 import { useUser } from '@tet/api/users';
@@ -13,19 +13,13 @@ export default function RedirectToTdbPage() {
   const router = useRouter();
 
   const collectiviteId = collectivite?.collectiviteId;
-  const isUserCollectivite = user.collectivites.some(
-    (c) => c.collectiviteId === collectiviteId
-  );
 
   useEffect(() => {
-    if (!collectiviteId) return;
-    router.replace(
-      makeTdbCollectiviteUrl({
-        collectiviteId,
-        view: isUserCollectivite ? 'personnel' : 'synthetique',
-      })
-    );
-  }, [collectiviteId, isUserCollectivite, router]);
+    if (collectiviteId === undefined) {
+      return;
+    }
+    router.replace(makeUserTdbUrl({ user, collectiviteId }));
+  }, [collectiviteId, router, user]);
 
   return <SpinnerLoader className="m-auto" />;
 }

--- a/apps/app/src/app/pages/CollectivitesEngagees/Views/referentiels/ReferentielCarte.tsx
+++ b/apps/app/src/app/pages/CollectivitesEngagees/Views/referentiels/ReferentielCarte.tsx
@@ -1,5 +1,5 @@
 import { referentielToName } from '@/app/app/labels';
-import { makeTdbCollectiviteUrl } from '@/app/app/paths';
+import { makeUserTdbUrl } from '@/app/tableaux-de-bord/make-user-tdb-url';
 import { appLabels } from '@/app/labels/catalog';
 import { NIVEAUX } from '@/app/referentiels/tableau-de-bord/labellisation/LabellisationInfo';
 import {
@@ -43,9 +43,7 @@ export const ReferentielCarte = ({ collectivite, isClickable }: Props) => {
 
   const user = useUser();
 
-  const isUserFromCollectivite = user.collectivites.some(
-    (c) => c.collectiviteId === collectiviteId
-  );
+  const tdbUrl = makeUserTdbUrl({ user, collectiviteId });
 
   return (
     <div className="relative h-full group">
@@ -62,14 +60,7 @@ export const ReferentielCarte = ({ collectivite, isClickable }: Props) => {
         className={classNames('h-full !border-primary-3 !py-5 !px-6 !gap-3', {
           'hover:!bg-primary-0': isClickable,
         })}
-        href={
-          isClickable
-            ? makeTdbCollectiviteUrl({
-                collectiviteId,
-                view: isUserFromCollectivite ? 'personnel' : 'synthetique',
-              })
-            : undefined
-        }
+        href={isClickable ? tdbUrl : undefined}
         onClick={() => tracker(Event.recherches.viewReferentiel)}
       >
         <div className="mb-0 text-lg font-bold text-primary-9">

--- a/apps/app/src/app/paths.ts
+++ b/apps/app/src/app/paths.ts
@@ -10,13 +10,15 @@ import type { ReferentielId } from '@tet/domain/referentiels';
 import { FicheSectionId } from '../plans/fiches/show-fiche/content/type';
 export type { ReferentielTableFilters };
 
+export const homePath = '/';
+
 export const signInPath = `/login`;
 export const signUpPath = `/signup`;
 export const resetPwdPath = `/recover`;
 export const rejoindreCollectivitePath = '/rejoindre-une-collectivite';
 
 /** Lien relatif vers « rejoindre une collectivité » (navigation intra-app). */
-export const makeRejoindreCollectiviteUrl = (redirectTo = '/') => {
+export const makeRejoindreCollectiviteUrl = (redirectTo = homePath) => {
   const params = new URLSearchParams({ redirect_to: redirectTo });
   return `${rejoindreCollectivitePath}?${params}`;
 };

--- a/apps/app/src/tableaux-de-bord/make-user-tdb-url.spec.ts
+++ b/apps/app/src/tableaux-de-bord/make-user-tdb-url.spec.ts
@@ -1,0 +1,69 @@
+import { defaultCollectivitePreferences } from '@tet/domain/collectivites';
+import {
+  AuditRole,
+  CollectiviteRole,
+  UserRolesAndPermissions,
+} from '@tet/domain/users';
+import { describe, expect, it } from 'vitest';
+import { makeUserTdbUrl } from './make-user-tdb-url';
+
+const COLLECTIVITE_ID = 4989;
+
+const toUser = ({
+  collectiviteRole,
+  auditRoles = [],
+}: {
+  collectiviteRole: CollectiviteRole | null;
+  auditRoles?: AuditRole[];
+}): UserRolesAndPermissions => ({
+  roles: [],
+  permissions: [],
+  collectivites: [
+    {
+      collectiviteId: COLLECTIVITE_ID,
+      collectiviteNom: 'Collectivite test',
+      collectiviteAccesRestreint: false,
+      collectivitePreferences: defaultCollectivitePreferences,
+      role: collectiviteRole,
+      permissions: [],
+      audits: auditRoles.map((role, index) => ({
+        auditId: index + 1,
+        referentielId: 'te' as const,
+        role,
+        permissions: [],
+      })),
+    },
+  ],
+});
+
+describe('makeUserTdbUrl', () => {
+  it('envoie un membre vers son suivi personnel', () => {
+    expect(
+      makeUserTdbUrl({
+        user: toUser({ collectiviteRole: CollectiviteRole.LECTURE }),
+        collectiviteId: COLLECTIVITE_ID,
+      })
+    ).toBe(`/collectivite/${COLLECTIVITE_ID}/tableau-de-bord/personnel`);
+  });
+
+  it('envoie vers la vue synthetique un auditeur rattaché par son seul audit', () => {
+    expect(
+      makeUserTdbUrl({
+        user: toUser({
+          collectiviteRole: null,
+          auditRoles: [AuditRole.AUDITEUR],
+        }),
+        collectiviteId: COLLECTIVITE_ID,
+      })
+    ).toBe(`/collectivite/${COLLECTIVITE_ID}/tableau-de-bord/synthetique`);
+  });
+
+  it('envoie vers la vue synthetique un utilisateur sans lien avec la collectivité', () => {
+    expect(
+      makeUserTdbUrl({
+        user: toUser({ collectiviteRole: CollectiviteRole.ADMIN }),
+        collectiviteId: 1,
+      })
+    ).toBe('/collectivite/1/tableau-de-bord/synthetique');
+  });
+});

--- a/apps/app/src/tableaux-de-bord/make-user-tdb-url.ts
+++ b/apps/app/src/tableaux-de-bord/make-user-tdb-url.ts
@@ -1,0 +1,19 @@
+import { makeTdbCollectiviteUrl } from '@/app/app/paths';
+import {
+  hasOwnCollectiviteRole,
+  UserRolesAndPermissions,
+} from '@tet/domain/users';
+
+export const makeUserTdbUrl = ({
+  user,
+  collectiviteId,
+}: {
+  user: UserRolesAndPermissions;
+  collectiviteId: number;
+}): string =>
+  makeTdbCollectiviteUrl({
+    collectiviteId,
+    view: hasOwnCollectiviteRole(user, { collectiviteId })
+      ? 'personnel'
+      : 'synthetique',
+  });

--- a/apps/app/src/ui/layout/header/header.tsx
+++ b/apps/app/src/ui/layout/header/header.tsx
@@ -1,8 +1,9 @@
 import { usePathname } from 'next/navigation';
 
-import { makeTdbCollectiviteUrl } from '@/app/app/paths';
+import { homePath } from '@/app/app/paths';
 import { useIsDemarchePcaetEnabled } from '@/app/demarches/pcaet/use-is-enabled';
 import { useReferentielTeEnabled } from '@/app/referentiels/use-referentiel-te-enabled';
+import { makeUserTdbUrl } from '@/app/tableaux-de-bord/make-user-tdb-url';
 import { useCollectiviteContext } from '@tet/api/collectivites';
 import { useUser } from '@tet/api/users';
 import { REFERENTIEL_TE_DISABLED_REFERENTIELS_DISPLAY } from '@tet/domain/collectivites';
@@ -23,22 +24,15 @@ export const Header = () => {
   const referentielTeEnabled = useReferentielTeEnabled();
   const isDemarchePcaetEnabled = useIsDemarchePcaetEnabled();
 
-  const isUserCollectivite = user.collectivites.some(
-    (c) => c.collectiviteId === collectivite?.collectiviteId
-  );
+  const rootUrl = collectivite
+    ? makeUserTdbUrl({ user, collectiviteId: collectivite.collectiviteId })
+    : homePath;
 
   return (
     <HeaderTet
       id={APP_HEADER_ID}
       pathname={pathname}
-      rootUrl={
-        collectivite?.collectiviteId
-          ? makeTdbCollectiviteUrl({
-              collectiviteId: collectivite.collectiviteId,
-              view: isUserCollectivite ? 'personnel' : 'synthetique',
-            })
-          : '/'
-      }
+      rootUrl={rootUrl}
       mainNav={makeMainNav({
         user,
         currentCollectivite: collectivite,

--- a/apps/app/src/ui/layout/header/main-nav/collectivite/generate-collectivite-nav-item.tsx
+++ b/apps/app/src/ui/layout/header/main-nav/collectivite/generate-collectivite-nav-item.tsx
@@ -4,6 +4,7 @@ import {
   makeRejoindreCollectiviteUrl,
   makeTdbCollectiviteUrl,
 } from '@/app/app/paths';
+import { makeUserTdbUrl } from '@/app/tableaux-de-bord/make-user-tdb-url';
 import { appLabels } from '@/app/labels/catalog';
 import { BadgeNiveauAcces } from '@/app/users/BadgeNiveauAcces';
 import {
@@ -70,16 +71,18 @@ export const generateCollectiviteNavItem = ({
       }),
       urlPrefix: ['/ma-collectivite'],
     },
-    ...user.collectivites.map((c) => ({
+    ...user.collectivites.map((collectivite) => ({
       children: (
-        <CollectiviteWithBadge collectivite={toCollectiviteCurrent(c, user)} />
+        <CollectiviteWithBadge
+          collectivite={toCollectiviteCurrent(collectivite, user)}
+        />
       ),
-      href: makeTdbCollectiviteUrl({
-        collectiviteId: c.collectiviteId,
-        view: 'personnel',
+      href: makeUserTdbUrl({
+        user,
+        collectiviteId: collectivite.collectiviteId,
       }),
       icon:
-        c.collectiviteId === currentCollectivite.collectiviteId
+        collectivite.collectiviteId === currentCollectivite.collectiviteId
           ? 'checkbox-circle-fill'
           : undefined,
     })),

--- a/apps/app/src/ui/layout/header/main-nav/collectivite/generate-tdb-dropdown.ts
+++ b/apps/app/src/ui/layout/header/main-nav/collectivite/generate-tdb-dropdown.ts
@@ -1,11 +1,14 @@
-import { makeTdbCollectiviteUrl } from '@/app/app/paths';
+import { makeUserTdbUrl } from '@/app/tableaux-de-bord/make-user-tdb-url';
+import { UserWithRolesAndPermissions } from '@tet/domain/users';
 import { CollectiviteNavItem } from './make-collectivite-nav';
 
 export const generateTdbLink = ({
+  user,
   collectiviteId,
   collectiviteAccesRestreint,
   isVisitor,
 }: {
+  user: UserWithRolesAndPermissions;
   collectiviteId: number;
   collectiviteAccesRestreint: boolean;
   isVisitor: boolean;
@@ -15,11 +18,7 @@ export const generateTdbLink = ({
   }
 
   return {
-    dataTest: isVisitor ? 'tdb-collectivite' : 'tdb-perso',
     icon: 'home-4-line',
-    href: makeTdbCollectiviteUrl({
-      collectiviteId,
-      view: isVisitor ? 'synthetique' : 'personnel',
-    }),
+    href: makeUserTdbUrl({ user, collectiviteId }),
   };
 };

--- a/apps/app/src/ui/layout/header/main-nav/collectivite/make-collectivite-nav.ts
+++ b/apps/app/src/ui/layout/header/main-nav/collectivite/make-collectivite-nav.ts
@@ -77,6 +77,7 @@ export const makeCollectiviteNav = ({
 
   const startItems: (CollectiviteNavItem | null)[] = [
     generateTdbLink({
+      user,
       collectiviteId,
       collectiviteAccesRestreint,
       isVisitor,

--- a/apps/app/src/ui/layout/header/main-nav/collectivite/make-role-edition-actions-indicateurs-nav.ts
+++ b/apps/app/src/ui/layout/header/main-nav/collectivite/make-role-edition-actions-indicateurs-nav.ts
@@ -26,7 +26,6 @@ export const makeSimplifiedViewNav = ({
           collectiviteId,
         }),
         children: appLabels.suiviPersonnel,
-        dataTest: 'tdb-perso',
         href: makeTdbCollectiviteUrl({
           collectiviteId,
           view: 'personnel',

--- a/packages/domain/src/users/authorizations/user-permission.rule.spec.ts
+++ b/packages/domain/src/users/authorizations/user-permission.rule.spec.ts
@@ -5,6 +5,7 @@ import {
 } from '../../collectivites/collectivite-preferences.schema';
 import { permissionsByRole } from './permission.models';
 import {
+  hasOwnCollectiviteRole,
   hasPermission,
   isReferentielOperationAllowed,
   isUserVisitor,
@@ -73,6 +74,50 @@ describe('isUserVisitor', () => {
     expect(isUserVisitor(user, { collectiviteId: COLLECTIVITE_ID })).toBe(
       false
     );
+  });
+});
+
+describe('hasOwnCollectiviteRole', () => {
+  it("est vrai pour un membre, même sans audit", () => {
+    const user = toUser({
+      collectiviteRole: CollectiviteRole.LECTURE,
+      auditRoles: [],
+    });
+
+    expect(
+      hasOwnCollectiviteRole(user, { collectiviteId: COLLECTIVITE_ID })
+    ).toBe(true);
+  });
+
+  it("est faux pour un auditeur rattaché par son seul audit en cours", () => {
+    const user = toUser({
+      collectiviteRole: null,
+      auditRoles: [AuditRole.AUDITEUR],
+    });
+
+    expect(
+      hasOwnCollectiviteRole(user, { collectiviteId: COLLECTIVITE_ID })
+    ).toBe(false);
+  });
+
+  it("est vrai pour un membre qui est aussi auditeur de sa collectivité", () => {
+    const user = toUser({
+      collectiviteRole: CollectiviteRole.EDITION,
+      auditRoles: [AuditRole.AUDITEUR],
+    });
+
+    expect(
+      hasOwnCollectiviteRole(user, { collectiviteId: COLLECTIVITE_ID })
+    ).toBe(true);
+  });
+
+  it("est faux pour une collectivité à laquelle l'utilisateur n'est pas rattaché", () => {
+    const user = toUser({
+      collectiviteRole: CollectiviteRole.ADMIN,
+      auditRoles: [],
+    });
+
+    expect(hasOwnCollectiviteRole(user, { collectiviteId: 999 })).toBe(false);
   });
 });
 

--- a/packages/domain/src/users/authorizations/user-permission.rules.ts
+++ b/packages/domain/src/users/authorizations/user-permission.rules.ts
@@ -162,15 +162,37 @@ export function hasCollectiviteRole(
   return false;
 }
 
-export function hasAnyCollectiviteRole(
+function findCollectivite(
+  user: UserRolesAndPermissions,
+  collectiviteId: number
+): CollectiviteRolesAndPermissions | undefined {
+  return user.collectivites.find(
+    (collectivite) => collectivite.collectiviteId === collectiviteId
+  );
+}
+
+export function hasOwnCollectiviteRole(
   user: UserRolesAndPermissions,
   { collectiviteId }: { collectiviteId: number }
-) {
-  return user.collectivites.some(
-    (collectivite) =>
-      collectivite.collectiviteId === collectiviteId &&
-      (collectivite.role !== null ||
-        collectivite.audits.some((audit) => audit.role !== null))
+): boolean {
+  const collectivite = findCollectivite(user, collectiviteId);
+
+  return collectivite !== undefined && collectivite.role !== null;
+}
+
+function hasAnyCollectiviteRole(
+  user: UserRolesAndPermissions,
+  { collectiviteId }: { collectiviteId: number }
+): boolean {
+  const collectivite = findCollectivite(user, collectiviteId);
+
+  if (collectivite === undefined) {
+    return false;
+  }
+
+  return (
+    collectivite.role !== null ||
+    collectivite.audits.some((audit) => audit.role !== null)
   );
 }
 


### PR DESCRIPTION
Un auditeur est rattaché à une collectivité **par son seul audit** : sa ligne dans `user.collectivites` porte `role: null` (`get-user-roles-and-permissions.adapter.ts`, `[...collectivites, ...collectivitesFromAuditsOnly]`). Tous les points de navigation le comptaient comme membre et l'envoyaient sur le suivi personnel — une page vide par construction pour lui, puisqu'il ne peut être pilote d'aucune fiche, indicateur ou mesure.

## Avant / Après

| | Destination du tableau de bord pour un auditeur non membre |
|---|---|
| **Avant** | `/tableau-de-bord/personnel` — quatre modules affichant tous « Aucun résultat » |
| **Après** | `/tableau-de-bord/synthetique` |

Un membre, y compris s'il est **aussi** auditeur de sa propre collectivité, continue d'atterrir sur son suivi personnel.

## La règle vit désormais en un seul endroit

Six sites décidaient entre les deux vues, chacun avec sa propre variante de `user.collectivites.some(...)` ou de `isVisitor`, suivie du même ternaire `? 'personnel' : 'synthetique'`.

Tout passe maintenant par **`makeUserTdbUrl({ user, collectiviteId })`** (`src/tableaux-de-bord/make-user-tdb-url.ts`), qui va directement du couple utilisateur/collectivité à l'URL. Plus aucun ternaire `personnel`/`synthetique` ailleurs dans l'app.

Il s'appuie sur **`hasOwnCollectiviteRole(user, { collectiviteId })`**, ajouté dans `user-permission.rules.ts` juste au-dessus de `hasAnyCollectiviteRole` : le contraste entre « un rôle propre » et « un rôle propre ou d'audit » se lit d'un coup d'œil, et la seconde faisait déjà la distinction en interne.

Sites migrés : les deux routes `tableau-de-bord/page.tsx`, `header.tsx` (URL racine), `generate-tdb-dropdown.ts` (nav principale), `generate-collectivite-nav-item.tsx` (sélecteur de collectivités) et `ReferentielCarte.tsx` (page Collectivités engagées).

Le prédicat n'est appelé directement que là où c'est le booléen qui est utile et non l'URL : le `dataTest` du lien de nav, et la garde de rendu de la page personnelle.

## Tester

Avec un compte auditeur sur une collectivité dont il n'est pas membre : le logo du header, l'entrée « tableau de bord » de la nav, le sélecteur de collectivités et la carte de la page Collectivités engagées mènent tous à `/tableau-de-bord/synthetique`. La route `/tableau-de-bord` y redirige également.

Avec un compte membre, rien ne change.

## Couverture

4 tests sur `hasOwnCollectiviteRole` (membre, auditeur seul, membre-et-auditeur, collectivité non rattachée) et 3 sur `makeUserTdbUrl`.

## Hors périmètre

`app/(authed)/collectivite/[collectiviteId]/layout.tsx` porte le même motif `user.collectivites.some(...)`, mais pour une garde d'accès des comptes non vérifiés — usage distinct, laissé inchangé.

Complète la correction du badge affichant l'identifiant technique au lieu du nom (#4838), qui vient de la même divergence : les rôles comptent le rattachement par audit, la liste des personnes de la collectivité ne le connaît pas.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Nouvelles fonctionnalités**
  - Les liens vers les tableaux de bord orientent automatiquement vers la vue personnelle pour les membres disposant d’un rôle propre.
  - Les auditeurs et utilisateurs sans rattachement sont redirigés vers la vue synthétique.
  - Les liens du tableau de bord sont harmonisés dans la navigation et les pages de collectivité.

- **Tests**
  - Ajout de tests couvrant les différents profils d’accès et scénarios de redirection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->