### PR TITLE
refactor(referentiels): retire le badge de mesure non concernée jamais affiché

### DIFF
--- a/apps/app/src/referentiels/preuves/AddPreuveReglementaire.tsx
+++ b/apps/app/src/referentiels/preuves/AddPreuveReglementaire.tsx
@@ -10,13 +10,12 @@ import { useAddPreuveReglementaireToAction } from './useAddPreuveToAction';
 export type TAddPreuveButtonProps = {
   preuve_id: string;
   actionId: string;
-  isDisabled: boolean;
   onDuplicatedDocumentsAdded?: TOnDuplicatedDocumentsAdded;
 };
 
 export const AddPreuveReglementaire = (props: TAddPreuveButtonProps) => {
   const [opened, setOpened] = useState(false);
-  const { preuve_id, actionId, isDisabled, onDuplicatedDocumentsAdded } = props;
+  const { preuve_id, actionId, onDuplicatedDocumentsAdded } = props;
   const handlers = useAddPreuveReglementaireToAction(preuve_id);
   const referentielId = getReferentielIdFromActionId(actionId);
   const { hasReferentielPermission } = useCurrentCollectivite();
@@ -45,7 +44,6 @@ export const AddPreuveReglementaire = (props: TAddPreuveButtonProps) => {
         dataTest={`AddPreuveReglementaire-${preuve_id}`}
         size="xs"
         icon="file-add-fill"
-        variant={isDisabled ? 'outlined' : 'primary'}
         title={appLabels.ajouterPreuve}
         onClick={() => setOpened(true)}
         className="w-12 flex items-center justify-center"

--- a/apps/app/src/referentiels/preuves/Bibliotheque/IdentifiantAction.tsx
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/IdentifiantAction.tsx
@@ -1,34 +1,11 @@
-import { Badge } from '@tet/ui';
-import { TPreuveAction } from './types';
-
 export type TIdentifiantActionProps = {
-  action: TPreuveAction;
+  identifiant: string;
 };
 
-/**
- * Affiche l'identifiant d'une action à laquelle une preuve est associée
- */
 export const IdentifiantAction = (props: TIdentifiantActionProps) => {
-  const { action } = props;
-  const { identifiant } = action;
+  const { identifiant } = props;
 
   return (
-    <span className="text-grey-8 text-sm font-medium flex gap-2">
-      {`(${identifiant})`}
-      {isDisabledAction(action) ? (
-        <Badge
-          title="Non concerné"
-          size="sm"
-          variant="grey"
-          trim={false}
-          className="whitespace-nowrap"
-        />
-      ) : null}
-    </span>
+    <span className="text-grey-8 text-sm font-medium">{`(${identifiant})`}</span>
   );
-};
-
-export const isDisabledAction = (action: TPreuveAction) => {
-  const { concerne, desactive } = action;
-  return concerne === false || desactive === true;
 };

--- a/apps/app/src/referentiels/preuves/Bibliotheque/PreuveReglementaire.stories.tsx
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/PreuveReglementaire.stories.tsx
@@ -1,7 +1,5 @@
-import { Meta} from '@storybook/nextjs-vite';
-import {
-  PreuveReglementaire,
-} from './PreuveReglementaire';
+import { Meta } from '@storybook/nextjs-vite';
+import { PreuveReglementaire } from './PreuveReglementaire';
 
 import {
   preuveReglementaireFichier,
@@ -28,34 +26,6 @@ export const Fichier = {
 export const Lien = {
   args: {
     preuves: [preuveReglementaireLien],
-  },
-};
-
-export const ActionNonConcernee = {
-  args: {
-    preuves: [
-      {
-        ...preuveReglementaireNonRenseignee,
-        action: {
-          ...preuveReglementaireNonRenseignee.action,
-          concerne: false,
-        },
-      },
-    ],
-  },
-};
-
-export const ActionDesactivee = {
-  args: {
-    preuves: [
-      {
-        ...preuveReglementaireNonRenseignee,
-        action: {
-          ...preuveReglementaireNonRenseignee.action,
-          desactive: true,
-        },
-      },
-    ],
   },
 };
 

--- a/apps/app/src/referentiels/preuves/Bibliotheque/PreuveReglementaire.tsx
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/PreuveReglementaire.tsx
@@ -1,10 +1,10 @@
 import { AddPreuveReglementaire } from '@/app/referentiels/preuves/AddPreuveReglementaire';
-import { InfoTooltip } from '@tet/ui';
+import { InfoTooltip, VisibleWhen } from '@tet/ui';
 import classNames from 'classnames';
 import DOMPurify from 'dompurify';
 import type { TOnDuplicatedDocumentsAdded } from '../AddPreuveModal/types';
 import type { DuplicatedDocumentInformation } from '../duplicated-document-state.utils';
-import { IdentifiantAction, isDisabledAction } from './IdentifiantAction';
+import { IdentifiantAction } from './IdentifiantAction';
 import PreuveDoc from './PreuveDoc';
 import { TPreuve, TPreuveReglementaire } from './types';
 
@@ -39,7 +39,6 @@ export const PreuveReglementaire = (props: TPreuveReglementaireProps) => {
   const first = preuves[0];
   const { action, preuve_reglementaire, fichier, lien } = first;
   const { id: preuve_id, nom, description } = preuve_reglementaire;
-  const isDisabled = isDisabledAction(action);
   const haveDoc = !!fichier || !!lien;
 
   return (
@@ -54,7 +53,9 @@ export const PreuveReglementaire = (props: TPreuveReglementaireProps) => {
           className="text-sm text-primary-9 font-bold flex flex-wrap gap-2 items-center uppercase max-w-80"
         >
           {nom}{' '}
-          {!(hideIdentifier ?? false) && <IdentifiantAction action={action} />}
+          <VisibleWhen condition={!hideIdentifier}>
+            <IdentifiantAction identifiant={action.identifiant} />
+          </VisibleWhen>
           {description && (
             <InfoTooltip
               label={
@@ -74,7 +75,6 @@ export const PreuveReglementaire = (props: TPreuveReglementaireProps) => {
         <AddPreuveReglementaire
           preuve_id={preuve_id}
           actionId={action.action_id}
-          isDisabled={isDisabled}
           onDuplicatedDocumentsAdded={onDuplicatedDocumentsAdded}
         />
       </div>

--- a/apps/app/src/referentiels/preuves/Bibliotheque/fixture.ts
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/fixture.ts
@@ -13,11 +13,7 @@ export const preuveReglementaireNonRenseignee: Omit<
   created_by: null,
   created_by_nom: 'Équipe territoires en transitions',
   action: {
-    nom: "Réaliser le diagnostic de l'économie circulaire",
-    concerne: true,
     action_id: 'eci_1.1.2',
-    desactive: false,
-    description: 'description action...',
     identifiant: '1.1.2',
     referentiel: 'eci',
   },
@@ -46,12 +42,7 @@ export const preuveReglementaireLien: TPreuveReglementaire = {
   created_by: '17440546-f389-4d4f-bfdb-b0c94a1bd0f9',
   created_by_nom: 'Yolo Dodo',
   action: {
-    nom: 'Élargir la gouvernance en interne et en externe',
-    concerne: true,
     action_id: 'eci_1.1.3',
-    desactive: false,
-    description:
-      '<p>La collectivité met en place une gouvernance élargie permettant de construire une stratégie et des actions Economie Circulaire  en adéquation avec la réalité du  territoire. Co-construite avec les acteurs du territoire, la stratégie Economie Circulaire sera ainsi  soutenue par les acteurs du territoire lors de  sa mise en œuvre.</p>\n',
     identifiant: '1.1.3',
     referentiel: 'eci',
   },
@@ -80,11 +71,7 @@ export const preuveReglementaireLienSansDescription: TPreuveReglementaire = {
   created_by: '17440546-f389-4d4f-bfdb-b0c94a1bd0f9',
   created_by_nom: 'Yili Didi',
   action: {
-    nom: 'Élargir la gouvernance en interne et en externe',
-    concerne: true,
     action_id: 'eci_1.1.4',
-    desactive: false,
-    description: 'description action...',
     identifiant: '1.1.4',
     referentiel: 'eci',
   },
@@ -115,12 +102,7 @@ export const preuveReglementaireFichier: TPreuveReglementaire = {
   created_by: '17440546-f389-4d4f-bfdb-b0c94a1bd0f9',
   created_by_nom: 'Yolo Dodo',
   action: {
-    nom: 'Élargir la gouvernance en interne et en externe',
-    concerne: true,
     action_id: 'eci_1.1.3',
-    desactive: false,
-    description:
-      '<p>La collectivité met en place une gouvernance élargie permettant de construire une stratégie et des actions Economie Circulaire  en adéquation avec la réalité du  territoire. Co-construite avec les acteurs du territoire, la stratégie Economie Circulaire sera ainsi  soutenue par les acteurs du territoire lors de  sa mise en œuvre.</p>\n',
     identifiant: '1.1.3',
     referentiel: 'eci',
   },
@@ -149,12 +131,7 @@ export const preuveComplementaireLien: TPreuveComplementaire = {
   created_by: '17440546-f389-4d4f-bfdb-b0c94a1bd0f9',
   created_by_nom: 'Yolo Dodo',
   action: {
-    nom: 'Élargir la gouvernance en interne et en externe',
-    concerne: true,
     action_id: 'eci_1.1.3',
-    desactive: false,
-    description:
-      '<p>La collectivité met en place une gouvernance élargie permettant de construire une stratégie et des actions Economie Circulaire  en adéquation avec la réalité du  territoire. Co-construite avec les acteurs du territoire, la stratégie Economie Circulaire sera ainsi  soutenue par les acteurs du territoire lors de  sa mise en œuvre.</p>\n',
     identifiant: '1.1.3',
     referentiel: 'eci',
   },
@@ -181,12 +158,7 @@ export const preuveComplementaireFichier: TPreuveComplementaire = {
   created_by: '17440546-f389-4d4f-bfdb-b0c94a1bd0f9',
   created_by_nom: 'Yolo Dodo',
   action: {
-    nom: 'Élargir la gouvernance en interne et en externe',
-    concerne: true,
     action_id: 'eci_1.1.3',
-    desactive: false,
-    description:
-      '<p>La collectivité met en place une gouvernance élargie permettant de construire une stratégie et des actions Economie Circulaire  en adéquation avec la réalité du  territoire. Co-construite avec les acteurs du territoire, la stratégie Economie Circulaire sera ainsi  soutenue par les acteurs du territoire lors de  sa mise en œuvre.</p>\n',
     identifiant: '1.1.3',
     referentiel: 'eci',
   },

--- a/apps/app/src/referentiels/preuves/Bibliotheque/types.ts
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/types.ts
@@ -90,12 +90,8 @@ type TPreuveAnnexeFields = {
 // action liée à une preuve réglementaire ou complémentaire
 export type TPreuveAction = {
   action_id: string;
-  nom: string;
-  description: string;
   identifiant: string;
   referentiel: string;
-  concerne: boolean;
-  desactive: boolean;
 };
 
 // champs propres aux preuves pour la labellisation


### PR DESCRIPTION
## Comportement

Aucun changement visible. Le badge « Non concerné » et le variant `outlined` du bouton d'ajout d'une preuve réglementaire étaient inatteignables.

## Pourquoi

`public.preuve` construit le champ `action` avec `jsonb_build_object('action_id', ad.action_id, 'identifiant', ad.identifiant, 'referentiel', ad.referentiel)`. `TPreuveAction` déclarait cinq champs de plus (`nom`, `description`, `concerne`, `desactive`) que la vue ne fournit jamais.

`isDisabledAction` retournait `concerne === false || desactive === true` sur deux `undefined` : toujours `false`. Le badge n'a donc jamais été rendu, et `AddPreuveReglementaire` a toujours reçu `isDisabled={false}`, soit le variant `primary` — celui du défaut du design system.

## Contenu

- `TPreuveAction` se resserre sur `action_id`, `identifiant`, `referentiel`.
- `isDisabledAction` et le `Badge` disparaissent d'`IdentifiantAction`, qui ne reçoit plus que l'`identifiant` qu'il affiche.
- La prop `isDisabled` disparaît d'`AddPreuveReglementaire` (un seul appelant) ; le `Button` retombe sur son variant par défaut.
- Les stories `ActionNonConcernee` et `ActionDesactivee`, qui mettaient en scène cet état inatteignable, sont supprimées, ainsi que les champs correspondants des fixtures.

## Hors scope

La forme des données consommées par `PreuvesAction` / `PreuveReglementaire` et le passage à un endpoint backend pour les documents d'une mesure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Améliorations**
  * Simplification de l’affichage des preuves réglementaires et de leurs identifiants d’action.
  * Les identifiants d’action sont désormais affichés uniquement lorsqu’ils sont pertinents et configurés pour être visibles.
  * Harmonisation de l’apparence des boutons d’ajout de preuve.
  * Suppression des états et informations d’action qui n’étaient plus utilisés, notamment les mentions « Non concerné » et « Désactivée ».

<!-- end of auto-generated comment: release notes by coderabbit.ai -->