### PR TITLE
fix(referentiels): refuse un fichier d'une autre collectivité au dépôt d'une preuve

### DIFF
--- a/apps/backend/src/referentiels/labellisations/create-preuve/create-labellisation-preuve.errors.ts
+++ b/apps/backend/src/referentiels/labellisations/create-preuve/create-labellisation-preuve.errors.ts
@@ -10,6 +10,7 @@ import {
 const specificErrors = [
   'UNAUTHORIZED',
   'DEMANDE_NOT_FOUND',
+  'FICHIER_NOT_FOUND',
   'LABELLISATION_IN_PROGRESS',
   'DATABASE_ERROR',
   ...referentielModeGuardSpecificErrors,
@@ -28,6 +29,11 @@ export const createLabellisationPreuveErrorConfig: TrpcErrorHandlerConfig<Specif
         code: 'BAD_REQUEST',
         message:
           'Aucune demande de labellisation trouvée pour cette collectivité et ce référentiel.',
+      },
+      FICHIER_NOT_FOUND: {
+        code: 'BAD_REQUEST',
+        message:
+          'Aucun fichier trouvé dans la bibliothèque de la collectivité de cette demande.',
       },
       LABELLISATION_IN_PROGRESS: {
         code: 'BAD_REQUEST',

--- a/apps/backend/src/referentiels/labellisations/create-preuve/create-preuve.router.e2e-spec.ts
+++ b/apps/backend/src/referentiels/labellisations/create-preuve/create-preuve.router.e2e-spec.ts
@@ -1,14 +1,20 @@
 import { INestApplication } from '@nestjs/common';
-import { addTestCollectiviteAndUsers } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import {
+  addTestCollectivite,
+  addTestCollectiviteAndUsers,
+} from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
 import { uploadCreateTestDocument } from '@tet/backend/collectivites/documents/documents.test-fixture';
+import { bibliothequeFichierTable } from '@tet/backend/collectivites/documents/models/bibliotheque-fichier.table';
 import { getAuthUserFromUserCredentials, signInWith } from '@tet/backend/test';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { Collectivite } from '@tet/domain/collectivites';
 import { ObjetPreuveEnum, ReferentielIdEnum } from '@tet/domain/referentiels';
 import { CollectiviteRole } from '@tet/domain/users';
 import { inferProcedureInput } from '@trpc/server';
+import { randomUUID } from 'crypto';
 import { eq } from 'drizzle-orm';
 import request from 'supertest';
+import { onTestFinished } from 'vitest';
 import {
   getTestApp,
   getTestDatabase,
@@ -78,7 +84,6 @@ describe('CreatePreuveRouter', () => {
       fileName: 'test-preuve.pdf',
     });
     createdDocumentId = createdDocument.id;
-
   });
 
   afterAll(async () => {
@@ -197,6 +202,67 @@ describe('CreatePreuveRouter', () => {
       commentaire: '',
       modifiedBy: readerUser.id,
     });
+  });
+
+  const addFichier = async (collectiviteId: number): Promise<number> => {
+    const [fichier] = await databaseService.db
+      .insert(bibliothequeFichierTable)
+      .values({
+        collectiviteId,
+        hash: randomUUID(),
+        filename: 'test-preuve.pdf',
+        confidentiel: false,
+      })
+      .returning();
+
+    return fichier.id;
+  };
+
+  const addFichierForAnotherCollectivite = async (): Promise<number> => {
+    const { collectivite: autreCollectivite, cleanup } =
+      await addTestCollectivite(databaseService);
+    onTestFinished(cleanup);
+
+    return addFichier(autreCollectivite.id);
+  };
+
+  const getDeletedFichierId = async (): Promise<number> => {
+    const fichierId = await addFichier(collectivite.id);
+    await databaseService.db
+      .delete(bibliothequeFichierTable)
+      .where(eq(bibliothequeFichierTable.id, fichierId));
+
+    return fichierId;
+  };
+
+  test('refuse un fichier appartenant à une autre collectivité que celle de la demande', async () => {
+    const caller = router.createCaller({ user: editorUser });
+    const { input } = await createValidInput();
+    const fichierId = await addFichierForAnotherCollectivite();
+
+    await expect(
+      caller.referentiels.labellisations.createLabellisationPreuve({
+        ...input,
+        fichierId,
+      })
+    ).rejects.toThrowError(
+      'Aucun fichier trouvé dans la bibliothèque de la collectivité de cette demande.'
+    );
+  });
+
+  test("refuse un fichier qui n'existe pas", async () => {
+    const caller = router.createCaller({ user: editorUser });
+    const { input } = await createValidInput();
+    const fichierId = await getDeletedFichierId();
+
+    await expect(
+      caller.referentiels.labellisations.createLabellisationPreuve({
+        ...input,
+        fichierId,
+      })
+    ).rejects.toThrowError(
+      'Aucun fichier trouvé dans la bibliothèque de la collectivité de cette demande.'
+    );
   });
 
   const validerAudit = async (auditId: number): Promise<void> => {

--- a/apps/backend/src/referentiels/labellisations/create-preuve/create-preuve.service.ts
+++ b/apps/backend/src/referentiels/labellisations/create-preuve/create-preuve.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { bibliothequeFichierTable } from '@tet/backend/collectivites/documents/models/bibliotheque-fichier.table';
 import { preuveLabellisationTable } from '@tet/backend/collectivites/documents/models/preuve-labellisation.table';
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
@@ -8,6 +9,7 @@ import { PreuveLabellisation } from '@tet/domain/collectivites';
 import { canModifyCandidatureDocuments } from '@tet/domain/referentiels';
 import { PermissionOperationEnum, ResourceType } from '@tet/domain/users';
 import { getErrorMessage } from '@tet/domain/utils';
+import { and, eq } from 'drizzle-orm';
 import { GetLabellisationService } from '../get-labellisation.service';
 import {
   CreateLabellisationPreuveError,
@@ -82,6 +84,21 @@ export class CreatePreuveService {
     }
 
     try {
+      const matchingFichiers = await this.databaseService.db
+        .select({ id: bibliothequeFichierTable.id })
+        .from(bibliothequeFichierTable)
+        .where(
+          and(
+            eq(bibliothequeFichierTable.id, fichierId),
+            eq(bibliothequeFichierTable.collectiviteId, demande.collectiviteId)
+          )
+        )
+        .limit(1);
+
+      if (matchingFichiers.length === 0) {
+        return failure(CreateLabellisationPreuveErrorEnum.FICHIER_NOT_FOUND);
+      }
+
       const preuve = {
         collectiviteId: demande.collectiviteId,
         demandeId: demandeId,


### PR DESCRIPTION
## Plan

`doc/plans/2026-08-26-001-feat-reclassement-objet-document-labellisation-plan.md`, § **PR 8**. Le plan est encore un artefact local, non commité sur `main`.

## Comportement livré

Le dépôt d'une preuve de labellisation refuse désormais un `fichierId` qui n'appartient pas à la collectivité de la demande.

Avant : `createLabellisationPreuve` déstructurait `fichierId` de l'input et l'insérait tel quel. Le contrôle de permission portait sur `demande.collectiviteId`, jamais sur le propriétaire du fichier. `preuve_base.fichier_id` ne porte aucune clé étrangère et le schéma d'entrée n'exigeait qu'un entier positif — or les `id` de `bibliotheque_fichier` sont des `serial` énumérables. Un membre en édition sur la collectivité A pouvait donc rattacher à une demande de A un fichier de la collectivité B (IDOR).

Après : le service vérifie l'appartenance du fichier avant l'insertion et rend `FICHIER_NOT_FOUND` (`BAD_REQUEST`) sinon. Le même contrôle couvre un `fichierId` inexistant.

## Surface de review

**Attention humaine :**
- `create-preuve.service.ts` — la sonde d'appartenance, ~15 lignes.
- `create-labellisation-preuve.errors.ts` — la nouvelle entrée `FICHIER_NOT_FOUND`.

**Mécanique :**
- `create-preuve.router.e2e-spec.ts` — deux tests et trois helpers de fixture.

## Test rouge

Commit `403e199a09` — les deux tests y échouent, la mutation résolvant au lieu de rejeter :

```
refuse un fichier appartenant à une autre collectivité → promise resolved "{ id: 2260, …}"
refuse un fichier qui n'existe pas                     → promise resolved "{ id: 2260, …}"
```

Le fix vient au commit suivant, `354a1c918c`, et fait passer la suite à 9/9.

## Hypothèses prises

- **La sonde est placée dans le `try` existant**, pas avant : un échec SQL retombe ainsi sur `DATABASE_ERROR` plutôt que de remonter en `throw` hors du `Result`.
- **Drizzle direct dans le service**, sans repository dédié. C'est la forme de `UpdateDocumentService.updateDocument`, qui fait exactement ce contrôle d'appartenance dans le fichier voisin, et le scope du plan ne prévoit pas de nouvelle couche.
- **`FICHIER_NOT_FOUND` couvre les deux cas** (fichier d'une autre collectivité, fichier inexistant) : ne pas les distinguer évite de rendre l'énumération des `id` observable depuis la réponse.

## Recherche anti-duplication

Cherché un helper d'appartenance fichier ↔ collectivité avant d'en écrire un : `document.service.ts`, `update-document/update-document.service.ts`, `store-document/store-document.service.ts`, `demarches/shared/demarche-documents.repository.ts`, `hide-confidentiel.utils.ts`. Aucun réutilisable — ils résolvent tous un fichier par `hash`, jamais par `id`. J'ai repris la forme du plus proche (`UpdateDocumentService`) plutôt que d'inventer une variante.

## Anti-scope

- Pas de contrainte en base sur `fichier_id` : ce serait une migration, donc une autre nature de PR, et le champ est volontairement sans FK.
- Les autres chemins d'écriture de preuves (`store-document`, `edit-preuve-document`) posent la même question et restent à auditer séparément — déjà noté comme anti-scope dans le plan.

## Zones de confiance basse

- L'`objet` de la preuve et le mode référentiel ne sont pas touchés ; si la PR 3 du plan (reclassement par le super-admin) atterrit d'abord, vérifier qu'elle ne réintroduit pas un chemin d'écriture qui contourne ce contrôle.

## Items ajoutés à DISCOVERED

Aucun.

## Vérifications

- `nx test backend create-preuve.router.e2e-spec.ts` → 9/9 (relancé `--skip-nx-cache`)
- `nx run backend:typecheck` → vert. Point sensible : élargir le type partagé `CreateLabellisationPreuveError` avait déjà cassé un consommateur par le passé ; ici aucun usage hors du dossier `create-preuve/`.
- `nx run backend:lint` → 0 erreur (warnings préexistants inchangés)

https://claude.ai/code/session_01JJ2DTMAhGVeC9AT6dqDZc2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Améliorations**
  * La création d’une preuve vérifie désormais que le fichier existe dans la bibliothèque de la collectivité concernée.
  * La création est refusée si le fichier appartient à une autre collectivité ou n’existe plus.
  * Un message d’erreur explicite est affiché lorsqu’aucun fichier correspondant n’est trouvé.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->