### PR TITLE
feat(referentiels): expose les documents d'une mesure via un endpoint

### DIFF
--- a/apps/backend/src/referentiels/documents/list-mesure-documents/list-mesure-documents.adapter.ts
+++ b/apps/backend/src/referentiels/documents/list-mesure-documents/list-mesure-documents.adapter.ts
@@ -1,0 +1,30 @@
+import { groupBy } from 'es-toolkit';
+
+type SupportRow = {
+  id: number | null;
+  fichier: unknown;
+  lien: unknown;
+};
+
+type AttenduRow = SupportRow & {
+  action: { actionId: string };
+  preuveReglementaire: { id: string };
+};
+
+function hasSupport({ id, fichier, lien }: SupportRow): boolean {
+  return id !== null && (fichier !== null || lien !== null);
+}
+
+export function toAttendus<Row extends AttenduRow>(rows: Row[]) {
+  return Object.values(
+    groupBy(
+      rows,
+      ({ action, preuveReglementaire }) =>
+        `${action.actionId}/${preuveReglementaire.id}`
+    )
+  ).map((depots) => ({
+    preuveReglementaire: depots[0].preuveReglementaire,
+    action: depots[0].action,
+    documents: depots.filter(hasSupport),
+  }));
+}

--- a/apps/backend/src/referentiels/documents/list-mesure-documents/list-mesure-documents.errors.ts
+++ b/apps/backend/src/referentiels/documents/list-mesure-documents/list-mesure-documents.errors.ts
@@ -1,0 +1,36 @@
+import {
+  createErrorsEnum,
+  TrpcErrorHandlerConfig,
+} from '@tet/backend/utils/trpc/trpc-error-handler';
+
+const specificErrors = [
+  'DOCUMENT_SCHEMA_MISMATCH',
+  'UNKNOWN_REFERENTIEL',
+] as const;
+type SpecificError = (typeof specificErrors)[number];
+
+export const listMesureDocumentsErrorConfig: TrpcErrorHandlerConfig<SpecificError> =
+  {
+    commonErrors: {
+      UNAUTHORIZED: {
+        code: 'FORBIDDEN',
+        message:
+          "Vous n'avez pas les permissions nécessaires pour lister les documents de cette mesure.",
+      },
+    },
+    specificErrors: {
+      DOCUMENT_SCHEMA_MISMATCH: {
+        code: 'INTERNAL_SERVER_ERROR',
+        message:
+          "Un document ne respecte pas le format attendu et n'a pas pu être rendu.",
+      },
+      UNKNOWN_REFERENTIEL: {
+        code: 'BAD_REQUEST',
+        message: "L'identifiant de mesure ne désigne aucun référentiel connu.",
+      },
+    },
+  };
+
+export const ListMesureDocumentsErrorEnum = createErrorsEnum(specificErrors);
+export type ListMesureDocumentsError =
+  keyof typeof ListMesureDocumentsErrorEnum;

--- a/apps/backend/src/referentiels/documents/list-mesure-documents/list-mesure-documents.input.ts
+++ b/apps/backend/src/referentiels/documents/list-mesure-documents/list-mesure-documents.input.ts
@@ -1,0 +1,11 @@
+import z from 'zod';
+
+export const listMesureDocumentsInputSchema = z.object({
+  collectiviteId: z.number().int().positive(),
+  actionId: z.string().min(1),
+  withSubActions: z.boolean().optional(),
+});
+
+export type ListMesureDocumentsInput = z.infer<
+  typeof listMesureDocumentsInputSchema
+>;

--- a/apps/backend/src/referentiels/documents/list-mesure-documents/list-mesure-documents.output.ts
+++ b/apps/backend/src/referentiels/documents/list-mesure-documents/list-mesure-documents.output.ts
@@ -1,0 +1,76 @@
+import z from 'zod';
+
+const fichierSchema = z.object({
+  id: z.number(),
+  collectiviteId: z.number(),
+  hash: z.string(),
+  filename: z.string(),
+  confidentiel: z.boolean().nullable(),
+  bucketId: z.string(),
+  filesize: z
+    .number()
+    .nullable()
+    .transform((filesize) => filesize ?? undefined),
+});
+
+const lienSchema = z.object({
+  url: z.string(),
+  titre: z.string(),
+});
+
+const supportSchema = z.union([
+  z.object({ fichier: fichierSchema, lien: z.null() }),
+  z.object({ fichier: z.null(), lien: lienSchema }),
+]);
+
+const mesureSchema = z.object({
+  actionId: z.string(),
+  identifiant: z.string(),
+});
+
+const attenduDefinitionSchema = z.object({
+  id: z.string(),
+  nom: z.string(),
+  description: z.string(),
+});
+
+const documentBaseSchema = z.object({
+  id: z.number(),
+  collectiviteId: z.number(),
+  commentaire: z.string().nullable(),
+  modifiedAt: z.string(),
+  modifiedBy: z.string().nullable(),
+  modifiedByNom: z.string().nullable(),
+  action: mesureSchema,
+});
+
+const documentReglementaireSchema = documentBaseSchema
+  .extend({
+    preuveType: z.literal('reglementaire'),
+    preuveReglementaire: attenduDefinitionSchema,
+  })
+  .and(supportSchema);
+
+const documentComplementaireSchema = documentBaseSchema
+  .extend({ preuveType: z.literal('complementaire') })
+  .and(supportSchema);
+
+const attenduSchema = z.object({
+  preuveReglementaire: attenduDefinitionSchema,
+  action: mesureSchema,
+  documents: z.array(documentReglementaireSchema),
+});
+
+export const listMesureDocumentsOutputSchema = z.object({
+  attendus: z.array(attenduSchema),
+  complementaires: z.array(documentComplementaireSchema),
+});
+
+export type ListMesureDocumentsOutput = z.infer<
+  typeof listMesureDocumentsOutputSchema
+>;
+export type Attendu = z.infer<typeof attenduSchema>;
+export type DocumentReglementaire = z.infer<typeof documentReglementaireSchema>;
+export type DocumentComplementaire = z.infer<
+  typeof documentComplementaireSchema
+>;

--- a/apps/backend/src/referentiels/documents/list-mesure-documents/list-mesure-documents.repository.ts
+++ b/apps/backend/src/referentiels/documents/list-mesure-documents/list-mesure-documents.repository.ts
@@ -1,0 +1,196 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  buildFichierSubquery,
+  buildFileInfoSql,
+} from '@tet/backend/collectivites/documents/file-info.utils';
+import { hideConfidentielFilter } from '@tet/backend/collectivites/documents/hide-confidentiel.utils';
+import { preuveActionTable } from '@tet/backend/collectivites/documents/models/preuve-action.table';
+import { preuveComplementaireTable } from '@tet/backend/collectivites/documents/models/preuve-complementaire.table';
+import { preuveReglementaireDefinitionTable } from '@tet/backend/collectivites/documents/models/preuve-reglementaire-definition.table';
+import { preuveReglementaireTable } from '@tet/backend/collectivites/documents/models/preuve-reglementaire.table';
+import { createdByNom, dcpTable } from '@tet/backend/users/models/dcp.table';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { failure, success } from '@tet/backend/utils/result.type';
+import { getErrorMessage } from '@tet/domain/utils';
+import { and, eq, getTableColumns, like, or, SQL, sql } from 'drizzle-orm';
+import { actionDefinitionTable } from '../../models/action-definition.table';
+import { ListMesureDocumentsErrorEnum } from './list-mesure-documents.errors';
+
+type MesureScope = {
+  collectiviteId: number;
+  actionId: string;
+  withSubActions?: boolean;
+  canReadConfidentiel: boolean;
+};
+
+const mesureColumns = {
+  action: {
+    actionId: actionDefinitionTable.actionId,
+    identifiant: actionDefinitionTable.identifiant,
+  },
+  modifiedByNom: createdByNom,
+};
+
+function buildMesureFilter({
+  actionId,
+  withSubActions,
+}: Pick<MesureScope, 'actionId' | 'withSubActions'>): SQL | undefined {
+  const mesure = eq(actionDefinitionTable.actionId, actionId);
+
+  if (!withSubActions) {
+    return mesure;
+  }
+
+  return or(mesure, like(actionDefinitionTable.actionId, `${actionId}.%`));
+}
+
+@Injectable()
+export class ListMesureDocumentsRepository {
+  private readonly logger = new Logger(ListMesureDocumentsRepository.name);
+
+  constructor(private readonly databaseService: DatabaseService) {}
+
+  async listAttendus(
+    {
+      collectiviteId,
+      actionId,
+      withSubActions,
+      canReadConfidentiel,
+    }: MesureScope,
+    tx?: Transaction
+  ) {
+    const db = tx ?? this.databaseService.db;
+    const fichier = buildFichierSubquery(db);
+
+    try {
+      const rows = await db
+        .select({
+          ...getTableColumns(preuveReglementaireTable),
+          fichier: buildFileInfoSql(fichier),
+          preuveReglementaire: {
+            ...getTableColumns(preuveReglementaireDefinitionTable),
+          },
+          ...mesureColumns,
+          preuveType: sql<'reglementaire'>`'reglementaire'`,
+        })
+        .from(preuveActionTable)
+        .innerJoin(
+          preuveReglementaireDefinitionTable,
+          eq(preuveReglementaireDefinitionTable.id, preuveActionTable.preuveId)
+        )
+        .innerJoin(
+          actionDefinitionTable,
+          and(
+            eq(actionDefinitionTable.actionId, preuveActionTable.actionId),
+            buildMesureFilter({ actionId, withSubActions })
+          )
+        )
+        .leftJoin(
+          preuveReglementaireTable,
+          and(
+            eq(
+              preuveReglementaireTable.preuveId,
+              preuveReglementaireDefinitionTable.id
+            ),
+            eq(preuveReglementaireTable.collectiviteId, collectiviteId)
+          )
+        )
+        .leftJoin(
+          fichier,
+          and(
+            eq(preuveReglementaireTable.fichierId, fichier.id),
+            eq(fichier.collectiviteId, collectiviteId)
+          )
+        )
+        .leftJoin(
+          dcpTable,
+          eq(preuveReglementaireTable.modifiedBy, dcpTable.id)
+        )
+        .where(
+          hideConfidentielFilter({
+            fichierIdColumn: preuveReglementaireTable.fichierId,
+            confidentielColumn: fichier.confidentiel,
+            canReadConfidentiel,
+          })
+        )
+        .orderBy(
+          actionDefinitionTable.actionId,
+          preuveReglementaireDefinitionTable.nom,
+          preuveReglementaireTable.id
+        );
+      return success(rows);
+    } catch (error) {
+      this.logger.error(
+        `Echec de la lecture des documents attendus de la mesure ${actionId} de la collectivite ${collectiviteId}: ${getErrorMessage(
+          error
+        )}`
+      );
+      return failure(ListMesureDocumentsErrorEnum.DATABASE_ERROR);
+    }
+  }
+
+  async listComplementaires(
+    {
+      collectiviteId,
+      actionId,
+      withSubActions,
+      canReadConfidentiel,
+    }: MesureScope,
+    tx?: Transaction
+  ) {
+    const db = tx ?? this.databaseService.db;
+    const fichier = buildFichierSubquery(db);
+
+    try {
+      const rows = await db
+        .select({
+          ...getTableColumns(preuveComplementaireTable),
+          fichier: buildFileInfoSql(fichier),
+          ...mesureColumns,
+          preuveType: sql<'complementaire'>`'complementaire'`,
+        })
+        .from(preuveComplementaireTable)
+        .innerJoin(
+          actionDefinitionTable,
+          and(
+            eq(
+              actionDefinitionTable.actionId,
+              preuveComplementaireTable.actionId
+            ),
+            buildMesureFilter({ actionId, withSubActions })
+          )
+        )
+        .leftJoin(
+          fichier,
+          and(
+            eq(preuveComplementaireTable.fichierId, fichier.id),
+            eq(fichier.collectiviteId, collectiviteId)
+          )
+        )
+        .leftJoin(
+          dcpTable,
+          eq(preuveComplementaireTable.modifiedBy, dcpTable.id)
+        )
+        .where(
+          and(
+            eq(preuveComplementaireTable.collectiviteId, collectiviteId),
+            hideConfidentielFilter({
+              fichierIdColumn: preuveComplementaireTable.fichierId,
+              confidentielColumn: fichier.confidentiel,
+              canReadConfidentiel,
+            })
+          )
+        )
+        .orderBy(actionDefinitionTable.actionId, preuveComplementaireTable.id);
+      return success(rows);
+    } catch (error) {
+      this.logger.error(
+        `Echec de la lecture des documents complementaires de la mesure ${actionId} de la collectivite ${collectiviteId}: ${getErrorMessage(
+          error
+        )}`
+      );
+      return failure(ListMesureDocumentsErrorEnum.DATABASE_ERROR);
+    }
+  }
+}

--- a/apps/backend/src/referentiels/documents/list-mesure-documents/list-mesure-documents.router.e2e-spec.ts
+++ b/apps/backend/src/referentiels/documents/list-mesure-documents/list-mesure-documents.router.e2e-spec.ts
@@ -1,0 +1,361 @@
+import { INestApplication } from '@nestjs/common';
+import { addTestCollectiviteAndUsers } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { seedTestDocument } from '@tet/backend/collectivites/documents/documents.test-fixture';
+import { bibliothequeFichierTable } from '@tet/backend/collectivites/documents/models/bibliotheque-fichier.table';
+import { preuveComplementaireTable } from '@tet/backend/collectivites/documents/models/preuve-complementaire.table';
+import { preuveReglementaireTable } from '@tet/backend/collectivites/documents/models/preuve-reglementaire.table';
+import {
+  getAuthUserFromUserCredentials,
+  getTestApp,
+  getTestDatabase,
+} from '@tet/backend/test';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { addTestUser } from '@tet/backend/users/users/users.test-fixture';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
+import { CollectiviteRole } from '@tet/domain/users';
+import { eq } from 'drizzle-orm';
+import { onTestFinished } from 'vitest';
+
+const MESURE = {
+  actionId: 'eci_1.1.4',
+  attendus: ['delib_strategie_eci', 'plan_action_eci'],
+  sousMesure: 'eci_1.1.4.1',
+  siblingSousMesure: 'eci_1.1.4.10',
+} as const;
+
+describe('List Mesure Documents Router', () => {
+  let router: TrpcRouter;
+  let db: DatabaseService;
+  let app: INestApplication;
+  let visiteurUser: AuthenticatedUser;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    router = await app.get(TrpcRouter);
+    db = await getTestDatabase(app);
+
+    const visiteurResult = await addTestUser(db);
+    visiteurUser = getAuthUserFromUserCredentials(visiteurResult.user);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  const createCollectivite = async ({
+    accesRestreint = false,
+  }: { accesRestreint?: boolean } = {}) => {
+    const { collectivite, users, cleanup } = await addTestCollectiviteAndUsers(
+      db,
+      {
+        collectivite: { accesRestreint },
+        users: [{ role: CollectiviteRole.EDITION }],
+      }
+    );
+    onTestFinished(cleanup);
+
+    const membre = users[0];
+    const collectiviteId = collectivite.id;
+
+    const addFichier = async (document: {
+      filename: string;
+      confidentiel?: boolean;
+    }) => {
+      const fichier = await seedTestDocument({
+        databaseService: db,
+        collectiviteId,
+        filename: document.filename,
+        confidentiel: document.confidentiel,
+      });
+      onTestFinished(async () => {
+        await db.db
+          .delete(bibliothequeFichierTable)
+          .where(eq(bibliothequeFichierTable.id, fichier.id));
+      });
+      return fichier;
+    };
+
+    return {
+      collectiviteId,
+      membreCaller: router.createCaller({
+        user: getAuthUserFromUserCredentials(membre),
+      }),
+
+      async addAttenduDepot({
+        preuveId,
+        titre,
+        fichierId,
+      }: {
+        preuveId: string;
+        titre: string;
+        fichierId?: number;
+      }) {
+        const [depot] = await db.db
+          .insert(preuveReglementaireTable)
+          .values({
+            collectiviteId,
+            preuveId,
+            titre,
+            url: fichierId ? null : `https://example.com/${titre}`,
+            fichierId: fichierId ?? null,
+            commentaire: '',
+            modifiedBy: membre.id,
+          })
+          .returning({ id: preuveReglementaireTable.id });
+        onTestFinished(async () => {
+          await db.db
+            .delete(preuveReglementaireTable)
+            .where(eq(preuveReglementaireTable.id, depot.id));
+        });
+      },
+
+      async addComplementaire({
+        actionId,
+        titre,
+      }: {
+        actionId: string;
+        titre: string;
+      }) {
+        const [depot] = await db.db
+          .insert(preuveComplementaireTable)
+          .values({
+            collectiviteId,
+            actionId,
+            titre,
+            url: `https://example.com/${titre}`,
+            commentaire: '',
+            modifiedBy: membre.id,
+          })
+          .returning({ id: preuveComplementaireTable.id });
+        onTestFinished(async () => {
+          await db.db
+            .delete(preuveComplementaireTable)
+            .where(eq(preuveComplementaireTable.id, depot.id));
+        });
+      },
+
+      addFichier,
+    };
+  };
+
+  test("rend les deux attendus de la mesure avec une liste de documents vide quand rien n'est déposé", async () => {
+    const { collectiviteId, membreCaller } = await createCollectivite();
+
+    const { attendus } =
+      await membreCaller.referentiels.documents.listMesureDocuments({
+        collectiviteId,
+        actionId: MESURE.actionId,
+      });
+
+    expect(
+      attendus.map(({ preuveReglementaire, documents }) => ({
+        attendu: preuveReglementaire.id,
+        nombreDeDocuments: documents.length,
+      }))
+    ).toEqual([
+      { attendu: MESURE.attendus[0], nombreDeDocuments: 0 },
+      { attendu: MESURE.attendus[1], nombreDeDocuments: 0 },
+    ]);
+  });
+
+  test("regroupe les deux dépôts d'un même attendu sous ce seul attendu", async () => {
+    const { collectiviteId, membreCaller, addAttenduDepot } =
+      await createCollectivite();
+
+    await addAttenduDepot({ preuveId: MESURE.attendus[0], titre: 'premier' });
+    await addAttenduDepot({ preuveId: MESURE.attendus[0], titre: 'second' });
+
+    const { attendus } =
+      await membreCaller.referentiels.documents.listMesureDocuments({
+        collectiviteId,
+        actionId: MESURE.actionId,
+      });
+
+    expect(
+      attendus.map(({ preuveReglementaire, documents }) => ({
+        attendu: preuveReglementaire.id,
+        titres: documents.map((document) => document.lien?.titre),
+      }))
+    ).toEqual([
+      { attendu: MESURE.attendus[0], titres: ['premier', 'second'] },
+      { attendu: MESURE.attendus[1], titres: [] },
+    ]);
+  });
+
+  test("ne rend pas le dépôt d'une autre collectivité sur le même attendu", async () => {
+    const autreCollectivite = await createCollectivite();
+    await autreCollectivite.addAttenduDepot({
+      preuveId: MESURE.attendus[0],
+      titre: 'depot-voisin',
+    });
+
+    const { collectiviteId, membreCaller, addAttenduDepot } =
+      await createCollectivite();
+    await addAttenduDepot({
+      preuveId: MESURE.attendus[0],
+      titre: 'depot-propre',
+    });
+
+    const { attendus } =
+      await membreCaller.referentiels.documents.listMesureDocuments({
+        collectiviteId,
+        actionId: MESURE.actionId,
+      });
+
+    expect(
+      attendus.flatMap(({ documents }) =>
+        documents.map((document) => document.lien?.titre)
+      )
+    ).toEqual(['depot-propre']);
+  });
+
+  test("laisse de côté les documents d'une sous-mesure quand withSubActions est absent", async () => {
+    const { collectiviteId, membreCaller, addComplementaire } =
+      await createCollectivite();
+
+    await addComplementaire({
+      actionId: MESURE.actionId,
+      titre: 'sur-la-mesure',
+    });
+    await addComplementaire({
+      actionId: MESURE.sousMesure,
+      titre: 'sur-la-sous-mesure',
+    });
+
+    const { complementaires } =
+      await membreCaller.referentiels.documents.listMesureDocuments({
+        collectiviteId,
+        actionId: MESURE.actionId,
+      });
+
+    expect(complementaires.map((document) => document.lien?.titre)).toEqual([
+      'sur-la-mesure',
+    ]);
+  });
+
+  test('descend dans les sous-mesures quand withSubActions est demandé', async () => {
+    const { collectiviteId, membreCaller, addComplementaire } =
+      await createCollectivite();
+
+    await addComplementaire({
+      actionId: MESURE.actionId,
+      titre: 'sur-la-mesure',
+    });
+    await addComplementaire({
+      actionId: MESURE.sousMesure,
+      titre: 'sur-la-sous-mesure',
+    });
+
+    const { complementaires } =
+      await membreCaller.referentiels.documents.listMesureDocuments({
+        collectiviteId,
+        actionId: MESURE.actionId,
+        withSubActions: true,
+      });
+
+    expect(complementaires.map((document) => document.lien?.titre)).toEqual([
+      'sur-la-mesure',
+      'sur-la-sous-mesure',
+    ]);
+  });
+
+  test('ne confond pas la sous-mesure 1.1.4.1 avec la sous-mesure 1.1.4.10', async () => {
+    const { collectiviteId, membreCaller, addComplementaire } =
+      await createCollectivite();
+
+    await addComplementaire({
+      actionId: MESURE.sousMesure,
+      titre: 'sur-1-1-4-1',
+    });
+    await addComplementaire({
+      actionId: MESURE.siblingSousMesure,
+      titre: 'sur-1-1-4-10',
+    });
+
+    const { complementaires } =
+      await membreCaller.referentiels.documents.listMesureDocuments({
+        collectiviteId,
+        actionId: MESURE.sousMesure,
+        withSubActions: true,
+      });
+
+    expect(complementaires.map((document) => document.lien?.titre)).toEqual([
+      'sur-1-1-4-1',
+    ]);
+  });
+
+  test('masque un document confidentiel à un visiteur non membre', async () => {
+    const { collectiviteId, membreCaller, addAttenduDepot, addFichier } =
+      await createCollectivite();
+
+    const fichierPublic = await addFichier({ filename: 'public.pdf' });
+    const fichierConfidentiel = await addFichier({
+      filename: 'confidentiel.pdf',
+      confidentiel: true,
+    });
+    await addAttenduDepot({
+      preuveId: MESURE.attendus[0],
+      titre: 'public',
+      fichierId: fichierPublic.id,
+    });
+    await addAttenduDepot({
+      preuveId: MESURE.attendus[0],
+      titre: 'confidentiel',
+      fichierId: fichierConfidentiel.id,
+    });
+
+    const visiteurCaller = router.createCaller({ user: visiteurUser });
+    const visiteurView =
+      await visiteurCaller.referentiels.documents.listMesureDocuments({
+        collectiviteId,
+        actionId: MESURE.actionId,
+      });
+    const membreView =
+      await membreCaller.referentiels.documents.listMesureDocuments({
+        collectiviteId,
+        actionId: MESURE.actionId,
+      });
+
+    const getFilenames = ({ attendus }: typeof visiteurView) =>
+      attendus.flatMap(({ documents }) =>
+        documents.map((document) => document.fichier?.filename)
+      );
+
+    expect(getFilenames(visiteurView)).toEqual(['public.pdf']);
+    expect(getFilenames(membreView)).toEqual([
+      'public.pdf',
+      'confidentiel.pdf',
+    ]);
+  });
+
+  test("refuse la lecture d'une collectivité en accès restreint à un utilisateur non membre", async () => {
+    const { collectiviteId } = await createCollectivite({
+      accesRestreint: true,
+    });
+
+    const visiteurCaller = router.createCaller({ user: visiteurUser });
+
+    await expect(
+      visiteurCaller.referentiels.documents.listMesureDocuments({
+        collectiviteId,
+        actionId: MESURE.actionId,
+      })
+    ).rejects.toThrow(
+      "Vous n'avez pas les permissions nécessaires pour lister les documents de cette mesure."
+    );
+  });
+
+  test('rejette un identifiant de mesure dont le préfixe ne désigne aucun référentiel', async () => {
+    const { collectiviteId, membreCaller } = await createCollectivite();
+
+    await expect(
+      membreCaller.referentiels.documents.listMesureDocuments({
+        collectiviteId,
+        actionId: 'inconnu_1.1.4',
+      })
+    ).rejects.toThrow(
+      "L'identifiant de mesure ne désigne aucun référentiel connu."
+    );
+  });
+});

--- a/apps/backend/src/referentiels/documents/list-mesure-documents/list-mesure-documents.router.ts
+++ b/apps/backend/src/referentiels/documents/list-mesure-documents/list-mesure-documents.router.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+import { createTrpcErrorHandler } from '@tet/backend/utils/trpc/trpc-error-handler';
+import { TrpcService } from '@tet/backend/utils/trpc/trpc.service';
+import { listMesureDocumentsErrorConfig } from './list-mesure-documents.errors';
+import { listMesureDocumentsInputSchema } from './list-mesure-documents.input';
+import { ListMesureDocumentsService } from './list-mesure-documents.service';
+
+@Injectable()
+export class ListMesureDocumentsRouter {
+  constructor(
+    private readonly trpc: TrpcService,
+    private readonly listMesureDocumentsService: ListMesureDocumentsService
+  ) {}
+
+  private readonly getResultDataOrThrowError = createTrpcErrorHandler(
+    listMesureDocumentsErrorConfig
+  );
+
+  router = this.trpc.router({
+    listMesureDocuments: this.trpc.authedProcedure
+      .input(listMesureDocumentsInputSchema)
+      .query(async ({ input, ctx: { user } }) => {
+        const result =
+          await this.listMesureDocumentsService.listMesureDocuments(input, {
+            user,
+          });
+        return this.getResultDataOrThrowError(result);
+      }),
+  });
+}

--- a/apps/backend/src/referentiels/documents/list-mesure-documents/list-mesure-documents.service.ts
+++ b/apps/backend/src/referentiels/documents/list-mesure-documents/list-mesure-documents.service.ts
@@ -1,0 +1,79 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ServiceSecondArg } from '@tet/backend/utils/nest/service-second-arg.utils';
+import { failure, Result, success } from '@tet/backend/utils/result.type';
+import { tryGetReferentielIdFromActionId } from '@tet/domain/referentiels';
+import { ReferentielDocumentsAccessService } from '../referentiel-documents-access.service';
+import { toAttendus } from './list-mesure-documents.adapter';
+import {
+  ListMesureDocumentsError,
+  ListMesureDocumentsErrorEnum,
+} from './list-mesure-documents.errors';
+import { ListMesureDocumentsInput } from './list-mesure-documents.input';
+import {
+  ListMesureDocumentsOutput,
+  listMesureDocumentsOutputSchema,
+} from './list-mesure-documents.output';
+import { ListMesureDocumentsRepository } from './list-mesure-documents.repository';
+
+@Injectable()
+export class ListMesureDocumentsService {
+  private readonly logger = new Logger(ListMesureDocumentsService.name);
+
+  constructor(
+    private readonly listMesureDocumentsRepository: ListMesureDocumentsRepository,
+    private readonly referentielDocumentsAccess: ReferentielDocumentsAccessService
+  ) {}
+
+  async listMesureDocuments(
+    { collectiviteId, actionId, withSubActions }: ListMesureDocumentsInput,
+    { user, tx }: ServiceSecondArg
+  ): Promise<Result<ListMesureDocumentsOutput, ListMesureDocumentsError>> {
+    const referentielId = tryGetReferentielIdFromActionId(actionId);
+    if (!referentielId) {
+      return failure(ListMesureDocumentsErrorEnum.UNKNOWN_REFERENTIEL);
+    }
+
+    const accessResult =
+      await this.referentielDocumentsAccess.checkUserCanReadDocuments(
+        { collectiviteId, referentielId },
+        { user, tx }
+      );
+    if (!accessResult.success) {
+      return failure(ListMesureDocumentsErrorEnum.UNAUTHORIZED);
+    }
+
+    const { canReadConfidentiel } = accessResult.data;
+    const scope = {
+      collectiviteId,
+      actionId,
+      withSubActions,
+      canReadConfidentiel,
+    };
+
+    const [attendusResult, complementairesResult] = await Promise.all([
+      this.listMesureDocumentsRepository.listAttendus(scope, tx),
+      this.listMesureDocumentsRepository.listComplementaires(scope, tx),
+    ]);
+
+    if (!attendusResult.success) {
+      return failure(attendusResult.error);
+    }
+    if (!complementairesResult.success) {
+      return failure(complementairesResult.error);
+    }
+
+    const parsing = listMesureDocumentsOutputSchema.safeParse({
+      attendus: toAttendus(attendusResult.data),
+      complementaires: complementairesResult.data,
+    });
+
+    if (!parsing.success) {
+      this.logger.error(
+        `Documents hors contrat pour la mesure ${actionId} de la collectivité ${collectiviteId}: ${parsing.error.message}`
+      );
+      return failure(ListMesureDocumentsErrorEnum.DOCUMENT_SCHEMA_MISMATCH);
+    }
+
+    return success(parsing.data);
+  }
+}

--- a/apps/backend/src/referentiels/referentiels.module.ts
+++ b/apps/backend/src/referentiels/referentiels.module.ts
@@ -57,6 +57,9 @@ import { ReferentielDocumentsAccessService } from './documents/referentiel-docum
 import { ListDocumentsRepository } from './documents/list-documents/list-documents.repository';
 import { ListDocumentsRouter } from './documents/list-documents/list-documents.router';
 import { ListDocumentsService } from './documents/list-documents/list-documents.service';
+import { ListMesureDocumentsRepository } from './documents/list-mesure-documents/list-mesure-documents.repository';
+import { ListMesureDocumentsRouter } from './documents/list-mesure-documents/list-mesure-documents.router';
+import { ListMesureDocumentsService } from './documents/list-mesure-documents/list-mesure-documents.service';
 import { ListPreuvesService } from './labellisations/list-preuves/list-preuves.service';
 import { RequestLabellisationRouter } from './labellisations/request-labellisation/request-labellisation.router';
 import { RequestLabellisationService } from './labellisations/request-labellisation/request-labellisation.service';
@@ -194,6 +197,9 @@ import { UpdateActionStatutService } from './update-action-statut/update-action-
     ListDocumentsRepository,
     ListDocumentsService,
     ListDocumentsRouter,
+    ListMesureDocumentsRepository,
+    ListMesureDocumentsService,
+    ListMesureDocumentsRouter,
     UpdateAuditReportService,
     UpdateAuditReportRouter,
     ValidateAuditService,

--- a/apps/backend/src/referentiels/referentiels.router.ts
+++ b/apps/backend/src/referentiels/referentiels.router.ts
@@ -6,6 +6,7 @@ import { AddPreuveRouter } from './add-preuve/add-preuve.router';
 import { CountPreuvesRouter } from './count-preuve/count-preuves.router';
 import { GetReferentielDefinitionRouter } from './definitions/get-referentiel-definition/get-referentiel-definition.router';
 import { ListDocumentsRouter } from './documents/list-documents/list-documents.router';
+import { ListMesureDocumentsRouter } from './documents/list-mesure-documents/list-mesure-documents.router';
 import { HandleMesurePilotesRouter } from './handle-mesure-pilotes/handle-mesure-pilotes.router';
 import { HandleMesuresServicesRouter } from './handle-mesure-services/handle-mesure-services.router';
 import { HistoriqueRouter } from './historique/historique.router';
@@ -45,6 +46,7 @@ export class ReferentielsRouter {
     private readonly validateAudit: ValidateAuditRouter,
     private readonly listPreuves: ListPreuvesRouter,
     private readonly listDocumentsRouter: ListDocumentsRouter,
+    private readonly listMesureDocumentsRouter: ListMesureDocumentsRouter,
     private readonly updateAuditReport: UpdateAuditReportRouter,
     private readonly assignPilotesRouter: HandleMesurePilotesRouter,
     private readonly assignServicesRouter: HandleMesuresServicesRouter,
@@ -95,7 +97,10 @@ export class ReferentielsRouter {
       this.updateAuditReport.router
     ),
 
-    documents: this.listDocumentsRouter.router,
+    documents: this.trpc.mergeRouters(
+      this.listDocumentsRouter.router,
+      this.listMesureDocumentsRouter.router
+    ),
 
     definitions: this.getReferentielDefinitionRouter.router,
 

--- a/packages/domain/src/referentiels/referentiel.utils.ts
+++ b/packages/domain/src/referentiels/referentiel.utils.ts
@@ -16,16 +16,21 @@ export class ReferentielException extends Error {
   }
 }
 
-export function getReferentielIdFromActionId(actionId: string): ReferentielId {
-  const unsafeReferentielId = actionId.split('_')[0];
+export function tryGetReferentielIdFromActionId(
+  actionId: string
+): ReferentielId | undefined {
+  const parsing = referentielIdEnumSchema.safeParse(actionId.split('_')[0]);
+  return parsing.success ? parsing.data : undefined;
+}
 
-  const parsing = referentielIdEnumSchema.safeParse(unsafeReferentielId);
-  if (parsing.success) {
-    return parsing.data;
+export function getReferentielIdFromActionId(actionId: string): ReferentielId {
+  const referentielId = tryGetReferentielIdFromActionId(actionId);
+  if (referentielId) {
+    return referentielId;
   }
 
   throw new ReferentielException(
-    `Invalid referentielId ${unsafeReferentielId} for actionId '${actionId}'`
+    `Invalid referentielId ${actionId.split('_')[0]} for actionId '${actionId}'`
   );
 }
 


### PR DESCRIPTION
## Comportement

`referentiels.documents.listMesureDocuments` rend les documents d'une mesure sous la forme `{ attendus, complementaires }`, chaque attendu portant déjà ses dépôts. Aucun consommateur : le branchement du panneau latéral fait l'objet d'une PR suivante.

## Pourquoi

Le front lit aujourd'hui la vue `public.preuve` en Supabase brut, puis regroupe lui-même les lignes plates par mesure et par attendu.

## Deux écarts volontaires avec la vue

**Le produit cartésien disparaît.** La branche réglementaire de la vue fait `FROM collectivite c LEFT JOIN preuve_reglementaire_definition prd ON true` — chaque collectivité croisée avec le catalogue entier des définitions d'attendus. La requête part de `preuve_action` et joint la définition puis la mesure : son coût ne dépend plus de la taille du catalogue.

**Le filtre des sous-mesures change de sémantique.** La vue compare les identifiants avec `ilike('1.1.4.1%')`, qui attrape aussi `1.1.4.10` à `1.1.4.14` — ces cinq mesures existent dans le référentiel ECI, le défaut est donc observable. Le filtre compare `action_id` à la mesure, ou à la mesure suivie d'un point.

## Contrat

Entrée `{ collectiviteId, actionId, withSubActions? }`. L'identifiant de mesure porte à lui seul le référentiel, dont le service dérive l'identifiant pour le contrôle de permission ; la mesure rendue ne répète donc pas `referentiel`, qu'aucun consommateur ne lit.

La sortie est en camelCase et ne porte que des champs renseignés : ni les relations `demande` / `audit` / `rapport` toujours nulles de la vue, ni son alias `created_at` sur `modified_at`.

## Surface de review

| attention humaine | mécanique |
|---|---|
| `list-mesure-documents.repository.ts` (211 l.) — les jointures et le filtre de sous-mesure | `referentiels.module.ts`, `referentiels.router.ts` — deux lignes de câblage |
| `list-mesure-documents.output.ts` (76 l.) — le contrat | |
| `list-mesure-documents.service.ts` (79 l.) — permission, composition, validation | |
| `referentiel.utils.ts` (+17 l.) — voir ci-dessous | |

## Ajout dans `@tet/domain`

`tryGetReferentielIdFromActionId` rend le référentiel ou rien. `getReferentielIdFromActionId` s'appuie dessus pour lever : son message et son comportement ne changent pas, ses 56 appelants non plus. Sans elle, le service devait rattraper une exception du domaine pour la convertir en `Result`, ce que l'ADR 0012 exclut.

## Recherche anti-duplication

Les quatre briques partagées avec `list-documents` sont réutilisées telles quelles, aucune n'est réécrite : `buildFichierSubquery` et `buildFileInfoSql` (`collectivites/documents/file-info.utils.ts`), `hideConfidentielFilter` (`collectivites/documents/hide-confidentiel.utils.ts`) et `ReferentielDocumentsAccessService` (`referentiels/documents/`). Toutes extraites par #4882.

## Tests

9 tests e2e. Chacun a été vu rouge par mutation du code de production :

| mutation | tests qui tombent |
|---|---|
| filtre des sous-mesures ramené à `LIKE '${actionId}%'` | `1.1.4.1` / `1.1.4.10` uniquement |
| `depots.filter(hasSupport)` retiré de l'adaptateur | 6, dont les attendus sans dépôt |
| `eq(collectiviteId)` retiré de la jointure du dépôt | l'isolation par collectivité uniquement |
| `canReadConfidentiel` forcé à `true` | la confidentialité uniquement |

Le test de confidentialité seede son fichier en base plutôt que de passer par l'upload HTTP : il ne dépend d'aucune session Supabase et couvre la forme du fichier rendu, la seule que les autres tests n'exercent pas.

## Zones de moindre confiance

`DOCUMENT_SCHEMA_MISMATCH` est déclarée mais aucun test ne l'atteint : il faudrait faire diverger une ligne du contrat pour l'exercer.

## Items ajoutés à DISCOVERED

- Renommer `list-preuves-archive` en `list-archives` et `list-audit-preuves` en `collect-audit-preuves` : le premier rend des archives ZIP et non des preuves, le second n'est pas un endpoint.
- Fusionner `list-preuves` et `list-documents`, qui lisent les mêmes tables pour deux surfaces — après la suppression de `public.preuve`.

## Hors scope

Le branchement du front, la suppression de `usePreuves` et de la vue `public.preuve`.
