### PR TITLE
Ajoute une variante `danger` pour les boutons

### DIFF
--- a/packages/ui/src/design-system/Button/Button.stories.tsx
+++ b/packages/ui/src/design-system/Button/Button.stories.tsx
@@ -135,7 +135,7 @@ export const Variants: Story = {
   render: () => (
     <div
       className="grid gap-5 items-end bg-grey-2 p-10"
-      style={{ gridTemplateColumns: 'repeat(6,fit-content(0))' }}
+      style={{ gridTemplateColumns: 'repeat(7,fit-content(0))' }}
     >
       {/* Icon buttons */}
       <Button
@@ -150,6 +150,7 @@ export const Variants: Story = {
       <Button icon="leaf-line" variant="outlined" size="sm" />
       <Button icon="leaf-line" variant="white" size="sm" />
       <Button icon="leaf-line" variant="grey" size="sm" />
+      <Button icon="leaf-line" variant="danger" size="sm" />
       <Button icon="leaf-line" variant="underlined" size="sm" />
 
       {/* Disabled icon buttons */}
@@ -158,6 +159,7 @@ export const Variants: Story = {
       <Button icon="leaf-line" variant="outlined" disabled size="sm" />
       <Button icon="leaf-line" variant="white" disabled size="sm" />
       <Button icon="leaf-line" variant="grey" disabled size="sm" />
+      <Button icon="leaf-line" variant="danger" disabled size="sm" />
       <Button icon="leaf-line" variant="underlined" disabled size="sm" />
 
       {/* Default buttons */}
@@ -175,6 +177,9 @@ export const Variants: Story = {
       </Button>
       <Button variant="grey" size="sm">
         Grey
+      </Button>
+      <Button variant="danger" size="sm">
+        Danger
       </Button>
       <Button variant="underlined" size="sm">
         Underlined
@@ -195,6 +200,9 @@ export const Variants: Story = {
       </Button>
       <Button variant="grey" disabled size="sm">
         Grey
+      </Button>
+      <Button variant="danger" disabled size="sm">
+        Danger
       </Button>
       <Button variant="underlined" disabled size="sm">
         Underlined
@@ -220,6 +228,9 @@ export const Variants: Story = {
       </Button>
       <Button icon="leaf-line" iconPosition="left" variant="grey" size="sm">
         Grey
+      </Button>
+      <Button icon="leaf-line" iconPosition="left" variant="danger" size="sm">
+        Danger
       </Button>
       <Button
         icon="leaf-line"
@@ -275,6 +286,15 @@ export const Variants: Story = {
         size="sm"
       >
         Grey
+      </Button>
+      <Button
+        icon="leaf-line"
+        iconPosition="right"
+        variant="danger"
+        disabled
+        size="sm"
+      >
+        Danger
       </Button>
       <Button
         icon="leaf-line"

--- a/packages/ui/src/design-system/Button/theme.ts
+++ b/packages/ui/src/design-system/Button/theme.ts
@@ -90,6 +90,20 @@ export const buttonThemeClassnames: Record<
       icon: 'fill-primary-4',
     },
   },
+  danger: {
+    default: {
+      text: 'text-white hover:text-white',
+      background: 'bg-error-1 hover:!bg-error-3',
+      border: 'border-error-1 hover:!border-error-3',
+      icon: 'fill-white group-hover:fill-white',
+    },
+    disabled: {
+      text: '!text-white',
+      background: '!bg-error-2',
+      border: '!border-error-2',
+      icon: 'fill-white',
+    },
+  },
   /**
    * Aspect lien : ni cadre ni trait au repos, le survol souligne le texte.
    * `underlined`, lui, porte son trait en permanence.

--- a/packages/ui/src/design-system/Button/types.ts
+++ b/packages/ui/src/design-system/Button/types.ts
@@ -11,6 +11,7 @@ export type ButtonVariant =
   | 'outlined'
   | 'white'
   | 'grey'
+  | 'danger'
   | 'underlined'
   | 'link';
 


### PR DESCRIPTION
permet de signaler une opération potentiellement destructive/non réversible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Ajout d’une variante de bouton « danger ».
  * Disponible pour les boutons standards, avec icône et désactivés.
  * Styles adaptés aux états normal et désactivé.

* **Documentation**
  * Mise à jour des exemples de composants pour présenter la nouvelle variante.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->