### PR TITLE
fix(labellisation): propage allowLegacyDocuments au calcul du CTA de demande d'audit

### DIFF
--- a/packages/domain/src/referentiels/labellisations/audit-request-availability/audit-request-availability.rules.spec.ts
+++ b/packages/domain/src/referentiels/labellisations/audit-request-availability/audit-request-availability.rules.spec.ts
@@ -118,6 +118,18 @@ describe('getAuditRequestAvailability', () => {
     });
   });
 
+  it("non-COT + étoile 2 avec une preuve legacy et aucun objet de preuve : disponible, comme le juge l'API", () => {
+    expect(
+      availabilityOf(
+        makeParcours({
+          conditionFichiers: { preuve_nombre: 1 },
+          preuvesObjets: [],
+        }),
+        { isCOT: false, maximumRequestableStar: 2 }
+      )
+    ).toEqual({ canRequest: true, reason: null });
+  });
+
   it('cycle déjà demandé : indisponible avec cycleUnavailable et la raison du cycle', () => {
     expect(
       availabilityOf(

--- a/packages/domain/src/referentiels/labellisations/audit-request-availability/audit-request-availability.rules.ts
+++ b/packages/domain/src/referentiels/labellisations/audit-request-availability/audit-request-availability.rules.ts
@@ -55,7 +55,8 @@ export function getAuditRequestAvailability(
       areAuditPrerequisitesMet(
         parcours,
         sujet,
-        sujet === SujetDemandeEnum.COT ? null : maximumRequestableStar
+        sujet === SujetDemandeEnum.COT ? null : maximumRequestableStar,
+        { allowLegacyDocuments: true }
       ).met
   );
   if (!hasSatisfiedPrerequisites) {


### PR DESCRIPTION
## Comportement livré

Le bouton « Demander un audit » cesse d'être grisé pour les collectivités dont les preuves de candidature ne sont comptées que par `conditionFichiers.preuve_nombre`, sans objet de preuve typé. Ces collectivités voyaient un CTA inactif et le tooltip des critères manquants, alors qu'un appel direct à `referentiels.labellisations.request` aboutissait.

## Mode de défaillance

`getAuditRequestAvailability` appelait `areAuditPrerequisitesMet` sans options, donc avec `allowLegacyDocuments = false`. Les deux autres appelants du même verdict passaient `true` :

| Appelant | Option |
|---|---|
| `audit-request-availability.rules.ts` (le CTA) | absente → `false` |
| `request-labellisation.service.ts:69-74` (l'API) | `true` |
| `useCycleLabellisation.ts:96-101` | `true` |

Trois appelants, deux contrats. L'interface était la plus stricte, donc le défaut était silencieux côté serveur mais bloquant côté utilisateur.

## Surface de review

| Fichier | Nature |
|---|---|
| `packages/domain/.../audit-request-availability.rules.ts` | **attention humaine** — 1 ligne |
| `packages/domain/.../audit-request-availability.rules.spec.ts` | test de régression |

Total : 2 fichiers, +14 / −1.

## Test rouge

Commit `76b1405726`, avant le fix. Vérifié en revenant dessus après rebase :

```
AssertionError: expected { canRequest: false, …(1) } to deeply equal { canRequest: true, reason: null }
- "canRequest": true,   "reason": null
+ "canRequest": false,  "reason": { "kind": "prerequisitesIncomplete" }
```

Le rouge est structurel : `getExpectedDocuments({ isCot: false, premiereEtoileObtenue: false, etoile: 2 })` renvoie `[ACTE_ENGAGEMENT, CANDIDATURE]`, qu'un `preuvesObjets` vide ne satisfait jamais sans le repli legacy.

Le fix est commit `6958d80ed9`.

## Hypothèses prises

- L'option est un paramètre de contexte d'appel, pas une constante : elle reste passée explicitement par les trois sites plutôt que factorisée.
- Le cas « aucune preuve du tout » (`preuve_nombre: 0`, `preuvesObjets: []`) doit rester refusé. La spec existante qui le couvre est inchangée et toujours verte.

## Zones low-confidence

Aucune. Une ligne, un test qui démontre le défaut, contrat verrouillé par 11 assertions préexistantes inchangées.

## Vérifications

- `nx test domain` : 350 tests / 33 fichiers verts
- `nx test app request-audit` : 28 tests verts
- `nx run domain:typecheck` vert
- `nx run domain:lint` : 0 erreur (1 warning préexistant dans `utils/get-error-message.ts`, fichier non touché)
- Aucun consommateur backend : `getAuditRequestAvailability` n'est appelé que depuis `apps/app`

## Contexte

PR 0a de la stack « CTA Demander un audit — gating COT vs non-COT », plan `doc/plans/2026-08-25-001-feat-cta-demande-audit-cot-plan.md`. Tête de stack, aucune dépendance. La PR 1 du plan réécrit ce même fichier et dépend donc de celle-ci.

Aucune nouvelle utility : le fix ne fait que propager une option existante.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Correctifs**
  * Les demandes d’audit peuvent désormais être considérées comme disponibles lorsqu’une preuve legacy suffisante existe, même sans objet de preuve associé.
  * La prise en compte des documents legacy est appliquée lors de la vérification des prérequis, notamment pour les demandes non-COT jusqu’à deux étoiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->