### PR TITLE
feat(makefile): forward test name patterns to nx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -352,8 +352,19 @@ lint-target: preflight-env-keys ## Lance le lint d'un projet Nx : make lint-targ
 typecheck: preflight-env-keys ## Lance le typecheck : make typecheck [project=<nx-project>]
 	@$(call run_node,pnpm exec nx $(if $(project),typecheck "$(project)",run-many -t typecheck --parallel=3))
 
-test: preflight-env-keys ## Lance les tests : make test [project=<nx-project>]
-	@$(call run_node,pnpm exec nx $(if $(project),test "$(project)",run-many -t test))
+# Goals après `test` (ex. make test project=backend diagnostic) : patterns
+# transmis à nx, pas des cibles Make. Sans ce no-op, make s'arrête sur
+# « No rule to make target ».
+ifeq ($(firstword $(MAKECMDGOALS)),test)
+TEST_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+ifneq ($(TEST_ARGS),)
+$(TEST_ARGS):
+	@:
+endif
+endif
+
+test: preflight-env-keys ## Lance les tests : make test [project=<nx-project>] [<pattern>...]
+	@$(call run_node,pnpm exec nx $(if $(project),test "$(project)" $(TEST_ARGS),run-many -t test))
 
 hooks: ## Active les hooks git du dépôt (.githooks)
 	@node scripts/toggle-hooks.mts on


### PR DESCRIPTION
## Summary
- Forwards trailing `make test` goals (e.g. `make test project=backend diagnostic`) as nx test name patterns
- Adds a no-op rule for those goals so Make no longer fails with `No rule to make target`

## Test plan
- [ ] `make -n test project=backend diagnostic` shows `nx test "backend" diagnostic`
- [ ] `make test project=backend diagnostic` runs only matching tests (no Make error)
- [ ] `make test` without a project still runs `nx run-many -t test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Améliorations**
  - La commande `make test` accepte désormais des paramètres supplémentaires pour cibler des tests ou des motifs spécifiques.
  - Ces paramètres sont transmis automatiquement à l’outil de test, avec ou sans projet indiqué.
  - Les motifs fournis ne provoquent plus d’erreur de règle Make inconnue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->