### PR TITLE
fix(labellisation): exige des référents désignés pour demander la 1ère étoile

### DIFF
--- a/apps/app/src/labels/catalog.ts
+++ b/apps/app/src/labels/catalog.ts
@@ -401,8 +401,6 @@ export const appLabels = {
     'Atteindre au moins 35 % de score pour pouvoir demander un audit de labellisation.',
   renseignerCriteresPourDemande:
     'Renseigner tous les critères attendus afin de pouvoir demander un audit ou une labellisation',
-  renseignerPilotesPourDemande:
-    "Désigner l'élu référent et le référent technique pour pouvoir demander un audit.",
   demarrerAuditChoixType: "Quel type d'audit souhaitez-vous demander ?",
   demarrerAuditChoixEtoile: 'Quelle étoile visez-vous ?',
   demarrerAuditEtoileOption: ({

--- a/apps/app/src/referentiels/audit-labellisation/checklist/checklist-actions.spec.tsx
+++ b/apps/app/src/referentiels/audit-labellisation/checklist/checklist-actions.spec.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { TCycleLabellisation } from '../../labellisations/useCycleLabellisation';
-import { useChecklist } from '../checklist.context';
+import { ChecklistContextValue, useChecklist } from '../checklist.context';
 import { ChecklistActions } from './checklist-actions';
 
 vi.mock('../checklist.context', () => ({
@@ -20,9 +20,7 @@ const mockedUseChecklist = vi.mocked(useChecklist);
 
 const obtenirPremiereEtoile = 'Obtenir la première étoile';
 
-const setCollectiviteCycle = (
-  cycle: Partial<TCycleLabellisation>
-): void => {
+const setCollectiviteCycle = (cycle: Partial<TCycleLabellisation>): void => {
   mockedUseChecklist.mockReturnValue({
     cycle: {
       isAuditeur: false,
@@ -36,7 +34,7 @@ const setCollectiviteCycle = (
     premiereEtoileObtenue: false,
     showActeEngagement: false,
     showCandidatureDocuments: false,
-  } as unknown as ReturnType<typeof useChecklist>);
+  } as unknown as ChecklistContextValue);
 };
 
 const premiereEtoileDemandeEnvoyee = {
@@ -44,6 +42,17 @@ const premiereEtoileDemandeEnvoyee = {
   audit: null,
   demande: { sujet: 'labellisation', etoiles: '1' },
 } as TCycleLabellisation['parcours'];
+
+const cycleSansDemande = {
+  status: 'non_demandee',
+  audit: null,
+  demande: null,
+} as TCycleLabellisation['parcours'];
+
+const renderFirstStarButton = (): HTMLElement => {
+  render(<ChecklistActions />);
+  return screen.getByRole('button', { name: obtenirPremiereEtoile });
+};
 
 beforeEach(() => {
   mockedUseChecklist.mockReset();
@@ -57,26 +66,26 @@ describe('ChecklistActions — bouton « Obtenir la première étoile »', () =>
       parcours: premiereEtoileDemandeEnvoyee,
     });
 
-    render(<ChecklistActions />);
-
-    const button = screen.getByRole('button', { name: obtenirPremiereEtoile });
-    expect(button.hasAttribute('disabled')).toBe(true);
+    expect(renderFirstStarButton().hasAttribute('disabled')).toBe(true);
   });
 
-  it('garde le bouton actif quand aucune demande première étoile n\'a été envoyée', () => {
+  it('désactive le bouton quand les critères ne sont pas tous remplis', () => {
+    setCollectiviteCycle({
+      canAskFirstStar: false,
+      status: 'non_demandee',
+      parcours: cycleSansDemande,
+    });
+
+    expect(renderFirstStarButton().hasAttribute('disabled')).toBe(true);
+  });
+
+  it("garde le bouton actif quand aucune demande n'a été envoyée et que les critères sont remplis", () => {
     setCollectiviteCycle({
       canAskFirstStar: true,
       status: 'non_demandee',
-      parcours: {
-        status: 'non_demandee',
-        audit: null,
-        demande: null,
-      } as TCycleLabellisation['parcours'],
+      parcours: cycleSansDemande,
     });
 
-    render(<ChecklistActions />);
-
-    const button = screen.getByRole('button', { name: obtenirPremiereEtoile });
-    expect(button.hasAttribute('disabled')).toBe(false);
+    expect(renderFirstStarButton().hasAttribute('disabled')).toBe(false);
   });
 });

--- a/apps/app/src/referentiels/audit-labellisation/use-referent-roles-defined.ts
+++ b/apps/app/src/referentiels/audit-labellisation/use-referent-roles-defined.ts
@@ -1,35 +1,34 @@
 import { useListActions } from '@/app/referentiels/actions/use-list-actions';
 import {
   ActionId,
-  AuditLabellisationReferentielId,
+  isAuditLabellisationReferentiel,
+  ReferentielId,
   ReferentRolesDefined,
   ROLE_IDENTIFIANTS,
 } from '@tet/domain/referentiels';
 import { useMemo } from 'react';
 
-const makeRoleActionId = (
-  referentielId: AuditLabellisationReferentielId,
-  identifiant: string
-): ActionId => `${referentielId}_${identifiant}`;
+const roleActionIds = (referentielId: ReferentielId): ActionId[] => {
+  if (!isAuditLabellisationReferentiel(referentielId)) {
+    return [];
+  }
+  const { eluReferent, referentTechnique } = ROLE_IDENTIFIANTS[referentielId];
+  return [
+    `${referentielId}_${eluReferent}`,
+    `${referentielId}_${referentTechnique}`,
+  ];
+};
 
 export const useReferentRolesDefined = (
-  referentielId: AuditLabellisationReferentielId
+  referentielId: ReferentielId
 ): { referentRolesDefined: ReferentRolesDefined; isLoaded: boolean } => {
-  const mapping = ROLE_IDENTIFIANTS[referentielId];
-  const eluReferentActionId = makeRoleActionId(
-    referentielId,
-    mapping.eluReferent
-  );
-  const referentTechniqueActionId = makeRoleActionId(
-    referentielId,
-    mapping.referentTechnique
-  );
+  const actionIds = roleActionIds(referentielId);
+  const [eluReferentActionId, referentTechniqueActionId] = actionIds;
 
-  const { data, isPending } = useListActions({
-    actionIds: [eluReferentActionId, referentTechniqueActionId],
-  });
+  const { data, isPending } = useListActions({ actionIds });
 
-  const hasPilotes = (actionId: ActionId): boolean =>
+  const hasPilotes = (actionId: ActionId | undefined): boolean =>
+    actionId !== undefined &&
     (data.find((action) => action.actionId === actionId)?.pilotes?.length ??
       0) > 0;
 

--- a/apps/app/src/referentiels/labellisations/request-audit/request-audit.button.spec.tsx
+++ b/apps/app/src/referentiels/labellisations/request-audit/request-audit.button.spec.tsx
@@ -2,14 +2,11 @@ import { useCurrentCollectivite } from '@tet/api/collectivites';
 import {
   ObjetPreuveEnum,
   ParcoursForAuditRequest,
-  ROLE_IDENTIFIANTS,
-  ReferentRolesDefined,
 } from '@tet/domain/referentiels';
 import { render, screen } from '@testing-library/react';
 import { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AuditViewerRole } from '../../audit-labellisation/audit-badge-status/types';
-import { useReferentRolesDefined } from '../../audit-labellisation/use-referent-roles-defined';
 import { useCycleLabellisation } from '../useCycleLabellisation';
 import { RequestAuditButton } from './request-audit.button';
 
@@ -19,10 +16,6 @@ vi.mock('@tet/api/collectivites', () => ({
 
 vi.mock('../useCycleLabellisation', () => ({
   useCycleLabellisation: vi.fn(),
-}));
-
-vi.mock('../../audit-labellisation/use-referent-roles-defined', () => ({
-  useReferentRolesDefined: vi.fn(),
 }));
 
 vi.mock('./request-audit.modal', () => ({
@@ -41,41 +34,28 @@ vi.mock('@tet/ui', async (importActual) => {
 
 const mockedUseCurrentCollectivite = vi.mocked(useCurrentCollectivite);
 const mockedUseCycleLabellisation = vi.mocked(useCycleLabellisation);
-const mockedUseReferentRolesDefined = vi.mocked(useReferentRolesDefined);
 
 const demanderAuditButton = /Demander un audit/;
-
-const ROLES_DEFINIS: ReferentRolesDefined = {
-  eluReferent: true,
-  referentTechnique: true,
-};
-
-const eluReferentActionId = `cae_${ROLE_IDENTIFIANTS.cae.eluReferent}`;
-const referentTechniqueActionId = `cae_${ROLE_IDENTIFIANTS.cae.referentTechnique}`;
-
-const setReferentRoles = (
-  referentRolesDefined: ReferentRolesDefined = ROLES_DEFINIS,
-  isLoaded = true
-): void => {
-  mockedUseReferentRolesDefined.mockReturnValue({ referentRolesDefined, isLoaded });
-};
 
 const setCycle = ({
   parcours,
   maximumRequestableStar,
   isCOT = false,
   viewerRole = 'auditee',
+  allReferentRolesDefined = true,
 }: {
   parcours: ParcoursForAuditRequest | null;
   maximumRequestableStar: number | null;
   isCOT?: boolean;
   viewerRole?: AuditViewerRole;
+  allReferentRolesDefined?: boolean;
 }): void => {
   mockedUseCycleLabellisation.mockReturnValue({
     parcours,
     isCOT,
     maximumRequestableStar,
     viewerRole,
+    allReferentRolesDefined,
   } as unknown as ReturnType<typeof useCycleLabellisation>);
 };
 
@@ -84,7 +64,6 @@ const requestableCycle = {
     status: 'non_demandee',
     demande: null,
     labellisation: null,
-    referentiel: 'cae',
     completude_ok: true,
     critere_score: {
       atteint: true,
@@ -97,10 +76,7 @@ const requestableCycle = {
       { objet: ObjetPreuveEnum.ACTE_ENGAGEMENT },
       { objet: ObjetPreuveEnum.CANDIDATURE },
     ],
-    criteres_action: [
-      { atteint: true, action_id: eluReferentActionId },
-      { atteint: true, action_id: referentTechniqueActionId },
-    ],
+    criteres_action: [{ atteint: true }, { atteint: true }],
   } as ParcoursForAuditRequest,
   maximumRequestableStar: 2,
 };
@@ -110,7 +86,6 @@ beforeEach(() => {
     collectiviteId: 1,
   } as unknown as ReturnType<typeof useCurrentCollectivite>);
   setCycle(requestableCycle);
-  setReferentRoles();
 });
 
 describe('RequestAuditButton — visibilité selon le rôle', () => {
@@ -119,7 +94,9 @@ describe('RequestAuditButton — visibilité selon le rôle', () => {
 
     const { container } = render(<RequestAuditButton referentielId="cae" />);
 
-    expect(screen.queryByRole('button', { name: demanderAuditButton })).toBeNull();
+    expect(
+      screen.queryByRole('button', { name: demanderAuditButton })
+    ).toBeNull();
     expect(container.firstChild).toBeNull();
   });
 
@@ -128,7 +105,9 @@ describe('RequestAuditButton — visibilité selon le rôle', () => {
 
     const { container } = render(<RequestAuditButton referentielId="cae" />);
 
-    expect(screen.queryByRole('button', { name: demanderAuditButton })).toBeNull();
+    expect(
+      screen.queryByRole('button', { name: demanderAuditButton })
+    ).toBeNull();
     expect(container.firstChild).toBeNull();
   });
 
@@ -191,7 +170,7 @@ describe('RequestAuditButton — état du bouton pour la collectivité auditée'
   });
 
   it("rend le bouton désactivé avec un tooltip quand l'élu référent ou le référent technique n'est pas désigné", () => {
-    setReferentRoles({ eluReferent: false, referentTechnique: true });
+    setCycle({ ...requestableCycle, allReferentRolesDefined: false });
 
     render(<RequestAuditButton referentielId="cae" />);
 
@@ -220,6 +199,7 @@ describe('RequestAuditButton — état du bouton pour la collectivité auditée'
       isCOT: false,
       maximumRequestableStar: 2,
       viewerRole: 'auditee',
+      allReferentRolesDefined: true,
     } as unknown as ReturnType<typeof useCycleLabellisation>);
 
     render(<RequestAuditButton referentielId="cae" />);

--- a/apps/app/src/referentiels/labellisations/request-audit/request-audit.button.tsx
+++ b/apps/app/src/referentiels/labellisations/request-audit/request-audit.button.tsx
@@ -11,7 +11,6 @@ import {
 import { Button, Icon, Tooltip } from '@tet/ui';
 import { ReactElement, ReactNode, useState } from 'react';
 import { match } from 'ts-pattern';
-import { useReferentRolesDefined } from '../../audit-labellisation/use-referent-roles-defined';
 import { useCycleLabellisation } from '../useCycleLabellisation';
 import { RequestAuditModal } from './request-audit.modal';
 
@@ -43,27 +42,22 @@ const tooltipForUnavailableReason = (
       { kind: 'prerequisitesIncomplete' },
       () => appLabels.renseignerCriteresPourDemande
     )
-    .with(
-      { kind: 'referentRolesUndefined' },
-      () => appLabels.renseignerPilotesPourDemande
-    )
     .exhaustive();
 
 export const RequestAuditButton = ({
   referentielId,
 }: RequestAuditButtonProps): ReactNode => {
   const { collectiviteId } = useCurrentCollectivite();
-  const { parcours, isCOT, maximumRequestableStar, viewerRole } =
-    useCycleLabellisation(referentielId);
-  const { referentRolesDefined, isLoaded: referentRolesLoaded } =
-    useReferentRolesDefined(referentielId);
+  const {
+    parcours,
+    isCOT,
+    maximumRequestableStar,
+    viewerRole,
+    allReferentRolesDefined,
+  } = useCycleLabellisation(referentielId);
   const [isOpen, setIsOpen] = useState(false);
 
-  if (
-    parcours === null ||
-    maximumRequestableStar === null ||
-    !referentRolesLoaded
-  ) {
+  if (parcours === null || maximumRequestableStar === null) {
     return null;
   }
 
@@ -74,7 +68,7 @@ export const RequestAuditButton = ({
   const availability = getAuditRequestAvailability(parcours, {
     isCOT,
     maximumRequestableStar,
-    referentRolesDefined,
+    allReferentRolesDefined,
   });
 
   const tooltip = availability.canRequest

--- a/apps/app/src/referentiels/labellisations/useCycleLabellisation.ts
+++ b/apps/app/src/referentiels/labellisations/useCycleLabellisation.ts
@@ -6,7 +6,9 @@ import {
 import { useQuery } from '@tanstack/react-query';
 import { useTRPC, useUser } from '@tet/api';
 import { useCurrentCollectivite } from '@tet/api/collectivites';
+import { useReferentRolesDefined } from '@/app/referentiels/audit-labellisation/use-referent-roles-defined';
 import {
+  areAllReferentRolesDefined,
   canRequestAuditOrLabellisation,
   canStartAudit as canStartAuditRule,
   Etoile,
@@ -34,6 +36,7 @@ export type TCycleLabellisation = {
   canStartAudit: boolean;
   peutDemander1ereEtoileCOT: boolean;
   canAskFirstStar: boolean;
+  allReferentRolesDefined: boolean;
 };
 
 export const useCycleLabellisation = (
@@ -65,6 +68,17 @@ export const useCycleLabellisation = (
 
   const canStartAudit = canStartAuditRule(parcours, user.id).canRequest;
 
+  const { referentRolesDefined, isLoaded: areReferentRolesLoaded } =
+    useReferentRolesDefined(referentielId);
+  const allReferentRolesDefined =
+    areReferentRolesLoaded && parcours !== null
+      ? areAllReferentRolesDefined(
+          parcours.criteres_action,
+          referentielId,
+          referentRolesDefined
+        )
+      : false;
+
   const canAskFirstStar = parcours
     ? hasMutatePermission &&
       canRequestAuditOrLabellisation(
@@ -72,7 +86,8 @@ export const useCycleLabellisation = (
         isCOT
           ? SujetDemandeEnum.LABELLISATION_COT
           : SujetDemandeEnum.LABELLISATION,
-        1
+        1,
+        { allReferentRolesDefined }
       ).canRequest
     : false;
 
@@ -82,7 +97,7 @@ export const useCycleLabellisation = (
         parcours,
         SujetDemandeEnum.LABELLISATION_COT,
         1,
-        { allowLegacyDocuments: true }
+        { allowLegacyDocuments: true, allReferentRolesDefined }
       ).canRequest
     : false;
 
@@ -97,7 +112,7 @@ export const useCycleLabellisation = (
           parcours,
           SujetDemandeEnum.LABELLISATION,
           maximumRequestableStar,
-          { allowLegacyDocuments: true }
+          { allowLegacyDocuments: true, allReferentRolesDefined }
         ).canRequest
       : false;
 
@@ -118,6 +133,7 @@ export const useCycleLabellisation = (
     labellisable,
     maximumRequestableStar,
     canAskFirstStar,
+    allReferentRolesDefined,
   };
 };
 

--- a/apps/backend/src/referentiels/labellisations/request-labellisation/request-labellisation.rules.spec.ts
+++ b/apps/backend/src/referentiels/labellisations/request-labellisation/request-labellisation.rules.spec.ts
@@ -38,7 +38,8 @@ describe('canRequestAuditOrLabellisation', () => {
     const result = canRequestAuditOrLabellisation(
       createParcours(),
       'cot',
-      1 as Etoile
+      1 as Etoile,
+      { allReferentRolesDefined: true }
     );
     expect(result.canRequest).toBe(false);
     expect(result.reason).toBe(
@@ -50,7 +51,8 @@ describe('canRequestAuditOrLabellisation', () => {
     const result = canRequestAuditOrLabellisation(
       createParcours(),
       'cot',
-      null
+      null,
+      { allReferentRolesDefined: true }
     );
     expect(result.canRequest).toBe(false);
     expect(result.reason).toBe(
@@ -62,7 +64,8 @@ describe('canRequestAuditOrLabellisation', () => {
     const result = canRequestAuditOrLabellisation(
       createParcours(),
       'labellisation_cot',
-      1
+      1,
+      { allReferentRolesDefined: true }
     );
     expect(result.canRequest).toBe(false);
     expect(result.reason).toBe(
@@ -74,7 +77,8 @@ describe('canRequestAuditOrLabellisation', () => {
     const result = canRequestAuditOrLabellisation(
       createParcours(),
       'labellisation',
-      null
+      null,
+      { allReferentRolesDefined: true }
     );
     expect(result.canRequest).toBe(false);
     expect(result.reason).toBe(
@@ -86,7 +90,8 @@ describe('canRequestAuditOrLabellisation', () => {
     const result = canRequestAuditOrLabellisation(
       createParcours({ isCot: true }),
       'labellisation_cot',
-      null
+      null,
+      { allReferentRolesDefined: true }
     );
     expect(result.canRequest).toBe(false);
     expect(result.reason).toBe(
@@ -98,7 +103,8 @@ describe('canRequestAuditOrLabellisation', () => {
     const result = canRequestAuditOrLabellisation(
       createParcours({ status: 'demande_envoyee' }),
       'labellisation',
-      1 as Etoile
+      1 as Etoile,
+      { allReferentRolesDefined: true }
     );
     expect(result.canRequest).toBe(false);
     expect(result.reason).toBe(
@@ -110,7 +116,8 @@ describe('canRequestAuditOrLabellisation', () => {
     const result = canRequestAuditOrLabellisation(
       createParcours({ completude_ok: false, isCot: true }),
       'cot',
-      null
+      null,
+      { allReferentRolesDefined: true }
     );
     expect(result.canRequest).toBe(false);
     expect(result.reason).toBe(
@@ -122,7 +129,8 @@ describe('canRequestAuditOrLabellisation', () => {
     const result = canRequestAuditOrLabellisation(
       createParcours({ isCot: true }),
       'cot',
-      null
+      null,
+      { allReferentRolesDefined: true }
     );
     expect(result.canRequest).toBe(true);
     expect(result.reason).toBeNull();
@@ -139,7 +147,8 @@ describe('canRequestAuditOrLabellisation', () => {
         },
       }),
       'labellisation',
-      2 as Etoile
+      2 as Etoile,
+      { allReferentRolesDefined: true }
     );
     expect(result.canRequest).toBe(false);
     expect(result.reason).toBe(
@@ -158,7 +167,8 @@ describe('canRequestAuditOrLabellisation', () => {
         },
       }),
       'labellisation',
-      1 as Etoile
+      1 as Etoile,
+      { allReferentRolesDefined: true }
     );
     expect(result).toEqual({ canRequest: true, reason: null });
   });
@@ -175,7 +185,8 @@ describe('canRequestAuditOrLabellisation', () => {
         },
       }),
       'labellisation',
-      4 as Etoile
+      4 as Etoile,
+      { allReferentRolesDefined: true }
     );
     expect(result).toEqual({ canRequest: true, reason: null });
   });
@@ -192,7 +203,8 @@ describe('canRequestAuditOrLabellisation', () => {
         },
       }),
       'labellisation',
-      5 as Etoile
+      5 as Etoile,
+      { allReferentRolesDefined: true }
     );
     expect(result.canRequest).toBe(false);
     expect(result.reason).toBe(
@@ -213,7 +225,8 @@ describe('canRequestAuditOrLabellisation', () => {
         ],
       }),
       'labellisation',
-      1 as Etoile
+      1 as Etoile,
+      { allReferentRolesDefined: true }
     );
     expect(result.canRequest).toBe(false);
     expect(result.reason).toBe(
@@ -223,9 +236,13 @@ describe('canRequestAuditOrLabellisation', () => {
 
   it('returns MISSING_FILE when labellisation, scores ok, but conditionFichiers not atteint', () => {
     const result = canRequestAuditOrLabellisation(
-      createParcours({ conditionFichiers: { preuve_nombre: 0 }, preuvesObjets: [] }),
+      createParcours({
+        conditionFichiers: { preuve_nombre: 0 },
+        preuvesObjets: [],
+      }),
       'labellisation',
-      1 as Etoile
+      1 as Etoile,
+      { allReferentRolesDefined: true }
     );
     expect(result.canRequest).toBe(false);
     expect(result.reason).toBe(
@@ -237,10 +254,12 @@ describe('canRequestAuditOrLabellisation', () => {
     const result = canRequestAuditOrLabellisation(
       createParcours({
         isCot: true,
-        conditionFichiers: { preuve_nombre: 0 }, preuvesObjets: [],
+        conditionFichiers: { preuve_nombre: 0 },
+        preuvesObjets: [],
       }),
       'labellisation_cot',
-      1 as Etoile
+      1 as Etoile,
+      { allReferentRolesDefined: true }
     );
     expect(result.canRequest).toBe(true);
     expect(result.reason).toBeNull();
@@ -252,7 +271,8 @@ describe('canRequestAuditOrLabellisation', () => {
         preuvesObjets: [],
       }),
       'labellisation',
-      1 as Etoile
+      1 as Etoile,
+      { allReferentRolesDefined: true }
     );
     expect(resultLabellisationOnly.canRequest).toBe(true);
     expect(resultLabellisationOnly.reason).toBeNull();
@@ -262,7 +282,8 @@ describe('canRequestAuditOrLabellisation', () => {
     const result = canRequestAuditOrLabellisation(
       createParcours(),
       'labellisation',
-      1 as Etoile
+      1 as Etoile,
+      { allReferentRolesDefined: true }
     );
     expect(result.canRequest).toBe(true);
     expect(result.reason).toBeNull();

--- a/apps/backend/src/referentiels/labellisations/request-labellisation/request-labellisation.service.ts
+++ b/apps/backend/src/referentiels/labellisations/request-labellisation/request-labellisation.service.ts
@@ -70,7 +70,7 @@ export class RequestLabellisationService {
       labellisation,
       sujet,
       etoiles,
-      { allowLegacyDocuments: true }
+      { allowLegacyDocuments: true, allReferentRolesDefined: true }
     );
     if (!canRequestResult.canRequest) {
       this.logger.error(

--- a/e2e/tests/referentiels/labellisations/premiere-etoile-referents-obligatoires.spec.ts
+++ b/e2e/tests/referentiels/labellisations/premiere-etoile-referents-obligatoires.spec.ts
@@ -1,0 +1,84 @@
+import { expect } from '@playwright/test';
+import {
+  AuditLabellisationReferentielId,
+  ObjetPreuveEnum,
+} from '@tet/domain/referentiels';
+import { testWithReferentiels as test } from '../referentiels.fixture';
+
+const referentiel: AuditLabellisationReferentielId = 'cae';
+
+const ELU_REFERENT = /Identifier un.+lu.+r.+f.+rent/i;
+const REFERENT_TECHNIQUE = /Identifier une personne technique/i;
+const EQUIPE_PROJET = /Mettre en place une .+quipe projet/i;
+
+test.describe('Demande 1ère étoile — désignation des référents obligatoire', () => {
+  test.beforeEach(async ({ page, collectivites }) => {
+    const { collectivite, user } = await collectivites.addCollectiviteAndUser({
+      userArgs: { autoLogin: true },
+    });
+    await user.precomputeReferentielSnapshot(collectivite.data.id, referentiel);
+
+    await page.goto('/');
+  });
+
+  test('une mesure de rôle sans référent désigné est non atteinte et le bouton désactivé ; désigner les référents la remplit et active le bouton', async ({
+    auditLabellisationPom,
+    collectivites,
+    referentiels,
+  }) => {
+    const collectivite = collectivites.getCollectivite();
+    const user = collectivite.getUser(0);
+
+    await referentiels.updateAllNeedReferentielStatutsToCompleteReferentiel(
+      user,
+      collectivite.data.id,
+      referentiel
+    );
+    await referentiels.updateAllNeedReferentielStatutsToMatchReferentielScoreCriteria(
+      user,
+      collectivite.data.id,
+      referentiel
+    );
+    await referentiels.seedLabellisationPreuve(
+      user,
+      collectivite.data.id,
+      referentiel,
+      ObjetPreuveEnum.ACTE_ENGAGEMENT
+    );
+
+    await auditLabellisationPom.goto(collectivite.data.id, referentiel);
+
+    const eluReferentRow = auditLabellisationPom.checklistRow(ELU_REFERENT);
+    const referentTechniqueRow =
+      auditLabellisationPom.checklistRow(REFERENT_TECHNIQUE);
+
+    // Les mesures de rôle portent le même statut « Fait » que les autres
+    // critères : seule la désignation les distingue.
+    await expect(
+      auditLabellisationPom
+        .checklistRow(EQUIPE_PROJET)
+        .getByLabel('Critère atteint')
+    ).toBeVisible();
+    await expect(
+      eluReferentRow.getByLabel('Critère non atteint')
+    ).toBeVisible();
+    await expect(
+      referentTechniqueRow.getByLabel('Critère non atteint')
+    ).toBeVisible();
+    await expect(
+      auditLabellisationPom.demanderPremiereEtoileButton
+    ).toBeDisabled();
+
+    await referentiels.seedRolePilotes(user, collectivite.data.id, referentiel);
+
+    await auditLabellisationPom.goto(collectivite.data.id, referentiel);
+
+    await expect(eluReferentRow.getByLabel('Critère atteint')).toBeVisible();
+    await expect(
+      referentTechniqueRow.getByLabel('Critère atteint')
+    ).toBeVisible();
+    await expect(
+      auditLabellisationPom.demanderPremiereEtoileButton
+    ).toBeEnabled();
+  });
+});

--- a/e2e/tests/referentiels/labellisations/request-labellisation-from-new-checklist.spec.ts
+++ b/e2e/tests/referentiels/labellisations/request-labellisation-from-new-checklist.spec.ts
@@ -1,8 +1,8 @@
 import { expect } from '@playwright/test';
-import { ReferentielId } from '@tet/domain/referentiels';
+import { AuditLabellisationReferentielId } from '@tet/domain/referentiels';
 import { testWithReferentiels as test } from '../referentiels.fixture';
 
-const referentiel: ReferentielId = 'cae';
+const referentiel: AuditLabellisationReferentielId = 'cae';
 
 test.describe('Demande 1ère étoile depuis la nouvelle vue audit-labellisation', () => {
   test.beforeEach(async ({ page, collectivites }) => {
@@ -17,7 +17,7 @@ test.describe('Demande 1ère étoile depuis la nouvelle vue audit-labellisation'
     await page.goto('/');
   });
 
-  test('Bouton désactivé tant que tous les critères ne sont pas remplis, activé puis envoi réussi une fois la checklist complète', async ({
+  test('Bouton désactivé tant que la checklist est incomplète ou les référents non désignés, activé puis envoi réussi une fois tout rempli', async ({
     auditLabellisationPom,
     referentiels,
     collectivites,
@@ -53,12 +53,23 @@ test.describe('Demande 1ère étoile depuis la nouvelle vue audit-labellisation'
     // Étape 4 — téléverser l'acte d'engagement
     await auditLabellisationPom.uploadActeEngagement();
 
-    // Étape 5 — bouton activé
+    // Étape 5 — bouton encore désactivé car ni l'élu référent ni le référent
+    // technique ne sont désignés : compléter les statuts ne suffit pas. Seule
+    // l'étape 6 change cet état, ce qui isole la désignation comme cause.
+    await expect(
+      auditLabellisationPom.demanderPremiereEtoileButton
+    ).toBeDisabled();
+
+    // Étape 6 — désigner l'élu référent et le référent technique
+    await referentiels.seedRolePilotes(user, collectivite.data.id, referentiel);
+
+    // Étape 7 — les deux rôles désignés, bouton activé
+    await auditLabellisationPom.goto(collectivite.data.id, referentiel);
     await expect(
       auditLabellisationPom.demanderPremiereEtoileButton
     ).toBeEnabled();
 
-    // Étape 6 — envoyer la demande, vérifier le succès
+    // Étape 8 — envoyer la demande, vérifier le succès
     await auditLabellisationPom.demanderPremiereEtoileButton.click();
     await auditLabellisationPom.envoyerDemandeButton.click();
     await expect(auditLabellisationPom.successMessage).toBeVisible();

--- a/packages/domain/src/referentiels/labellisations/audit-request-availability/audit-request-availability.rules.spec.ts
+++ b/packages/domain/src/referentiels/labellisations/audit-request-availability/audit-request-availability.rules.spec.ts
@@ -1,19 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import { Etoile } from '../labellisation-etoile.enum.schema';
 import { ObjetPreuveEnum } from '../objet-preuve.enum.schema';
-import { ROLE_IDENTIFIANTS, ReferentRolesDefined } from '../role-mesures/role-mesures';
 import {
+  AuditRequestAvailability,
   getAuditRequestAvailability,
   ParcoursForAuditRequest,
 } from './audit-request-availability.rules';
-
-const ROLES_DESIGNES: ReferentRolesDefined = {
-  eluReferent: true,
-  referentTechnique: true,
-};
-
-const eluReferentActionId = `cae_${ROLE_IDENTIFIANTS.cae.eluReferent}`;
-const referentTechniqueActionId = `cae_${ROLE_IDENTIFIANTS.cae.referentTechnique}`;
 
 const makeParcours = (
   overrides: Partial<ParcoursForAuditRequest> = {}
@@ -21,7 +13,6 @@ const makeParcours = (
   status: 'non_demandee',
   demande: null,
   labellisation: null,
-  referentiel: 'cae',
   completude_ok: true,
   critere_score: {
     atteint: true,
@@ -35,7 +26,7 @@ const makeParcours = (
     { objet: ObjetPreuveEnum.ACTE_ENGAGEMENT },
     { objet: ObjetPreuveEnum.CANDIDATURE },
   ],
-  criteres_action: [{ atteint: true, action_id: 'cae_1.1.1' }],
+  criteres_action: [{ atteint: true }],
   ...overrides,
 });
 
@@ -44,11 +35,11 @@ const availabilityOf = (
   options: {
     isCOT: boolean;
     maximumRequestableStar: Etoile;
-    referentRolesDefined?: ReferentRolesDefined;
+    allReferentRolesDefined?: boolean;
   }
-): ReturnType<typeof getAuditRequestAvailability> =>
+): AuditRequestAvailability =>
   getAuditRequestAvailability(parcours, {
-    referentRolesDefined: ROLES_DESIGNES,
+    allReferentRolesDefined: true,
     ...options,
   });
 
@@ -67,13 +58,10 @@ describe('getAuditRequestAvailability', () => {
 
   it("COT + maximumRequestableStar = 1 : indisponible, aucun type d'audit demandable avant la 2e étoile", () => {
     expect(
-      availabilityOf(
-        makeParcours({ isCot: true, etoiles: 1 as Etoile }),
-        {
-          isCOT: true,
-          maximumRequestableStar: 1,
-        }
-      )
+      availabilityOf(makeParcours({ isCot: true, etoiles: 1 as Etoile }), {
+        isCOT: true,
+        maximumRequestableStar: 1,
+      })
     ).toEqual({
       canRequest: false,
       reason: { kind: 'noRequestableAuditType' },
@@ -105,10 +93,7 @@ describe('getAuditRequestAvailability', () => {
     expect(
       availabilityOf(
         makeParcours({
-          criteres_action: [
-            { atteint: true, action_id: 'cae_1.1.1' },
-            { atteint: false, action_id: 'cae_1.1.2' },
-          ],
+          criteres_action: [{ atteint: true }, { atteint: false }],
         }),
         { isCOT: false, maximumRequestableStar: 2 }
       )
@@ -121,7 +106,10 @@ describe('getAuditRequestAvailability', () => {
   it('non-COT + étoile 2 sans fichier de candidature : indisponible (prérequis incomplets)', () => {
     expect(
       availabilityOf(
-        makeParcours({ conditionFichiers: { preuve_nombre: 0 }, preuvesObjets: [] }),
+        makeParcours({
+          conditionFichiers: { preuve_nombre: 0 },
+          preuvesObjets: [],
+        }),
         { isCOT: false, maximumRequestableStar: 2 }
       )
     ).toEqual({
@@ -186,64 +174,17 @@ describe('getAuditRequestAvailability', () => {
     ).toEqual({ canRequest: true, reason: null });
   });
 
-  it("non-COT + étoile 2, critères atteints mais élu référent non désigné : indisponible (pilotes de rôle incomplets)", () => {
+  it('indisponible quand les référents ne sont pas désignés, même avec tous les critères atteints', () => {
     expect(
-      availabilityOf(
-        makeParcours({
-          criteres_action: [
-            { atteint: true, action_id: eluReferentActionId },
-            { atteint: true, action_id: referentTechniqueActionId },
-          ],
-        }),
-        {
-          isCOT: false,
-          maximumRequestableStar: 2,
-          referentRolesDefined: { eluReferent: false, referentTechnique: true },
-        }
-      )
+      availabilityOf(makeParcours(), {
+        isCOT: false,
+        maximumRequestableStar: 2,
+        allReferentRolesDefined: false,
+      })
     ).toEqual({
       canRequest: false,
-      reason: { kind: 'referentRolesUndefined' },
+      reason: { kind: 'prerequisitesIncomplete' },
     });
-  });
-
-  it("non-COT + étoile 2, critères atteints mais référent technique non désigné : indisponible (pilotes de rôle incomplets)", () => {
-    expect(
-      availabilityOf(
-        makeParcours({
-          criteres_action: [
-            { atteint: true, action_id: eluReferentActionId },
-            { atteint: true, action_id: referentTechniqueActionId },
-          ],
-        }),
-        {
-          isCOT: false,
-          maximumRequestableStar: 2,
-          referentRolesDefined: { eluReferent: true, referentTechnique: false },
-        }
-      )
-    ).toEqual({
-      canRequest: false,
-      reason: { kind: 'referentRolesUndefined' },
-    });
-  });
-
-  it('non-COT + étoile 2, critères atteints et élu référent + référent technique désignés : disponible', () => {
-    expect(
-      availabilityOf(
-        makeParcours({
-          criteres_action: [
-            { atteint: true, action_id: eluReferentActionId },
-            { atteint: true, action_id: referentTechniqueActionId },
-          ],
-        }),
-        {
-          isCOT: false,
-          maximumRequestableStar: 2,
-          referentRolesDefined: { eluReferent: true, referentTechnique: true },
-        }
-      )
-    ).toEqual({ canRequest: true, reason: null });
   });
 
   it("cycleUnavailable prime sur l'absence de type (l'utilisateur doit d'abord finir le cycle en cours)", () => {

--- a/packages/domain/src/referentiels/labellisations/audit-request-availability/audit-request-availability.rules.ts
+++ b/packages/domain/src/referentiels/labellisations/audit-request-availability/audit-request-availability.rules.ts
@@ -6,29 +6,19 @@ import {
   areAuditPrerequisitesMet,
   ParcoursForAuditPrerequisites,
 } from '../request-labellisation/request-labellisation.rules';
-import {
-  isReferentRoleDefined,
-  ReferentRolesDefined,
-} from '../role-mesures/role-mesures';
 import { canStartNewAuditCycle } from '../start-new-audit-cycle/start-new-audit-cycle.rules';
 import { StartNewAuditCycleRulesErrors } from '../start-new-audit-cycle/start-new-audit-cycle.rules-errors';
 
 export type ParcoursForAuditRequest = Pick<
   ParcoursLabellisation,
-  'status' | 'demande' | 'labellisation' | 'referentiel'
+  'status' | 'demande' | 'labellisation'
 > &
-  Omit<ParcoursForAuditPrerequisites, 'criteres_action'> & {
-    criteres_action: Pick<
-      ParcoursLabellisation['criteres_action'][number],
-      'atteint' | 'action_id'
-    >[];
-  };
+  ParcoursForAuditPrerequisites;
 
 export type AuditRequestUnavailableReason =
   | { kind: 'cycleUnavailable'; cause: StartNewAuditCycleRulesErrors }
   | { kind: 'noRequestableAuditType' }
-  | { kind: 'prerequisitesIncomplete' }
-  | { kind: 'referentRolesUndefined' };
+  | { kind: 'prerequisitesIncomplete' };
 
 export type AuditRequestAvailability =
   | { canRequest: true; reason: null }
@@ -39,11 +29,11 @@ export function getAuditRequestAvailability(
   {
     isCOT,
     maximumRequestableStar,
-    referentRolesDefined,
+    allReferentRolesDefined,
   }: {
     isCOT: boolean;
     maximumRequestableStar: Etoile;
-    referentRolesDefined: ReferentRolesDefined;
+    allReferentRolesDefined: boolean;
   }
 ): AuditRequestAvailability {
   const cycleAvailability = canStartNewAuditCycle(parcours);
@@ -67,18 +57,12 @@ export function getAuditRequestAvailability(
       areAuditPrerequisitesMet(
         parcours,
         sujet,
-        sujet === SujetDemandeEnum.COT ? null : maximumRequestableStar
+        sujet === SujetDemandeEnum.COT ? null : maximumRequestableStar,
+        { allReferentRolesDefined }
       ).met
   );
   if (!hasSatisfiedPrerequisites) {
     return { canRequest: false, reason: { kind: 'prerequisitesIncomplete' } };
-  }
-
-  const allReferentRolesDefined = parcours.criteres_action.every((critere) =>
-    isReferentRoleDefined(critere, parcours.referentiel, referentRolesDefined)
-  );
-  if (!allReferentRolesDefined) {
-    return { canRequest: false, reason: { kind: 'referentRolesUndefined' } };
   }
 
   return { canRequest: true, reason: null };

--- a/packages/domain/src/referentiels/labellisations/request-labellisation/request-labellisation.rules.spec.ts
+++ b/packages/domain/src/referentiels/labellisations/request-labellisation/request-labellisation.rules.spec.ts
@@ -11,6 +11,8 @@ type DemandeEtOuAudit = NonNullable<
   Parameters<typeof getParcoursLabellisationStatus>[0]
 >;
 
+const ROLES_OK = { allReferentRolesDefined: true };
+
 const baseParcours: ParcoursLabellisationForRequest = {
   status: 'non_demandee',
   completude_ok: true,
@@ -40,22 +42,32 @@ describe('canRequestAuditOrLabellisation — pieces attendues par etoile demande
     preuvesObjets: [{ objet: ObjetPreuveEnum.ACTE_ENGAGEMENT }],
   };
 
-  it("autorise la premiere etoile avec le seul acte, meme si le score permet la labellisation", () => {
+  it('autorise la premiere etoile avec le seul acte, meme si le score permet la labellisation', () => {
     expect(
-      canRequestAuditOrLabellisation(acteSeulDepose, 'labellisation', 1)
+      canRequestAuditOrLabellisation(
+        acteSeulDepose,
+        'labellisation',
+        1,
+        ROLES_OK
+      )
     ).toEqual({ canRequest: true, reason: null });
   });
 
   it('refuse la deuxieme etoile tant que le dossier de candidature manque', () => {
     expect(
-      canRequestAuditOrLabellisation(acteSeulDepose, 'labellisation', 2)
+      canRequestAuditOrLabellisation(
+        acteSeulDepose,
+        'labellisation',
+        2,
+        ROLES_OK
+      )
     ).toEqual({
       canRequest: false,
       reason: RequestLabellisationRulesErrorsEnum.MISSING_FILE,
     });
   });
 
-  it("refuse la premiere etoile quand seul le dossier de candidature est depose", () => {
+  it('refuse la premiere etoile quand seul le dossier de candidature est depose', () => {
     expect(
       canRequestAuditOrLabellisation(
         {
@@ -63,7 +75,8 @@ describe('canRequestAuditOrLabellisation — pieces attendues par etoile demande
           preuvesObjets: [{ objet: ObjetPreuveEnum.CANDIDATURE }],
         },
         'labellisation',
-        1
+        1,
+        ROLES_OK
       )
     ).toEqual({
       canRequest: false,
@@ -72,7 +85,7 @@ describe('canRequestAuditOrLabellisation — pieces attendues par etoile demande
   });
 });
 
-describe('canRequestAuditOrLabellisation — documents deposes depuis l\'ancien ecran', () => {
+describe("canRequestAuditOrLabellisation — documents deposes depuis l'ancien ecran", () => {
   const parcoursSansObjet: ParcoursLabellisationForRequest = {
     ...baseParcours,
     conditionFichiers: { preuve_nombre: 1 },
@@ -81,16 +94,22 @@ describe('canRequestAuditOrLabellisation — documents deposes depuis l\'ancien 
 
   it('refuse la demande par defaut', () => {
     expect(
-      canRequestAuditOrLabellisation(parcoursSansObjet, 'labellisation', 1)
+      canRequestAuditOrLabellisation(
+        parcoursSansObjet,
+        'labellisation',
+        1,
+        ROLES_OK
+      )
     ).toEqual({
       canRequest: false,
       reason: RequestLabellisationRulesErrorsEnum.MISSING_FILE,
     });
   });
 
-  it('autorise la demande quand l\'appelant tolere les documents sans objet', () => {
+  it("autorise la demande quand l'appelant tolere les documents sans objet", () => {
     expect(
       canRequestAuditOrLabellisation(parcoursSansObjet, 'labellisation', 1, {
+        allReferentRolesDefined: true,
         allowLegacyDocuments: true,
       })
     ).toEqual({ canRequest: true, reason: null });
@@ -106,7 +125,7 @@ describe('canRequestAuditOrLabellisation — documents deposes depuis l\'ancien 
         },
         'labellisation',
         1,
-        { allowLegacyDocuments: true }
+        { allowLegacyDocuments: true, ...ROLES_OK }
       )
     ).toEqual({
       canRequest: false,
@@ -115,10 +134,10 @@ describe('canRequestAuditOrLabellisation — documents deposes depuis l\'ancien 
   });
 });
 
-describe('canRequestAuditOrLabellisation — plafond d\'étoile dérivé du score réalisé', () => {
+describe("canRequestAuditOrLabellisation — plafond d'étoile dérivé du score réalisé", () => {
   it('autorise une étoile au-delà des étoiles obtenues quand le score réalisé le permet', () => {
     expect(
-      canRequestAuditOrLabellisation(baseParcours, 'labellisation', 2)
+      canRequestAuditOrLabellisation(baseParcours, 'labellisation', 2, ROLES_OK)
     ).toEqual({ canRequest: true, reason: null });
   });
 
@@ -130,7 +149,8 @@ describe('canRequestAuditOrLabellisation — plafond d\'étoile dérivé du scor
           critere_score: { ...baseParcours.critere_score, atteint: false },
         },
         'labellisation',
-        1
+        1,
+        ROLES_OK
       )
     ).toEqual({ canRequest: true, reason: null });
   });
@@ -143,12 +163,48 @@ describe('canRequestAuditOrLabellisation — plafond d\'étoile dérivé du scor
           critere_score: { ...baseParcours.critere_score, score_fait: 0.35 },
         },
         'labellisation',
-        3
+        3,
+        ROLES_OK
       )
     ).toEqual({
       canRequest: false,
       reason: 'SCORE_GLOBAL_CRITERIA_NOT_SATISFIED',
     });
+  });
+});
+
+describe('canRequestAuditOrLabellisation — designation des referents', () => {
+  it("refuse la demande quand un referent de role n'est pas designe", () => {
+    expect(
+      canRequestAuditOrLabellisation(baseParcours, 'labellisation', 1, {
+        allReferentRolesDefined: false,
+      })
+    ).toEqual({
+      canRequest: false,
+      reason:
+        RequestLabellisationRulesErrorsEnum.SCORE_ACTIONS_CRITERIA_NOT_SATISFIED,
+    });
+  });
+
+  it('refuse aussi un audit COT, dont les criteres de score ne sont pourtant pas evalues', () => {
+    expect(
+      canRequestAuditOrLabellisation(
+        { ...baseParcours, isCot: true },
+        'cot',
+        null,
+        { allReferentRolesDefined: false }
+      )
+    ).toEqual({
+      canRequest: false,
+      reason:
+        RequestLabellisationRulesErrorsEnum.SCORE_ACTIONS_CRITERIA_NOT_SATISFIED,
+    });
+  });
+
+  it('accepte la demande une fois les referents designes', () => {
+    expect(
+      canRequestAuditOrLabellisation(baseParcours, 'labellisation', 1, ROLES_OK)
+    ).toEqual({ canRequest: true, reason: null });
   });
 });
 
@@ -159,12 +215,12 @@ describe('getParcoursLabellisationStatus — état consolidé du cycle', () => {
     date_fin: null,
   };
 
-  it('retourne non_demandee quand il n\'y a ni demande ni audit', () => {
+  it("retourne non_demandee quand il n'y a ni demande ni audit", () => {
     expect(getParcoursLabellisationStatus(null)).toBe('non_demandee');
     expect(getParcoursLabellisationStatus(undefined)).toBe('non_demandee');
-    expect(
-      getParcoursLabellisationStatus({ demande: null, audit: null })
-    ).toBe('non_demandee');
+    expect(getParcoursLabellisationStatus({ demande: null, audit: null })).toBe(
+      'non_demandee'
+    );
   });
 
   it('retourne demande_envoyee quand la demande est envoyee (en_cours = false) sans audit demarre', () => {
@@ -176,7 +232,7 @@ describe('getParcoursLabellisationStatus — état consolidé du cycle', () => {
     ).toBe('demande_envoyee');
   });
 
-  it('retourne non_demandee tant que la demande est en cours d\'edition (en_cours = true)', () => {
+  it("retourne non_demandee tant que la demande est en cours d'edition (en_cours = true)", () => {
     expect(
       getParcoursLabellisationStatus({
         demande: { en_cours: true },
@@ -185,13 +241,13 @@ describe('getParcoursLabellisationStatus — état consolidé du cycle', () => {
     ).toBe('non_demandee');
   });
 
-  it('retourne audit_en_cours quand l\'audit a une date de debut et n\'est pas valide', () => {
+  it("retourne audit_en_cours quand l'audit a une date de debut et n'est pas valide", () => {
     expect(
       getParcoursLabellisationStatus({ demande: null, audit: auditEnCours })
     ).toBe('audit_en_cours');
   });
 
-  it('retourne audit_valide quand l\'audit est valide', () => {
+  it("retourne audit_valide quand l'audit est valide", () => {
     expect(
       getParcoursLabellisationStatus({
         demande: null,
@@ -200,7 +256,7 @@ describe('getParcoursLabellisationStatus — état consolidé du cycle', () => {
     ).toBe('audit_valide');
   });
 
-  it('priorise audit_valide sur audit_en_cours quand l\'audit demarre est aussi valide', () => {
+  it("priorise audit_valide sur audit_en_cours quand l'audit demarre est aussi valide", () => {
     expect(
       getParcoursLabellisationStatus({
         demande: null,
@@ -209,7 +265,7 @@ describe('getParcoursLabellisationStatus — état consolidé du cycle', () => {
     ).toBe('audit_valide');
   });
 
-  it('priorise audit_en_cours sur demande_envoyee quand l\'audit est demarre', () => {
+  it("priorise audit_en_cours sur demande_envoyee quand l'audit est demarre", () => {
     expect(
       getParcoursLabellisationStatus({
         demande: { en_cours: false },

--- a/packages/domain/src/referentiels/labellisations/request-labellisation/request-labellisation.rules.ts
+++ b/packages/domain/src/referentiels/labellisations/request-labellisation/request-labellisation.rules.ts
@@ -68,7 +68,10 @@ export function canRequestAuditOrLabellisation(
   parcours: ParcoursLabellisationForRequest,
   sujet: SujetDemande,
   etoiles: Etoile | null,
-  { allowLegacyDocuments = false }: { allowLegacyDocuments?: boolean } = {}
+  {
+    allowLegacyDocuments = false,
+    allReferentRolesDefined,
+  }: { allowLegacyDocuments?: boolean; allReferentRolesDefined: boolean }
 ):
   | {
       canRequest: false;
@@ -111,6 +114,7 @@ export function canRequestAuditOrLabellisation(
 
   const prerequisites = areAuditPrerequisitesMet(parcours, sujet, etoiles, {
     allowLegacyDocuments,
+    allReferentRolesDefined,
   });
   if (!prerequisites.met) {
     return {
@@ -142,7 +146,10 @@ export function areAuditPrerequisitesMet(
   parcours: ParcoursForAuditPrerequisites,
   sujet: SujetDemande,
   etoiles: Etoile | null,
-  { allowLegacyDocuments = false }: { allowLegacyDocuments?: boolean } = {}
+  {
+    allowLegacyDocuments = false,
+    allReferentRolesDefined,
+  }: { allowLegacyDocuments?: boolean; allReferentRolesDefined: boolean }
 ):
   | { met: true; reason: null }
   | { met: false; reason: AuditPrerequisitesError } {
@@ -153,6 +160,14 @@ export function areAuditPrerequisitesMet(
     };
   }
 
+  if (!allReferentRolesDefined) {
+    return {
+      met: false,
+      reason:
+        RequestLabellisationRulesErrorsEnum.SCORE_ACTIONS_CRITERIA_NOT_SATISFIED,
+    };
+  }
+
   if (sujet === 'cot') {
     // Pour un audit seul sans labellisation, il suffit d'avoir le référentiel complet pour pouvoir demander un audit
     // il n'y a pas de critères de score
@@ -160,7 +175,9 @@ export function areAuditPrerequisitesMet(
   }
 
   // Pour les autres, il faut vérifier les critères de score
-  if ((etoiles ?? 0) > getMaxRequestableStar(parcours.critere_score.score_fait)) {
+  if (
+    (etoiles ?? 0) > getMaxRequestableStar(parcours.critere_score.score_fait)
+  ) {
     return {
       met: false,
       reason:

--- a/packages/domain/src/referentiels/labellisations/role-mesures/role-mesures.spec.ts
+++ b/packages/domain/src/referentiels/labellisations/role-mesures/role-mesures.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  areAllReferentRolesDefined,
   isReferentRoleDefined,
   ROLE_IDENTIFIANTS,
   ReferentRolesDefined,
@@ -32,7 +33,7 @@ describe('roleKeyByIdentifiant', () => {
     );
   });
 
-  it("ne mappe pas un identifiant absent du référentiel", () => {
+  it('ne mappe pas un identifiant absent du référentiel', () => {
     expect(roleKeyByIdentifiant('cae').get('0.0.0.0')).toBeUndefined();
   });
 });
@@ -40,11 +41,7 @@ describe('roleKeyByIdentifiant', () => {
 describe('isReferentRoleDefined', () => {
   it("considère présent tout critère d'un référentiel hors audit-labellisation", () => {
     expect(
-      isReferentRoleDefined(
-        { action_id: 'te_1.1.1' },
-        'te',
-        TOUS_ROLES_DEFINIS
-      )
+      isReferentRoleDefined({ action_id: 'te_1.1.1' }, 'te', TOUS_ROLES_DEFINIS)
     ).toBe(true);
   });
 
@@ -86,7 +83,7 @@ describe('isReferentRoleDefined', () => {
     ).toBe(false);
   });
 
-  it('est faux quand le référent technique n\'est pas désigné', () => {
+  it("est faux quand le référent technique n'est pas désigné", () => {
     expect(
       isReferentRoleDefined(
         toCritere(ROLE_IDENTIFIANTS.cae.referentTechnique),
@@ -94,5 +91,58 @@ describe('isReferentRoleDefined', () => {
         { eluReferent: true, referentTechnique: false }
       )
     ).toBe(false);
+  });
+});
+
+describe('areAllReferentRolesDefined', () => {
+  const criteresAvecLesDeuxRoles = [
+    toCritere(ROLE_IDENTIFIANTS.cae.eluReferent),
+    toCritere(ROLE_IDENTIFIANTS.cae.referentTechnique),
+  ];
+
+  it('est vrai quand les deux rôles sont désignés', () => {
+    expect(
+      areAllReferentRolesDefined(
+        criteresAvecLesDeuxRoles,
+        'cae',
+        TOUS_ROLES_DEFINIS
+      )
+    ).toBe(true);
+  });
+
+  it("est faux quand aucun élu référent n'est désigné", () => {
+    expect(
+      areAllReferentRolesDefined(criteresAvecLesDeuxRoles, 'cae', {
+        eluReferent: false,
+        referentTechnique: true,
+      })
+    ).toBe(false);
+  });
+
+  it("est faux quand aucun référent technique n'est désigné", () => {
+    expect(
+      areAllReferentRolesDefined(criteresAvecLesDeuxRoles, 'cae', {
+        eluReferent: true,
+        referentTechnique: false,
+      })
+    ).toBe(false);
+  });
+
+  it("est vrai quand aucune mesure de rôle n'est au programme de l'étoile visée", () => {
+    expect(
+      areAllReferentRolesDefined([toCritere('1.1.2.0.1')], 'cae', {
+        eluReferent: false,
+        referentTechnique: false,
+      })
+    ).toBe(true);
+  });
+
+  it('est vrai sur un référentiel sans mesure de rôle', () => {
+    expect(
+      areAllReferentRolesDefined(criteresAvecLesDeuxRoles, 'te', {
+        eluReferent: false,
+        referentTechnique: false,
+      })
+    ).toBe(true);
   });
 });

--- a/packages/domain/src/referentiels/labellisations/role-mesures/role-mesures.ts
+++ b/packages/domain/src/referentiels/labellisations/role-mesures/role-mesures.ts
@@ -48,3 +48,12 @@ export const isReferentRoleDefined = (
       : undefined;
   return roleKey === undefined || referentRolesDefined[roleKey];
 };
+
+export const areAllReferentRolesDefined = (
+  criteres: readonly { action_id: string }[],
+  referentiel: ReferentielId,
+  referentRolesDefined: ReferentRolesDefined
+): boolean =>
+  criteres.every((critere) =>
+    isReferentRoleDefined(critere, referentiel, referentRolesDefined)
+  );


### PR DESCRIPTION
CT-4713 — le bouton « Obtenir la première étoile » est actif alors que la checklist affiche des critères non remplis.

## Comportement livré

Le bouton reste désactivé tant qu'aucun pilote n'est désigné sur « Identifier un⸱e élu⸱e référent⸱e » et « Identifier une personne technique ». C'est ce que faisait déjà « Demander un audit » : les deux boutons voisins décidaient du même fait avec des règles différentes.

La règle vit dans **une seule fonction**, `areAuditPrerequisitesMet`, commune aux deux chemins. `allReferentRolesDefined` y est un paramètre **requis** — pas de valeur par défaut : supposer les référents désignés serait le comportement le plus permissif sur une règle dont l'objet est de restreindre. Le compilateur force donc chaque appelant à se positionner.

Un référent non désigné rend `criteria-incomplete`, pas un motif dédié : sa ligne de checklist affiche déjà « Critère non atteint ».

## Portée : la demande d'audit est touchée aussi

Au-delà du ticket, `AuditRequestUnavailableReason` perd `referentRolesUndefined`, replié sur `prerequisitesIncomplete`, pour que les deux boutons expliquent le même blocage de la même façon. Le libellé `renseignerPilotesPourDemande`, sans appelant, disparaît.

**La PR n'est donc pas purement front** : trois fichiers de `packages/domain` et le service backend sont modifiés.

## Pas de plan lié

Le travail part d'un diagnostic, pas d'un `/ce-plan`. La convention de PR du repo demande un plan linké ; il n'y en a pas, et c'est assumé.

## Surface de review

**Attention humaine :**
- `packages/domain/.../request-labellisation.rules.ts` — le garde et **sa position avant la sortie `sujet === 'cot'`** : c'est la ligne où une inattention changerait le comportement des audits COT
- `packages/domain/.../audit-request-availability.rules.ts` — fusion des motifs, type d'entrée réduit
- `apps/app/.../useCycleLabellisation.ts` — source unique du fait côté front
- `apps/app/.../use-referent-roles-defined.ts` — élargi à tout `ReferentielId`, requête scopée

**Mécanique :** `request-audit.button.tsx`, `catalog.ts`, `request-labellisation.service.ts`, specs, e2e.

Note : `checklist-actions.spec.tsx` est un diff **spec seule** — le composant est identique à `main`, mais son comportement change via `cycle.canAskFirstStar`, qui intègre désormais les référents.

## Test rouge

Commit `ecbc08d56b`, vérifié en isolation sur `main` : 2 échecs / 3 succès. Le fix est en `97d3e26bbf`.

## Tests

Le garde a ses cas propres dans `request-labellisation.rules.spec.ts`, dont un qui **fige l'extension aux audits COT** — effet du placement avant la sortie anticipée, désormais explicite plutôt que silencieux.

Deux e2e, deux sujets distincts :
- `request-labellisation-from-new-checklist.spec.ts` — le **parcours** complet jusqu'à l'envoi. Il discrimine par sa séquence : entre « désactivé après l'acte » et « activé », seule la désignation change.
- `premiere-etoile-referents-obligatoires.spec.ts` — le **pourquoi** : « Mettre en place une équipe projet » atteinte prouve que les statuts sont posés, tandis que les deux mesures de rôle restent non atteintes faute de désignation.

Vérifié par mutation : en forçant `allReferentRolesDefined` à `true`, l'échec tombe sur `toBeDisabled` **après** que les assertions de lignes soient passées.

`request-labellisation-from-new-checklist.spec.ts` **aurait cassé** sans ce diff : il ne désignait jamais de pilote.

## Une approche explorée puis abandonnée

Une première version supprimait aussi la branche de `addIsScoreConditionSatisfied` qui évalue un critère sur le score agrégé de sa sous-action parente. **Elle a été retirée : c'était une régression.**

Quand une sous-action porte un statut substantiel, le moteur marque ses tâches `NON_RENSEIGNABLE` (`scores.service.ts:1702-1707`) et le sélecteur de statut disparaît de l'UI (`action-statut.dropdown.tsx:70-72`). Cette branche est la contrepartie de ce mécanisme, pas un contournement. Sans elle, `cae_1.1.2.0.1` (PCAET), `cae_1.1.2.0.2` (BGES), `cae_5.1.1.3.2` et `eci_1.1.3.1` devenaient non atteints **sans aucun moyen pour l'utilisateur de les corriger**.

## Ce que la review a trouvé, et qui est corrigé

Une review multi-agents a tourné sur la branche. Quatre findings réels :

- **Régression de performance introduite par la centralisation.** `useReferentRolesDefined` laissait `referentielIds` à son défaut `[CAE, ECI, TE]`, et `useCycleLabellisation` l'appelle désormais : les pages `referentiel/te/*` chargeaient l'arbre complet de CAE (~1471 actions) et ECI (~368) pour lire deux pilotes, résultat jeté. Requête scopée au référentiel affiché, et aucune requête quand il n'a pas de mesure de rôle.
- **Deux cibles CI rouges** : la spec backend jumelle (17 appels non migrés, 16 tests) et `nx run domain:typecheck` (10 erreurs sur des fixtures portant des champs retirés du type). `vitest` ne typecheck pas et `tsconfig.lib.json` exclut les specs — les deux angles morts se recouvraient.
- **Diff resserré** : `ask-premiere-etoile-button-state.ts` et son spec en sortent, l'inversion de condition qui y restait étant un no-op de style.
- **Tests non discriminants** : deux cas devenus identiques, un rejouant le défaut du helper, deux intitulés annonçant des référents absents de leur fixture, un mock incomplet.

## Zones de moindre confiance

**Le `true` en dur dans `request-labellisation.service.ts`.** Le seul chemin d'écriture serveur opte out : le contrôle est tenu en UI seulement. Comportement identique à `main`, mais la ligne affirme désormais un fait qu'elle ne vérifie pas. Traité dans une PR dédiée qui chargera les pilotes.

**Le garde de chargement de `RequestAuditButton`.** `allReferentRolesDefined` vaut `false` pendant le fetch sans que `isLoading` le reflète, et le garde `!referentRolesLoaded` a disparu du composant. Le traçage du montage montre que le bouton est rendu sous le spinner de `criteres-labellisation.view.tsx`, donc **non atteignable aujourd'hui** — mais la propriété de sûreté a migré vers un ancêtre, sans test.

**Guidage utilisateur.** Le tooltip générique `renseignerCriteresPourDemande` est aussi le sous-titre du header juste au-dessus : l'utilisateur voit un bouton grisé et une phrase qu'il a déjà sous les yeux. Conséquence assumée de la fusion des motifs, à confirmer côté produit.

## Vérifications

| | |
|---|---|
| `nx run-many -t typecheck -p domain backend app` | vert |
| `packages/domain` | 320/320 |
| `apps/app` | 596/596 |
| backend `request-labellisation.rules.spec.ts` | 16/16 |
| e2e 1ère étoile + demandes d'audit, `--workers=2 --retries=2` | 9/9 |
| prettier sur les fichiers touchés | propre |

Deux pièges d'exécution locale, sans effet sur la CI :
- lancer les e2e **depuis la racine** (`pnpm exec playwright test --config ./e2e/playwright.config.mjs`) ; depuis `e2e/`, tout test déposant un fichier échoue sur un chemin d'exemple relatif ;
- reconstruire `packages/domain/dist` (`nx build domain`) après toute modification du domaine, sinon `apps/app` teste l'ancienne règle sans le dire.

## Suites identifiées, hors périmètre

Une carte des vérifications front/domaine/backend a fait ressortir des doublons **antérieurs à cette PR**, aucun ne traçant à CT-4713 :

- `rempli` (`get-labellisation.service.ts`) réimplémente les prérequis et **n'a aucun lecteur** — supprimable seul, meilleur rapport valeur/risque ;
- `getExpectedDocuments` est appelé à trois endroits avec trois étoiles différentes ;
- le critère de score existe en trois versions (`critere_score.atteint`, `getMaxRequestableStar`, `getMinimumScore`) — le domaine a même un test qui verrouille l'écart ;
- deux specs distinctes testent la même fonction domaine (c'est ce doublon qui a produit les 16 tests rouges) ;
- trois flags de `useCycleLabellisation` n'ont plus de lecteur applicatif.

Les deux derniers touchent des lignes de cette PR : à rebaser sur `main` mergé plutôt qu'à mener en parallèle.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * La demande de labellisation est désormais activée uniquement lorsque tous les rôles référents requis sont renseignés.
  * Ajout de libellés pour les documents supplémentaires, les plans importés ou créés, les plans déjà rattachés et les statuts en lecture seule.
  * Affichage du nombre d’actions avec une formulation adaptée au singulier et au pluriel.

* **Améliorations**
  * Plusieurs intitulés ont été raccourcis, renommés ou harmonisés.
  * Suppression de libellés obsolètes liés aux documents, sections, pilotes et étapes de création de plan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->