### PR TITLE
test(labellisation): couvre en e2e le gating COT vs non-COT du CTA de demande d'audit

### DIFF
--- a/apps/app/src/referentiels/labellisations/request-audit/request-audit.button.spec.tsx
+++ b/apps/app/src/referentiels/labellisations/request-audit/request-audit.button.spec.tsx
@@ -146,15 +146,6 @@ describe('RequestAuditButton — état du bouton pour la collectivité auditée'
     expect(getTooltipLabel()).toBeNull();
   });
 
-  it("rend le bouton désactivé avec un tooltip quand aucun type d'audit n'est demandable", () => {
-    setCycle({ ...requestableCycle, maximumRequestableStar: 1 });
-
-    render(<RequestAuditButton referentielId="cae" />);
-
-    expect(getRequestAuditButton().disabled).toBe(true);
-    expect(getTooltipLabel()).not.toBeNull();
-  });
-
   const setCotCycleBelowAuditableScore = (completudeOk: boolean): void =>
     setCycle({
       parcours: {

--- a/apps/app/src/referentiels/labellisations/request-audit/request-audit.form.spec.tsx
+++ b/apps/app/src/referentiels/labellisations/request-audit/request-audit.form.spec.tsx
@@ -97,7 +97,7 @@ describe('RequestAuditForm', () => {
     expect(targetStarField(container)).not.toBeNull();
   });
 
-  it("COT sous 35 % : les deux types COT sont proposés, le labellisant grisé, sans sélecteur d'étoile", () => {
+  it("COT sous 35 % : les trois types sont proposés, les deux labellisants grisés, sans sélecteur d'étoile", () => {
     const { container } = renderForm({
       isCOT: true,
       maximumRequestableStar: 1,

--- a/e2e/tests/referentiels/labellisations/audit-labellisation.pom.ts
+++ b/e2e/tests/referentiels/labellisations/audit-labellisation.pom.ts
@@ -29,6 +29,9 @@ export class AuditLabellisationPom {
   readonly auditTypeGroup: Locator;
   readonly auditTypeCotRadio: Locator;
   readonly auditTypeCotAvecLabellisationRadio: Locator;
+  readonly auditTypeLabellisationRadio: Locator;
+  readonly auditTypeRadios: Locator;
+  readonly tooltip: Locator;
   readonly targetStarSelect: Locator;
   readonly envoyerAuditButton: Locator;
   readonly auditSuccessToast: Locator;
@@ -89,6 +92,12 @@ export class AuditLabellisationPom {
       'radio',
       { name: 'Audit COT avec labellisation' }
     );
+    this.auditTypeLabellisationRadio = this.auditModal.getByRole('radio', {
+      name: 'Audit de labellisation',
+      exact: true,
+    });
+    this.auditTypeRadios = this.auditModal.getByRole('radio');
+    this.tooltip = page.getByRole('tooltip');
     this.targetStarSelect = this.auditModal.getByTestId('target-star');
     this.envoyerAuditButton = this.auditModal.getByRole('button', {
       name: 'Envoyer ma demande',
@@ -158,6 +167,14 @@ export class AuditLabellisationPom {
   async openAuditModal(): Promise<void> {
     await this.demanderAuditButton.click();
     await expect(this.auditModal).toBeVisible();
+  }
+
+  /**
+   * Survole le CTA pour faire apparaitre son tooltip. `force` est necessaire :
+   * le bouton est desactive dans les cas ou le motif nous interesse.
+   */
+  async hoverDemanderAudit(): Promise<void> {
+    await this.demanderAuditButton.hover({ force: true });
   }
 
   async selectTargetStar(star: 2 | 3 | 4 | 5): Promise<void> {

--- a/e2e/tests/referentiels/labellisations/demandes-audit-labellisation.spec.ts
+++ b/e2e/tests/referentiels/labellisations/demandes-audit-labellisation.spec.ts
@@ -4,6 +4,13 @@ import { testWithReferentiels as test } from '../referentiels.fixture';
 
 const referentiel: AuditLabellisationReferentielId = 'cae';
 
+const COMPLETUDE_TOOLTIP =
+  'Renseigner les statuts de toutes les mesures du référentiel';
+const CRITERES_TOOLTIP =
+  'Renseigner tous les critères attendus afin de pouvoir demander un audit ou une labellisation';
+const SCORE_TOOLTIP =
+  'Atteindre au moins 35 % de score pour pouvoir demander un audit de labellisation.';
+
 test.describe('Demandes depuis la nouvelle vue audit-labellisation', () => {
   test('visiteur : ni « Obtenir la première étoile » ni « Demander un audit »', async ({
     page,
@@ -30,6 +37,86 @@ test.describe('Demandes depuis la nouvelle vue audit-labellisation', () => {
       auditLabellisationPom.demanderPremiereEtoileButton
     ).toHaveCount(0);
     await expect(auditLabellisationPom.demanderAuditButton).toHaveCount(0);
+  });
+
+  test('CT COT sans statuts renseignés : CTA désactivé, le tooltip nomme la complétude', async ({
+    collectivites,
+    auditLabellisationPom,
+  }) => {
+    const { collectivite, user } = await collectivites.addCollectiviteAndUser({
+      userArgs: { autoLogin: true },
+      collectiviteArgs: { isCOT: true },
+    });
+    const collectiviteId = collectivite.data.id;
+    await user.precomputeReferentielSnapshot(collectiviteId, referentiel);
+
+    await auditLabellisationPom.goto(collectiviteId, referentiel);
+
+    await expect(auditLabellisationPom.demanderAuditButton).toBeDisabled();
+    await auditLabellisationPom.hoverDemanderAudit();
+    await expect(auditLabellisationPom.tooltip).toHaveText(COMPLETUDE_TOOLTIP);
+  });
+
+  test("CT COT complète sous 35 % : les trois types sont offerts, seul l'audit COT seul est demandable", async ({
+    collectivites,
+    referentiels,
+    auditLabellisationPom,
+  }) => {
+    const { collectivite, user } = await collectivites.addCollectiviteAndUser({
+      userArgs: { autoLogin: true },
+      collectiviteArgs: { isCOT: true },
+    });
+    const collectiviteId = collectivite.data.id;
+    await user.precomputeReferentielSnapshot(collectiviteId, referentiel);
+    await referentiels.updateAllNeedReferentielStatutsToCompleteReferentiel(
+      user,
+      collectiviteId,
+      referentiel
+    );
+
+    await auditLabellisationPom.goto(collectiviteId, referentiel);
+    await expect(auditLabellisationPom.demanderAuditButton).toBeEnabled();
+
+    await auditLabellisationPom.openAuditModal();
+    await expect(auditLabellisationPom.auditTypeRadios).toHaveCount(3);
+    await expect(auditLabellisationPom.auditTypeCotRadio).toBeEnabled();
+    await expect(
+      auditLabellisationPom.auditTypeCotAvecLabellisationRadio
+    ).toBeDisabled();
+    await expect(
+      auditLabellisationPom.auditTypeLabellisationRadio
+    ).toBeDisabled();
+    await expect(
+      auditLabellisationPom.auditModal.getByText(CRITERES_TOOLTIP)
+    ).toHaveCount(2);
+
+    await auditLabellisationPom.auditTypeCotRadio.click();
+    await auditLabellisationPom.envoyerAuditButton.click();
+
+    await expect(auditLabellisationPom.auditSuccessToast).toBeVisible();
+  });
+
+  test('CT non-COT complète sous 35 % : CTA désactivé, le tooltip nomme le score', async ({
+    collectivites,
+    referentiels,
+    auditLabellisationPom,
+  }) => {
+    const { collectivite, user } = await collectivites.addCollectiviteAndUser({
+      userArgs: { autoLogin: true },
+    });
+    const collectiviteId = collectivite.data.id;
+    await user.precomputeReferentielSnapshot(collectiviteId, referentiel);
+    await referentiels.updateAllNeedReferentielStatutsToCompleteReferentiel(
+      user,
+      collectiviteId,
+      referentiel
+    );
+
+    await auditLabellisationPom.goto(collectiviteId, referentiel);
+
+    await expect(auditLabellisationPom.demanderAuditButton).toBeDisabled();
+    await auditLabellisationPom.hoverDemanderAudit();
+    await expect(auditLabellisationPom.tooltip).toHaveText(SCORE_TOOLTIP);
   });
 
   test('audit COT sans labellisation : envoi ferme la modale', async ({
@@ -159,6 +246,7 @@ test.describe('Demandes depuis la nouvelle vue audit-labellisation', () => {
       await auditLabellisationPom.goto(collectiviteId, ref);
       await auditLabellisationPom.uploadCandidatureDocument();
       await auditLabellisationPom.openAuditModal();
+      await expect(auditLabellisationPom.auditTypeGroup).toHaveCount(0);
       await auditLabellisationPom.selectTargetStar(2);
       await auditLabellisationPom.envoyerAuditButton.click();
 


### PR DESCRIPTION
## Ce que ça couvre

C'est la seule PR de la stack qui vérifie que le plan atteint son objectif. Les PRs #4863 à #4869 s'appuient sur des specs de composant qui mockent `useCycleLabellisation` : le chemin réel — vrai parcours, vrai score, vrai statut COT — n'était jamais exercé.

| Scénario | Assertions |
|---|---|
| CT COT sans statuts renseignés | CTA désactivé, tooltip « Renseigner les statuts de toutes les mesures du référentiel » |
| CT COT complète, score < 35 % | CTA actif ; **exactement 3** radios ; `cot` activé ; les deux sujets labellisants désactivés, porteurs du message générique ; l'envoi de l'audit COT seul aboutit |
| CT non-COT complète, score < 35 % | CTA désactivé, tooltip « Atteindre au moins 35 % de score… » |
| CT non-COT complète, score maximal | **absence** du groupe de choix de type, rendue explicite |

Le dernier remplace une couverture accidentelle : le test non-COT existant ne cliquait aucun radio, il allait droit à `selectTargetStar`. Il ne gardait donc pas « pas de choix de type » — un radio ajouté par erreur pour les non-COT serait passé inaperçu.

Le scénario 2 assert le **nombre** d'options, pas seulement la présence des trois attendues : c'est ce qui attrape un sujet en trop.

## Outillage

Le POM gagne trois locators : `auditTypeLabellisationRadio` — sans lui la présence du sujet `labellisation` chez une CT COT n'est pas assertable, le POM ne déclarait que les deux radios COT —, `auditTypeRadios` pour le décompte, et `tooltip`.

Aucune fixture créée : les trois états de complétude sont atteignables avec l'existant (aucun helper de statuts / `updateAllNeedReferentielStatutsToCompleteReferentiel` / `updateAllReferentielStatutsToFait`).

## Vérifications

`pnpm exec playwright test demandes-audit-labellisation` : **11 tests verts** en local, les 8 préexistants compris. `nx test app` : 652 tests / 97 fichiers verts. `nx run e2e:typecheck` et `nx run e2e:lint` verts (0 erreur).

## Un obstacle local à connaître, qui n'affecte pas la CI

En local, ces e2e — **y compris les 8 préexistantes** — échouaient toutes sur `goto`, la modale d'incitation ProConnect « Rattachez ProConnect à votre compte / Rappel 1 sur 3 » recouvrant la page. Elle s'affiche une fois par session pour tout utilisateur sans identité liée, donc pour chaque utilisateur créé par une fixture.

La CI n'est pas touchée : `canShowIncentive` exige `statut.enabled`, faux quand le provider OIDC n'est pas configuré, et les runs e2e de `main` sont verts. C'est donc un écart d'environnement local, pas une régression.

Pour valider ces tests j'ai neutralisé la modale par une rustine locale non commitée (`sessionStorage['oidc-modal-seen']` via `addInitScript`). **Elle n'est pas dans ce diff** — l'anti-scope du plan interdit de toucher aux fixtures, et ce sujet mérite sa propre décision : soit on neutralise la modale dans la fixture e2e, soit on désactive le provider OIDC dans le `.env` local. À trancher hors de cette PR.

## Ménage rendu possible par cette couverture

Deux corrections dans les specs de composant, sans perte de couverture :

- **Un cas supprimé** — `request-audit.button.spec.tsx`, « quand aucun type d'audit n'est demandable » partageait sa prémisse exacte avec « non-COT sous 35 % de score » (même parcours non-COT complet, même `maximumRequestableStar: 1`) en s'arrêtant à « le tooltip existe ». Le second assert le libellé complet : le premier n'attrapait plus rien.
- **Un titre corrigé** — `request-audit.form.spec.tsx`, « COT sous 35 % » annonçait deux types proposés alors que son corps en assert trois depuis la réintroduction du sujet `labellisation` (#4875).

Les autres recoupements avec l'e2e sont conservés délibérément : les specs de composant gardent le mapping `motif → libellé`, fonction pure, en ~100 ms ; l'e2e garde le câblage en ~7 s avec la stack complète. Les supprimer déplacerait la détection d'une régression de libellé vers la CI.

## Surface de review

| Fichier | Nature |
|---|---|
| `demandes-audit-labellisation.spec.ts` | **attention humaine** — les scénarios sont la spécification exécutable |
| `audit-labellisation.pom.ts` | mécanique — 3 locators, 1 helper de survol |
| `request-audit.button.spec.tsx`, `request-audit.form.spec.tsx` | ménage — 1 cas subsumé retiré, 1 titre corrigé |

Aucune ligne de logique applicative. Ciblage par rôle et libellé accessible, aucun `data-test` ajouté. Les libellés attendus sont vérifiés identiques à `appLabels` (`completudeCritere`, `renseignerCriteresPourDemande`, `demanderAuditScoreInsuffisant`).

## Contexte

PR 5 et dernière de la stack « CTA Demander un audit — gating COT vs non-COT », plan `doc/plans/2026-08-25-001-feat-cta-demande-audit-cot-plan.md`. Suit #4863, #4867, #4868, #4869 et #4875, toutes mergées. Branche sur `main`.
