### PR TITLE
refactor(referentiels): lit les documents de l'onglet Documents depuis le backend

### DIFF
--- a/apps/app/src/labels/catalog.ts
+++ b/apps/app/src/labels/catalog.ts
@@ -1480,6 +1480,8 @@ export const appLabels = {
   erreurChargementPage: 'Erreur lors du chargement de la page !',
   erreurChargementCriteres:
     'Erreur lors du chargement des critères de labellisation.',
+  erreurChargementDocuments:
+    'Erreur lors du chargement des documents. Veuillez réessayer.',
   rechargerPage: 'Recharger la page',
   banniere: 'Bannière',
   banniereType: 'Type',

--- a/apps/app/src/referentiels/documents/data/use-list-documents.ts
+++ b/apps/app/src/referentiels/documents/data/use-list-documents.ts
@@ -1,0 +1,41 @@
+import { useQuery } from '@tanstack/react-query';
+import { useTRPC } from '@tet/api';
+import { ReferentielId } from '@tet/domain/referentiels';
+import {
+  TPreuveAudit,
+  TPreuveLabellisation,
+  TPreuveRapport,
+} from '../../preuves/Bibliotheque/types';
+
+type ReferentielDocuments = {
+  labellisation: TPreuveLabellisation[];
+  audit: TPreuveAudit[];
+  rapport: TPreuveRapport[];
+};
+
+type ReferentielDocumentsQuery =
+  | { status: 'loading' }
+  | { status: 'error' }
+  | { status: 'loaded'; documents: ReferentielDocuments };
+
+export const useListDocuments = ({
+  collectiviteId,
+  referentielId,
+}: {
+  collectiviteId: number;
+  referentielId: ReferentielId;
+}): ReferentielDocumentsQuery => {
+  const trpc = useTRPC();
+
+  const { data, isError } = useQuery(
+    trpc.referentiels.documents.listDocuments.queryOptions({
+      collectiviteId,
+      referentielId,
+    })
+  );
+
+  if (data) {
+    return { status: 'loaded', documents: data };
+  }
+  return isError ? { status: 'error' } : { status: 'loading' };
+};

--- a/apps/app/src/referentiels/documents/documents.view.tsx
+++ b/apps/app/src/referentiels/documents/documents.view.tsx
@@ -3,9 +3,11 @@
 import { useGetCollectivite } from '@/app/collectivites/collectivites/use-get-collectivite';
 import { appLabels } from '@/app/labels/catalog';
 import PreuveDoc from '@/app/referentiels/preuves/Bibliotheque/PreuveDoc';
+import SpinnerLoader from '@/app/ui/shared/SpinnerLoader';
 import { useCurrentCollectivite } from '@tet/api/collectivites';
-import { usePreuvesParType } from '../preuves/usePreuves';
+import { Alert } from '@tet/ui';
 import { useReferentielId } from '../referentiel-context';
+import { useListDocuments } from './data/use-list-documents';
 import { AddRapportVisite } from './AddRapportVisite';
 import { groupeParDemande } from './groupeParDemande';
 import { addInfoToEntry, PreuvesLabellisation } from './PreuveLabellisation';
@@ -22,14 +24,14 @@ export const DocumentsView = () => {
   const referentielId = useReferentielId();
   const tableData = useTableData(referentielId);
 
-  const preuves = usePreuvesParType({
-    preuve_types: ['audit', 'labellisation', 'rapport'],
-  });
+  const documents = useListDocuments({ collectiviteId, referentielId });
+  const { labellisation, audit, rapport } =
+    documents.status === 'loaded'
+      ? documents.documents
+      : { labellisation: [], audit: [], rapport: [] };
 
-  const { labellisation, audit, rapport } = preuves;
-  const labellisationEtAudit = [...(labellisation || []), ...(audit || [])];
   const demandesLabellisationEtAudit = Object.entries(
-    groupeParDemande(labellisationEtAudit, referentielId)
+    groupeParDemande([...labellisation, ...audit], referentielId)
   )
     .map(addInfoToEntry)
     .sort((a, b) => b.info.timestamp - a.info.timestamp);
@@ -46,12 +48,19 @@ export const DocumentsView = () => {
 
   const showDocumentsTitle = showDemandesLabellisationEtAudit || showRapports;
 
+  const showEmptyRapportsMessage =
+    isReadOnly && documents.status === 'loaded' && rapport.length === 0;
+
   if (isNewReferentiel) {
     return null;
   }
 
   return (
     <div data-test="BibliothequeDocs" className="flex flex-col gap-8">
+      {documents.status === 'loading' && <SpinnerLoader className="m-auto" />}
+      {documents.status === 'error' && (
+        <Alert state="error" title={appLabels.erreurChargementDocuments} />
+      )}
       {showDemandesLabellisationEtAudit && (
         <section data-test="labellisation">
           <h2 className="mb-6 text-2xl">
@@ -66,10 +75,10 @@ export const DocumentsView = () => {
             {appLabels.rapportsDeVisiteAnnuelle}
           </h2>
           {!isReadOnly && <AddRapportVisite />}
-          {isReadOnly && (!rapport || rapport.length === 0) && (
+          {showEmptyRapportsMessage && (
             <p>{appLabels.aucunRapportVisiteAnnuelle}</p>
           )}
-          {rapport?.map((preuve) => (
+          {rapport.map((preuve) => (
             <div className="py-4" key={preuve.id}>
               <PreuveDoc preuve={preuve} />
             </div>

--- a/apps/app/src/referentiels/documents/groupeParDemande.test.ts
+++ b/apps/app/src/referentiels/documents/groupeParDemande.test.ts
@@ -1,5 +1,6 @@
 import { TPreuveAuditEtLabellisation } from '@/app/referentiels/preuves/Bibliotheque/types';
 import { describe, expect, test } from 'vitest';
+import { addInfoToEntry } from './PreuveLabellisation';
 import { groupeParDemande } from './groupeParDemande';
 
 describe('groupeParDemande', () => {
@@ -219,3 +220,67 @@ const preuves_audit_sans_demande: TPreuveAuditEtLabellisation[] = [
     },
   },
 ];
+
+const closedCyclePreuves: TPreuveAuditEtLabellisation[] = [
+  {
+    preuve_type: 'audit',
+    id: 12,
+    collectivite_id: 1,
+    fichier: {
+      hash: '9c1185a5c5e9fc54612808977ee8f548b2258d31c3b0f4a9e0e0f0e0f0e0f0e0',
+      filename: 'rapport-final.pdf',
+      filesize: 12345,
+      bucket_id: '576b747e-bb30-4407-8d8c-566daf9e7a2d',
+      confidentiel: false,
+    },
+    lien: null,
+    commentaire: '',
+    created_at: '2024-03-15T10:00:00.000000+00:00',
+    created_by: '17440546-f389-4d4f-bfdb-b0c94a1bd0f9',
+    created_by_nom: 'Yolo Dodo',
+    action: null,
+    preuve_reglementaire: null,
+    demande: {
+      id: 63,
+      date: '2024-01-10T00:00:00.000000+00:00',
+      sujet: 'labellisation',
+      etoiles: '3',
+      en_cours: false,
+      referentiel: 'eci',
+      collectivite_id: 1,
+      modified_at: null,
+      envoyee_le: null,
+      demandeur: null,
+      associated_collectivite_id: null,
+    },
+    rapport: null,
+    audit: {
+      id: 101,
+      collectivite_id: 1,
+      demande_id: 63,
+      date_debut: '2024-02-01T00:00:00.000000+00:00',
+      date_fin: '2024-03-15T00:00:00.000000+00:00',
+      clos: true,
+      valide: true,
+      referentiel_id: 'eci',
+    },
+  },
+];
+
+describe('addInfoToEntry', () => {
+  test('derive l’etoile et l’annee depuis la demande quand le cycle n’a pas d’audit', () => {
+    const { info } = addInfoToEntry(['62', preuves_demande2]);
+
+    expect(info.etoile).toBe('2');
+    expect(info.annee).toBe(2023);
+    expect(info.audit).toBeNull();
+  });
+
+  test('date le cycle sur la fin de l’audit plutot que sur son debut ou sur la demande', () => {
+    const { info } = addInfoToEntry(['63', closedCyclePreuves]);
+
+    expect(new Date(info.timestamp).toISOString()).toBe(
+      '2024-03-15T00:00:00.000Z'
+    );
+  });
+});

--- a/apps/app/src/referentiels/preuves/useAddPreuves.ts
+++ b/apps/app/src/referentiels/preuves/useAddPreuves.ts
@@ -203,6 +203,9 @@ export const invalidateQueries = (
     queryKey: ['preuve', collectiviteId],
   });
   queryClient.invalidateQueries({
+    queryKey: trpc.referentiels.documents.listDocuments.pathKey(),
+  });
+  queryClient.invalidateQueries({
     queryKey: ['fiche_action'],
   });
   queryClient.invalidateQueries({

--- a/apps/backend/src/collectivites/documents/document.controller.e2e-spec.ts
+++ b/apps/backend/src/collectivites/documents/document.controller.e2e-spec.ts
@@ -1,10 +1,6 @@
 import { INestApplication } from '@nestjs/common';
 import { addTestCollectiviteAndUsers } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
-import {
-  getTestApp,
-  getTestDatabase,
-  signInWith,
-} from '@tet/backend/test';
+import { getTestApp, getTestDatabase, signInWith } from '@tet/backend/test';
 import { addTestUser } from '@tet/backend/users/users/users.test-fixture';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { CollectiviteRole } from '@tet/domain/users';

--- a/apps/backend/src/collectivites/documents/documents.test-fixture.ts
+++ b/apps/backend/src/collectivites/documents/documents.test-fixture.ts
@@ -1,7 +1,9 @@
+import { collectiviteBucketTable } from '@tet/backend/collectivites/shared/models/collectivite-bucket.table';
 import { DatabaseServiceInterface } from '@tet/backend/utils/database/database-service.interface';
 import { BibliothequeFichier } from '@tet/domain/collectivites';
-import { eq } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 import fs from 'fs';
+import { randomUUID } from 'node:crypto';
 import path from 'path';
 import TestAgent from 'supertest/lib/agent';
 import { bibliothequeFichierTable } from './models/bibliotheque-fichier.table';
@@ -10,6 +12,7 @@ const PDF_SAMPLES_DIR = path.join(__dirname, './samples');
 const DEFAULT_PDF_SAMPLE_FILE = 'document_test.pdf';
 // un autre fichier pour les cas de tests où on a besoin de 2 fichiers/hash différents
 export const OTHER_PDF_SAMPLE_FILE = 'document_test_2.pdf';
+const TEST_DOCUMENT_SIZE_IN_BYTES = 1024;
 
 export async function uploadCreateTestDocument({
   collectiviteId,
@@ -37,6 +40,50 @@ export async function uploadCreateTestDocument({
     .expect(201);
   const createdDocument: BibliothequeFichier = response.body;
   return createdDocument;
+}
+
+export type TestDocument = typeof bibliothequeFichierTable.$inferSelect;
+
+export async function seedTestDocument({
+  databaseService,
+  collectiviteId,
+  filename,
+  confidentiel = false,
+}: {
+  databaseService: DatabaseServiceInterface;
+  collectiviteId: number;
+  filename: string;
+  confidentiel?: boolean;
+}): Promise<TestDocument> {
+  const [bucket] = await databaseService.db
+    .select({ bucketId: collectiviteBucketTable.bucketId })
+    .from(collectiviteBucketTable)
+    .where(eq(collectiviteBucketTable.collectiviteId, collectiviteId))
+    .limit(1);
+  if (!bucket) {
+    throw new Error(
+      `Aucun bucket pour la collectivite ${collectiviteId}, impossible d'y deposer un document`
+    );
+  }
+
+  const [document] = await databaseService.db
+    .insert(bibliothequeFichierTable)
+    .values({
+      collectiviteId,
+      hash: randomUUID(),
+      filename,
+      confidentiel,
+    })
+    .returning();
+
+  await databaseService.db.execute(
+    sql`insert into storage.objects (bucket_id, name, metadata)
+        values (${bucket.bucketId}, ${document.hash}, ${JSON.stringify({
+      size: TEST_DOCUMENT_SIZE_IN_BYTES,
+    })}::jsonb)`
+  );
+
+  return document;
 }
 
 export async function deleteAllDocuments({

--- a/apps/backend/src/collectivites/documents/edit-preuve-document/edit-preuve-document.errors.ts
+++ b/apps/backend/src/collectivites/documents/edit-preuve-document/edit-preuve-document.errors.ts
@@ -20,7 +20,7 @@ export const editPreuveDocumentErrorConfig: TrpcErrorHandlerConfig<SpecificError
       PREUVE_FICHIER: {
         code: 'BAD_REQUEST',
         message:
-          "Cette preuve est un fichier : le lien ne peut pas être modifié via cette opération.",
+          'Cette preuve est un fichier : le lien ne peut pas être modifié via cette opération.',
       },
       LABELLISATION_IN_PROGRESS: {
         code: 'BAD_REQUEST',

--- a/apps/backend/src/collectivites/documents/file-info.utils.ts
+++ b/apps/backend/src/collectivites/documents/file-info.utils.ts
@@ -1,0 +1,62 @@
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { BibliothequeFichier } from '@tet/domain/collectivites';
+import { and, eq, sql } from 'drizzle-orm';
+import { collectiviteBucketTable } from '../shared/models/collectivite-bucket.table';
+import { bibliothequeFichierTable } from './models/bibliotheque-fichier.table';
+import { storageObjectTable } from './models/storage-object.table';
+
+export type FichierSubquery = ReturnType<typeof buildFichierSubquery>;
+
+export function buildFichierSubquery(db: DatabaseService['db'] | Transaction) {
+  return db
+    .select({
+      id: bibliothequeFichierTable.id,
+      collectiviteId: bibliothequeFichierTable.collectiviteId,
+      hash: bibliothequeFichierTable.hash,
+      filename: bibliothequeFichierTable.filename,
+      confidentiel: bibliothequeFichierTable.confidentiel,
+      bucketId: collectiviteBucketTable.bucketId,
+      filesize: sql<
+        number | null
+      >`(${storageObjectTable.metadata}->>'size')::integer`.as('filesize'),
+    })
+    .from(bibliothequeFichierTable)
+    .innerJoin(
+      collectiviteBucketTable,
+      eq(
+        collectiviteBucketTable.collectiviteId,
+        bibliothequeFichierTable.collectiviteId
+      )
+    )
+    .innerJoin(
+      storageObjectTable,
+      and(
+        eq(storageObjectTable.bucketId, collectiviteBucketTable.bucketId),
+        eq(storageObjectTable.name, bibliothequeFichierTable.hash)
+      )
+    )
+    .as('fichier');
+}
+
+export function buildFileInfoSql(fichier: FichierSubquery) {
+  return sql<
+    | (BibliothequeFichier & {
+        bucketId: string;
+        filesize: number | null;
+      })
+    | null
+  >`
+      CASE WHEN ${fichier.id} IS NULL THEN NULL
+      ELSE json_build_object(
+        'id', ${fichier.id},
+        'collectiviteId', ${fichier.collectiviteId},
+        'hash', ${fichier.hash},
+        'filename', ${fichier.filename},
+        'confidentiel', ${fichier.confidentiel},
+        'bucketId', ${fichier.bucketId},
+        'filesize', ${fichier.filesize}
+      )
+      END
+    `;
+}

--- a/apps/backend/src/collectivites/documents/hide-confidentiel.utils.ts
+++ b/apps/backend/src/collectivites/documents/hide-confidentiel.utils.ts
@@ -1,17 +1,18 @@
 import { Column, eq, isNull, or, SQL } from 'drizzle-orm';
-import { bibliothequeFichierTable } from './models/bibliotheque-fichier.table';
 
 // `confidentiel === null` traité comme confidentiel (fail-closed) ; les liens
 // (sans fichier) ne portent jamais de confidentialité et restent visibles.
-export function hideConfidentielFilter(
-  fichierIdColumn: Column,
-  canReadConfidentiel: boolean
-): SQL | undefined {
+export function hideConfidentielFilter({
+  fichierIdColumn,
+  confidentielColumn,
+  canReadConfidentiel,
+}: {
+  fichierIdColumn: Column;
+  confidentielColumn: Column;
+  canReadConfidentiel: boolean;
+}): SQL | undefined {
   if (canReadConfidentiel) {
     return undefined;
   }
-  return or(
-    isNull(fichierIdColumn),
-    eq(bibliothequeFichierTable.confidentiel, false)
-  );
+  return or(isNull(fichierIdColumn), eq(confidentielColumn, false));
 }

--- a/apps/backend/src/collectivites/documents/update-document/update-document.router.e2e-spec.ts
+++ b/apps/backend/src/collectivites/documents/update-document/update-document.router.e2e-spec.ts
@@ -4,10 +4,7 @@ import {
   deleteAllDocuments,
   uploadCreateTestDocument,
 } from '@tet/backend/collectivites/documents/documents.test-fixture';
-import {
-  getAuthUserFromUserCredentials,
-  signInWith,
-} from '@tet/backend/test';
+import { getAuthUserFromUserCredentials, signInWith } from '@tet/backend/test';
 import { addTestUser } from '@tet/backend/users/users/users.test-fixture';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';

--- a/apps/backend/src/referentiels/documents/list-documents/list-documents.adapter.ts
+++ b/apps/backend/src/referentiels/documents/list-documents/list-documents.adapter.ts
@@ -1,0 +1,18 @@
+import { ObjectToSnake, objectToSnake } from 'ts-case-convert';
+
+const emptyPreuveRelations = {
+  action: null,
+  preuve_reglementaire: null,
+  demande: null,
+  audit: null,
+  rapport: null,
+};
+
+export function toPreuve<Row extends object>(
+  preuve: Row
+): typeof emptyPreuveRelations & ObjectToSnake<Row> {
+  return {
+    ...emptyPreuveRelations,
+    ...objectToSnake(preuve),
+  };
+}

--- a/apps/backend/src/referentiels/documents/list-documents/list-documents.errors.ts
+++ b/apps/backend/src/referentiels/documents/list-documents/list-documents.errors.ts
@@ -1,0 +1,27 @@
+import {
+  createErrorsEnum,
+  TrpcErrorHandlerConfig,
+} from '@tet/backend/utils/trpc/trpc-error-handler';
+
+const specificErrors = ['DOCUMENT_SCHEMA_MISMATCH'] as const;
+type SpecificError = (typeof specificErrors)[number];
+
+export const listDocumentsErrorConfig: TrpcErrorHandlerConfig<SpecificError> = {
+  commonErrors: {
+    UNAUTHORIZED: {
+      code: 'FORBIDDEN',
+      message:
+        "Vous n'avez pas les permissions nécessaires pour lister les documents de ce référentiel.",
+    },
+  },
+  specificErrors: {
+    DOCUMENT_SCHEMA_MISMATCH: {
+      code: 'INTERNAL_SERVER_ERROR',
+      message:
+        "Un document ne respecte pas le format attendu et n'a pas pu être rendu.",
+    },
+  },
+};
+
+export const ListDocumentsErrorEnum = createErrorsEnum(specificErrors);
+export type ListDocumentsError = keyof typeof ListDocumentsErrorEnum;

--- a/apps/backend/src/referentiels/documents/list-documents/list-documents.input.ts
+++ b/apps/backend/src/referentiels/documents/list-documents/list-documents.input.ts
@@ -1,0 +1,9 @@
+import { referentielIdEnumSchema } from '@tet/domain/referentiels';
+import z from 'zod';
+
+export const listDocumentsInputSchema = z.object({
+  collectiviteId: z.number().int().positive(),
+  referentielId: referentielIdEnumSchema,
+});
+
+export type ListDocumentsInput = z.infer<typeof listDocumentsInputSchema>;

--- a/apps/backend/src/referentiels/documents/list-documents/list-documents.output.ts
+++ b/apps/backend/src/referentiels/documents/list-documents/list-documents.output.ts
@@ -1,0 +1,106 @@
+import {
+  etoileAsStringEnumSchema,
+  referentielIdEnumSchema,
+  sujetDemandeEnumSchema,
+} from '@tet/domain/referentiels';
+import z from 'zod';
+
+const fichierSchema = z.object({
+  id: z.number(),
+  collectivite_id: z.number(),
+  hash: z.string(),
+  filename: z.string(),
+  confidentiel: z.boolean().nullable(),
+  bucket_id: z.string(),
+  filesize: z
+    .number()
+    .nullable()
+    .transform((filesize) => filesize ?? undefined),
+});
+
+const supportSchema = z.union([
+  z.object({ fichier: fichierSchema, lien: z.null() }),
+  z.object({ fichier: z.null(), lien: z.null() }),
+]);
+
+const documentBaseSchema = z.object({
+  id: z.number(),
+  collectivite_id: z.number(),
+  fichier_id: z.number().nullable(),
+  url: z.string().nullable(),
+  titre: z.string().nullable(),
+  commentaire: z.string().nullable(),
+  modified_at: z.string(),
+  modified_by: z.string().nullable(),
+  created_at: z.string(),
+  created_by: z.string().nullable(),
+  created_by_nom: z.string().nullable(),
+  action: z.null(),
+  preuve_reglementaire: z.null(),
+});
+
+const demandeSchema = z.object({
+  id: z.number(),
+  collectivite_id: z.number(),
+  referentiel: referentielIdEnumSchema,
+  en_cours: z.boolean(),
+  etoiles: z.nullable(etoileAsStringEnumSchema),
+  date: z.string(),
+  sujet: z.nullable(sujetDemandeEnumSchema),
+  modified_at: z.string().nullable(),
+  envoyee_le: z.string().nullable(),
+  demandeur: z.string().nullable(),
+  associated_collectivite_id: z.number().nullable(),
+});
+
+const auditSchema = z.object({
+  id: z.number(),
+  collectivite_id: z.number(),
+  referentiel_id: referentielIdEnumSchema,
+  demande_id: z.number().nullable(),
+  date_debut: z.string().nullable(),
+  date_fin: z.string().nullable(),
+  valide: z.boolean(),
+  date_cnl: z.string().nullable(),
+  valide_labellisation: z.boolean().nullable(),
+  clos: z.boolean(),
+});
+
+const documentLabellisationSchema = documentBaseSchema
+  .extend({
+    preuve_type: z.literal('labellisation'),
+    demande_id: z.number(),
+    objet: z.enum(['acte_engagement', 'candidature']).nullable(),
+    demande: demandeSchema,
+    audit: z.null(),
+    rapport: z.null(),
+  })
+  .and(supportSchema);
+
+const documentAuditSchema = documentBaseSchema
+  .extend({
+    preuve_type: z.literal('audit'),
+    audit_id: z.number(),
+    demande: demandeSchema.nullable(),
+    audit: auditSchema,
+    rapport: z.null(),
+  })
+  .and(supportSchema);
+
+const documentRapportSchema = documentBaseSchema
+  .extend({
+    preuve_type: z.literal('rapport'),
+    date: z.string(),
+    demande: z.null(),
+    audit: z.null(),
+    rapport: z.object({ date: z.string() }),
+  })
+  .and(supportSchema);
+
+export const listDocumentsOutputSchema = z.object({
+  labellisation: z.array(documentLabellisationSchema),
+  audit: z.array(documentAuditSchema),
+  rapport: z.array(documentRapportSchema),
+});
+
+export type ListDocumentsOutput = z.infer<typeof listDocumentsOutputSchema>;

--- a/apps/backend/src/referentiels/documents/list-documents/list-documents.repository.ts
+++ b/apps/backend/src/referentiels/documents/list-documents/list-documents.repository.ts
@@ -1,0 +1,220 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  buildFichierSubquery,
+  buildFileInfoSql,
+} from '@tet/backend/collectivites/documents/file-info.utils';
+import { hideConfidentielFilter } from '@tet/backend/collectivites/documents/hide-confidentiel.utils';
+import { preuveAuditTable } from '@tet/backend/collectivites/documents/models/preuve-audit.table';
+import { preuveLabellisationTable } from '@tet/backend/collectivites/documents/models/preuve-labellisation.table';
+import { preuveRapportTable } from '@tet/backend/collectivites/documents/models/preuve-rapport.table';
+import { createdByNom, dcpTable } from '@tet/backend/users/models/dcp.table';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { failure, success } from '@tet/backend/utils/result.type';
+import { getErrorMessage } from '@tet/domain/utils';
+import { and, desc, eq, getTableColumns, sql } from 'drizzle-orm';
+import { auditTable } from '../../labellisations/audit.table';
+import { labellisationDemandeTable } from '../../labellisations/labellisation-demande.table';
+import { ListDocumentsErrorEnum } from './list-documents.errors';
+import { ListDocumentsInput } from './list-documents.input';
+
+type DocumentsScope = {
+  collectiviteId: number;
+  referentielId: ListDocumentsInput['referentielId'];
+  canReadConfidentiel: boolean;
+};
+
+@Injectable()
+export class ListDocumentsRepository {
+  private readonly logger = new Logger(ListDocumentsRepository.name);
+
+  constructor(private readonly databaseService: DatabaseService) {}
+
+  async listLabellisationDocuments(
+    { collectiviteId, referentielId, canReadConfidentiel }: DocumentsScope,
+    tx?: Transaction
+  ) {
+    const db = tx ?? this.databaseService.db;
+    const fichier = buildFichierSubquery(db);
+
+    try {
+      const documents = await db
+        .select({
+          ...getTableColumns(preuveLabellisationTable),
+          fichier: buildFileInfoSql(fichier),
+          demande: {
+            ...getTableColumns(labellisationDemandeTable),
+          },
+          createdBy: preuveLabellisationTable.modifiedBy,
+          createdAt: preuveLabellisationTable.modifiedAt,
+          createdByNom: createdByNom,
+          preuveType: sql<'labellisation'>`'labellisation'`,
+        })
+        .from(preuveLabellisationTable)
+        .innerJoin(
+          labellisationDemandeTable,
+          and(
+            eq(
+              preuveLabellisationTable.demandeId,
+              labellisationDemandeTable.id
+            ),
+            eq(labellisationDemandeTable.collectiviteId, collectiviteId),
+            eq(labellisationDemandeTable.referentiel, referentielId)
+          )
+        )
+        .leftJoin(
+          fichier,
+          and(
+            eq(preuveLabellisationTable.fichierId, fichier.id),
+            eq(fichier.collectiviteId, collectiviteId)
+          )
+        )
+        .leftJoin(
+          dcpTable,
+          eq(preuveLabellisationTable.modifiedBy, dcpTable.id)
+        )
+        .where(
+          and(
+            eq(preuveLabellisationTable.collectiviteId, collectiviteId),
+            hideConfidentielFilter({
+              fichierIdColumn: preuveLabellisationTable.fichierId,
+              confidentielColumn: fichier.confidentiel,
+              canReadConfidentiel,
+            })
+          )
+        )
+        .orderBy(preuveLabellisationTable.id);
+
+      return success(documents);
+    } catch (error) {
+      this.logger.error(
+        `Echec de la lecture des documents de labellisation du referentiel ${referentielId} de la collectivite ${collectiviteId}: ${getErrorMessage(
+          error
+        )}`
+      );
+      return failure(ListDocumentsErrorEnum.DATABASE_ERROR);
+    }
+  }
+
+  async listAuditDocuments(
+    { collectiviteId, referentielId, canReadConfidentiel }: DocumentsScope,
+    tx?: Transaction
+  ) {
+    const db = tx ?? this.databaseService.db;
+    const fichier = buildFichierSubquery(db);
+
+    try {
+      const documents = await db
+        .select({
+          ...getTableColumns(preuveAuditTable),
+          fichier: buildFileInfoSql(fichier),
+          demande: {
+            ...getTableColumns(labellisationDemandeTable),
+          },
+          audit: {
+            ...getTableColumns(auditTable),
+          },
+          createdBy: preuveAuditTable.modifiedBy,
+          createdAt: preuveAuditTable.modifiedAt,
+          createdByNom: createdByNom,
+          preuveType: sql<'audit'>`'audit'`,
+        })
+        .from(preuveAuditTable)
+        .innerJoin(
+          auditTable,
+          and(
+            eq(preuveAuditTable.auditId, auditTable.id),
+            eq(auditTable.collectiviteId, collectiviteId),
+            eq(auditTable.referentielId, referentielId)
+          )
+        )
+        .leftJoin(
+          labellisationDemandeTable,
+          eq(auditTable.demandeId, labellisationDemandeTable.id)
+        )
+        .leftJoin(
+          fichier,
+          and(
+            eq(preuveAuditTable.fichierId, fichier.id),
+            eq(fichier.collectiviteId, collectiviteId)
+          )
+        )
+        .leftJoin(dcpTable, eq(preuveAuditTable.modifiedBy, dcpTable.id))
+        .where(
+          and(
+            eq(preuveAuditTable.collectiviteId, collectiviteId),
+            hideConfidentielFilter({
+              fichierIdColumn: preuveAuditTable.fichierId,
+              confidentielColumn: fichier.confidentiel,
+              canReadConfidentiel,
+            })
+          )
+        )
+        .orderBy(preuveAuditTable.id);
+
+      return success(documents);
+    } catch (error) {
+      this.logger.error(
+        `Echec de la lecture des documents d'audit du referentiel ${referentielId} de la collectivite ${collectiviteId}: ${getErrorMessage(
+          error
+        )}`
+      );
+      return failure(ListDocumentsErrorEnum.DATABASE_ERROR);
+    }
+  }
+
+  async listRapportDocuments(
+    {
+      collectiviteId,
+      canReadConfidentiel,
+    }: Omit<DocumentsScope, 'referentielId'>,
+    tx?: Transaction
+  ) {
+    const db = tx ?? this.databaseService.db;
+    const fichier = buildFichierSubquery(db);
+
+    try {
+      const documents = await db
+        .select({
+          ...getTableColumns(preuveRapportTable),
+          fichier: buildFileInfoSql(fichier),
+          createdBy: preuveRapportTable.modifiedBy,
+          createdAt: preuveRapportTable.modifiedAt,
+          createdByNom: createdByNom,
+          preuveType: sql<'rapport'>`'rapport'`,
+          rapport: sql<{
+            date: string;
+          }>`json_build_object('date', ${preuveRapportTable.date})`,
+        })
+        .from(preuveRapportTable)
+        .leftJoin(
+          fichier,
+          and(
+            eq(preuveRapportTable.fichierId, fichier.id),
+            eq(fichier.collectiviteId, collectiviteId)
+          )
+        )
+        .leftJoin(dcpTable, eq(preuveRapportTable.modifiedBy, dcpTable.id))
+        .where(
+          and(
+            eq(preuveRapportTable.collectiviteId, collectiviteId),
+            hideConfidentielFilter({
+              fichierIdColumn: preuveRapportTable.fichierId,
+              confidentielColumn: fichier.confidentiel,
+              canReadConfidentiel,
+            })
+          )
+        )
+        .orderBy(desc(preuveRapportTable.date), desc(preuveRapportTable.id));
+
+      return success(documents);
+    } catch (error) {
+      this.logger.error(
+        `Echec de la lecture des rapports de visite de la collectivite ${collectiviteId}: ${getErrorMessage(
+          error
+        )}`
+      );
+      return failure(ListDocumentsErrorEnum.DATABASE_ERROR);
+    }
+  }
+}

--- a/apps/backend/src/referentiels/documents/list-documents/list-documents.router.e2e-spec.ts
+++ b/apps/backend/src/referentiels/documents/list-documents/list-documents.router.e2e-spec.ts
@@ -1,0 +1,474 @@
+import { INestApplication } from '@nestjs/common';
+import { addTestCollectiviteAndUsers } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import {
+  OTHER_PDF_SAMPLE_FILE,
+  uploadCreateTestDocument,
+} from '@tet/backend/collectivites/documents/documents.test-fixture';
+import { preuveAuditTable } from '@tet/backend/collectivites/documents/models/preuve-audit.table';
+import { preuveLabellisationTable } from '@tet/backend/collectivites/documents/models/preuve-labellisation.table';
+import { preuveRapportTable } from '@tet/backend/collectivites/documents/models/preuve-rapport.table';
+import {
+  createTRPCClientFromCaller,
+  getAuthUserFromUserCredentials,
+  getTestApp,
+  getTestDatabase,
+  signInWith,
+} from '@tet/backend/test';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { addTestUser } from '@tet/backend/users/users/users.test-fixture';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
+import { ReferentielIdEnum } from '@tet/domain/referentiels';
+import { CollectiviteRole } from '@tet/domain/users';
+import { eq } from 'drizzle-orm';
+import request from 'supertest';
+import { onTestFinished } from 'vitest';
+import { createAuditWithOnTestFinished } from '../../referentiels.test-fixture';
+import { createTestDemandePreuve } from '../../labellisations/create-preuve/create-preuve.test-fixture';
+
+describe('List Documents Router', () => {
+  let router: TrpcRouter;
+  let db: DatabaseService;
+  let app: INestApplication;
+  let visiteurUser: AuthenticatedUser;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    router = await app.get(TrpcRouter);
+    db = await getTestDatabase(app);
+
+    const visiteurResult = await addTestUser(db);
+    visiteurUser = getAuthUserFromUserCredentials(visiteurResult.user);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  const createCollectiviteWithCycle = async ({
+    accesRestreint,
+  }: {
+    accesRestreint: boolean;
+  }) => {
+    const { collectivite, users, cleanup } = await addTestCollectiviteAndUsers(
+      db,
+      {
+        collectivite: { accesRestreint },
+        users: [{ role: CollectiviteRole.EDITION }],
+      }
+    );
+    onTestFinished(cleanup);
+
+    const membre = users[0];
+    const membreSignInResponse = await signInWith({
+      email: membre.email,
+      password: membre.password,
+    });
+
+    const { audit, demande } = await createAuditWithOnTestFinished({
+      databaseService: db,
+      collectiviteId: collectivite.id,
+      referentielId: ReferentielIdEnum.CAE,
+      withDemande: true,
+      dateDebut: null,
+    });
+
+    const uploadFichier = (document: {
+      fileName: string;
+      sampleFileName?: string;
+      confidentiel?: boolean;
+    }) =>
+      uploadCreateTestDocument({
+        collectiviteId: collectivite.id,
+        testAgent: request(app.getHttpServer()),
+        token: membreSignInResponse.data.session?.access_token ?? '',
+        fileName: document.fileName,
+        sampleFileName: document.sampleFileName,
+        confidentiel: document.confidentiel,
+      });
+
+    const membreCaller = router.createCaller({
+      user: getAuthUserFromUserCredentials(membre),
+    });
+
+    return {
+      collectiviteId: collectivite.id,
+      demandeId: demande?.id ?? null,
+      membreCaller,
+      uploadFichier,
+      addPreuve: (document?: {
+        fileName?: string;
+        sampleFileName?: string;
+        confidentiel?: boolean;
+      }) =>
+        createTestDemandePreuve(
+          createTRPCClientFromCaller(membreCaller),
+          request(app.getHttpServer()),
+          membreSignInResponse.data.session?.access_token ?? '',
+          collectivite.id,
+          ReferentielIdEnum.CAE,
+          document
+        ),
+      insertPreuveAudit: async (document: {
+        fileName: string;
+        sampleFileName?: string;
+        confidentiel?: boolean;
+      }) => {
+        const fichier = await uploadFichier(document);
+        const [preuve] = await db.db
+          .insert(preuveAuditTable)
+          .values({
+            collectiviteId: collectivite.id,
+            auditId: audit.id,
+            fichierId: fichier.id,
+            commentaire: '',
+            modifiedBy: membre.id,
+          })
+          .returning({ id: preuveAuditTable.id });
+        onTestFinished(async () => {
+          await db.db
+            .delete(preuveAuditTable)
+            .where(eq(preuveAuditTable.id, preuve.id));
+        });
+      },
+      insertRapport: async (document: {
+        fileName: string;
+        sampleFileName?: string;
+        confidentiel?: boolean;
+        date?: string;
+      }) => {
+        const fichier = await uploadFichier(document);
+        const [preuve] = await db.db
+          .insert(preuveRapportTable)
+          .values({
+            collectiviteId: collectivite.id,
+            fichierId: fichier.id,
+            commentaire: '',
+            modifiedBy: membre.id,
+            date: document.date ?? '2026-01-15T00:00:00.000Z',
+          })
+          .returning({ id: preuveRapportTable.id });
+        onTestFinished(async () => {
+          await db.db
+            .delete(preuveRapportTable)
+            .where(eq(preuveRapportTable.id, preuve.id));
+        });
+      },
+    };
+  };
+
+  test('rend les rapports de visite du plus recent au plus ancien', async () => {
+    const { collectiviteId, membreCaller, insertRapport } =
+      await createCollectiviteWithCycle({ accesRestreint: false });
+    await insertRapport({
+      fileName: 'visite-2024.pdf',
+      date: '2024-06-15T00:00:00.000Z',
+    });
+    await insertRapport({
+      fileName: 'visite-2026.pdf',
+      sampleFileName: OTHER_PDF_SAMPLE_FILE,
+      date: '2026-06-15T00:00:00.000Z',
+    });
+
+    const documents = await membreCaller.referentiels.documents.listDocuments({
+      collectiviteId,
+      referentielId: ReferentielIdEnum.CAE,
+    });
+
+    expect(documents.rapport.map((preuve) => preuve.fichier?.filename)).toEqual(
+      ['visite-2026.pdf', 'visite-2024.pdf']
+    );
+  });
+
+  test('rend le dernier rapport depose en premier quand deux rapports partagent la meme date', async () => {
+    const { collectiviteId, membreCaller, insertRapport } =
+      await createCollectiviteWithCycle({ accesRestreint: false });
+    await insertRapport({
+      fileName: 'visite-deposee-en-premier.pdf',
+      date: '2026-06-15T00:00:00.000Z',
+    });
+    await insertRapport({
+      fileName: 'visite-deposee-en-second.pdf',
+      sampleFileName: OTHER_PDF_SAMPLE_FILE,
+      date: '2026-06-15T00:00:00.000Z',
+    });
+
+    const documents = await membreCaller.referentiels.documents.listDocuments({
+      collectiviteId,
+      referentielId: ReferentielIdEnum.CAE,
+    });
+
+    expect(documents.rapport.map((preuve) => preuve.fichier?.filename)).toEqual(
+      ['visite-deposee-en-second.pdf', 'visite-deposee-en-premier.pdf']
+    );
+  });
+
+  test("n'expose pas le fichier d'une autre collectivite porte par un document", async () => {
+    const cycle = await createCollectiviteWithCycle({ accesRestreint: false });
+    const otherCycle = await createCollectiviteWithCycle({
+      accesRestreint: false,
+    });
+    const otherCycleFichier = await otherCycle.uploadFichier({
+      fileName: 'document-de-la-collectivite-voisine.pdf',
+    });
+
+    const [preuve] = await db.db
+      .insert(preuveLabellisationTable)
+      .values({
+        collectiviteId: cycle.collectiviteId,
+        demandeId: cycle.demandeId as number,
+        fichierId: otherCycleFichier.id,
+        commentaire: '',
+        modifiedBy: visiteurUser.id,
+      })
+      .returning({ id: preuveLabellisationTable.id });
+    onTestFinished(async () => {
+      await db.db
+        .delete(preuveLabellisationTable)
+        .where(eq(preuveLabellisationTable.id, preuve.id));
+    });
+
+    const documents =
+      await cycle.membreCaller.referentiels.documents.listDocuments({
+        collectiviteId: cycle.collectiviteId,
+        referentielId: ReferentielIdEnum.CAE,
+      });
+
+    expect(
+      documents.labellisation.map((document) => document.fichier)
+    ).not.toContainEqual(
+      expect.objectContaining({
+        filename: 'document-de-la-collectivite-voisine.pdf',
+      })
+    );
+  });
+
+  test('rend les documents de labellisation du référentiel à un visiteur vérifié non membre', async () => {
+    const { collectiviteId, addPreuve } = await createCollectiviteWithCycle({
+      accesRestreint: false,
+    });
+    await addPreuve({ fileName: 'dossier-candidature.pdf' });
+
+    const visiteurCaller = router.createCaller({ user: visiteurUser });
+    const documents = await visiteurCaller.referentiels.documents.listDocuments(
+      {
+        collectiviteId,
+        referentielId: ReferentielIdEnum.CAE,
+      }
+    );
+
+    expect(
+      documents.labellisation.map((document) => document.fichier?.filename)
+    ).toEqual(['dossier-candidature.pdf']);
+    expect(documents.audit).toEqual([]);
+    expect(documents.rapport).toEqual([]);
+  });
+
+  test('expose le champ objet sur les documents de labellisation', async () => {
+    const { collectiviteId, addPreuve } = await createCollectiviteWithCycle({
+      accesRestreint: false,
+    });
+    await addPreuve({ fileName: 'acte-candidature.pdf' });
+
+    const visiteurCaller = router.createCaller({ user: visiteurUser });
+    const documents = await visiteurCaller.referentiels.documents.listDocuments(
+      {
+        collectiviteId,
+        referentielId: ReferentielIdEnum.CAE,
+      }
+    );
+
+    expect(documents.labellisation[0].audit).toBeNull();
+    expect(documents.labellisation[0]).toHaveProperty('objet');
+    expect(documents.labellisation[0].objet).toBeNull();
+  });
+
+  test('conserve chaque document dans son cycle via demande', async () => {
+    const { collectiviteId, addPreuve } = await createCollectiviteWithCycle({
+      accesRestreint: false,
+    });
+    await addPreuve({ fileName: 'piece-du-cycle.pdf' });
+
+    const visiteurCaller = router.createCaller({ user: visiteurUser });
+    const documents = await visiteurCaller.referentiels.documents.listDocuments(
+      {
+        collectiviteId,
+        referentielId: ReferentielIdEnum.CAE,
+      }
+    );
+
+    const document = documents.labellisation[0];
+    expect(document.demande).not.toBeNull();
+    expect(document.demande?.referentiel).toBe(ReferentielIdEnum.CAE);
+    expect(document.preuve_type).toBe('labellisation');
+  });
+
+  test('masque les documents confidentiels à un visiteur non membre', async () => {
+    const { collectiviteId, membreCaller, addPreuve } =
+      await createCollectiviteWithCycle({ accesRestreint: false });
+
+    await addPreuve({ fileName: 'piece-publique.pdf' });
+    await addPreuve({
+      fileName: 'piece-confidentielle.pdf',
+      sampleFileName: OTHER_PDF_SAMPLE_FILE,
+      confidentiel: true,
+    });
+
+    const visiteurCaller = router.createCaller({ user: visiteurUser });
+    const documentsVisiteur =
+      await visiteurCaller.referentiels.documents.listDocuments({
+        collectiviteId,
+        referentielId: ReferentielIdEnum.CAE,
+      });
+
+    expect(
+      documentsVisiteur.labellisation.map(
+        (document) => document.fichier?.filename
+      )
+    ).toEqual(['piece-publique.pdf']);
+
+    const documentsMembre =
+      await membreCaller.referentiels.documents.listDocuments({
+        collectiviteId,
+        referentielId: ReferentielIdEnum.CAE,
+      });
+
+    expect(
+      documentsMembre.labellisation.map(
+        (document) => document.fichier?.filename
+      )
+    ).toEqual(['piece-publique.pdf', 'piece-confidentielle.pdf']);
+  });
+
+  test("refuse la lecture d'une collectivité en accès restreint à un utilisateur non membre", async () => {
+    const { collectiviteId, addPreuve } = await createCollectiviteWithCycle({
+      accesRestreint: true,
+    });
+    await addPreuve();
+
+    const visiteurCaller = router.createCaller({ user: visiteurUser });
+
+    await expect(
+      visiteurCaller.referentiels.documents.listDocuments({
+        collectiviteId,
+        referentielId: ReferentielIdEnum.CAE,
+      })
+    ).rejects.toThrow(
+      "Vous n'avez pas les permissions nécessaires pour lister les documents de ce référentiel."
+    );
+  });
+
+  test("n'expose pas les documents d'une autre collectivité", async () => {
+    const cycle = await createCollectiviteWithCycle({
+      accesRestreint: false,
+    });
+    await cycle.addPreuve({ fileName: 'document-demande.pdf' });
+
+    const otherCycle = await createCollectiviteWithCycle({
+      accesRestreint: false,
+    });
+    await otherCycle.addPreuve({ fileName: 'document-voisin.pdf' });
+
+    const visiteurCaller = router.createCaller({ user: visiteurUser });
+    const documents = await visiteurCaller.referentiels.documents.listDocuments(
+      {
+        collectiviteId: cycle.collectiviteId,
+        referentielId: ReferentielIdEnum.CAE,
+      }
+    );
+
+    expect(
+      documents.labellisation.map((document) => document.fichier?.filename)
+    ).toEqual(['document-demande.pdf']);
+  });
+
+  test("n'expose pas les documents de labellisation d'un autre référentiel", async () => {
+    const { collectiviteId, addPreuve } = await createCollectiviteWithCycle({
+      accesRestreint: false,
+    });
+    await addPreuve({ fileName: 'document-cae.pdf' });
+
+    const visiteurCaller = router.createCaller({ user: visiteurUser });
+    const documents = await visiteurCaller.referentiels.documents.listDocuments(
+      {
+        collectiviteId,
+        referentielId: ReferentielIdEnum.ECI,
+      }
+    );
+
+    expect(documents.labellisation).toEqual([]);
+  });
+
+  test("masque les documents d'audit confidentiels à un visiteur non membre", async () => {
+    const { collectiviteId, membreCaller, insertPreuveAudit } =
+      await createCollectiviteWithCycle({ accesRestreint: false });
+
+    await insertPreuveAudit({
+      fileName: 'rapport-audit.pdf',
+    });
+    await insertPreuveAudit({
+      fileName: 'annexe-confidentielle.pdf',
+      sampleFileName: OTHER_PDF_SAMPLE_FILE,
+      confidentiel: true,
+    });
+
+    const visiteurCaller = router.createCaller({ user: visiteurUser });
+    const documentsVisiteur =
+      await visiteurCaller.referentiels.documents.listDocuments({
+        collectiviteId,
+        referentielId: ReferentielIdEnum.CAE,
+      });
+
+    expect(
+      documentsVisiteur.audit.map((document) => document.fichier?.filename)
+    ).toEqual(['rapport-audit.pdf']);
+
+    const documentsMembre =
+      await membreCaller.referentiels.documents.listDocuments({
+        collectiviteId,
+        referentielId: ReferentielIdEnum.CAE,
+      });
+
+    expect(
+      documentsMembre.audit.map((document) => document.fichier?.filename)
+    ).toEqual(['rapport-audit.pdf', 'annexe-confidentielle.pdf']);
+  });
+
+  test('masque les rapports de visite confidentiels à un visiteur non membre', async () => {
+    const { collectiviteId, membreCaller, insertRapport } =
+      await createCollectiviteWithCycle({ accesRestreint: false });
+
+    await insertRapport({
+      fileName: 'visite-annuelle.pdf',
+      date: '2026-06-15T00:00:00.000Z',
+    });
+    await insertRapport({
+      fileName: 'visite-confidentielle.pdf',
+      sampleFileName: OTHER_PDF_SAMPLE_FILE,
+      confidentiel: true,
+      date: '2025-06-15T00:00:00.000Z',
+    });
+
+    const visiteurCaller = router.createCaller({ user: visiteurUser });
+    const documentsVisiteur =
+      await visiteurCaller.referentiels.documents.listDocuments({
+        collectiviteId,
+        referentielId: ReferentielIdEnum.CAE,
+      });
+
+    expect(
+      documentsVisiteur.rapport.map((document) => document.fichier?.filename)
+    ).toEqual(['visite-annuelle.pdf']);
+    expect(documentsVisiteur.rapport[0].rapport.date).toBeDefined();
+
+    const documentsMembre =
+      await membreCaller.referentiels.documents.listDocuments({
+        collectiviteId,
+        referentielId: ReferentielIdEnum.CAE,
+      });
+
+    expect(
+      documentsMembre.rapport.map((document) => document.fichier?.filename)
+    ).toEqual(['visite-annuelle.pdf', 'visite-confidentielle.pdf']);
+  });
+});

--- a/apps/backend/src/referentiels/documents/list-documents/list-documents.router.ts
+++ b/apps/backend/src/referentiels/documents/list-documents/list-documents.router.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@nestjs/common';
+import { createTrpcErrorHandler } from '@tet/backend/utils/trpc/trpc-error-handler';
+import { TrpcService } from '@tet/backend/utils/trpc/trpc.service';
+import { listDocumentsErrorConfig } from './list-documents.errors';
+import { listDocumentsInputSchema } from './list-documents.input';
+import { ListDocumentsService } from './list-documents.service';
+
+@Injectable()
+export class ListDocumentsRouter {
+  constructor(
+    private readonly trpc: TrpcService,
+    private readonly listDocumentsService: ListDocumentsService
+  ) {}
+
+  private readonly getResultDataOrThrowError = createTrpcErrorHandler(
+    listDocumentsErrorConfig
+  );
+
+  router = this.trpc.router({
+    listDocuments: this.trpc.authedProcedure
+      .input(listDocumentsInputSchema)
+      .query(async ({ input, ctx: { user } }) => {
+        const result = await this.listDocumentsService.listDocuments(input, {
+          user,
+        });
+        return this.getResultDataOrThrowError(result);
+      }),
+  });
+}

--- a/apps/backend/src/referentiels/documents/list-documents/list-documents.service.ts
+++ b/apps/backend/src/referentiels/documents/list-documents/list-documents.service.ts
@@ -1,0 +1,72 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ServiceSecondArg } from '@tet/backend/utils/nest/service-second-arg.utils';
+import { failure, Result, success } from '@tet/backend/utils/result.type';
+import { ReferentielDocumentsAccessService } from '../referentiel-documents-access.service';
+import { toPreuve } from './list-documents.adapter';
+import {
+  ListDocumentsError,
+  ListDocumentsErrorEnum,
+} from './list-documents.errors';
+import { ListDocumentsInput } from './list-documents.input';
+import {
+  ListDocumentsOutput,
+  listDocumentsOutputSchema,
+} from './list-documents.output';
+import { ListDocumentsRepository } from './list-documents.repository';
+
+@Injectable()
+export class ListDocumentsService {
+  private readonly logger = new Logger(ListDocumentsService.name);
+
+  constructor(
+    private readonly listDocumentsRepository: ListDocumentsRepository,
+    private readonly referentielDocumentsAccess: ReferentielDocumentsAccessService
+  ) {}
+
+  async listDocuments(
+    { collectiviteId, referentielId }: ListDocumentsInput,
+    { user, tx }: ServiceSecondArg
+  ): Promise<Result<ListDocumentsOutput, ListDocumentsError>> {
+    const accessResult =
+      await this.referentielDocumentsAccess.checkUserCanReadDocuments(
+        { collectiviteId, referentielId },
+        { user, tx }
+      );
+    if (!accessResult.success) {
+      return failure(ListDocumentsErrorEnum.UNAUTHORIZED);
+    }
+    const { canReadConfidentiel } = accessResult.data;
+    const scope = { collectiviteId, referentielId, canReadConfidentiel };
+
+    const [labellisation, audit, rapport] = await Promise.all([
+      this.listDocumentsRepository.listLabellisationDocuments(scope, tx),
+      this.listDocumentsRepository.listAuditDocuments(scope, tx),
+      this.listDocumentsRepository.listRapportDocuments(scope, tx),
+    ]);
+
+    if (!labellisation.success) {
+      return failure(labellisation.error);
+    }
+    if (!audit.success) {
+      return failure(audit.error);
+    }
+    if (!rapport.success) {
+      return failure(rapport.error);
+    }
+
+    const documents = listDocumentsOutputSchema.safeParse({
+      labellisation: labellisation.data.map(toPreuve),
+      audit: audit.data.map(toPreuve),
+      rapport: rapport.data.map(toPreuve),
+    });
+
+    if (!documents.success) {
+      this.logger.error(
+        `Documents hors contrat pour le référentiel ${referentielId} de la collectivité ${collectiviteId}: ${documents.error.message}`
+      );
+      return failure(ListDocumentsErrorEnum.DOCUMENT_SCHEMA_MISMATCH);
+    }
+
+    return success(documents.data);
+  }
+}

--- a/apps/backend/src/referentiels/documents/referentiel-documents-access.service.ts
+++ b/apps/backend/src/referentiels/documents/referentiel-documents-access.service.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@nestjs/common';
+import CollectivitesService from '@tet/backend/collectivites/services/collectivites.service';
+import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
+import { ServiceSecondArg } from '@tet/backend/utils/nest/service-second-arg.utils';
+import { failure, Result, success } from '@tet/backend/utils/result.type';
+import { ReferentielId } from '@tet/domain/referentiels';
+import { ResourceType } from '@tet/domain/users';
+
+@Injectable()
+export class ReferentielDocumentsAccessService {
+  constructor(
+    private readonly permissions: PermissionService,
+    private readonly collectivitesService: CollectivitesService
+  ) {}
+
+  async checkUserCanReadDocuments(
+    {
+      collectiviteId,
+      referentielId,
+    }: { collectiviteId: number; referentielId: ReferentielId },
+    { user, tx }: ServiceSecondArg
+  ): Promise<Result<{ canReadConfidentiel: boolean }, 'UNAUTHORIZED'>> {
+    const isCollectivitePrivate = await this.collectivitesService.isPrivate(
+      collectiviteId
+    );
+
+    const [readResult, readConfidentielResult] = await Promise.all([
+      this.permissions.isAllowed(
+        user,
+        isCollectivitePrivate
+          ? 'referentiels.read_confidentiel'
+          : 'referentiels.read',
+        ResourceType.REFERENTIEL,
+        { collectiviteId, referentielId },
+        tx
+      ),
+      this.permissions.isAllowed(
+        user,
+        'collectivites.documents.read_confidentiel',
+        ResourceType.COLLECTIVITE,
+        { collectiviteId },
+        tx
+      ),
+    ]);
+
+    if (!readResult.success) {
+      return failure('UNAUTHORIZED');
+    }
+
+    return success({ canReadConfidentiel: readConfidentielResult.success });
+  }
+}

--- a/apps/backend/src/referentiels/labellisations/labellisations.test-fixture.ts
+++ b/apps/backend/src/referentiels/labellisations/labellisations.test-fixture.ts
@@ -1,4 +1,4 @@
-import { bibliothequeFichierTable } from '@tet/backend/collectivites/documents/models/bibliotheque-fichier.table';
+import { seedTestDocument } from '@tet/backend/collectivites/documents/documents.test-fixture';
 import { preuveLabellisationTable } from '@tet/backend/collectivites/documents/models/preuve-labellisation.table';
 import { auditTable } from '@tet/backend/referentiels/labellisations/audit.table';
 import { auditeurTable } from '@tet/backend/referentiels/labellisations/auditeur.table';
@@ -13,7 +13,6 @@ import {
 } from '@tet/domain/referentiels';
 import { TRPCClient } from '@trpc/client';
 import { and, eq } from 'drizzle-orm';
-import { randomUUID } from 'node:crypto';
 import {
   cleanupReferentielActionStatutsAndLabellisations,
   updateAllNeedReferentielStatutsToCompleteReferentiel,
@@ -352,15 +351,11 @@ export async function seedLabellisationPreuve({
     throw new Error('Aucune demande à laquelle rattacher la preuve');
   }
 
-  const [fichier] = await databaseService.db
-    .insert(bibliothequeFichierTable)
-    .values({
-      collectiviteId,
-      hash: randomUUID(),
-      filename: 'test-preuve.pdf',
-      confidentiel: false,
-    })
-    .returning();
+  const fichier = await seedTestDocument({
+    databaseService,
+    collectiviteId,
+    filename: 'test-preuve.pdf',
+  });
 
   await databaseService.db.insert(preuveLabellisationTable).values({
     collectiviteId,

--- a/apps/backend/src/referentiels/labellisations/list-preuves/list-preuves-audit.input.ts
+++ b/apps/backend/src/referentiels/labellisations/list-preuves/list-preuves-audit.input.ts
@@ -4,6 +4,4 @@ export const listPreuvesAuditInputSchema = z.object({
   auditId: z.number().int().positive(),
 });
 
-export type ListPreuvesAuditInput = z.infer<
-  typeof listPreuvesAuditInputSchema
->;
+export type ListPreuvesAuditInput = z.infer<typeof listPreuvesAuditInputSchema>;

--- a/apps/backend/src/referentiels/labellisations/list-preuves/list-preuves.service.ts
+++ b/apps/backend/src/referentiels/labellisations/list-preuves/list-preuves.service.ts
@@ -1,23 +1,20 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { ReferentielDocumentsAccessService } from '../../documents/referentiel-documents-access.service';
+import {
+  buildFichierSubquery,
+  buildFileInfoSql,
+} from '@tet/backend/collectivites/documents/file-info.utils';
 import { hideConfidentielFilter } from '@tet/backend/collectivites/documents/hide-confidentiel.utils';
-import { bibliothequeFichierTable } from '@tet/backend/collectivites/documents/models/bibliotheque-fichier.table';
 import { preuveAuditTable } from '@tet/backend/collectivites/documents/models/preuve-audit.table';
 import { preuveLabellisationTable } from '@tet/backend/collectivites/documents/models/preuve-labellisation.table';
-import { storageObjectTable } from '@tet/backend/collectivites/documents/models/storage-object.table';
-import { collectiviteBucketTable } from '@tet/backend/collectivites/shared/models/collectivite-bucket.table';
-import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { createdByNom, dcpTable } from '@tet/backend/users/models/dcp.table';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
-import CollectivitesService from '@tet/backend/collectivites/services/collectivites.service';
-import { failure, Result, success } from '@tet/backend/utils/result.type';
+import { Result } from '@tet/backend/utils/result.type';
 import {
-  BibliothequeFichier,
   LegacyPreuveAuditWithFichier,
   LegacyPreuveLabellisationWithFichier,
 } from '@tet/domain/collectivites';
-import { ReferentielId } from '@tet/domain/referentiels';
-import { ResourceType } from '@tet/domain/users';
 import { getErrorMessage } from '@tet/domain/utils';
 import { and, eq, getTableColumns, sql } from 'drizzle-orm';
 import { ObjectToSnake, objectToSnake } from 'ts-case-convert';
@@ -41,43 +38,9 @@ export class ListPreuvesService {
 
   constructor(
     private readonly databaseService: DatabaseService,
-    private readonly permissions: PermissionService,
     private readonly getLabellisationService: GetLabellisationService,
-    private readonly collectivitesService: CollectivitesService
+    private readonly referentielDocumentsAccess: ReferentielDocumentsAccessService
   ) {}
-
-  private async checkUserDocumentsAccess(
-    {
-      collectiviteId,
-      referentielId,
-    }: { collectiviteId: number; referentielId: ReferentielId },
-    user: AuthenticatedUser
-  ): Promise<Result<{ canReadConfidentiel: boolean }, 'UNAUTHORIZED'>> {
-    const collectivitePrivate = await this.collectivitesService.isPrivate(
-      collectiviteId
-    );
-
-    const permissionResult = await this.permissions.isAllowed(
-      user,
-      collectivitePrivate
-        ? 'referentiels.read_confidentiel'
-        : 'referentiels.read',
-      ResourceType.REFERENTIEL,
-      { collectiviteId, referentielId }
-    );
-    if (!permissionResult.success) {
-      return failure('UNAUTHORIZED');
-    }
-
-    const confidentielResult = await this.permissions.isAllowed(
-      user,
-      'collectivites.documents.read_confidentiel',
-      ResourceType.COLLECTIVITE,
-      { collectiviteId }
-    );
-
-    return success({ canReadConfidentiel: confidentielResult.success });
-  }
 
   async listPreuvesAudit(
     { auditId }: ListPreuvesAuditInput,
@@ -100,27 +63,31 @@ export class ListPreuvesService {
       }
     }
     const auditData = auditResult.data;
-    const accessResult = await this.checkUserDocumentsAccess(
-      {
-        collectiviteId: auditData.collectiviteId,
-        referentielId: auditData.referentielId,
-      },
-      user
-    );
+    const accessResult =
+      await this.referentielDocumentsAccess.checkUserCanReadDocuments(
+        {
+          collectiviteId: auditData.collectiviteId,
+          referentielId: auditData.referentielId,
+        },
+        { user }
+      );
     if (!accessResult.success) {
       return {
         success: false,
         error: 'UNAUTHORIZED',
       };
     }
+
     const { canReadConfidentiel } = accessResult.data;
 
     try {
       // Get the preuve
+      const fichier = buildFichierSubquery(this.databaseService.db);
+
       const preuves = await this.databaseService.db
         .select({
           ...getTableColumns(preuveAuditTable),
-          fichier: this.getFileInfoSql(),
+          fichier: buildFileInfoSql(fichier),
           demande: {
             ...getTableColumns(labellisationDemandeTable),
           },
@@ -137,24 +104,7 @@ export class ListPreuvesService {
           rapport: sql<null>`null`,
         })
         .from(preuveAuditTable)
-        .leftJoin(
-          bibliothequeFichierTable,
-          eq(preuveAuditTable.fichierId, bibliothequeFichierTable.id)
-        )
-        .leftJoin(
-          collectiviteBucketTable,
-          eq(
-            collectiviteBucketTable.collectiviteId,
-            bibliothequeFichierTable.collectiviteId
-          )
-        )
-        .leftJoin(
-          storageObjectTable,
-          and(
-            eq(storageObjectTable.bucketId, collectiviteBucketTable.bucketId),
-            eq(storageObjectTable.name, bibliothequeFichierTable.hash)
-          )
-        )
+        .leftJoin(fichier, eq(preuveAuditTable.fichierId, fichier.id))
         .leftJoin(auditTable, eq(preuveAuditTable.auditId, auditTable.id))
         .leftJoin(
           labellisationDemandeTable,
@@ -164,12 +114,14 @@ export class ListPreuvesService {
         .where(
           and(
             eq(preuveAuditTable.auditId, auditId),
-            hideConfidentielFilter(
-              preuveAuditTable.fichierId,
-              canReadConfidentiel
-            )
+            hideConfidentielFilter({
+              fichierIdColumn: preuveAuditTable.fichierId,
+              confidentielColumn: fichier.confidentiel,
+              canReadConfidentiel,
+            })
           )
-        );
+        )
+        .orderBy(preuveAuditTable.id);
 
       return {
         success: true,
@@ -216,27 +168,31 @@ export class ListPreuvesService {
     }
     const demande = demandeResult.data;
 
-    const accessResult = await this.checkUserDocumentsAccess(
-      {
-        collectiviteId: demande.collectiviteId,
-        referentielId: demande.referentiel,
-      },
-      user
-    );
+    const accessResult =
+      await this.referentielDocumentsAccess.checkUserCanReadDocuments(
+        {
+          collectiviteId: demande.collectiviteId,
+          referentielId: demande.referentiel,
+        },
+        { user }
+      );
     if (!accessResult.success) {
       return {
         success: false,
         error: 'UNAUTHORIZED',
       };
     }
+
     const { canReadConfidentiel } = accessResult.data;
 
     try {
       // Get the preuve
+      const fichier = buildFichierSubquery(this.databaseService.db);
+
       const preuves = await this.databaseService.db
         .select({
           ...getTableColumns(preuveLabellisationTable),
-          fichier: this.getFileInfoSql(),
+          fichier: buildFileInfoSql(fichier),
           demande: {
             ...getTableColumns(labellisationDemandeTable),
           },
@@ -251,24 +207,7 @@ export class ListPreuvesService {
           audit: sql<null>`null`,
         })
         .from(preuveLabellisationTable)
-        .leftJoin(
-          bibliothequeFichierTable,
-          eq(preuveLabellisationTable.fichierId, bibliothequeFichierTable.id)
-        )
-        .leftJoin(
-          collectiviteBucketTable,
-          eq(
-            collectiviteBucketTable.collectiviteId,
-            bibliothequeFichierTable.collectiviteId
-          )
-        )
-        .leftJoin(
-          storageObjectTable,
-          and(
-            eq(storageObjectTable.bucketId, collectiviteBucketTable.bucketId),
-            eq(storageObjectTable.name, bibliothequeFichierTable.hash)
-          )
-        )
+        .leftJoin(fichier, eq(preuveLabellisationTable.fichierId, fichier.id))
         .leftJoin(
           labellisationDemandeTable,
           eq(preuveLabellisationTable.demandeId, labellisationDemandeTable.id)
@@ -280,10 +219,11 @@ export class ListPreuvesService {
         .where(
           and(
             eq(preuveLabellisationTable.demandeId, demandeId),
-            hideConfidentielFilter(
-              preuveLabellisationTable.fichierId,
-              canReadConfidentiel
-            )
+            hideConfidentielFilter({
+              fichierIdColumn: preuveLabellisationTable.fichierId,
+              confidentielColumn: fichier.confidentiel,
+              canReadConfidentiel,
+            })
           )
         )
         // Ordre stable par id croissant : le front traite `preuves[0]` comme
@@ -307,26 +247,5 @@ export class ListPreuvesService {
           error instanceof Error ? error : new Error(getErrorMessage(error)),
       };
     }
-  }
-
-  private getFileInfoSql() {
-    return sql<
-      | (BibliothequeFichier & {
-          bucketId: string;
-        })
-      | null
-    >`
-      CASE WHEN ${bibliothequeFichierTable.id} IS NULL THEN NULL
-      ELSE json_build_object(
-        'id', ${bibliothequeFichierTable.id},
-        'collectiviteId', ${bibliothequeFichierTable.collectiviteId},
-        'hash', ${bibliothequeFichierTable.hash},
-        'filename', ${bibliothequeFichierTable.filename},
-        'confidentiel', ${bibliothequeFichierTable.confidentiel},
-        'bucketId', ${collectiviteBucketTable.bucketId},
-        'filesize', (${storageObjectTable.metadata}->>'size')::integer
-      )
-      END
-    `;
   }
 }

--- a/apps/backend/src/referentiels/preuves-archive/list-audit-preuves/collect-preuves.repository.ts
+++ b/apps/backend/src/referentiels/preuves-archive/list-audit-preuves/collect-preuves.repository.ts
@@ -74,14 +74,20 @@ export class CollectPreuvesRepository {
         .innerJoin(
           actionDefinitionTable,
           and(
-            eq(actionDefinitionTable.actionId, preuveComplementaireTable.actionId),
+            eq(
+              actionDefinitionTable.actionId,
+              preuveComplementaireTable.actionId
+            ),
             eq(actionDefinitionTable.referentielId, referentielId)
           )
         )
         .leftJoin(
           bibliothequeFichierTable,
           and(
-            eq(preuveComplementaireTable.fichierId, bibliothequeFichierTable.id),
+            eq(
+              preuveComplementaireTable.fichierId,
+              bibliothequeFichierTable.id
+            ),
             eq(bibliothequeFichierTable.collectiviteId, collectiviteId)
           )
         )
@@ -95,10 +101,11 @@ export class CollectPreuvesRepository {
         .where(
           and(
             eq(preuveComplementaireTable.collectiviteId, collectiviteId),
-            hideConfidentielFilter(
-              preuveComplementaireTable.fichierId,
-              canReadConfidentiel
-            )
+            hideConfidentielFilter({
+              fichierIdColumn: preuveComplementaireTable.fichierId,
+              confidentielColumn: bibliothequeFichierTable.confidentiel,
+              canReadConfidentiel,
+            })
           )
         );
 
@@ -162,10 +169,11 @@ export class CollectPreuvesRepository {
         .where(
           and(
             eq(preuveReglementaireTable.collectiviteId, collectiviteId),
-            hideConfidentielFilter(
-              preuveReglementaireTable.fichierId,
-              canReadConfidentiel
-            )
+            hideConfidentielFilter({
+              fichierIdColumn: preuveReglementaireTable.fichierId,
+              confidentielColumn: bibliothequeFichierTable.confidentiel,
+              canReadConfidentiel,
+            })
           )
         );
 
@@ -219,10 +227,11 @@ export class CollectPreuvesRepository {
           and(
             eq(preuveLabellisationTable.demandeId, demandeId),
             eq(preuveLabellisationTable.collectiviteId, collectiviteId),
-            hideConfidentielFilter(
-              preuveLabellisationTable.fichierId,
-              canReadConfidentiel
-            )
+            hideConfidentielFilter({
+              fichierIdColumn: preuveLabellisationTable.fichierId,
+              confidentielColumn: bibliothequeFichierTable.confidentiel,
+              canReadConfidentiel,
+            })
           )
         );
 
@@ -276,10 +285,11 @@ export class CollectPreuvesRepository {
           and(
             eq(preuveAuditTable.auditId, auditId),
             eq(preuveAuditTable.collectiviteId, collectiviteId),
-            hideConfidentielFilter(
-              preuveAuditTable.fichierId,
-              canReadConfidentiel
-            )
+            hideConfidentielFilter({
+              fichierIdColumn: preuveAuditTable.fichierId,
+              confidentielColumn: bibliothequeFichierTable.confidentiel,
+              canReadConfidentiel,
+            })
           )
         );
 

--- a/apps/backend/src/referentiels/referentiels.module.ts
+++ b/apps/backend/src/referentiels/referentiels.module.ts
@@ -50,6 +50,10 @@ import { HandleMesureAuditStatutRouter } from './labellisations/handle-mesure-au
 import { HandleMesureAuditStatutService } from './labellisations/handle-mesure-audit-statut/handle-mesure-audit-statut.service';
 import { LabellisationService } from './labellisations/labellisation.service';
 import { ListPreuvesRouter } from './labellisations/list-preuves/list-preuves.router';
+import { ReferentielDocumentsAccessService } from './documents/referentiel-documents-access.service';
+import { ListDocumentsRepository } from './documents/list-documents/list-documents.repository';
+import { ListDocumentsRouter } from './documents/list-documents/list-documents.router';
+import { ListDocumentsService } from './documents/list-documents/list-documents.service';
 import { ListPreuvesService } from './labellisations/list-preuves/list-preuves.service';
 import { RequestLabellisationRouter } from './labellisations/request-labellisation/request-labellisation.router';
 import { RequestLabellisationService } from './labellisations/request-labellisation/request-labellisation.service';
@@ -177,8 +181,12 @@ import { UpdateActionStatutService } from './update-action-statut/update-action-
     RequestLabellisationRouter,
     CreatePreuveService,
     CreatePreuveRouter,
+    ReferentielDocumentsAccessService,
     ListPreuvesService,
     ListPreuvesRouter,
+    ListDocumentsRepository,
+    ListDocumentsService,
+    ListDocumentsRouter,
     UpdateAuditReportService,
     UpdateAuditReportRouter,
     ValidateAuditService,

--- a/apps/backend/src/referentiels/referentiels.router.ts
+++ b/apps/backend/src/referentiels/referentiels.router.ts
@@ -14,6 +14,7 @@ import { RequestLabellisationRouter } from './labellisations/request-labellisati
 import { StartAuditRouter } from './labellisations/start-audit/start-audit.router';
 import { ValidateAuditRouter } from './labellisations/validate-audit/validate-audit.router';
 import { CountPreuvesRouter } from './count-preuve/count-preuves.router';
+import { ListDocumentsRouter } from './documents/list-documents/list-documents.router';
 import { ListActionsRouter } from './list-actions/list-actions.router';
 import { GetPreuvesArchiveRouter } from './preuves-archive/get-preuves-archive/get-preuves-archive.router';
 import { ListPreuvesArchiveRouter } from './preuves-archive/list-preuves-archive/list-preuves-archive.router';
@@ -41,6 +42,7 @@ export class ReferentielsRouter {
     private readonly createPreuve: CreatePreuveRouter,
     private readonly validateAudit: ValidateAuditRouter,
     private readonly listPreuves: ListPreuvesRouter,
+    private readonly listDocumentsRouter: ListDocumentsRouter,
     private readonly updateAuditReport: UpdateAuditReportRouter,
     private readonly assignPilotesRouter: HandleMesurePilotesRouter,
     private readonly assignServicesRouter: HandleMesuresServicesRouter,
@@ -81,6 +83,8 @@ export class ReferentielsRouter {
       this.listPreuves.router,
       this.updateAuditReport.router
     ),
+
+    documents: this.listDocumentsRouter.router,
 
     definitions: this.getReferentielDefinitionRouter.router,
 


### PR DESCRIPTION
## Ce que la PR livre

L'onglet Documents du référentiel est servi par `referentiels.documents.listDocuments({ collectiviteId, referentielId })`, qui rend les documents de **labellisation**, d'**audit** et les **rapports**.

Le contrôle d'accès passe par `permissionService.isAllowed`. Les deux gardes de #4871 s'appliquent aux trois requêtes : escalade de permission sur une collectivité en accès restreint, exclusion des documents confidentiels sans `collectivites.documents.read_confidentiel`.

Le champ `preuve_labellisation.objet` est disponible côté front, ce qui débloque le reclassement des documents par le super-admin.

## Documents confidentiels

`public.preuve` renvoie la ligne d'un document confidentiel avec `fichier` et `lien` à `null` ; le front reçoit une entrée vide qui ne rend aucune carte. L'endpoint ne renvoie pas la ligne.

Un cycle dont **tous** les documents d'audit sont confidentiels n'a donc plus d'objet `audit` pour un lecteur non habilité, et `getCycleInfo` se rabat sur la demande. Le rendu est identique : `Title` traduit `audit_en_cours` et `demande_envoyee` par le même « (en cours) ». Le seul autre consommateur de `info.audit` est le calcul du droit d'édition, qui exige `referentiels.mutate` — que les non-membres n'ont pas. Tout membre, auditeur compris, a `collectivites.documents.read_confidentiel` et reçoit l'audit.

## Découpage backend

`list-documents.repository.ts` porte les trois requêtes Drizzle, `list-documents.adapter.ts` l'assemblage au format `TPreuve` — un document ne porte que les relations de son type, les autres restent à `null`.

Chaque méthode du repository capture ses erreurs SQL, rend un `Result`, loge sa propre branche et accepte `tx` en dernier argument, sur le modèle de `list-axes.repository.ts`. Le service autorise, compose et valide le contrat ; il prend `ServiceSecondArg` en dernier argument et propage son `tx`.

`ReferentielDocumentsAccessService` porte la règle d'accès partagée avec `ListPreuvesService`, dans `referentiels/documents/` où son unique module fournisseur la déclare. `checkUserCanReadDocuments` résout les deux permissions en parallèle et rend `Result<{ canReadConfidentiel }, 'UNAUTHORIZED'>`.

## Contrat de sortie

`list-documents.output.ts` décrit la réponse. Le service la passe en `safeParse` : un document hors contrat est logué avec son référentiel et sa collectivité, et remonte en `DOCUMENT_SCHEMA_MISMATCH`.

Le schéma déclare l'union **fichier / ni fichier ni lien**. L'invariant est vérifié à l'exécution, et le front le reçoit typé — `TPreuve` est identique à `main`, sans cast ni mapper.

La base garantit l'invariant par deux mécanismes conjoints :

```sql
CHECK ((fichier_id IS NOT NULL AND url IS NULL) OR (url IS NOT NULL AND fichier_id IS NULL))
lien GENERATED ALWAYS AS (CASE WHEN url IS NOT NULL THEN jsonb_object(…) ELSE NULL END)
```

Le second membre couvre la référence orpheline : `fichier_id` ne porte pas de clé étrangère.

Le lien est absent du contrat. Aucun chemin d'écriture ne le produit sur ces trois types — `createLabellisationPreuveInputSchema` n'accepte que `fichierId`, et le `addLink` d'`AddPreuveModal` n'est câblé que sur les annexes de fiche. En production, `preuve_labellisation`, `preuve_audit` et `preuve_rapport` ont zéro ligne avec une `url`.

Le contrat est en `snake_case`, comme `TPreuve` côté front. `UNAUTHORIZED` et `DATABASE_ERROR` restent les erreurs communes, donc `FORBIDDEN` en 403 ; le message spécialisé passe par le slot `commonErrors`.

## Collecte du fichier par sous-requête

`buildFichierSubquery` joint `bibliotheque_fichier → collectivite_bucket → storage.objects` en `INNER` et se rattache aux preuves en `LEFT JOIN` sur `fichier_id` — le schéma de la vue `public.bibliotheque_fichier`.

Une collectivité porte souvent plusieurs buckets : 18 en production, au moins deux dès qu'elle est passée par l'archivage. Joindre `collectivite_bucket` depuis la requête appelante multiplie chaque document par ce nombre ; l'`INNER JOIN` à l'intérieur de la sous-requête ramène une ligne par fichier. `ListPreuvesService` bénéficie de la même correction : la checklist audit-labellisation passe de 9 à 5 lignes pour 5 documents.

`buildFileInfoSql` et `hideConfidentielFilter` prennent leurs colonnes en argument, ce qui rend impossible une requête qui compile en oubliant une jointure.

## Scoping

Chaque branche filtre sur sa collectivité, dans le `WHERE` en plus de la jointure, ce qui rend l'index `preuve_labellisation_idx_collectivite` utilisable.

La jointure vers le fichier porte la même contrainte. Sans elle, un document dont le `fichier_id` désigne une autre collectivité exposait ses `filename`, `hash` et `bucket_id` : la sous-requête balaie toute la bibliothèque, `preuve_base.fichier_id` n'a pas de clé étrangère, et `createLabellisationPreuve` insère le `fichierId` du payload sans vérifier son propriétaire. La vue évaluait ses gardes sur la collectivité **propriétaire du fichier**. Le trou d'écriture reste ouvert, PR 8 du plan.

Les rapports de visite sont rendus du plus récent au plus ancien, l'ordre que portait la vue, et départagés par leur `id` : deux rapports de même date sortent dans un ordre déterminé.

## Front

`useListDocuments` rend une union discriminée : `{ status: 'loading' }`, `{ status: 'error' }` ou `{ status: 'loaded', documents }`. L'onglet affiche un spinner pendant le chargement, une alerte en cas d'échec, et n'annonce l'absence de rapport que sur `'loaded'`. Le hook ne complète pas une réponse absente par trois listes vides : `isLoading` de React Query vaut `isPending && isFetching`, donc une requête en pause rend `data` absente sans le lever.

L'onglet rejoint le fan-out d'invalidation partagé par les écritures de preuves. Il lit une clé tRPC là où le fan-out n'invalidait que `['preuve', collectiviteId]` : sans cet ajout, déposer un rapport, en supprimer un ou renommer un document laisse la liste figée jusqu'au rechargement.

## Périmètre

Les branches `complementaire` et `reglementaire` restent sur `public.preuve` : leurs consommateurs (`action-preuve.panel.tsx`, `action-documents.download-button.tsx`) sont hors de cet onglet. La vue perd un consommateur sur trois.

L'adaptateur `toAuditEnCours` de #4879 reste en place : `usePreuves` l'appelle toujours, et il garde la vue dont la clé `referentiel` diverge de `referentiel_id`.

## Droits

L'endpoint exige `referentiels.read` là où la RLS de la vue se contente de `is_authenticated()`. Le visiteur vérifié non-membre conserve l'accès. Le compte authentifié non vérifié (`CONNECTED`) le perd.

## Couverture

`groupeParDemande` et `addInfoToEntry` consomment `preuve.demande?.id`, `preuve.audit?.demande_id`, `preuve.audit?.id`, `demande.etoiles`, `demande.date`, `audit.date_debut`, `audit.date_fin`. Une divergence de champ casse le groupement par cycle sans lever d'erreur.

12 tests e2e sur l'endpoint : documents rendus à un visiteur vérifié non membre, `objet` présent, rattachement au cycle via `demande`, masquage des confidentiels sur les trois branches, refus en accès restreint, exclusion des documents d'une autre collectivité, exclusion des documents de labellisation d'un autre référentiel, non-exposition d'un fichier appartenant à une autre collectivité, ordre décroissant des rapports, et ordre déterminé entre deux rapports de même date.

Côté front, `groupeParDemande` couvre le groupement par demande et l'exclusion d'un autre référentiel ; `addInfoToEntry` l'étoile et l'année dérivées de la demande sans audit, et la datation du cycle sur la fin de l'audit.

## Points ouverts

- **Les rôles `AUDITEUR_AUDIT_VALIDE` et `AUDITEUR_AUDIT_NON_DEMARRE` héritent de `collectiviteLecturePermissions` sans expiration**, là où `est_auditeur` de la vue exige `now() <@ tstzrange(date_debut, date_fin)`. `collectiviteLecturePermissions` contient aussi `referentiels.read_confidentiel`, donc un auditeur hors fenêtre franchit également la garde d'accès restreint. Le modèle vaut déjà pour `list-preuves` et `list-audit-preuves`. Décision produit, PR 10 du plan.
- **`labellisation.demande` n'a aucun index sur `collectivite_id`**, et celui d'`audit` est partiel sur `WHERE NOT clos`, donc inutilisable pour un onglet qui rend aussi les audits clos. Accès introduit par cette PR — `list-preuves` filtrait par clé primaire. PR 9 du plan.
- **`ListPreuvesService` construit encore ses requêtes Drizzle dans le service.** La PR y réduit la surface sans en extraire de repository.
- **La branche `rapport` n'est pas scopée par référentiel** — `preuve_rapport` ne porte pas cette colonne. Parité avec la vue, que la signature de l'endpoint ne dit pas.
- **La validation vit dans le service** plutôt qu'en `.output()` sur le routeur, à rebours des quinze routeurs qui utilisent `.output()`. Elle rend une erreur typée et couvre tout appelant.

## Surface de review

Attention humaine : `list-documents.service.ts`, `list-documents.repository.ts`, `list-documents.output.ts`, `file-info.utils.ts`, `referentiel-documents-access.service.ts`, `documents.view.tsx`, `data/use-list-documents.ts`.

Mécaniques : input, erreurs, adaptateur, router, câblage module/router.

## Vérifications

`list-documents` e2e 12/12, `list-preuves` e2e 6/6, `preuves-archive` identique au baseline `main`, `groupeParDemande` 4/4, typecheck backend et `nx run app:typecheck` propres, lint sans nouveau warning.

Sortie de l'endpoint comparée à celle de `public.preuve` sur une collectivité couvrant les trois branches, deux cycles, un `objet` à `null`, un confidentiel par branche et deux buckets : un membre et un visiteur vérifié non membre reçoivent les mêmes documents qu'avant.

Le front résout `AppRouter` via le `dist` du backend : lancer `nx run backend:typecheck` avant le typecheck front.

## Plan

PR 2 de la stack, plan `doc/plans/2026-08-26-001-feat-reclassement-objet-document-labellisation-plan.md`. Suivent l'API de reclassement de l'objet réservée au super-admin, puis l'UI dans cet onglet. Le plan porte aussi les PR 7 à 10 : libellé « (en cours) » sur un cycle clos, IDOR au dépôt d'une preuve, index manquants, borne temporelle du rôle auditeur.
