### PR TITLE
refactor(referentiels): regroupe les documents attendus dans un adaptateur

### DIFF
--- a/apps/app/src/referentiels/actions/action-preuve.panel.tsx
+++ b/apps/app/src/referentiels/actions/action-preuve.panel.tsx
@@ -1,3 +1,4 @@
+import { toDocumentsAttendus } from '@/app/referentiels/preuves/preuve-view.adapter';
 import { PreuvesAction } from '@/app/referentiels/preuves/PreuvesAction';
 import {
   TActionDef,
@@ -40,12 +41,13 @@ const ActionPreuvePanel = (props: TActionPreuvePanelProps) => {
     withSubActions,
     disabled: disableFetch,
   });
+  const attendus = toDocumentsAttendus(reglementaire ?? []);
 
   return (
     <PreuvesAction
       action={action}
       withSubActions={withSubActions}
-      reglementaires={reglementaire || []}
+      attendus={attendus}
       complementaires={complementaire || []}
       showWarning={showWarning}
       hideIdentifier={hideIdentifier}

--- a/apps/app/src/referentiels/preuves/AddPreuveReglementaire.tsx
+++ b/apps/app/src/referentiels/preuves/AddPreuveReglementaire.tsx
@@ -10,13 +10,12 @@ import { useAddPreuveReglementaireToAction } from './useAddPreuveToAction';
 export type TAddPreuveButtonProps = {
   preuve_id: string;
   actionId: string;
-  isDisabled: boolean;
   onDuplicatedDocumentsAdded?: TOnDuplicatedDocumentsAdded;
 };
 
 export const AddPreuveReglementaire = (props: TAddPreuveButtonProps) => {
   const [opened, setOpened] = useState(false);
-  const { preuve_id, actionId, isDisabled, onDuplicatedDocumentsAdded } = props;
+  const { preuve_id, actionId, onDuplicatedDocumentsAdded } = props;
   const handlers = useAddPreuveReglementaireToAction(preuve_id);
   const referentielId = getReferentielIdFromActionId(actionId);
   const { hasReferentielPermission } = useCurrentCollectivite();
@@ -45,7 +44,6 @@ export const AddPreuveReglementaire = (props: TAddPreuveButtonProps) => {
         dataTest={`AddPreuveReglementaire-${preuve_id}`}
         size="xs"
         icon="file-add-fill"
-        variant={isDisabled ? 'outlined' : 'primary'}
         title={appLabels.ajouterPreuve}
         onClick={() => setOpened(true)}
         className="w-12 flex items-center justify-center"

--- a/apps/app/src/referentiels/preuves/Bibliotheque/IdentifiantAction.tsx
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/IdentifiantAction.tsx
@@ -1,34 +1,11 @@
-import { Badge } from '@tet/ui';
-import { TPreuveAction } from './types';
-
 export type TIdentifiantActionProps = {
-  action: TPreuveAction;
+  identifiant: string;
 };
 
-/**
- * Affiche l'identifiant d'une action à laquelle une preuve est associée
- */
 export const IdentifiantAction = (props: TIdentifiantActionProps) => {
-  const { action } = props;
-  const { identifiant } = action;
+  const { identifiant } = props;
 
   return (
-    <span className="text-grey-8 text-sm font-medium flex gap-2">
-      {`(${identifiant})`}
-      {isDisabledAction(action) ? (
-        <Badge
-          title="Non concerné"
-          size="sm"
-          variant="grey"
-          trim={false}
-          className="whitespace-nowrap"
-        />
-      ) : null}
-    </span>
+    <span className="text-grey-8 text-sm font-medium">{`(${identifiant})`}</span>
   );
-};
-
-export const isDisabledAction = (action: TPreuveAction) => {
-  const { concerne, desactive } = action;
-  return concerne === false || desactive === true;
 };

--- a/apps/app/src/referentiels/preuves/Bibliotheque/PreuveReglementaire.stories.tsx
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/PreuveReglementaire.stories.tsx
@@ -1,11 +1,12 @@
 import { Meta } from '@storybook/nextjs-vite';
-import { PreuveReglementaire } from './PreuveReglementaire';
-
+import { toDocumentsAttendus } from '../preuve-view.adapter';
 import {
   preuveReglementaireFichier,
   preuveReglementaireLien,
+  preuveReglementaireLienSameAttendu,
   preuveReglementaireNonRenseignee,
 } from './fixture';
+import { PreuveReglementaire } from './PreuveReglementaire';
 
 export default {
   component: PreuveReglementaire,
@@ -13,24 +14,27 @@ export default {
 
 export const NonRenseignee = {
   args: {
-    preuves: [preuveReglementaireNonRenseignee],
+    attendu: toDocumentsAttendus([preuveReglementaireNonRenseignee])[0],
   },
 };
 
 export const Fichier = {
   args: {
-    preuves: [preuveReglementaireFichier],
+    attendu: toDocumentsAttendus([preuveReglementaireFichier])[0],
   },
 };
 
 export const Lien = {
   args: {
-    preuves: [preuveReglementaireLien],
+    attendu: toDocumentsAttendus([preuveReglementaireLien])[0],
   },
 };
 
 export const Multiple = {
   args: {
-    preuves: [preuveReglementaireFichier, preuveReglementaireLien],
+    attendu: toDocumentsAttendus([
+      preuveReglementaireFichier,
+      preuveReglementaireLienSameAttendu,
+    ])[0],
   },
 };

--- a/apps/app/src/referentiels/preuves/Bibliotheque/PreuveReglementaire.stories.tsx
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/PreuveReglementaire.stories.tsx
@@ -1,7 +1,5 @@
-import { Meta} from '@storybook/nextjs-vite';
-import {
-  PreuveReglementaire,
-} from './PreuveReglementaire';
+import { Meta } from '@storybook/nextjs-vite';
+import { PreuveReglementaire } from './PreuveReglementaire';
 
 import {
   preuveReglementaireFichier,
@@ -28,34 +26,6 @@ export const Fichier = {
 export const Lien = {
   args: {
     preuves: [preuveReglementaireLien],
-  },
-};
-
-export const ActionNonConcernee = {
-  args: {
-    preuves: [
-      {
-        ...preuveReglementaireNonRenseignee,
-        action: {
-          ...preuveReglementaireNonRenseignee.action,
-          concerne: false,
-        },
-      },
-    ],
-  },
-};
-
-export const ActionDesactivee = {
-  args: {
-    preuves: [
-      {
-        ...preuveReglementaireNonRenseignee,
-        action: {
-          ...preuveReglementaireNonRenseignee.action,
-          desactive: true,
-        },
-      },
-    ],
   },
 };
 

--- a/apps/app/src/referentiels/preuves/Bibliotheque/PreuveReglementaire.tsx
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/PreuveReglementaire.tsx
@@ -6,10 +6,10 @@ import type { TOnDuplicatedDocumentsAdded } from '../AddPreuveModal/types';
 import type { DuplicatedDocumentInformation } from '../duplicated-document-state.utils';
 import { IdentifiantAction } from './IdentifiantAction';
 import PreuveDoc from './PreuveDoc';
-import { TPreuve, TPreuveReglementaire } from './types';
+import { TDocumentAttendu, TPreuveReglementaire } from './types';
 
 export type TPreuveReglementaireProps = {
-  preuves: TPreuveReglementaire[];
+  attendu: TDocumentAttendu;
   hideIdentifier?: boolean;
   displayInPanel?: boolean;
   getDuplicatedDocumentInformation?: (
@@ -23,23 +23,14 @@ export type TPreuveReglementaireProps = {
  */
 export const PreuveReglementaire = (props: TPreuveReglementaireProps) => {
   const {
-    preuves,
+    attendu,
     hideIdentifier,
     displayInPanel,
     getDuplicatedDocumentInformation,
     onDuplicatedDocumentsAdded,
   } = props;
-
-  // n'affiche rien quand la liste est vide
-  if (!preuves.length) {
-    return null;
-  }
-
-  // lit les informations du 1er item (identiques aux suivants)
-  const first = preuves[0];
-  const { action, preuve_reglementaire, fichier, lien } = first;
+  const { action, preuve_reglementaire, documents } = attendu;
   const { id: preuve_id, nom, description } = preuve_reglementaire;
-  const haveDoc = !!fichier || !!lien;
 
   return (
     <div className="flex flex-col gap-5 pb-5">
@@ -79,17 +70,17 @@ export const PreuveReglementaire = (props: TPreuveReglementaireProps) => {
         />
       </div>
       {/* Liens vers les documents */}
-      {haveDoc && (
+      <VisibleWhen condition={documents.length > 0}>
         <div>
           <div
             className={classNames('grid gap-5', {
               'md:grid-cols-2 lg:grid-cols-3': !displayInPanel,
             })}
           >
-            {preuves.map((preuve) => (
+            {documents.map((preuve) => (
               <PreuveDoc
                 key={preuve.id}
-                preuve={preuve as TPreuve}
+                preuve={preuve}
                 duplicatedDocumentInformation={getDuplicatedDocumentInformation?.(
                   preuve
                 )}
@@ -97,7 +88,7 @@ export const PreuveReglementaire = (props: TPreuveReglementaireProps) => {
             ))}
           </div>
         </div>
-      )}
+      </VisibleWhen>
     </div>
   );
 };

--- a/apps/app/src/referentiels/preuves/Bibliotheque/PreuveReglementaire.tsx
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/PreuveReglementaire.tsx
@@ -1,10 +1,10 @@
 import { AddPreuveReglementaire } from '@/app/referentiels/preuves/AddPreuveReglementaire';
-import { InfoTooltip } from '@tet/ui';
+import { InfoTooltip, VisibleWhen } from '@tet/ui';
 import classNames from 'classnames';
 import DOMPurify from 'dompurify';
 import type { TOnDuplicatedDocumentsAdded } from '../AddPreuveModal/types';
 import type { DuplicatedDocumentInformation } from '../duplicated-document-state.utils';
-import { IdentifiantAction, isDisabledAction } from './IdentifiantAction';
+import { IdentifiantAction } from './IdentifiantAction';
 import PreuveDoc from './PreuveDoc';
 import { TPreuve, TPreuveReglementaire } from './types';
 
@@ -39,7 +39,6 @@ export const PreuveReglementaire = (props: TPreuveReglementaireProps) => {
   const first = preuves[0];
   const { action, preuve_reglementaire, fichier, lien } = first;
   const { id: preuve_id, nom, description } = preuve_reglementaire;
-  const isDisabled = isDisabledAction(action);
   const haveDoc = !!fichier || !!lien;
 
   return (
@@ -54,7 +53,9 @@ export const PreuveReglementaire = (props: TPreuveReglementaireProps) => {
           className="text-sm text-primary-9 font-bold flex flex-wrap gap-2 items-center uppercase max-w-80"
         >
           {nom}{' '}
-          {!(hideIdentifier ?? false) && <IdentifiantAction action={action} />}
+          <VisibleWhen condition={!hideIdentifier}>
+            <IdentifiantAction identifiant={action.identifiant} />
+          </VisibleWhen>
           {description && (
             <InfoTooltip
               label={
@@ -74,7 +75,6 @@ export const PreuveReglementaire = (props: TPreuveReglementaireProps) => {
         <AddPreuveReglementaire
           preuve_id={preuve_id}
           actionId={action.action_id}
-          isDisabled={isDisabled}
           onDuplicatedDocumentsAdded={onDuplicatedDocumentsAdded}
         />
       </div>

--- a/apps/app/src/referentiels/preuves/Bibliotheque/fixture.ts
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/fixture.ts
@@ -1,10 +1,8 @@
 import { TPreuveComplementaire, TPreuveReglementaire } from './types';
 
-export const preuveReglementaireNonRenseignee: Omit<
-  TPreuveReglementaire,
-  'id'
-> = {
+export const preuveReglementaireNonRenseignee: TPreuveReglementaire = {
   preuve_type: 'reglementaire',
+  id: 0,
   collectivite_id: 1,
   fichier: null,
   lien: null,
@@ -115,6 +113,13 @@ export const preuveReglementaireFichier: TPreuveReglementaire = {
   demande: null,
   audit: null,
   rapport: null,
+};
+
+export const preuveReglementaireLienSameAttendu: TPreuveReglementaire = {
+  ...preuveReglementaireLien,
+  id: 13,
+  action: preuveReglementaireFichier.action,
+  preuve_reglementaire: preuveReglementaireFichier.preuve_reglementaire,
 };
 
 export const preuveComplementaireLien: TPreuveComplementaire = {

--- a/apps/app/src/referentiels/preuves/Bibliotheque/fixture.ts
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/fixture.ts
@@ -13,11 +13,7 @@ export const preuveReglementaireNonRenseignee: Omit<
   created_by: null,
   created_by_nom: 'Équipe territoires en transitions',
   action: {
-    nom: "Réaliser le diagnostic de l'économie circulaire",
-    concerne: true,
     action_id: 'eci_1.1.2',
-    desactive: false,
-    description: 'description action...',
     identifiant: '1.1.2',
     referentiel: 'eci',
   },
@@ -46,12 +42,7 @@ export const preuveReglementaireLien: TPreuveReglementaire = {
   created_by: '17440546-f389-4d4f-bfdb-b0c94a1bd0f9',
   created_by_nom: 'Yolo Dodo',
   action: {
-    nom: 'Élargir la gouvernance en interne et en externe',
-    concerne: true,
     action_id: 'eci_1.1.3',
-    desactive: false,
-    description:
-      '<p>La collectivité met en place une gouvernance élargie permettant de construire une stratégie et des actions Economie Circulaire  en adéquation avec la réalité du  territoire. Co-construite avec les acteurs du territoire, la stratégie Economie Circulaire sera ainsi  soutenue par les acteurs du territoire lors de  sa mise en œuvre.</p>\n',
     identifiant: '1.1.3',
     referentiel: 'eci',
   },
@@ -80,11 +71,7 @@ export const preuveReglementaireLienSansDescription: TPreuveReglementaire = {
   created_by: '17440546-f389-4d4f-bfdb-b0c94a1bd0f9',
   created_by_nom: 'Yili Didi',
   action: {
-    nom: 'Élargir la gouvernance en interne et en externe',
-    concerne: true,
     action_id: 'eci_1.1.4',
-    desactive: false,
-    description: 'description action...',
     identifiant: '1.1.4',
     referentiel: 'eci',
   },
@@ -115,12 +102,7 @@ export const preuveReglementaireFichier: TPreuveReglementaire = {
   created_by: '17440546-f389-4d4f-bfdb-b0c94a1bd0f9',
   created_by_nom: 'Yolo Dodo',
   action: {
-    nom: 'Élargir la gouvernance en interne et en externe',
-    concerne: true,
     action_id: 'eci_1.1.3',
-    desactive: false,
-    description:
-      '<p>La collectivité met en place une gouvernance élargie permettant de construire une stratégie et des actions Economie Circulaire  en adéquation avec la réalité du  territoire. Co-construite avec les acteurs du territoire, la stratégie Economie Circulaire sera ainsi  soutenue par les acteurs du territoire lors de  sa mise en œuvre.</p>\n',
     identifiant: '1.1.3',
     referentiel: 'eci',
   },
@@ -149,12 +131,7 @@ export const preuveComplementaireLien: TPreuveComplementaire = {
   created_by: '17440546-f389-4d4f-bfdb-b0c94a1bd0f9',
   created_by_nom: 'Yolo Dodo',
   action: {
-    nom: 'Élargir la gouvernance en interne et en externe',
-    concerne: true,
     action_id: 'eci_1.1.3',
-    desactive: false,
-    description:
-      '<p>La collectivité met en place une gouvernance élargie permettant de construire une stratégie et des actions Economie Circulaire  en adéquation avec la réalité du  territoire. Co-construite avec les acteurs du territoire, la stratégie Economie Circulaire sera ainsi  soutenue par les acteurs du territoire lors de  sa mise en œuvre.</p>\n',
     identifiant: '1.1.3',
     referentiel: 'eci',
   },
@@ -181,12 +158,7 @@ export const preuveComplementaireFichier: TPreuveComplementaire = {
   created_by: '17440546-f389-4d4f-bfdb-b0c94a1bd0f9',
   created_by_nom: 'Yolo Dodo',
   action: {
-    nom: 'Élargir la gouvernance en interne et en externe',
-    concerne: true,
     action_id: 'eci_1.1.3',
-    desactive: false,
-    description:
-      '<p>La collectivité met en place une gouvernance élargie permettant de construire une stratégie et des actions Economie Circulaire  en adéquation avec la réalité du  territoire. Co-construite avec les acteurs du territoire, la stratégie Economie Circulaire sera ainsi  soutenue par les acteurs du territoire lors de  sa mise en œuvre.</p>\n',
     identifiant: '1.1.3',
     referentiel: 'eci',
   },

--- a/apps/app/src/referentiels/preuves/Bibliotheque/types.ts
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/types.ts
@@ -53,15 +53,17 @@ type TPreuveBase = (
   //  modified_by_nom: string | null;
 };
 
+export type TPreuveReglementaireDefinition = {
+  id: string;
+  nom: string;
+  description: string;
+};
+
 // champs propres aux preuves réglèmentaires
 type TPreuveReglementaireFields = {
   preuve_type: 'reglementaire';
   action: TPreuveAction;
-  preuve_reglementaire: {
-    id: string;
-    nom: string;
-    description: string;
-  };
+  preuve_reglementaire: TPreuveReglementaireDefinition;
   demande: null;
   audit: null;
   rapport: null;
@@ -144,6 +146,12 @@ export type TPreuve =
   | TPreuveLabellisation
   | TPreuveAudit
   | TPreuveRapport;
+
+export type TDocumentAttendu = {
+  action: TPreuveAction;
+  preuve_reglementaire: TPreuveReglementaireDefinition;
+  documents: TPreuveReglementaire[];
+};
 
 // identifiants des types de preuves
 export type TPreuveType = TPreuve['preuve_type'];

--- a/apps/app/src/referentiels/preuves/Bibliotheque/types.ts
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/types.ts
@@ -90,12 +90,8 @@ type TPreuveAnnexeFields = {
 // action liée à une preuve réglementaire ou complémentaire
 export type TPreuveAction = {
   action_id: string;
-  nom: string;
-  description: string;
   identifiant: string;
   referentiel: string;
-  concerne: boolean;
-  desactive: boolean;
 };
 
 // champs propres aux preuves pour la labellisation

--- a/apps/app/src/referentiels/preuves/PreuvesAction.stories.tsx
+++ b/apps/app/src/referentiels/preuves/PreuvesAction.stories.tsx
@@ -1,13 +1,14 @@
 import { Meta } from '@storybook/nextjs-vite';
 // import { action } from 'storybook/actions';
 import {
-    preuveComplementaireFichier,
-    preuveComplementaireLien,
-    preuveReglementaireFichier,
-    preuveReglementaireLien,
-    preuveReglementaireLienSansDescription,
-    preuveReglementaireNonRenseignee,
+  preuveComplementaireFichier,
+  preuveComplementaireLien,
+  preuveReglementaireFichier,
+  preuveReglementaireLien,
+  preuveReglementaireLienSansDescription,
+  preuveReglementaireNonRenseignee,
 } from './Bibliotheque/fixture';
+import { toDocumentsAttendus } from './preuve-view.adapter';
 import { PreuvesAction } from './PreuvesAction';
 
 export default {
@@ -21,12 +22,12 @@ export const SansPreuvesComplementaires = {
       identifiant: '1.2.3.4',
       referentiel: 'cae',
     },
-    reglementaires: [
+    attendus: toDocumentsAttendus([
       preuveReglementaireNonRenseignee,
       preuveReglementaireFichier,
       preuveReglementaireLien,
       preuveReglementaireLienSansDescription,
-    ],
+    ]),
   },
 };
 
@@ -37,12 +38,12 @@ export const AvecPreuvesComplementaires = {
       identifiant: '1.2.3.4',
       referentiel: 'cae',
     },
-    reglementaires: [
+    attendus: toDocumentsAttendus([
       preuveReglementaireNonRenseignee,
       preuveReglementaireFichier,
       preuveReglementaireLien,
       preuveReglementaireLienSansDescription,
-    ],
+    ]),
     complementaires: [preuveComplementaireFichier, preuveComplementaireLien],
   },
 };
@@ -55,7 +56,7 @@ export const SansPreuvesAttendues = {
       referentiel: 'cae',
     },
     withSubActions: true,
-    reglementaires: [],
+    attendus: [],
     complementaires: [],
   },
 };
@@ -67,7 +68,7 @@ export const AvecMessageAvertissement = {
       identifiant: '1.2.4',
       referentiel: 'cae',
     },
-    reglementaires: [],
+    attendus: [],
     complementaires: [preuveComplementaireFichier],
     showWarning: true,
   },

--- a/apps/app/src/referentiels/preuves/PreuvesAction.tsx
+++ b/apps/app/src/referentiels/preuves/PreuvesAction.tsx
@@ -7,10 +7,7 @@ import classNames from 'classnames';
 import { ComponentPropsWithoutRef, Fragment } from 'react';
 import PreuveDoc from './Bibliotheque/PreuveDoc';
 import { PreuveReglementaire } from './Bibliotheque/PreuveReglementaire';
-import {
-  TPreuveComplementaire,
-  TPreuveReglementaire,
-} from './Bibliotheque/types';
+import { TDocumentAttendu, TPreuveComplementaire } from './Bibliotheque/types';
 import { useDuplicatedDocumentState } from './duplicated-document-state.utils';
 import { TActionDef } from './usePreuves';
 
@@ -19,7 +16,7 @@ export interface TPreuvesActionProps extends ComponentPropsWithoutRef<'div'> {
   withSubActions?: boolean;
   showWarning?: boolean;
   hideIdentifier?: boolean;
-  reglementaires?: TPreuveReglementaire[];
+  attendus?: TDocumentAttendu[];
   complementaires?: TPreuveComplementaire[];
   displayInPanel?: boolean;
 }
@@ -28,7 +25,7 @@ export const PreuvesAction = (props: TPreuvesActionProps) => {
   const {
     action,
     withSubActions,
-    reglementaires,
+    attendus = [],
     complementaires,
     showWarning,
     hideIdentifier,
@@ -46,42 +43,34 @@ export const PreuvesAction = (props: TPreuvesActionProps) => {
   const showComplementaires =
     canEditReferentiel ||
     (!canEditReferentiel && complementaires && complementaires.length > 0);
-  const {
-    registerDuplicatedDocuments,
-    getDuplicatedDocumentInformation,
-  } = useDuplicatedDocumentState();
+  const { registerDuplicatedDocuments, getDuplicatedDocumentInformation } =
+    useDuplicatedDocumentState();
 
-  const reglementairesParActionId = reglementaires?.length
-    ? Array.from(groupByActionId(reglementaires))
-    : null;
+  const hasAttendus = attendus.length > 0;
 
   return (
     <div data-test={`preuves-${action.actionId}`} {...otherProps}>
-      {reglementairesParActionId ? (
+      {hasAttendus ? (
         <div data-test="attendues">
-          {reglementairesParActionId.map(([, preuvesList]) => {
-            const preuvesParDefinitionId = Array.from(
-              groupByPreuveDefinitionId(preuvesList)
-            );
-            return preuvesParDefinitionId.map(
-              ([preuveId, preuvesSubList], idx) => (
-                <Fragment key={preuveId}>
-                  <PreuveReglementaire
-                    preuves={preuvesSubList}
-                    hideIdentifier={hideIdentifier}
-                    displayInPanel={displayInPanel}
-                    getDuplicatedDocumentInformation={
-                      getDuplicatedDocumentInformation
-                    }
-                    onDuplicatedDocumentsAdded={registerDuplicatedDocuments}
-                  />
-                  {(showComplementaires ||
-                    (idx !== preuvesParDefinitionId.length - 1 &&
-                      !showComplementaires)) && (
-                    <Divider className="mb-6 border-grey-3" />
-                  )}
-                </Fragment>
-              )
+          {attendus.map((attendu, index) => {
+            const { action_id } = attendu.action;
+            const isLastAttenduOfAction = !attendus
+              .slice(index + 1)
+              .some((next) => next.action.action_id === action_id);
+            const showDivider = showComplementaires || !isLastAttenduOfAction;
+            return (
+              <Fragment key={`${action_id}/${attendu.preuve_reglementaire.id}`}>
+                <PreuveReglementaire
+                  attendu={attendu}
+                  hideIdentifier={hideIdentifier}
+                  displayInPanel={displayInPanel}
+                  getDuplicatedDocumentInformation={
+                    getDuplicatedDocumentInformation
+                  }
+                  onDuplicatedDocumentsAdded={registerDuplicatedDocuments}
+                />
+                {showDivider && <Divider className="mb-6 border-grey-3" />}
+              </Fragment>
             );
           })}
         </div>
@@ -125,10 +114,10 @@ export const PreuvesAction = (props: TPreuvesActionProps) => {
                   <PreuveDoc
                     key={preuve.id}
                     preuve={preuve}
-                    displayIdentifier={!(hideIdentifier ?? false)}
-                    duplicatedDocumentInformation={
-                      getDuplicatedDocumentInformation(preuve)
-                    }
+                    displayIdentifier={!hideIdentifier}
+                    duplicatedDocumentInformation={getDuplicatedDocumentInformation(
+                      preuve
+                    )}
                   />
                 ))}
               </div>
@@ -146,22 +135,4 @@ export const PreuvesAction = (props: TPreuvesActionProps) => {
       )}
     </div>
   );
-};
-
-const groupByActionId = (preuves: TPreuveReglementaire[]) => {
-  const byId = new Map<string, TPreuveReglementaire[]>();
-  preuves.forEach((preuve) => {
-    const { action_id } = preuve.action;
-    byId.set(action_id, [...(byId.get(action_id) || []), preuve]);
-  });
-  return byId;
-};
-
-const groupByPreuveDefinitionId = (preuves: TPreuveReglementaire[]) => {
-  const byId = new Map<string, TPreuveReglementaire[]>();
-  preuves.forEach((preuve) => {
-    const { id } = preuve.preuve_reglementaire;
-    byId.set(id, [...(byId.get(id) || []), preuve]);
-  });
-  return byId;
 };

--- a/apps/app/src/referentiels/preuves/preuve-view.adapter.spec.ts
+++ b/apps/app/src/referentiels/preuves/preuve-view.adapter.spec.ts
@@ -1,5 +1,16 @@
 import { describe, expect, test } from 'vitest';
-import { AuditFromView, toAuditEnCours } from './preuve-view.adapter';
+import {
+  preuveReglementaireFichier,
+  preuveReglementaireLien,
+  preuveReglementaireLienSameAttendu,
+  preuveReglementaireLienSansDescription,
+  preuveReglementaireNonRenseignee,
+} from './Bibliotheque/fixture';
+import {
+  AuditFromView,
+  toAuditEnCours,
+  toDocumentsAttendus,
+} from './preuve-view.adapter';
 
 const auditFromView: AuditFromView = {
   id: 101,
@@ -31,5 +42,59 @@ describe('toAuditEnCours', () => {
       clos: false,
       valide: true,
     });
+  });
+});
+
+describe('toDocumentsAttendus', () => {
+  test('regroupe les deux dépôts répondant au même attendu', () => {
+    expect(
+      toDocumentsAttendus([
+        preuveReglementaireFichier,
+        preuveReglementaireLienSameAttendu,
+      ])
+    ).toEqual([
+      {
+        action: preuveReglementaireFichier.action,
+        preuve_reglementaire: preuveReglementaireFichier.preuve_reglementaire,
+        documents: [
+          preuveReglementaireFichier,
+          preuveReglementaireLienSameAttendu,
+        ],
+      },
+    ]);
+  });
+
+  test("sépare les deux attendus d'une même mesure", () => {
+    const attendus = toDocumentsAttendus([
+      preuveReglementaireFichier,
+      preuveReglementaireLien,
+    ]);
+
+    expect(
+      attendus.map(({ preuve_reglementaire }) => preuve_reglementaire.id)
+    ).toEqual(['etude_vulnerabilite', 'agenda']);
+  });
+
+  test('ne fusionne pas un même attendu porté par deux mesures différentes', () => {
+    const attendus = toDocumentsAttendus([
+      preuveReglementaireFichier,
+      preuveReglementaireLienSansDescription,
+    ]);
+
+    expect(attendus.map(({ action }) => action.action_id)).toEqual([
+      'eci_1.1.3',
+      'eci_1.1.4',
+    ]);
+  });
+
+  test("rend une liste de documents vide quand l'attendu n'a reçu aucun dépôt", () => {
+    expect(toDocumentsAttendus([preuveReglementaireNonRenseignee])).toEqual([
+      {
+        action: preuveReglementaireNonRenseignee.action,
+        preuve_reglementaire:
+          preuveReglementaireNonRenseignee.preuve_reglementaire,
+        documents: [],
+      },
+    ]);
   });
 });

--- a/apps/app/src/referentiels/preuves/preuve-view.adapter.ts
+++ b/apps/app/src/referentiels/preuves/preuve-view.adapter.ts
@@ -1,5 +1,7 @@
 import { TAuditEnCours } from '@/app/referentiels/audits/types';
 import { ReferentielId } from '@tet/domain/referentiels';
+import { groupBy } from 'es-toolkit';
+import { TDocumentAttendu, TPreuveReglementaire } from './Bibliotheque/types';
 
 export type AuditFromView = Omit<TAuditEnCours, 'referentiel_id'> & {
   referentiel: ReferentielId;
@@ -12,3 +14,21 @@ export const toAuditEnCours = ({
   ...audit,
   referentiel_id: referentiel,
 });
+
+const hasDocument = (preuve: TPreuveReglementaire): boolean =>
+  preuve.fichier !== null || preuve.lien !== null;
+
+export const toDocumentsAttendus = (
+  preuvesReglementaires: TPreuveReglementaire[]
+): TDocumentAttendu[] =>
+  Object.values(
+    groupBy(
+      preuvesReglementaires,
+      ({ action, preuve_reglementaire }) =>
+        `${action.action_id}/${preuve_reglementaire.id}`
+    )
+  ).map((preuves) => ({
+    action: preuves[0].action,
+    preuve_reglementaire: preuves[0].preuve_reglementaire,
+    documents: preuves.filter(hasDocument),
+  }));


### PR DESCRIPTION
> Empilée sur #4917. Le diff propre est celui contre `refactor/mesure-non-concernee-badge-mort`.

## Comportement

Aucun changement visible.

## Pourquoi

`PreuvesAction` enchaînait deux regroupements sur la liste plate rendue par `public.preuve` — par `action_id`, puis par identifiant de définition — et `PreuveReglementaire` lisait `preuves[0]` pour en tirer le titre de l'attendu et la mesure, en supposant que les items suivants portaient les mêmes valeurs.

La vue croise chaque collectivité avec chaque définition d'attendu, donc un attendu sans dépôt sort sous la forme d'une ligne où seuls `action` et `preuve_reglementaire` sont renseignés. Cette ligne servait à la fois de porteuse de l'attendu et de faux document.

## Contenu

- `toDocumentsAttendus`, adaptateur pur de la vue, regroupe les lignes par `action_id` et identifiant de définition et rend `{ action, preuve_reglementaire, documents }` — la forme que l'endpoint backend rendra.
- La ligne d'un attendu sans dépôt ne porte plus que l'attendu : elle sort de `documents`, qui vaut alors `[]`.
- `PreuvesAction` reçoit `attendus` au lieu de `reglementaires` et perd ses deux `groupBy` ; `PreuveReglementaire` reçoit un `attendu` au lieu d'une liste dont il fallait lire le premier élément.
- La suppression du séparateur après le dernier attendu d'une mesure est conservée à l'identique, mais la condition ne suppose plus que l'adaptateur rend contigus les attendus d'une même mesure.
- 4 tests sur l'adaptateur, dont deux complémentaires : deux attendus d'une même mesure ne fusionnent pas, un même attendu porté par deux mesures non plus.

## Note

`preuveReglementaireNonRenseignee` était typée `Omit<TPreuveReglementaire, 'id'>` parce que la vue rend `id = null` pour un attendu sans dépôt, ce que `TPreuveBase` ne sait pas exprimer. La fixture reçoit un `id` pour rester utilisable ; le modèle lui-même est traité dans la PR suivante, qui sépare `Preuve` et `ExpectedPreuve`.

## Hors scope

L'endpoint `list-mesure-documents` et la suppression de `usePreuves`.
