### PR TITLE
fix(referentiels): applique les contrôles d'accès manquants sur la liste des preuves

### DIFF
--- a/apps/backend/src/collectivites/documents/hide-confidentiel.utils.ts
+++ b/apps/backend/src/collectivites/documents/hide-confidentiel.utils.ts
@@ -1,0 +1,17 @@
+import { Column, eq, isNull, or, SQL } from 'drizzle-orm';
+import { bibliothequeFichierTable } from './models/bibliotheque-fichier.table';
+
+// `confidentiel === null` traité comme confidentiel (fail-closed) ; les liens
+// (sans fichier) ne portent jamais de confidentialité et restent visibles.
+export function hideConfidentielFilter(
+  fichierIdColumn: Column,
+  canReadConfidentiel: boolean
+): SQL | undefined {
+  if (canReadConfidentiel) {
+    return undefined;
+  }
+  return or(
+    isNull(fichierIdColumn),
+    eq(bibliothequeFichierTable.confidentiel, false)
+  );
+}

--- a/apps/backend/src/referentiels/labellisations/create-preuve/create-preuve.test-fixture.ts
+++ b/apps/backend/src/referentiels/labellisations/create-preuve/create-preuve.test-fixture.ts
@@ -10,7 +10,12 @@ export async function createTestDemandePreuve(
   testAgent: TestAgent,
   token: string,
   collectiviteId: number,
-  referentiel: ReferentielId
+  referentiel: ReferentielId,
+  document?: {
+    fileName?: string;
+    sampleFileName?: string;
+    confidentiel?: boolean;
+  }
 ): Promise<PreuveLabellisation> {
   const parcours =
     await trpcClient.referentiels.labellisations.getParcours.query({
@@ -26,7 +31,9 @@ export async function createTestDemandePreuve(
     collectiviteId,
     testAgent,
     token,
-    fileName: 'test-preuve.pdf',
+    fileName: document?.fileName ?? 'test-preuve.pdf',
+    sampleFileName: document?.sampleFileName,
+    confidentiel: document?.confidentiel,
   });
 
   const demandePreuve =

--- a/apps/backend/src/referentiels/labellisations/list-preuves/list-preuves.router.e2e-spec.ts
+++ b/apps/backend/src/referentiels/labellisations/list-preuves/list-preuves.router.e2e-spec.ts
@@ -1,6 +1,11 @@
 import { INestApplication } from '@nestjs/common';
 import { addTestCollectiviteAndUsers } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
 import {
+  OTHER_PDF_SAMPLE_FILE,
+  uploadCreateTestDocument,
+} from '@tet/backend/collectivites/documents/documents.test-fixture';
+import { preuveAuditTable } from '@tet/backend/collectivites/documents/models/preuve-audit.table';
+import {
   createTRPCClientFromCaller,
   getAuthUserFromUserCredentials,
   getTestApp,
@@ -15,6 +20,7 @@ import { Collectivite } from '@tet/domain/collectivites';
 import { ReferentielIdEnum } from '@tet/domain/referentiels';
 import { CollectiviteRole } from '@tet/domain/users';
 import request from 'supertest';
+import { onTestFinished } from 'vitest';
 import { createAuditWithOnTestFinished } from '../../referentiels.test-fixture';
 import { createTestDemandePreuve } from '../create-preuve/create-preuve.test-fixture';
 
@@ -117,6 +123,179 @@ describe('List Preuves Router', () => {
 
       expect(preuves).toBeDefined();
       expect(Array.isArray(preuves)).toBe(true);
+    });
+  });
+
+  describe('List Preuves - Restrictions de lecture', () => {
+    const createCollectiviteAvecDemande = async ({
+      accesRestreint,
+    }: {
+      accesRestreint: boolean;
+    }) => {
+      const { collectivite, users, cleanup } =
+        await addTestCollectiviteAndUsers(db, {
+          collectivite: { accesRestreint },
+          users: [{ role: CollectiviteRole.EDITION }],
+        });
+      onTestFinished(cleanup);
+
+      const membre = users[0];
+      const membreSignInResponse = await signInWith({
+        email: membre.email,
+        password: membre.password,
+      });
+
+      const { audit, demande } = await createAuditWithOnTestFinished({
+        databaseService: db,
+        collectiviteId: collectivite.id,
+        referentielId: ReferentielIdEnum.CAE,
+        withDemande: true,
+        dateDebut: null,
+      });
+      if (!demande) {
+        throw new Error('No demande found');
+      }
+
+      const membreCaller = router.createCaller({
+        user: getAuthUserFromUserCredentials(membre),
+      });
+
+      return {
+        collectiviteId: collectivite.id,
+        auditId: audit.id,
+        demandeId: demande.id,
+        membreCaller,
+        deposeUnePreuve: (document?: {
+          fileName?: string;
+          sampleFileName?: string;
+          confidentiel?: boolean;
+        }) =>
+          createTestDemandePreuve(
+            createTRPCClientFromCaller(membreCaller),
+            request(app.getHttpServer()),
+            membreSignInResponse.data.session?.access_token ?? '',
+            collectivite.id,
+            ReferentielIdEnum.CAE,
+            document
+          ),
+        // Le depot d'une preuve d'audit n'a pas de service backend : le front
+        // insere directement dans preuve_audit via Supabase (useAddPreuveAudit).
+        deposeUnePreuveAudit: async (document: {
+          fileName: string;
+          sampleFileName?: string;
+          confidentiel?: boolean;
+        }) => {
+          const fichier = await uploadCreateTestDocument({
+            collectiviteId: collectivite.id,
+            testAgent: request(app.getHttpServer()),
+            token: membreSignInResponse.data.session?.access_token ?? '',
+            fileName: document.fileName,
+            sampleFileName: document.sampleFileName,
+            confidentiel: document.confidentiel,
+          });
+          await db.db.insert(preuveAuditTable).values({
+            collectiviteId: collectivite.id,
+            auditId: audit.id,
+            fichierId: fichier.id,
+            commentaire: '',
+            modifiedBy: membre.id,
+          });
+        },
+      };
+    };
+
+    test("refuse de lister les preuves d'une collectivite en acces restreint a un utilisateur non membre", async () => {
+      const { demandeId, deposeUnePreuve } =
+        await createCollectiviteAvecDemande({ accesRestreint: true });
+      await deposeUnePreuve();
+
+      const visiteurCaller = router.createCaller({ user: visiteurUser });
+
+      await expect(
+        visiteurCaller.referentiels.labellisations.listPreuvesLabellisation({
+          demandeId,
+        })
+      ).rejects.toThrow(
+        "Vous n'avez pas les permissions nécessaires pour lister les preuves de cette demande."
+      );
+    });
+
+    test("refuse de lister les preuves d'audit d'une collectivite en acces restreint a un utilisateur non membre", async () => {
+      const { auditId } = await createCollectiviteAvecDemande({
+        accesRestreint: true,
+      });
+
+      const visiteurCaller = router.createCaller({ user: visiteurUser });
+
+      await expect(
+        visiteurCaller.referentiels.labellisations.listPreuvesAudit({ auditId })
+      ).rejects.toThrow(
+        "Vous n'avez pas les permissions nécessaires pour lister les preuves de cet audit."
+      );
+    });
+
+    test("masque les documents d'audit confidentiels a un utilisateur non membre", async () => {
+      const { auditId, membreCaller, deposeUnePreuveAudit } =
+        await createCollectiviteAvecDemande({ accesRestreint: false });
+
+      await deposeUnePreuveAudit({ fileName: 'audit-public.pdf' });
+      await deposeUnePreuveAudit({
+        fileName: 'audit-confidentiel.pdf',
+        sampleFileName: OTHER_PDF_SAMPLE_FILE,
+        confidentiel: true,
+      });
+
+      const visiteurCaller = router.createCaller({ user: visiteurUser });
+      const preuvesVisiteur =
+        await visiteurCaller.referentiels.labellisations.listPreuvesAudit({
+          auditId,
+        });
+
+      expect(preuvesVisiteur.map((preuve) => preuve.fichier?.filename)).toEqual(
+        ['audit-public.pdf']
+      );
+
+      const preuvesMembre =
+        await membreCaller.referentiels.labellisations.listPreuvesAudit({
+          auditId,
+        });
+
+      expect(preuvesMembre.map((preuve) => preuve.fichier?.filename)).toEqual([
+        'audit-public.pdf',
+        'audit-confidentiel.pdf',
+      ]);
+    });
+
+    test('masque les documents confidentiels a un utilisateur non membre', async () => {
+      const { demandeId, membreCaller, deposeUnePreuve } =
+        await createCollectiviteAvecDemande({ accesRestreint: false });
+
+      await deposeUnePreuve({ fileName: 'preuve-publique.pdf' });
+      await deposeUnePreuve({
+        fileName: 'preuve-confidentielle.pdf',
+        sampleFileName: OTHER_PDF_SAMPLE_FILE,
+        confidentiel: true,
+      });
+
+      const visiteurCaller = router.createCaller({ user: visiteurUser });
+      const preuvesVisiteur =
+        await visiteurCaller.referentiels.labellisations.listPreuvesLabellisation(
+          { demandeId }
+        );
+
+      expect(preuvesVisiteur.map((preuve) => preuve.fichier?.filename)).toEqual(
+        ['preuve-publique.pdf']
+      );
+
+      const preuvesMembre =
+        await membreCaller.referentiels.labellisations.listPreuvesLabellisation(
+          { demandeId }
+        );
+
+      expect(preuvesMembre.map((preuve) => preuve.fichier?.filename)).toEqual([
+        'preuve-publique.pdf',
+        'preuve-confidentielle.pdf',
+      ]);
     });
   });
 });

--- a/apps/backend/src/referentiels/labellisations/list-preuves/list-preuves.service.ts
+++ b/apps/backend/src/referentiels/labellisations/list-preuves/list-preuves.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { hideConfidentielFilter } from '@tet/backend/collectivites/documents/hide-confidentiel.utils';
 import { bibliothequeFichierTable } from '@tet/backend/collectivites/documents/models/bibliotheque-fichier.table';
 import { preuveAuditTable } from '@tet/backend/collectivites/documents/models/preuve-audit.table';
 import { preuveLabellisationTable } from '@tet/backend/collectivites/documents/models/preuve-labellisation.table';
@@ -8,12 +9,14 @@ import { PermissionService } from '@tet/backend/users/authorizations/permission.
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { createdByNom, dcpTable } from '@tet/backend/users/models/dcp.table';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
-import { Result } from '@tet/backend/utils/result.type';
+import CollectivitesService from '@tet/backend/collectivites/services/collectivites.service';
+import { failure, Result, success } from '@tet/backend/utils/result.type';
 import {
   BibliothequeFichier,
   LegacyPreuveAuditWithFichier,
   LegacyPreuveLabellisationWithFichier,
 } from '@tet/domain/collectivites';
+import { ReferentielId } from '@tet/domain/referentiels';
 import { ResourceType } from '@tet/domain/users';
 import { getErrorMessage } from '@tet/domain/utils';
 import { and, eq, getTableColumns, sql } from 'drizzle-orm';
@@ -39,8 +42,42 @@ export class ListPreuvesService {
   constructor(
     private readonly databaseService: DatabaseService,
     private readonly permissions: PermissionService,
-    private readonly getLabellisationService: GetLabellisationService
+    private readonly getLabellisationService: GetLabellisationService,
+    private readonly collectivitesService: CollectivitesService
   ) {}
+
+  private async checkUserDocumentsAccess(
+    {
+      collectiviteId,
+      referentielId,
+    }: { collectiviteId: number; referentielId: ReferentielId },
+    user: AuthenticatedUser
+  ): Promise<Result<{ canReadConfidentiel: boolean }, 'UNAUTHORIZED'>> {
+    const collectivitePrivate = await this.collectivitesService.isPrivate(
+      collectiviteId
+    );
+
+    const permissionResult = await this.permissions.isAllowed(
+      user,
+      collectivitePrivate
+        ? 'referentiels.read_confidentiel'
+        : 'referentiels.read',
+      ResourceType.REFERENTIEL,
+      { collectiviteId, referentielId }
+    );
+    if (!permissionResult.success) {
+      return failure('UNAUTHORIZED');
+    }
+
+    const confidentielResult = await this.permissions.isAllowed(
+      user,
+      'collectivites.documents.read_confidentiel',
+      ResourceType.COLLECTIVITE,
+      { collectiviteId }
+    );
+
+    return success({ canReadConfidentiel: confidentielResult.success });
+  }
 
   async listPreuvesAudit(
     { auditId }: ListPreuvesAuditInput,
@@ -63,22 +100,20 @@ export class ListPreuvesService {
       }
     }
     const auditData = auditResult.data;
-    // Check permissions
-    const permissionResult = await this.permissions.isAllowed(
-      user,
-      'referentiels.read',
-      ResourceType.REFERENTIEL,
+    const accessResult = await this.checkUserDocumentsAccess(
       {
         collectiviteId: auditData.collectiviteId,
         referentielId: auditData.referentielId,
-      }
+      },
+      user
     );
-    if (!permissionResult.success) {
+    if (!accessResult.success) {
       return {
         success: false,
         error: 'UNAUTHORIZED',
       };
     }
+    const { canReadConfidentiel } = accessResult.data;
 
     try {
       // Get the preuve
@@ -126,7 +161,15 @@ export class ListPreuvesService {
           eq(auditTable.demandeId, labellisationDemandeTable.id)
         )
         .leftJoin(dcpTable, eq(preuveAuditTable.modifiedBy, dcpTable.id))
-        .where(eq(preuveAuditTable.auditId, auditId));
+        .where(
+          and(
+            eq(preuveAuditTable.auditId, auditId),
+            hideConfidentielFilter(
+              preuveAuditTable.fichierId,
+              canReadConfidentiel
+            )
+          )
+        );
 
       return {
         success: true,
@@ -173,22 +216,20 @@ export class ListPreuvesService {
     }
     const demande = demandeResult.data;
 
-    // Check permissions
-    const permissionResult = await this.permissions.isAllowed(
-      user,
-      'referentiels.read',
-      ResourceType.REFERENTIEL,
+    const accessResult = await this.checkUserDocumentsAccess(
       {
         collectiviteId: demande.collectiviteId,
         referentielId: demande.referentiel,
-      }
+      },
+      user
     );
-    if (!permissionResult.success) {
+    if (!accessResult.success) {
       return {
         success: false,
         error: 'UNAUTHORIZED',
       };
     }
+    const { canReadConfidentiel } = accessResult.data;
 
     try {
       // Get the preuve
@@ -236,7 +277,15 @@ export class ListPreuvesService {
           dcpTable,
           eq(preuveLabellisationTable.modifiedBy, dcpTable.id)
         )
-        .where(eq(preuveLabellisationTable.demandeId, demandeId))
+        .where(
+          and(
+            eq(preuveLabellisationTable.demandeId, demandeId),
+            hideConfidentielFilter(
+              preuveLabellisationTable.fichierId,
+              canReadConfidentiel
+            )
+          )
+        )
         // Ordre stable par id croissant : le front traite `preuves[0]` comme
         // l'acte d'engagement (déposé en premier), il faut donc un ordre
         // déterministe et non l'ordre physique arbitraire de Postgres.

--- a/apps/backend/src/referentiels/preuves-archive/list-audit-preuves/collect-preuves.repository.ts
+++ b/apps/backend/src/referentiels/preuves-archive/list-audit-preuves/collect-preuves.repository.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { hideConfidentielFilter } from '@tet/backend/collectivites/documents/hide-confidentiel.utils';
 import { bibliothequeFichierTable } from '@tet/backend/collectivites/documents/models/bibliotheque-fichier.table';
 import { preuveActionTable } from '@tet/backend/collectivites/documents/models/preuve-action.table';
 import { preuveAuditTable } from '@tet/backend/collectivites/documents/models/preuve-audit.table';
@@ -12,7 +13,7 @@ import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { failure, success, type Result } from '@tet/backend/utils/result.type';
 import { ReferentielId } from '@tet/domain/referentiels';
 import { getErrorMessage } from '@tet/domain/utils';
-import { and, eq, inArray, isNull, or, sql, type Column, type SQL } from 'drizzle-orm';
+import { and, eq, inArray, sql, type SQL } from 'drizzle-orm';
 import { z } from 'zod';
 import {
   PreuvesArchiveErrorEnum,
@@ -94,7 +95,7 @@ export class CollectPreuvesRepository {
         .where(
           and(
             eq(preuveComplementaireTable.collectiviteId, collectiviteId),
-            this.hideConfidentielFilter(
+            hideConfidentielFilter(
               preuveComplementaireTable.fichierId,
               canReadConfidentiel
             )
@@ -161,7 +162,7 @@ export class CollectPreuvesRepository {
         .where(
           and(
             eq(preuveReglementaireTable.collectiviteId, collectiviteId),
-            this.hideConfidentielFilter(
+            hideConfidentielFilter(
               preuveReglementaireTable.fichierId,
               canReadConfidentiel
             )
@@ -218,7 +219,7 @@ export class CollectPreuvesRepository {
           and(
             eq(preuveLabellisationTable.demandeId, demandeId),
             eq(preuveLabellisationTable.collectiviteId, collectiviteId),
-            this.hideConfidentielFilter(
+            hideConfidentielFilter(
               preuveLabellisationTable.fichierId,
               canReadConfidentiel
             )
@@ -275,7 +276,7 @@ export class CollectPreuvesRepository {
           and(
             eq(preuveAuditTable.auditId, auditId),
             eq(preuveAuditTable.collectiviteId, collectiviteId),
-            this.hideConfidentielFilter(
+            hideConfidentielFilter(
               preuveAuditTable.fichierId,
               canReadConfidentiel
             )
@@ -301,21 +302,6 @@ export class CollectPreuvesRepository {
         .select({ bucketId: collectiviteBucketTable.bucketId })
         .from(collectiviteBucketTable)
         .where(eq(collectiviteBucketTable.collectiviteId, collectiviteId))
-    );
-  }
-
-  // `confidentiel === null` traité comme confidentiel (fail-closed) ; les liens
-  // (sans fichier) ne portent jamais de confidentialité et restent visibles.
-  private hideConfidentielFilter(
-    fichierIdColumn: Column,
-    canReadConfidentiel: boolean
-  ): SQL | undefined {
-    if (canReadConfidentiel) {
-      return undefined;
-    }
-    return or(
-      isNull(fichierIdColumn),
-      eq(bibliothequeFichierTable.confidentiel, false)
     );
   }
 


### PR DESCRIPTION
## Comportement livré

`listPreuvesAudit` et `listPreuvesLabellisation` appliquent désormais les deux règles d'accès que porte la vue `public.preuve` et que les endpoints backend avaient perdues :

- **Accès restreint** — sur une collectivité `access_restreint`, la permission exigée passe de `referentiels.read` à `referentiels.read_confidentiel`, que seuls les membres possèdent.
- **Confidentialité** — les documents marqués confidentiels sont exclus de la réponse pour qui n'a pas `collectivites.documents.read_confidentiel`.

Avant ce correctif, `referentiels.read` suffisait. Or il est accordé au visiteur vérifié **au niveau plateforme** : `hasPermission` calcule `roleAllows = hasPermissionForCollectivite || hasPermissionForPlatform`, donc un utilisateur vérifié non membre passait sur n'importe quelle collectivité, et recevait la liste complète — `filename` et `bucketId` des documents confidentiels compris. Ces deux endpoints alimentent la checklist audit-labellisation.

Asymétrie qui confirme l'oubli plutôt que la décision : `count-preuves.service.ts`, même domaine, même donnée, porte déjà le garde d'accès restreint.

## Test rouge

Commit `8dcb89b343`, avant le fix. Les deux tests échouent sur leurs assertions, pas sur leur setup :

- accès restreint → `promise resolved "[ { id: 1421, …(20) } ]" instead of rejecting`
- confidentialité → le visiteur reçoit `preuve-confidentielle.pdf`

Le fix est en `761dbee95a`. Deux tests supplémentaires couvrent `listPreuvesAudit` : l'accès restreint (`bab934604c`) et la confidentialité (`7da3c68ca7`).

Les quatre tests sont vérifiés rouges en remettant le service d'`origin/main` :

| Test | Échec sans le fix |
|---|---|
| accès restreint, `listPreuvesLabellisation` | `promise resolved "[ { id: 1466, …(20) } ]" instead of rejecting` |
| accès restreint, `listPreuvesAudit` | `promise resolved "[]" instead of rejecting` |
| confidentialité, `listPreuvesLabellisation` | `expected [ 'preuve-publique.pdf', …(1) ] to deeply equal [ 'preuve-publique.pdf' ]` |
| confidentialité, `listPreuvesAudit` | `expected [ 'audit-public.pdf', …(1) ] to deeply equal [ 'audit-public.pdf' ]` |

Les 6 tests du fichier passent après.

## Surface de review

Attention humaine :

- `list-preuves.service.ts` — les deux autorisations et leur application aux deux requêtes
- `list-preuves.router.e2e-spec.ts` — les deux tests de non-régression
- `hide-confidentiel.utils.ts` — le prédicat extrait

Mécaniques :

- `collect-preuves.repository.ts` — la méthode privée devient un import, 4 appels renommés
- `create-preuve.test-fixture.ts` — un paramètre optionnel ajouté, aucun appelant existant modifié

## Recherche anti-duplication

Aucune utility nouvelle. Les deux mécanismes existaient et sont réutilisés :

- escalade d'accès restreint : `CollectivitesService.isPrivate()` + `read` → `read_confidentiel`, idiome présent dans 12 services (`get-plan`, `list-axes`, `list-actions`, `count-preuves`…)
- filtrage confidentiel : patron de `list-audit-preuves.service.ts:52`, qui résout la permission et la passe au repository

## Une entorse assumée au mono-nature

Le prédicat de confidentialité était une **méthode privée** de `CollectPreuvesRepository`, avec sa sémantique fail-closed : `confidentiel === null` traité comme confidentiel, liens sans fichier toujours visibles. Il devient une fonction exportée dans `collectivites/documents/hide-confidentiel.utils.ts`, et les deux consommateurs l'importent.

Placement : pas `.table.ts`, qui déclare une définition de table et non un prédicat d'autorisation. Pas `.rules.ts` non plus, réservé au domaine pur — aucun fichier `.rules.ts` du backend n'importe drizzle. `.utils.ts` a le précédent exact avec `conflict.utils.ts`, qui héberge un constructeur d'expression drizzle partagé.

C'est une extraction dans une PR de fix. Choix délibéré : recopier une garde de sécurité fail-closed, c'est la garantir divergente à terme. Si le découpage strict est préféré, elle peut sortir en PR préalable.

## Zones de moindre confiance

- La fixture de dépôt d'une preuve d'audit **insère directement dans `preuve_audit`** au lieu de passer par un service, ce que la convention du repo écarte d'ordinaire. Justification : il n'existe aucun service backend pour ce dépôt — le chemin d'écriture réel est un `insert` Supabase client-direct depuis le front (`useAddPreuveAudit`). L'insert reproduit donc la production plutôt que de la contourner. Si un jour ce write-path passe au backend, la fixture doit suivre.
- Le resserrement touche aussi le compte authentifié **non vérifié** (`CONNECTED`, aucune permission), qui perd l'accès. Comportement voulu, aligné sur le reste du modèle.

## Échecs de tests pré-existants, vérifiés sur `origin/main`

Identiques avec et sans ce changement :

- `preuves-archive` — `2 failed | 14 passed`. Erreurs `storage.objects` (`column "level" does not exist`, `Direct deletion from storage tables is not allowed`) : schéma Supabase local désaligné du modèle Drizzle.
- `list-labellisations.controller` — `2 failed | 3 passed`. Recherche par `communeCode` et par texte, cohérent avec le seed local incomplet.

`collect-preuves.repository.ts` échoue à `prettier --check`, déjà sur `origin/main`. Non reformaté pour ne pas gonfler le diff.

## Plan

Cette PR est la première d'une stack de 4. Plan : `doc/plans/2026-08-26-001-feat-reclassement-objet-document-labellisation-plan.md`.

Suite : lecture de l'onglet Documents déplacée au backend, puis reclassement de l'objet d'un document par le super-admin. Ce correctif est indépendant et déployable seul.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Améliorations**
  - Renforcement du contrôle d’accès aux preuves et documents selon les droits de lecture.
  - Les documents confidentiels sont désormais masqués pour les personnes ne disposant pas des autorisations nécessaires.
  - L’accès aux preuves des collectivités privées est limité aux membres autorisés.
  - Les utilisateurs habilités conservent l’accès aux documents confidentiels.

- **Tests**
  - Ajout de scénarios de vérification couvrant les restrictions d’accès et la confidentialité des documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

