### PR TITLE
feat(collectivites): autorise le super-admin à reclasser l'objet d'un document

### DIFF
--- a/apps/backend/src/collectivites/documents/edit-preuve-document/edit-preuve-document.input.ts
+++ b/apps/backend/src/collectivites/documents/edit-preuve-document/edit-preuve-document.input.ts
@@ -1,16 +1,40 @@
-import { lienSchema, preuveTypeEnumSchema } from '@tet/domain/collectivites';
+import {
+  lienSchema,
+  preuveTypeEnumSchema,
+  preuveTypeEnumValues,
+} from '@tet/domain/collectivites';
+import { objetPreuveEnumSchema } from '@tet/domain/referentiels';
 import z from 'zod';
 
+const commonFields = {
+  preuveId: z.number().int().positive(),
+  lien: z.object(lienSchema.shape).optional(),
+  commentaire: z.string().optional(),
+};
+
 export const updatePreuveInputSchema = z
-  .object({
-    preuveId: z.number().int().positive(),
-    preuveType: preuveTypeEnumSchema,
-    lien: z.object(lienSchema.shape).optional(),
-    commentaire: z.string().optional(),
-  })
-  .refine((d) => d.lien !== undefined || d.commentaire !== undefined, {
-    message: 'au moins un des champs lien ou commentaire doit être fourni',
-  });
+  .discriminatedUnion('preuveType', [
+    z.object({
+      ...commonFields,
+      preuveType: z.literal('labellisation'),
+      objet: z.optional(z.nullable(objetPreuveEnumSchema)),
+    }),
+    z.object({
+      ...commonFields,
+      preuveType: z.enum(preuveTypeEnumValues).exclude(['labellisation']),
+      objet: z.optional(z.undefined()),
+    }),
+  ])
+  .refine(
+    (input) =>
+      input.lien !== undefined ||
+      input.commentaire !== undefined ||
+      input.objet !== undefined,
+    {
+      message:
+        'au moins un des champs lien, commentaire ou objet doit être fourni',
+    }
+  );
 
 export type UpdatePreuveInput = z.infer<typeof updatePreuveInputSchema>;
 

--- a/apps/backend/src/collectivites/documents/edit-preuve-document/edit-preuve-document.repository.ts
+++ b/apps/backend/src/collectivites/documents/edit-preuve-document/edit-preuve-document.repository.ts
@@ -7,7 +7,7 @@ import {
   CommonErrorEnum,
 } from '@tet/backend/utils/trpc/common-errors';
 import { PreuveBase, PreuveType } from '@tet/domain/collectivites';
-import { LabellisationAudit } from '@tet/domain/referentiels';
+import { LabellisationAudit, ObjetPreuve } from '@tet/domain/referentiels';
 import { getErrorMessage } from '@tet/domain/utils';
 import { desc, eq } from 'drizzle-orm';
 import { DocumentBase } from '../models/document.basetable';
@@ -18,6 +18,28 @@ import { preuveTableByType } from '../models/preuve-tables.map';
 export type PreuveDocumentPatch = {
   lien?: { url: string; titre: string };
   commentaire?: string;
+} & (
+  | { preuveType: 'labellisation'; objet?: ObjetPreuve | null }
+  | { preuveType: Exclude<PreuveType, 'labellisation'> }
+);
+
+type PreuveLabellisationPatch = Extract<
+  PreuveDocumentPatch,
+  { preuveType: 'labellisation' }
+>;
+
+function isPreuveLabellisationPatch(
+  patch: PreuveDocumentPatch
+): patch is PreuveLabellisationPatch {
+  return patch.preuveType === 'labellisation';
+}
+
+type PreuveDocumentColumns = Partial<
+  Pick<DocumentBase, 'modifiedBy' | 'url' | 'titre' | 'commentaire'>
+>;
+
+type PreuveLabellisationColumns = PreuveDocumentColumns & {
+  objet?: ObjetPreuve | null;
 };
 
 @Injectable()
@@ -65,32 +87,22 @@ export class EditPreuveDocumentRepository {
   }
 
   async updateById(
-    preuveType: PreuveType,
     preuveId: number,
     modifiedBy: string,
     patch: PreuveDocumentPatch
   ): Promise<Result<PreuveBase, CommonError>> {
-    const set: {
-      modifiedBy: string;
-      url?: string | null;
-      titre?: string | null;
-      commentaire?: string | null;
-    } = { modifiedBy };
+    const columns: PreuveDocumentColumns = {};
     if (patch.lien !== undefined) {
-      set.url = patch.lien.url.trim();
-      set.titre = patch.lien.titre.trim();
+      columns.modifiedBy = modifiedBy;
+      columns.url = patch.lien.url.trim();
+      columns.titre = patch.lien.titre.trim();
     }
     if (patch.commentaire !== undefined) {
-      set.commentaire = patch.commentaire.trim();
+      columns.modifiedBy = modifiedBy;
+      columns.commentaire = patch.commentaire.trim();
     }
-
     try {
-      const table = preuveTableByType[preuveType];
-      const [row] = await this.databaseService.db
-        .update(table)
-        .set(set)
-        .where(eq(table.id, preuveId))
-        .returning();
+      const [row] = await this.updateRow({ preuveId, columns, patch });
       if (!row) {
         return failure(CommonErrorEnum.NOT_FOUND);
       }
@@ -98,15 +110,43 @@ export class EditPreuveDocumentRepository {
       return success(this.rowToPreuveBase(row));
     } catch (error) {
       this.logger.error(
-        `Erreur lors de la mise à jour de la preuve ${preuveType} ${preuveId}: ${getErrorMessage(
-          error
-        )}`
+        `Erreur lors de la mise à jour de la preuve ${
+          patch.preuveType
+        } ${preuveId}: ${getErrorMessage(error)}`
       );
       return failure(
         CommonErrorEnum.DATABASE_ERROR,
         error instanceof Error ? error : new Error(getErrorMessage(error))
       );
     }
+  }
+
+  private updateRow({
+    preuveId,
+    columns,
+    patch,
+  }: {
+    preuveId: number;
+    columns: PreuveDocumentColumns;
+    patch: PreuveDocumentPatch;
+  }) {
+    if (isPreuveLabellisationPatch(patch)) {
+      const labellisationColumns: PreuveLabellisationColumns = { ...columns };
+      if (patch.objet !== undefined) {
+        labellisationColumns.objet = patch.objet;
+      }
+      return this.databaseService.db
+        .update(preuveLabellisationTable)
+        .set(labellisationColumns)
+        .where(eq(preuveLabellisationTable.id, preuveId))
+        .returning();
+    }
+    const table = preuveTableByType[patch.preuveType];
+    return this.databaseService.db
+      .update(table)
+      .set(columns)
+      .where(eq(table.id, preuveId))
+      .returning();
   }
 
   async deleteById(

--- a/apps/backend/src/collectivites/documents/edit-preuve-document/edit-preuve-document.router.e2e-spec.ts
+++ b/apps/backend/src/collectivites/documents/edit-preuve-document/edit-preuve-document.router.e2e-spec.ts
@@ -18,7 +18,7 @@ import {
 } from '@tet/backend/users/users/users.test-fixture';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
-import { Collectivite, PreuveType } from '@tet/domain/collectivites';
+import { Collectivite } from '@tet/domain/collectivites';
 import {
   ObjetPreuve,
   ObjetPreuveEnum,
@@ -29,6 +29,7 @@ import { eq } from 'drizzle-orm';
 import request from 'supertest';
 import { onTestFinished } from 'vitest';
 import { preuveLabellisationTable } from '../models/preuve-labellisation.table';
+import { updatePreuveInputSchema } from './edit-preuve-document.input';
 
 describe('EditPreuveDocumentRouter', () => {
   let app: INestApplication;
@@ -305,30 +306,17 @@ describe('EditPreuveDocumentRouter', () => {
       ).rejects.toThrowError(/labellisation en cours/i);
     });
 
-    test("un objet envoye sur un type de preuve qui n'en porte pas est refuse", async () => {
-      const caller = router.createCaller({ user: editorUser });
-      const ficheId = await createFiche({
-        caller,
-        ficheInput: {
-          titre: 'Fiche avec annexe',
-          collectiviteId: collectivite.id,
-        },
-      });
-      const annexe = await caller.plans.fiches.addAnnexe({
-        ficheId,
-        lien: { url: 'https://example.com', titre: 'X' },
+    test("un objet envoye sur un type de preuve qui n'en porte pas est refuse", () => {
+      const rejet = updatePreuveInputSchema.safeParse({
+        preuveId: 1,
+        preuveType: 'annexe',
+        commentaire: 'commentaire modifié',
+        objet: ObjetPreuveEnum.CANDIDATURE,
       });
 
-      const preuveType: PreuveType = 'annexe';
-
-      await expect(
-        caller.collectivites.documents.updatePreuve({
-          preuveId: annexe.id,
-          preuveType,
-          commentaire: 'commentaire modifié',
-          objet: ObjetPreuveEnum.CANDIDATURE,
-        })
-      ).rejects.toThrowError();
+      expect(rejet.error?.issues.map((issue) => issue.path)).toEqual([
+        ['objet'],
+      ]);
     });
 
     test("un super-admin reclasse l'objet d'un document dont l'audit est validé", async () => {

--- a/apps/backend/src/collectivites/documents/edit-preuve-document/edit-preuve-document.router.e2e-spec.ts
+++ b/apps/backend/src/collectivites/documents/edit-preuve-document/edit-preuve-document.router.e2e-spec.ts
@@ -12,13 +12,23 @@ import {
   signInWith,
 } from '@tet/backend/test';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
-import { addTestUser } from '@tet/backend/users/users/users.test-fixture';
+import {
+  addAndEnableUserSuperAdminMode,
+  addTestUser,
+} from '@tet/backend/users/users/users.test-fixture';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
-import { Collectivite } from '@tet/domain/collectivites';
-import { ReferentielIdEnum } from '@tet/domain/referentiels';
+import { Collectivite, PreuveType } from '@tet/domain/collectivites';
+import {
+  ObjetPreuve,
+  ObjetPreuveEnum,
+  ReferentielIdEnum,
+} from '@tet/domain/referentiels';
 import { CollectiviteRole } from '@tet/domain/users';
+import { eq } from 'drizzle-orm';
 import request from 'supertest';
+import { onTestFinished } from 'vitest';
+import { preuveLabellisationTable } from '../models/preuve-labellisation.table';
 
 describe('EditPreuveDocumentRouter', () => {
   let app: INestApplication;
@@ -27,6 +37,7 @@ describe('EditPreuveDocumentRouter', () => {
 
   let collectivite: Collectivite;
   let editorUser: AuthenticatedUser;
+  let adminUser: AuthenticatedUser;
   let visiteurUser: AuthenticatedUser;
   let editorAuthToken: string;
   let fichierId: number;
@@ -38,12 +49,20 @@ describe('EditPreuveDocumentRouter', () => {
 
     const testCollectiviteAndUsersResult = await addTestCollectiviteAndUsers(
       db,
-      { users: [{ role: CollectiviteRole.EDITION }] }
+      {
+        users: [
+          { role: CollectiviteRole.EDITION },
+          { role: CollectiviteRole.ADMIN },
+        ],
+      }
     );
 
     collectivite = testCollectiviteAndUsersResult.collectivite;
     const editorFixture = testCollectiviteAndUsersResult.users[0];
     editorUser = getAuthUserFromUserCredentials(editorFixture);
+    adminUser = getAuthUserFromUserCredentials(
+      testCollectiviteAndUsersResult.users[1]
+    );
 
     const signIn = await signInWith({
       email: editorFixture.email,
@@ -224,7 +243,7 @@ describe('EditPreuveDocumentRouter', () => {
   });
 
   describe('documents de candidature (preuve labellisation)', () => {
-    const createCandidaturePreuve = async () => {
+    const createCandidaturePreuve = async (objet?: ObjetPreuve) => {
       const caller = router.createCaller({ user: editorUser });
       const { audit, demande } = await createAuditWithOnTestFinished({
         databaseService: db,
@@ -241,6 +260,7 @@ describe('EditPreuveDocumentRouter', () => {
           demandeId: demande.id,
           fichierId,
           commentaire: '',
+          objet,
         });
 
       return { caller, preuve, auditId: audit.id };
@@ -283,6 +303,170 @@ describe('EditPreuveDocumentRouter', () => {
           commentaire: 'tentative de modification',
         })
       ).rejects.toThrowError(/labellisation en cours/i);
+    });
+
+    test("un objet envoye sur un type de preuve qui n'en porte pas est refuse", async () => {
+      const caller = router.createCaller({ user: editorUser });
+      const ficheId = await createFiche({
+        caller,
+        ficheInput: {
+          titre: 'Fiche avec annexe',
+          collectiviteId: collectivite.id,
+        },
+      });
+      const annexe = await caller.plans.fiches.addAnnexe({
+        ficheId,
+        lien: { url: 'https://example.com', titre: 'X' },
+      });
+
+      const preuveType: PreuveType = 'annexe';
+
+      await expect(
+        caller.collectivites.documents.updatePreuve({
+          preuveId: annexe.id,
+          preuveType,
+          commentaire: 'commentaire modifié',
+          objet: ObjetPreuveEnum.CANDIDATURE,
+        })
+      ).rejects.toThrowError();
+    });
+
+    test("un super-admin reclasse l'objet d'un document dont l'audit est validé", async () => {
+      const { caller, preuve, auditId } = await createCandidaturePreuve();
+      await validerAuditEnCours(auditId);
+
+      const { cleanup } = await addAndEnableUserSuperAdminMode({
+        app,
+        caller,
+        userId: editorUser.id,
+      });
+      onTestFinished(cleanup);
+
+      const updated = await caller.collectivites.documents.updatePreuve({
+        preuveId: preuve.id,
+        preuveType: 'labellisation',
+        objet: ObjetPreuveEnum.CANDIDATURE,
+      });
+
+      expect(updated.id).toBe(preuve.id);
+      const [row] = await db.db
+        .select({ objet: preuveLabellisationTable.objet })
+        .from(preuveLabellisationTable)
+        .where(eq(preuveLabellisationTable.id, preuve.id));
+      expect(row.objet).toBe(ObjetPreuveEnum.CANDIDATURE);
+    });
+
+    test("un super-admin qui joint un commentaire au reclassement retombe sous le verrou de l'audit", async () => {
+      const { caller, preuve, auditId } = await createCandidaturePreuve();
+      await validerAuditEnCours(auditId);
+
+      const { cleanup } = await addAndEnableUserSuperAdminMode({
+        app,
+        caller,
+        userId: editorUser.id,
+      });
+      onTestFinished(cleanup);
+
+      await expect(
+        caller.collectivites.documents.updatePreuve({
+          preuveId: preuve.id,
+          preuveType: 'labellisation',
+          objet: ObjetPreuveEnum.CANDIDATURE,
+          commentaire: 'reclassement accompagné d une edition',
+        })
+      ).rejects.toThrowError(/labellisation en cours/i);
+
+      const [row] = await db.db
+        .select({ objet: preuveLabellisationTable.objet })
+        .from(preuveLabellisationTable)
+        .where(eq(preuveLabellisationTable.id, preuve.id));
+      expect(row.objet).toBeNull();
+    });
+
+    test("un super-admin declasse l'objet d'un document en le passant a null", async () => {
+      const { caller, preuve } = await createCandidaturePreuve(
+        ObjetPreuveEnum.CANDIDATURE
+      );
+
+      const { cleanup } = await addAndEnableUserSuperAdminMode({
+        app,
+        caller,
+        userId: editorUser.id,
+      });
+      onTestFinished(cleanup);
+
+      await caller.collectivites.documents.updatePreuve({
+        preuveId: preuve.id,
+        preuveType: 'labellisation',
+        objet: null,
+      });
+
+      const [row] = await db.db
+        .select({ objet: preuveLabellisationTable.objet })
+        .from(preuveLabellisationTable)
+        .where(eq(preuveLabellisationTable.id, preuve.id));
+      expect(row.objet).toBeNull();
+    });
+
+    test("un admin de la collectivite ne peut pas reclasser l'objet d'un document", async () => {
+      const { preuve } = await createCandidaturePreuve();
+      const adminCaller = router.createCaller({ user: adminUser });
+
+      await expect(
+        adminCaller.collectivites.documents.updatePreuve({
+          preuveId: preuve.id,
+          preuveType: 'labellisation',
+          objet: ObjetPreuveEnum.ACTE_ENGAGEMENT,
+        })
+      ).rejects.toThrowError(/Droits insuffisants|permissions nécessaires/i);
+    });
+
+    test("un editeur de la collectivite ne peut pas reclasser l'objet d'un document", async () => {
+      const { caller, preuve } = await createCandidaturePreuve();
+
+      await expect(
+        caller.collectivites.documents.updatePreuve({
+          preuveId: preuve.id,
+          preuveType: 'labellisation',
+          objet: ObjetPreuveEnum.ACTE_ENGAGEMENT,
+        })
+      ).rejects.toThrowError(/Droits insuffisants|permissions nécessaires/i);
+    });
+
+    test("le reclassement par un tiers preserve le deposant d'origine", async () => {
+      const { preuve } = await createCandidaturePreuve();
+
+      const [preuveBeforeReclassement] = await db.db
+        .select({ modifiedBy: preuveLabellisationTable.modifiedBy })
+        .from(preuveLabellisationTable)
+        .where(eq(preuveLabellisationTable.id, preuve.id));
+      expect(preuveBeforeReclassement.modifiedBy).toBe(editorUser.id);
+
+      const superAdminResult = await addTestUser(db);
+      const superAdminUser = getAuthUserFromUserCredentials(
+        superAdminResult.user
+      );
+      const superAdminCaller = router.createCaller({ user: superAdminUser });
+      const { cleanup } = await addAndEnableUserSuperAdminMode({
+        app,
+        caller: superAdminCaller,
+        userId: superAdminUser.id,
+      });
+      onTestFinished(cleanup);
+
+      await superAdminCaller.collectivites.documents.updatePreuve({
+        preuveId: preuve.id,
+        preuveType: 'labellisation',
+        objet: ObjetPreuveEnum.ACTE_ENGAGEMENT,
+      });
+
+      const [preuveAfterReclassement] = await db.db
+        .select({ modifiedBy: preuveLabellisationTable.modifiedBy })
+        .from(preuveLabellisationTable)
+        .where(eq(preuveLabellisationTable.id, preuve.id));
+      expect(preuveAfterReclassement.modifiedBy).toBe(
+        preuveBeforeReclassement.modifiedBy
+      );
     });
   });
 });

--- a/apps/backend/src/collectivites/documents/edit-preuve-document/edit-preuve-document.service.ts
+++ b/apps/backend/src/collectivites/documents/edit-preuve-document/edit-preuve-document.service.ts
@@ -9,7 +9,10 @@ import {
   getReferentielIdFromActionId,
 } from '@tet/domain/referentiels';
 import { PermissionOperationEnum, ResourceType } from '@tet/domain/users';
-import { EditPreuveDocumentError } from './edit-preuve-document.errors';
+import {
+  EditPreuveDocumentError,
+  EditPreuveDocumentErrorEnum,
+} from './edit-preuve-document.errors';
 import {
   RemovePreuveInput,
   UpdatePreuveInput,
@@ -58,7 +61,7 @@ export class EditPreuveDocumentService {
     input: UpdatePreuveInput,
     user: AuthenticatedUser
   ): Promise<Result<PreuveBase, EditPreuveDocumentError>> {
-    const { preuveId, preuveType, lien, commentaire } = input;
+    const { preuveId, preuveType, lien, commentaire, objet } = input;
 
     const preuve = await this.editPreuveDocumentRepository.findById(
       preuveType,
@@ -88,19 +91,35 @@ export class EditPreuveDocumentService {
       return failure(modeError);
     }
 
-    if (!(await this.canModifyPreuve(preuveType, preuveId))) {
-      return failure('LABELLISATION_IN_PROGRESS');
+    if (objet !== undefined) {
+      const objetPermissionResult = await this.permissionService.isAllowed(
+        user,
+        'collectivites.documents.mutate_objet',
+        ResourceType.COLLECTIVITE,
+        { collectiviteId: preuve.collectiviteId }
+      );
+      if (!objetPermissionResult.success) {
+        return failure(CommonErrorEnum.UNAUTHORIZED);
+      }
+    }
+
+    const isEditingLienOrCommentaire =
+      lien !== undefined || commentaire !== undefined;
+    if (isEditingLienOrCommentaire) {
+      const isPreuveEditable = await this.canModifyPreuve(preuveType, preuveId);
+      if (!isPreuveEditable) {
+        return failure(EditPreuveDocumentErrorEnum.LABELLISATION_IN_PROGRESS);
+      }
     }
 
     if (preuve.fichierId != null && lien !== undefined) {
-      return failure('PREUVE_FICHIER');
+      return failure(EditPreuveDocumentErrorEnum.PREUVE_FICHIER);
     }
 
     return this.editPreuveDocumentRepository.updateById(
-      preuveType,
       preuveId,
       user.id,
-      { lien, commentaire }
+      input
     );
   }
 
@@ -139,7 +158,7 @@ export class EditPreuveDocumentService {
     }
 
     if (!(await this.canModifyPreuve(preuveType, preuveId))) {
-      return failure('LABELLISATION_IN_PROGRESS');
+      return failure(EditPreuveDocumentErrorEnum.LABELLISATION_IN_PROGRESS);
     }
 
     return this.editPreuveDocumentRepository.deleteById(preuveType, preuveId);

--- a/packages/domain/src/users/authorizations/permission-operation.enum.schema.ts
+++ b/packages/domain/src/users/authorizations/permission-operation.enum.schema.ts
@@ -20,6 +20,7 @@ export const PermissionOperations = [
   'collectivites.documents.read',
   'collectivites.documents.read_confidentiel',
   'collectivites.documents.mutate',
+  'collectivites.documents.mutate_objet',
 
   // Référentiels
   'referentiels.read',

--- a/packages/domain/src/users/authorizations/permission.models.ts
+++ b/packages/domain/src/users/authorizations/permission.models.ts
@@ -69,6 +69,7 @@ export const permissionsByRole: Record<UserRole, PermissionOperation[]> = {
   [PlatformRole.SUPER_ADMIN]: [
     ...collectiviteAdminPermissions,
 
+    'collectivites.documents.mutate_objet',
     'collectivites.mutate',
     'plans.fiches.import',
     'utils.banner.mutate',


### PR DESCRIPTION
## Ce que la PR livre

`collectivites.documents.updatePreuve` accepte `objet` sur les documents de labellisation, ce qui permet de reclasser une pièce en `acte_engagement`, en `candidature`, ou de la déclasser vers `null`.

La collectivité 2898 en production porte 8 pièces dont l'`objet` est nul, déposées avant l'ajout de la colonne. Son audit étant validé, la garde métier interdit tout nouveau dépôt, et le critère « Documents de candidature » reste orange sans recours. Cette API donne le recours.

Ce qui est réservé au super-admin, c'est le **reclassement d'un document existant**. Poser l'`objet` au dépôt reste ouvert : `createLabellisationPreuve` accepte le champ et n'exige que `referentiels.mutate`.

## Contrat d'entrée

`updatePreuveInputSchema` est une union discriminée sur `preuveType`. La branche `'labellisation'` porte `objet` ; l'autre le déclare `z.optional(z.undefined())`, ce qui le **rejette** au lieu de le laisser stripper par zod.

L'exclusion est construite depuis la source d'énumération, sans liste dupliquée ni cast :

```ts
preuveType: z.enum(preuveTypeEnumValues).exclude(['labellisation'])
```

Ajouter une valeur à `preuveTypeEnumValues` la fait tomber automatiquement dans la branche non-labellisation ; retirer ou renommer `'labellisation'` casse la compilation.

La déclaration explicite sur les deux branches compte : l'`excess property check` de TypeScript, face à une union, autorise toute clé présente dans au moins un membre dès que le discriminant est une variable et non un littéral — la forme des deux appelants existants (`useEditPreuve.ts`, `preuveType: preuve.preuve_type`). Sans elle, `{ preuveType, commentaire, objet }` sur un `rapport` compilait, `objet` était silencieusement supprimé, la garde `mutate_objet` n'était jamais évaluée et l'appel répondait 200 sans avoir reclassé.

Aucun narrowing d'exécution n'est nécessaire en aval : `objet` est déclaré sur les deux branches, donc le service le déstructure directement, et `PreuveDocumentPatch` porte le discriminant jusqu'au repository, dont le branchement sur la table est un narrowing typé.

```ts
export type PreuveDocumentPatch = {
  lien?: { url: string; titre: string };
  commentaire?: string;
} & (
  | { preuveType: 'labellisation'; objet?: ObjetPreuve | null }
  | { preuveType: Exclude<PreuveType, 'labellisation'> }
);
```

## Autorisations

Deux règles indépendantes.

`lien` et `commentaire` restent régis par la garde d'audit existante : un document de candidature reste verrouillé une fois l'audit validé.

`objet` est régi par `collectivites.documents.mutate_objet`, nouvelle opération accordée au seul `SUPER_ADMIN`, et **ignore** cette garde. C'est ce qui permet de reclasser une pièce sur un cycle clos.

Un membre de la collectivité, y compris admin, passe la garde d'écriture générale `collectivites.documents.mutate` puis se voit refuser `objet`.

Les deux règles ne se contaminent pas : un reclassement accompagné d'un `commentaire` retombe sous le verrou de l'audit et la mutation entière est rejetée, `objet` compris.

## Paternité du dépôt

Un reclassement ne touche pas `modified_by`. La colonne ne suit que les changements de `lien` ou de `commentaire`, donc un document reste attribué à celui qui l'a déposé après passage du support.

Le trigger `update_modified_by` ne protège pas ce cas : il fait `COALESCE(auth.uid(), new.modified_by)`, et `auth.uid()` est nul côté backend, qui se connecte avec le rôle propriétaire. La garantie est portée par le repository et verrouillée par un test.

**Limite connue** : le trigger `modified_at` est inconditionnel, et la vue `public.preuve` expose `modified_at` sous `created_at`. Un reclassement décale donc la date de dépôt affichée sur la carte, sans changer l'auteur affiché, et l'acteur du reclassement n'est tracé nulle part. Corriger cela demande de toucher au trigger ou à la dérivation de `created_at` — hors périmètre.

## Couverture

Six tests e2e ajoutés à `edit-preuve-document.router.e2e-spec.ts`, chacun tenant une assertion que les autres ne couvrent pas :

| test | ce qu'il fige |
|---|---|
| un super-admin reclasse sur un audit validé | l'`objet` est écrit malgré le verrou |
| un super-admin déclasse vers `null` | le `nullable` du contrat |
| un éditeur de la collectivité est refusé | le contrôle de `mutate_objet` |
| un reclassement par un tiers | `modified_by` reste sur le déposant |
| un `objet` sur un type qui n'en porte pas | le rejet, et non le strip silencieux |
| un reclassement accompagné d'un commentaire | la garde d'audit se réapplique |

Les trois tests de non-régression existants restent verts : suppression et modification d'un document de candidature refusées après validation.

## Périmètre

Aucune UI n'émet le champ. Le support peut s'en servir par tRPC dès le déploiement ; l'écran de reclassement est la PR suivante du plan.

L'ouverture au référent est écartée. Les autres chemins d'écriture de preuves ne sont pas touchés.

Trois codes d'erreur du service passent désormais par `EditPreuveDocumentErrorEnum` au lieu de littéraux — `LABELLISATION_IN_PROGRESS` ×2, `PREUVE_FICHIER`. Deux d'entre eux sont hors du périmètre de la feature : le fichier écrivait déjà `CommonErrorEnum.UNAUTHORIZED` à côté, et laisser une chaîne en dur voisine de deux corrigées aurait été pire. Valeurs identiques, aucun changement de comportement.

## Points ouverts

- **`SUPER_ADMIN` est self-service** : `toggleSuperAdminRole` s'applique à soi-même et n'exige que `is_support`. Tout membre du support s'accorde donc `mutate_objet` en un appel. C'est le modèle existant, que cette PR n'élargit pas, mais « super-admin » veut dire ici « l'équipe support ».
- **`preuveBaseSchema` ne contient pas `objet`**, donc la réponse de la mutation ne renvoie pas la valeur écrite. Les tests relisent la base.
- **`permissionsByRole` n'a pas de test de snapshot** : rien n'attraperait un spread accidentel de la liste `SUPER_ADMIN` dans un autre rôle.
- **Le `WHERE` des écritures ne porte que `id`**, sans `collectiviteId`. Non exploitable — l'autorisation lit la collectivité sur la ligne en base et le payload ne porte aucun identifiant parent — mais la règle IDOR de `apps/backend/CLAUDE.md` demande les deux. Préexistant sur toutes les branches.

## Vérifications

`edit-preuve-document` e2e 15/15, typecheck backend et `nx run app:typecheck` propres, lint propre.

`depot-permissions.service.e2e-spec` échoue sur un `CHECK` de `demarche.status` qui refuse `'instruit'` — vérifié identique sans cette branche, c'est une dérive du schéma local.

## Plan

PR 3 de la stack, plan `doc/plans/2026-08-26-001-feat-reclassement-objet-document-labellisation-plan.md`. Basée sur #4882 pour éviter les conflits sur les fichiers de documents. Suit : l'UI de reclassement dans l'onglet Documents.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Ajout de la possibilité de renseigner, modifier, reclasser ou supprimer l’objet associé aux preuves de labellisation.
  * Les contrôles d’accès garantissent que seuls les profils autorisés peuvent modifier cet objet.
  * Les reclassements peuvent verrouiller l’audit lorsqu’un commentaire est ajouté.
* **Améliorations**
  * Renforcement de la validation des informations selon le type de preuve.
  * Préservation du déposant d’origine lors des modifications effectuées par un tiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->