### PR TITLE
feat(labellisation): distingue le motif de completude dans le CTA de demande d'audit

### DIFF
--- a/apps/app/src/referentiels/labellisations/request-audit/request-audit.button.spec.tsx
+++ b/apps/app/src/referentiels/labellisations/request-audit/request-audit.button.spec.tsx
@@ -174,7 +174,7 @@ describe('RequestAuditButton — état du bouton pour la collectivité auditée'
 
     expect(getRequestAuditButton().disabled).toBe(true);
     expect(getTooltipLabel()).toBe(
-      'Renseigner tous les critères attendus afin de pouvoir demander un audit ou une labellisation'
+      'Renseigner les statuts de toutes les mesures du référentiel'
     );
   });
 
@@ -185,6 +185,29 @@ describe('RequestAuditButton — état du bouton pour la collectivité auditée'
 
     expect(getRequestAuditButton().disabled).toBe(false);
     expect(getTooltipLabel()).toBeNull();
+  });
+
+  it('motif autre que la complétude : le tooltip reste la phrase générique sur les critères attendus', () => {
+    setCycle({
+      parcours: {
+        ...requestableCycle.parcours,
+        isCot: false,
+        completude_ok: true,
+        criteres_action: [
+          { atteint: true, action_id: 'cae_5.1.2.1.1' },
+          { atteint: false, action_id: 'cae_1.1.1' },
+        ],
+      } as ParcoursForAuditRequest,
+      isCOT: false,
+      maximumRequestableStar: 2,
+    });
+
+    render(<RequestAuditButton referentielId="cae" />);
+
+    expect(getRequestAuditButton().disabled).toBe(true);
+    expect(getTooltipLabel()).toBe(
+      'Renseigner tous les critères attendus afin de pouvoir demander un audit ou une labellisation'
+    );
   });
 
   it('non-COT dont tous les statuts sont renseignés mais sous 35 % de score : bouton désactivé, le score manque', () => {

--- a/apps/app/src/referentiels/labellisations/request-audit/request-audit.button.tsx
+++ b/apps/app/src/referentiels/labellisations/request-audit/request-audit.button.tsx
@@ -41,6 +41,9 @@ const tooltipForUnavailableReason = (
     )
     .with(
       { kind: 'auditTypeUnavailable', cause: 'REFERENTIEL_NOT_COMPLETED' },
+      () => appLabels.completudeCritere
+    )
+    .with(
       {
         kind: 'auditTypeUnavailable',
         cause: 'SCORE_GLOBAL_CRITERIA_NOT_SATISFIED',


### PR DESCRIPTION
## Comportement livré

Une CT COT dont les statuts ne sont pas tous renseignés lit **pourquoi** son CTA est grisé :

| | Tooltip de « Demander un audit » |
|---|---|
| Avant | « Renseigner tous les critères attendus afin de pouvoir demander un audit ou une labellisation » |
| Après | « Renseigner les statuts de toutes les mesures du référentiel » |

Le tooltip cite mot pour mot la ligne de checklist que l'utilisateur doit aller remplir. C'est pertinent parce que le sujet `cot` ne peut échouer **que** sur la complétude : tous les autres prérequis sont court-circuités par `areAuditPrerequisitesMet`.

## Changement

Une branche du `match` change de libellé. Les 6 branches restent `.exhaustive()`.

| Motif | Libellé |
|---|---|
| `REFERENTIEL_NOT_COMPLETED` | **`completudeCritere`** ← seule modification |
| `SCORE_BELOW_AUDITABLE_STAR` | `demanderAuditScoreInsuffisant` |
| 4 autres `AuditPrerequisitesError` | `renseignerCriteresPourDemande` |

Aucun libellé créé, aucun type introduit, `packages/domain` absent du diff : le motif est transporté depuis #4863 et déjà mappé depuis #4868.

## Surface de review

`request-audit.button.tsx` — 1 branche de `match`. ~2 lignes de logique. Le reste est la spec.

## Hypothèses

**Écart assumé avec la formulation du PO.** Il avait écrit « Renseigner au moins le 1er critère pour demander un audit ». La réutilisation de `completudeCritere` dit la même chose sans la référence positionnelle au « 1er critère », qui deviendrait fausse dès qu'une ligne est insérée au-dessus dans le tableau. Si le PO tient à sa formulation exacte, une clé est créée à ce moment-là.

**`REFERENT_ROLES_NOT_DEFINED` reste fusionné** dans le libellé générique — choix délibéré de #4849, la ligne de checklist portant déjà « Critère non atteint ». Le motif est disponible depuis #4863 : le jour où le PO le veut, c'est une ligne de `match`, sans changement domaine.

## Anti-scope

- Parcours de demande de 1re étoile (`AskPremiereEtoileButton`, `canAskFirstStar`) → intact, le verrou référents y reste
- `areAuditPrerequisitesMet` → intact, la règle est celle de #4849

## Vérifications

- `nx test app` : 647 tests / 96 fichiers verts, dont la non-régression « un motif autre que la complétude rend toujours la phrase générique »
- `nx run app:typecheck` (project + spec) vert · eslint 0 erreur
- `git diff` : 2 fichiers, aucun sous `packages/domain`, `catalog.ts` intouché

## Contexte

PR 4 de la stack « CTA Demander un audit — gating COT vs non-COT », plan `doc/plans/2026-08-25-001-feat-cta-demande-audit-cot-plan.md`. Dépend de #4868 (mergée). Suivante et dernière : PR 5, la couverture e2e.
