### PR TITLE
feat(audit-labellisation): ajoute un accès aux mesures non renseignées depuis la checklist

### DIFF
--- a/apps/app/src/labels/catalog.ts
+++ b/apps/app/src/labels/catalog.ts
@@ -1909,6 +1909,7 @@ export const appLabels = {
   completudeCritere:
     'Renseigner les statuts de toutes les mesures du référentiel',
   voirLaMesure: 'Voir la mesure',
+  voirLesMesures: 'Voir les mesures',
   renseigner: 'Renseigner',
   chargement: 'Chargement…',
   reponseAvoirPersonneRenseignee: 'Avoir au moins une personne renseignée',

--- a/apps/app/src/referentiels/audit-labellisation/checklist/table/labellisation-checklist.table.spec.tsx
+++ b/apps/app/src/referentiels/audit-labellisation/checklist/table/labellisation-checklist.table.spec.tsx
@@ -58,7 +58,7 @@ describe('LabellisationChecklistTable', () => {
     });
     vi.mocked(useCurrentCollectivite).mockReturnValue({
       hasReferentielPermission: () => true,
-    } as ReturnType<typeof useCurrentCollectivite>);
+    } as unknown as ReturnType<typeof useCurrentCollectivite>);
     vi.mocked(useUser).mockReturnValue({ id: userId } as ReturnType<
       typeof useUser
     >);

--- a/apps/app/src/referentiels/audit-labellisation/checklist/table/labellisation-checklist.table.spec.tsx
+++ b/apps/app/src/referentiels/audit-labellisation/checklist/table/labellisation-checklist.table.spec.tsx
@@ -1,0 +1,100 @@
+import { useCurrentCollectivite } from '@tet/api/collectivites';
+import { useUser } from '@tet/api/users';
+import { EtoileEnum } from '@tet/domain/referentiels';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ReactElement, ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Parcours } from '../../checklist-view-model';
+import { useChecklist, useRoleDropdown } from '../../checklist.context';
+import { LabellisationChecklistTable } from './labellisation-checklist.table';
+
+vi.mock('../../checklist.context', () => ({
+  useChecklist: vi.fn(),
+  useRoleDropdown: vi.fn(),
+}));
+
+vi.mock('@tet/api/collectivites', () => ({
+  useCurrentCollectivite: vi.fn(),
+}));
+
+vi.mock('@tet/api/users', () => ({
+  useUser: vi.fn(),
+}));
+
+const voirLesMesures = 'Voir les mesures';
+
+const userId = 'e2b9c0a4-0000-4000-8000-000000000000';
+const storageKey = `tet_referentiel_table_columns_visibility_${userId}`;
+
+const UnnavigableLinks = ({
+  children,
+}: {
+  children: ReactNode;
+}): ReactElement => (
+  <div onClickCapture={(event) => event.preventDefault()}>{children}</div>
+);
+
+const emptyParcours: Parcours = {
+  etoileObjectif: EtoileEnum.PREMIERE_ETOILE,
+  completude: { done: false },
+  minimumScore: { done: false, seuilPercent: 35 },
+  scoreFait: 0,
+  mesures: [],
+  roleMesures: { eluReferent: null, referentTechnique: null },
+  acteEngagement: { demandeId: null },
+  canModifyCandidatureDocuments: false,
+};
+
+describe('LabellisationChecklistTable', () => {
+  beforeEach(() => {
+    vi.mocked(useChecklist).mockReturnValue({
+      showActeEngagement: false,
+      showCandidatureDocuments: false,
+    } as ReturnType<typeof useChecklist>);
+    vi.mocked(useRoleDropdown).mockReturnValue({
+      activeActionId: null,
+      openDropdown: vi.fn(),
+      closeDropdown: vi.fn(),
+    });
+    vi.mocked(useCurrentCollectivite).mockReturnValue({
+      hasReferentielPermission: () => true,
+    } as ReturnType<typeof useCurrentCollectivite>);
+    vi.mocked(useUser).mockReturnValue({ id: userId } as ReturnType<
+      typeof useUser
+    >);
+    window.localStorage.clear();
+  });
+
+  const renderChecklist = (): void => {
+    render(
+      <UnnavigableLinks>
+        <LabellisationChecklistTable
+          viewModel={emptyParcours}
+          collectiviteId={4172}
+          referentielId="eci"
+        />
+      </UnnavigableLinks>
+    );
+  };
+
+  it('renvoie vers les mesures filtrées sur le statut non renseigné', () => {
+    renderChecklist();
+
+    expect(
+      screen.getByRole('link', { name: voirLesMesures }).getAttribute('href')
+    ).toBe('/collectivite/4172/referentiel/eci/progression?s=non_renseigne');
+  });
+
+  it("réaffiche la colonne statut que l'utilisateur avait masquée", () => {
+    window.localStorage.setItem(storageKey, JSON.stringify({ statut: false }));
+    renderChecklist();
+
+    fireEvent.click(screen.getByRole('link', { name: voirLesMesures }));
+
+    expect(JSON.parse(window.localStorage.getItem(storageKey) ?? '{}')).toEqual(
+      {
+        statut: true,
+      }
+    );
+  });
+});

--- a/apps/app/src/referentiels/audit-labellisation/checklist/table/labellisation-checklist.table.tsx
+++ b/apps/app/src/referentiels/audit-labellisation/checklist/table/labellisation-checklist.table.tsx
@@ -1,10 +1,15 @@
 'use client';
 
-import { makeReferentielTacheUrl } from '@/app/app/paths';
+import { makeReferentielTacheUrl, makeReferentielUrl } from '@/app/app/paths';
 import { appLabels } from '@/app/labels/catalog';
 import ActionStatutBadge from '@/app/referentiels/actions/action-statut/action-statut.badge';
+import { useShowReferentielTableColumn } from '@/app/referentiels/referentiel.table/use-referentiel-table-column-visibility';
 import { useCurrentCollectivite } from '@tet/api/collectivites';
-import { ActionId, ReferentielId } from '@tet/domain/referentiels';
+import {
+  ActionId,
+  ReferentielId,
+  StatutAvancementEnum,
+} from '@tet/domain/referentiels';
 import { ChecklistTable, PillButton } from '@tet/ui';
 import { ReactElement } from 'react';
 import {
@@ -79,15 +84,51 @@ const MesureActionButton = ({
   );
 };
 
+const MesuresNonRenseigneesButton = ({
+  collectiviteId,
+  referentielId,
+}: {
+  collectiviteId: number;
+  referentielId: ReferentielId;
+}): ReactElement => {
+  const showColumn = useShowReferentielTableColumn();
+
+  return (
+    <PillButton
+      icon="arrow-right-line"
+      href={makeReferentielUrl({
+        collectiviteId,
+        referentielId,
+        filters: { statuts: [StatutAvancementEnum.NON_RENSEIGNE] },
+      })}
+      onClick={() => showColumn('statut')}
+    >
+      {appLabels.voirLesMesures}
+    </PillButton>
+  );
+};
+
+type CompletudeRowProps = {
+  completude: Parcours['completude'];
+  collectiviteId: number;
+  referentielId: ReferentielId;
+};
+
 const CompletudeRow = ({
   completude,
-}: {
-  completude: Parcours['completude'];
-}): ReactElement => (
+  collectiviteId,
+  referentielId,
+}: CompletudeRowProps): ReactElement => (
   <ChecklistTable.Row
     done={completude.done}
     criterion={{
       label: appLabels.completudeCritere,
+      action: (
+        <MesuresNonRenseigneesButton
+          collectiviteId={collectiviteId}
+          referentielId={referentielId}
+        />
+      ),
     }}
     answer={
       <span className="inline-flex flex-wrap items-center gap-1">
@@ -198,7 +239,11 @@ export const LabellisationChecklistTable = ({
         labelHeader={appLabels.criteres}
         answerHeader={appLabels.elementsAttendus}
       />
-      <CompletudeRow completude={viewModel.completude} />
+      <CompletudeRow
+        completude={viewModel.completude}
+        collectiviteId={collectiviteId}
+        referentielId={referentielId}
+      />
       <MinimumScoreRow minimumScore={viewModel.minimumScore} />
       <MesuresRows
         mesures={viewModel.mesures}

--- a/apps/app/src/referentiels/audit-labellisation/checklist/table/labellisation-checklist.table.tsx
+++ b/apps/app/src/referentiels/audit-labellisation/checklist/table/labellisation-checklist.table.tsx
@@ -133,7 +133,7 @@ const CompletudeRow = ({
     answer={
       <span className="inline-flex flex-wrap items-center gap-1">
         {appLabels.completudeReponsePrefix}
-        <ActionStatutBadge statut="non_renseigne" />
+        <ActionStatutBadge statut={StatutAvancementEnum.NON_RENSEIGNE} />
       </span>
     }
   />

--- a/apps/app/src/referentiels/referentiel.table/use-referentiel-table-column-visibility.spec.ts
+++ b/apps/app/src/referentiels/referentiel.table/use-referentiel-table-column-visibility.spec.ts
@@ -1,0 +1,63 @@
+import { useUser } from '@tet/api/users';
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  useReferentielTableColumnVisibility,
+  useShowReferentielTableColumn,
+} from './use-referentiel-table-column-visibility';
+
+vi.mock('@tet/api/users', () => ({
+  useUser: vi.fn(),
+}));
+
+const userId = 'e2b9c0a4-0000-4000-8000-000000000000';
+const storageKey = `tet_referentiel_table_columns_visibility_${userId}`;
+
+const setStoredVisibility = (visibility: Record<string, boolean>): void => {
+  window.localStorage.setItem(storageKey, JSON.stringify(visibility));
+};
+
+const getStoredVisibility = (): Record<string, boolean> =>
+  JSON.parse(window.localStorage.getItem(storageKey) ?? '{}');
+
+describe('useShowReferentielTableColumn', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.mocked(useUser).mockReturnValue({ id: userId } as ReturnType<
+      typeof useUser
+    >);
+  });
+
+  it("rend visible une colonne que l'utilisateur avait masquée", () => {
+    setStoredVisibility({ statut: false, pilotes: false });
+
+    const { result } = renderHook(() => useShowReferentielTableColumn());
+    act(() => result.current('statut'));
+
+    expect(getStoredVisibility()).toEqual({ statut: true, pilotes: false });
+  });
+
+  it('laisse visibles les autres colonnes déjà affichées', () => {
+    setStoredVisibility({ statut: false, pilotes: true });
+
+    const { result } = renderHook(() => useShowReferentielTableColumn());
+    act(() => result.current('statut'));
+
+    expect(getStoredVisibility()).toEqual({ statut: true, pilotes: true });
+  });
+
+  it('réaffiche la colonne statut détaillé avec la colonne statut', () => {
+    setStoredVisibility({ statut: false });
+
+    const { result: show } = renderHook(() => useShowReferentielTableColumn());
+    act(() => show.current('statut'));
+
+    const { result: visibility } = renderHook(() =>
+      useReferentielTableColumnVisibility({ auditColumnsScope: 'none' })
+    );
+
+    expect(visibility.current.columnVisibility.statut).toBe(true);
+    expect(visibility.current.columnVisibility.statutDetaille).toBe(true);
+  });
+});

--- a/apps/app/src/referentiels/referentiel.table/use-referentiel-table-column-visibility.ts
+++ b/apps/app/src/referentiels/referentiel.table/use-referentiel-table-column-visibility.ts
@@ -92,13 +92,25 @@ function getStorageKey(userId: string) {
   return `${STORAGE_KEY_PREFIX}_${userId}`;
 }
 
+type StoredColumnVisibility = readonly [
+  VisibilityState | undefined,
+  (next: VisibilityState) => void
+];
+
+function useStoredColumnVisibility(): StoredColumnVisibility {
+  const user = useUser();
+
+  return useLocalStorage<VisibilityState>(
+    getStorageKey(user.id),
+    getDefaultColumnVisibility(REFERENTIEL_TABLE_COLUMN_OPTIONS)
+  );
+}
+
 export function useReferentielTableColumnVisibility({
   auditColumnsScope,
 }: {
   auditColumnsScope: AuditColumnsScope;
 }): ReferentielTableColumnVisibility {
-  const user = useUser();
-
   const columnOptions = useMemo<ReferentielTableColumnOption[]>(
     () => [
       ...REFERENTIEL_TABLE_COLUMN_OPTIONS,
@@ -107,10 +119,7 @@ export function useReferentielTableColumnVisibility({
     [auditColumnsScope]
   );
 
-  const [stored, setStored] = useLocalStorage<VisibilityState>(
-    getStorageKey(user.id),
-    getDefaultColumnVisibility(REFERENTIEL_TABLE_COLUMN_OPTIONS)
-  );
+  const [stored, setStored] = useStoredColumnVisibility();
 
   const columnVisibility: VisibilityState = {
     ...getDefaultColumnVisibility(columnOptions),
@@ -141,4 +150,16 @@ export function useReferentielTableColumnVisibility({
     setVisibleColumnIds,
     columnOptions,
   };
+}
+
+export function useShowReferentielTableColumn(): (
+  columnId: ReferentielTableColumnId
+) => void {
+  const [stored, setStored] = useStoredColumnVisibility();
+
+  return useCallback(
+    (columnId: ReferentielTableColumnId) =>
+      setStored({ ...(stored ?? {}), [columnId]: true }),
+    [stored, setStored]
+  );
 }

--- a/apps/app/src/referentiels/referentiel.table/use-referentiel-table-column-visibility.ts
+++ b/apps/app/src/referentiels/referentiel.table/use-referentiel-table-column-visibility.ts
@@ -100,10 +100,12 @@ type StoredColumnVisibility = readonly [
 function useStoredColumnVisibility(): StoredColumnVisibility {
   const user = useUser();
 
-  return useLocalStorage<VisibilityState>(
+  const [stored, setStored] = useLocalStorage<VisibilityState>(
     getStorageKey(user.id),
     getDefaultColumnVisibility(REFERENTIEL_TABLE_COLUMN_OPTIONS)
   );
+
+  return [stored, setStored];
 }
 
 export function useReferentielTableColumnVisibility({

--- a/e2e/tests/referentiels/labellisations/checklist-voir-mesures.spec.ts
+++ b/e2e/tests/referentiels/labellisations/checklist-voir-mesures.spec.ts
@@ -1,0 +1,83 @@
+import { expect } from '@playwright/test';
+import { ReferentielId } from '@tet/domain/referentiels';
+import { testWithReferentiels as test } from '../referentiels.fixture';
+
+const referentielId: ReferentielId = 'eci';
+
+const COMPLETUDE_ROW_PATTERN =
+  /Renseigner les statuts de toutes les mesures du référentiel/;
+
+const VOIR_LES_MESURES = 'Voir les mesures';
+
+const STATUT_COLUMN = 'Statut';
+
+const STATUT_COLUMN_HEADER = /^Statut/;
+
+test.describe('Checklist audit-labellisation — accès aux mesures non renseignées', () => {
+  test.beforeEach(async ({ page, collectivites }) => {
+    const { collectivite, user } = await collectivites.addCollectiviteAndUser({
+      userArgs: { autoLogin: true },
+    });
+    await user.precomputeReferentielSnapshot(
+      collectivite.data.id,
+      referentielId
+    );
+    await page.goto('/');
+  });
+
+  test('« Voir les mesures » ouvre la progression filtrée sur le statut non renseigné', async ({
+    page,
+    auditLabellisationPom,
+    collectivites,
+  }) => {
+    const collectiviteId = collectivites.getCollectivite().data.id;
+
+    await auditLabellisationPom.goto(collectiviteId, referentielId);
+
+    await auditLabellisationPom
+      .checklistRow(COMPLETUDE_ROW_PATTERN)
+      .getByRole('link', { name: VOIR_LES_MESURES })
+      .click();
+
+    await page.waitForURL(
+      `**/collectivite/${collectiviteId}/referentiel/${referentielId}/progression?s=non_renseigne`
+    );
+  });
+
+  test("le clic réaffiche durablement la colonne statut que l'utilisateur avait masquée", async ({
+    page,
+    auditLabellisationPom,
+    collectivites,
+  }) => {
+    const collectiviteId = collectivites.getCollectivite().data.id;
+    const progressionUrl = `/collectivite/${collectiviteId}/referentiel/${referentielId}/progression`;
+    const statutColumnHeader = page.getByRole('columnheader', {
+      name: STATUT_COLUMN_HEADER,
+    });
+    const statutColumnCheckbox = page.getByRole('checkbox', {
+      name: STATUT_COLUMN,
+      exact: true,
+    });
+
+    await page.goto(progressionUrl);
+    await expect(statutColumnHeader).toBeVisible();
+
+    await page.getByRole('button', { name: 'Colonnes' }).click();
+    await statutColumnCheckbox.uncheck();
+    await page.keyboard.press('Escape');
+    await page.reload();
+    await expect(statutColumnHeader).toBeHidden();
+
+    await auditLabellisationPom.goto(collectiviteId, referentielId);
+    await auditLabellisationPom
+      .checklistRow(COMPLETUDE_ROW_PATTERN)
+      .getByRole('link', { name: VOIR_LES_MESURES })
+      .click();
+    await page.waitForURL(`**${progressionUrl}?s=non_renseigne`);
+
+    await page.reload();
+    await expect(statutColumnHeader).toBeVisible();
+    await page.getByRole('button', { name: 'Colonnes' }).click();
+    await expect(statutColumnCheckbox).toBeChecked();
+  });
+});


### PR DESCRIPTION
## Comportement livré

Dans la checklist de labellisation, la ligne « Renseigner les statuts de toutes les mesures du référentiel » porte désormais, au survol, un bouton **« Voir les mesures »** — même emplacement et même mécanique que le « Renseigner » des lignes élu·e référent·e / référent·e technique.

Il ouvre la vue progression du référentiel filtrée sur le statut non renseigné :

```
/collectivite/4172/referentiel/eci/progression?s=non_renseigne
```

La visibilité des colonnes du tableau de progression est une préférence persistée par utilisateur (localStorage). Si la colonne « Statut » avait été masquée, la page d'arrivée listerait les mesures à renseigner sans offrir de quoi les renseigner : le bouton la remet donc visible au clic, et la case correspondante est re-cochée dans le sélecteur « Colonnes ».

## Surface de review

**Attention humaine :**
- `apps/app/src/referentiels/referentiel.table/use-referentiel-table-column-visibility.ts` — extraction de `useStoredColumnVisibility` (le `useLocalStorage` était inline) et ajout de `useShowReferentielTableColumn`, seule API publique nouvelle.
- `apps/app/src/referentiels/audit-labellisation/checklist/table/labellisation-checklist.table.tsx` — `MesuresNonRenseigneesButton` + branchement sur `criterion.action` de `CompletudeRow`.

**Mécanique :**
- `apps/app/src/labels/catalog.ts` — une entrée, `voirLesMesures`.
- Les deux `.spec` ajoutés.
- `ActionStatutBadge` de la ligne de complétude : littéral `"non_renseigne"` remplacé par `StatutAvancementEnum.NON_RENSEIGNE`, déjà importé dans le fichier pour le filtre de l'URL.

## Réutilisation de l'existant

Rien de neuf côté URL ni côté hover :
- l'URL passe par `makeReferentielUrl({ collectiviteId, referentielId, filters })` (`src/app/paths.ts`), qui sérialise déjà `statuts` vers la clé `s` via `referentielFiltersSerializer` ;
- le CTA au survol est déjà porté par le DS : `ChecklistTable` rend `criterion.action` en `opacity-0 group-hover:opacity-100 group-focus-within:opacity-100` ;
- la valeur du statut vient de `StatutAvancementEnum.NON_RENSEIGNE`, pas d'un littéral.

Cherché avant d'écrire `useShowReferentielTableColumn` : aucun utilitaire n'exposait l'écriture de la préférence de colonnes hors de `useReferentielTableColumnVisibility`, dont l'API (`setVisibleColumnIds`) impose de fournir la liste complète des colonnes visibles — inutilisable pour n'en forcer qu'une.

## Hypothèses

- Le bouton est rendu quel que soit `completude.done`, comme le « Voir la mesure » des lignes mesures, et sans condition de permission : c'est une navigation en lecture, accessible aux visiteurs.
- Ré-afficher la colonne est traité comme un effet du clic, pas comme un invariant global du tableau : filtrer sur `statuts` depuis le formulaire de filtres avec la colonne masquée reste possible, comportement inchangé.

## Zones de moindre confiance

- `useLocalStorage` de react-use écrit ses valeurs par défaut à l'initialisation. La page checklist monte désormais ce hook, donc la clé `tet_referentiel_table_columns_visibility_<userId>` est créée avec les défauts pour un utilisateur qui n'aurait jamais ouvert la vue progression. Sans conséquence visible (ce sont les défauts qu'il aurait eus), mais c'est une écriture qui n'existait pas sur cette page.
- Le clic milieu / « ouvrir dans un nouvel onglet » ne déclenche pas `onClick` : dans ce cas la colonne n'est pas ré-affichée. Le lien reste correct, seule la préférence de colonne n'est pas touchée.

## Tests

- `labellisation-checklist.table.spec.tsx` — la ligne complétude pointe vers `/collectivite/4172/referentiel/eci/progression?s=non_renseigne` ; le clic ré-affiche la colonne masquée.
- `use-referentiel-table-column-visibility.spec.ts` — `useShowReferentielTableColumn` rend visible une colonne masquée, préserve les autres préférences, et entraîne `statutDetaille` avec `statut`.

`nx run app:typecheck` vert, eslint et prettier vert sur les fichiers touchés.

## Hors scope, non touché

Rien.

## DISCOVERED

Rien ajouté.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Nouvelles fonctionnalités**
  - Ajout d’un bouton « Voir les mesures » dans le tableau de complétude.
  - Accès direct aux mesures dont le statut est « Non renseigné », avec filtrage automatique.
  - La colonne « Statut » s’affiche automatiquement lors de l’accès aux mesures concernées.
  - Les préférences de visibilité des colonnes restent conservées lors de la réactivation d’une colonne.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
