### PR TITLE
feat(labellisation): reintroduit l'audit de labellisation dans l'offre des CT COT

### DIFF
--- a/apps/app/src/referentiels/labellisations/request-audit/request-audit.form.spec.tsx
+++ b/apps/app/src/referentiels/labellisations/request-audit/request-audit.form.spec.tsx
@@ -108,10 +108,11 @@ describe('RequestAuditForm', () => {
     expect(getRadioButtonByName('Audit COT avec labellisation').disabled).toBe(
       true
     );
+    expect(getRadioButtonByName('Audit de labellisation').disabled).toBe(true);
     expect(targetStarField(container)).toBeNull();
   });
 
-  it("COT avec score >= 35% : les deux types COT sont proposés, l'audit de labellisation nu ne l'est pas", () => {
+  it("COT avec score >= 35% : les trois types sont proposés, l'audit de labellisation compris", () => {
     renderForm({
       isCOT: true,
       maximumRequestableStar: 3,
@@ -124,8 +125,8 @@ describe('RequestAuditForm', () => {
       within(group).getByRole('radio', { name: 'Audit COT avec labellisation' })
     ).toBeDefined();
     expect(
-      within(group).queryByRole('radio', { name: 'Audit de labellisation' })
-    ).toBeNull();
+      within(group).getByRole('radio', { name: 'Audit de labellisation' })
+    ).toBeDefined();
   });
 
   it("COT avec score >= 35% : le sélecteur d'étoile apparaît au choix d'un audit labellisant", () => {

--- a/packages/domain/src/referentiels/labellisations/audit-type-options/audit-type-options.rules.spec.ts
+++ b/packages/domain/src/referentiels/labellisations/audit-type-options/audit-type-options.rules.spec.ts
@@ -32,13 +32,17 @@ const makeParcours = (
 });
 
 describe('listAuditTypeOptions — quels sujets sont proposés', () => {
-  it("COT : l'offre se limite aux deux sujets COT, quel que soit le score", () => {
+  it("COT : les trois sujets sont offerts, l'audit de labellisation compris", () => {
     expect(
       listAuditTypeOptions(makeParcours({ isCot: true }), {
         isCOT: true,
         maximumRequestableStar: 5,
       }).map((option) => option.sujet)
-    ).toEqual([SujetDemandeEnum.COT, SujetDemandeEnum.LABELLISATION_COT]);
+    ).toEqual([
+      SujetDemandeEnum.COT,
+      SujetDemandeEnum.LABELLISATION_COT,
+      SujetDemandeEnum.LABELLISATION,
+    ]);
   });
 
   it("non-COT : l'offre se limite à l'audit de labellisation, quel que soit le score", () => {
@@ -50,7 +54,7 @@ describe('listAuditTypeOptions — quels sujets sont proposés', () => {
     ).toEqual([SujetDemandeEnum.LABELLISATION]);
   });
 
-  it("COT sous 35 % de score : l'audit COT seul reste demandable, le sujet labellisant non", () => {
+  it("COT sous 35 % de score : l'audit COT seul reste demandable, les sujets labellisants non", () => {
     expect(
       listAuditTypeOptions(makeParcours({ isCot: true }), {
         isCOT: true,
@@ -60,6 +64,11 @@ describe('listAuditTypeOptions — quels sujets sont proposés', () => {
       { sujet: SujetDemandeEnum.COT, isRequestable: true, reason: null },
       {
         sujet: SujetDemandeEnum.LABELLISATION_COT,
+        isRequestable: false,
+        reason: 'SCORE_BELOW_AUDITABLE_STAR',
+      },
+      {
+        sujet: SujetDemandeEnum.LABELLISATION,
         isRequestable: false,
         reason: 'SCORE_BELOW_AUDITABLE_STAR',
       },
@@ -81,7 +90,7 @@ describe('listAuditTypeOptions — quels sujets sont proposés', () => {
     ]);
   });
 
-  it('COT a partir de 35 % de score : les deux sujets COT sont demandables', () => {
+  it('COT a partir de 35 % de score : les trois sujets sont demandables', () => {
     expect(
       listAuditTypeOptions(makeParcours({ isCot: true }), {
         isCOT: true,
@@ -91,6 +100,11 @@ describe('listAuditTypeOptions — quels sujets sont proposés', () => {
       { sujet: SujetDemandeEnum.COT, isRequestable: true, reason: null },
       {
         sujet: SujetDemandeEnum.LABELLISATION_COT,
+        isRequestable: true,
+        reason: null,
+      },
+      {
+        sujet: SujetDemandeEnum.LABELLISATION,
         isRequestable: true,
         reason: null,
       },
@@ -134,10 +148,15 @@ describe('listAuditTypeOptions — pourquoi un sujet proposé n est pas demandab
         isRequestable: false,
         reason: 'REFERENTIEL_NOT_COMPLETED',
       },
+      {
+        sujet: SujetDemandeEnum.LABELLISATION,
+        isRequestable: false,
+        reason: 'REFERENTIEL_NOT_COMPLETED',
+      },
     ]);
   });
 
-  it("référents non désignés : l'audit COT seul reste demandable, pas le sujet labellisant", () => {
+  it("référents non désignés : l'audit COT seul reste demandable, pas les sujets labellisants", () => {
     expect(
       listAuditTypeOptions(
         makeParcours({
@@ -151,6 +170,11 @@ describe('listAuditTypeOptions — pourquoi un sujet proposé n est pas demandab
       { sujet: SujetDemandeEnum.COT, isRequestable: true, reason: null },
       {
         sujet: SujetDemandeEnum.LABELLISATION_COT,
+        isRequestable: false,
+        reason: 'REFERENT_ROLES_NOT_DEFINED',
+      },
+      {
+        sujet: SujetDemandeEnum.LABELLISATION,
         isRequestable: false,
         reason: 'REFERENT_ROLES_NOT_DEFINED',
       },
@@ -176,6 +200,11 @@ describe('listAuditTypeOptions — pourquoi un sujet proposé n est pas demandab
         isRequestable: false,
         reason: 'SCORE_ACTIONS_CRITERIA_NOT_SATISFIED',
       },
+      {
+        sujet: SujetDemandeEnum.LABELLISATION,
+        isRequestable: false,
+        reason: 'SCORE_ACTIONS_CRITERIA_NOT_SATISFIED',
+      },
     ]);
   });
 
@@ -197,7 +226,7 @@ describe('listAuditTypeOptions — pourquoi un sujet proposé n est pas demandab
     ]);
   });
 
-  it("un document sans objet ne remplace pas les pieces attendues : seul l'audit COT reste demandable", () => {
+  it("un document sans objet ne remplace pas les pieces attendues : seul l'audit COT seul reste demandable", () => {
     expect(
       listAuditTypeOptions(
         makeParcours({
@@ -211,6 +240,11 @@ describe('listAuditTypeOptions — pourquoi un sujet proposé n est pas demandab
       { sujet: SujetDemandeEnum.COT, isRequestable: true, reason: null },
       {
         sujet: SujetDemandeEnum.LABELLISATION_COT,
+        isRequestable: false,
+        reason: 'MISSING_FILE',
+      },
+      {
+        sujet: SujetDemandeEnum.LABELLISATION,
         isRequestable: false,
         reason: 'MISSING_FILE',
       },

--- a/packages/domain/src/referentiels/labellisations/audit-type-options/audit-type-options.rules.ts
+++ b/packages/domain/src/referentiels/labellisations/audit-type-options/audit-type-options.rules.ts
@@ -36,7 +36,7 @@ const requiresAuditableStar = (sujet: SujetDemande): boolean =>
 
 const listAvailableSujets = (isCOT: boolean): readonly SujetDemande[] =>
   AUDIT_TYPES_BY_ASCENDING_REQUIREMENTS.filter(
-    (sujet) => requiresCot(sujet) === isCOT
+    (sujet) => isCOT || !requiresCot(sujet)
   );
 
 const toAuditTypeOption = (


### PR DESCRIPTION
## Comportement livré

Une CT COT peut faire un audit de labellisation classique, pas seulement un audit COT. La modale lui rend les trois sujets :

```
Quel type d'audit souhaitez-vous demander ?
  ○ Audit COT sans labellisation
  ○ Audit COT avec labellisation
      * Penser à joindre les documents de labellisation.
  ○ Audit de labellisation        ← réintroduit
```

Une CT non-COT reste sur le seul « Audit de labellisation ». Inchangé.

## Changement

Une ligne, dans la règle d'offre :

```diff
-AUDIT_TYPES_BY_ASCENDING_REQUIREMENTS.filter((sujet) => requiresCot(sujet) === isCOT)
+AUDIT_TYPES_BY_ASCENDING_REQUIREMENTS.filter((sujet) => isCOT || !requiresCot(sujet))
```

**Renverse l'hypothèse 3 de #4868**, qui restreignait les CT COT à `cot` + `labellisation_cot`. Cette hypothèse était le point signalé en tête de #4868 comme « à confirmer avec le PO » ; l'arbitrage est tombé dans l'autre sens.

**Le reste de #4868 est conservé** — c'est ce qu'il faut vérifier en review :

- `SCORE_BELOW_AUDITABLE_STAR` reste le motif d'indisponibilité des sujets labellisants sous 35 %
- `noRequestableAuditType` reste supprimé, la liste n'est jamais vide
- `getAuditRequestAvailability` restitue toujours le motif de l'option la moins exigeante
- le tooltip de complétude de #4869 est intact

Aucun type touché, aucun libellé créé, `request-labellisation.rules.ts` intact — l'API n'a jamais rejeté `labellisation` pour une CT COT, donc rien à y changer.

## Surface de review

| Fichier | Nature |
|---|---|
| `audit-type-options.rules.ts` | **attention humaine** — 1 ligne |
| `audit-type-options.rules.spec.ts` | 7 cas : un troisième sujet attendu partout |
| `request-audit.form.spec.tsx` | 2 cas |

## Ce que les specs verrouillent

Le troisième sujet n'est pas seulement *présent* : il porte le **même motif** que `labellisation_cot` dans chaque cas d'indisponibilité — complétude, référents, critère d'action, document manquant, score sous le seuil. C'est l'hypothèse 6 du plan (« `labellisation_cot` et `labellisation` ont exactement les mêmes prérequis »), qui n'était plus observable tant qu'une CT COT ne voyait pas les deux.

## Vérifications

- `nx test domain` : 411 tests / 33 fichiers · `nx test app` : 653 tests / 97 fichiers
- typecheck domain + app verts · lint 0 erreur des deux côtés, baselines de warnings inchangées (1 et 104)

## Contexte

Correctif d'offre sur la stack « CTA Demander un audit — gating COT vs non-COT », plan `doc/plans/2026-08-25-001-feat-cta-demande-audit-cot-plan.md`. Suit #4863, #4867, #4868 et #4869, toutes mergées.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Nouvelles fonctionnalités**
  - L’option « Audit de labellisation » est désormais proposée dans les parcours COT.
  - Elle reste désactivée lorsque le score COT est inférieur à 35 %.
  - À partir de 35 %, les trois types d’audit disponibles sont affichés, sous réserve du respect des critères applicables.

- **Tests**
  - Les vérifications couvrent désormais la disponibilité, l’éligibilité et l’état activé ou désactivé de l’option selon le score et les conditions du dossier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->