### PR TITLE
Utilise les liens complémentaires vers les actions origine dans la bascule des commentaires d'avancement

### DIFF
--- a/apps/backend/src/referentiels/compute-score/scores.service.ts
+++ b/apps/backend/src/referentiels/compute-score/scores.service.ts
@@ -932,8 +932,10 @@ export default class ScoresService {
 
     const referentiel = await this.getReferentielsService.getReferentielTree(
       referentielId,
-      true,
-      parameters.avecReferentielsOrigine
+      {
+        onlyForScoring: true,
+        getActionsOrigine: parameters.avecReferentielsOrigine,
+      }
     );
 
     const getReferentielMultipleScoresResponse = {
@@ -1095,8 +1097,10 @@ export default class ScoresService {
     if (!referentiel) {
       referentiel = await this.getReferentielsService.getReferentielTree(
         referentielId,
-        true,
-        parameters.avecReferentielsOrigine
+        {
+          onlyForScoring: true,
+          getActionsOrigine: parameters.avecReferentielsOrigine,
+        }
       );
     }
 

--- a/apps/backend/src/referentiels/correlated-actions/correlated-actions.dto.ts
+++ b/apps/backend/src/referentiels/correlated-actions/correlated-actions.dto.ts
@@ -2,10 +2,13 @@ import { actionScoreWithOnlyPointsSchema } from '@tet/domain/referentiels';
 import { z } from 'zod';
 import { corelatedActionWithScoreSchema } from './referentiel-action-origine-with-score.dto';
 import { correlatedActionSchema } from './referentiel-action-origine.dto';
+import { correlatedActionTexteSchema } from './referentiel-action-origine-texte.dto';
 
 export const correlatedActionsFieldsSchema = z.object({
   referentielsOrigine: z.string().array().optional(),
   actionsOrigine: correlatedActionSchema.array().optional(),
+  /** liens complémentaires (sans pondération) réservés à la fusion des commentaires lors de la bascule TE */
+  actionsOrigineTexte: correlatedActionTexteSchema.array().optional(),
 });
 
 export type CorrelatedActionsFields = z.infer<

--- a/apps/backend/src/referentiels/correlated-actions/get-action-origine-texte.dto.ts
+++ b/apps/backend/src/referentiels/correlated-actions/get-action-origine-texte.dto.ts
@@ -1,0 +1,10 @@
+import { actionOrigineTexteSchema } from '@tet/domain/referentiels';
+import { z } from 'zod';
+
+export const getActionOrigineTexteDtoSchema = z.object({
+  ...actionOrigineTexteSchema.shape,
+  origineActionNom: z.string().optional().nullable(),
+});
+export type GetActionOrigineTexteDtoSchema = z.infer<
+  typeof getActionOrigineTexteDtoSchema
+>;

--- a/apps/backend/src/referentiels/correlated-actions/referentiel-action-origine-texte-with-score.dto.ts
+++ b/apps/backend/src/referentiels/correlated-actions/referentiel-action-origine-texte-with-score.dto.ts
@@ -1,0 +1,12 @@
+import { actionScoreWithOnlyPointsAndStatutsSchema } from '@tet/domain/referentiels';
+import { z } from 'zod';
+import { correlatedActionTexteSchema } from './referentiel-action-origine-texte.dto';
+
+export const corelatedActionTexteWithScoreSchema =
+  correlatedActionTexteSchema.extend({
+    score: actionScoreWithOnlyPointsAndStatutsSchema.nullable(),
+  });
+
+export type CorrelatedActionTexteWithScore = z.infer<
+  typeof corelatedActionTexteWithScoreSchema
+>;

--- a/apps/backend/src/referentiels/correlated-actions/referentiel-action-origine-texte.dto.ts
+++ b/apps/backend/src/referentiels/correlated-actions/referentiel-action-origine-texte.dto.ts
@@ -1,0 +1,10 @@
+import { referentielIdEnumSchema } from '@tet/domain/referentiels';
+import { z } from 'zod';
+
+export const correlatedActionTexteSchema = z.object({
+  referentielId: referentielIdEnumSchema,
+  actionId: z.string(),
+  nom: z.string().nullable(),
+});
+
+export type CorrelatedActionTexte = z.infer<typeof correlatedActionTexteSchema>;

--- a/apps/backend/src/referentiels/definitions/get-referentiel-definition/get-referentiel.controller.ts
+++ b/apps/backend/src/referentiels/definitions/get-referentiel-definition/get-referentiel.controller.ts
@@ -71,7 +71,9 @@ export class GetReferentielController {
   async getReferentiel(
     @Param(REFERENTIEL_ID_PARAM_KEY) referentielId: ReferentielId
   ) {
-    return this.getReferentielService.getReferentielTree(referentielId, true);
+    return this.getReferentielService.getReferentielTree(referentielId, {
+      onlyForScoring: true,
+    });
   }
 
   @AllowPublicAccess()

--- a/apps/backend/src/referentiels/export-score/load-score-comparison.service.ts
+++ b/apps/backend/src/referentiels/export-score/load-score-comparison.service.ts
@@ -468,10 +468,8 @@ export class LoadScoreComparisonService {
   private async getActionDescriptions(
     referentielId: ReferentielId
   ): Promise<Record<ActionId, string>> {
-    const referentiel = await this.getReferentielService.getReferentielTree(
-      referentielId,
-      false
-    );
+    const referentiel =
+      await this.getReferentielService.getReferentielTree(referentielId);
 
     const descriptions: Record<string, string> = {};
 

--- a/apps/backend/src/referentiels/get-referentiel/get-referentiel.service.ts
+++ b/apps/backend/src/referentiels/get-referentiel/get-referentiel.service.ts
@@ -181,9 +181,11 @@ export class GetReferentielService {
 
   async getReferentielTree(
     referentielId: ReferentielId,
-    onlyForScoring?: boolean,
-    getActionsOrigine?: boolean,
-    withPreuves?: boolean
+    options?: {
+      onlyForScoring?: boolean;
+      getActionsOrigine?: boolean;
+      withPreuves?: boolean;
+    }
   ): Promise<ReferentielResponse> {
     this.logger.log(`Get referentiel ${referentielId}`);
 
@@ -195,14 +197,17 @@ export class GetReferentielService {
     const actionDefinitions = await this.getActionDefinitionsWithParent(
       referentielId,
       referentielDefinition.version,
-      { withSelectColumns: onlyForScoring ? 'essential' : 'all', withPreuves }
+      {
+        withSelectColumns: options?.onlyForScoring ? 'essential' : 'all',
+        withPreuves: options?.withPreuves,
+      }
     );
 
     this.logger.log(
       `${actionDefinitions.length} actions trouvees pour le referentiel ${referentielId}`
     );
 
-    const actionOrigines = getActionsOrigine
+    const actionOrigines = options?.getActionsOrigine
       ? await this.getActionsOrigine(referentielId)
       : null;
 

--- a/apps/backend/src/referentiels/get-referentiel/get-referentiel.service.ts
+++ b/apps/backend/src/referentiels/get-referentiel/get-referentiel.service.ts
@@ -60,7 +60,7 @@ export class GetReferentielService {
     return await this.databaseService.db
       .select({
         ...getTableColumns(actionOrigineTable),
-        origine_action_nom: actionDefinitionTable.nom,
+        origineActionNom: actionDefinitionTable.nom,
       })
       .from(actionOrigineTable)
       .leftJoin(

--- a/apps/backend/src/referentiels/get-referentiel/get-referentiel.service.ts
+++ b/apps/backend/src/referentiels/get-referentiel/get-referentiel.service.ts
@@ -19,8 +19,10 @@ import {
 import { and, asc, eq, getTableColumns, ilike, sql } from 'drizzle-orm';
 import { isNil } from 'es-toolkit';
 import { actionOrigineTable } from '../correlated-actions/action-origine.table';
+import { actionOrigineTexteTable } from '../correlated-actions/action-origine-texte.table';
 import { CorrelatedActionsFields } from '../correlated-actions/correlated-actions.dto';
 import { GetActionOrigineDtoSchema } from '../correlated-actions/get-action-origine.dto';
+import { GetActionOrigineTexteDtoSchema } from '../correlated-actions/get-action-origine-texte.dto';
 import { GetReferentielDefinitionService } from '../definitions/get-referentiel-definition/get-referentiel-definition.service';
 import { actionDefinitionTagTable } from '../models/action-definition-tag.table';
 import { actionDefinitionTable } from '../models/action-definition.table';
@@ -71,6 +73,31 @@ export class GetReferentielService {
         eq(actionOrigineTable.referentielId, referentielId as ReferentielId)
       )
       .orderBy(asc(actionOrigineTable.actionId));
+  }
+
+  private async getActionsOrigineTexte(
+    referentielId: ReferentielId
+  ): Promise<GetActionOrigineTexteDtoSchema[]> {
+    return await this.databaseService.db
+      .select({
+        ...getTableColumns(actionOrigineTexteTable),
+        origineActionNom: actionDefinitionTable.nom,
+      })
+      .from(actionOrigineTexteTable)
+      .leftJoin(
+        actionDefinitionTable,
+        eq(
+          actionOrigineTexteTable.origineActionId,
+          actionDefinitionTable.actionId
+        )
+      )
+      .where(
+        eq(
+          actionOrigineTexteTable.referentielId,
+          referentielId as ReferentielId
+        )
+      )
+      .orderBy(asc(actionOrigineTexteTable.actionId));
   }
 
   private getActionDefinitionTags() {
@@ -185,6 +212,7 @@ export class GetReferentielService {
       onlyForScoring?: boolean;
       getActionsOrigine?: boolean;
       withPreuves?: boolean;
+      getActionsOrigineTexte?: boolean;
     }
   ): Promise<ReferentielResponse> {
     this.logger.log(`Get referentiel ${referentielId}`);
@@ -211,10 +239,15 @@ export class GetReferentielService {
       ? await this.getActionsOrigine(referentielId)
       : null;
 
+    const actionOrigineTextes = options?.getActionsOrigineTexte
+      ? await this.getActionsOrigineTexte(referentielId)
+      : null;
+
     const actionsTree = buildReferentielTree(
       actionDefinitions,
       referentielDefinition.hierarchie,
-      actionOrigines
+      actionOrigines,
+      actionOrigineTextes
     );
 
     return {
@@ -228,7 +261,8 @@ export class GetReferentielService {
 export function buildReferentielTree(
   actionDefinitions: ActionDefinitionAvecParent[],
   orderedActionTypes: ActionType[],
-  actionOrigines?: GetActionOrigineDtoSchema[] | null
+  actionOrigines?: GetActionOrigineDtoSchema[] | null,
+  actionOrigineTextes?: GetActionOrigineTexteDtoSchema[] | null
 ) {
   const rootAction = actionDefinitions.find((action) => !action.parentActionId);
   if (!rootAction) {
@@ -249,7 +283,8 @@ export function buildReferentielTree(
     actionDefinitions,
     orderedActionTypes,
     referentiel.level,
-    actionOrigines
+    actionOrigines,
+    actionOrigineTextes
   );
 
   return referentiel;
@@ -264,7 +299,8 @@ function attacheActionsEnfant(
   actionDefinitions: ActionDefinitionAvecParent[],
   orderActionTypes: ActionType[],
   currentLevel: number,
-  actionOrigines?: GetActionOrigineDtoSchema[] | null
+  actionOrigines?: GetActionOrigineDtoSchema[] | null,
+  actionOrigineTextes?: GetActionOrigineTexteDtoSchema[] | null
 ): void {
   const actionsEnfant = actionDefinitions.filter(
     (action) => action.parentActionId === referentiel.actionId
@@ -297,6 +333,22 @@ function attacheActionsEnfant(
         )
       ).values(),
     ];
+  }
+
+  if (actionOrigineTextes) {
+    const associatedActionOrigineTextes = actionOrigineTextes.filter(
+      (origine) => origine.actionId === referentiel.actionId
+    );
+
+    referentiel.actionsOrigineTexte = associatedActionOrigineTextes.map(
+      (origine) => ({
+        referentielId: referentielIdEnumSchema.parse(
+          origine.origineReferentielId
+        ),
+        actionId: origine.origineActionId,
+        nom: origine.origineActionNom || null,
+      })
+    );
   }
 
   if (actionsEnfant.length) {
@@ -364,7 +416,8 @@ function attacheActionsEnfant(
         actionDefinitions,
         orderActionTypes,
         levelEnfant,
-        actionOrigines
+        actionOrigines,
+        actionOrigineTextes
       );
     });
 

--- a/apps/backend/src/referentiels/import-referentiel/import-referentiel.service.ts
+++ b/apps/backend/src/referentiels/import-referentiel/import-referentiel.service.ts
@@ -455,12 +455,11 @@ export class ImportReferentielService extends BaseSpreadsheetImporterService {
 
     this.logger.log(`Import du référentiel ${referentielId} terminé`);
 
-    return this.referentielService.getReferentielTree(
-      referentielId,
-      false,
-      true,
-      true
-    );
+    return this.referentielService.getReferentielTree(referentielId, {
+      onlyForScoring: false,
+      getActionsOrigine: true,
+      withPreuves: true,
+    });
   }
 
   async verifyReferentiel(referentielId: ReferentielId) {

--- a/apps/backend/src/referentiels/switch-to-te/build-switch-to-te-context.service.ts
+++ b/apps/backend/src/referentiels/switch-to-te/build-switch-to-te-context.service.ts
@@ -74,6 +74,7 @@ export class BuildSwitchToTeContextService {
       {
         onlyForScoring: true,
         getActionsOrigine: true,
+        getActionsOrigineTexte: true,
       }
     );
 

--- a/apps/backend/src/referentiels/switch-to-te/build-switch-to-te-context.service.ts
+++ b/apps/backend/src/referentiels/switch-to-te/build-switch-to-te-context.service.ts
@@ -71,8 +71,10 @@ export class BuildSwitchToTeContextService {
 
     const referentielTe = await this.getReferentielService.getReferentielTree(
       ReferentielIdEnum.TE,
-      true,
-      true
+      {
+        onlyForScoring: true,
+        getActionsOrigine: true,
+      }
     );
 
     const { scoresPayload } =

--- a/apps/backend/src/referentiels/switch-to-te/merge-commentaires/merge-commentaires.rules.e2e-spec.ts
+++ b/apps/backend/src/referentiels/switch-to-te/merge-commentaires/merge-commentaires.rules.e2e-spec.ts
@@ -1,5 +1,6 @@
 import { INestApplication } from '@nestjs/common';
 import { addTestCollectiviteAndUser } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { actionDefinitionTable } from '@tet/backend/referentiels/models/action-definition.table';
 import {
   getAuthUserFromUserCredentials,
   getTestApp,
@@ -19,7 +20,6 @@ import {
 } from '@tet/domain/referentiels';
 import { CollectiviteRole } from '@tet/domain/users';
 import { eq } from 'drizzle-orm';
-import { actionDefinitionTable } from '../../models/action-definition.table';
 import { BuildSwitchToTeContextService } from '../build-switch-to-te-context.service';
 import { CreatePreSwitchSnapshotsService } from '../create-pre-switch-snapshots.service';
 import {
@@ -52,6 +52,29 @@ const MERGE_COMMENTAIRES_FIXTURE = {
   },
   /** TE 1.1.1.3 : origine « Nouvelle action », sans source CAE/ECI */
   teNativeActionId: 'te_1.1.1.3',
+} as const;
+
+const ACTION_ORIGINE_TEXTE_FIXTURE = {
+  /**
+   * TE 6.3.3.1 : `action_origine_texte` pointe exclusivement vers Eci_2.5.2,
+   * alors que `action_origine` référence Eci_2.5.1 (source distincte) —
+   * permet de vérifier que `action_origine_texte`, quand renseigné, prime
+   * sur `action_origine`.
+   */
+  teActionAvecOrigineTexteUnique: {
+    teActionId: 'te_6.3.3.1',
+    origineTexteActionId: 'eci_2.5.2',
+    autreOrigineActionId: 'eci_2.5.1',
+  },
+  /**
+   * TE 6.1.3.4 : aucune ligne `action_origine_texte`, seules des origines
+   * `action_origine` (CAE) sont disponibles — exerce le repli sur
+   * `action_origine`.
+   */
+  teActionSansOrigineTexte: {
+    teActionId: 'te_6.1.3.4',
+    caeOrigineActionId: 'cae_6.2.2.3.5',
+  },
 } as const;
 
 describe('mergeCommentaires', () => {
@@ -300,5 +323,88 @@ describe('mergeCommentaires', () => {
           commentaire.actionId === MERGE_COMMENTAIRES_FIXTURE.teNativeActionId
       )
     ).toBe(false);
+  });
+
+  describe('action_origine_texte', () => {
+    test('renseigné avec une seule origine : utilise exclusivement ce lien, ignore action_origine même avec texte valide', async () => {
+      const { teActionId, origineTexteActionId, autreOrigineActionId } =
+        ACTION_ORIGINE_TEXTE_FIXTURE.teActionAvecOrigineTexteUnique;
+
+      onTestFinished(cleanupCollectiviteReferentielData);
+      await setupTest();
+
+      await setActionStatut(origineTexteActionId, StatutAvancementEnum.FAIT);
+      await setActionStatut(autreOrigineActionId, StatutAvancementEnum.FAIT);
+      await setActionCommentaire(
+        origineTexteActionId,
+        '<p>Bloc ECI utilisé via action_origine_texte.</p>'
+      );
+      await setActionCommentaire(
+        autreOrigineActionId,
+        '<p>Bloc ignoré car action_origine_texte est renseigné pour cette cible.</p>'
+      );
+
+      const data = await mergeFromPrefs(prefsEligibleCaeAndEci);
+
+      const teCommentaire = data.find(
+        (commentaire) => commentaire.actionId === teActionId
+      );
+
+      expect(teCommentaire?.commentaire).toContain(origineTexteActionId);
+      expect(teCommentaire?.commentaire).toContain(
+        'Bloc ECI utilisé via action_origine_texte.'
+      );
+      expect(teCommentaire?.commentaire).not.toContain(autreOrigineActionId);
+      expect(teCommentaire?.commentaire).not.toContain(
+        'Bloc ignoré car action_origine_texte est renseigné pour cette cible.'
+      );
+    });
+
+    test('renseigné mais source non concernée : pas de commentaire, pas de repli sur action_origine', async () => {
+      const { teActionId, origineTexteActionId, autreOrigineActionId } =
+        ACTION_ORIGINE_TEXTE_FIXTURE.teActionAvecOrigineTexteUnique;
+
+      onTestFinished(cleanupCollectiviteReferentielData);
+      await setupTest();
+
+      await setActionStatut(origineTexteActionId, 'non_concerne');
+      await setActionStatut(autreOrigineActionId, StatutAvancementEnum.FAIT);
+      await setActionCommentaire(
+        origineTexteActionId,
+        '<p>Bloc ECI mais source non concernée.</p>'
+      );
+      await setActionCommentaire(
+        autreOrigineActionId,
+        '<p>Bloc disponible mais jamais utilisé (pas de repli attendu).</p>'
+      );
+
+      const data = await mergeFromPrefs(prefsEligibleCaeAndEci);
+
+      expect(
+        data.some((commentaire) => commentaire.actionId === teActionId)
+      ).toBe(false);
+    });
+
+    test('non renseigné : comportement inchangé, basé sur action_origine (non-régression)', async () => {
+      const { teActionId, caeOrigineActionId } =
+        ACTION_ORIGINE_TEXTE_FIXTURE.teActionSansOrigineTexte;
+
+      onTestFinished(cleanupCollectiviteReferentielData);
+      await setupTest();
+
+      await setActionStatut(caeOrigineActionId, StatutAvancementEnum.FAIT);
+      await setActionCommentaire(
+        caeOrigineActionId,
+        '<p>Explication CAE, aucune ligne action_origine_texte pour cette cible.</p>'
+      );
+
+      const data = await mergeFromPrefs(prefsEligibleCaeOnly);
+
+      const teCommentaire = data.find(
+        (commentaire) => commentaire.actionId === teActionId
+      );
+
+      expect(teCommentaire?.commentaire).toContain(caeOrigineActionId);
+    });
   });
 });

--- a/apps/backend/src/referentiels/switch-to-te/merge-commentaires/merge-commentaires.rules.e2e-spec.ts
+++ b/apps/backend/src/referentiels/switch-to-te/merge-commentaires/merge-commentaires.rules.e2e-spec.ts
@@ -18,6 +18,8 @@ import {
   type ScoreSnapshot,
 } from '@tet/domain/referentiels';
 import { CollectiviteRole } from '@tet/domain/users';
+import { eq } from 'drizzle-orm';
+import { actionDefinitionTable } from '../../models/action-definition.table';
 import { BuildSwitchToTeContextService } from '../build-switch-to-te-context.service';
 import { CreatePreSwitchSnapshotsService } from '../create-pre-switch-snapshots.service';
 import {
@@ -166,6 +168,36 @@ describe('mergeCommentaires', () => {
     expect(teCommentaire?.commentaire).toContain(caeOrigineActionId);
     expect(teCommentaire?.commentaire).toContain('FAIT');
     expect(teCommentaire?.commentaire).toContain(sourceCommentaire);
+  });
+
+  test("le nom de l'action source apparaît dans le header du bloc (fix alias origineActionNom)", async () => {
+    onTestFinished(cleanupCollectiviteReferentielData);
+    await setupTest();
+
+    const { teActionId, caeOrigineActionId } =
+      MERGE_COMMENTAIRES_FIXTURE.teActionCae1to1;
+
+    await setActionStatut(caeOrigineActionId, StatutAvancementEnum.FAIT);
+    await setActionCommentaire(
+      caeOrigineActionId,
+      '<p>Explication pour vérifier le nom affiché.</p>'
+    );
+
+    const [{ nom }] = await databaseService.db
+      .select({ nom: actionDefinitionTable.nom })
+      .from(actionDefinitionTable)
+      .where(eq(actionDefinitionTable.actionId, caeOrigineActionId));
+    expect(nom).toBeTruthy();
+
+    const data = await mergeFromPrefs(prefsEligibleCaeOnly);
+
+    const teCommentaire = data.find(
+      (commentaire) => commentaire.actionId === teActionId
+    );
+
+    expect(teCommentaire?.commentaire).toContain(
+      `${caeOrigineActionId} - ${nom} - FAIT`
+    );
   });
 
   test('CAE + ECI write, fusion N→1 : deux blocs ordonnés CAE puis ECI', async () => {

--- a/apps/backend/src/referentiels/switch-to-te/merge-commentaires/merge-commentaires.rules.ts
+++ b/apps/backend/src/referentiels/switch-to-te/merge-commentaires/merge-commentaires.rules.ts
@@ -118,11 +118,11 @@ export const mergeCommentairesFromSources = (
 
 export const buildMergeCommentaireSourcesFromCible = (
   ctx: SwitchToTeContext,
-  originesConcernees: ActionCible['originesConcernees']
+  originesCommentaire: ActionCible['originesCommentaire']
 ): MergeCommentaireSource[] => {
   const sources: MergeCommentaireSource[] = [];
 
-  for (const origine of originesConcernees) {
+  for (const origine of originesCommentaire) {
     const scoreMap = ctx.scoreMapsByReferentiel.get(
       origine.referentielId as ReferentielId
     );
@@ -153,7 +153,7 @@ export const mergeCommentaires = (
   for (const cible of ctx.cibles.sousActionsEtTaches) {
     const sources = buildMergeCommentaireSourcesFromCible(
       ctx,
-      cible.originesConcernees
+      cible.originesCommentaire
     );
     const commentaire = mergeCommentairesFromSources(sources);
 

--- a/apps/backend/src/referentiels/switch-to-te/merge-pilotes/merge-pilotes.rules.spec.ts
+++ b/apps/backend/src/referentiels/switch-to-te/merge-pilotes/merge-pilotes.rules.spec.ts
@@ -195,6 +195,7 @@ describe('mergePilotes', () => {
     actionId: overrides.actionId,
     actionsOrigine: overrides.actionsOrigine ?? [],
     originesConcernees: overrides.originesConcernees ?? [],
+    originesCommentaire: overrides.originesCommentaire ?? [],
     concernee: overrides.concernee ?? true,
   });
 

--- a/apps/backend/src/referentiels/switch-to-te/merge-services/merge-services.rules.spec.ts
+++ b/apps/backend/src/referentiels/switch-to-te/merge-services/merge-services.rules.spec.ts
@@ -161,6 +161,7 @@ describe('mergeServices', () => {
     actionId: overrides.actionId,
     actionsOrigine: overrides.actionsOrigine ?? [],
     originesConcernees: overrides.originesConcernees ?? [],
+    originesCommentaire: overrides.originesCommentaire ?? [],
     concernee: overrides.concernee ?? true,
   });
 

--- a/apps/backend/src/referentiels/switch-to-te/shared/action-cible.spec.ts
+++ b/apps/backend/src/referentiels/switch-to-te/shared/action-cible.spec.ts
@@ -22,6 +22,11 @@ type TestTreeNode = ActionTreeNode<{
     ponderation: number;
     nom: string | null;
   }[];
+  actionsOrigineTexte?: {
+    referentielId: string;
+    actionId: string;
+    nom: string | null;
+  }[];
 }>;
 
 const createActionScore = (overrides: Partial<ActionScore> = {}): ActionScore =>
@@ -55,6 +60,18 @@ const eciOrigine = (actionId: string) => ({
   referentielId: ReferentielIdEnum.ECI,
   actionId,
   ponderation: 1,
+  nom: null,
+});
+
+const caeOrigineTexte = (actionId: string) => ({
+  referentielId: ReferentielIdEnum.CAE,
+  actionId,
+  nom: null,
+});
+
+const eciOrigineTexte = (actionId: string) => ({
+  referentielId: ReferentielIdEnum.ECI,
+  actionId,
   nom: null,
 });
 
@@ -266,6 +283,116 @@ describe('listSousActionsEtTachesCibles', () => {
       'te_sous_action',
       'te_tache',
     ]);
+  });
+
+  describe('originesCommentaire', () => {
+    it('sans actionsOrigineTexte, égale originesConcernees (non-régression)', () => {
+      const cible = listSousActionsEtTachesCibles({
+        referentielTe: createReferentielTe(tree),
+        scoreMapsByReferentiel,
+        teScoreMap: new Map(),
+      }).find((c) => c.actionId === 'te_sous_action');
+
+      expect(cible?.originesCommentaire).toEqual(cible?.originesConcernees);
+    });
+
+    it('avec actionsOrigineTexte renseigné pointant vers une autre source, ne contient que cette source texte', () => {
+      const treeAvecTexte: TestTreeNode = {
+        ...tree,
+        actionsEnfant: [
+          {
+            ...tree.actionsEnfant[0],
+            actionsEnfant: [
+              {
+                ...tree.actionsEnfant[0].actionsEnfant[0],
+                actionsEnfant: [
+                  {
+                    ...tree.actionsEnfant[0].actionsEnfant[0].actionsEnfant[0],
+                    actionsEnfant: [
+                      {
+                        actionId: 'te_sous_action',
+                        actionType: ActionTypeEnum.SOUS_ACTION,
+                        actionsOrigine: [caeOrigine('cae_sous_action')],
+                        actionsOrigineTexte: [eciOrigineTexte('eci_tache')],
+                        actionsEnfant: [],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      const cible = listSousActionsEtTachesCibles({
+        referentielTe: createReferentielTe(treeAvecTexte),
+        scoreMapsByReferentiel,
+        teScoreMap: new Map(),
+      }).find((c) => c.actionId === 'te_sous_action');
+
+      expect(cible?.originesCommentaire.map((o) => o.actionId)).toEqual([
+        'eci_tache',
+      ]);
+    });
+
+    it('avec actionsOrigineTexte renseigné mais dont la source est filtrée (non concernée), vide sans repli sur action_origine', () => {
+      const scoreMapsAvecCaeSousActionNonConcernee = new Map<
+        ReferentielId,
+        Map<string, ActionScore>
+      >([
+        [
+          ReferentielIdEnum.CAE,
+          new Map([
+            ['cae_sous_action', createActionScore()],
+            [
+              'cae_non_concernee_texte',
+              createActionScore({ concerne: false }),
+            ],
+          ]),
+        ],
+        [ReferentielIdEnum.ECI, new Map([['eci_tache', createActionScore()]])],
+      ]);
+
+      const treeAvecTexteNonConcerne: TestTreeNode = {
+        ...tree,
+        actionsEnfant: [
+          {
+            ...tree.actionsEnfant[0],
+            actionsEnfant: [
+              {
+                ...tree.actionsEnfant[0].actionsEnfant[0],
+                actionsEnfant: [
+                  {
+                    ...tree.actionsEnfant[0].actionsEnfant[0].actionsEnfant[0],
+                    actionsEnfant: [
+                      {
+                        actionId: 'te_sous_action',
+                        actionType: ActionTypeEnum.SOUS_ACTION,
+                        actionsOrigine: [caeOrigine('cae_sous_action')],
+                        actionsOrigineTexte: [
+                          caeOrigineTexte('cae_non_concernee_texte'),
+                        ],
+                        actionsEnfant: [],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      const cible = listSousActionsEtTachesCibles({
+        referentielTe: createReferentielTe(treeAvecTexteNonConcerne),
+        scoreMapsByReferentiel: scoreMapsAvecCaeSousActionNonConcernee,
+        teScoreMap: new Map(),
+      }).find((c) => c.actionId === 'te_sous_action');
+
+      expect(cible?.originesCommentaire).toEqual([]);
+      expect(cible?.originesConcernees).toHaveLength(1);
+    });
   });
 });
 

--- a/apps/backend/src/referentiels/switch-to-te/shared/action-cible.ts
+++ b/apps/backend/src/referentiels/switch-to-te/shared/action-cible.ts
@@ -6,12 +6,20 @@ import {
   type ActionScore,
   type ReferentielId,
 } from '@tet/domain/referentiels';
+import { type CorrelatedActionTexte } from '../../correlated-actions/referentiel-action-origine-texte.dto';
 import { CorrelatedActionWithScore } from '../../correlated-actions/referentiel-action-origine-with-score.dto';
 import {
   buildCorrelatedActionsWithScore,
   dedupeOrigines,
   filterOriginesConcernees,
 } from './action-origine';
+
+/** Source d'une origine utilisée pour la fusion des commentaires (action_origine ou action_origine_texte) */
+export type CommentaireOrigine = {
+  referentielId: ReferentielId;
+  actionId: string;
+  nom: string | null;
+};
 
 /**
  * Action destination de la bascule + origines résolues depuis les snapshots pre-switch-te.
@@ -25,6 +33,13 @@ export type ActionCible = {
   actionsOrigine: CorrelatedAction[];
   /** origines avec score snapshot + filtre concerne !== false */
   originesConcernees: CorrelatedActionWithScore[];
+  /**
+   * source des commentaires uniquement : action_origine_texte si renseigné pour cette
+   * cible (tout ou rien, sans repli même si le filtre "concerné" réduit à [] ensuite),
+   * sinon égal à `originesConcernees`. Ne doit être lu que par mergeCommentaires —
+   * mergeStatuts/mergePilotes/mergeServices restent sur `originesConcernees`.
+   */
+  originesCommentaire: CommentaireOrigine[];
 };
 
 export const isCibleConcernee = (
@@ -51,21 +66,36 @@ const buildActionCible = (
   actionId: string,
   actionsOrigine: CorrelatedAction[],
   scoreMapsByReferentiel: Map<ReferentielId, Map<string, ActionScore>>,
-  teScoreMap: Map<string, ActionScore>
+  teScoreMap: Map<string, ActionScore>,
+  actionsOrigineTexte: CorrelatedActionTexte[] = []
 ): ActionCible => {
   const correlatedActions = buildCorrelatedActionsWithScore(
     actionsOrigine,
     scoreMapsByReferentiel
   );
 
+  const originesConcernees = filterOriginesConcernees(
+    correlatedActions,
+    scoreMapsByReferentiel
+  );
+
+  const originesCommentaire: CommentaireOrigine[] =
+    actionsOrigineTexte.length > 0
+      ? filterOriginesConcernees(
+          buildCorrelatedActionsWithScore(
+            actionsOrigineTexte,
+            scoreMapsByReferentiel
+          ),
+          scoreMapsByReferentiel
+        )
+      : originesConcernees;
+
   return {
     actionId,
     concernee: isCibleConcernee(teScoreMap, actionId),
     actionsOrigine,
-    originesConcernees: filterOriginesConcernees(
-      correlatedActions,
-      scoreMapsByReferentiel
-    ),
+    originesConcernees,
+    originesCommentaire,
   };
 };
 
@@ -88,7 +118,8 @@ export const listSousActionsEtTachesCibles = (input: {
       teAction.actionId,
       teAction.actionsOrigine ?? [],
       input.scoreMapsByReferentiel,
-      input.teScoreMap
+      input.teScoreMap,
+      teAction.actionsOrigineTexte ?? []
     )
   );
 };

--- a/apps/backend/src/referentiels/switch-to-te/shared/action-origine.spec.ts
+++ b/apps/backend/src/referentiels/switch-to-te/shared/action-origine.spec.ts
@@ -7,6 +7,7 @@ import {
 } from '@tet/domain/referentiels';
 import { hierarchiesByReferentielIdForTests } from './referentiel-hierarchies.test-fixture';
 import {
+  buildCorrelatedActionsWithScore,
   collectMesureOrigineIds,
   dedupeOrigines,
   filterOriginesConcernees,
@@ -130,6 +131,33 @@ describe('filterOriginesConcernees', () => {
         scoreMapsByReferentiel
       )
     ).toHaveLength(0);
+  });
+
+  it('fonctionne avec une origine sans ponderation (action_origine_texte)', () => {
+    const caeScoreMap = new Map<string, ActionScore>([
+      ['cae_1', createActionScore({ concerne: true })],
+      ['cae_2', createActionScore({ concerne: false })],
+    ]);
+    const scoreMapsByReferentiel = new Map<
+      ReferentielId,
+      Map<string, ActionScore>
+    >([[ReferentielIdEnum.CAE, caeScoreMap]]);
+
+    const origineTexteSansPonderation = buildCorrelatedActionsWithScore(
+      [
+        { referentielId: ReferentielIdEnum.CAE, actionId: 'cae_1', nom: null },
+        { referentielId: ReferentielIdEnum.CAE, actionId: 'cae_2', nom: null },
+      ],
+      scoreMapsByReferentiel
+    );
+
+    const resultat = filterOriginesConcernees(
+      origineTexteSansPonderation,
+      scoreMapsByReferentiel
+    );
+
+    expect(resultat.map((origine) => origine.actionId)).toEqual(['cae_1']);
+    expect(resultat[0]).not.toHaveProperty('ponderation');
   });
 });
 

--- a/apps/backend/src/referentiels/switch-to-te/shared/action-origine.ts
+++ b/apps/backend/src/referentiels/switch-to-te/shared/action-origine.ts
@@ -1,4 +1,3 @@
-import { type CorrelatedActionWithScore } from '@tet/backend/referentiels/correlated-actions/referentiel-action-origine-with-score.dto';
 import { type CorrelatedAction } from '@tet/backend/referentiels/correlated-actions/referentiel-action-origine.dto';
 import {
   ReferentielIdEnum,
@@ -72,10 +71,10 @@ export const actionScoreToCorrelatedActionScore = (
     : {}),
 });
 
-export const buildCorrelatedActionsWithScore = (
-  actionsOrigine: CorrelatedAction[],
+export const buildCorrelatedActionsWithScore = <T extends ActionOrigineRef>(
+  actionsOrigine: T[],
   scoreMapsByReferentiel: Map<ReferentielId, Map<string, ActionScore>>
-): CorrelatedActionWithScore[] =>
+): (T & { score: ActionScoreWithOnlyPointsAndStatuts | null })[] =>
   actionsOrigine.map((origine) => {
     const scoreMap = scoreMapsByReferentiel.get(
       origine.referentielId as ReferentielId
@@ -90,10 +89,10 @@ export const buildCorrelatedActionsWithScore = (
     };
   });
 
-export const filterOriginesConcernees = (
-  correlatedActions: CorrelatedActionWithScore[],
+export const filterOriginesConcernees = <T extends ActionOrigineRef>(
+  correlatedActions: T[],
   scoreMapsByReferentiel: Map<ReferentielId, Map<string, ActionScore>>
-): CorrelatedActionWithScore[] =>
+): T[] =>
   correlatedActions.filter((origine) => {
     const scoreMap = scoreMapsByReferentiel.get(
       origine.referentielId as ReferentielId

--- a/apps/backend/src/referentiels/switch-to-te/shared/correspondance-origine-cible.spec.ts
+++ b/apps/backend/src/referentiels/switch-to-te/shared/correspondance-origine-cible.spec.ts
@@ -41,6 +41,7 @@ const createCible = (
   actionId: overrides.actionId,
   actionsOrigine: overrides.actionsOrigine ?? [],
   originesConcernees: overrides.originesConcernees ?? [],
+  originesCommentaire: overrides.originesCommentaire ?? [],
   concernee: overrides.concernee ?? true,
 });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Les commentaires fusionnés affichent désormais le nom de l’action à l’origine du commentaire.
  * Les informations textuelles d’origine sont prises en compte lorsqu’elles sont disponibles, avec filtrage selon la pertinence des actions.
  * Les référentiels peuvent transmettre ces informations d’origine lors de leur consultation et de la bascule vers le référentiel cible.

* **Tests**
  * Ajout de tests couvrant les priorités, filtres et cas sans origine textuelle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->