### PR TITLE
refactor(indicateurs): migre IndicateurValeurAvecMetadonnesDefinition vers camelCase

### DIFF
--- a/apps/backend/src/demarches/pcaet/shared/demarche-pcaet-diagnostic.service.ts
+++ b/apps/backend/src/demarches/pcaet/shared/demarche-pcaet-diagnostic.service.ts
@@ -127,8 +127,8 @@ export class DemarchePcaetDiagnosticService {
     );
 
     const valeurs = rows.flatMap((row) => {
-      const indicateurId = row.indicateur_definition?.id;
-      const dateValeur = row.indicateur_valeur.dateValeur;
+      const indicateurId = row.indicateurDefinition?.id;
+      const dateValeur = row.indicateurValeur.dateValeur;
       if (indicateurId === undefined || dateValeur === null) {
         return [];
       }
@@ -137,10 +137,10 @@ export class DemarchePcaetDiagnosticService {
           indicateurId,
           year: Number(dateValeur.slice(0, 4)),
           dateValeur,
-          sourceId: row.indicateur_source_metadonnee?.sourceId ?? null,
-          millesime: row.indicateur_source_metadonnee?.dateVersion ?? null,
-          resultat: row.indicateur_valeur.resultat ?? null,
-          objectif: row.indicateur_valeur.objectif ?? null,
+          sourceId: row.indicateurSourceMetadonnee?.sourceId ?? null,
+          millesime: row.indicateurSourceMetadonnee?.dateVersion ?? null,
+          resultat: row.indicateurValeur.resultat ?? null,
+          objectif: row.indicateurValeur.objectif ?? null,
         },
       ];
     });

--- a/apps/backend/src/indicateurs/indicateurs/export-indicateurs/export-indicateurs.builder.spec.ts
+++ b/apps/backend/src/indicateurs/indicateurs/export-indicateurs/export-indicateurs.builder.spec.ts
@@ -1,6 +1,6 @@
+import { IndicateurValeurAvecMetadonnesDefinition } from '@tet/domain/indicateurs';
 import { Workbook } from 'exceljs';
 import { describe, expect, it } from 'vitest';
-import { IndicateurValeurAvecMetadonnesDefinition } from '../../valeurs/indicateur-valeur.table';
 import { buildConsolidatedSheet } from './export-indicateurs.builder';
 
 /**
@@ -16,13 +16,13 @@ function makeValeur(params: {
 }): IndicateurValeurAvecMetadonnesDefinition {
   const { indicateurId, annee, resultat, objectif, sourceId } = params;
   return {
-    indicateur_valeur: {
+    indicateurValeur: {
       dateValeur: `${annee}-01-01`,
       resultat: resultat ?? null,
       objectif: objectif ?? null,
     },
-    indicateur_definition: { id: indicateurId },
-    indicateur_source_metadonnee: sourceId
+    indicateurDefinition: { id: indicateurId },
+    indicateurSourceMetadonnee: sourceId
       ? { id: 1, sourceId, dateVersion: `${annee}-01-01` }
       : null,
   } as unknown as IndicateurValeurAvecMetadonnesDefinition;

--- a/apps/backend/src/indicateurs/indicateurs/export-indicateurs/export-indicateurs.builder.ts
+++ b/apps/backend/src/indicateurs/indicateurs/export-indicateurs/export-indicateurs.builder.ts
@@ -1,10 +1,10 @@
 import { PersonneTagOrUser, Tag } from '@tet/domain/collectivites';
+import { IndicateurValeurAvecMetadonnesDefinition } from '@tet/domain/indicateurs';
 import { Workbook, Worksheet } from 'exceljs';
 import {
   adjustColumnWidth,
   BOLD,
 } from '../../../utils/excel/export-excel.utils';
-import { IndicateurValeurAvecMetadonnesDefinition } from '../../valeurs/indicateur-valeur.table';
 
 type EnfantRow = {
   id: number;
@@ -120,9 +120,9 @@ function collectYears(
   const resultat = new Set<number>();
   const objectif = new Set<number>();
   for (const v of indicateursValeurs) {
-    const annee = new Date(v.indicateur_valeur.dateValeur).getFullYear();
-    if (v.indicateur_valeur.resultat !== null) resultat.add(annee);
-    if (v.indicateur_valeur.objectif !== null) objectif.add(annee);
+    const annee = new Date(v.indicateurValeur.dateValeur).getFullYear();
+    if (v.indicateurValeur.resultat !== null) resultat.add(annee);
+    if (v.indicateurValeur.objectif !== null) objectif.add(annee);
   }
   return {
     resultat: [...resultat].sort((a, b) => a - b),
@@ -135,13 +135,13 @@ function indexValeurs(
 ): Map<number, IndicateurValeurs> {
   const map = new Map<number, IndicateurValeurs>();
   for (const v of indicateursValeurs) {
-    const id = v.indicateur_definition?.id;
+    const id = v.indicateurDefinition?.id;
     if (!id) continue;
     const entry = map.get(id) ?? {
       collectivite: [],
       parSource: new Map<string, IndicateurValeurAvecMetadonnesDefinition[]>(),
     };
-    const metadonnee = v.indicateur_source_metadonnee;
+    const metadonnee = v.indicateurSourceMetadonnee;
     if (metadonnee) {
       const bucket = entry.parSource.get(metadonnee.sourceId) ?? [];
       bucket.push(v);
@@ -218,12 +218,12 @@ function addValeursRow(
   const objectifByYear = new Map<number, number | null>();
 
   for (const v of valeurs) {
-    const annee = new Date(v.indicateur_valeur.dateValeur).getFullYear();
-    if (v.indicateur_valeur.resultat !== null) {
-      resultatByYear.set(annee, v.indicateur_valeur.resultat);
+    const annee = new Date(v.indicateurValeur.dateValeur).getFullYear();
+    if (v.indicateurValeur.resultat !== null) {
+      resultatByYear.set(annee, v.indicateurValeur.resultat);
     }
-    if (v.indicateur_valeur.objectif !== null) {
-      objectifByYear.set(annee, v.indicateur_valeur.objectif);
+    if (v.indicateurValeur.objectif !== null) {
+      objectifByYear.set(annee, v.indicateurValeur.objectif);
     }
   }
 

--- a/apps/backend/src/indicateurs/trajectoires/trajectoires-data.service.ts
+++ b/apps/backend/src/indicateurs/trajectoires/trajectoires-data.service.ts
@@ -21,6 +21,7 @@ import {
   IndicateurSourceMetadonnee,
   IndicateurSourceMetadonneeCreate,
   IndicateurValeur,
+  IndicateurValeurAvecMetadonnesDefinition,
   VerificationTrajectoireStatus,
 } from '@tet/domain/indicateurs';
 import { PermissionOperationEnum, ResourceType } from '@tet/domain/users';
@@ -29,7 +30,6 @@ import { DateTime } from 'luxon';
 import { AuthUser } from '../../users/models/auth.models';
 import IndicateurSourcesService from '../sources/indicateur-sources.service';
 import CrudValeursService from '../valeurs/crud-valeurs.service';
-import { IndicateurValeurAvecMetadonnesDefinition } from '../valeurs/indicateur-valeur.table';
 import { DonneesARemplirResultType } from './donnees-a-remplir-result.dto';
 import { DonneesARemplirValeurType } from './donnees-a-remplir-valeur.dto';
 import { DataInputForTrajectoireCompute } from './donnees-calcul-trajectoire-a-remplir.dto';
@@ -343,7 +343,7 @@ export default class TrajectoiresDataService {
     return data
       .map(
         (indicateurValeur) =>
-          indicateurValeur.indicateur_source_metadonnee?.sourceId
+          indicateurValeur.indicateurSourceMetadonnee?.sourceId
       )
       .filter((source) => source !== undefined);
   }
@@ -408,7 +408,7 @@ export default class TrajectoiresDataService {
       flatten(this.SNBC_EMISSIONS_GES_IDENTIFIANTS_REFERENTIEL),
       (data) =>
         hasEnoughEmissionsGesDataFromSource(
-          data.map((v) => v.indicateur_valeur.resultat)
+          data.map((v) => v.indicateurValeur.resultat)
         ).isDataSufficient,
       this.RARE_SOURCE_ID,
       {
@@ -427,7 +427,7 @@ export default class TrajectoiresDataService {
       flatten(this.SNBC_SEQUESTRATION_IDENTIFIANTS_REFERENTIEL),
       (data) =>
         hasEnoughCarbonSequestrationDataFromSource(
-          data.map((v) => v.indicateur_valeur.resultat)
+          data.map((v) => v.indicateurValeur.resultat)
         ).isDataSufficient,
       this.ALDO_SOURCE_ID,
       {
@@ -446,7 +446,7 @@ export default class TrajectoiresDataService {
       flatten(this.SNBC_CONSOMMATIONS_IDENTIFIANTS_REFERENTIEL),
       (data) =>
         hasEnoughConsommationsFinalesDataFromSource(
-          data.map((v) => v.indicateur_valeur.resultat)
+          data.map((v) => v.indicateurValeur.resultat)
         ).isDataSufficient,
       this.RARE_SOURCE_ID,
       {
@@ -505,8 +505,8 @@ export default class TrajectoiresDataService {
       maxBy(
         allIndicateurValeurs,
         (item: IndicateurValeurAvecMetadonnesDefinition) =>
-          new Date(item.indicateur_valeur.modifiedAt).getTime()
-      )?.indicateur_valeur.modifiedAt ?? null;
+          new Date(item.indicateurValeur.modifiedAt).getTime()
+      )?.indicateurValeur.modifiedAt ?? null;
 
     return {
       sources: uniqueSources,
@@ -543,45 +543,45 @@ export default class TrajectoiresDataService {
         identifiants.forEach((identifiant) => {
           const identifiantIndicateurValeurs = indicateurValeurs.filter(
             (indicateurValeur) =>
-              indicateurValeur.indicateur_definition?.identifiantReferentiel ===
+              indicateurValeur.indicateurDefinition?.identifiantReferentiel ===
                 identifiant &&
-              !isNil(indicateurValeur.indicateur_valeur.resultat)
+              !isNil(indicateurValeur.indicateurValeur.resultat)
           );
 
           const identifiantIndicateurValeur2015 =
             identifiantIndicateurValeurs.find(
               (indicateurValeur) =>
-                indicateurValeur.indicateur_valeur.dateValeur ===
+                indicateurValeur.indicateurValeur.dateValeur ===
                 this.SNBC_DATE_DEBUT_REFERENCE
             );
           if (
             identifiantIndicateurValeur2015 &&
-            !isNil(identifiantIndicateurValeur2015.indicateur_valeur.resultat) // 0 est une valeur valide
+            !isNil(identifiantIndicateurValeur2015.indicateurValeur.resultat) // 0 est une valeur valide
           ) {
             // Si il n'y a pas déjà eu une valeur manquante qui a placé la valeur à null
             if (valeurARemplir.valeur !== null) {
               valeurARemplir.valeur +=
-                identifiantIndicateurValeur2015.indicateur_valeur.resultat;
+                identifiantIndicateurValeur2015.indicateurValeur.resultat;
               if (
                 !valeurARemplir.dateMax ||
-                identifiantIndicateurValeur2015.indicateur_valeur.dateValeur >
+                identifiantIndicateurValeur2015.indicateurValeur.dateValeur >
                   valeurARemplir.dateMax
               ) {
                 valeurARemplir.dateMax =
-                  identifiantIndicateurValeur2015.indicateur_valeur.dateValeur;
+                  identifiantIndicateurValeur2015.indicateurValeur.dateValeur;
               }
               if (
                 !valeurARemplir.dateMin ||
-                identifiantIndicateurValeur2015.indicateur_valeur.dateValeur <
+                identifiantIndicateurValeur2015.indicateurValeur.dateValeur <
                   valeurARemplir.dateMin
               ) {
                 valeurARemplir.dateMin =
-                  identifiantIndicateurValeur2015.indicateur_valeur.dateValeur;
+                  identifiantIndicateurValeur2015.indicateurValeur.dateValeur;
               }
             }
           } else {
             const indicateurValeurs = identifiantIndicateurValeurs.map(
-              (v) => v.indicateur_valeur
+              (v) => v.indicateurValeur
             );
             let interpolationOrClosestResultat =
               this.getInterpolationValeur(indicateurValeurs);
@@ -797,7 +797,7 @@ export default class TrajectoiresDataService {
       sources: [this.SNBC_SOURCE.id],
     });
 
-    const valeursResponse = valeurs.map((v) => v.indicateur_valeur);
+    const valeursResponse = valeurs.map((v) => v.indicateurValeur);
     const existingTrajectoireData =
       this.processExistingTrajectoireData(valeursResponse);
 

--- a/apps/backend/src/indicateurs/valeurs/crud-valeurs.service.spec.ts
+++ b/apps/backend/src/indicateurs/valeurs/crud-valeurs.service.spec.ts
@@ -9,6 +9,7 @@ import {
   IndicateurDefinitionTiny,
   IndicateurSourceMetadonnee,
   IndicateurValeur,
+  IndicateurValeurAvecMetadonnesDefinition,
 } from '@tet/domain/indicateurs';
 import { cloneDeep } from 'es-toolkit';
 import CollectivitesService from '../../collectivites/services/collectivites.service';
@@ -20,7 +21,6 @@ import { ListIndicateursService } from '../indicateurs/list-indicateurs/list-ind
 import IndicateurSourcesService from '../sources/indicateur-sources.service';
 import CrudValeursService from './crud-valeurs.service';
 import IndicateurExpressionService from './indicateur-expression.service';
-import { IndicateurValeurAvecMetadonnesDefinition } from './indicateur-valeur.table';
 import { indicateur1, indicateur2, indicateur3 } from './tests/fixture';
 
 describe('Indicateurs → crud-valeurs.service', () => {
@@ -438,7 +438,7 @@ describe('Indicateurs → crud-valeurs.service', () => {
     it('Même collectivite, Même date, Même indicateur mais deux sources différentes > pas de dédoublonnage', async () => {
       const indicateurValeurs: IndicateurValeurAvecMetadonnesDefinition[] = [
         {
-          indicateur_valeur: {
+          indicateurValeur: {
             id: 17,
             collectiviteId: 4936,
             indicateurId: 4,
@@ -456,7 +456,7 @@ describe('Indicateurs → crud-valeurs.service', () => {
             calculAuto: false,
             calculAutoIdentifiantsManquants: null,
           },
-          indicateur_definition: {
+          indicateurDefinition: {
             id: 4,
             groupementId: null,
             collectiviteId: null,
@@ -482,7 +482,7 @@ describe('Indicateurs → crud-valeurs.service', () => {
             exprSeuil: null,
             libelleCibleSeuil: null,
           },
-          indicateur_source_metadonnee: {
+          indicateurSourceMetadonnee: {
             id: 1,
             sourceId: 'rare',
             dateVersion: '2024-07-18T00:00:00.000Z',
@@ -494,7 +494,7 @@ describe('Indicateurs → crud-valeurs.service', () => {
           },
         },
         {
-          indicateur_valeur: {
+          indicateurValeur: {
             id: 875,
             collectiviteId: 4936,
             indicateurId: 4,
@@ -512,7 +512,7 @@ describe('Indicateurs → crud-valeurs.service', () => {
             calculAuto: false,
             calculAutoIdentifiantsManquants: null,
           },
-          indicateur_definition: {
+          indicateurDefinition: {
             id: 4,
             groupementId: null,
             collectiviteId: null,
@@ -538,7 +538,7 @@ describe('Indicateurs → crud-valeurs.service', () => {
             exprSeuil: null,
             libelleCibleSeuil: null,
           },
-          indicateur_source_metadonnee: {
+          indicateurSourceMetadonnee: {
             id: 2,
             sourceId: 'snbc',
             dateVersion: '2024-07-11T00:00:00.000Z',
@@ -567,7 +567,7 @@ describe('Indicateurs → crud-valeurs.service', () => {
     it('Même collectivite, Même source, Même date mais deux indicateurs différentes > pas de dédoublonnage', async () => {
       const indicateurValeurs: IndicateurValeurAvecMetadonnesDefinition[] = [
         {
-          indicateur_valeur: {
+          indicateurValeur: {
             id: 17,
             collectiviteId: 4936,
             indicateurId: 4,
@@ -585,7 +585,7 @@ describe('Indicateurs → crud-valeurs.service', () => {
             calculAuto: false,
             calculAutoIdentifiantsManquants: null,
           },
-          indicateur_definition: {
+          indicateurDefinition: {
             id: 4,
             groupementId: null,
             collectiviteId: null,
@@ -611,7 +611,7 @@ describe('Indicateurs → crud-valeurs.service', () => {
             exprSeuil: null,
             libelleCibleSeuil: null,
           },
-          indicateur_source_metadonnee: {
+          indicateurSourceMetadonnee: {
             id: 1,
             sourceId: 'rare',
             dateVersion: '2024-07-18T00:00:00.000Z',
@@ -623,7 +623,7 @@ describe('Indicateurs → crud-valeurs.service', () => {
           },
         },
         {
-          indicateur_valeur: {
+          indicateurValeur: {
             id: 18,
             collectiviteId: 4936,
             indicateurId: 9,
@@ -641,7 +641,7 @@ describe('Indicateurs → crud-valeurs.service', () => {
             calculAuto: false,
             calculAutoIdentifiantsManquants: null,
           },
-          indicateur_definition: {
+          indicateurDefinition: {
             id: 9,
             groupementId: null,
             collectiviteId: null,
@@ -666,7 +666,7 @@ describe('Indicateurs → crud-valeurs.service', () => {
             exprSeuil: null,
             libelleCibleSeuil: null,
           },
-          indicateur_source_metadonnee: {
+          indicateurSourceMetadonnee: {
             id: 1,
             sourceId: 'rare',
             dateVersion: '2024-07-18T00:00:00.000Z',
@@ -695,7 +695,7 @@ describe('Indicateurs → crud-valeurs.service', () => {
     it('Même collectivite, Même date, Même indicateur mais une source et une donnée utilisateur > pas de dédoublonnage', async () => {
       const indicateurValeurs: IndicateurValeurAvecMetadonnesDefinition[] = [
         {
-          indicateur_valeur: {
+          indicateurValeur: {
             id: 17,
             collectiviteId: 4936,
             indicateurId: 4,
@@ -713,7 +713,7 @@ describe('Indicateurs → crud-valeurs.service', () => {
             calculAuto: false,
             calculAutoIdentifiantsManquants: null,
           },
-          indicateur_definition: {
+          indicateurDefinition: {
             id: 4,
             groupementId: null,
             collectiviteId: null,
@@ -739,7 +739,7 @@ describe('Indicateurs → crud-valeurs.service', () => {
             exprSeuil: null,
             libelleCibleSeuil: null,
           },
-          indicateur_source_metadonnee: {
+          indicateurSourceMetadonnee: {
             id: 1,
             sourceId: 'rare',
             dateVersion: '2024-07-18T00:00:00.000Z',
@@ -751,7 +751,7 @@ describe('Indicateurs → crud-valeurs.service', () => {
           },
         },
         {
-          indicateur_valeur: {
+          indicateurValeur: {
             id: 875,
             collectiviteId: 4936,
             indicateurId: 4,
@@ -769,7 +769,7 @@ describe('Indicateurs → crud-valeurs.service', () => {
             calculAuto: false,
             calculAutoIdentifiantsManquants: null,
           },
-          indicateur_definition: {
+          indicateurDefinition: {
             id: 4,
             groupementId: null,
             collectiviteId: null,
@@ -795,7 +795,7 @@ describe('Indicateurs → crud-valeurs.service', () => {
             exprSeuil: null,
             libelleCibleSeuil: null,
           },
-          indicateur_source_metadonnee: null,
+          indicateurSourceMetadonnee: null,
         },
       ];
       const indicateurValeursDedoublonnees =
@@ -815,7 +815,7 @@ describe('Indicateurs → crud-valeurs.service', () => {
     it('Même indicateur, Même source, Même date mais deux collectivités différentes > pas de dédoublonnage', async () => {
       const indicateurValeurs: IndicateurValeurAvecMetadonnesDefinition[] = [
         {
-          indicateur_valeur: {
+          indicateurValeur: {
             id: 17,
             collectiviteId: 4936,
             indicateurId: 4,
@@ -833,7 +833,7 @@ describe('Indicateurs → crud-valeurs.service', () => {
             calculAuto: false,
             calculAutoIdentifiantsManquants: null,
           },
-          indicateur_definition: {
+          indicateurDefinition: {
             id: 4,
             groupementId: null,
             collectiviteId: null,
@@ -859,7 +859,7 @@ describe('Indicateurs → crud-valeurs.service', () => {
             exprSeuil: null,
             libelleCibleSeuil: null,
           },
-          indicateur_source_metadonnee: {
+          indicateurSourceMetadonnee: {
             id: 1,
             sourceId: 'rare',
             dateVersion: '2024-07-18T00:00:00.000Z',
@@ -871,7 +871,7 @@ describe('Indicateurs → crud-valeurs.service', () => {
           },
         },
         {
-          indicateur_valeur: {
+          indicateurValeur: {
             id: 875,
             collectiviteId: 2012,
             indicateurId: 4,
@@ -889,7 +889,7 @@ describe('Indicateurs → crud-valeurs.service', () => {
             calculAuto: false,
             calculAutoIdentifiantsManquants: null,
           },
-          indicateur_definition: {
+          indicateurDefinition: {
             id: 4,
             groupementId: null,
             collectiviteId: null,
@@ -915,7 +915,7 @@ describe('Indicateurs → crud-valeurs.service', () => {
             exprSeuil: null,
             libelleCibleSeuil: null,
           },
-          indicateur_source_metadonnee: {
+          indicateurSourceMetadonnee: {
             id: 1,
             sourceId: 'rare',
             dateVersion: '2024-07-18T00:00:00.000Z',
@@ -944,7 +944,7 @@ describe('Indicateurs → crud-valeurs.service', () => {
     it('Même collectivite, Même indicateur, Même source mais deux dates différentes > pas de dédoublonnage', async () => {
       const indicateurValeurs: IndicateurValeurAvecMetadonnesDefinition[] = [
         {
-          indicateur_valeur: {
+          indicateurValeur: {
             id: 17,
             collectiviteId: 4936,
             indicateurId: 4,
@@ -962,7 +962,7 @@ describe('Indicateurs → crud-valeurs.service', () => {
             calculAuto: false,
             calculAutoIdentifiantsManquants: null,
           },
-          indicateur_definition: {
+          indicateurDefinition: {
             id: 4,
             groupementId: null,
             collectiviteId: null,
@@ -988,7 +988,7 @@ describe('Indicateurs → crud-valeurs.service', () => {
             exprSeuil: null,
             libelleCibleSeuil: null,
           },
-          indicateur_source_metadonnee: {
+          indicateurSourceMetadonnee: {
             id: 1,
             sourceId: 'rare',
             dateVersion: '2024-07-18T00:00:00.000Z',
@@ -1000,7 +1000,7 @@ describe('Indicateurs → crud-valeurs.service', () => {
           },
         },
         {
-          indicateur_valeur: {
+          indicateurValeur: {
             id: 875,
             collectiviteId: 4936,
             indicateurId: 4,
@@ -1018,7 +1018,7 @@ describe('Indicateurs → crud-valeurs.service', () => {
             calculAuto: false,
             calculAutoIdentifiantsManquants: null,
           },
-          indicateur_definition: {
+          indicateurDefinition: {
             id: 4,
             groupementId: null,
             collectiviteId: null,
@@ -1044,7 +1044,7 @@ describe('Indicateurs → crud-valeurs.service', () => {
             exprSeuil: null,
             libelleCibleSeuil: null,
           },
-          indicateur_source_metadonnee: {
+          indicateurSourceMetadonnee: {
             id: 1,
             sourceId: 'rare',
             dateVersion: '2024-07-18T00:00:00.000Z',
@@ -1072,7 +1072,7 @@ describe('Indicateurs → crud-valeurs.service', () => {
 
     it('Même source, même date et métadonnées différentes, on prend la plus récente', async () => {
       const indicateurValeur1: IndicateurValeurAvecMetadonnesDefinition = {
-        indicateur_valeur: {
+        indicateurValeur: {
           id: 17,
           collectiviteId: 4936,
           indicateurId: 4,
@@ -1090,7 +1090,7 @@ describe('Indicateurs → crud-valeurs.service', () => {
           calculAuto: false,
           calculAutoIdentifiantsManquants: null,
         },
-        indicateur_definition: {
+        indicateurDefinition: {
           id: 4,
           groupementId: null,
           collectiviteId: null,
@@ -1115,7 +1115,7 @@ describe('Indicateurs → crud-valeurs.service', () => {
           exprSeuil: null,
           libelleCibleSeuil: null,
         },
-        indicateur_source_metadonnee: {
+        indicateurSourceMetadonnee: {
           id: 1,
           sourceId: 'rare',
           dateVersion: '2024-07-18T00:00:00.000Z',
@@ -1127,7 +1127,7 @@ describe('Indicateurs → crud-valeurs.service', () => {
         },
       };
       const indicateurValeur2: IndicateurValeurAvecMetadonnesDefinition = {
-        indicateur_valeur: {
+        indicateurValeur: {
           id: 875,
           collectiviteId: 4936,
           indicateurId: 4,
@@ -1145,7 +1145,7 @@ describe('Indicateurs → crud-valeurs.service', () => {
           calculAuto: false,
           calculAutoIdentifiantsManquants: null,
         },
-        indicateur_definition: {
+        indicateurDefinition: {
           id: 4,
           groupementId: null,
           collectiviteId: null,
@@ -1170,7 +1170,7 @@ describe('Indicateurs → crud-valeurs.service', () => {
           exprSeuil: null,
           libelleCibleSeuil: null,
         },
-        indicateur_source_metadonnee: {
+        indicateurSourceMetadonnee: {
           id: 2,
           sourceId: 'rare',
           dateVersion: '2024-08-01T00:00:00.000Z',
@@ -1209,7 +1209,7 @@ describe('Indicateurs → crud-valeurs.service', () => {
 
     it("Doublon parfait, on en conserve qu'un", async () => {
       const indicateurValeur1: IndicateurValeurAvecMetadonnesDefinition = {
-        indicateur_valeur: {
+        indicateurValeur: {
           id: 17,
           collectiviteId: 4936,
           indicateurId: 4,
@@ -1227,7 +1227,7 @@ describe('Indicateurs → crud-valeurs.service', () => {
           calculAuto: false,
           calculAutoIdentifiantsManquants: null,
         },
-        indicateur_definition: {
+        indicateurDefinition: {
           id: 4,
           groupementId: null,
           collectiviteId: null,
@@ -1252,7 +1252,7 @@ describe('Indicateurs → crud-valeurs.service', () => {
           exprSeuil: null,
           libelleCibleSeuil: null,
         },
-        indicateur_source_metadonnee: {
+        indicateurSourceMetadonnee: {
           id: 1,
           sourceId: 'rare',
           dateVersion: '2024-07-18T00:00:00.000Z',

--- a/apps/backend/src/indicateurs/valeurs/crud-valeurs.service.ts
+++ b/apps/backend/src/indicateurs/valeurs/crud-valeurs.service.ts
@@ -21,6 +21,7 @@ import {
   IndicateurSource,
   IndicateurSourceMetadonnee,
   IndicateurValeur,
+  IndicateurValeurAvecMetadonnesDefinition,
   IndicateurValeurCreate,
   IndicateurValeurGroupee,
   IndicateurValeursGroupeeParSource,
@@ -74,10 +75,7 @@ import { indicateurSourceTable } from '../shared/models/indicateur-source.table'
 import { DeleteIndicateursValeursRequestType } from './delete-indicateur-valeurs.request';
 import { DeleteValeurIndicateur } from './delete-valeur-indicateur.request';
 import { GetIndicateursValeursResponse } from './get-indicateur-valeurs.response';
-import {
-  IndicateurValeurAvecMetadonnesDefinition,
-  indicateurValeurTable,
-} from './indicateur-valeur.table';
+import { indicateurValeurTable } from './indicateur-valeur.table';
 import { ListIndicateurValeursInput } from './list-indicateur-valeurs.input';
 import { UpsertValeurIndicateur } from './upsert-valeur-indicateur.request';
 
@@ -192,7 +190,7 @@ export default class CrudValeursService {
     let result: IndicateurValeurAvecMetadonnesDefinition[] =
       await (tx ?? this.databaseService.db)
         .select({
-          indicateur_valeur: {
+          indicateurValeur: {
             ...omit(getTableColumns(indicateurValeurTable), [
               'createdAt',
               'modifiedAt',
@@ -200,7 +198,7 @@ export default class CrudValeursService {
             createdAt: sqlToDateTimeISO(indicateurValeurTable.createdAt),
             modifiedAt: sqlToDateTimeISO(indicateurValeurTable.modifiedAt),
           },
-          indicateur_definition: {
+          indicateurDefinition: {
             ...omit(getTableColumns(indicateurDefinitionTable), [
               'createdAt',
               'modifiedAt',
@@ -208,7 +206,7 @@ export default class CrudValeursService {
             createdAt: sqlToDateTimeISO(indicateurDefinitionTable.createdAt),
             modifiedAt: sqlToDateTimeISO(indicateurDefinitionTable.modifiedAt),
           },
-          indicateur_source_metadonnee: getTableColumns(
+          indicateurSourceMetadonnee: getTableColumns(
             indicateurSourceMetadonneeTable
           ),
           confidentiel: indicateurCollectiviteTable.confidentiel,
@@ -344,7 +342,7 @@ export default class CrudValeursService {
     const indicateurValeurs = await this.getIndicateursValeurs(options);
 
     const indicateurValeursSeules = indicateurValeurs.map((v) => ({
-      ...v.indicateur_valeur,
+      ...v.indicateurValeur,
       confidentiel: v.confidentiel,
     }));
 
@@ -394,9 +392,9 @@ export default class CrudValeursService {
     } = {};
     const uniqueIndicateurMetadonnees = Object.values(
       indicateurValeurs.reduce((acc, v) => {
-        if (v.indicateur_source_metadonnee?.id) {
-          acc[v.indicateur_source_metadonnee.id.toString()] =
-            v.indicateur_source_metadonnee;
+        if (v.indicateurSourceMetadonnee?.id) {
+          acc[v.indicateurSourceMetadonnee.id.toString()] =
+            v.indicateurSourceMetadonnee;
         }
         return acc;
       }, initialMetadonneesAcc)
@@ -1127,20 +1125,20 @@ export default class CrudValeursService {
     } = {};
     const uniqueIndicateurValeurs = Object.values(
       indicateurValeurs.reduce((acc, v) => {
-        const cleUnicite = `${v.indicateur_valeur.indicateurId}_${
-          v.indicateur_valeur.collectiviteId
-        }_${v.indicateur_valeur.dateValeur}_${
-          v.indicateur_source_metadonnee?.sourceId || COLLECTIVITE_SOURCE_ID
+        const cleUnicite = `${v.indicateurValeur.indicateurId}_${
+          v.indicateurValeur.collectiviteId
+        }_${v.indicateurValeur.dateValeur}_${
+          v.indicateurSourceMetadonnee?.sourceId || COLLECTIVITE_SOURCE_ID
         }`;
         if (!acc[cleUnicite]) {
           acc[cleUnicite] = v;
         } else {
           // On garde la valeur la plus récente en priorité
           if (
-            v.indicateur_source_metadonnee &&
-            acc[cleUnicite].indicateur_source_metadonnee &&
-            v.indicateur_source_metadonnee.dateVersion >
-              acc[cleUnicite].indicateur_source_metadonnee.dateVersion
+            v.indicateurSourceMetadonnee &&
+            acc[cleUnicite].indicateurSourceMetadonnee &&
+            v.indicateurSourceMetadonnee.dateVersion >
+              acc[cleUnicite].indicateurSourceMetadonnee.dateVersion
           ) {
             acc[cleUnicite] = v;
           }

--- a/apps/backend/src/indicateurs/valeurs/indicateur-valeur.table.ts
+++ b/apps/backend/src/indicateurs/valeurs/indicateur-valeur.table.ts
@@ -6,11 +6,6 @@ import {
   modifiedBy,
 } from '@tet/backend/utils/column.utils';
 import {
-  IndicateurDefinition,
-  IndicateurSourceMetadonnee,
-  IndicateurValeur,
-} from '@tet/domain/indicateurs';
-import {
   boolean,
   date,
   doublePrecision,
@@ -55,13 +50,3 @@ export const indicateurValeurTable = pgTable('indicateur_valeur', {
   createdBy,
   modifiedBy,
 });
-
-export interface IndicateurValeurAvecMetadonnesDefinition {
-  indicateur_valeur: IndicateurValeur;
-
-  indicateur_definition: IndicateurDefinition | null;
-
-  indicateur_source_metadonnee: IndicateurSourceMetadonnee | null;
-
-  confidentiel?: boolean | null;
-}

--- a/packages/domain/src/indicateurs/valeurs/indicateur-valeur.schema.ts
+++ b/packages/domain/src/indicateurs/valeurs/indicateur-valeur.schema.ts
@@ -1,9 +1,13 @@
 import * as z from 'zod/mini';
 import {
+  IndicateurDefinition,
   indicateurDefinitionSchema,
   indicateurDefinitionSchemaTiny,
 } from '../definitions/indicateur-definition.schema';
-import { indicateurSourceMetadonneeSchema } from '../shared/indicateur-source-metadonnee.schema';
+import {
+  IndicateurSourceMetadonnee,
+  indicateurSourceMetadonneeSchema,
+} from '../shared/indicateur-source-metadonnee.schema';
 import { indicateurSourceSchema } from '../shared/indicateur-source.schema';
 
 export const indicateurValeurSchema = z.object({
@@ -95,6 +99,14 @@ export type IndicateurValeurWithIdentifiant = IndicateurValeur & {
   indicateurIdentifiant?: string | null;
   sourceId?: string | null;
 };
+
+export interface IndicateurValeurAvecMetadonnesDefinition {
+  indicateurValeur: IndicateurValeur;
+  indicateurDefinition: IndicateurDefinition | null;
+  indicateurSourceMetadonnee: IndicateurSourceMetadonnee | null;
+  confidentiel?: boolean | null;
+}
+
 export type IndicateurAvecValeurs = z.infer<typeof indicateurAvecValeursSchema>;
 export type IndicateurValeursGroupeeParSource = z.infer<
   typeof indicateurValeursGroupeeParSourceSchema


### PR DESCRIPTION
Définit le type dans le package domain avec des propriétés camelCase
(indicateurValeur, indicateurDefinition, indicateurSourceMetadonnee) en plus
des propriétés snake_case existantes, désormais dépréciées. Toutes les
utilisations backend sont migrées vers les nouvelles propriétés.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Améliorations**
  - Harmonisation de la nomenclature des données d’indicateurs pour une meilleure cohérence.
  - Fiabilisation de l’accès aux valeurs, définitions et métadonnées associées.
  - Maintien du comportement existant pour les exports, les trajectoires, les validations et le dédoublonnage.
- **Compatibilité**
  - Les données d’indicateurs utilisent désormais une nomenclature harmonisée ; les anciens noms de propriétés ne sont plus pris en charge.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->