### PR TITLE
Bloque la bascule TE pour les collectivités de type syndicat

### DIFF
--- a/apps/backend/src/referentiels/switch-to-te/get-switch-to-te-status.output.ts
+++ b/apps/backend/src/referentiels/switch-to-te/get-switch-to-te-status.output.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 
 const switchToTeBlockerSchema = z.discriminatedUnion('type', [
   z.object({ type: z.literal('COT_ACTIVE') }),
+  z.object({ type: z.literal('COLLECTIVITE_IS_SYNDICAT') }),
   z.object({
     type: z.literal('AUDIT_IN_PROGRESS'),
     referentiel: z.enum(referentielIdEnumValues),

--- a/apps/backend/src/referentiels/switch-to-te/switch-to-te.errors.ts
+++ b/apps/backend/src/referentiels/switch-to-te/switch-to-te.errors.ts
@@ -12,6 +12,7 @@ const specificErrors = [
   'ALREADY_SWITCHED',
   'NOT_ELIGIBLE',
   'COT_ACTIVE',
+  'COLLECTIVITE_IS_SYNDICAT',
   'AUDIT_REQUEST_IN_PROGRESS',
   'AUDIT_IN_PROGRESS',
   'PRE_SWITCH_SNAPSHOT_FAILED',
@@ -40,6 +41,11 @@ export const switchToTeTrpcErrorEntries = {
     code: 'FORBIDDEN',
     message:
       "La bascule n'est pas possible : un contrat d'objectif (COT) est actif pour cette collectivité",
+  },
+  COLLECTIVITE_IS_SYNDICAT: {
+    code: 'FORBIDDEN',
+    message:
+      "La bascule n'est pas possible : les collectivités de type syndicat ne sont pas éligibles au référentiel TE",
   },
   AUDIT_REQUEST_IN_PROGRESS: {
     code: 'CONFLICT',

--- a/apps/backend/src/referentiels/switch-to-te/switch-to-te.router.e2e-spec.ts
+++ b/apps/backend/src/referentiels/switch-to-te/switch-to-te.router.e2e-spec.ts
@@ -104,10 +104,14 @@ describe('SwitchToTeRouter', () => {
   // crée une collectivité éligible avec ses préférences et retourne le caller
   // admin et l'utilisateur admin associé
   async function setupEligibleCollectivite(
-    referentiels: CollectiviteReferentielPreferences
+    referentiels: CollectiviteReferentielPreferences,
+    collectiviteArgs?: Parameters<
+      typeof addTestCollectiviteAndUsers
+    >[1]['collectivite']
   ) {
     const fixture = await addTestCollectiviteAndUsers(databaseService, {
       users: [{ role: CollectiviteRole.ADMIN }],
+      collectivite: collectiviteArgs,
     });
     onTestFinished(() => fixture.cleanup());
 
@@ -489,6 +493,26 @@ describe('SwitchToTeRouter', () => {
       expect(status).toEqual({
         value: 'BLOCKED',
         blockers: [{ type: 'COT_ACTIVE' }],
+      });
+    });
+
+    test('BLOCKED (COLLECTIVITE_IS_SYNDICAT) pour une collectivité de type syndicat', async () => {
+      const { collectiviteId, adminCaller } = await setupEligibleCollectivite(
+        {
+          cae: { display: true, mode: 'write' },
+          eci: { display: false, mode: 'archived' },
+          te: { display: true, mode: 'readonly' },
+        },
+        { natureInsee: 'SIVU' }
+      );
+
+      const status = await adminCaller.referentiels.getSwitchToTeStatus({
+        collectiviteId,
+      });
+
+      expect(status).toEqual({
+        value: 'BLOCKED',
+        blockers: [{ type: 'COLLECTIVITE_IS_SYNDICAT' }],
       });
     });
 

--- a/apps/backend/src/referentiels/switch-to-te/switch-to-te.rules.spec.ts
+++ b/apps/backend/src/referentiels/switch-to-te/switch-to-te.rules.spec.ts
@@ -118,14 +118,29 @@ describe('canSwitchToTe', () => {
 describe('getSwitchToTeBlockers', () => {
   test('COT actif seul → un blocage COT_ACTIVE', () => {
     expect(
-      getSwitchToTeBlockers({ cotActif: true, referentielsEnWrite: [] })
+      getSwitchToTeBlockers({
+        cotActif: true,
+        isSyndicat: false,
+        referentielsEnWrite: [],
+      })
     ).toEqual([{ type: 'COT_ACTIVE' }]);
+  });
+
+  test('collectivité syndicat seule → un blocage COLLECTIVITE_IS_SYNDICAT', () => {
+    expect(
+      getSwitchToTeBlockers({
+        cotActif: false,
+        isSyndicat: true,
+        referentielsEnWrite: [],
+      })
+    ).toEqual([{ type: 'COLLECTIVITE_IS_SYNDICAT' }]);
   });
 
   test('audit en cours sur cae → AUDIT_IN_PROGRESS', () => {
     expect(
       getSwitchToTeBlockers({
         cotActif: false,
+        isSyndicat: false,
         referentielsEnWrite: [{ referentiel: 'cae', status: 'audit_en_cours' }],
       })
     ).toEqual([{ type: 'AUDIT_IN_PROGRESS', referentiel: 'cae' }]);
@@ -135,6 +150,7 @@ describe('getSwitchToTeBlockers', () => {
     expect(
       getSwitchToTeBlockers({
         cotActif: false,
+        isSyndicat: false,
         referentielsEnWrite: [
           { referentiel: 'eci', status: 'demande_envoyee' },
         ],
@@ -146,6 +162,7 @@ describe('getSwitchToTeBlockers', () => {
     expect(
       getSwitchToTeBlockers({
         cotActif: false,
+        isSyndicat: false,
         referentielsEnWrite: [
           { referentiel: 'cae', status: 'audit_valide' },
           { referentiel: 'eci', status: 'non_demandee' },
@@ -154,16 +171,18 @@ describe('getSwitchToTeBlockers', () => {
     ).toEqual([]);
   });
 
-  test('multi-blocages : COT en premier puis cae avant eci', () => {
+  test('multi-blocages : syndicat puis COT puis cae avant eci', () => {
     expect(
       getSwitchToTeBlockers({
         cotActif: true,
+        isSyndicat: true,
         referentielsEnWrite: [
           { referentiel: 'cae', status: 'audit_en_cours' },
           { referentiel: 'eci', status: 'demande_envoyee' },
         ],
       })
     ).toEqual([
+      { type: 'COLLECTIVITE_IS_SYNDICAT' },
       { type: 'COT_ACTIVE' },
       { type: 'AUDIT_IN_PROGRESS', referentiel: 'cae' },
       { type: 'AUDIT_REQUEST_IN_PROGRESS', referentiel: 'eci' },
@@ -176,6 +195,7 @@ describe('getSwitchToTeBlockers', () => {
     expect(
       getSwitchToTeBlockers({
         cotActif: false,
+        isSyndicat: false,
         referentielsEnWrite: [],
       })
     ).toEqual([]);

--- a/apps/backend/src/referentiels/switch-to-te/switch-to-te.rules.ts
+++ b/apps/backend/src/referentiels/switch-to-te/switch-to-te.rules.ts
@@ -44,24 +44,30 @@ export function canSwitchToTe(
  */
 export type SwitchToTeBlocker =
   | { type: 'COT_ACTIVE' }
+  | { type: 'COLLECTIVITE_IS_SYNDICAT' }
   | { type: 'AUDIT_IN_PROGRESS'; referentiel: ReferentielId }
   | { type: 'AUDIT_REQUEST_IN_PROGRESS'; referentiel: ReferentielId };
 
 /**
  * Détermine les blocages à la bascule vers TE à partir de l'état fourni.
  *
- * Ordre des blocages : COT d'abord (niveau collectivité), puis par référentiel
- * dans l'ordre fourni (`cae` avant `eci`). Un audit en cours prime sur une
- * simple demande envoyée pour un même référentiel.
+ * Ordre des blocages : syndicat puis COT (niveau collectivité), puis par
+ * référentiel dans l'ordre fourni (`cae` avant `eci`). Un audit en cours prime
+ * sur une simple demande envoyée pour un même référentiel.
  */
 export function getSwitchToTeBlockers(input: {
   cotActif: boolean;
+  isSyndicat: boolean;
   referentielsEnWrite: {
     referentiel: ReferentielId;
     status: ParcoursLabellisationStatus;
   }[];
 }): SwitchToTeBlocker[] {
   const blockers: SwitchToTeBlocker[] = [];
+
+  if (input.isSyndicat) {
+    blockers.push({ type: 'COLLECTIVITE_IS_SYNDICAT' });
+  }
 
   if (input.cotActif) {
     blockers.push({ type: 'COT_ACTIVE' });

--- a/apps/backend/src/referentiels/switch-to-te/switch-to-te.service.ts
+++ b/apps/backend/src/referentiels/switch-to-te/switch-to-te.service.ts
@@ -1,11 +1,15 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { CollectiviteReferentielModeService } from '@tet/backend/collectivites/collectivite-referentiel-mode/collectivite-referentiel-mode.service';
+import CollectivitesService from '@tet/backend/collectivites/services/collectivites.service';
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
 import type { ServiceSecondArg } from '@tet/backend/utils/nest/service-second-arg.utils';
 import { failure, success, type Result } from '@tet/backend/utils/result.type';
 import { TrackingService } from '@tet/backend/utils/tracking/tracking.service';
 import { TransactionManager } from '@tet/backend/utils/transaction/transaction-manager.service';
-import { type CollectiviteReferentielPreferences } from '@tet/domain/collectivites';
+import {
+  CollectiviteSousTypeEnum,
+  type CollectiviteReferentielPreferences,
+} from '@tet/domain/collectivites';
 import {
   getParcoursLabellisationStatus,
   ReferentielIdEnum,
@@ -37,6 +41,7 @@ export class SwitchToTeService {
   constructor(
     private readonly trackingService: TrackingService,
     private readonly permissionService: PermissionService,
+    private readonly collectivitesService: CollectivitesService,
     private readonly collectiviteReferentielModeService: CollectiviteReferentielModeService,
     private readonly getLabellisationService: GetLabellisationService,
     private readonly transactionManager: TransactionManager,
@@ -56,13 +61,15 @@ export class SwitchToTeService {
     SwitchToTeError
   > = {
     COT_ACTIVE: SwitchToTeErrorEnum.COT_ACTIVE,
+    COLLECTIVITE_IS_SYNDICAT: SwitchToTeErrorEnum.COLLECTIVITE_IS_SYNDICAT,
     AUDIT_REQUEST_IN_PROGRESS: SwitchToTeErrorEnum.AUDIT_REQUEST_IN_PROGRESS,
     AUDIT_IN_PROGRESS: SwitchToTeErrorEnum.AUDIT_IN_PROGRESS,
   };
 
   /**
-   * Calcule les blocages COT / demande / audit à partir de lectures read-only.
-   * N'itère que sur les référentiels sources (cae/eci) encore en `mode: write`.
+   * Calcule les blocages syndicat / COT / demande / audit à partir de lectures
+   * read-only. N'itère que sur les référentiels sources (cae/eci) encore en
+   * `mode: write`.
    */
   async getSwitchToTeBlockers(
     collectiviteId: number,
@@ -72,8 +79,9 @@ export class SwitchToTeService {
       (referentiel) => prefs[referentiel].mode === 'write'
     );
 
-    const [cotActif, referentielsEnWrite] = await Promise.all([
+    const [cotActif, isSyndicat, referentielsEnWrite] = await Promise.all([
       this.getLabellisationService.isCotActif(collectiviteId),
+      this.isSyndicat(collectiviteId),
       Promise.all(
         referentielsToCheck.map(async (referentiel) => {
           const demandeEtAudit =
@@ -89,7 +97,17 @@ export class SwitchToTeService {
       ),
     ]);
 
-    return getSwitchToTeBlockers({ cotActif, referentielsEnWrite });
+    return getSwitchToTeBlockers({ cotActif, isSyndicat, referentielsEnWrite });
+  }
+
+  /**
+   * Les collectivités de type syndicat (SMF, SMO, SIVU, SIVOM) ne sont pas
+   * éligibles au référentiel TE.
+   */
+  private async isSyndicat(collectiviteId: number): Promise<boolean> {
+    const { soustype } =
+      await this.collectivitesService.getCollectiviteAvecType(collectiviteId);
+    return soustype === CollectiviteSousTypeEnum.SYNDICAT;
   }
 
   /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Les syndicats ne sont désormais plus éligibles au passage vers le référentiel TE.
  * Un statut bloqué et un message explicite sont affichés lorsqu’une collectivité de type syndicat tente cette transition.
  * Ce blocage est prioritaire sur les autres motifs d’inéligibilité.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->