### PR TITLE
feat(labellisation): l'offre de types d'audit depend du statut COT, le score devient un motif d'indisponibilite

### DIFF
--- a/apps/app/src/referentiels/labellisations/request-audit/request-audit.button.spec.tsx
+++ b/apps/app/src/referentiels/labellisations/request-audit/request-audit.button.spec.tsx
@@ -37,6 +37,19 @@ const mockedUseCycleLabellisation = vi.mocked(useCycleLabellisation);
 
 const demanderAuditButton = /Demander un audit/;
 
+const getRequestAuditButton = (): HTMLButtonElement => {
+  const button = screen.getByRole('button', { name: demanderAuditButton });
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error('bouton « Demander un audit » inattendu');
+  }
+  return button;
+};
+
+const getTooltipLabel = (): string | null =>
+  document
+    .querySelector('[data-tooltip-label]')
+    ?.getAttribute('data-tooltip-label') ?? null;
+
 const setCycle = ({
   parcours,
   maximumRequestableStar,
@@ -129,12 +142,8 @@ describe('RequestAuditButton — état du bouton pour la collectivité auditée'
   it('rend le bouton actif sans tooltip quand la demande est possible', () => {
     render(<RequestAuditButton referentielId="cae" />);
 
-    const button = screen.getByRole('button', { name: demanderAuditButton });
-    if (!(button instanceof HTMLButtonElement)) {
-      throw new Error('bouton « Demander un audit » inattendu');
-    }
-    expect(button.disabled).toBe(false);
-    expect(document.querySelector('[data-tooltip-label]')).toBeNull();
+    expect(getRequestAuditButton().disabled).toBe(false);
+    expect(getTooltipLabel()).toBeNull();
   });
 
   it("rend le bouton désactivé avec un tooltip quand aucun type d'audit n'est demandable", () => {
@@ -142,41 +151,49 @@ describe('RequestAuditButton — état du bouton pour la collectivité auditée'
 
     render(<RequestAuditButton referentielId="cae" />);
 
-    const button = screen.getByRole('button', { name: demanderAuditButton });
-    if (!(button instanceof HTMLButtonElement)) {
-      throw new Error('bouton « Demander un audit » inattendu');
-    }
-    expect(button.disabled).toBe(true);
-    expect(document.querySelector('[data-tooltip-label]')).not.toBeNull();
+    expect(getRequestAuditButton().disabled).toBe(true);
+    expect(getTooltipLabel()).not.toBeNull();
   });
 
-  it("rend le bouton actif pour un COT sous 35 % de score : l'audit COT seul n'exige aucune étoile", () => {
+  const setCotCycleBelowAuditableScore = (completudeOk: boolean): void =>
     setCycle({
       parcours: {
         ...requestableCycle.parcours,
         isCot: true,
         etoiles: 1,
+        completude_ok: completudeOk,
       } as ParcoursForAuditRequest,
       isCOT: true,
       maximumRequestableStar: 1,
     });
 
+  it('COT dont les statuts ne sont pas tous renseignés : bouton désactivé, la complétude manque', () => {
+    setCotCycleBelowAuditableScore(false);
+
     render(<RequestAuditButton referentielId="cae" />);
 
-    const button = screen.getByRole('button', { name: demanderAuditButton });
-    if (!(button instanceof HTMLButtonElement)) {
-      throw new Error('bouton « Demander un audit » inattendu');
-    }
-    expect(button.disabled).toBe(false);
-    expect(document.querySelector('[data-tooltip-label]')).toBeNull();
+    expect(getRequestAuditButton().disabled).toBe(true);
+    expect(getTooltipLabel()).toBe(
+      'Renseigner tous les critères attendus afin de pouvoir demander un audit ou une labellisation'
+    );
   });
 
-  it('rend le bouton désactivé pour un non-COT sous 35 % de score, avec le tooltip de score', () => {
+  it("COT dont tous les statuts sont renseignés : bouton actif, l'audit COT seul n'exige rien de plus", () => {
+    setCotCycleBelowAuditableScore(true);
+
+    render(<RequestAuditButton referentielId="cae" />);
+
+    expect(getRequestAuditButton().disabled).toBe(false);
+    expect(getTooltipLabel()).toBeNull();
+  });
+
+  it('non-COT dont tous les statuts sont renseignés mais sous 35 % de score : bouton désactivé, le score manque', () => {
     setCycle({
       parcours: {
         ...requestableCycle.parcours,
         isCot: false,
         etoiles: 1,
+        completude_ok: true,
       } as ParcoursForAuditRequest,
       isCOT: false,
       maximumRequestableStar: 1,
@@ -184,16 +201,8 @@ describe('RequestAuditButton — état du bouton pour la collectivité auditée'
 
     render(<RequestAuditButton referentielId="cae" />);
 
-    const button = screen.getByRole('button', { name: demanderAuditButton });
-    if (!(button instanceof HTMLButtonElement)) {
-      throw new Error('bouton « Demander un audit » inattendu');
-    }
-    expect(button.disabled).toBe(true);
-    expect(
-      document
-        .querySelector('[data-tooltip-label]')
-        ?.getAttribute('data-tooltip-label')
-    ).toBe(
+    expect(getRequestAuditButton().disabled).toBe(true);
+    expect(getTooltipLabel()).toBe(
       'Atteindre au moins 35 % de score pour pouvoir demander un audit de labellisation.'
     );
   });
@@ -209,12 +218,8 @@ describe('RequestAuditButton — état du bouton pour la collectivité auditée'
 
     render(<RequestAuditButton referentielId="cae" />);
 
-    const button = screen.getByRole('button', { name: demanderAuditButton });
-    if (!(button instanceof HTMLButtonElement)) {
-      throw new Error('bouton « Demander un audit » inattendu');
-    }
-    expect(button.disabled).toBe(true);
-    expect(document.querySelector('[data-tooltip-label]')).not.toBeNull();
+    expect(getRequestAuditButton().disabled).toBe(true);
+    expect(getTooltipLabel()).not.toBeNull();
   });
 
   it('rend le bouton désactivé avec un tooltip quand les prérequis de labellisation sont incomplets', () => {
@@ -240,11 +245,7 @@ describe('RequestAuditButton — état du bouton pour la collectivité auditée'
 
     render(<RequestAuditButton referentielId="cae" />);
 
-    const button = screen.getByRole('button', { name: demanderAuditButton });
-    if (!(button instanceof HTMLButtonElement)) {
-      throw new Error('bouton « Demander un audit » inattendu');
-    }
-    expect(button.disabled).toBe(true);
-    expect(document.querySelector('[data-tooltip-label]')).not.toBeNull();
+    expect(getRequestAuditButton().disabled).toBe(true);
+    expect(getTooltipLabel()).not.toBeNull();
   });
 });

--- a/apps/app/src/referentiels/labellisations/request-audit/request-audit.button.spec.tsx
+++ b/apps/app/src/referentiels/labellisations/request-audit/request-audit.button.spec.tsx
@@ -150,7 +150,7 @@ describe('RequestAuditButton — état du bouton pour la collectivité auditée'
     expect(document.querySelector('[data-tooltip-label]')).not.toBeNull();
   });
 
-  it('rend le bouton désactivé pour un COT quand maximumRequestableStar < 2', () => {
+  it("rend le bouton actif pour un COT sous 35 % de score : l'audit COT seul n'exige aucune étoile", () => {
     setCycle({
       parcours: {
         ...requestableCycle.parcours,
@@ -167,8 +167,35 @@ describe('RequestAuditButton — état du bouton pour la collectivité auditée'
     if (!(button instanceof HTMLButtonElement)) {
       throw new Error('bouton « Demander un audit » inattendu');
     }
+    expect(button.disabled).toBe(false);
+    expect(document.querySelector('[data-tooltip-label]')).toBeNull();
+  });
+
+  it('rend le bouton désactivé pour un non-COT sous 35 % de score, avec le tooltip de score', () => {
+    setCycle({
+      parcours: {
+        ...requestableCycle.parcours,
+        isCot: false,
+        etoiles: 1,
+      } as ParcoursForAuditRequest,
+      isCOT: false,
+      maximumRequestableStar: 1,
+    });
+
+    render(<RequestAuditButton referentielId="cae" />);
+
+    const button = screen.getByRole('button', { name: demanderAuditButton });
+    if (!(button instanceof HTMLButtonElement)) {
+      throw new Error('bouton « Demander un audit » inattendu');
+    }
     expect(button.disabled).toBe(true);
-    expect(document.querySelector('[data-tooltip-label]')).not.toBeNull();
+    expect(
+      document
+        .querySelector('[data-tooltip-label]')
+        ?.getAttribute('data-tooltip-label')
+    ).toBe(
+      'Atteindre au moins 35 % de score pour pouvoir demander un audit de labellisation.'
+    );
   });
 
   it("rend le bouton désactivé avec un tooltip quand l'élu référent ou le référent technique n'est pas désigné", () => {

--- a/apps/app/src/referentiels/labellisations/request-audit/request-audit.button.tsx
+++ b/apps/app/src/referentiels/labellisations/request-audit/request-audit.button.tsx
@@ -36,11 +36,21 @@ const tooltipForUnavailableReason = (
       getRequestAuditTooltip(cause)
     )
     .with(
-      { kind: 'noRequestableAuditType' },
+      { kind: 'auditTypeUnavailable', cause: 'SCORE_BELOW_AUDITABLE_STAR' },
       () => appLabels.demanderAuditScoreInsuffisant
     )
     .with(
-      { kind: 'prerequisitesIncomplete' },
+      { kind: 'auditTypeUnavailable', cause: 'REFERENTIEL_NOT_COMPLETED' },
+      {
+        kind: 'auditTypeUnavailable',
+        cause: 'SCORE_GLOBAL_CRITERIA_NOT_SATISFIED',
+      },
+      {
+        kind: 'auditTypeUnavailable',
+        cause: 'SCORE_ACTIONS_CRITERIA_NOT_SATISFIED',
+      },
+      { kind: 'auditTypeUnavailable', cause: 'REFERENT_ROLES_NOT_DEFINED' },
+      { kind: 'auditTypeUnavailable', cause: 'MISSING_FILE' },
       () => appLabels.renseignerCriteresPourDemande
     )
     .exhaustive();

--- a/apps/app/src/referentiels/labellisations/request-audit/request-audit.form.spec.tsx
+++ b/apps/app/src/referentiels/labellisations/request-audit/request-audit.form.spec.tsx
@@ -71,6 +71,14 @@ const renderForm = (props: {
 const targetStarField = (container: HTMLElement): Element | null =>
   container.querySelector('[data-test="target-star"]');
 
+const getRadioButtonByName = (name: string): HTMLInputElement => {
+  const element = screen.getByRole('radio', { name });
+  if (!(element instanceof HTMLInputElement)) {
+    throw new Error(`radio inattendu pour « ${name} »`);
+  }
+  return element;
+};
+
 const getSubmitButton = (): HTMLButtonElement => {
   const button = screen.getByRole('button', { name: SUBMIT_BUTTON });
   if (!(button instanceof HTMLButtonElement)) {
@@ -89,16 +97,21 @@ describe('RequestAuditForm', () => {
     expect(targetStarField(container)).not.toBeNull();
   });
 
-  it("COT avec score < 35% : ni choix de type, ni sélecteur d'étoile", () => {
+  it("COT sous 35 % : les deux types COT sont proposés, le labellisant grisé, sans sélecteur d'étoile", () => {
     const { container } = renderForm({
       isCOT: true,
       maximumRequestableStar: 1,
     });
-    expect(screen.queryByRole('group', { name: AUDIT_TYPE_LEGEND })).toBeNull();
+    expect(getRadioButtonByName('Audit COT sans labellisation').disabled).toBe(
+      false
+    );
+    expect(getRadioButtonByName('Audit COT avec labellisation').disabled).toBe(
+      true
+    );
     expect(targetStarField(container)).toBeNull();
   });
 
-  it('COT avec score >= 35% : les trois types sont proposés', () => {
+  it("COT avec score >= 35% : les deux types COT sont proposés, l'audit de labellisation nu ne l'est pas", () => {
     renderForm({
       isCOT: true,
       maximumRequestableStar: 3,
@@ -111,8 +124,8 @@ describe('RequestAuditForm', () => {
       within(group).getByRole('radio', { name: 'Audit COT avec labellisation' })
     ).toBeDefined();
     expect(
-      within(group).getByRole('radio', { name: 'Audit de labellisation' })
-    ).toBeDefined();
+      within(group).queryByRole('radio', { name: 'Audit de labellisation' })
+    ).toBeNull();
   });
 
   it("COT avec score >= 35% : le sélecteur d'étoile apparaît au choix d'un audit labellisant", () => {
@@ -122,7 +135,7 @@ describe('RequestAuditForm', () => {
     });
     expect(targetStarField(container)).toBeNull();
     fireEvent.click(
-      screen.getByRole('radio', { name: 'Audit de labellisation' })
+      screen.getByRole('radio', { name: 'Audit COT avec labellisation' })
     );
     expect(targetStarField(container)).not.toBeNull();
   });
@@ -207,7 +220,7 @@ describe('RequestAuditForm', () => {
     expect(getSubmitButton().disabled).toBe(true);
 
     fireEvent.click(
-      screen.getByRole('radio', { name: 'Audit de labellisation' })
+      screen.getByRole('radio', { name: 'Audit COT avec labellisation' })
     );
 
     await waitFor(() => expect(getSubmitButton().disabled).toBe(false));

--- a/packages/domain/src/referentiels/labellisations/audit-request-availability/audit-request-availability.rules.spec.ts
+++ b/packages/domain/src/referentiels/labellisations/audit-request-availability/audit-request-availability.rules.spec.ts
@@ -40,10 +40,13 @@ const availabilityOf = (
     maximumRequestableStar: Etoile;
   }
 ): AuditRequestAvailability =>
-  getAuditRequestAvailability(parcours, listAuditTypeOptions(parcours, context));
+  getAuditRequestAvailability(
+    parcours,
+    listAuditTypeOptions(parcours, context)
+  );
 
 describe('getAuditRequestAvailability', () => {
-  it("non-COT + maximumRequestableStar < 2 : indisponible, aucun type d'audit demandable", () => {
+  it('non-COT sous 35 % de score : indisponible, le seul type offert exige une étoile auditable', () => {
     expect(
       availabilityOf(makeParcours({ etoiles: 1 as Etoile }), {
         isCOT: false,
@@ -51,20 +54,20 @@ describe('getAuditRequestAvailability', () => {
       })
     ).toEqual({
       canRequest: false,
-      reason: { kind: 'noRequestableAuditType' },
+      reason: {
+        kind: 'auditTypeUnavailable',
+        cause: 'SCORE_BELOW_AUDITABLE_STAR',
+      },
     });
   });
 
-  it("COT + maximumRequestableStar = 1 : indisponible, aucun type d'audit demandable avant la 2e étoile", () => {
+  it("COT sous 35 % de score : disponible, l'audit COT seul n'exige aucune étoile", () => {
     expect(
       availabilityOf(makeParcours({ isCot: true, etoiles: 1 as Etoile }), {
         isCOT: true,
         maximumRequestableStar: 1,
       })
-    ).toEqual({
-      canRequest: false,
-      reason: { kind: 'noRequestableAuditType' },
-    });
+    ).toEqual({ canRequest: true, reason: null });
   });
 
   it('non-COT + maximumRequestableStar = 2 : disponible (audit de labellisation demandable)', () => {
@@ -76,7 +79,7 @@ describe('getAuditRequestAvailability', () => {
     ).toEqual({ canRequest: true, reason: null });
   });
 
-  it('non-COT + étoile 2 mais référentiel incomplet : indisponible (prérequis incomplets)', () => {
+  it('non-COT + étoile 2 mais référentiel incomplet : indisponible, complétude manquante', () => {
     expect(
       availabilityOf(makeParcours({ completude_ok: false }), {
         isCOT: false,
@@ -84,11 +87,14 @@ describe('getAuditRequestAvailability', () => {
       })
     ).toEqual({
       canRequest: false,
-      reason: { kind: 'prerequisitesIncomplete' },
+      reason: {
+        kind: 'auditTypeUnavailable',
+        cause: 'REFERENTIEL_NOT_COMPLETED',
+      },
     });
   });
 
-  it("non-COT + étoile 2 avec un critère d'action non atteint : indisponible (prérequis incomplets)", () => {
+  it("non-COT + étoile 2 avec un critère d'action non atteint : indisponible, critère d'action manquant", () => {
     expect(
       availabilityOf(
         makeParcours({
@@ -101,11 +107,14 @@ describe('getAuditRequestAvailability', () => {
       )
     ).toEqual({
       canRequest: false,
-      reason: { kind: 'prerequisitesIncomplete' },
+      reason: {
+        kind: 'auditTypeUnavailable',
+        cause: 'SCORE_ACTIONS_CRITERIA_NOT_SATISFIED',
+      },
     });
   });
 
-  it('non-COT + étoile 2 sans fichier de candidature : indisponible (prérequis incomplets)', () => {
+  it('non-COT + étoile 2 sans fichier de candidature : indisponible, document manquant', () => {
     expect(
       availabilityOf(
         makeParcours({
@@ -116,7 +125,10 @@ describe('getAuditRequestAvailability', () => {
       )
     ).toEqual({
       canRequest: false,
-      reason: { kind: 'prerequisitesIncomplete' },
+      reason: {
+        kind: 'auditTypeUnavailable',
+        cause: 'MISSING_FILE',
+      },
     });
   });
 
@@ -190,11 +202,30 @@ describe('getAuditRequestAvailability', () => {
       )
     ).toEqual({
       canRequest: false,
-      reason: { kind: 'prerequisitesIncomplete' },
+      reason: {
+        kind: 'auditTypeUnavailable',
+        cause: 'REFERENT_ROLES_NOT_DEFINED',
+      },
     });
   });
 
-  it("cycleUnavailable prime sur l'absence de type (l'utilisateur doit d'abord finir le cycle en cours)", () => {
+  it("COT sans référents désignés : disponible, l'audit COT seul n'exige que la complétude", () => {
+    expect(
+      availabilityOf(
+        makeParcours({
+          isCot: true,
+          criteres_action: [{ atteint: true, action_id: 'cae_5.1.2.1.1' }],
+          referentRolesDefined: {
+            eluReferent: false,
+            referentTechnique: false,
+          },
+        }),
+        { isCOT: true, maximumRequestableStar: 2 }
+      )
+    ).toEqual({ canRequest: true, reason: null });
+  });
+
+  it("cycleUnavailable prime sur l'indisponibilité de type (l'utilisateur doit d'abord finir le cycle en cours)", () => {
     expect(
       availabilityOf(
         makeParcours({

--- a/packages/domain/src/referentiels/labellisations/audit-request-availability/audit-request-availability.rules.ts
+++ b/packages/domain/src/referentiels/labellisations/audit-request-availability/audit-request-availability.rules.ts
@@ -1,4 +1,7 @@
-import { AuditTypeOption } from '../audit-type-options/audit-type-options.rules';
+import {
+  AuditTypeOption,
+  AuditTypeUnavailableReason,
+} from '../audit-type-options/audit-type-options.rules';
 import { ParcoursLabellisation } from '../parcours-labellisation.schema';
 import { ParcoursForAuditPrerequisites } from '../request-labellisation/request-labellisation.rules';
 import { canStartNewAuditCycle } from '../start-new-audit-cycle/start-new-audit-cycle.rules';
@@ -12,8 +15,16 @@ export type ParcoursForAuditRequest = Pick<
 
 export type AuditRequestUnavailableReason =
   | { kind: 'cycleUnavailable'; cause: StartNewAuditCycleRulesErrors }
-  | { kind: 'noRequestableAuditType' }
-  | { kind: 'prerequisitesIncomplete' };
+  | { kind: 'auditTypeUnavailable'; cause: AuditTypeUnavailableReason };
+
+type UnavailableAuditTypeOption = Extract<
+  AuditTypeOption,
+  { isRequestable: false }
+>;
+
+const isUnavailableAuditType = (
+  option: AuditTypeOption
+): option is UnavailableAuditTypeOption => !option.isRequestable;
 
 export type AuditRequestAvailability =
   | { canRequest: true; reason: null }
@@ -31,13 +42,22 @@ export function getAuditRequestAvailability(
     };
   }
 
-  if (auditTypeOptions.length === 0) {
-    return { canRequest: false, reason: { kind: 'noRequestableAuditType' } };
+  const hasRequestableAuditType = auditTypeOptions.some(
+    (option) => option.isRequestable
+  );
+  const leastDemandingUnavailableType = auditTypeOptions.find(
+    isUnavailableAuditType
+  );
+
+  if (hasRequestableAuditType || !leastDemandingUnavailableType) {
+    return { canRequest: true, reason: null };
   }
 
-  if (!auditTypeOptions.some((option) => option.isRequestable)) {
-    return { canRequest: false, reason: { kind: 'prerequisitesIncomplete' } };
-  }
-
-  return { canRequest: true, reason: null };
+  return {
+    canRequest: false,
+    reason: {
+      kind: 'auditTypeUnavailable',
+      cause: leastDemandingUnavailableType.reason,
+    },
+  };
 }

--- a/packages/domain/src/referentiels/labellisations/audit-type-options/audit-type-options.rules.spec.ts
+++ b/packages/domain/src/referentiels/labellisations/audit-type-options/audit-type-options.rules.spec.ts
@@ -31,26 +31,57 @@ const makeParcours = (
   ...overrides,
 });
 
-describe("listAuditTypeOptions — quels sujets sont proposés", () => {
-  it('COT sous 35 % de score : aucun sujet proposé', () => {
+describe('listAuditTypeOptions — quels sujets sont proposés', () => {
+  it("COT : l'offre se limite aux deux sujets COT, quel que soit le score", () => {
+    expect(
+      listAuditTypeOptions(makeParcours({ isCot: true }), {
+        isCOT: true,
+        maximumRequestableStar: 5,
+      }).map((option) => option.sujet)
+    ).toEqual([SujetDemandeEnum.COT, SujetDemandeEnum.LABELLISATION_COT]);
+  });
+
+  it("non-COT : l'offre se limite à l'audit de labellisation, quel que soit le score", () => {
+    expect(
+      listAuditTypeOptions(makeParcours(), {
+        isCOT: false,
+        maximumRequestableStar: 5,
+      }).map((option) => option.sujet)
+    ).toEqual([SujetDemandeEnum.LABELLISATION]);
+  });
+
+  it("COT sous 35 % de score : l'audit COT seul reste demandable, le sujet labellisant non", () => {
     expect(
       listAuditTypeOptions(makeParcours({ isCot: true }), {
         isCOT: true,
         maximumRequestableStar: 1,
       })
-    ).toEqual([]);
+    ).toEqual([
+      { sujet: SujetDemandeEnum.COT, isRequestable: true, reason: null },
+      {
+        sujet: SujetDemandeEnum.LABELLISATION_COT,
+        isRequestable: false,
+        reason: 'SCORE_BELOW_AUDITABLE_STAR',
+      },
+    ]);
   });
 
-  it('non-COT sous 35 % de score : aucun sujet proposé', () => {
+  it('non-COT sous 35 % de score : le seul sujet offert exige une étoile auditable', () => {
     expect(
       listAuditTypeOptions(makeParcours(), {
         isCOT: false,
         maximumRequestableStar: 1,
       })
-    ).toEqual([]);
+    ).toEqual([
+      {
+        sujet: SujetDemandeEnum.LABELLISATION,
+        isRequestable: false,
+        reason: 'SCORE_BELOW_AUDITABLE_STAR',
+      },
+    ]);
   });
 
-  it('COT a partir de 35 % de score : les trois sujets sont proposés et demandables', () => {
+  it('COT a partir de 35 % de score : les deux sujets COT sont demandables', () => {
     expect(
       listAuditTypeOptions(makeParcours({ isCot: true }), {
         isCOT: true,
@@ -63,15 +94,10 @@ describe("listAuditTypeOptions — quels sujets sont proposés", () => {
         isRequestable: true,
         reason: null,
       },
-      {
-        sujet: SujetDemandeEnum.LABELLISATION,
-        isRequestable: true,
-        reason: null,
-      },
     ]);
   });
 
-  it("non-COT a partir de 35 % de score : seul l'audit de labellisation est proposé", () => {
+  it("non-COT a partir de 35 % de score : l'audit de labellisation est demandable", () => {
     expect(
       listAuditTypeOptions(makeParcours(), {
         isCOT: false,
@@ -92,7 +118,10 @@ describe('listAuditTypeOptions — pourquoi un sujet proposé n est pas demandab
     expect(
       listAuditTypeOptions(
         makeParcours({ isCot: true, completude_ok: false }),
-        { isCOT: true, maximumRequestableStar: 2 }
+        {
+          isCOT: true,
+          maximumRequestableStar: 2,
+        }
       )
     ).toEqual([
       {
@@ -105,15 +134,10 @@ describe('listAuditTypeOptions — pourquoi un sujet proposé n est pas demandab
         isRequestable: false,
         reason: 'REFERENTIEL_NOT_COMPLETED',
       },
-      {
-        sujet: SujetDemandeEnum.LABELLISATION,
-        isRequestable: false,
-        reason: 'REFERENTIEL_NOT_COMPLETED',
-      },
     ]);
   });
 
-  it("référents non désignés : l'audit COT seul reste demandable, pas les sujets labellisants", () => {
+  it("référents non désignés : l'audit COT seul reste demandable, pas le sujet labellisant", () => {
     expect(
       listAuditTypeOptions(
         makeParcours({
@@ -127,11 +151,6 @@ describe('listAuditTypeOptions — pourquoi un sujet proposé n est pas demandab
       { sujet: SujetDemandeEnum.COT, isRequestable: true, reason: null },
       {
         sujet: SujetDemandeEnum.LABELLISATION_COT,
-        isRequestable: false,
-        reason: 'REFERENT_ROLES_NOT_DEFINED',
-      },
-      {
-        sujet: SujetDemandeEnum.LABELLISATION,
         isRequestable: false,
         reason: 'REFERENT_ROLES_NOT_DEFINED',
       },
@@ -157,18 +176,16 @@ describe('listAuditTypeOptions — pourquoi un sujet proposé n est pas demandab
         isRequestable: false,
         reason: 'SCORE_ACTIONS_CRITERIA_NOT_SATISFIED',
       },
-      {
-        sujet: SujetDemandeEnum.LABELLISATION,
-        isRequestable: false,
-        reason: 'SCORE_ACTIONS_CRITERIA_NOT_SATISFIED',
-      },
     ]);
   });
 
-  it('aucun document de candidature déposé : les sujets labellisants réclament le fichier', () => {
+  it('aucun document de candidature déposé : le sujet labellisant réclame le fichier', () => {
     expect(
       listAuditTypeOptions(
-        makeParcours({ conditionFichiers: { preuve_nombre: 0 }, preuvesObjets: [] }),
+        makeParcours({
+          conditionFichiers: { preuve_nombre: 0 },
+          preuvesObjets: [],
+        }),
         { isCOT: false, maximumRequestableStar: 2 }
       )
     ).toEqual([
@@ -194,11 +211,6 @@ describe('listAuditTypeOptions — pourquoi un sujet proposé n est pas demandab
       { sujet: SujetDemandeEnum.COT, isRequestable: true, reason: null },
       {
         sujet: SujetDemandeEnum.LABELLISATION_COT,
-        isRequestable: false,
-        reason: 'MISSING_FILE',
-      },
-      {
-        sujet: SujetDemandeEnum.LABELLISATION,
         isRequestable: false,
         reason: 'MISSING_FILE',
       },

--- a/packages/domain/src/referentiels/labellisations/audit-type-options/audit-type-options.rules.ts
+++ b/packages/domain/src/referentiels/labellisations/audit-type-options/audit-type-options.rules.ts
@@ -1,4 +1,7 @@
-import { SujetDemande, SujetDemandeEnum } from '../labellisation-demande.schema';
+import {
+  SujetDemande,
+  SujetDemandeEnum,
+} from '../labellisation-demande.schema';
 import { Etoile, EtoileEnum } from '../labellisation-etoile.enum.schema';
 import {
   areAuditPrerequisitesMet,
@@ -6,12 +9,16 @@ import {
   ParcoursForAuditPrerequisites,
 } from '../request-labellisation/request-labellisation.rules';
 
+export type AuditTypeUnavailableReason =
+  | AuditPrerequisitesError
+  | 'SCORE_BELOW_AUDITABLE_STAR';
+
 export type AuditTypeOption =
   | { sujet: SujetDemande; isRequestable: true; reason: null }
   | {
       sujet: SujetDemande;
       isRequestable: false;
-      reason: AuditPrerequisitesError;
+      reason: AuditTypeUnavailableReason;
     };
 
 export const AUDIT_TYPES_BY_ASCENDING_REQUIREMENTS = [
@@ -24,28 +31,34 @@ const requiresCot = (sujet: SujetDemande): boolean =>
   sujet === SujetDemandeEnum.COT ||
   sujet === SujetDemandeEnum.LABELLISATION_COT;
 
-const listAvailableSujets = ({
-  isCOT,
-  maximumRequestableStar,
-}: {
-  isCOT: boolean;
-  maximumRequestableStar: Etoile;
-}): readonly SujetDemande[] =>
-  maximumRequestableStar < EtoileEnum.DEUXIEME_ETOILE
-    ? []
-    : AUDIT_TYPES_BY_ASCENDING_REQUIREMENTS.filter(
-        (sujet) => isCOT || !requiresCot(sujet)
-      );
+const requiresAuditableStar = (sujet: SujetDemande): boolean =>
+  sujet !== SujetDemandeEnum.COT;
+
+const listAvailableSujets = (isCOT: boolean): readonly SujetDemande[] =>
+  AUDIT_TYPES_BY_ASCENDING_REQUIREMENTS.filter(
+    (sujet) => requiresCot(sujet) === isCOT
+  );
 
 const toAuditTypeOption = (
   parcours: ParcoursForAuditPrerequisites,
   sujet: SujetDemande,
   maximumRequestableStar: Etoile
 ): AuditTypeOption => {
+  if (
+    requiresAuditableStar(sujet) &&
+    maximumRequestableStar < EtoileEnum.DEUXIEME_ETOILE
+  ) {
+    return {
+      sujet,
+      isRequestable: false,
+      reason: 'SCORE_BELOW_AUDITABLE_STAR',
+    };
+  }
+
   const prerequisites = areAuditPrerequisitesMet(
     parcours,
     sujet,
-    sujet === SujetDemandeEnum.COT ? null : maximumRequestableStar
+    requiresAuditableStar(sujet) ? maximumRequestableStar : null
   );
 
   if (prerequisites.met) {
@@ -58,6 +71,6 @@ export const listAuditTypeOptions = (
   parcours: ParcoursForAuditPrerequisites,
   context: { isCOT: boolean; maximumRequestableStar: Etoile }
 ): AuditTypeOption[] =>
-  listAvailableSujets(context).map((sujet) =>
+  listAvailableSujets(context.isCOT).map((sujet) =>
     toAuditTypeOption(parcours, sujet, context.maximumRequestableStar)
   );


### PR DESCRIPTION
## Comportement livré

Une CT COT sous 35 % de score, référentiel complet, peut demander un audit COT seul — le bouton était mort jusqu'ici. L'option « avec labellisation » lui apparaît grisée.

| Cas | Avant | Après |
|---|---|---|
| COT, score < 35 % | bouton désactivé, tooltip score | bouton actif, 2 options dont 1 grisée |
| COT, score ≥ 35 % | 3 options | 2 options (`labellisation` nu retiré) |
| non-COT | — | inchangé |

## Changements

**L'offre ne dépend plus que du statut COT** : `cot` + `labellisation_cot` pour une CT COT, `labellisation` seul sinon.

```ts
AUDIT_TYPES_BY_ASCENDING_REQUIREMENTS.filter((sujet) => requiresCot(sujet) === isCOT)
```

**Le seuil de 35 % devient un motif d'indisponibilité** au lieu d'un filtre d'existence :

```ts
export type AuditTypeUnavailableReason = AuditPrerequisitesError | 'SCORE_BELOW_AUDITABLE_STAR';
```

`SCORE_BELOW_AUDITABLE_STAR` n'est volontairement pas un `AuditPrerequisitesError` : avec `maximumRequestableStar = 1`, le garde `1 > 1` est faux, donc `areAuditPrerequisitesMet` **passe**. C'est une pré-condition des sujets qui exigent une étoile, pas un prérequis en échec.

**`noRequestableAuditType` disparaît** : la liste n'est plus jamais vide. `getAuditRequestAvailability` restitue le motif de la première option de l'ordre ascendant — la moins exigeante, celle dont l'utilisateur est le plus proche.

Le mapping de tooltip garde ses deux libellés actuels, en 6 branches `.exhaustive()` : `SCORE_BELOW_AUDITABLE_STAR` → « Atteindre au moins 35 % de score… », les 5 `AuditPrerequisitesError` → « Renseigner tous les critères attendus… ».

## Surface de review

| Fichier | Nature |
|---|---|
| `audit-type-options.rules.ts` | **attention humaine** — offre + nouveau motif |
| `audit-request-availability.rules.ts` | **attention humaine** — restitution du motif |
| `request-audit.button.tsx` | **attention humaine** — mapping tooltip |
| les 4 specs | mécaniques |

~50 lignes de logique nouvelle.

## Hypothèses

**L'API reste permissive, volontairement.** On ne restreint que l'offre côté UI : `canRequestAuditOrLabellisation` continue d'accepter `labellisation` de n'importe quelle collectivité. Resserrer le contrat est reporté, pas oublié — PR dédiée si le besoin se confirme.

`request-audit.form.spec.tsx` sort du scope annoncé par le plan : 4 de ses cas affirment qu'une CT COT voit 3 types et cliquent sur une option qui n'existe plus pour elle.

## Anti-scope

- Tooltip dédié au motif `REFERENTIEL_NOT_COMPLETED` → PR 4
- Prérequis « référents désignés » relâché pour l'audit COT → déjà livré par #4849

## Prior art

Aucune utility ni composant créés. `AuditPrerequisitesError` est transporté tel quel, aucun motif renommé ni fusionné (`rg 'noRequestableAuditType'`, `rg 'prerequisitesIncomplete'` : plus aucune occurrence). `requiresAuditableStar` est ajouté à côté de `requiresCot`, même fichier, même patron.

Le helper `getRadioButtonByName` est dupliqué entre `request-audit.form.spec.tsx` et `audit-type.field.spec.tsx` : candidat à extraction, laissé en l'état pour ne pas rouvrir un fichier de #4867.

## Vérifications

- `nx test domain` : 376 tests / 32 fichiers · `nx test app` : 645 tests / 96 fichiers
- `nx run domain:typecheck`, `nx run app:typecheck` verts
- lint : 0 erreur des deux côtés, baselines de warnings inchangées (1 et 104)

Aucun item `DISCOVERED` ajouté.

## Contexte

PR 3 de la stack « CTA Demander un audit — gating COT vs non-COT », plan `doc/plans/2026-08-25-001-feat-cta-demande-audit-cot-plan.md`. Dépend de #4867 (mergée). Suivante : PR 4.
