### PR TITLE
chore(labellisation): supprime les flags morts de useCycleLabellisation

### DIFF
--- a/apps/app/src/referentiels/audit-labellisation/checklist/is-audit-actif.spec.ts
+++ b/apps/app/src/referentiels/audit-labellisation/checklist/is-audit-actif.spec.ts
@@ -37,10 +37,7 @@ function makeCycle(
     status: 'audit_en_cours',
     isAuditeur: true,
     isCOT: false,
-    labellisable: true,
-    peutDemanderEtoile: false,
     peutCommencerAudit: false,
-    peutDemander1ereEtoileCOT: false,
     ...rest,
   } as TCycleLabellisation;
 }

--- a/apps/app/src/referentiels/labellisations/DemandeLabellisationModal.stories.tsx
+++ b/apps/app/src/referentiels/labellisations/DemandeLabellisationModal.stories.tsx
@@ -173,7 +173,6 @@ export const LabellisableCOT = {
   args: {
     parcoursLabellisation: {
       status: 'non_demandee',
-      labellisable: true,
       isCOT: true,
       parcours: {
         collectivite_id: 1,

--- a/apps/app/src/referentiels/labellisations/useCycleLabellisation.ts
+++ b/apps/app/src/referentiels/labellisations/useCycleLabellisation.ts
@@ -28,11 +28,8 @@ export type TCycleLabellisation = {
   isConductingAudit: boolean;
   viewerRole: AuditViewerRole;
   isCOT: boolean;
-  labellisable: boolean;
   maximumRequestableStar: Etoile | null;
-  peutDemanderEtoile: boolean;
   canStartAudit: boolean;
-  peutDemander1ereEtoileCOT: boolean;
   canAskFirstStar: boolean;
 };
 
@@ -76,32 +73,9 @@ export const useCycleLabellisation = (
       ).canRequest
     : false;
 
-  const peutDemander1ereEtoileCOT = parcours
-    ? hasMutatePermission &&
-      canRequestAuditOrLabellisation(
-        parcours,
-        SujetDemandeEnum.LABELLISATION_COT,
-        1,
-        { allowLegacyDocuments: true }
-      ).canRequest
-    : false;
-
   const maximumRequestableStar = parcours
     ? getMaxRequestableStar(parcours.critere_score.score_fait)
     : null;
-
-  const peutDemanderEtoile =
-    parcours !== null && maximumRequestableStar !== null
-      ? hasMutatePermission &&
-        canRequestAuditOrLabellisation(
-          parcours,
-          SujetDemandeEnum.LABELLISATION,
-          maximumRequestableStar,
-          { allowLegacyDocuments: true }
-        ).canRequest
-      : false;
-
-  const labellisable = peutDemanderEtoile && maximumRequestableStar !== 1;
 
   return {
     parcours,
@@ -112,10 +86,7 @@ export const useCycleLabellisation = (
     isConductingAudit,
     viewerRole,
     isCOT,
-    peutDemanderEtoile,
-    peutDemander1ereEtoileCOT,
     canStartAudit,
-    labellisable,
     maximumRequestableStar,
     canAskFirstStar,
   };


### PR DESCRIPTION
## Comportement livré

Aucun changement à l'écran. `TCycleLabellisation` ne décrit plus que ce que quelqu'un lit, et deux appels de règle disparaissent de chaque rendu de la page audit-labellisation.

## Ce qui est supprimé

`peutDemanderEtoile`, `labellisable` et `peutDemander1ereEtoileCOT` étaient calculés à chaque rendu — deux appels à `canRequestAuditOrLabellisation` plus un dérivé — sans qu'aucun site de production ne les lise. Reliquat d'avant l'extraction de `getAskPremiereEtoileButtonState` et de `RequestAuditButton`, qui portent désormais leurs propres règles.

## Preuve de recherche

```
$ grep -rn "peutDemanderEtoile\|peutDemander1ereEtoileCOT" apps/app/src e2e/tests
useCycleLabellisation.ts:33    peutDemanderEtoile: boolean;          ← définition
useCycleLabellisation.ts:35    peutDemander1ereEtoileCOT: boolean;   ← définition
useCycleLabellisation.ts:79    const peutDemander1ereEtoileCOT = …   ← calcul
useCycleLabellisation.ts:93    const peutDemanderEtoile = …          ← calcul
useCycleLabellisation.ts:104   const labellisable = …                ← calcul
useCycleLabellisation.ts:115-116, 118                                ← retour
is-audit-actif.spec.ts:40-43                                         ← fixture (pose, ne lit pas)

$ grep -rn "labellisable" apps/app/src e2e/tests
DemandeLabellisationModal.stories.tsx:137,154  ← noms de story « Non labellisable COT », pas des lectures
DemandeLabellisationModal.stories.tsx:176      ← fixture (pose, ne lit pas)
```

Aucune lecture en production. Les seuls consommateurs sont deux fixtures qui **écrivent** ces champs.

> ⚠️ `rg` renvoie un faux négatif sur ces symboles dans ce repo (0 occurrence alors que le fichier les contient). La recherche ci-dessus utilise `grep -rn`. À garder en tête pour toute vérification de dead code.

## Conservés volontairement

`canAskFirstStar` et `canStartAudit` restent : ils ont des consommateurs réels (`checklist-actions.tsx:22`, `AuditeurActions`).

## Surface de review

| Fichier | Nature |
|---|---|
| `useCycleLabellisation.ts` | **attention humaine** — la seule question est « personne ne lit vraiment ces champs ? », tranchée par la recherche ci-dessus |
| `is-audit-actif.spec.ts` | fixture |
| `DemandeLabellisationModal.stories.tsx` | fixture |

Total : 3 fichiers, **−33 lignes, 0 insertion**. Suppression pure.

## Note

`is-audit-actif.spec.ts` pose aussi `peutCommencerAudit`, un champ qui n'existe dans aucune version de `TCycleLabellisation` — le `as TCycleLabellisation` de la fixture masque l'excès de propriétés. Préexistant à cette PR et hors de son scope : je ne le touche pas.

## Vérifications

- `nx run app:typecheck` vert
- `nx test app` : 643 tests / 95 fichiers verts
- `nx run app:lint` : 0 erreur (104 warnings préexistants)

## Contexte

PR 0c de la stack « CTA Demander un audit — gating COT vs non-COT », plan `doc/plans/2026-08-25-001-feat-cta-demande-audit-cot-plan.md`. Racine de stack, **aucune dépendance** — indépendante de la PR 0a (#4860) et de la PR 0b (#4861).

Aucune nouvelle utility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplification des informations exposées pour les cycles de labellisation.
  - Suppression des indicateurs obsolètes liés à l’éligibilité à la labellisation et aux demandes d’étoiles.
  - Conservation des informations nécessaires au démarrage des audits et au calcul du niveau d’étoile maximal.

- **Tests**
  - Mise à jour des scénarios de test et des exemples associés à la nouvelle structure des cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->