### PR TITLE
Prend en compte les liens de niveau action dans la bascule des commentaires

### DIFF
--- a/apps/backend/src/referentiels/switch-to-te/build-switch-to-te-context.service.ts
+++ b/apps/backend/src/referentiels/switch-to-te/build-switch-to-te-context.service.ts
@@ -22,6 +22,7 @@ import {
   type ScoreSnapshot,
 } from '@tet/domain/referentiels';
 import {
+  listCommentaireCibles,
   listMesuresCibles,
   listSousActionsEtTachesCibles,
 } from './shared/action-cible';
@@ -94,6 +95,7 @@ export class BuildSwitchToTeContextService {
     };
     const mesures = listMesuresCibles(listCiblesInput);
     const sousActionsEtTaches = listSousActionsEtTachesCibles(listCiblesInput);
+    const commentaires = listCommentaireCibles(listCiblesInput);
     const hierarchiesByReferentielId =
       await this.getReferentielDefinitionService.getHierarchiesByReferentielIds(
         sourceReferentiels
@@ -141,6 +143,7 @@ export class BuildSwitchToTeContextService {
       cibles: {
         sousActionsEtTaches,
         mesures,
+        commentaires,
       },
       sourceFicheLinks,
     });

--- a/apps/backend/src/referentiels/switch-to-te/merge-commentaires/merge-commentaires.rules.e2e-spec.ts
+++ b/apps/backend/src/referentiels/switch-to-te/merge-commentaires/merge-commentaires.rules.e2e-spec.ts
@@ -75,6 +75,17 @@ const ACTION_ORIGINE_TEXTE_FIXTURE = {
     teActionId: 'te_6.1.3.4',
     caeOrigineActionId: 'cae_6.2.2.3.5',
   },
+  /**
+   * TE 1.1.1 (niveau action / sous-mesure) : `action_origine_texte` pointe vers
+   * Cae_1.1.2 (niveau action également) et aucune ligne `action_origine`
+   * n'existe à ce niveau. La cible est donc absente de `sousActionsEtTaches` —
+   * vérifie que les liens texte de niveau action sont pris en compte pour la
+   * fusion des commentaires.
+   */
+  teActionNiveauActionAvecOrigineTexte: {
+    teActionId: 'te_1.1.1',
+    origineTexteActionId: 'cae_1.1.2',
+  },
 } as const;
 
 describe('mergeCommentaires', () => {
@@ -405,6 +416,42 @@ describe('mergeCommentaires', () => {
       );
 
       expect(teCommentaire?.commentaire).toContain(caeOrigineActionId);
+    });
+
+    test('lien de niveau action : recopie le commentaire de la source action sur la sous-mesure TE (cible absente de sousActionsEtTaches)', async () => {
+      const { teActionId, origineTexteActionId } =
+        ACTION_ORIGINE_TEXTE_FIXTURE.teActionNiveauActionAvecOrigineTexte;
+
+      onTestFinished(cleanupCollectiviteReferentielData);
+      await setupTest();
+
+      await setActionCommentaire(
+        origineTexteActionId,
+        '<p>Diagnostic CAE de niveau action, à recopier sur la sous-mesure TE.</p>'
+      );
+
+      const ctxResult = await buildCtx(prefsEligibleCaeOnly);
+      expect(ctxResult.success).toBe(true);
+      if (!ctxResult.success) {
+        throw new Error('buildSwitchToTeContext a échoué');
+      }
+
+      // la cible de niveau action n'est pas dans sousActionsEtTaches
+      expect(
+        ctxResult.data.cibles.sousActionsEtTaches.some(
+          (cible) => cible.actionId === teActionId
+        )
+      ).toBe(false);
+
+      const data = mergeCommentaires(ctxResult.data);
+      const teCommentaire = data.find(
+        (commentaire) => commentaire.actionId === teActionId
+      );
+
+      expect(teCommentaire?.commentaire).toContain(origineTexteActionId);
+      expect(teCommentaire?.commentaire).toContain(
+        'Diagnostic CAE de niveau action, à recopier sur la sous-mesure TE.'
+      );
     });
   });
 });

--- a/apps/backend/src/referentiels/switch-to-te/merge-commentaires/merge-commentaires.rules.ts
+++ b/apps/backend/src/referentiels/switch-to-te/merge-commentaires/merge-commentaires.rules.ts
@@ -150,7 +150,7 @@ export const mergeCommentaires = (
 ): ActionCommentaireCreate[] => {
   const actionCommentaires: ActionCommentaireCreate[] = [];
 
-  for (const cible of ctx.cibles.sousActionsEtTaches) {
+  for (const cible of ctx.cibles.commentaires) {
     const sources = buildMergeCommentaireSourcesFromCible(
       ctx,
       cible.originesCommentaire

--- a/apps/backend/src/referentiels/switch-to-te/merge-pilotes/merge-pilotes.rules.spec.ts
+++ b/apps/backend/src/referentiels/switch-to-te/merge-pilotes/merge-pilotes.rules.spec.ts
@@ -208,7 +208,7 @@ describe('mergePilotes', () => {
     hierarchiesByReferentielId: hierarchies,
     pilotesByMesureActionId,
     servicesByMesureActionId: new Map(),
-    cibles: { sousActionsEtTaches: [], mesures },
+    cibles: { sousActionsEtTaches: [], mesures, commentaires: [] },
     sourceFicheLinks: [],
     correspondanceIndexes: {
       directSousActionByOrigineId: new Map(),

--- a/apps/backend/src/referentiels/switch-to-te/merge-services/merge-services.rules.spec.ts
+++ b/apps/backend/src/referentiels/switch-to-te/merge-services/merge-services.rules.spec.ts
@@ -174,7 +174,7 @@ describe('mergeServices', () => {
     hierarchiesByReferentielId: hierarchies,
     pilotesByMesureActionId: new Map(),
     servicesByMesureActionId,
-    cibles: { sousActionsEtTaches: [], mesures },
+    cibles: { sousActionsEtTaches: [], mesures, commentaires: [] },
     sourceFicheLinks: [],
     correspondanceIndexes: {
       directSousActionByOrigineId: new Map(),

--- a/apps/backend/src/referentiels/switch-to-te/shared/action-cible.spec.ts
+++ b/apps/backend/src/referentiels/switch-to-te/shared/action-cible.spec.ts
@@ -9,6 +9,7 @@ import {
 } from '@tet/domain/referentiels';
 import {
   isCibleConcernee,
+  listCommentaireCibles,
   listMesuresCibles,
   listSousActionsEtTachesCibles,
 } from './action-cible';
@@ -393,6 +394,102 @@ describe('listSousActionsEtTachesCibles', () => {
       expect(cible?.originesCommentaire).toEqual([]);
       expect(cible?.originesConcernees).toHaveLength(1);
     });
+  });
+});
+
+describe('listCommentaireCibles', () => {
+  const tree: TestTreeNode = {
+    actionId: 'te',
+    actionType: ActionTypeEnum.REFERENTIEL,
+    actionsEnfant: [
+      {
+        actionId: 'te_1',
+        actionType: ActionTypeEnum.AXE,
+        actionsEnfant: [
+          {
+            actionId: 'te_1.1',
+            actionType: ActionTypeEnum.SOUS_AXE,
+            actionsEnfant: [
+              {
+                // niveau ACTION avec lien texte uniquement (ex. cae_1.1.2 -> te_1.1.1)
+                actionId: 'te_1.1.1',
+                actionType: ActionTypeEnum.ACTION,
+                actionsOrigineTexte: [caeOrigineTexte('cae_1.1.2')],
+                actionsEnfant: [
+                  {
+                    actionId: 'te_1.1.1.1',
+                    actionType: ActionTypeEnum.SOUS_ACTION,
+                    actionsOrigine: [caeOrigine('cae_sous_action')],
+                    actionsEnfant: [],
+                  },
+                  {
+                    // sous-action avec lien texte seul, sans action_origine
+                    actionId: 'te_1.1.1.2',
+                    actionType: ActionTypeEnum.SOUS_ACTION,
+                    actionsOrigineTexte: [eciOrigineTexte('eci_tache')],
+                    actionsEnfant: [],
+                  },
+                ],
+              },
+              {
+                // niveau ACTION sans aucune origine -> exclu
+                actionId: 'te_1.1.2',
+                actionType: ActionTypeEnum.ACTION,
+                actionsEnfant: [],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+
+  const scoreMapsByReferentiel = new Map<
+    ReferentielId,
+    Map<string, ActionScore>
+  >([
+    [
+      ReferentielIdEnum.CAE,
+      new Map([
+        ['cae_1.1.2', createActionScore()],
+        ['cae_sous_action', createActionScore()],
+      ]),
+    ],
+    [ReferentielIdEnum.ECI, new Map([['eci_tache', createActionScore()]])],
+  ]);
+
+  const listCibles = () =>
+    listCommentaireCibles({
+      referentielTe: createReferentielTe(tree),
+      scoreMapsByReferentiel,
+      teScoreMap: new Map(),
+    });
+
+  it('inclut les cibles de niveau action porteuses d’un action_origine_texte', () => {
+    const cible = listCibles().find((c) => c.actionId === 'te_1.1.1');
+
+    expect(cible?.originesCommentaire.map((o) => o.actionId)).toEqual([
+      'cae_1.1.2',
+    ]);
+  });
+
+  it('inclut les sous-actions dotées d’un action_origine_texte sans action_origine', () => {
+    const cible = listCibles().find((c) => c.actionId === 'te_1.1.1.2');
+
+    expect(cible?.originesCommentaire.map((o) => o.actionId)).toEqual([
+      'eci_tache',
+    ]);
+  });
+
+  it('inclut les sous-actions à origine directe (repli sur originesConcernees)', () => {
+    const cible = listCibles().find((c) => c.actionId === 'te_1.1.1.1');
+
+    expect(cible?.originesCommentaire).toEqual(cible?.originesConcernees);
+    expect(cible?.originesCommentaire).toHaveLength(1);
+  });
+
+  it('exclut les nœuds sans aucune origine', () => {
+    expect(listCibles().map((c) => c.actionId)).not.toContain('te_1.1.2');
   });
 });
 

--- a/apps/backend/src/referentiels/switch-to-te/shared/action-cible.ts
+++ b/apps/backend/src/referentiels/switch-to-te/shared/action-cible.ts
@@ -36,7 +36,8 @@ export type ActionCible = {
   /**
    * source des commentaires uniquement : action_origine_texte si renseigné pour cette
    * cible (tout ou rien, sans repli même si le filtre "concerné" réduit à [] ensuite),
-   * sinon égal à `originesConcernees`. Ne doit être lu que par mergeCommentaires —
+   * sinon égal à `originesConcernees`. Ne doit être lu que par mergeCommentaires
+   * (via `ctx.cibles.commentaires` / `listCommentaireCibles`) —
    * mergeStatuts/mergePilotes/mergeServices restent sur `originesConcernees`.
    */
   originesCommentaire: CommentaireOrigine[];
@@ -123,6 +124,39 @@ export const listSousActionsEtTachesCibles = (input: {
     )
   );
 };
+
+/**
+ * Cibles pour la fusion des commentaires uniquement.
+ *
+ * Contrairement à `listSousActionsEtTachesCibles` (taillé pour `mergeStatuts` :
+ * uniquement `SOUS_ACTION | TACHE` avec au moins une `action_origine`), on retient
+ * ici **tous les niveaux** (action / sous-action / tâche) dès qu'une origine
+ * exploitable existe : `action_origine` **ou** `action_origine_texte`.
+ *
+ * C'est ce qui permet de prendre en compte les liens `action_origine_texte` de
+ * niveau action (ex. `cae_1.1.2 -> te_1.1.1`), ainsi que les sous-actions qui n'ont
+ * qu'un lien `action_origine_texte` sans `action_origine`.
+ */
+export const listCommentaireCibles = (input: {
+  referentielTe: ReferentielResponse;
+  scoreMapsByReferentiel: Map<ReferentielId, Map<string, ActionScore>>;
+  teScoreMap: Map<string, ActionScore>;
+}): ActionCible[] =>
+  flatMapActionsEnfants(input.referentielTe.itemsTree)
+    .filter(
+      (action) =>
+        (action.actionsOrigine?.length ?? 0) > 0 ||
+        (action.actionsOrigineTexte?.length ?? 0) > 0
+    )
+    .map((action) =>
+      buildActionCible(
+        action.actionId,
+        action.actionsOrigine ?? [],
+        input.scoreMapsByReferentiel,
+        input.teScoreMap,
+        action.actionsOrigineTexte ?? []
+      )
+    );
 
 export const listMesuresCibles = (input: {
   referentielTe: ReferentielResponse;

--- a/apps/backend/src/referentiels/switch-to-te/shared/switch-to-te-context.ts
+++ b/apps/backend/src/referentiels/switch-to-te/shared/switch-to-te-context.ts
@@ -25,5 +25,7 @@ export type SwitchToTeContext = {
   cibles: {
     mesures: ActionCible[];
     sousActionsEtTaches: ActionCible[];
+    /** cibles tous niveaux (action / sous-action / tâche) pour mergeCommentaires */
+    commentaires: ActionCible[];
   };
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Améliorations**
  * La fusion des commentaires prend désormais en compte les cibles pertinentes à tous les niveaux : actions, sous-actions et tâches.
  * Les commentaires associés à des liens d’origine textuels sont correctement reportés sur les cibles correspondantes du référentiel TE.
  * Les cibles sans origine exploitable sont exclues afin d’éviter la création de commentaires incorrects.

* **Tests**
  * Ajout de scénarios couvrant les liens d’origine textuels au niveau des actions et des sous-actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->