### PR TITLE
feat(ui): add a split button to the design system

### DIFF
--- a/packages/ui/src/design-system/Button/index.ts
+++ b/packages/ui/src/design-system/Button/index.ts
@@ -2,4 +2,5 @@ export * from './Button';
 export * from './button-menu';
 export * from './ButtonGroup';
 export * from './pill-button';
+export * from './split-button';
 export * from './types';

--- a/packages/ui/src/design-system/Button/split-button.stories.tsx
+++ b/packages/ui/src/design-system/Button/split-button.stories.tsx
@@ -1,0 +1,98 @@
+import { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { ButtonSize, ButtonVariant } from './types';
+import { SplitButton } from './split-button';
+
+const menuActions = [
+  {
+    icon: 'import-line',
+    label: 'Importer un plan',
+    onClick: () => console.log('Importer'),
+  },
+  {
+    icon: 'file-copy-line',
+    label: 'Dupliquer un plan existant',
+    onClick: () => console.log('Dupliquer'),
+  },
+];
+
+const meta: Meta<typeof SplitButton> = {
+  component: SplitButton,
+  argTypes: {
+    variant: {
+      control: { type: 'select' },
+    },
+    size: {
+      control: { type: 'select' },
+    },
+    icon: {
+      control: { type: 'text' },
+    },
+  },
+  args: {
+    children: 'Créer un plan',
+    icon: 'add-line',
+    size: 'sm',
+    onClick: () => console.log('Action principale'),
+    menuActions,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SplitButton>;
+
+/** Bouton scindé par défaut : `variant` et `size` se règlent dans les contrôles. */
+export const Default: Story = {};
+
+export const Disabled: Story = {
+  args: { disabled: true },
+};
+
+/** Le bouton-icône s'aligne sur la hauteur de l'action principale, à chaque taille. */
+export const Sizes: Story = {
+  render: (args) => (
+    <div className="flex flex-wrap items-end gap-5">
+      {(['xs', 'sm', 'md', 'xl'] as ButtonSize[]).map((size) => (
+        <SplitButton key={size} {...args} size={size}>
+          {size}
+        </SplitButton>
+      ))}
+    </div>
+  ),
+};
+
+/**
+ * Les variantes en aplat portent un trait de séparation ; les variantes
+ * détourées se contentent de leurs bordures. `underlined` et `unstyled` n'ont
+ * ni fond ni rayon : le bouton scindé n'a pas de sens pour elles.
+ */
+export const Variants: Story = {
+  render: (args) => {
+    const variants: ButtonVariant[] = [
+      'primary',
+      'secondary',
+      'outlined',
+      'white',
+      'grey',
+    ];
+    return (
+      <div className="flex flex-col gap-5 bg-grey-2 p-10">
+        <div className="flex flex-wrap items-end gap-5">
+          {variants.map((variant) => (
+            <SplitButton key={variant} {...args} variant={variant}>
+              {variant}
+            </SplitButton>
+          ))}
+        </div>
+        <div className="flex flex-wrap items-end gap-5">
+          {variants.map((variant) => (
+            <SplitButton key={variant} {...args} variant={variant} disabled>
+              {variant}
+            </SplitButton>
+          ))}
+        </div>
+      </div>
+    );
+  },
+};

--- a/packages/ui/src/design-system/Button/split-button.tsx
+++ b/packages/ui/src/design-system/Button/split-button.tsx
@@ -1,0 +1,63 @@
+import { Placement } from '@floating-ui/react';
+
+import { uiLabels } from '../../labels/catalog';
+import { cn } from '../../utils/cn';
+import { Button } from './Button';
+import { ButtonMenu, MenuAction } from './button-menu';
+import { ButtonProps, ButtonVariant } from './types';
+
+/**
+ * Séparation entre les deux moitiés, sur les variantes dont la bordure se
+ * confond avec le fond. Les variantes détourées (`outlined`, `grey`) ont déjà
+ * un trait visible : leurs bordures se superposent, rien à ajouter.
+ */
+const dividerClassnames: Partial<Record<ButtonVariant, string>> = {
+  primary: 'border-l-primary-7 hover:!border-l-primary-6',
+  secondary: 'border-l-secondary-2 hover:!border-l-secondary-1',
+  white: 'border-l-grey-3 hover:!border-l-grey-3',
+};
+
+type Props = {
+  /** Actions secondaires, rangées derrière la flèche. */
+  menuActions: MenuAction[];
+  /** Placement du menu par rapport au bouton, `bottom-end` par défaut. */
+  menuPlacement?: Placement;
+  /** `data-test` de la flèche — l'action principale reçoit `dataTest`. */
+  menuDataTest?: string;
+} & ButtonProps;
+
+/**
+ * Bouton scindé : l'action principale reste à un clic, les actions secondaires
+ * se rangent derrière la flèche. À préférer au `ButtonMenu` quand une action
+ * domine nettement les autres, sinon la principale coûterait deux gestes.
+ */
+export const SplitButton = ({
+  menuActions,
+  menuPlacement,
+  menuDataTest,
+  className,
+  ...props
+}: Props) => {
+  const { variant = 'primary', size = 'md', disabled } = props;
+
+  return (
+    // `items-stretch` : le bouton-icône a son propre padding (`p-2.5` en `sm`
+    // là où la moitié texte fait `py-2.5`), il serait plus court de quelques
+    // pixels s'il ne s'alignait pas sur la hauteur de l'action principale.
+    <div className={cn('flex w-fit items-stretch', className)}>
+      <Button {...props} className="rounded-r-none" />
+      <ButtonMenu
+        variant={variant}
+        size={size}
+        disabled={disabled}
+        icon="arrow-down-s-line"
+        aria-label={uiLabels.autresActions}
+        dataTest={menuDataTest}
+        // `-ml-px` : les deux bordures adjacentes se superposent au lieu de
+        // dessiner un trait de 2px.
+        className={cn('-ml-px rounded-l-none', dividerClassnames[variant])}
+        menu={{ actions: menuActions, placement: menuPlacement }}
+      />
+    </div>
+  );
+};

--- a/packages/ui/src/labels/catalog.ts
+++ b/packages/ui/src/labels/catalog.ts
@@ -16,6 +16,7 @@ const uiLabels = {
   supprimer: "Supprimer",
   creer: "Créer",
   aucuneOptionDisponible: "Aucune option disponible",
+  autresActions: "Autres actions",
   editerOption: "Éditer l'option",
   nomDeLOption: "Nom de l'option",
   supprimerUneOption: "Supprimer une option",


### PR DESCRIPTION
Validé avec Ugo bien sûr, je propose l'ajout d'un nouveau composant le `SplitButton` !

<img width="958" height="206" alt="image" src="https://github.com/user-attachments/assets/6cb225cc-0323-460d-b669-ca98fc7a7b84" />

<img width="622" height="202" alt="image" src="https://github.com/user-attachments/assets/7d44e8f8-70e5-4e68-afde-84d1dccc6ccf" />

Le but d'un split button est de permettre d'avoir une action principale et directement accessible ainsi que des actions secondaires accessible en utilisant le bouton de droite comme ce que l'on a sur Github par exemple: 

<img width="347" height="205" alt="image" src="https://github.com/user-attachments/assets/ef4bca4b-bfcc-4a15-aa2f-e9a4fa7cfdca" />

Le fait qu'il y ait 2 boutons le différencie du dropdown qui n'a pas d'action principale et qui ne fait qu'ouvrir le menu. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Ajout d’un bouton scindé combinant une action principale et un menu d’actions secondaires.
  * Prise en charge des variantes visuelles, tailles, états désactivés et placement du menu.
  * Ajout de contrôles et d’exemples interactifs pour les différents états du composant.

* **Libellés**
  * Ajout du libellé français « Autres actions ».

<!-- end of auto-generated comment: release notes by coderabbit.ai -->