### PR TITLE
feat(referentiels): permet de reclasser un document depuis l'onglet Documents

### DIFF
--- a/apps/app/src/labels/referentiels.labels.ts
+++ b/apps/app/src/labels/referentiels.labels.ts
@@ -1,6 +1,15 @@
 import { plural } from '@tet/ui/labels/plural';
 
 export const referentielsLabels = {
+  reclasserDocument: 'Reclasser le document',
+  reclasserDocumentTitre: "Reclasser l'objet du document",
+  reclasserDocumentLegende:
+    'À quel attendu de la candidature ce document répond-il ?',
+  reclasserDocumentActeEngagement: "Acte d'engagement",
+  reclasserDocumentCandidature: 'Document de candidature',
+  reclasserDocumentNonClasse: 'Non classé',
+  reclasserDocumentSucces: "L'objet du document a été modifié",
+  reclasserDocumentEchec: "Échec de la modification de l'objet du document",
   /** Noms */
   referentielCae: 'Climat Air Énergie',
   referentielEci: 'Économie Circulaire',

--- a/apps/app/src/plans/fiches/show-fiche/content/documents/documents.view.tsx
+++ b/apps/app/src/plans/fiches/show-fiche/content/documents/documents.view.tsx
@@ -1,4 +1,5 @@
 import { appLabels } from '@/app/labels/catalog';
+import { MUTATION_ACTIONS } from '@/app/referentiels/preuves/Bibliotheque/carte-document-action';
 import CarteDocument from '@/app/referentiels/preuves/Bibliotheque/CarteDocument';
 import { useDuplicatedDocumentState } from '@/app/referentiels/preuves/duplicated-document-state.utils';
 import SpinnerLoader from '@/app/ui/shared/SpinnerLoader';
@@ -61,11 +62,11 @@ export const DocumentsView = () => {
           {(doc) => (
             <CarteDocument
               key={doc.id}
-              isReadonly={isReadonly}
               document={doc}
               duplicatedDocumentInformation={getDuplicatedDocumentInformation(
                 doc
               )}
+              allowedActions={isReadonly ? [] : MUTATION_ACTIONS}
             />
           )}
         </ContentLayout.Content>

--- a/apps/app/src/referentiels/documents/PreuveLabellisation.tsx
+++ b/apps/app/src/referentiels/documents/PreuveLabellisation.tsx
@@ -2,6 +2,10 @@ import { appLabels } from '@/app/labels/catalog';
 import { TAuditEnCours } from '@/app/referentiels/audits/types';
 import { canUserUpdateAuditReport } from '@/app/referentiels/preuves/Bibliotheque/canUserUpdateAuditReport';
 import CarteDocument from '@/app/referentiels/preuves/Bibliotheque/CarteDocument';
+import {
+  CarteDocumentAction,
+  MUTATION_ACTIONS,
+} from '@/app/referentiels/preuves/Bibliotheque/carte-document-action';
 import { TPreuveAuditEtLabellisation } from '@/app/referentiels/preuves/Bibliotheque/types';
 import { useCurrentCollectivite } from '@tet/api/collectivites';
 import { useUser } from '@tet/api/users';
@@ -88,11 +92,14 @@ const DocAuditOuLabellisation = ({
     audit: info.audit,
     canMutateReferentiels,
   });
+  const allowedActions: CarteDocumentAction[] = canUpdate
+    ? [...MUTATION_ACTIONS, 'replace']
+    : [];
 
   return (
     <CarteDocument
       document={preuve}
-      isReadonly={!canUpdate}
+      allowedActions={allowedActions}
       classComment="pb-0 mb-2"
     />
   );

--- a/apps/app/src/referentiels/documents/PreuveLabellisation.tsx
+++ b/apps/app/src/referentiels/documents/PreuveLabellisation.tsx
@@ -7,6 +7,7 @@ import {
   MUTATION_ACTIONS,
 } from '@/app/referentiels/preuves/Bibliotheque/carte-document-action';
 import { TPreuveAuditEtLabellisation } from '@/app/referentiels/preuves/Bibliotheque/types';
+import { useSuperAdminMode } from '@/app/users/authorizations/super-admin-mode/super-admin-mode.provider';
 import { useCurrentCollectivite } from '@tet/api/collectivites';
 import { useUser } from '@tet/api/users';
 import {
@@ -92,9 +93,12 @@ const DocAuditOuLabellisation = ({
     audit: info.audit,
     canMutateReferentiels,
   });
-  const allowedActions: CarteDocumentAction[] = canUpdate
-    ? [...MUTATION_ACTIONS, 'replace']
-    : [];
+  const { isSuperAdminRoleEnabled } = useSuperAdminMode();
+
+  const allowedActions: CarteDocumentAction[] = [
+    ...(canUpdate ? [...MUTATION_ACTIONS, 'replace' as const] : []),
+    ...(isSuperAdminRoleEnabled ? ['reclassify' as const] : []),
+  ];
 
   return (
     <CarteDocument

--- a/apps/app/src/referentiels/documents/groupeParDemande.test.ts
+++ b/apps/app/src/referentiels/documents/groupeParDemande.test.ts
@@ -39,6 +39,7 @@ describe('groupeParDemande', () => {
 const preuves_demande1: TPreuveAuditEtLabellisation[] = [
   {
     preuve_type: 'labellisation',
+    objet: null,
     id: 8,
     collectivite_id: 1,
     fichier: {
@@ -73,6 +74,7 @@ const preuves_demande1: TPreuveAuditEtLabellisation[] = [
   },
   {
     preuve_type: 'labellisation',
+    objet: null,
     id: 7,
     collectivite_id: 1,
     fichier: {
@@ -153,6 +155,7 @@ const preuves_demande1: TPreuveAuditEtLabellisation[] = [
 const preuves_demande2: TPreuveAuditEtLabellisation[] = [
   {
     preuve_type: 'labellisation',
+    objet: null,
     id: 9,
     collectivite_id: 1,
     fichier: {

--- a/apps/app/src/referentiels/documents/reclassify-document/data/use-reclassify-document.ts
+++ b/apps/app/src/referentiels/documents/reclassify-document/data/use-reclassify-document.ts
@@ -1,0 +1,28 @@
+import { appLabels } from '@/app/labels/catalog';
+import { invalidateQueries } from '@/app/referentiels/preuves/useAddPreuves';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useTRPC } from '@tet/api';
+
+export const useReclassifyDocument = (collectiviteId: number) => {
+  const queryClient = useQueryClient();
+  const trpc = useTRPC();
+
+  return useMutation(
+    trpc.collectivites.documents.updatePreuve.mutationOptions({
+      meta: {
+        success: appLabels.reclasserDocumentSucces,
+        error: appLabels.reclasserDocumentEchec,
+      },
+      onSuccess: () => {
+        invalidateQueries(queryClient, collectiviteId, {
+          invalidateParcours: true,
+          trpc,
+        });
+        queryClient.invalidateQueries({
+          queryKey:
+            trpc.referentiels.labellisations.listPreuvesLabellisation.pathKey(),
+        });
+      },
+    })
+  );
+};

--- a/apps/app/src/referentiels/documents/reclassify-document/reclassify-document.field.spec.tsx
+++ b/apps/app/src/referentiels/documents/reclassify-document/reclassify-document.field.spec.tsx
@@ -1,0 +1,56 @@
+import { ObjetPreuveEnum } from '@tet/domain/referentiels';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ReclassifyDocumentField } from './reclassify-document.field';
+
+const ACTE_ENGAGEMENT_LABEL = "Acte d'engagement";
+const CANDIDATURE_LABEL = 'Document de candidature';
+const NON_CLASSE_LABEL = 'Non classé';
+
+const getRadioButtonByName = (name: string): HTMLInputElement => {
+  const element = screen.getByRole('radio', { name });
+  if (!(element instanceof HTMLInputElement)) {
+    throw new Error(`unexpected radio for "${name}"`);
+  }
+  return element;
+};
+
+const renderField = (
+  value: Parameters<typeof ReclassifyDocumentField>[0]['value']
+): { onChange: ReturnType<typeof vi.fn> } => {
+  const onChange = vi.fn();
+  render(<ReclassifyDocumentField value={value} onChange={onChange} />);
+  return { onChange };
+};
+
+describe('ReclassifyDocumentField', () => {
+  it("coche le choix correspondant à l'objet courant du document", () => {
+    renderField(ObjetPreuveEnum.CANDIDATURE);
+
+    expect(getRadioButtonByName(CANDIDATURE_LABEL).checked).toBe(true);
+    expect(getRadioButtonByName(ACTE_ENGAGEMENT_LABEL).checked).toBe(false);
+    expect(getRadioButtonByName(NON_CLASSE_LABEL).checked).toBe(false);
+  });
+
+  it('coche « non classé » pour un document sans objet', () => {
+    renderField(null);
+
+    expect(getRadioButtonByName(NON_CLASSE_LABEL).checked).toBe(true);
+  });
+
+  it("remonte l'objet sélectionné", () => {
+    const { onChange } = renderField(ObjetPreuveEnum.CANDIDATURE);
+
+    fireEvent.click(getRadioButtonByName(ACTE_ENGAGEMENT_LABEL));
+
+    expect(onChange).toHaveBeenCalledWith(ObjetPreuveEnum.ACTE_ENGAGEMENT);
+  });
+
+  it("remonte une absence d'objet quand « non classé » est choisi", () => {
+    const { onChange } = renderField(ObjetPreuveEnum.CANDIDATURE);
+
+    fireEvent.click(getRadioButtonByName(NON_CLASSE_LABEL));
+
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+});

--- a/apps/app/src/referentiels/documents/reclassify-document/reclassify-document.field.tsx
+++ b/apps/app/src/referentiels/documents/reclassify-document/reclassify-document.field.tsx
@@ -1,0 +1,43 @@
+import { appLabels } from '@/app/labels/catalog';
+import { ObjetPreuve, ObjetPreuveEnum } from '@tet/domain/referentiels';
+import { RadioButton } from '@tet/ui';
+import { ReactNode } from 'react';
+
+const selectableObjets = [
+  ObjetPreuveEnum.ACTE_ENGAGEMENT,
+  ObjetPreuveEnum.CANDIDATURE,
+  null,
+] as const;
+
+const objetLabels: Record<ObjetPreuve | 'null', string> = {
+  [ObjetPreuveEnum.ACTE_ENGAGEMENT]: appLabels.reclasserDocumentActeEngagement,
+  [ObjetPreuveEnum.CANDIDATURE]: appLabels.reclasserDocumentCandidature,
+  null: appLabels.reclasserDocumentNonClasse,
+};
+
+const toLabelKey = (objet: ObjetPreuve | null): ObjetPreuve | 'null' =>
+  objet ?? 'null';
+
+export const ReclassifyDocumentField = ({
+  value,
+  onChange,
+}: {
+  value: ObjetPreuve | null;
+  onChange: (objet: ObjetPreuve | null) => void;
+}): ReactNode => (
+  <fieldset className="flex flex-col gap-4 m-0 p-0 border-0">
+    <legend className="mb-2 p-0 font-medium text-primary-9">
+      {appLabels.reclasserDocumentLegende}
+    </legend>
+    {selectableObjets.map((objet) => (
+      <RadioButton
+        key={toLabelKey(objet)}
+        name="objet-document"
+        value={toLabelKey(objet)}
+        checked={value === objet}
+        onChange={() => onChange(objet)}
+        label={objetLabels[toLabelKey(objet)]}
+      />
+    ))}
+  </fieldset>
+);

--- a/apps/app/src/referentiels/documents/reclassify-document/reclassify-document.modal.tsx
+++ b/apps/app/src/referentiels/documents/reclassify-document/reclassify-document.modal.tsx
@@ -1,0 +1,53 @@
+import { appLabels } from '@/app/labels/catalog';
+import { ObjetPreuve } from '@tet/domain/referentiels';
+import { Modal, ModalFooterOKCancel } from '@tet/ui';
+import { ReactNode, useState } from 'react';
+import { useReclassifyDocument } from './data/use-reclassify-document';
+import { ReclassifyDocumentField } from './reclassify-document.field';
+
+type ReclassifyDocumentModalProps = {
+  preuveId: number;
+  collectiviteId: number;
+  objet: ObjetPreuve | null;
+  isOpen: boolean;
+  setIsOpen: (open: boolean) => void;
+};
+
+export const ReclassifyDocumentModal = ({
+  preuveId,
+  collectiviteId,
+  objet,
+  isOpen,
+  setIsOpen,
+}: ReclassifyDocumentModalProps): ReactNode => {
+  const [selectedObjet, setSelectedObjet] = useState(objet);
+  const { mutate: reclassifyDocument } = useReclassifyDocument(collectiviteId);
+
+  return (
+    <Modal
+      openState={{ isOpen, setIsOpen }}
+      title={appLabels.reclasserDocumentTitre}
+      render={() => (
+        <ReclassifyDocumentField
+          value={selectedObjet}
+          onChange={setSelectedObjet}
+        />
+      )}
+      renderFooter={({ close }) => (
+        <ModalFooterOKCancel
+          btnCancelProps={{ onClick: close }}
+          btnOKProps={{
+            onClick: () => {
+              reclassifyDocument({
+                preuveId,
+                preuveType: 'labellisation',
+                objet: selectedObjet,
+              });
+              close();
+            },
+          }}
+        />
+      )}
+    />
+  );
+};

--- a/apps/app/src/referentiels/preuves/Bibliotheque/CarteDocument.tsx
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/CarteDocument.tsx
@@ -1,17 +1,17 @@
 import { appLabels } from '@/app/labels/catalog';
 import { AddPreuveModal } from '@/app/referentiels/preuves/AddPreuveModal';
 import {
-    getTextFormattedDate,
-    getTruncatedText,
+  getTextFormattedDate,
+  getTruncatedText,
 } from '@/app/utils/formatUtils';
 import {
-    Button,
-    Card,
-    Icon,
-    Modal,
-    Notification,
-    Tooltip,
-    VisibleWhen,
+  Button,
+  Card,
+  Icon,
+  Modal,
+  Notification,
+  Tooltip,
+  VisibleWhen,
 } from '@tet/ui';
 import classNames from 'classnames';
 import { useState } from 'react';
@@ -22,6 +22,7 @@ import {
   isActionCarriedBy,
 } from './carte-document-action';
 import DocumentInput from './DocumentInput';
+import { ReclassifyDocumentModal } from '@/app/referentiels/documents/reclassify-document/reclassify-document.modal';
 import { DuplicatedDocumentAlert } from './duplicated-document.alert';
 import { EditerDocumentModal } from './EditerDocumentModal';
 import { EditerLienModal } from './EditerLienModal';
@@ -151,6 +152,9 @@ const CarteDocument = ({
               replace: isShown('replace')
                 ? () => setOpenAction('replace')
                 : undefined,
+              reclassify: isShown('reclassify')
+                ? () => setOpenAction('reclassify')
+                : undefined,
               delete: isShown('delete')
                 ? () => setOpenAction('delete')
                 : undefined,
@@ -244,6 +248,17 @@ const CarteDocument = ({
         </Card>
       </div>
 
+      {document.preuve_type === 'labellisation' && (
+        <VisibleWhen condition={openAction === 'reclassify'}>
+          <ReclassifyDocumentModal
+            preuveId={document.id}
+            collectiviteId={document.collectivite_id}
+            objet={document.objet}
+            isOpen={openAction === 'reclassify'}
+            setIsOpen={closeAction}
+          />
+        </VisibleWhen>
+      )}
       {openAction === 'delete' && (
         <AlerteSuppression
           isOpen={true}

--- a/apps/app/src/referentiels/preuves/Bibliotheque/CarteDocument.tsx
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/CarteDocument.tsx
@@ -4,7 +4,6 @@ import {
     getTextFormattedDate,
     getTruncatedText,
 } from '@/app/utils/formatUtils';
-import { useUser } from '@tet/api/users';
 import {
     Button,
     Card,
@@ -18,7 +17,10 @@ import classNames from 'classnames';
 import { useState } from 'react';
 import type { DuplicatedDocumentInformation } from '../duplicated-document-state.utils';
 import AlerteSuppression from './AlerteSuppression';
-import { canUserUpdateAuditReport } from './canUserUpdateAuditReport';
+import {
+  CarteDocumentAction,
+  isActionCarriedBy,
+} from './carte-document-action';
 import DocumentInput from './DocumentInput';
 import { DuplicatedDocumentAlert } from './duplicated-document.alert';
 import { EditerDocumentModal } from './EditerDocumentModal';
@@ -72,16 +74,16 @@ const ReplaceAuditReportModal = ({
 );
 
 type CarteDocumentProps = {
-  isReadonly: boolean;
   document: TPreuve;
+  allowedActions: readonly CarteDocumentAction[];
   displayIdentifier?: boolean;
   classComment?: string;
   duplicatedDocumentInformation?: DuplicatedDocumentInformation;
 };
 
 const CarteDocument = ({
-  isReadonly,
   document,
+  allowedActions,
   displayIdentifier,
   classComment,
   duplicatedDocumentInformation,
@@ -96,23 +98,25 @@ const CarteDocument = ({
     rapport,
   } = document;
   const dateVisite = rapport?.date;
-  const isAuditReport = document.preuve_type === 'audit';
   const replaceAuditReport = useReplaceAuditReportFile(
     document.collectivite_id
   );
-  const user = useUser();
-  const canShowReplace = canUserUpdateAuditReport(user, document);
+
+  const shownActions = allowedActions.filter((allowedAction) =>
+    isActionCarriedBy(allowedAction, document.preuve_type)
+  );
+  const isShown = (action: CarteDocumentAction) =>
+    shownActions.includes(action);
 
   const handlers = useEditPreuve(document);
   const { remove, editComment } = handlers;
 
-  const [openAction, setOpenAction] = useState<
-    'edit' | 'replace' | 'delete' | null
-  >(null);
+  const [openAction, setOpenAction] = useState<CarteDocumentAction | null>(
+    null
+  );
   const closeAction = () => setOpenAction(null);
   const [isFullCommentaire, setIsFullCommentaire] = useState(false);
   const isEditingComment = editComment.isEditing;
-  const hasAtLeastOneAction = !isReadonly || canShowReplace;
 
   const { truncatedText: truncatedCom, isTextTruncated: isComTruncated } =
     getTruncatedText(commentaire, 160);
@@ -135,20 +139,21 @@ const CarteDocument = ({
             </div>
           </Tooltip>
         )}
-        {hasAtLeastOneAction && !isEditingComment && (
+        {shownActions.length > 0 && !isEditingComment && (
           <MenuCarteDocument
             document={document}
             className="absolute top-4 right-4 invisible group-hover:visible"
             actions={{
-              edit: !isReadonly ? () => setOpenAction('edit') : undefined,
-              comment: !isReadonly ? () => editComment.enter() : undefined,
-              replace: canShowReplace
+              edit: isShown('edit') ? () => setOpenAction('edit') : undefined,
+              comment: isShown('comment')
+                ? () => editComment.enter()
+                : undefined,
+              replace: isShown('replace')
                 ? () => setOpenAction('replace')
                 : undefined,
-              delete:
-                !isReadonly && !isAuditReport
-                  ? () => setOpenAction('delete')
-                  : undefined,
+              delete: isShown('delete')
+                ? () => setOpenAction('delete')
+                : undefined,
             }}
           />
         )}
@@ -239,7 +244,7 @@ const CarteDocument = ({
         </Card>
       </div>
 
-      {openAction === 'delete' && !isReadonly && (
+      {openAction === 'delete' && (
         <AlerteSuppression
           isOpen={true}
           setIsOpen={closeAction}

--- a/apps/app/src/referentiels/preuves/Bibliotheque/MenuCarteDocument.tsx
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/MenuCarteDocument.tsx
@@ -44,10 +44,25 @@ const DeleteDocumentButton = ({ onDelete }: { onDelete: () => void }) => (
   <DeleteButton title={appLabels.supprimer} size="xs" onClick={onDelete} />
 );
 
+const ReclassifyDocumentButton = ({
+  onReclassify,
+}: {
+  onReclassify: () => void;
+}) => (
+  <Button
+    title={appLabels.reclasserDocument}
+    icon="price-tag-3-line"
+    variant="grey"
+    size="xs"
+    onClick={onReclassify}
+  />
+);
+
 export type CarteDocumentActions = {
   edit?: () => void;
   replace?: () => void;
   comment?: () => void;
+  reclassify?: () => void;
   delete?: () => void;
 };
 
@@ -68,6 +83,9 @@ const MenuCarteDocument = ({
     )}
     {actions.replace && <ReplaceFileButton onReplace={actions.replace} />}
     {actions.comment && <CommentButton onComment={actions.comment} />}
+    {actions.reclassify && (
+      <ReclassifyDocumentButton onReclassify={actions.reclassify} />
+    )}
     {actions.delete && <DeleteDocumentButton onDelete={actions.delete} />}
   </div>
 );

--- a/apps/app/src/referentiels/preuves/Bibliotheque/PreuveDoc.tsx
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/PreuveDoc.tsx
@@ -2,6 +2,7 @@ import { useOptionalReferentielId } from '@/app/referentiels/referentiel-context
 import { useCurrentCollectivite } from '@tet/api/collectivites';
 import type { DuplicatedDocumentInformation } from '../duplicated-document-state.utils';
 import CarteDocument from './CarteDocument';
+import { MUTATION_ACTIONS } from './carte-document-action';
 import { TPreuve } from './types';
 
 export type TPreuveDocProps = {
@@ -19,6 +20,7 @@ const PreuveDoc = (props: TPreuveDocProps) => {
   const canMutate = referentielId
     ? hasReferentielPermission('referentiels.mutate', referentielId)
     : hasCollectivitePermission('referentiels.mutate');
+  const canEdit = canMutate && !props.readonly;
 
   return (
     <CarteDocument
@@ -26,7 +28,7 @@ const PreuveDoc = (props: TPreuveDocProps) => {
       displayIdentifier={props.displayIdentifier}
       duplicatedDocumentInformation={props.duplicatedDocumentInformation}
       document={props.preuve}
-      isReadonly={!canMutate || props.readonly || false}
+      allowedActions={canEdit ? MUTATION_ACTIONS : []}
     />
   );
 };

--- a/apps/app/src/referentiels/preuves/Bibliotheque/carte-document-action.spec.ts
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/carte-document-action.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CarteDocumentAction,
+  isActionCarriedBy,
+} from './carte-document-action';
+import { TPreuveType } from './types';
+
+const PREUVE_TYPES: readonly TPreuveType[] = [
+  'reglementaire',
+  'complementaire',
+  'annexe',
+  'labellisation',
+  'audit',
+  'rapport',
+];
+
+const preuveTypesCarrying = (action: CarteDocumentAction): TPreuveType[] =>
+  PREUVE_TYPES.filter((preuveType) => isActionCarriedBy(action, preuveType));
+
+describe('isActionCarriedBy', () => {
+  it("seul un rapport d'audit porte le remplacement de fichier", () => {
+    expect(preuveTypesCarrying('replace')).toEqual(['audit']);
+  });
+
+  it("tout document sauf un rapport d'audit porte la suppression", () => {
+    expect(preuveTypesCarrying('delete')).toEqual([
+      'reglementaire',
+      'complementaire',
+      'annexe',
+      'labellisation',
+      'rapport',
+    ]);
+  });
+
+  it("l'edition et le commentaire ne dependent pas du type de document", () => {
+    expect(preuveTypesCarrying('edit')).toEqual(PREUVE_TYPES);
+    expect(preuveTypesCarrying('comment')).toEqual(PREUVE_TYPES);
+  });
+});

--- a/apps/app/src/referentiels/preuves/Bibliotheque/carte-document-action.spec.ts
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/carte-document-action.spec.ts
@@ -18,6 +18,10 @@ const preuveTypesCarrying = (action: CarteDocumentAction): TPreuveType[] =>
   PREUVE_TYPES.filter((preuveType) => isActionCarriedBy(action, preuveType));
 
 describe('isActionCarriedBy', () => {
+  it('seul un document de labellisation porte le reclassement', () => {
+    expect(preuveTypesCarrying('reclassify')).toEqual(['labellisation']);
+  });
+
   it("seul un rapport d'audit porte le remplacement de fichier", () => {
     expect(preuveTypesCarrying('replace')).toEqual(['audit']);
   });

--- a/apps/app/src/referentiels/preuves/Bibliotheque/carte-document-action.ts
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/carte-document-action.ts
@@ -1,0 +1,20 @@
+import { match } from 'ts-pattern';
+import { TPreuveType } from './types';
+
+export type CarteDocumentAction = 'edit' | 'comment' | 'replace' | 'delete';
+
+export const MUTATION_ACTIONS: readonly CarteDocumentAction[] = [
+  'edit',
+  'comment',
+  'delete',
+];
+
+export const isActionCarriedBy = (
+  action: CarteDocumentAction,
+  preuveType: TPreuveType
+): boolean =>
+  match(action)
+    .with('replace', () => preuveType === 'audit')
+    .with('delete', () => preuveType !== 'audit')
+    .with('edit', 'comment', () => true)
+    .exhaustive();

--- a/apps/app/src/referentiels/preuves/Bibliotheque/carte-document-action.ts
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/carte-document-action.ts
@@ -1,7 +1,12 @@
 import { match } from 'ts-pattern';
 import { TPreuveType } from './types';
 
-export type CarteDocumentAction = 'edit' | 'comment' | 'replace' | 'delete';
+export type CarteDocumentAction =
+  | 'edit'
+  | 'comment'
+  | 'replace'
+  | 'reclassify'
+  | 'delete';
 
 export const MUTATION_ACTIONS: readonly CarteDocumentAction[] = [
   'edit',
@@ -15,6 +20,7 @@ export const isActionCarriedBy = (
 ): boolean =>
   match(action)
     .with('replace', () => preuveType === 'audit')
+    .with('reclassify', () => preuveType === 'labellisation')
     .with('delete', () => preuveType !== 'audit')
     .with('edit', 'comment', () => true)
     .exhaustive();

--- a/apps/app/src/referentiels/preuves/Bibliotheque/types.ts
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/types.ts
@@ -1,5 +1,5 @@
 import { TAuditEnCours } from '@/app/referentiels/audits/types';
-import { LabellisationDemande } from '@tet/domain/referentiels';
+import { LabellisationDemande, ObjetPreuve } from '@tet/domain/referentiels';
 import { ObjectToSnake } from 'ts-case-convert';
 import { TEditState } from './useEditState';
 
@@ -106,6 +106,7 @@ type TPreuveLabellisationFields = {
   demande: ObjectToSnake<LabellisationDemande>;
   audit: null;
   rapport: null;
+  objet: ObjetPreuve | null;
 };
 
 // champs propres aux rapports d'audit


### PR DESCRIPTION
<img width="768" height="83" alt="reclassement-carte" src="https://github.com/user-attachments/assets/cc797953-a912-44f9-9bc9-f9e7b07680fe" />
<img width="640" height="296" alt="reclassement-modale" src="https://github.com/user-attachments/assets/a70f3c31-942e-470d-9a7c-77fbc28af5ce" />

## Ce que la PR livre

Sur une carte de document de labellisation, une action de reclassement ouvre une modale à trois choix — **acte d'engagement**, **document de candidature**, **non classé** — préremplie sur la valeur courante.

Elle n'est visible que du super-admin. Pour tout autre utilisateur, l'onglet Documents est strictement inchangé.

C'est le dernier maillon de la chaîne ouverte par #4882 (le champ `objet` arrive côté front) et #4908 (la mutation l'accepte), toutes deux mergées. La collectivité 2898 en production porte 8 pièces sans `objet` sur un audit validé : le support peut désormais les reclasser depuis l'écran, sans passer par tRPC.

## Deux natures dans un même diff

La PR porte la feature **et** un refactor de `CarteDocument` qu'elle a rendu nécessaire. Les conventions demandent une nature par PR ; le découpage a été écarté sciemment, parce que le refactor n'a d'intérêt qu'appuyé sur un troisième cas d'usage — c'est l'ajout du reclassement qui a révélé que la carte décidait des permissions à la place de ses appelants. La table de review ci-dessous sépare les deux.

## Où vit la décision

`CarteDocument` ne décide plus qui a le droit de quoi. Elle reçoit les actions permises :

```tsx
type CarteDocumentProps = {
  document: TPreuve;
  allowedActions: readonly CarteDocumentAction[];
  displayIdentifier?: boolean;
  classComment?: string;
};
```

L'appelant dit **qui a le droit**, la carte ne retient que **ce que le document porte** :

```ts
export const isActionCarriedBy = (
  action: CarteDocumentAction,
  preuveType: TPreuveType
): boolean =>
  match(action)
    .with('replace', () => preuveType === 'audit')
    .with('reclassify', () => preuveType === 'labellisation')
    .with('delete', () => preuveType !== 'audit')
    .with('edit', 'comment', () => true)
    .exhaustive();
```

Cette règle vit dans `carte-document-action.ts`, hors du composant : elle relève du document, pas du rendu, et l'`.exhaustive()` force sa mise à jour quand une action s'ajoutera. `MUTATION_ACTIONS` y nomme le jeu `edit | comment | delete`, que les appelants étendent au lieu de le recopier.

Répartition des permissions, désormais toutes en amont :

| appelant | actions accordées | d'où vient le droit |
|---|---|---|
| `PreuveLabellisation` | `MUTATION_ACTIONS` + `replace` + `reclassify` | `canUpdate` existant, `isSuperAdminRoleEnabled` |
| `PreuveDoc` | `MUTATION_ACTIONS` | `referentiels.mutate` + prop `readonly` |
| `documents.view` (fiche) | `MUTATION_ACTIONS` | `isReadonly` de la fiche |

`useUser` et `useSuperAdminMode` quittent la carte. La prop `isReadonly` disparaît : c'était un booléen négatif que chaque appelant dérivait déjà d'un fait positif.

Deux gardes tombent avec elle. `canShowReplace` valait exactement le complément du `isReadonly` que `PreuveLabellisation` calculait pour un rapport d'audit — `canUserUpdateAuditReport` appelé deux fois, dans deux sens opposés, à deux étages. Et `openAction === 'delete' && !isReadonly` re-testait un droit sans lequel le bouton n'existait pas.

`MenuCarteDocument` reste une rangée de boutons-icônes conditionnels, pas un menu déroulant. `CarteDocumentActions` gagne un `reclassify?` et le bouton se rend comme les quatre autres.

## Contrat du champ

`ReclassifyDocumentField` manipule directement `ObjetPreuve | null` — pas de valeur sentinelle pour « non classé ». Le champ émet `null`, la mutation l'envoie tel quel, et le déclassement passe par le même chemin que les deux autres choix.

`TPreuveLabellisation` porte désormais `objet`. L'endpoint de #4882 le renvoyait déjà, mais le type front ne le déclarait pas — sans cette ligne la carte ne peut pas lire la valeur courante. Le plan ne l'avait pas listé.

## Mutation

`useReclassifyDocument` suit le pattern canonique `useMutation(trpc.x.y.mutationOptions(...))` et déclare ses messages via `meta` : le subscriber global rend le toast, aucun `setToast` posé à la main.

Le succès rejoint le fan-out d'invalidation des écritures de preuves, avec `invalidateParcours: true` — reclasser un document change les critères de la checklist audit-labellisation, qui doit se rafraîchir.

## Surface de review

| fichier | nature | attention |
|---|---|---|
| `CarteDocument.tsx` | refactor | **humaine** — API du composant, disparition de `isReadonly` |
| `carte-document-action.ts` | refactor | **humaine** — la règle document → actions |
| `PreuveLabellisation.tsx` | refactor | **humaine** — c'est là qu'atterrit le droit super-admin |
| `reclassify-document.modal.tsx` / `.field.tsx` | feature | **humaine** — contrat du champ |
| `use-reclassify-document.ts` | feature | **humaine** — clés d'invalidation |
| `PreuveDoc.tsx`, `documents.view.tsx` | refactor | mécanique — report d'un droit déjà calculé |
| `MenuCarteDocument.tsx`, `types.ts`, `referentiels.labels.ts` | feature | mécanique |
| `groupeParDemande.test.ts` | feature | mécanique — `objet: null` sur 3 fixtures |
| `*.spec.ts(x)` | les deux | mécanique |

## Couverture

`ReclassifyDocumentField` — 4 tests, chacun tenant une assertion que les autres ne couvrent pas :

| test | ce qu'il fige |
|---|---|
| coche le choix correspondant à l'objet courant | la présélection |
| coche « non classé » pour un document sans objet | le cas `null` |
| remonte l'objet sélectionné | la remontée du choix |
| remonte une absence d'objet sur « non classé » | l'émission de `null` |

`isActionCarriedBy` — 4 tests énumérant, par action, les types de document qui la portent. Ils figent notamment qu'un rapport d'audit ne propose jamais la suppression et que le reclassement n'existe que sur un document de labellisation, quoi qu'accorde l'appelant.

Le champ et la règle sont extraits dans leurs propres fichiers pour être testables sans tRPC, sur le modèle de `audit-type.field.tsx` / `.spec.tsx` du domaine voisin.

## Périmètre

Le même contrôle dans la checklist audit-labellisation est une autre surface, hors de cette PR. L'`objet` n'est pas affiché aux non-super-admins.

## Points ouverts

- **Le droit super-admin lui-même n'est pas testé.** Il vit maintenant dans `PreuveLabellisation`, qui consomme `useUser`, `useCurrentCollectivite` et tRPC — `apps/app/CLAUDE.md` écarte ces composants des tests unitaires. Ce que le refactor a rendu testable, c'est l'autre moitié de la décision : quels documents portent l'action.
- **Changement de comportement à valider.** `replace` n'est plus accordé que par `PreuveLabellisation`, alors que la carte le calculait auparavant pour tous ses appelants. Vérifié qu'aucun `preuve_type === 'audit'` ne transite par `PreuveDoc` — il ne sert qu'aux rapports de visite, aux preuves d'action et réglementaires — mais c'est le point à contredire si un cas a été manqué.
- **Le libellé « Non classé »** ne reprend aucun terme du domaine : la base parle d'`objet` nul. À arbitrer avec le produit si un autre mot est attendu à l'écran.
- **`!(hideIdentifier ?? false)`**, dans `PreuvesAction.tsx` et `PreuveReglementaire.tsx`, est équivalent à `!hideIdentifier` — le `??` y est mort. Préexistant, hors de ce diff, non corrigé ici.

## Vérifications

Suite `app` complète : 708 tests, 101 fichiers, verts. `nx run app:typecheck` propre, lint sans nouveau warning. CI verte sur `6039348502`, 4 shards e2e compris.

Chaque test a été vu rouge sur sa propre ligne de production : présélection (`checked`), traduction du choix, remontée de l'événement, et la règle `reclassify` en la relâchant en `preuveType !== 'audit'`.

## Plan

PR 4 de la stack, plan `doc/plans/2026-08-26-001-feat-reclassement-objet-document-labellisation-plan.md`. #4882 et #4908 sont mergées ; cette PR est désormais basée sur `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Ajout d’une action « Reclasser le document » pour les documents de labellisation.
  * Une fenêtre permet de choisir entre « Acte d’engagement », « Candidature » ou « Non classé ».
  * Des messages indiquent la réussite ou l’échec de l’opération.

* **Améliorations**
  * Les actions disponibles sur les documents s’adaptent désormais aux droits d’accès et au type de document.
  * Les données affichées sont actualisées après un reclassement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->