### PR TITLE
[DX] Speed "make up"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,8 @@ out
 
 # Docker data
 docker-data
+# Journal de la reconstruction en tâche de fond du socle des apps (make up)
+.docker/node-base-build.log
 
 # Environments
 

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,10 @@ run_node = $(compose_here); \
 		$(call decrypt_env,$(ENV_ROOT)) -q -- $(1); \
 	fi
 
+# Surcharges du Makefile (Makefile.local compris) relayées aux scripts node :
+# binaire docker, enveloppe dotenvx, binaire make qu'ils rappellent.
+node_env = DOCKER="$(DOCKER)" DOTENVX="$(DOTENVX)" MAKE="$(MAKE)"
+
 colored = red()    { printf '\033[31m%s\033[0m\n' "$$*"; }; \
           green()  { printf '\033[32m%s\033[0m\n' "$$*"; }; \
           yellow() { printf '\033[33m%s\033[0m\n' "$$*"; }; \
@@ -71,7 +75,7 @@ env_target = $(if $(app),apps/$(app)/.env,$$(node scripts/pick-env-file.mts))
         install dev graph \
 	hooks hooks-off \
         infra-up services-scoped-up worktree worktree-env worktree-prune guard-main warn-shared-db \
-        up services-up node-base stop down cache-clean workflow-graph logs ps tui \
+        up services-up node-base heal-db stop down cache-clean workflow-graph logs ps tui \
         preflight-inotify preflight-env-keys ensure-deps inotify-persist \
         db-init db-migrate db-seed db-reset db-shell db-import-referentiels db-restore-local-from-prod-backup seeds_rebuild_from_source \
         cms-pull cms-pull-local
@@ -116,14 +120,16 @@ env-keys: ## Crée .env.keys par collage dans le terminal
 ## —— 🐳 Stack locale (services + apps) ———————————————————————————————————————
 # internes (absents du help) :
 # - services-up : tous les services, sans prompt (db-init)
-# - node-base : socle commun des images d'apps (.docker/apps/base.Dockerfile),
-#   construit avec l'UID/GID hôte ; les .docker/apps/<app>/ font FROM tet-node-dev
-services-up:
-	@$(call heal_db,$(COMPOSE))
+# - node-base : socle commun des conteneurs d'apps (tet-node-dev), construit
+#   avec l'UID/GID hôte — tous les services d'apps l'utilisent tel quel
+# - heal-db : répare un db « running » mais détaché du réseau (voir plus bas)
+services-up: heal-db
 	COMPOSE_PROFILES=$(SERVICES_PROFILES) $(COMPOSE) up -d --wait
 
+# Empreinte de l'image, reconstruction en tâche de fond, recréation des
+# conteneurs dessus : cf. scripts/node-base.mts.
 node-base:
-	$(DOCKER) build -t tet-node-dev -f .docker/apps/base.Dockerfile --build-arg UID=$(UID) --build-arg GID=$(GID) .docker/apps
+	@$(node_env) node scripts/node-base.mts build
 
 preflight-env-keys:
 	@$(colored); \
@@ -194,48 +200,21 @@ compose_here = if [ -n "$(IS_WORKTREE)" ]; then \
 # donc pas réparé par un simple `up`. Les services qui migrent au boot
 # (gotrue/storage/realtime) plantent alors sur « db introuvable » (SERVFAIL).
 # On détecte le cas (conteneur présent, 0 réseau attaché) et on le force-recreate
-# avant de démarrer les services. $(1) = commande compose du contexte courant.
-heal_db = cid=$$($(1) --profile '*' ps -q db 2>/dev/null); \
+heal-db:
+	@cid=$$($(COMPOSE) --profile '*' ps -q db 2>/dev/null); \
 	if [ -n "$$cid" ] && [ "$$($(DOCKER) inspect "$$cid" --format '{{len .NetworkSettings.Networks}}' 2>/dev/null)" = 0 ]; then \
 		echo "⚠ db détaché du réseau — recréation avant démarrage des services"; \
-		$(1) up -d --force-recreate --wait db; \
+		$(COMPOSE) up -d --force-recreate --wait db; \
 	fi
 
 stop:
 	@$(compose_here); $$C --profile '*' stop
 
-up: preflight-env-keys ensure-deps cache-clean ## Lance la stack cochée en conteneurs : make up [p="<profile>"] (profiles : x dans make tui)
-	@if [ -n "$(IS_WORKTREE)" ]; then \
-		node scripts/worktree-env.mts || exit 1; \
-		node scripts/pick-stack.mts $(if $(p),--profile "$(p)") >/dev/null || exit 1; \
-		apps=$$(node scripts/dev-apps.mts apps) || exit 1; \
-		$(MAKE) --no-print-directory preflight-inotify || exit 1; \
-		$(MAKE) --no-print-directory node-base || exit 1; \
-		infra=$$(node scripts/dev-apps.mts infra $$apps) || exit 1; \
-		COMPOSE_PROFILES=$$infra $(MAKE) -C $(MAIN_ROOT) --no-print-directory services-scoped-up || exit 1; \
-		set -a; . ./.env.local; set +a; \
-		$(compose_here); profiles=$$(echo $$apps | tr ' ' ','); \
-		enabled=$$(COMPOSE_PROFILES=$$profiles $$C config --services); \
-		stop=""; for svc in $$($$C --profile '*' ps --format '{{.Service}}'); do \
-			echo "$$enabled" | grep -qx "$$svc" || stop="$$stop $$svc"; done; \
-		if [ -n "$$stop" ]; then echo "⏹ arrêt des composants décochés :$$stop"; \
-			$$C --profile '*' stop $$stop; fi; \
-		COMPOSE_PROFILES=$$profiles $$C up -d --build --wait --remove-orphans || \
-			{ echo "✗ une app n'est pas devenue saine — make logs s=<app> pour investiguer"; exit 1; }; \
-	else \
-		profiles=$$(node scripts/pick-stack.mts $(if $(p),--profile "$(p)")) || exit 1; \
-		if node scripts/dev-apps.mts has-app "$$profiles"; then \
-			$(MAKE) --no-print-directory preflight-inotify || exit 1; \
-			$(MAKE) --no-print-directory node-base || exit 1; fi; \
-		enabled=$$(COMPOSE_PROFILES=$$profiles $(COMPOSE) config --services); \
-		stop=""; for svc in $$($(COMPOSE) --profile '*' ps --format '{{.Service}}'); do \
-			echo "$$enabled" | grep -qx "$$svc" || stop="$$stop $$svc"; done; \
-		if [ -n "$$stop" ]; then echo "⏹ arrêt des composants décochés :$$stop"; \
-			$(COMPOSE) --profile '*' stop $$stop; fi; \
-		$(call heal_db,$(COMPOSE)); \
-		COMPOSE_PROFILES=$$profiles $(COMPOSE) up -d --build --wait --remove-orphans || \
-			{ echo "✗ une app n'est pas devenue saine — les services restent en marche ; make logs s=<app> pour investiguer"; exit 1; }; \
-	fi
+# Chemin volontairement minimal : rien qui puisse être évité ne s'exécute à
+# chaque démarrage — d'où les options, qui couvrent les cas restants. Le
+# déroulé (sélection, socle des apps, infra, up) vit dans scripts/up.mts.
+up: preflight-env-keys ensure-deps $(if $(filter 1,$(clean)),cache-clean) ## Lance la stack cochée en conteneurs : make up [ask=1] [p="<profile>"] [clean=1] [build=1]
+	@$(node_env) node scripts/up.mts $(if $(p),--profile "$(p)") $(if $(filter 1,$(ask)),--ask) $(if $(filter 1,$(build)),--build)
 	@if [ -t 0 ] && [ -t 1 ]; then $(MAKE) --no-print-directory tui; fi
 
 down: ## Stoppe tout (les données sont conservées ; worktree : sa stack d'apps seulement)
@@ -392,6 +371,5 @@ infra-up:
 		COMPOSE_PROFILES=$$profiles $(MAKE) -C $(MAIN_ROOT) --no-print-directory services-scoped-up; \
 	else COMPOSE_PROFILES=$$profiles $(COMPOSE) up -d --wait; fi
 
-services-scoped-up:
-	@$(call heal_db,$(COMPOSE))
+services-scoped-up: heal-db
 	$(COMPOSE) up -d --wait

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
 -include Makefile.local
 
 DOCKER ?= docker
-DOTENVX ?= npx -y @dotenvx/dotenvx
+# dotenvx installé par pnpm plutôt que `npx -y` : npx réinterroge le registre à
+# CHAQUE appel (~6 s), et une cible comme `up` en enchaîne une demi-douzaine.
+# Repli sur npx tant que node_modules n'existe pas (tout premier make install).
+DOTENVX ?= $(if $(wildcard node_modules/.bin/dotenvx),node_modules/.bin/dotenvx,npx -y @dotenvx/dotenvx)
 ENV_KEYS = --env-keys-file=.env.keys
 
 ENV_ROOT = .env

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ La stack locale est décrite dans [`docker-compose.yml`](./docker-compose.yml) e
 
 ```shell
 make db-init            # première installation : services + migrations + référentiels + données de test
-make up                 # sélecteur des conteneurs à lancer (services + apps, mémorisé)
+make up                 # relance la stack mémorisée (ask=1 pour re-choisir les composants)
 make down               # stoppe tout (les données sont conservées entre les sessions)
 make logs s=backend
 make tui                # tableau de bord interactif : statuts, URLs, logs navigables, start/stop/restart
@@ -176,6 +176,17 @@ make db-shell           # psql dans la base locale
 `make db-init` enchaîne : démarrage des services, migrations [sqitch](./data_layer/sqitch), import des définitions (indicateurs, questions de personnalisation, référentiels) via les tests backend — qui lisent les CSV du dépôt mais démarrent le backend complet, d'où le besoin de `.env.keys` — puis chargement des données de test ([`data_layer/seed`](./data_layer/seed)). La commande est idempotente : migrations et seeds déjà appliqués sont sautés. À noter : elle exécute les tests backend **sur l'hôte** (`make install` requis au préalable).
 
 En mode Docker, les dépendances vivent dans le volume `node-modules`, réinstallées incrémentalement par le service `deps` à chaque `make up` — après un changement de `pnpm-lock.yaml`, un simple `make up` suffit donc.
+
+`make up` est optimisé pour être rejoué en boucle : il ne redemande pas les composants (la sélection est mémorisée dans `.env.local`) et ne reconstruit rien qui n'ait changé. Ses options couvrent les cas restants :
+
+| Option | Effet |
+| --- | --- |
+| `make up ask=1` | rouvre le sélecteur de composants |
+| `make up p="<profile>"` | rejoue un profile nommé (sauvé par `x` dans `make tui`) |
+| `make up clean=1` | purge les caches de build avant de démarrer (`make cache-clean`) — utile après un rebase, au prix d'un rebuild Turbopack complet |
+| `make up build=1` | force la reconstruction des images à build local (strapi, sqitch) |
+
+Le socle des apps (`tet-node-dev`, cf. [`.docker/apps/base.Dockerfile`](./.docker/apps/base.Dockerfile)) porte l'empreinte de son Dockerfile et de l'UID/GID hôte. S'il a changé, `make up` **démarre d'abord** sur l'image existante puis reconstruit en tâche de fond (`.docker/node-base-build.log`) et recrée les conteneurs concernés dessus ; seule son absence totale bloque le démarrage.
 
 #### Git worktrees & agents
 

--- a/package.json
+++ b/package.json
@@ -165,6 +165,7 @@
     "zod": "4.1.12"
   },
   "devDependencies": {
+    "@dotenvx/dotenvx": "2.21.0",
     "@eslint/js": "8.57.0",
     "@hey-api/client-fetch": "0.10.2",
     "@hey-api/openapi-ts": "0.86.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -465,6 +465,9 @@ importers:
         specifier: 4.1.12
         version: 4.1.12
     devDependencies:
+      '@dotenvx/dotenvx':
+        specifier: 2.21.0
+        version: 2.21.0
       '@eslint/js':
         specifier: 8.57.0
         version: 8.57.0
@@ -1618,6 +1621,16 @@ packages:
     resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
     peerDependencies:
       react: '>=16.8.0'
+
+  '@dotenvx/dotenvx@2.21.0':
+    resolution: {integrity: sha512-BL6yuTmYeK2ak9YLpiBEI4Xuf9YkTJJH+DKK53CqR+TPaF5RiJ4VJpOy1pWjjipbZH9dcpfkkjf/PonJ+zcbFg==}
+    hasBin: true
+
+  '@dotenvx/primitives@2.2.0':
+    resolution: {integrity: sha512-jrUocPqHfGeYuvNKmrzNJCIHW7Xb6m5CuxUESyCHmGlzQByho2EdX45ctfTgWSELeSrcfwuB0Q8iHdlmmlxhUA==}
+
+  '@dotenvx/tooling@1.0.3':
+    resolution: {integrity: sha512-Gd6qQol/ICb4MPRWpiIH56y+pR9AVB7kPBkbhrLSGLtAiF4Qgy+k651/f2pze0Xbm3H5XewbPfIm4y9K+ic30Q==}
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
@@ -15710,6 +15723,10 @@ packages:
     resolution: {integrity: sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==}
     engines: {node: '>=12.20'}
 
+  yocto-spinner@1.2.2:
+    resolution: {integrity: sha512-DODGl1wJjA/s5pnJFKau9lIYHT81lnhob1i3e1TjxZRxEhWRKl74nTbWE6H5KlkViQQTo/Z29YFdxzTZAMY3ng==}
+    engines: {node: '>=18.19'}
+
   yoctocolors-cjs@2.1.2:
     resolution: {integrity: sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==}
     engines: {node: '>=18'}
@@ -16898,6 +16915,16 @@ snapshots:
     dependencies:
       react: 19.2.3
       tslib: 2.8.1
+
+  '@dotenvx/dotenvx@2.21.0':
+    dependencies:
+      '@dotenvx/primitives': 2.2.0
+      '@dotenvx/tooling': 1.0.3
+      yocto-spinner: 1.2.2
+
+  '@dotenvx/primitives@2.2.0': {}
+
+  '@dotenvx/tooling@1.0.3': {}
 
   '@drizzle-team/brocli@0.10.2': {}
 
@@ -33496,6 +33523,10 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yocto-queue@1.2.1: {}
+
+  yocto-spinner@1.2.2:
+    dependencies:
+      yoctocolors: 2.1.2
 
   yoctocolors-cjs@2.1.2: {}
 

--- a/scripts/compose.mts
+++ b/scripts/compose.mts
@@ -1,0 +1,107 @@
+// Contexte docker compose du checkout courant : binaire docker, enveloppe
+// dotenvx (les .env du dépôt sont chiffrés — jamais de `docker compose` nu) et
+// projet/fichiers selon le checkout. Miroir en TypeScript des macros COMPOSE /
+// compose_here du Makefile, partagé par up.mts et node-base.mts.
+//
+// Tronc principal : la stack partagée `tet` (name: fixe du docker-compose.yml).
+// Worktree lié : ses apps seules, dans le projet tet-wt<slot>
+// (docker-compose.worktree.yml) — l'infra vit dans la stack du tronc.
+import { execFileSync, spawnSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { readEnvValue, readEnvVars } from './env-local.mts';
+
+const ENV_LOCAL = '.env.local';
+
+export const DOCKER = process.env.DOCKER ?? 'docker';
+
+// Surchargeable par le Makefile (DOTENVX) : binaire local quand pnpm l'a
+// installé, `npx -y @dotenvx/dotenvx` sinon — d'où le split sur l'espace.
+const DOTENVX = (process.env.DOTENVX ?? 'npx -y @dotenvx/dotenvx').split(' ');
+
+const git = (...args: string[]): string =>
+  execFileSync('git', args, { encoding: 'utf8' }).trim();
+
+// Détection indépendante du cwd (même critère que worktree-env.mts) : dans un
+// worktree lié, le git-dir propre diffère du git-dir commun.
+const gitCommonDir = git(
+  'rev-parse',
+  '--path-format=absolute',
+  '--git-common-dir'
+);
+export const isWorktree =
+  resolve(git('rev-parse', '--path-format=absolute', '--absolute-git-dir')) !==
+  resolve(gitCommonDir);
+/** Racine du checkout principal, propriétaire de la stack `tet`. */
+export const mainRoot = dirname(gitCommonDir);
+/** Racine du checkout courant (tronc ou worktree). */
+export const repoRoot = git('rev-parse', '--show-toplevel');
+
+const portSlot = (): string => readEnvValue(ENV_LOCAL, 'TET_PORT_SLOT') ?? '';
+
+// Les ports décalés d'un worktree (*_PORT) vivent dans son .env.local, que
+// compose ne charge pas de lui-même (seul le .env du projet l'est) : sans eux
+// l'interpolation du docker-compose retomberait sur les ports standard, déjà
+// pris par le tronc.
+const contextEnv = (): NodeJS.ProcessEnv =>
+  isWorktree
+    ? {
+        ...process.env,
+        ...readEnvVars(ENV_LOCAL),
+        COMPOSE_PROJECT_NAME: `tet-wt${portSlot()}`,
+      }
+    : { ...process.env };
+
+const composeArgv = (args: string[]): string[] => [
+  ...DOTENVX.slice(1),
+  'run',
+  '-q',
+  '--env-keys-file=.env.keys',
+  '-f',
+  '.env',
+  '--',
+  DOCKER,
+  'compose',
+  ...(isWorktree
+    ? ['-f', 'docker-compose.yml', '-f', 'docker-compose.worktree.yml']
+    : []),
+  ...args,
+];
+
+interface ComposeOptions {
+  /** Valeur de COMPOSE_PROFILES pour cette commande (sinon : celle du contexte). */
+  profiles?: string[];
+}
+
+/** Lance une commande compose en laissant sa sortie à l'écran ; rend son code. */
+export const compose = (args: string[], opts: ComposeOptions = {}): number => {
+  const { status } = spawnSync(DOTENVX[0], composeArgv(args), {
+    cwd: repoRoot,
+    stdio: 'inherit',
+    env: withProfiles(opts),
+  });
+  return status ?? 1;
+};
+
+/** Idem, mais capture stdout (chaîne vide si la commande échoue). */
+export const composeOut = (
+  args: string[],
+  opts: ComposeOptions = {}
+): string => {
+  const { status, stdout } = spawnSync(DOTENVX[0], composeArgv(args), {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    env: withProfiles(opts),
+  });
+  return status === 0 ? stdout.trim() : '';
+};
+
+/** Lignes non vides de la sortie d'une commande compose. */
+export const composeLines = (
+  args: string[],
+  opts: ComposeOptions = {}
+): string[] => composeOut(args, opts).split('\n').filter(Boolean);
+
+const withProfiles = ({ profiles }: ComposeOptions): NodeJS.ProcessEnv =>
+  profiles
+    ? { ...contextEnv(), COMPOSE_PROFILES: profiles.join(',') }
+    : contextEnv();

--- a/scripts/dev-apps.mts
+++ b/scripts/dev-apps.mts
@@ -66,7 +66,9 @@ const appsOrFail = (names: string[]): string[] => {
   const unknown = names.filter((n) => !APPS[n]);
   if (unknown.length) {
     console.error(
-      `✗ app(s) inconnue(s) : ${unknown.join(', ')} — apps : ${Object.keys(APPS).join(', ')}`
+      `✗ app(s) inconnue(s) : ${unknown.join(', ')} — apps : ${Object.keys(
+        APPS
+      ).join(', ')}`
     );
     process.exit(1);
   }
@@ -115,7 +117,9 @@ const resolveApps = (args: string[]): string[] => {
   const saved = savedProfiles().filter((p) => APPS[p]);
   if (saved.length) return saved;
   if (process.stderr.isTTY) {
-    const picked = spawnSync('node', ['scripts/pick-stack.mts'], {
+    // --ask : on n'arrive ici que faute d'apps dans la sélection mémorisée —
+    // il faut donc bien un choix, pas le rejeu silencieux de pick-stack.
+    const picked = spawnSync('node', ['scripts/pick-stack.mts', '--ask'], {
       stdio: ['inherit', 'pipe', 'inherit'],
       encoding: 'utf8',
     });
@@ -129,14 +133,16 @@ const resolveApps = (args: string[]): string[] => {
     process.exit(1);
   }
   console.error(
-    `✗ pas de TTY et pas de sélection mémorisée — précisez make dev apps=<${Object.keys(APPS).join(',')}…>`
+    `✗ pas de TTY et pas de sélection mémorisée — précisez make dev apps=<${Object.keys(
+      APPS
+    ).join(',')}…>`
   );
   process.exit(1);
 };
 
 // Profils d'infra à démarrer pour ces apps : leurs besoins + les composants
 // d'infra cochés explicitement dans la sélection (ex. studio).
-const infraFor = (apps: string[]): string[] => [
+export const infraFor = (apps: string[]): string[] => [
   ...new Set([
     ...explicitInfra(),
     ...appsOrFail(apps).flatMap((a) => APPS[a].infra),
@@ -183,7 +189,9 @@ const checkPorts = async (apps: string[]): Promise<void> => {
   );
   if (busy.length) {
     console.error(
-      `✗ port(s) déjà occupé(s) : ${busy.join(', ')} — un autre make dev tourne ?`
+      `✗ port(s) déjà occupé(s) : ${busy.join(
+        ', '
+      )} — un autre make dev tourne ?`
     );
     process.exit(1);
   }

--- a/scripts/env-local.mts
+++ b/scripts/env-local.mts
@@ -15,6 +15,25 @@ export const readEnvValue = (file: string, key: string): string | null => {
   return line ? line.slice(key.length + 1).trim() : null;
 };
 
+// Toutes les paires du fichier, quotes de valeur retirées — l'équivalent d'un
+// `set -a; . ./.env.local` côté shell (les ports d'un worktree passés à
+// docker compose, cf. compose.mts). Lignes vides et commentaires ignorés.
+export const readEnvVars = (file: string): Record<string, string> =>
+  Object.fromEntries(
+    readLines(file)
+      .filter(
+        (l) => l.trim() && !l.trimStart().startsWith('#') && l.includes('=')
+      )
+      .map((l) => {
+        const at = l.indexOf('=');
+        const value = l.slice(at + 1).trim();
+        const unquoted = /^(['"]).*\1$/s.test(value)
+          ? value.slice(1, -1)
+          : value;
+        return [l.slice(0, at).trim(), unquoted];
+      })
+  );
+
 export const writeEnvValue = (
   file: string,
   key: string,

--- a/scripts/node-base.mts
+++ b/scripts/node-base.mts
@@ -1,0 +1,160 @@
+// Socle commun des conteneurs d'apps : l'image tet-node-dev construite depuis
+// .docker/apps/base.Dockerfile, dont tous les services d'apps du
+// docker-compose dérivent tels quels.
+//
+// Le build ne dépend QUE du Dockerfile et de l'UID/GID hôte : leur empreinte,
+// posée en label, dit si l'image présente est encore celle qu'on construirait
+// aujourd'hui — sans repasser par `docker build`, qui coûte ~2 s de résolution
+// registre même quand tout est en cache. Une image obsolète ne bloque pas le
+// démarrage : la stack part sur l'existante, la reconstruction se fait en
+// tâche de fond et les conteneurs sont recréés dessus à la fin.
+//
+// Importable (up.mts) et exécutable :
+//   node scripts/node-base.mts <build|swap|rebuild|state>
+import { execFileSync, spawn, spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { openSync, readFileSync } from 'node:fs';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { compose, composeLines, DOCKER, repoRoot } from './compose.mts';
+
+export const IMAGE = 'tet-node-dev';
+
+const DOCKERFILE = '.docker/apps/base.Dockerfile';
+const CONTEXT = '.docker/apps';
+const LABEL = 'tet.fingerprint';
+/** Journal de la reconstruction détachée (gitignoré). */
+export const LOG = '.docker/node-base-build.log';
+
+const id = (key: 'UID' | 'GID'): string =>
+  process.env[key] ??
+  String((key === 'UID' ? process.getuid?.() : process.getgid?.()) ?? 1000);
+
+const fingerprint = (): string => {
+  const sha = createHash('sha1')
+    .update(readFileSync(`${repoRoot}/${DOCKERFILE}`))
+    .digest('hex')
+    .slice(0, 12);
+  return `${sha}-${id('UID')}-${id('GID')}`;
+};
+
+const imageLabel = (): string | null => {
+  const { status, stdout } = spawnSync(
+    DOCKER,
+    [
+      'image',
+      'inspect',
+      IMAGE,
+      '--format',
+      `{{index .Config.Labels "${LABEL}"}}`,
+    ],
+    { encoding: 'utf8' }
+  );
+  return status === 0 ? stdout.trim() : null;
+};
+
+/**
+ * missing : rien avec quoi démarrer (build bloquant) ;
+ * stale : démarrable, mais à reconstruire (en tâche de fond) ;
+ * ok : rien à faire.
+ */
+export type BaseState = 'missing' | 'stale' | 'ok';
+
+export const state = (): BaseState => {
+  const label = imageLabel();
+  if (label === null) return 'missing';
+  return label === fingerprint() ? 'ok' : 'stale';
+};
+
+export const build = (): void => {
+  const { status } = spawnSync(
+    DOCKER,
+    // prettier-ignore
+    ['build', '-t', IMAGE, '-f', DOCKERFILE, '--build-arg', `UID=${id('UID')}`, '--build-arg', `GID=${id('GID')}`, '--label', `${LABEL}=${fingerprint()}`, CONTEXT],
+    { cwd: repoRoot, stdio: 'inherit' }
+  );
+  if (status !== 0) process.exit(status ?? 1);
+};
+
+// Services à recréer : ceux qui tournent sur l'image du socle. `docker inspect
+// .Config.Image` donne la référence DÉCLARÉE du conteneur (« tet-node-dev »),
+// contrairement au champ Image de `compose ps` qui bascule sur le sha dès que
+// le tag a été réattribué — c'est-à-dire précisément après un rebuild.
+const servicesOnBaseImage = (): string[] => {
+  const ids = composeLines([
+    '--profile',
+    '*',
+    'ps',
+    '--status',
+    'running',
+    '-q',
+  ]);
+  if (!ids.length) return [];
+  const rows = execFileSync(
+    DOCKER,
+    // prettier-ignore
+    ['inspect', '--format', `{{.Config.Image}} {{index .Config.Labels "com.docker.compose.service"}}`, ...ids],
+    { encoding: 'utf8' }
+  );
+  return rows
+    .split('\n')
+    .filter((l) => l.startsWith(`${IMAGE} `))
+    .map((l) => l.split(' ')[1]);
+};
+
+/** Reconstruit puis recrée les conteneurs qui tournaient sur l'ancienne image. */
+export const swap = (): void => {
+  build();
+  const services = servicesOnBaseImage();
+  if (!services.length) return;
+  console.error(`🔄 recréation sur le nouveau socle : ${services.join(', ')}`);
+  // --no-deps : seuls ces conteneurs sont recréés, l'infra sous eux ne bouge pas.
+  compose([
+    '--profile',
+    '*',
+    'up',
+    '-d',
+    '--no-deps',
+    '--force-recreate',
+    '--wait',
+    ...services,
+  ]);
+};
+
+/** Détache le swap (apt + toolchain : plusieurs minutes) et rend la main. */
+export const rebuildInBackground = (): void => {
+  const log = openSync(`${repoRoot}/${LOG}`, 'w');
+  const child = spawn(
+    process.execPath,
+    [fileURLToPath(import.meta.url), 'swap'],
+    { cwd: repoRoot, detached: true, stdio: ['ignore', log, log] }
+  );
+  child.unref();
+  console.error(
+    `🛠 socle des apps obsolète — reconstruction en tâche de fond (${LOG}), les apps redémarreront dessus`
+  );
+};
+
+const isMain =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isMain) {
+  switch (process.argv[2]) {
+    case 'build':
+      build();
+      break;
+    case 'swap':
+      swap();
+      break;
+    case 'rebuild':
+      rebuildInBackground();
+      break;
+    case 'state':
+      process.stdout.write(state());
+      break;
+    default:
+      console.error(
+        'usage : node scripts/node-base.mts <build|swap|rebuild|state>'
+      );
+      process.exit(1);
+  }
+}

--- a/scripts/pick-stack.mts
+++ b/scripts/pick-stack.mts
@@ -1,9 +1,12 @@
-// Sélecteur interactif des composants de la stack locale pour `make up`.
+// Sélecteur des composants de la stack locale pour `make up`.
 // Affiche une liste à cocher (services + apps, un profil docker compose par
 // composant), complète automatiquement les dépendances entre profils, persiste
 // la sélection dans .env.local (COMPOSE_PROFILES, convention native compose)
 // et écrit la valeur sur stdout pour que le Makefile la capture ; l'UI passe
-// par stderr. Sans TTY, ressort la dernière sélection sans prompt.
+// par stderr.
+// Le prompt n'apparaît QUE s'il n'y a rien à rejouer (premier démarrage) ou
+// sur `--ask` (`make up ask=1`) : une fois la stack choisie, `make up` doit
+// redémarrer sans rien demander. Sans TTY, jamais de prompt.
 // `--profile <nom>` : applique un profile enregistré (TET_STACK_PROFILES,
 // sauvé par x dans make tui) sans prompt — voie de `make up p="<nom>"`.
 import prompts from 'prompts';
@@ -67,15 +70,17 @@ const withRequirements = (selection: string[]): string[] => {
   return COMPONENTS.map((c) => c.value).filter((v) => result.has(v));
 };
 
-const saved = readSaved() ?? DEFAULT_SELECTION;
+const stored = readSaved();
+const saved = stored ?? DEFAULT_SELECTION;
 
 const profileFlagAt = process.argv.indexOf('--profile');
 const profileArg = profileFlagAt >= 0 ? process.argv[profileFlagAt + 1] : null;
+const wantsPrompt = process.argv.includes('--ask');
 
 let selection: string[] | undefined;
 // Un nouveau choix (profil rejoué ou picker interactif) redéfinit ce qui est
-// « explicite » ; la seule relecture non-interactive de la sélection
-// mémorisée (agents, hors TTY) n'en décide aucun et ne doit pas y toucher.
+// « explicite » ; un simple rejeu de la sélection mémorisée (démarrage sans
+// --ask, ou hors TTY) n'en décide aucun et ne doit pas y toucher.
 let isFreshChoice = true;
 // `profileFlagAt >= 0` (pas `profileArg != null`) : `--profile` en dernière
 // position, sans valeur, doit échouer explicitement plutôt que retomber en
@@ -91,7 +96,9 @@ if (profileFlagAt >= 0) {
     const names = Object.keys(storedProfiles);
     console.error(
       names.length
-        ? `✗ profile inconnu : « ${profileArg} » — profiles enregistrés : ${names.map((n) => `« ${n} »`).join(', ')}`
+        ? `✗ profile inconnu : « ${profileArg} » — profiles enregistrés : ${names
+            .map((n) => `« ${n} »`)
+            .join(', ')}`
         : '✗ aucun profile enregistré — sauvegardez-en un avec x dans make tui'
     );
     process.exit(1);
@@ -108,9 +115,17 @@ if (profileFlagAt >= 0) {
     );
     process.exit(1);
   }
-} else if (!process.stderr.isTTY) {
+} else if (!process.stderr.isTTY || (stored && !wantsPrompt)) {
+  // Rejeu de la sélection mémorisée : aucun choix nouveau n'est fait, donc pas
+  // de réécriture de l'infra « explicite » (cf. saveExplicitInfra plus bas).
   selection = saved;
   isFreshChoice = false;
+  if (stored)
+    console.error(
+      `▸ composants mémorisés : ${saved.join(
+        ', '
+      )} (make up ask=1 pour changer)`
+    );
 } else {
   const { picked } = await prompts(
     {

--- a/scripts/up.mts
+++ b/scripts/up.mts
@@ -1,0 +1,127 @@
+// Démarrage de la stack conteneurisée — le corps de `make up`.
+// Enchaîne, dans l'ordre : sélection des composants (pick-stack.mts), socle des
+// apps, infra, arrêt des composants décochés, `compose up`.
+//
+// Deux contextes, d'où les branchements :
+//  - tronc principal : la stack `tet` complète, infra et apps ensemble ;
+//  - worktree lié : ses apps seules (projet tet-wt<slot>) — l'infra qu'elles
+//    exigent est démarrée dans la stack du tronc, via un make -C là-bas.
+//
+// Options relayées par le Makefile : --profile <nom> (profile enregistré),
+// --ask (rouvrir le sélecteur), --build (reconstruire les images à build
+// local : strapi, sqitch).
+import { spawnSync } from 'node:child_process';
+import {
+  compose,
+  composeLines,
+  isWorktree,
+  mainRoot,
+  repoRoot,
+} from './compose.mts';
+import { APPS, infraFor } from './dev-apps.mts';
+import * as nodeBase from './node-base.mts';
+
+process.chdir(repoRoot);
+
+const args = process.argv.slice(2);
+const wantsBuild = args.includes('--build');
+// --profile <nom> et --ask sont l'affaire du sélecteur : relayés tels quels.
+const pickerArgs = args.filter((a) => a !== '--build');
+
+const fail = (message: string): never => {
+  console.error(message);
+  process.exit(1);
+};
+
+// Cibles du Makefile réutilisées telles quelles (préflight inotify, infra du
+// tronc) : leur logique n'a pas à être dupliquée ici.
+const make = (targets: string[], env: NodeJS.ProcessEnv = {}): void => {
+  const { status } = spawnSync(
+    process.env.MAKE ?? 'make',
+    ['--no-print-directory', ...targets],
+    { stdio: 'inherit', env: { ...process.env, ...env } }
+  );
+  if (status !== 0) process.exit(status ?? 1);
+};
+
+const node = (script: string, scriptArgs: string[] = []): string => {
+  const { status, stdout } = spawnSync(
+    process.execPath,
+    [script, ...scriptArgs],
+    { encoding: 'utf8', stdio: ['inherit', 'pipe', 'inherit'] }
+  );
+  if (status !== 0) process.exit(status ?? 1);
+  return stdout.trim();
+};
+
+// ——— 1. Sélection des composants ———————————————————————————————————————————
+if (isWorktree) node('scripts/worktree-env.mts');
+
+const profiles = node('scripts/pick-stack.mts', pickerArgs).split(',');
+const apps = profiles.filter((p) => APPS[p]);
+if (isWorktree && !apps.length)
+  fail(
+    '✗ aucune app cochée — un worktree ne lance que des apps (make up ask=1)'
+  );
+
+// Profils démarrés ICI : dans un worktree, les apps seules (leur infra tourne
+// dans la stack du tronc) ; sur le tronc, toute la sélection.
+const local = isWorktree ? apps : profiles;
+
+// ——— 2. Socle des apps ————————————————————————————————————————————————————
+// Une image absente bloque (rien avec quoi démarrer) ; obsolète, on démarre
+// dessus et on reconstruit après coup (cf. étape 6).
+let baseState: nodeBase.BaseState = 'ok';
+if (apps.length) {
+  make(['preflight-inotify']);
+  baseState = nodeBase.state();
+  if (baseState === 'missing') {
+    console.error(
+      '🛠 socle des apps absent — construction (plusieurs minutes la 1re fois)'
+    );
+    nodeBase.build();
+  }
+}
+
+// ——— 3. Infra ——————————————————————————————————————————————————————————————
+if (isWorktree)
+  make(['-C', mainRoot, 'services-scoped-up'], {
+    COMPOSE_PROFILES: infraFor(apps).join(','),
+  });
+else make(['heal-db']);
+
+// ——— 4. Arrêt des composants décochés —————————————————————————————————————
+const enabled = composeLines(['config', '--services'], { profiles: local });
+const running = composeLines([
+  '--profile',
+  '*',
+  'ps',
+  '--format',
+  '{{.Service}}',
+]);
+const unselected = running.filter((svc) => !enabled.includes(svc));
+if (unselected.length) {
+  console.error(`⏹ arrêt des composants décochés : ${unselected.join(', ')}`);
+  compose(['--profile', '*', 'stop', ...unselected]);
+}
+
+// ——— 5. Démarrage —————————————————————————————————————————————————————————
+const up = compose(
+  [
+    'up',
+    '-d',
+    ...(wantsBuild ? ['--build'] : []),
+    '--wait',
+    '--remove-orphans',
+  ],
+  { profiles: local }
+);
+if (up !== 0)
+  fail(
+    isWorktree
+      ? "✗ une app n'est pas devenue saine — make logs s=<app> pour investiguer"
+      : "✗ une app n'est pas devenue saine — les services restent en marche ; make logs s=<app> pour investiguer"
+  );
+
+// ——— 6. Socle obsolète : rattrapage en tâche de fond ——————————————————————
+if (baseState === 'stale') nodeBase.rebuildInBackground();


### PR DESCRIPTION
`make up` prenait plusieurs minutes à chaque démarrage et se faisait en 2 temps, alors que la stack
était déjà là. Trois causes, plus un nettoyage.

**`npx -y @dotenvx/dotenvx` → 6 s par appel.** npx réinterroge le registre à
chaque fois ; `up` en enchaîne une demi-douzaine. dotenvx passe en
devDependency et le Makefile prend le binaire local (0,38 s), avec repli sur
npx tant que `node_modules` n'existe pas.

**`cache-clean` en prérequis de `up`.** Purger `.next` coûte un rebuild
Turbopack complet à chaque démarrage. Devient opt-in : `make up clean=1`
(le geste utile après un rebase). `--build` aussi : `make up build=1`.

**Le socle des apps reconstruit à chaque fois.** L'image `tet-node-dev` ne
dépend que de son Dockerfile et de l'UID/GID hôte : un label portant leur
empreinte remplace le `docker build`. Si elle est obsolète, la stack démarre
**quand même** sur l'image existante, la reconstruction part en tâche de fond
(`.docker/node-base-build.log`) et les conteneurs concernés sont recréés
dessus à la fin. Seule une image absente bloque le démarrage.

**Le sélecteur de composants** ne s'ouvre plus qu'au premier démarrage ou sur
`make up ask=1` ; sinon la sélection mémorisée est rejouée.

**Résultat : `make up` à vide passe de plusieurs minutes à ~13 s**, dominées
par `deps` (`pnpm install`) et `libs` (`nx build-deps`) dans les conteneurs,
qui restent voulus.

## Lisibilité

La recette `up` (42 lignes de shell dans le Makefile) part dans
`scripts/up.mts`, en 6 étapes numérotées. Deux modules l'accompagnent :
`compose.mts` (contexte docker compose : dotenvx, projet `tet` vs
`tet-wt<slot>`) et `node-base.mts` (empreinte, build, swap du socle). La macro
`heal_db` devient une vraie cible `heal-db`.

## Changement de comportement

Dans un **worktree** sans app cochée, on rouvrait le sélecteur ; c'est
maintenant une erreur explicite — un worktree ne démarre jamais d'infra
localement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Nouvelles fonctionnalités**
  - `make up` orchestre désormais le démarrage des services avec sélection de profils, nettoyage et reconstruction à la demande.
  - La sélection des composants est mémorisée, modifiable ou rejouable.
  - Le socle Docker commun est vérifié et peut être reconstruit automatiquement en arrière-plan.
  - La prise en charge des worktrees et des environnements locaux est améliorée.
  - Les services peuvent corriger automatiquement leur état de base de données au démarrage.

- **Documentation**
  - Le guide de démarrage décrit les options disponibles, la gestion du cache et la reconstruction des images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->