### PR TITLE
[Batch pcaet depot avis] bypass étape diagnostic

### DIFF
--- a/apps/backend/src/demarches/pcaet/shared/demarche-pcaet-guards.service.ts
+++ b/apps/backend/src/demarches/pcaet/shared/demarche-pcaet-guards.service.ts
@@ -1,6 +1,7 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { DemarcheDocumentsRepository } from '@tet/backend/demarches/shared/demarche-documents.repository';
 import { DemarchePlanActionsRepository } from '@tet/backend/demarches/shared/demarche-plan-actions.repository';
+import ConfigurationService from '@tet/backend/utils/config/configuration.service';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { Transaction } from '@tet/backend/utils/database/transaction.utils';
 import {
@@ -42,6 +43,11 @@ export type DemarchePcaetGuardContext = DemarchePcaetGuardTarget & {
   pilotes: readonly { userId?: string | null }[];
   /** Plans rattachés au programme d'actions de la démarche. */
   planActionIds?: readonly number[];
+  /**
+   * Environnements de démonstration : le dossier se passe d'un diagnostic
+   * complet (cf. DEMARCHE_PCAET_BYPASS_DIAGNOSTIC). Faux partout ailleurs.
+   */
+  isDiagnosticBypassed?: boolean;
   /** Pièces amont requises couvertes, au sens de la règle documentaire. */
   documentsComplets?: boolean;
   /** Diagnostic tel qu'il est en base ; sert aussi aux photos figées. */
@@ -73,7 +79,8 @@ const GUARD_EVALUATORS: Record<DemarchePcaetGuardId, GuardEvaluator> = {
     context.planActionIds === undefined
       ? undefined
       : context.documentsComplets &&
-        isDemarchePcaetDiagnosticComplet(context.diagnosticPayload) &&
+        (context.isDiagnosticBypassed === true ||
+          isDemarchePcaetDiagnosticComplet(context.diagnosticPayload)) &&
         context.planActionIds.length > 0,
 
   // Le délai d'avis n'a de sens qu'une fois la démarche transmise ; son
@@ -96,12 +103,32 @@ const GUARD_EVALUATORS: Record<DemarchePcaetGuardId, GuardEvaluator> = {
  */
 @Injectable()
 export class DemarchePcaetGuardsService {
+  private readonly logger = new Logger(DemarchePcaetGuardsService.name);
+
   constructor(
     private readonly pilotesRepository: DemarchePcaetPilotesRepository,
     private readonly diagnosticService: DemarchePcaetDiagnosticService,
     private readonly documentsRepository: DemarcheDocumentsRepository,
-    private readonly planActionsRepository: DemarchePlanActionsRepository
+    private readonly planActionsRepository: DemarchePlanActionsRepository,
+    private readonly configurationService: ConfigurationService
   ) {}
+
+  /**
+   * Le contournement s'annonce à chaque évaluation plutôt qu'une fois au
+   * démarrage : un dossier transmis sans diagnostic complet doit être
+   * explicable en lisant les logs de la transmission.
+   */
+  private isDiagnosticBypassed(): boolean {
+    const isBypassed =
+      this.configurationService.get('DEMARCHE_PCAET_BYPASS_DIAGNOSTIC') ===
+      true;
+    if (isBypassed) {
+      this.logger.warn(
+        'DEMARCHE_PCAET_BYPASS_DIAGNOSTIC actif : le diagnostic n’est pas exigé pour compléter le dossier PCAET (environnement de démonstration)'
+      );
+    }
+    return isBypassed;
+  }
 
   /**
    * Lit ce dont dépendent les guards du statut courant, et rien de plus : le
@@ -146,6 +173,7 @@ export class DemarchePcaetGuardsService {
       ...demarche,
       pilotes,
       planActionIds,
+      isDiagnosticBypassed: needsDossier ? this.isDiagnosticBypassed() : false,
       diagnosticPayload,
       documentsComplets:
         needsDossier && documentsSnapshot

--- a/apps/backend/src/demarches/pcaet/transmettre-pour-avis/transmettre-pour-avis.router.e2e-spec.ts
+++ b/apps/backend/src/demarches/pcaet/transmettre-pour-avis/transmettre-pour-avis.router.e2e-spec.ts
@@ -8,11 +8,13 @@ import {
   getTestApp,
   getTestDatabase,
 } from '@tet/backend/test';
+import ConfigurationService from '@tet/backend/utils/config/configuration.service';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
 import { CollectiviteRole } from '@tet/domain/users';
 import { listEnabledTransitions } from '@tet/domain/utils';
 import { eq } from 'drizzle-orm';
+import { onTestFinished, vi } from 'vitest';
 import { demarcheStatusHistoryTable } from '@tet/backend/demarches/shared/models/demarche-status-history.table';
 import { demarcheTable } from '@tet/backend/demarches/shared/models/demarche.table';
 import {
@@ -321,6 +323,55 @@ describe('Cycle de vie de la démarche PCAET (transitions)', () => {
       demarcheId: created.id,
     });
 
+    const transmise = await caller.demarches.pcaet.transmettrePourAvis({
+      collectiviteId: collectivite.id,
+      demarcheId: created.id,
+    });
+    expect(transmise.status).toBe('transmis_pour_avis');
+  });
+
+  test('Le contournement de démonstration dispense le dossier de son diagnostic', async () => {
+    const { caller, collectivite } = await freshEditor();
+    const created = await caller.demarches.pcaet.create({
+      collectiviteId: collectivite.id,
+    });
+
+    // Dossier complet sauf le diagnostic : sans contournement, refusé.
+    await coverTestDocumentsPcaet(db, {
+      collectiviteId: collectivite.id,
+      demarcheId: created.id,
+    });
+    await attachTestPlanToDemarchePcaet(db, {
+      collectiviteId: collectivite.id,
+      demarcheId: created.id,
+    });
+    await expect(
+      caller.demarches.pcaet.transmettrePourAvis({
+        collectiviteId: collectivite.id,
+        demarcheId: created.id,
+      })
+    ).rejects.toThrow('DOSSIER_INCOMPLET');
+
+    // Seule cette clé est détournée : le reste de la configuration doit
+    // continuer de répondre, l'application entière la lit.
+    const configurationService = app.get(ConfigurationService);
+    const get = configurationService.get.bind(configurationService);
+    const spy = vi
+      .spyOn(configurationService, 'get')
+      .mockImplementation((key) =>
+        key === 'DEMARCHE_PCAET_BYPASS_DIAGNOSTIC' ? true : get(key)
+      );
+    onTestFinished(() => {
+      spy.mockRestore();
+    });
+
+    const avecBypass = await caller.demarches.pcaet.get({
+      collectiviteId: collectivite.id,
+      demarcheId: created.id,
+    });
+    expect(listEnabledTransitions(avecBypass.transitions)).toContain(
+      'transmettre_pour_avis'
+    );
     const transmise = await caller.demarches.pcaet.transmettrePourAvis({
       collectiviteId: collectivite.id,
       demarcheId: created.id,

--- a/apps/backend/src/utils/config/configuration.model.ts
+++ b/apps/backend/src/utils/config/configuration.model.ts
@@ -151,6 +151,16 @@ export const backendConfigurationSchema = z.object({
     .describe(
       'List of email addresses that are allowed to receive emails sent by the SMTP server'
     ),
+  // Contournement de démonstration : renseigner un diagnostic PCAET entier
+  // (plusieurs centaines de lignes d'indicateurs) n'est pas tenable en COPIL.
+  // Réservé aux environnements de démonstration — laissé à false partout
+  // ailleurs, la règle de complétude du dossier s'applique alors normalement.
+  DEMARCHE_PCAET_BYPASS_DIAGNOSTIC: z
+    .stringbool()
+    .default(false)
+    .describe(
+      'Environnements de démonstration uniquement : dispense le dossier PCAET d’un diagnostic complet pour être transmis pour avis'
+    ),
   DELAY_IN_MIN_BEFORE_NOTIFY_PILOTE: z.coerce
     .number()
     .int()


### PR DESCRIPTION
**Dev temporaire pour la démo:**

Sous DEMARCHE_PCAET_BYPASS_DIAGNOSTIC, le guard dossierComplet n'exige plus le diagnostic — pièces requises et programme d'actions restent obligatoires. À false par défaut, donc sans effet hors environnement de démonstration.

> [!CAUTION]
> À revert quand l'étape de diagnostic sera complètement livré

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Ajout d’une option de configuration permettant, dans les environnements de démonstration, de transmettre un dossier PCAET complet sans diagnostic complet.
  * L’option est désactivée par défaut pour préserver le parcours standard.
  * Un avertissement est affiché lorsque ce contournement est activé.

* **Tests**
  * Ajout de vérifications confirmant le comportement avec et sans l’option de contournement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->