### PR TITLE
fix(referentiels): normalise le référentiel de l'audit à la lecture de la vue preuve

### DIFF
--- a/apps/app/src/referentiels/documents/groupeParDemande.test.ts
+++ b/apps/app/src/referentiels/documents/groupeParDemande.test.ts
@@ -35,7 +35,7 @@ describe('groupeParDemande', () => {
   });
 });
 
-const preuves_demande1 = [
+const preuves_demande1: TPreuveAuditEtLabellisation[] = [
   {
     preuve_type: 'labellisation',
     id: 8,
@@ -45,6 +45,7 @@ const preuves_demande1 = [
       filename: 'doc1.pdf',
       filesize: 978700,
       bucket_id: '576b747e-bb30-4407-8d8c-566daf9e7a2d',
+      confidentiel: false,
     },
     lien: null,
     commentaire: '',
@@ -61,6 +62,10 @@ const preuves_demande1 = [
       en_cours: true,
       referentiel: 'eci',
       collectivite_id: 1,
+      modified_at: null,
+      envoyee_le: null,
+      demandeur: null,
+      associated_collectivite_id: null,
     },
     rapport: null,
     audit: null,
@@ -74,6 +79,7 @@ const preuves_demande1 = [
       filename: 'doc2.pdf',
       filesize: 66632,
       bucket_id: '576b747e-bb30-4407-8d8c-566daf9e7a2d',
+      confidentiel: false,
     },
     lien: null,
     commentaire: '',
@@ -90,6 +96,10 @@ const preuves_demande1 = [
       en_cours: true,
       referentiel: 'eci',
       collectivite_id: 1,
+      modified_at: null,
+      envoyee_le: null,
+      demandeur: null,
+      associated_collectivite_id: null,
     },
     rapport: null,
     audit: null,
@@ -103,6 +113,7 @@ const preuves_demande1 = [
       filename: 'rapport.pdf',
       filesize: 5468713,
       bucket_id: '576b747e-bb30-4407-8d8c-566daf9e7a2d',
+      confidentiel: false,
     },
     lien: null,
     commentaire: '',
@@ -119,20 +130,26 @@ const preuves_demande1 = [
       en_cours: true,
       referentiel: 'eci',
       collectivite_id: 1,
+      modified_at: null,
+      envoyee_le: null,
+      demandeur: null,
+      associated_collectivite_id: null,
     },
     rapport: null,
     audit: {
+      id: 100,
       collectivite_id: 1,
+      demande_id: 61,
       date_debut: '2023-02-22T18:34:42.460935+00:00',
       date_fin: null,
-      id: 100,
-      referentiel: 'eci',
+      clos: false,
       valide: true,
+      referentiel_id: 'eci',
     },
   },
-] as TPreuveAuditEtLabellisation[];
+];
 
-const preuves_demande2 = [
+const preuves_demande2: TPreuveAuditEtLabellisation[] = [
   {
     preuve_type: 'labellisation',
     id: 9,
@@ -142,6 +159,7 @@ const preuves_demande2 = [
       filename: 'doc1.pdf',
       filesize: 978700,
       bucket_id: '576b747e-bb30-4407-8d8c-566daf9e7a2d',
+      confidentiel: false,
     },
     lien: null,
     commentaire: '',
@@ -158,13 +176,17 @@ const preuves_demande2 = [
       en_cours: true,
       referentiel: 'eci',
       collectivite_id: 1,
+      modified_at: null,
+      envoyee_le: null,
+      demandeur: null,
+      associated_collectivite_id: null,
     },
     rapport: null,
     audit: null,
   },
-] as TPreuveAuditEtLabellisation[];
+];
 
-const preuves_audit_sans_demande = [
+const preuves_audit_sans_demande: TPreuveAuditEtLabellisation[] = [
   {
     preuve_type: 'audit',
     id: 10,
@@ -174,6 +196,7 @@ const preuves_audit_sans_demande = [
       filename: 'doc1.pdf',
       filesize: 978700,
       bucket_id: '576b747e-bb30-4407-8d8c-566daf9e7a2d',
+      confidentiel: false,
     },
     lien: null,
     commentaire: '',
@@ -185,13 +208,14 @@ const preuves_audit_sans_demande = [
     demande: null,
     rapport: null,
     audit: {
+      id: 100,
       collectivite_id: 1,
       demande_id: null,
       date_debut: '2023-02-22T18:34:42.460935+00:00',
       date_fin: null,
-      id: 100,
-      referentiel_id: 'cae',
+      clos: false,
       valide: true,
+      referentiel_id: 'cae',
     },
   },
-] as TPreuveAuditEtLabellisation[];
+];

--- a/apps/app/src/referentiels/preuves/preuve-view.adapter.spec.ts
+++ b/apps/app/src/referentiels/preuves/preuve-view.adapter.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'vitest';
+import { AuditFromView, toAuditEnCours } from './preuve-view.adapter';
+
+const auditFromView: AuditFromView = {
+  id: 101,
+  collectivite_id: 1,
+  demande_id: null,
+  date_debut: '2023-02-22T18:34:42.460935+00:00',
+  date_fin: null,
+  clos: false,
+  valide: true,
+  referentiel: 'cae',
+};
+
+describe('toAuditEnCours', () => {
+  test('expose le référentiel sous referentiel_id, seule clé que consomme l’application', () => {
+    expect(toAuditEnCours(auditFromView).referentiel_id).toBe('cae');
+  });
+
+  test('ne laisse pas fuiter la clé referentiel de la vue', () => {
+    expect(toAuditEnCours(auditFromView)).not.toHaveProperty('referentiel');
+  });
+
+  test('conserve les autres champs de l’audit', () => {
+    expect(toAuditEnCours(auditFromView)).toMatchObject({
+      id: 101,
+      collectivite_id: 1,
+      demande_id: null,
+      date_debut: '2023-02-22T18:34:42.460935+00:00',
+      date_fin: null,
+      clos: false,
+      valide: true,
+    });
+  });
+});

--- a/apps/app/src/referentiels/preuves/preuve-view.adapter.ts
+++ b/apps/app/src/referentiels/preuves/preuve-view.adapter.ts
@@ -1,0 +1,14 @@
+import { TAuditEnCours } from '@/app/referentiels/audits/types';
+import { ReferentielId } from '@tet/domain/referentiels';
+
+export type AuditFromView = Omit<TAuditEnCours, 'referentiel_id'> & {
+  referentiel: ReferentielId;
+};
+
+export const toAuditEnCours = ({
+  referentiel,
+  ...audit
+}: AuditFromView): TAuditEnCours => ({
+  ...audit,
+  referentiel_id: referentiel,
+});

--- a/apps/app/src/referentiels/preuves/usePreuves.ts
+++ b/apps/app/src/referentiels/preuves/usePreuves.ts
@@ -3,6 +3,7 @@ import { DBClient, useSupabase } from '@tet/api';
 import { useCollectiviteId } from '@tet/api/collectivites';
 import { ActionListItem } from '../actions/use-list-actions';
 import { TPreuve, TPreuvesParType, TPreuveType } from './Bibliotheque/types';
+import { AuditFromView, toAuditEnCours } from './preuve-view.adapter';
 
 export type TActionDef = Pick<
   ActionListItem,
@@ -74,7 +75,10 @@ const fetch = async (
     return [];
   }
 
-  return data;
+  return data.map((preuve) => {
+    const audit = preuve.audit as AuditFromView | null;
+    return audit ? { ...preuve, audit: toAuditEnCours(audit) } : preuve;
+  });
 };
 
 /**


### PR DESCRIPTION
## Comportement livré

Un document d'audit rattaché à un audit **sans demande de labellisation** réapparaît dans l'onglet Documents du référentiel. Il en était silencieusement absent.

## Mode de défaillance

La vue `public.preuve` sérialise l'audit avec `to_jsonb(a.*)`, et la colonne de `labellisation.audit` s'appelle **`referentiel`**. Vérifié en base :

```sql
select jsonb_object_keys(to_jsonb(a.*)) from labellisation.audit a;
-- id, clos, valide, date_cnl, date_fin, date_debut, demande_id, referentiel, collectivite_id, ...
```

Aucun `referentiel_id`. Or c'est la clé que déclare `TAuditEnCours` — `ObjectToSnake<Pick<LabellisationAudit, … 'referentielId'>>` — et que l'application lit partout.

`groupeParDemande` résout le référentiel d'un document ainsi :

```ts
const referentiel = preuve.demande?.referentiel || preuve.audit?.referentiel_id;
```

`preuve.audit?.referentiel_id` valant toujours `undefined`, la comparaison `referentiel !== referentielId` écartait le document. Un document d'audit **rattaché à une demande** s'en sortait, son référentiel étant lu sur la demande — seuls les audits sans demande étaient perdus, ce qui explique que ça n'ait pas sauté aux yeux.

## Le correctif

La clé divergente est normalisée **là où la vue est lue**, dans `usePreuves`, par un adaptateur pur `toAuditEnCours`. L'application ne connaît donc qu'une seule clé, `referentiel_id`, et `TAuditEnCours` reste strict.

Aucun consommateur n'a besoin de se défendre : `groupeParDemande`, `types.ts` et `PreuveLabellisation.tsx` sont **identiques à `main`**. Le correctif tient dans le point d'entrée de la donnée, pas dispersé chez ceux qui la consomment.

L'adaptateur disparaîtra avec la vue, quand la lecture de cet onglet passera au backend — celui-ci produit déjà `referentiel_id`.

## Pourquoi les tests ne l'attrapaient pas

Les trois fixtures de `groupeParDemande.test.ts` étaient annotées `as TPreuveAuditEtLabellisation[]`. Le cast désactivait toute vérification, et elles décrivaient une forme qui n'existe **ni dans la vue, ni dans le type**.

Le premier commit les type à la déclaration. Le compilateur révèle alors ce qui leur manquait : `confidentiel` sur chacun des six `fichier`, `clos` et `demande_id` sur chaque `audit`, et `modified_at` / `envoyee_le` / `demandeur` / `associated_collectivite_id` sur chaque `demande`, tous pourtant déclarés dans `labellisationDemandeSchema`. Plus aucun cast dans le fichier.

## Surface de review

| Fichier | Nature |
|---|---|
| `preuve-view.adapter.ts` | l'adaptateur, 14 lignes |
| `preuve-view.adapter.spec.ts` | son contrat : `referentiel_id` exposé, `referentiel` ne fuit pas, reste de l'audit conservé |
| `usePreuves.ts` | la normalisation au retour du fetch |
| `groupeParDemande.test.ts` | fixtures typées |

## Une réserve à signaler

La démonstration par test rouge ne prend pas la même forme que d'habitude. Le premier correctif que j'avais écrit lisait les deux clés en aval, ce qui se prouvait par un test rouge sur `groupeParDemande`. En normalisant à la source, la garde devient le contrat de l'adaptateur — qui n'existe pas sur `main`, donc pas de rouge à exhiber sur une assertion pré-existante. La preuve du bug reste la requête SQL ci-dessus.

## Contexte

Découvert en préparant le déplacement de la lecture de cet onglet vers le backend. L'endpoint backend renvoie `referentiel_id`, donc il aurait corrigé ce bug **comme effet de bord invisible d'un refactor**. Ce correctif le sort de là et rend ce refactor neutre en comportement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Correctifs**
  - Amélioration de la gestion des audits associés aux preuves.
  - Les informations de référentiel sont désormais correctement reconnues lors du chargement des preuves.
  - Les autres données des audits sont conservées sans modification.
  - Les preuves dépourvues d’audit continuent d’être traitées normalement.

- **Tests**
  - Renforcement de la couverture des cas liés à la conversion et à l’intégrité des données d’audit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->