### PR TITLE
Préserve les sauts de ligne lors de la fusion des commentaires

### DIFF
--- a/apps/backend/src/referentiels/switch-to-te/merge-commentaires/merge-commentaires.rules.ts
+++ b/apps/backend/src/referentiels/switch-to-te/merge-commentaires/merge-commentaires.rules.ts
@@ -10,6 +10,7 @@ import {
   type ReferentielId,
 } from '@tet/domain/referentiels';
 import { htmlToText } from '@tet/domain/utils';
+import { normalizeExplicationToHtml } from './normalize-explication-to-html';
 
 export const MERGE_COMMENTAIRES_PREFIX =
   '<p><span data-text-color="red">Les textes ci-après et les statuts associés sont issus de la bascule depuis les anciens référentiels CAE et/ou ECi. Ils sont à actualiser pour répondre à l\'actuelle sous-mesure.</span></p>\n<p>&nbsp;</p>';
@@ -91,7 +92,9 @@ export const buildSourceBlockHeader = (
 };
 
 export const buildSourceBlock = (source: MergeCommentaireSource): string =>
-  `${buildSourceBlockHeader(source)}\n${source.explication}`;
+  `${buildSourceBlockHeader(source)}\n${normalizeExplicationToHtml(
+    source.explication
+  )}`;
 
 export const sortMergeCommentaireSources = (
   sources: MergeCommentaireSource[]

--- a/apps/backend/src/referentiels/switch-to-te/merge-commentaires/normalize-explication-to-html.spec.ts
+++ b/apps/backend/src/referentiels/switch-to-te/merge-commentaires/normalize-explication-to-html.spec.ts
@@ -1,0 +1,64 @@
+import {
+  isExplicationHtml,
+  legacyPlainTextToHtml,
+  normalizeExplicationToHtml,
+} from './normalize-explication-to-html';
+
+describe('normalize-explication-to-html', () => {
+  describe('isExplicationHtml', () => {
+    it('détecte le HTML même précédé d espaces', () => {
+      expect(isExplicationHtml('<p>déjà migré</p>')).toBe(true);
+      expect(isExplicationHtml('  \n<p>déjà migré</p>')).toBe(true);
+    });
+
+    it('rejette le texte brut', () => {
+      expect(isExplicationHtml('ligne 1\nligne 2')).toBe(false);
+      expect(isExplicationHtml('a < b')).toBe(false);
+    });
+  });
+
+  describe('legacyPlainTextToHtml', () => {
+    it('crée un paragraphe par ligne', () => {
+      expect(legacyPlainTextToHtml('ligne 1\nligne 2')).toBe(
+        '<p>ligne 1</p>\n<p>ligne 2</p>'
+      );
+    });
+
+    it('insère un paragraphe non vide entre deux sections séparées par une ligne vide', () => {
+      expect(
+        legacyPlainTextToHtml('parking A\nparking B\n\nVISITE 2025')
+      ).toBe(
+        '<p>parking A</p>\n<p>parking B</p>\n<p>&nbsp;</p>\n<p>VISITE 2025</p>'
+      );
+    });
+
+    it('gère les retours chariot Windows', () => {
+      expect(legacyPlainTextToHtml('ligne 1\r\nligne 2')).toBe(
+        '<p>ligne 1</p>\n<p>ligne 2</p>'
+      );
+    });
+
+    it('échappe les caractères spéciaux HTML', () => {
+      expect(legacyPlainTextToHtml('a < b && c > d')).toBe(
+        '<p>a &lt; b &amp;&amp; c &gt; d</p>'
+      );
+    });
+
+    it('retourne un paragraphe vide si le texte ne contient que des lignes vides', () => {
+      expect(legacyPlainTextToHtml('\n  \n')).toBe('<p>&nbsp;</p>');
+    });
+  });
+
+  describe('normalizeExplicationToHtml', () => {
+    it('conserve le HTML déjà migré tel quel', () => {
+      const html = '<p class="!text-base">déjà migré</p>';
+      expect(normalizeExplicationToHtml(html)).toBe(html);
+    });
+
+    it('convertit le texte brut hérité en préservant les sauts de ligne', () => {
+      expect(normalizeExplicationToHtml('ligne 1\nligne 2')).toBe(
+        '<p>ligne 1</p>\n<p>ligne 2</p>'
+      );
+    });
+  });
+});

--- a/apps/backend/src/referentiels/switch-to-te/merge-commentaires/normalize-explication-to-html.ts
+++ b/apps/backend/src/referentiels/switch-to-te/merge-commentaires/normalize-explication-to-html.ts
@@ -1,0 +1,51 @@
+/**
+ * Ligne vide dans le texte source (éventuellement avec espaces).
+ * Aligné sur `parseLegacyPlainTextToBlocks` côté UI.
+ */
+const BLANK_LINE_PATTERN = /\r?\n[ \t]*\r?\n+/;
+
+const escapeHtml = (text: string): string =>
+  text
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+
+/** Vrai si l'explication est déjà du HTML (déjà migrée via le RichTextEditor). */
+export const isExplicationHtml = (explication: string): boolean =>
+  explication.trim().startsWith('<');
+
+/**
+ * Convertit le texte brut hérité (saisi en BDD dans une textarea avant l'ajout
+ * du RichTextEditor) en HTML, en préservant les sauts de ligne et les lignes
+ * vides. Sans cette conversion, l'inlining du texte brut dans le commentaire
+ * fusionné (déjà en HTML) fait perdre le formatage initial.
+ */
+export const legacyPlainTextToHtml = (explication: string): string => {
+  const sections = explication
+    .split(BLANK_LINE_PATTERN)
+    .map((section) => section.trim())
+    .filter(Boolean);
+
+  const paragraphs: string[] = [];
+
+  for (const section of sections) {
+    if (paragraphs.length > 0) {
+      paragraphs.push('<p>&nbsp;</p>');
+    }
+    for (const line of section.split(/\r?\n/)) {
+      paragraphs.push(`<p>${escapeHtml(line)}</p>`);
+    }
+  }
+
+  return paragraphs.length > 0 ? paragraphs.join('\n') : '<p>&nbsp;</p>';
+};
+
+/**
+ * Normalise une explication source en HTML avant son inlining dans le
+ * commentaire fusionné : le HTML déjà migré est conservé tel quel, le texte brut
+ * hérité est converti en préservant son formatage.
+ */
+export const normalizeExplicationToHtml = (explication: string): string =>
+  isExplicationHtml(explication)
+    ? explication
+    : legacyPlainTextToHtml(explication);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Améliorations**
  * Les explications héritées sont désormais correctement converties en HTML lors de la fusion des commentaires.
  * Les paragraphes, retours à la ligne et lignes vides sont préservés.
  * Les contenus déjà au format HTML restent inchangés.
  * Les caractères spéciaux sont automatiquement échappés pour éviter un affichage incorrect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->