### PR TITLE
fix(labellisation): aligne isCot sur le COT actif

### DIFF
--- a/apps/backend/src/collectivites/collectivites/collectivites.test-fixture.ts
+++ b/apps/backend/src/collectivites/collectivites/collectivites.test-fixture.ts
@@ -58,22 +58,24 @@ export async function cleanupCollectivitePrerequisites(
     .where(eq(invitationTable.collectiviteId, collectiviteId));
 }
 
-export async function setCollectiviteAsCOT(
+export type CollectiviteCotStatus = 'active' | 'inactive' | 'none';
+
+export async function setCollectiviteCotStatus(
   { db }: DatabaseServiceInterface,
   collectiviteId: number,
-  isCOT: boolean
+  status: CollectiviteCotStatus
 ): Promise<void> {
-  if (isCOT) {
-    await db.insert(cotTable).values({
-      collectiviteId: collectiviteId,
-      actif: true,
-      signataire: collectiviteId,
-    });
-  } else {
-    await db
-      .delete(cotTable)
-      .where(eq(cotTable.collectiviteId, collectiviteId));
+  await db.delete(cotTable).where(eq(cotTable.collectiviteId, collectiviteId));
+
+  if (status === 'none') {
+    return;
   }
+
+  await db.insert(cotTable).values({
+    collectiviteId: collectiviteId,
+    actif: status === 'active',
+    signataire: collectiviteId,
+  });
 }
 
 // ajoute une collectivité
@@ -105,7 +107,7 @@ export async function addTestCollectivite(
       }));
 
     if (collectiviteArgs.isCOT) {
-      await setCollectiviteAsCOT({ db }, result.id, true);
+      await setCollectiviteCotStatus({ db }, result.id, 'active');
     }
 
     const collectiviteId = result?.id;

--- a/apps/backend/src/referentiels/labellisations/get-labellisation.service.ts
+++ b/apps/backend/src/referentiels/labellisations/get-labellisation.service.ts
@@ -394,17 +394,6 @@ export class GetLabellisationService {
     });
   }
 
-  async isCot(collectiviteId: number) {
-    const cotResult = await this.db
-      .select()
-      .from(cotTable)
-      .where(eq(cotTable.collectiviteId, collectiviteId))
-      .limit(1);
-    // CUrrent implementation,
-    // TODO: is that normal that we don't check if the cot is active?
-    return cotResult.length > 0;
-  }
-
   /**
    * Vrai si la collectivité a un COT explicitement actif (`cot.actif = true`).
    * Contrairement à `isCot`, on teste bien le flag `actif` et pas seulement
@@ -512,7 +501,7 @@ export class GetLabellisationService {
     collectiviteId: number;
     referentielId: ReferentielId;
   }): Promise<TLabellisationAndDemandeAndAudit> {
-    const isCot = await this.isCot(collectiviteId);
+    const isCot = await this.isCotActif(collectiviteId);
     const currentLabellisation = await this.getCurrentLabellisation({
       collectiviteId,
       referentielId,

--- a/apps/backend/src/referentiels/labellisations/request-labellisation/request-labellisation.router.e2e-spec.ts
+++ b/apps/backend/src/referentiels/labellisations/request-labellisation/request-labellisation.router.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { INestApplication } from '@nestjs/common';
 import {
   addTestCollectiviteAndUsers,
-  setCollectiviteAsCOT,
+  setCollectiviteCotStatus,
 } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
 import {
   createTRPCClientFromCaller,
@@ -287,9 +287,9 @@ describe('Request Labellisation Router', () => {
     test('AUDIT_REQUESTED_FOR_COLLECTIVITE_NOT_COT', async () => {
       const caller = router.createCaller({ user: adminUser });
 
-      await setCollectiviteAsCOT(db, collectivite.id, false);
+      await setCollectiviteCotStatus(db, collectivite.id, 'none');
       onTestFinished(async () => {
-        await setCollectiviteAsCOT(db, collectivite.id, true);
+        await setCollectiviteCotStatus(db, collectivite.id, 'active');
       });
 
       await expect(
@@ -309,6 +309,26 @@ describe('Request Labellisation Router', () => {
           referentiel: ReferentielIdEnum.CAE,
           sujet: 'labellisation_cot',
           etoiles: 1,
+        })
+      ).rejects.toThrow(
+        'Un audit COT ne peut être demandé par une collectivité non COT.'
+      );
+    });
+
+    test('un COT inactif ne permet pas de demander un audit COT', async () => {
+      const caller = router.createCaller({ user: adminUser });
+
+      await setCollectiviteCotStatus(db, collectivite.id, 'inactive');
+      onTestFinished(async () => {
+        await setCollectiviteCotStatus(db, collectivite.id, 'active');
+      });
+
+      await expect(
+        caller.referentiels.labellisations.requestLabellisation({
+          collectiviteId: collectivite.id,
+          referentiel: ReferentielIdEnum.CAE,
+          sujet: 'cot',
+          etoiles: null,
         })
       ).rejects.toThrow(
         'Un audit COT ne peut être demandé par une collectivité non COT.'
@@ -365,9 +385,9 @@ describe('Request Labellisation Router', () => {
       const caller = router.createCaller({ user: adminUser });
       const trpcClient = createTRPCClientFromCaller(caller);
 
-      await setCollectiviteAsCOT(db, collectivite.id, false);
+      await setCollectiviteCotStatus(db, collectivite.id, 'none');
       onTestFinished(async () => {
-        await setCollectiviteAsCOT(db, collectivite.id, true);
+        await setCollectiviteCotStatus(db, collectivite.id, 'active');
       });
 
       await updateAllNeedReferentielStatutsToCompleteReferentiel(
@@ -439,9 +459,9 @@ describe('Request Labellisation Router', () => {
       const caller = router.createCaller({ user: adminUser });
       const trpcClient = createTRPCClientFromCaller(caller);
 
-      await setCollectiviteAsCOT(db, collectivite.id, false);
+      await setCollectiviteCotStatus(db, collectivite.id, 'none');
       onTestFinished(async () => {
-        await setCollectiviteAsCOT(db, collectivite.id, true);
+        await setCollectiviteCotStatus(db, collectivite.id, 'active');
       });
 
       await updateAllNeedReferentielStatutsToCompleteReferentiel(

--- a/apps/backend/src/referentiels/switch-to-te/switch-to-te.router.e2e-spec.ts
+++ b/apps/backend/src/referentiels/switch-to-te/switch-to-te.router.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { INestApplication } from '@nestjs/common';
 import {
   addTestCollectiviteAndUsers,
-  setCollectiviteAsCOT,
+  setCollectiviteCotStatus,
 } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
 import { collectiviteTable } from '@tet/backend/collectivites/shared/models/collectivite.table';
 import { createAudit } from '@tet/backend/referentiels/labellisations/labellisations.test-fixture';
@@ -298,7 +298,7 @@ describe('SwitchToTeRouter', () => {
       eci: { display: false, mode: 'archived' },
       te: { display: true, mode: 'readonly' },
     });
-    await setCollectiviteAsCOT(databaseService, collectiviteId, true);
+    await setCollectiviteCotStatus(databaseService, collectiviteId, 'active');
 
     await expect(
       adminCaller.referentiels.switchToTe({ collectiviteId })
@@ -480,7 +480,7 @@ describe('SwitchToTeRouter', () => {
         eci: { display: false, mode: 'archived' },
         te: { display: true, mode: 'readonly' },
       });
-      await setCollectiviteAsCOT(databaseService, collectiviteId, true);
+      await setCollectiviteCotStatus(databaseService, collectiviteId, 'active');
 
       const status = await adminCaller.referentiels.getSwitchToTeStatus({
         collectiviteId,


### PR DESCRIPTION
## Comportement livré

Une collectivité dont la ligne `cot` existe avec `actif = false` est désormais traitée comme non-COT côté API, comme elle l'est déjà côté interface.

> ✅ **Population impactée : zéro.** `select count(*) from cot where actif = false;` renvoie **0** en production (relevé le 2026-08-26). Aucune collectivité ne change de comportement : cette PR aligne le code sur ce que la donnée dit déjà, et ferme la divergence avant qu'une première ligne `cot` inactive ne la déclenche.

## Mode de défaillance

`GetLabellisationService.isCot` renvoyait vrai dès qu'une ligne `cot` existait, sans tester `cot.actif`. Le code portait lui-même le doute :

```ts
// CUrrent implementation,
// TODO: is that normal that we don't check if the cot is active?
return cotResult.length > 0;
```

Deux lectures du même fait coexistaient :

| Lecture | Sémantique |
|---|---|
| `parcours.isCot` (`get-labellisation.service.ts`) | la ligne `cot` existe |
| `useCycleLabellisation.isCOT` (interface) | `identite.activeCOT` = `coalesce(cot.actif, false)` |

L'interface était la plus stricte, donc le défaut était silencieux à l'écran mais actif côté serveur. Pour une collectivité à COT inactif :

1. **`request-labellisation.rules.ts:92`** — l'API lui acceptait les sujets `cot` et `labellisation_cot`, que l'interface ne lui propose pas.
2. **`request-labellisation.rules.ts:209` et `:216`** — elle obtenait sa première étoile **sans déposer l'acte d'engagement**, l'exemption COT s'appliquant à tort par deux chemins : le court-circuit `isCot && etoiles === 1`, et `getExpectedDocuments({ isCot: parcours.isCot })` qui ne réclame `ACTE_ENGAGEMENT` que si `!isCot`.

## Le fix

`getLabellisationAndDemandeAndAudit` lit `isCotActif`, qui teste `actif = true`. `isCot` n'a plus d'appelant et disparaît, avec son TODO. Il ne reste qu'une lecture de « est COT » dans le service.

## Test de régression

`un COT inactif ne permet pas de demander un audit COT`, dans `request-labellisation.router.e2e-spec.ts`. Vérifié rouge avant le fix — la demande aboutissait au lieu d'être refusée avec « Un audit COT ne peut être demandé par une collectivité non COT. ».

Le test frère `Can request 1ère étoile for cot if all criteria are satisfied except the file` reste vert : l'exemption d'acte d'engagement fonctionne toujours pour un COT réellement actif.

> Les trois commits d'origine (outillage → test rouge → fix) ont été squashés à la demande. La vérification du rouge a bien eu lieu avant le squash.

## Outillage de test

Le test exige de construire une ligne `cot` inactive, que `setCollectiviteAsCOT` ne savait pas produire : son booléen n'exprimait que deux des trois états réels — ligne absente, ligne active, ligne inactive. Il devient `setCollectiviteCotStatus(db, id, 'active' | 'inactive' | 'none')`. Les huit sites d'appel passent la valeur équivalente à leur booléen précédent : aucun comportement de test ne change.

### Recherche anti-duplication

`CollectiviteCotStatus` est un type neuf. Recherche effectuée :

| Recherche | Résultat |
|---|---|
| `rg "CotStatus\|StatutCot\|CotStatut\|cotStatus"` sur `apps/backend/src`, `apps/app/src`, `packages/domain/src`, `packages/ui/src` | aucun |
| `cot.table.ts` | une colonne `actif: boolean`, aucun enum ni colonne de statut |
| `packages/domain/src` : `isCot` / `isCOT` / `activeCOT` | aucun ; le domaine ne connaît le COT que par `activeCOT: z.boolean().optional()` (`collectivite.schema.ts:13`) |

Les deux représentations existantes sont des booléens — `activeCOT` et `parcours.isCot` — dont aucune ne peut exprimer trois états. Le type reste confiné aux fixtures : il décrit un état de base de données à construire, pas un concept métier, et n'entre pas en concurrence avec `activeCOT`.

## Surface de review

| Fichier | Nature |
|---|---|
| `get-labellisation.service.ts` | **attention humaine** — substitution de l'appel, suppression de `isCot` |
| `collectivites.test-fixture.ts` | outillage de test |
| `request-labellisation.router.e2e-spec.ts` | test de régression + renommages mécaniques |
| `switch-to-te.router.e2e-spec.ts` | renommages mécaniques (3 lignes) |

Total : 4 fichiers, +46 / −35.

## Note de rebase

Rebasée sur `main` après 9 commits, dont trois dans la zone. `374f51c3dd` a supprimé le bloc `expectedDocuments` de `get-labellisation.service.ts` : la déduplication de lecture que portait la version précédente de cette PR est devenue sans objet et a été retirée. Un appelant de `setCollectiviteAsCOT` apparu entre-temps (`switch-to-te.router.e2e-spec.ts:483`) a été rattaché au renommage — le rebase fusionnait proprement ligne à ligne mais laissait une référence morte.

## Vérifications

- `nx test backend 'request-labellisation.router'` : 17/18
  - Le 18ᵉ, `Can request if a file has been uploaded`, échoue sur `expected 201 "Created", got 401 "Unauthorized"` dans `uploadCreateTestDocument`, avec un rejet non géré de `google-auth-library` en parallèle (credentials locaux corrompus). **Non vérifié contre `main`** — le diff ne touche ni l'auth ni les documents, mais c'est signalé plutôt que déclaré. À confirmer par la CI.
- `nx test backend 'switch-to-te.router'` : 17/17 verts
- `nx run backend:typecheck` vert
- `nx run backend:lint` : 0 erreur (150 warnings préexistants)

## Contexte

PR 0b de la stack « CTA Demander un audit — gating COT vs non-COT », plan `doc/plans/2026-08-25-001-feat-cta-demande-audit-cot-plan.md`. Racine de stack, **aucune dépendance** — indépendante de la PR 0a (#4860).

Elle n'est pas non plus une dépendance technique de la PR 3 du plan, mais elle transforme son invariant I4 d'implication (`activeCOT ⟹ parcours.isCot`) en équivalence : à merger avant.
