### PR TITLE
refactor(indicateurs): retire les propriétés snake_case dépréciées de IndicateurValeurAvecMetadonnesDefinition

### DIFF
--- a/apps/backend/src/indicateurs/valeurs/crud-valeurs.service.ts
+++ b/apps/backend/src/indicateurs/valeurs/crud-valeurs.service.ts
@@ -187,10 +187,10 @@ export default class CrudValeursService {
 
     const conditions = this.getIndicateurValeursSqlConditions(options);
 
-    let result: IndicateurValeurAvecMetadonnesDefinition[] = (
+    let result: IndicateurValeurAvecMetadonnesDefinition[] =
       await (tx ?? this.databaseService.db)
         .select({
-          indicateur_valeur: {
+          indicateurValeur: {
             ...omit(getTableColumns(indicateurValeurTable), [
               'createdAt',
               'modifiedAt',
@@ -198,7 +198,7 @@ export default class CrudValeursService {
             createdAt: sqlToDateTimeISO(indicateurValeurTable.createdAt),
             modifiedAt: sqlToDateTimeISO(indicateurValeurTable.modifiedAt),
           },
-          indicateur_definition: {
+          indicateurDefinition: {
             ...omit(getTableColumns(indicateurDefinitionTable), [
               'createdAt',
               'modifiedAt',
@@ -206,7 +206,7 @@ export default class CrudValeursService {
             createdAt: sqlToDateTimeISO(indicateurDefinitionTable.createdAt),
             modifiedAt: sqlToDateTimeISO(indicateurDefinitionTable.modifiedAt),
           },
-          indicateur_source_metadonnee: getTableColumns(
+          indicateurSourceMetadonnee: getTableColumns(
             indicateurSourceMetadonneeTable
           ),
           confidentiel: indicateurCollectiviteTable.confidentiel,
@@ -240,13 +240,7 @@ export default class CrudValeursService {
             )
           )
         )
-        .where(and(...conditions))
-    ).map((row) => ({
-      ...row,
-      indicateurValeur: row.indicateur_valeur,
-      indicateurDefinition: row.indicateur_definition,
-      indicateurSourceMetadonnee: row.indicateur_source_metadonnee,
-    }));
+        .where(and(...conditions));
 
     this.logger.log(`Récupération de ${result.length} valeurs d'indicateurs`);
     if (!ignoreDedoublonnage) {

--- a/packages/domain/src/indicateurs/valeurs/indicateur-valeur.schema.ts
+++ b/packages/domain/src/indicateurs/valeurs/indicateur-valeur.schema.ts
@@ -101,18 +101,9 @@ export type IndicateurValeurWithIdentifiant = IndicateurValeur & {
 };
 
 export interface IndicateurValeurAvecMetadonnesDefinition {
-  /** @deprecated utiliser `indicateurValeur` */
-  indicateur_valeur?: IndicateurValeur;
   indicateurValeur: IndicateurValeur;
-
-  /** @deprecated utiliser `indicateurDefinition` */
-  indicateur_definition?: IndicateurDefinition | null;
   indicateurDefinition: IndicateurDefinition | null;
-
-  /** @deprecated utiliser `indicateurSourceMetadonnee` */
-  indicateur_source_metadonnee?: IndicateurSourceMetadonnee | null;
   indicateurSourceMetadonnee: IndicateurSourceMetadonnee | null;
-
   confidentiel?: boolean | null;
 }
 


### PR DESCRIPTION
Supprime indicateur_valeur / indicateur_definition / indicateur_source_metadonnee,
remplacées par leurs équivalents camelCase dans la précédente PR. Simplifie la
requête de crud-valeurs.service.ts pour sélectionner directement les alias
camelCase.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>