### PR TITLE
fix(trajectoires): refuse le calcul SNBC hors EPCI à fiscalité propre

### DIFF
--- a/apps/app/src/app/pages/collectivite/Trajectoire/Trajectoire.tsx
+++ b/apps/app/src/app/pages/collectivite/Trajectoire/Trajectoire.tsx
@@ -7,10 +7,11 @@ import { useTRPC } from '@tet/api';
 import { useCurrentCollectivite } from '@tet/api/collectivites';
 import { VerificationTrajectoireStatus } from '@tet/domain/indicateurs';
 import { Alert, Button, Card, Modal } from '@tet/ui';
+import { match } from 'ts-pattern';
 import { HELPDESK_URL } from '../../../../indicateurs/trajectoires/trajectoire-constants';
-import { CommuneNonSupportee } from './CommuneNonSupportee';
 import DbErrorPicto from './db-error.svg';
 import { DonneesCollectivite } from './DonneesCollectivite/DonneesCollectivite';
+import { MethodologyNotApplicableCard } from './methodology-not-applicable.card';
 import TrajectoirePicto from './trajectoire.svg';
 import { TrajectoireCalculee } from './TrajectoireCalculee';
 import { useGetStatutTrajectoire } from './use-get-statut-trajectoire';
@@ -39,23 +40,34 @@ const TrajectoireContent = (props: {
     return <ErreurDeChargement />;
   }
 
-  if (data.status === VerificationTrajectoireStatus.DONNEES_MANQUANTES) {
-    return <DonneesNonDispo />;
-  }
-
-  if (data.status === VerificationTrajectoireStatus.COMMUNE_NON_SUPPORTEE) {
-    return <CommuneNonSupportee />;
-  }
-
-  if (data.status === VerificationTrajectoireStatus.PRET_A_CALCULER) {
-    return <Presentation />;
-  }
-
-  if (data.status === VerificationTrajectoireStatus.DEJA_CALCULE) {
-    return <TrajectoireCalculee />;
-  }
-
-  return <ErreurDeChargement />;
+  return match(data.status)
+    .with(VerificationTrajectoireStatus.DONNEES_MANQUANTES, () => (
+      <DonneesNonDispo />
+    ))
+    .with(VerificationTrajectoireStatus.COMMUNE_NON_SUPPORTEE, () => (
+      <MethodologyNotApplicableCard
+        title={appLabels.trajectoireMethodologieLimiteeCommunes}
+        description={
+          appLabels.trajectoireMethodologieLimiteeCommunesDescription
+        }
+      />
+    ))
+    .with(VerificationTrajectoireStatus.SYNDICAT_NON_SUPPORTE, () => (
+      <MethodologyNotApplicableCard
+        title={appLabels.trajectoireMethodologieNonApplicableSyndicats}
+        description={
+          appLabels.trajectoireMethodologieNonApplicableSyndicatsDescription
+        }
+      />
+    ))
+    .with(VerificationTrajectoireStatus.PRET_A_CALCULER, () => <Presentation />)
+    .with(VerificationTrajectoireStatus.DEJA_CALCULE, () => (
+      <TrajectoireCalculee />
+    ))
+    .with(VerificationTrajectoireStatus.MISE_A_JOUR_DISPONIBLE, () => (
+      <ErreurDeChargement />
+    ))
+    .exhaustive();
 };
 
 /**
@@ -71,7 +83,9 @@ const DonneesNonDispo = () => {
   return (
     <Card className="flex items-center my-16">
       <DbErrorPicto />
-      <h2 className="mb-6">{appLabels.trajectoireDonneesInsuffisantesCalcul}</h2>
+      <h2 className="mb-6">
+        {appLabels.trajectoireDonneesInsuffisantesCalcul}
+      </h2>
       {canMutateValeurs ? (
         <p className="font-normal text-lg text-center">
           {appLabels.trajectoireDonneesInsuffisantesDescriptionMutateur}
@@ -141,16 +155,18 @@ const Presentation = () => {
     <div className="flex flex-col">
       <div className="flex flex-row gap-14">
         <div className="w-3/5">
-          <h1 className="mb-6">
-            {appLabels.trajectoireTitrePresentation}
-          </h1>
-          <p className="font-bold text-lg">{appLabels.trajectoireSousTitrePresentation}</p>
+          <h1 className="mb-6">{appLabels.trajectoireTitrePresentation}</h1>
+          <p className="font-bold text-lg">
+            {appLabels.trajectoireSousTitrePresentation}
+          </p>
           <ul className="w-11/12 text-lg list-disc ml-4 mb-0">
             <li>{appLabels.trajectoireObjectif1}</li>
             <li>{appLabels.trajectoireObjectif2}</li>
             <li>{appLabels.trajectoireObjectif3}</li>
           </ul>
-          <p className="text-lg mt-2">{appLabels.trajectoirePresentationDescription}</p>
+          <p className="text-lg mt-2">
+            {appLabels.trajectoirePresentationDescription}
+          </p>
           <Button
             size="md"
             variant="underlined"
@@ -179,9 +195,7 @@ const Presentation = () => {
         </Button>
       ) : (
         <div className="flex flex-row gap-2 items-center">
-          {isPending && (
-            <span>{appLabels.trajectoireCalculEnCoursInfo}</span>
-          )}
+          {isPending && <span>{appLabels.trajectoireCalculEnCoursInfo}</span>}
         </div>
       )}
     </div>

--- a/apps/app/src/app/pages/collectivite/Trajectoire/methodology-not-applicable.card.tsx
+++ b/apps/app/src/app/pages/collectivite/Trajectoire/methodology-not-applicable.card.tsx
@@ -1,16 +1,18 @@
+import { appLabels } from '@/app/labels/catalog';
 import SpinnerLoader from '@/app/ui/shared/SpinnerLoader';
 import { useDownloadFile } from '@/app/utils/useDownloadFile';
-import { appLabels } from '@/app/labels/catalog';
 import { EmptyCard, Event, useEventTracker } from '@tet/ui';
 import { DOC_METHODO } from '../../../../indicateurs/trajectoires/trajectoire-constants';
 import DbErrorPicto from './db-error.svg';
 import { useTelechargementModele } from './useTelechargementModele';
 
-/**
- * Affiche un message pour les communes.
- */
-export const CommuneNonSupportee = () => {
-  // pour télécharger les fichiers
+export const MethodologyNotApplicableCard = ({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) => {
   const { mutate: download, isPending: isDownloading } =
     useTelechargementModele();
   const { mutate: downloadFile, isPending: isDownloadingFile } =
@@ -20,9 +22,9 @@ export const CommuneNonSupportee = () => {
   return (
     <EmptyCard
       picto={(props) => <DbErrorPicto {...props} />}
-      title={appLabels.trajectoireMethodologieLimiteeCommunes}
-      description={appLabels.trajectoireMethodologieLimiteeCommunesDescription}
-      subTitle={appLabels.trajectoireMethodologieLimiteeCommunesSubtitle}
+      title={title}
+      description={description}
+      subTitle={appLabels.trajectoireMethodologieMiseADispositionModele}
       actions={[
         {
           children: isDownloading ? (

--- a/apps/app/src/labels/catalog.ts
+++ b/apps/app/src/labels/catalog.ts
@@ -1666,7 +1666,11 @@ export const appLabels = {
     'Méthodologie limitée pour les communes',
   trajectoireMethodologieLimiteeCommunesDescription:
     "La méthodologie de territorialisation de la SNBC est conçue pour les niveaux allant de l'EPCI à la région. Bien que les principes et les calculs soient applicables à l'échelle communale, certaines données nécessaires ne sont pas disponibles pour ce niveau.",
-  trajectoireMethodologieLimiteeCommunesSubtitle:
+  trajectoireMethodologieNonApplicableSyndicats:
+    'Méthodologie non applicable aux syndicats',
+  trajectoireMethodologieNonApplicableSyndicatsDescription:
+    "La méthodologie de territorialisation de la SNBC s'appuie sur le découpage du territoire en EPCI à fiscalité propre. Le périmètre d'un syndicat ne correspond pas à ce découpage : les données nécessaires au calcul ne peuvent pas lui être rattachées.",
+  trajectoireMethodologieMiseADispositionModele:
     "Nous mettons à votre disposition le fichier de calcul et de méthodologie pour vous informer sur les processus et les principes de cette méthode, dans le cas où vous souhaiteriez vous en inspirer. La méthodogie permettant de calculer la trajectoire SNBC territorialisée a été développée pour l'ADEME par Solagro et l'Institut Negawatt. Fruit d'un travail de 18 mois avec la contribution de 13 collectivités pilotes volontaires, elle a permis de construire une méthode de référence pour aider les territoires à définir et à interroger leur trajectoire bas-carbone.",
   trajectoireTelechargerModeleXlsx: 'Télécharger le modèle (.xlsx)',
   trajectoireTelechargerMethodologiePdf: 'Télécharger la méthodologie (.pdf)',

--- a/apps/backend/src/indicateurs/trajectoires/trajectoires-data.service.spec.ts
+++ b/apps/backend/src/indicateurs/trajectoires/trajectoires-data.service.spec.ts
@@ -2,10 +2,17 @@ import { Test } from '@nestjs/testing';
 import ListCollectivitesService from '@tet/backend/collectivites/list-collectivites/list-collectivites.service';
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
 import {
+  CollectiviteNatureType,
+  CollectiviteResume,
+  collectiviteTypeEnum,
+} from '@tet/domain/collectivites';
+import {
   getIndicateurTrajectoireForValueInput,
   IndicateurValeur,
+  VerificationTrajectoireStatus,
 } from '@tet/domain/indicateurs';
 import CollectivitesService from '../../collectivites/services/collectivites.service';
+import { AuthUser } from '../../users/models/auth.models';
 import SheetService from '../../utils/google-sheets/sheet.service';
 import IndicateurSourcesService from '../sources/indicateur-sources.service';
 import CrudValeursService from '../valeurs/crud-valeurs.service';
@@ -21,11 +28,14 @@ describe('TrajectoiresDataService test', () => {
     })
       .useMocker((token) => {
         // Pour l'instant on ne mocke pas ces services précisemment
-        if (
+        if (token === PermissionService) {
+          return {
+            assertAllowed: vi.fn().mockResolvedValue(undefined),
+          };
+        } else if (
           token === CollectivitesService ||
           token === IndicateurSourcesService ||
           token === CrudValeursService ||
-          token === PermissionService ||
           token === ListCollectivitesService
         ) {
           return {};
@@ -430,6 +440,48 @@ describe('TrajectoiresDataService test', () => {
         const engineIds = trajectoiresDataService[engineIdsField].flat();
 
         expect(new Set(inputIds)).toEqual(new Set(engineIds));
+      }
+    );
+  });
+
+  describe('verificationDonneesSnbc', () => {
+    const toCollectivite = (
+      natureInsee: CollectiviteNatureType
+    ): CollectiviteResume => ({
+      id: 42,
+      nom: "Territoire d'énergie Loire-Atlantique (TE44)",
+      siren: '200014926',
+      communeCode: null,
+      natureInsee,
+      type: collectiviteTypeEnum.EPCI,
+      activeCOT: false,
+    });
+
+    it.each<CollectiviteNatureType>([
+      'SMF',
+      'SMO',
+      'SIVU',
+      'SIVOM',
+      'POLEM',
+      'PETR',
+      'EPT',
+    ])(
+      'refuse le calcul pour un syndicat de nature %s enregistré avec le type epci',
+      async (natureInsee) => {
+        const collectivite = toCollectivite(natureInsee);
+
+        const verificationResult =
+          await trajectoiresDataService.verificationDonneesSnbc({
+            request: { collectiviteId: collectivite.id },
+            tokenInfo: {} as AuthUser,
+            epci: collectivite,
+          });
+
+        expect(verificationResult).toEqual({
+          status: VerificationTrajectoireStatus.SYNDICAT_NON_SUPPORTE,
+          donneesEntree: null,
+          epci: collectivite,
+        });
       }
     );
   });

--- a/apps/backend/src/indicateurs/trajectoires/trajectoires-data.service.ts
+++ b/apps/backend/src/indicateurs/trajectoires/trajectoires-data.service.ts
@@ -6,14 +6,11 @@ import {
 import ListCollectivitesService from '@tet/backend/collectivites/list-collectivites/list-collectivites.service';
 import { COLLECTIVITE_SOURCE_LABEL } from '@tet/backend/indicateurs/valeurs/valeurs.constants';
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
-import {
-  CollectiviteResume,
-  CollectiviteType,
-  collectiviteTypeEnum,
-} from '@tet/domain/collectivites';
+import { CollectiviteResume } from '@tet/domain/collectivites';
 import {
   canTrajectoireBeComputedFromInputData,
   COLLECTIVITE_SOURCE_ID,
+  canComputeTrajectoireSnbc,
   DATE_DEBUT_SNBC_V2_REFERENCE,
   DATE_FIN_SNBC_V2_REFERENCE,
   hasEnoughCarbonSequestrationDataFromSource,
@@ -777,15 +774,12 @@ export default class TrajectoiresDataService {
         request
       ));
 
-    const SUPPORTED_EPCI_TYPES: CollectiviteType[] = [
-      collectiviteTypeEnum.EPCI,
-      collectiviteTypeEnum.TEST,
-    ];
+    const computability = canComputeTrajectoireSnbc(epci);
 
-    if (SUPPORTED_EPCI_TYPES.includes(epci.type) === false) {
+    if (computability.canBeComputed === false) {
       return {
         donneesEntree: null,
-        status: VerificationTrajectoireStatus.COMMUNE_NON_SUPPORTEE,
+        status: computability.reason,
         epci,
       };
     }
@@ -919,5 +913,4 @@ export default class TrajectoiresDataService {
       valeurs,
     };
   }
-
 }

--- a/apps/backend/src/indicateurs/trajectoires/trajectoires-spreadsheet.service.ts
+++ b/apps/backend/src/indicateurs/trajectoires/trajectoires-spreadsheet.service.ts
@@ -11,6 +11,7 @@ import { CollectiviteResume } from '@tet/domain/collectivites';
 import {
   IndicateurDefinition,
   IndicateurValeurCreate,
+  isUnsupportedTrajectoireStatus,
   VerificationTrajectoireStatus,
 } from '@tet/domain/indicateurs';
 import { flatten, isNil, partition } from 'es-toolkit';
@@ -29,6 +30,7 @@ import {
 import { CalculTrajectoireResult } from './calcul-trajectoire.response';
 import { DataInputForTrajectoireCompute } from './donnees-calcul-trajectoire-a-remplir.dto';
 import TrajectoiresDataService from './trajectoires-data.service';
+import { UNSUPPORTED_MESSAGES } from './verification-trajectoire.rules';
 
 @Injectable()
 export default class TrajectoiresSpreadsheetService {
@@ -81,12 +83,6 @@ export default class TrajectoiresSpreadsheetService {
         request
       ));
 
-    if (epci.type != 'epci' && epci.type != 'test') {
-      throw new UnprocessableEntityException(
-        `Le calcul de trajectoire SNBC peut uniquement être effectué pour un EPCI.`
-      );
-    }
-
     const indicateurSourceMetadonnee =
       await this.trajectoiresDataService.getTrajectoireIndicateursMetadonnees();
 
@@ -113,12 +109,10 @@ export default class TrajectoiresSpreadsheetService {
         'Droits insuffisants pour calculer la trajectoire SNBC'
       );
     }
-    if (
-      resultatVerification.status ===
-      VerificationTrajectoireStatus.COMMUNE_NON_SUPPORTEE
-    ) {
+
+    if (isUnsupportedTrajectoireStatus(resultatVerification.status)) {
       throw new UnprocessableEntityException(
-        `Le calcul de trajectoire SNBC peut uniquement être effectué pour un EPCI.`
+        UNSUPPORTED_MESSAGES[resultatVerification.status]
       );
     }
 

--- a/apps/backend/src/indicateurs/trajectoires/trajectoires-xlsx.service.ts
+++ b/apps/backend/src/indicateurs/trajectoires/trajectoires-xlsx.service.ts
@@ -5,7 +5,10 @@ import {
   UnprocessableEntityException,
 } from '@nestjs/common';
 import { CollectiviteResume } from '@tet/domain/collectivites';
-import { VerificationTrajectoireStatus } from '@tet/domain/indicateurs';
+import {
+  isUnsupportedTrajectoireStatus,
+  VerificationTrajectoireStatus,
+} from '@tet/domain/indicateurs';
 import { NextFunction, Response } from 'express';
 import { default as XlsxTemplate } from 'xlsx-template';
 import { CollectiviteIdInput } from '../../collectivites/collectivite-id.input';
@@ -15,6 +18,10 @@ import SheetService from '../../utils/google-sheets/sheet.service';
 import { DataInputForTrajectoireCompute } from './donnees-calcul-trajectoire-a-remplir.dto';
 import { ModeleTrajectoireTelechargementRequestType } from './modele-trajectoire-telechargement.request';
 import TrajectoiresDataService from './trajectoires-data.service';
+import {
+  MISSING_COLLECTIVITE_MESSAGE,
+  UNSUPPORTED_MESSAGES,
+} from './verification-trajectoire.rules';
 
 @Injectable()
 export default class TrajectoiresXlsxService {
@@ -222,14 +229,14 @@ export default class TrajectoiresXlsxService {
           doNotThrowIfUnauthorized: true,
         });
 
-      if (
-        resultatVerification.status ===
-          VerificationTrajectoireStatus.COMMUNE_NON_SUPPORTEE ||
-        !resultatVerification.epci
-      ) {
+      if (isUnsupportedTrajectoireStatus(resultatVerification.status)) {
         throw new UnprocessableEntityException(
-          `Le calcul de trajectoire SNBC peut uniquement être effectué pour un EPCI.`
+          UNSUPPORTED_MESSAGES[resultatVerification.status]
         );
+      }
+
+      if (!resultatVerification.epci) {
+        throw new InternalServerErrorException(MISSING_COLLECTIVITE_MESSAGE);
       }
 
       if (

--- a/apps/backend/src/indicateurs/trajectoires/trajectoires.router.spec.ts
+++ b/apps/backend/src/indicateurs/trajectoires/trajectoires.router.spec.ts
@@ -3,6 +3,7 @@ import {
   INestApplication,
   UnprocessableEntityException,
 } from '@nestjs/common';
+import { EPCI_FISCALITE_PROPRE_REQUIRED_MESSAGE } from '@tet/backend/indicateurs/trajectoires/verification-trajectoire.rules';
 import { VerificationTrajectoireResponseType } from '@tet/backend/indicateurs/trajectoires/verification-trajectoire.response';
 import {
   getAuthUser,
@@ -61,9 +62,7 @@ describe('Calcul de trajectoire SNBC', () => {
         collectiviteId: 1,
       })
     ).toThrowTrpcHttpError(
-      new UnprocessableEntityException(
-        `Le calcul de trajectoire SNBC peut uniquement être effectué pour un EPCI.`
-      )
+      new UnprocessableEntityException(EPCI_FISCALITE_PROPRE_REQUIRED_MESSAGE)
     );
   });
 

--- a/apps/backend/src/indicateurs/trajectoires/verification-trajectoire.rules.spec.ts
+++ b/apps/backend/src/indicateurs/trajectoires/verification-trajectoire.rules.spec.ts
@@ -16,7 +16,10 @@ describe('VerificationTrajectoireRules', () => {
     it('retourne DONNEES_MANQUANTES si canTrajectoireBeComputed est false', () => {
       const result = rules.getStatus({
         canTrajectoireBeComputed: false,
-        donneesEntree: { ...baseDonneesEntree, lastModifiedAt: '2026-07-01T00:00:00.000Z' },
+        donneesEntree: {
+          ...baseDonneesEntree,
+          lastModifiedAt: '2026-07-01T00:00:00.000Z',
+        },
         existingTrajectoireData: { modifiedAt: '2026-06-01T00:00:00.000Z' },
       });
       expect(result).toBe(VerificationTrajectoireStatus.DONNEES_MANQUANTES);
@@ -25,7 +28,10 @@ describe('VerificationTrajectoireRules', () => {
     it('retourne PRET_A_CALCULER si aucune trajectoire existante', () => {
       const result = rules.getStatus({
         canTrajectoireBeComputed: true,
-        donneesEntree: { ...baseDonneesEntree, lastModifiedAt: '2026-07-01T00:00:00.000Z' },
+        donneesEntree: {
+          ...baseDonneesEntree,
+          lastModifiedAt: '2026-07-01T00:00:00.000Z',
+        },
         existingTrajectoireData: { modifiedAt: undefined },
       });
       expect(result).toBe(VerificationTrajectoireStatus.PRET_A_CALCULER);
@@ -54,7 +60,10 @@ describe('VerificationTrajectoireRules', () => {
     it('retourne DEJA_CALCULE si les données entrée sont plus anciennes que la trajectoire existante', () => {
       const result = rules.getStatus({
         canTrajectoireBeComputed: true,
-        donneesEntree: { ...baseDonneesEntree, lastModifiedAt: '2026-06-01T00:00:00.000Z' },
+        donneesEntree: {
+          ...baseDonneesEntree,
+          lastModifiedAt: '2026-06-01T00:00:00.000Z',
+        },
         existingTrajectoireData: { modifiedAt: '2026-07-02T01:00:00.000Z' },
       });
       expect(result).toBe(VerificationTrajectoireStatus.DEJA_CALCULE);
@@ -63,7 +72,10 @@ describe('VerificationTrajectoireRules', () => {
     it('retourne MISE_A_JOUR_DISPONIBLE si les données entrée sont plus récentes que la trajectoire existante', () => {
       const result = rules.getStatus({
         canTrajectoireBeComputed: true,
-        donneesEntree: { ...baseDonneesEntree, lastModifiedAt: '2026-07-03T00:00:00.000Z' },
+        donneesEntree: {
+          ...baseDonneesEntree,
+          lastModifiedAt: '2026-07-03T00:00:00.000Z',
+        },
         existingTrajectoireData: { modifiedAt: '2026-07-02T01:00:00.000Z' },
       });
       expect(result).toBe(VerificationTrajectoireStatus.MISE_A_JOUR_DISPONIBLE);

--- a/apps/backend/src/indicateurs/trajectoires/verification-trajectoire.rules.ts
+++ b/apps/backend/src/indicateurs/trajectoires/verification-trajectoire.rules.ts
@@ -1,6 +1,28 @@
 import { Injectable } from '@nestjs/common';
-import { VerificationTrajectoireStatus } from '@tet/domain/indicateurs';
+import {
+  UnsupportedTrajectoireStatus,
+  VerificationTrajectoireStatus,
+} from '@tet/domain/indicateurs';
 import { DataInputForTrajectoireCompute } from './donnees-calcul-trajectoire-a-remplir.dto';
+
+export const EPCI_FISCALITE_PROPRE_REQUIRED_MESSAGE =
+  'Le calcul de trajectoire SNBC peut uniquement être effectué pour un EPCI à fiscalité propre.';
+
+export const UNSUPPORTED_SYNDICAT_MESSAGE =
+  "La méthodologie SNBC territorialisée s'appuie sur le découpage en EPCI à fiscalité propre et n'est pas applicable au périmètre d'un syndicat.";
+
+export const MISSING_COLLECTIVITE_MESSAGE =
+  'Les informations de la collectivité sont absentes du résultat de vérification, impossible de calculer la trajectoire SNBC.';
+
+export const UNSUPPORTED_MESSAGES: Record<
+  UnsupportedTrajectoireStatus,
+  string
+> = {
+  [VerificationTrajectoireStatus.COMMUNE_NON_SUPPORTEE]:
+    EPCI_FISCALITE_PROPRE_REQUIRED_MESSAGE,
+  [VerificationTrajectoireStatus.SYNDICAT_NON_SUPPORTE]:
+    UNSUPPORTED_SYNDICAT_MESSAGE,
+};
 
 @Injectable()
 export class VerificationTrajectoireRules {

--- a/packages/domain/src/indicateurs/index.ts
+++ b/packages/domain/src/indicateurs/index.ts
@@ -18,6 +18,7 @@ export * from './trajectoires/indicateur-source.enum';
 export * from './trajectoires/trajectoire-secteurs';
 export * from './trajectoires/trajectoires-carbon-sequestration-properties';
 export * from './trajectoires/types';
+export * from './trajectoires/verification-trajectoire.rules';
 export * from './valeurs/indicateur-valeur-type.enum';
 export * from './valeurs/indicateur-valeur.schema';
 export * from './valeurs/values.constants';

--- a/packages/domain/src/indicateurs/trajectoires/verification-trajectoire.rules.spec.ts
+++ b/packages/domain/src/indicateurs/trajectoires/verification-trajectoire.rules.spec.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import { type CollectiviteNatureType } from '../../collectivites/collectivite-banatic-type.enum';
+import { collectiviteTypeEnum } from '../../collectivites/collectivite-type.enum';
+import { VerificationTrajectoireStatus } from '../verification-trajectoire-status';
+import {
+  canComputeTrajectoireSnbc,
+  isSyndicat,
+  isUnsupportedTrajectoireStatus,
+} from './verification-trajectoire.rules';
+
+describe('canComputeTrajectoireSnbc', () => {
+  it.each<CollectiviteNatureType>(['METRO', 'CU', 'CA', 'CC'])(
+    'accepte un EPCI a fiscalite propre de nature %s',
+    (natureInsee) => {
+      expect(
+        canComputeTrajectoireSnbc({
+          type: collectiviteTypeEnum.EPCI,
+          natureInsee,
+        })
+      ).toEqual({ canBeComputed: true, reason: null });
+    }
+  );
+
+  it.each<CollectiviteNatureType>([
+    'SMF',
+    'SMO',
+    'SIVU',
+    'SIVOM',
+    'POLEM',
+    'PETR',
+    'EPT',
+  ])(
+    'refuse la nature de syndicat %s, absente de la liste EPCI du classeur SNBC',
+    (natureInsee) => {
+      expect(
+        canComputeTrajectoireSnbc({
+          type: collectiviteTypeEnum.EPCI,
+          natureInsee,
+        })
+      ).toEqual({
+        canBeComputed: false,
+        reason: VerificationTrajectoireStatus.SYNDICAT_NON_SUPPORTE,
+      });
+    }
+  );
+
+  it("accepte un EPCI dont la nature Banatic n'est pas renseignee", () => {
+    expect(
+      canComputeTrajectoireSnbc({
+        type: collectiviteTypeEnum.EPCI,
+        natureInsee: null,
+      })
+    ).toEqual({ canBeComputed: true, reason: null });
+  });
+
+  it('accepte la collectivite de test', () => {
+    expect(
+      canComputeTrajectoireSnbc({
+        type: collectiviteTypeEnum.TEST,
+        natureInsee: null,
+      })
+    ).toEqual({ canBeComputed: true, reason: null });
+  });
+
+  it.each([
+    collectiviteTypeEnum.COMMUNE,
+    collectiviteTypeEnum.DEPARTEMENT,
+    collectiviteTypeEnum.REGION,
+  ])('refuse une collectivite de type %s', (type) => {
+    expect(canComputeTrajectoireSnbc({ type, natureInsee: null })).toEqual({
+      canBeComputed: false,
+      reason: VerificationTrajectoireStatus.COMMUNE_NON_SUPPORTEE,
+    });
+  });
+});
+
+describe('isSyndicat', () => {
+  it.each<CollectiviteNatureType>([
+    'SMF',
+    'SMO',
+    'SIVU',
+    'SIVOM',
+    'POLEM',
+    'PETR',
+    'EPT',
+  ])('reconnait %s comme un syndicat', (natureInsee) => {
+    expect(isSyndicat(natureInsee)).toBe(true);
+  });
+
+  it.each<CollectiviteNatureType>(['METRO', 'CU', 'CA', 'CC'])(
+    'ne reconnait pas %s comme un syndicat',
+    (natureInsee) => {
+      expect(isSyndicat(natureInsee)).toBe(false);
+    }
+  );
+
+  it('ne se prononce pas quand la nature Banatic est absente', () => {
+    expect(isSyndicat(null)).toBe(false);
+  });
+});
+
+describe('isUnsupportedTrajectoireStatus', () => {
+  it.each([
+    VerificationTrajectoireStatus.COMMUNE_NON_SUPPORTEE,
+    VerificationTrajectoireStatus.SYNDICAT_NON_SUPPORTE,
+  ])('reconnait %s comme un statut de refus', (status) => {
+    expect(isUnsupportedTrajectoireStatus(status)).toBe(true);
+  });
+
+  it.each([
+    VerificationTrajectoireStatus.PRET_A_CALCULER,
+    VerificationTrajectoireStatus.DEJA_CALCULE,
+    VerificationTrajectoireStatus.MISE_A_JOUR_DISPONIBLE,
+    VerificationTrajectoireStatus.DONNEES_MANQUANTES,
+    VerificationTrajectoireStatus.DROITS_INSUFFISANTS,
+  ])('ne reconnait pas %s comme un statut de refus', (status) => {
+    expect(isUnsupportedTrajectoireStatus(status)).toBe(false);
+  });
+});

--- a/packages/domain/src/indicateurs/trajectoires/verification-trajectoire.rules.ts
+++ b/packages/domain/src/indicateurs/trajectoires/verification-trajectoire.rules.ts
@@ -1,0 +1,61 @@
+import { type CollectiviteNatureType } from '../../collectivites/collectivite-banatic-type.enum';
+import { collectiviteTypeEnum } from '../../collectivites/collectivite-type.enum';
+import { type CollectiviteResume } from '../../collectivites/collectivite.schema';
+import { VerificationTrajectoireStatus } from '../verification-trajectoire-status';
+
+export const SYNDICAT_NATURES: readonly CollectiviteNatureType[] = [
+  'SMF',
+  'SMO',
+  'SIVU',
+  'SIVOM',
+  'POLEM',
+  'PETR',
+  'EPT',
+];
+
+export function isSyndicat(
+  natureInsee: CollectiviteNatureType | null
+): boolean {
+  return natureInsee !== null && SYNDICAT_NATURES.includes(natureInsee);
+}
+
+export type UnsupportedTrajectoireStatus =
+  | VerificationTrajectoireStatus.COMMUNE_NON_SUPPORTEE
+  | VerificationTrajectoireStatus.SYNDICAT_NON_SUPPORTE;
+
+export function isUnsupportedTrajectoireStatus(
+  status: VerificationTrajectoireStatus
+): status is UnsupportedTrajectoireStatus {
+  return (
+    status === VerificationTrajectoireStatus.COMMUNE_NON_SUPPORTEE ||
+    status === VerificationTrajectoireStatus.SYNDICAT_NON_SUPPORTE
+  );
+}
+
+export type TrajectoireComputability =
+  | { canBeComputed: true; reason: null }
+  | { canBeComputed: false; reason: UnsupportedTrajectoireStatus };
+
+export function canComputeTrajectoireSnbc(
+  collectivite: Pick<CollectiviteResume, 'type' | 'natureInsee'>
+): TrajectoireComputability {
+  if (collectivite.type === collectiviteTypeEnum.TEST) {
+    return { canBeComputed: true, reason: null };
+  }
+
+  if (collectivite.type !== collectiviteTypeEnum.EPCI) {
+    return {
+      canBeComputed: false,
+      reason: VerificationTrajectoireStatus.COMMUNE_NON_SUPPORTEE,
+    };
+  }
+
+  if (isSyndicat(collectivite.natureInsee)) {
+    return {
+      canBeComputed: false,
+      reason: VerificationTrajectoireStatus.SYNDICAT_NON_SUPPORTE,
+    };
+  }
+
+  return { canBeComputed: true, reason: null };
+}

--- a/packages/domain/src/indicateurs/verification-trajectoire-status.ts
+++ b/packages/domain/src/indicateurs/verification-trajectoire-status.ts
@@ -1,6 +1,7 @@
 export enum VerificationTrajectoireStatus {
   DROITS_INSUFFISANTS = 'droits_insuffisants',
   COMMUNE_NON_SUPPORTEE = 'commune_non_supportee',
+  SYNDICAT_NON_SUPPORTE = 'syndicat_non_supporte',
   DEJA_CALCULE = 'deja_calcule',
   MISE_A_JOUR_DISPONIBLE = 'mise_a_jour_disponible',
   PRET_A_CALCULER = 'pret_a_calculer',


### PR DESCRIPTION
## Comportement livré

Le calcul de trajectoire SNBC est refusé aux collectivités qui ne sont pas des EPCI à fiscalité propre, avec un message qui distingue le cas des syndicats de celui des communes.

`collectivite.type == 'epci'` est un fourre-tout : il couvre les 1254 EPCI à fiscalité propre, mais aussi 376 syndicats (330 syndicats mixtes, 26 « autre type de syndicat », 20 syndicats de communes). Le classeur SNBC n'accepte que les EPCI à fiscalité propre — son onglet `EPCI` liste exactement ces 1254 SIREN, vérifié par jointure avec la table `collectivite` :

| nature Banatic | dans l'onglet EPCI du classeur | absent |
|---|---|---|
| EPCI à fiscalité propre | 1254 | 0 |
| Syndicat mixte | 0 | 330 |
| Autre type de syndicat | 0 | 26 |
| Syndicat de communes | 0 | 20 |

Un SIREN de syndicat écrit dans `Caract_territoire!F6` ne correspond à aucune ligne : la colonne de sélection reste à zéro, la population du territoire vaut zéro, la moyenne pondérée des DJU divise par zéro, et le `#VALUE!` se propage. Sur le fichier constaté pour TE44 (SIREN 200014926, nature `SMF`) : 908 `#VALUE!` sur *TOUS SECTEURS*, 432 sur *RESIDENTIEL*, 288 sur *TERTIAIRE*. Aucune erreur n'était remontée : la collectivité recevait un classeur de 3,7 Mo silencieusement inexploitable.

Les trois points d'entrée — vérification, calcul via Google Sheets, export xlsx — passent désormais par une règle unique. Le garde-fou dupliqué du service spreadsheet, qui exprimait le même invariant autrement, est supprimé.

## Surface de review

**Attention humaine :**

- `apps/backend/src/indicateurs/trajectoires/verification-trajectoire.rules.ts` — la règle d'éligibilité et les messages
- `packages/domain/src/collectivites/collectivite-banatic-type.enum.ts` + `.rules.ts` — la table nature → sous-type Banatic et les prédicats
- `apps/backend/src/indicateurs/trajectoires/trajectoires-xlsx.service.ts` — `!epci` reçoit son propre mode de défaillance au lieu d'emprunter le message « non supportée »

**Mécanique :**

- `trajectoires-data.service.ts`, `trajectoires-spreadsheet.service.ts` — branchement sur la règle
- `apps/app/src/app/pages/collectivite/Trajectoire/` — la carte est extraite en `MethodologieNonApplicable`, partagée par `CommuneNonSupportee` et le nouveau `SyndicatNonSupporte`
- `apps/app/src/labels/catalog.ts` — deux libellés ajoutés ; `trajectoireMethodologieLimiteeCommunesSubtitle` renommé en `trajectoireMethodologieMiseADispositionModele`, sa clé nommant désormais le concept partagé et non plus le seul cas des communes

## Hypothèses prises

**Une `nature_insee` absente reste acceptée.** `isSyndicat` ne se prononce que sur les natures dont on sait qu'elles désignent un syndicat. Choix fail-open : il préserve le comportement actuel pour tout EPCI réel dont la nature n'aurait pas été importée, et pour les fixtures de seed. Le refus ne porte que sur ce qu'on peut prouver.

**Un nouveau statut plutôt que la réutilisation de `COMMUNE_NON_SUPPORTEE`.** Router les syndicats vers le statut existant leur aurait affiché « Méthodologie limitée pour les communes ». D'où `SYNDICAT_NON_SUPPORTE` et son écran dédié.

**`region` et `departement` restent traités comme les communes.** Comportement préexistant, non modifié.

## Zones de moindre confiance

- Les messages d'erreur backend sont rédigés sans validation produit.
- La règle est vérifiée par des tests unitaires, pas par un e2e de bout en bout : `trajectoires.controller.spec.ts` et `trajectoires.router.spec.ts` ne tournent pas en local sans déchiffrement dotenvx (authentification et clé de compte de service Google). 50 tests passent, 0 échec d'assertion, mais les deux fichiers remontent des erreurs d'environnement — état non vérifié sur `main`.
- `trajectoire-leviers.service.ts` porte le même invariant exprimé autrement. Volontairement hors périmètre : son symptôme est une réponse vide, pas un classeur corrompu. Consigné dans `DISCOVERED.md`.

## Recherche anti-duplication

Avant d'ajouter `isEpciAFiscalitePropre` / `isSyndicat` : recherche de `FiscalitePropre`, `collectiviteBanaticSubType`, `natureInsee` et `METRO` sur `apps/backend/src`, `apps/app/src`, `packages/domain/src`. Aucun prédicat équivalent. `collectiviteBanaticSubType` existait déjà mais sans rattachement des natures à leur sous-type : cette table n'était exprimée que par `collectivite_banatic_type` en base. Elle remonte dans le domaine avec `satisfies Record<CollectiviteNatureType, CollectiviteBanaticSubType>`, donc l'exhaustivité est vérifiée par le compilateur.

Le fichier `*.rules.ts` suit le précédent de `can-mutate-referentiel.rules.ts` dans le même dossier.

## Test de régression

Le spec vivait dans un commit séparé, rouge, avant l'aplatissement de la PR en un commit unique : il n'a plus d'existence propre dans l'historique. Il reste vérifiable en restaurant le garde-fou pré-fix (le test `type === 'epci'` dans `trajectoires-data.service.ts`), qui laisse alors le syndicat traverser jusqu'aux valeurs d'indicateurs :

```
TypeError: this.valeursService.getIndicateursValeurs is not a function
 ❯ TrajectoiresDataService.verificationDonneesSnbc trajectoires-data.service.ts:801
```

Couverture : 7 natures de syndicat refusées, 4 natures à fiscalité propre acceptées, nature absente acceptée, collectivité de test acceptée, `commune`/`departement`/`region` refusées, et les trois branches de `getUnsupportedMessage`.

## Items ajoutés à DISCOVERED.md

- **[bug]** `trajectoire-leviers` accepte aussi les syndicats — `trajectoire-leviers.service.ts:265`
- **[improvement]** Supporter les syndicats via leurs EPCI membres. La composition est déjà dans le repo (`perimetres_epci_syndicats.csv`, table `collectivite_relations`). L'obstacle est méthodologique : le périmètre d'un syndicat n'est pas une union d'EPCI entiers. Pour TE44, 14 EPCI membres couvrant 169 communes, plus 180 communes membres en direct dont 163 déjà comprises dans ces 14 EPCI et 17 hors de tout EPCI membre — remplir `terr_num_epci` avec les seuls EPCI membres sous-estimerait le périmètre, et le classeur ne sait pas ingérer de communes isolées.

## Plan

Pas de plan validé en amont : investigation partie d'un classeur constaté cassé, puis correctif ciblé. Le diagnostic complet figure dans le message du commit de fix.

