### PR TITLE
Améliore l'inférence des réponses de personnalisation à partir des données Banatic

### DIFF
--- a/apps/backend/src/collectivites/personnalisations/personnalisations.test-fixture.ts
+++ b/apps/backend/src/collectivites/personnalisations/personnalisations.test-fixture.ts
@@ -1,3 +1,4 @@
+import { collectiviteBanatic2025PerimetreTable } from '@tet/backend/collectivites/shared/models/collectivite-banatic-2025-perimetre.table';
 import { collectiviteBanatic2025TransfertTable } from '@tet/backend/collectivites/shared/models/collectivite-banatic-2025-transfert.table';
 import { actionDefinitionTable } from '@tet/backend/referentiels/models/action-definition.table';
 import { actionRelationTable } from '@tet/backend/referentiels/models/action-relation.table';
@@ -353,6 +354,7 @@ export async function addTestCollectiviteTransfertCompetence(
     collectiviteId: number;
     competenceCode: number;
     natureTransfert?: string;
+    nbCommunesTransferees?: number;
   }
 ): Promise<{ cleanup: () => Promise<void> }> {
   await db
@@ -374,6 +376,33 @@ export async function addTestCollectiviteTransfertCompetence(
               collectiviteBanatic2025TransfertTable.competenceCode,
               data.competenceCode
             )
+          )
+        );
+    },
+  };
+}
+
+/** fixe le périmètre Banatic (nb de communes membres) d'une collectivité */
+export async function addTestCollectiviteBanaticPerimetre(
+  { db }: DatabaseServiceInterface,
+  data: {
+    collectiviteId: number;
+    nbCommunesMembres: number;
+  }
+): Promise<{ cleanup: () => Promise<void> }> {
+  await db
+    .insert(collectiviteBanatic2025PerimetreTable)
+    .values(data)
+    .onConflictDoNothing();
+
+  return {
+    cleanup: async () => {
+      await db
+        .delete(collectiviteBanatic2025PerimetreTable)
+        .where(
+          eq(
+            collectiviteBanatic2025PerimetreTable.collectiviteId,
+            data.collectiviteId
           )
         );
     },
@@ -615,6 +644,10 @@ export async function addTestQuestionBanaticCompetencePourCollectivite(
     collectiviteId: number;
     thematiqueId: string;
     collectiviteType: CollectiviteType;
+    /** si fourni avec nbCommunesMembres, alimente le comptage de la délégation */
+    nbCommunesTransferees?: number;
+    /** si fourni, crée une ligne collectivite_banatic_2025_perimetre */
+    nbCommunesMembres?: number;
   }
 ): Promise<{
   questionBinaireCompetenceBanaticId: string;
@@ -642,7 +675,16 @@ export async function addTestQuestionBanaticCompetencePourCollectivite(
       collectiviteId: data.collectiviteId,
       competenceCode,
       natureTransfert: 'transfert de test',
+      nbCommunesTransferees: data.nbCommunesTransferees,
     });
+
+  const { cleanup: cleanupCollectiviteBanaticPerimetre } =
+    data.nbCommunesMembres !== undefined
+      ? await addTestCollectiviteBanaticPerimetre(databaseService, {
+          collectiviteId: data.collectiviteId,
+          nbCommunesMembres: data.nbCommunesMembres,
+        })
+      : { cleanup: async () => undefined };
 
   const {
     ids: [questionBinaireCompetenceBanaticId],
@@ -676,6 +718,7 @@ export async function addTestQuestionBanaticCompetencePourCollectivite(
     await cleanupQuestionBinaireBanatic();
     await cleanupCollectiviteBanaticCompetence();
     await cleanupCollectiviteTransfertCompetence();
+    await cleanupCollectiviteBanaticPerimetre();
     await cleanupBanaticCompetence();
   };
 

--- a/apps/backend/src/collectivites/personnalisations/services/personnalisation-reponses-effectives.repository.e2e-spec.ts
+++ b/apps/backend/src/collectivites/personnalisations/services/personnalisation-reponses-effectives.repository.e2e-spec.ts
@@ -55,6 +55,48 @@ describe('PersonnalisationReponsesEffectivesRepository', () => {
     expect(payload[questionBinaireCompetenceBanaticId]).toBe(true);
   });
 
+  test('infère false quand la délégation au syndicat est totale (toutes les communes membres)', async () => {
+    const { questionBinaireCompetenceBanaticId, cleanup } =
+      await addTestQuestionBanaticCompetencePourCollectivite(databaseService, {
+        collectiviteId: testData.collectivite.id,
+        thematiqueId: testData.thematiqueId,
+        collectiviteType: testData.collectivite.type,
+        nbCommunesMembres: 71,
+        nbCommunesTransferees: 71,
+      });
+    onTestFinished(cleanup);
+
+    const payload = await databaseService.db.transaction((tx) =>
+      reponsesEffectivesService.getReponsesEffectivesPayload(
+        testData.collectivite.id,
+        tx
+      )
+    );
+
+    expect(payload[questionBinaireCompetenceBanaticId]).toBe(false);
+  });
+
+  test('garde true quand la délégation au syndicat est partielle', async () => {
+    const { questionBinaireCompetenceBanaticId, cleanup } =
+      await addTestQuestionBanaticCompetencePourCollectivite(databaseService, {
+        collectiviteId: testData.collectivite.id,
+        thematiqueId: testData.thematiqueId,
+        collectiviteType: testData.collectivite.type,
+        nbCommunesMembres: 71,
+        nbCommunesTransferees: 40,
+      });
+    onTestFinished(cleanup);
+
+    const payload = await databaseService.db.transaction((tx) =>
+      reponsesEffectivesService.getReponsesEffectivesPayload(
+        testData.collectivite.id,
+        tx
+      )
+    );
+
+    expect(payload[questionBinaireCompetenceBanaticId]).toBe(true);
+  });
+
   test('inclut une réponse choix valide et omet les questions sans réponse', async () => {
     await databaseService.db.insert(reponseChoixTable).values({
       collectiviteId: testData.collectivite.id,

--- a/apps/backend/src/collectivites/personnalisations/services/personnalisation-reponses-effectives.repository.ts
+++ b/apps/backend/src/collectivites/personnalisations/services/personnalisation-reponses-effectives.repository.ts
@@ -4,6 +4,7 @@ import { reponseBinaireTable } from '@tet/backend/collectivites/personnalisation
 import { reponseChoixTable } from '@tet/backend/collectivites/personnalisations/models/reponse-choix.table';
 import { reponseProportionTable } from '@tet/backend/collectivites/personnalisations/models/reponse-proportion.table';
 import { collectiviteBanatic2025CompetenceTable } from '@tet/backend/collectivites/shared/models/collectivite-banatic-2025-competence.table';
+import { collectiviteBanatic2025PerimetreTable } from '@tet/backend/collectivites/shared/models/collectivite-banatic-2025-perimetre.table';
 import { collectiviteBanatic2025TransfertTable } from '@tet/backend/collectivites/shared/models/collectivite-banatic-2025-transfert.table';
 import { banatic2025CompetenceTable } from '@tet/backend/shared/models/banatic-2025-competence.table';
 import { Transaction } from '@tet/backend/utils/database/transaction.utils';
@@ -69,7 +70,21 @@ export class PersonnalisationReponsesEffectivesRepository {
       .select({
         competenceCode: banatic2025CompetenceTable.competenceCode,
         competenceIntitule: banatic2025CompetenceTable.intitule,
-        competenceExercee: collectiviteBanatic2025CompetenceTable.exercice,
+        // Compétence *effectivement* exercée : la valeur brute Banatic
+        // (`collectivite_banatic_2025_competence.exercice`) bascule à `false`
+        // uniquement quand la délégation aux groupements intermédiaires est
+        // totale (toutes les communes membres délèguent la compétence).
+        // cf. plan doc/plans/2026-06-30-001, règle métier « option B — stricte ».
+        competenceExercee: sql<
+          boolean | null
+        >`case
+            when ${collectiviteBanatic2025CompetenceTable.exercice} is null then null
+            when ${collectiviteBanatic2025CompetenceTable.exercice} = false then false
+            when ${collectiviteBanatic2025PerimetreTable.nbCommunesMembres} > 0
+              and ${collectiviteBanatic2025TransfertTable.nbCommunesTransferees} >= ${collectiviteBanatic2025PerimetreTable.nbCommunesMembres}
+              then false
+            else ${collectiviteBanatic2025CompetenceTable.exercice}
+          end`.as('competence_exercee'),
         natureTransfert: collectiviteBanatic2025TransfertTable.natureTransfert,
       })
       .from(banatic2025CompetenceTable)
@@ -98,6 +113,10 @@ export class PersonnalisationReponsesEffectivesRepository {
             banatic2025CompetenceTable.competenceCode
           )
         )
+      )
+      .leftJoin(
+        collectiviteBanatic2025PerimetreTable,
+        eq(collectiviteBanatic2025PerimetreTable.collectiviteId, collectiviteId)
       )
       .as('competence');
   }

--- a/apps/backend/src/collectivites/shared/models/collectivite-banatic-2025-perimetre.table.ts
+++ b/apps/backend/src/collectivites/shared/models/collectivite-banatic-2025-perimetre.table.ts
@@ -1,0 +1,23 @@
+import { integer, pgTable, timestamp } from 'drizzle-orm/pg-core';
+import { collectiviteTable } from './collectivite.table';
+
+/**
+ * Périmètre Banatic 2025 d'un EPCI : nombre de communes membres (snapshot).
+ *
+ * Sert de dénominateur pour inférer une délégation totale d'une compétence :
+ * `nb_communes_transferees >= nb_communes_membres` (cf. plan 2026-06-30-001).
+ * Source : fichier data.gouv « base nationale sur les intercommunalités »,
+ * comptage NON filtré par population.
+ */
+export const collectiviteBanatic2025PerimetreTable = pgTable(
+  'collectivite_banatic_2025_perimetre',
+  {
+    collectiviteId: integer('collectivite_id')
+      .primaryKey()
+      .references(() => collectiviteTable.id, { onDelete: 'cascade' }),
+    nbCommunesMembres: integer('nb_communes_membres').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  }
+);

--- a/apps/backend/src/collectivites/shared/models/collectivite-banatic-2025-transfert.table.ts
+++ b/apps/backend/src/collectivites/shared/models/collectivite-banatic-2025-transfert.table.ts
@@ -12,6 +12,9 @@ export const collectiviteBanatic2025TransfertTable = pgTable(
       .notNull()
       .references(() => banatic2025CompetenceTable.competenceCode),
     natureTransfert: text('nature_transfert'),
+    // Nombre de communes distinctes dont la compétence est transférée via l'EPCI
+    // vers un groupement intermédiaire (numérateur de la délégation totale).
+    nbCommunesTransferees: integer('nb_communes_transferees'),
   },
   (table) => ({
     collectiviteBanatic2025TransfertPkey: primaryKey({

--- a/apps/tools/src/migrations/banatic2025/README.md
+++ b/apps/tools/src/migrations/banatic2025/README.md
@@ -4,7 +4,7 @@ Scripts d'import des données du référentiel Banatic 2025 dans la base de donn
 
 ## Prérequis
 
-1. La migration Sqitch `referentiel/banatic_2025` doit être déployée.
+1. Les migrations Sqitch `referentiel/banatic_2025` et `referentiel/banatic_2025_perimetre` doivent être déployées.
 2. Les fichiers CSV source Banatic 2025 (téléchargés depuis le dossier "Tech" dans le drive TeT).
 3. Le backend doit être compilé (`pnpm run build:backend`) pour résoudre les imports `@tet/backend/*`.
 
@@ -18,6 +18,13 @@ Placez les fichiers dans un répertoire (par défaut `~/Downloads/source_banatic
 | `2_interco_competences_banatic.csv` | Compétences par groupement (une ligne par EPCI, colonnes OUI/NON) |
 | `3_transfert_code_<CODE>.csv` | Transferts de compétence (un fichier par code compétence) |
 | `4_banatic_retrocompatibilite.csv` | Table de correspondance Banatic 2021 → 2025 |
+
+Le périmètre des EPCI (étape 3bis) n'utilise pas un fichier du drive Tech mais le CSV
+**déjà versionné** dans le repo :
+`apps/backend/src/collectivites/import-collectivite-relations/perimetre-epci-a-fp.csv`
+(dataset data.gouv « base nationale sur les intercommunalités », une ligne par
+EPCI/commune, séparateur `;`). Pour le rafraîchir :
+`https://www.data.gouv.fr/api/1/datasets/r/6e05c448-62cc-4470-aa0f-4f31adea0bc4`.
 
 ## Ordre d'exécution
 
@@ -57,10 +64,25 @@ tsx apps/tools/src/migrations/banatic2025/import-banatic-2025-collectivite-compe
   "$SOURCE_DIR/2_interco_competences_banatic.csv"
 ```
 
+### 3bis. Périmètre des EPCI
+
+Peuple la table `collectivite_banatic_2025_perimetre` (nombre de communes membres
+par EPCI, dénominateur pour l'inférence de délégation totale d'une compétence).
+Comptage des communes **distinctes** par SIREN d'EPCI, **sans filtre de population**
+(la colonne `nb_membres` du CSV sert seulement de contrôle : un écart est loggé,
+le recomptage fait foi). Requiert les collectivités créées à l'étape 3 ;
+indépendant de l'étape 4.
+
+```bash
+tsx apps/tools/src/migrations/banatic2025/import-banatic-2025-perimetre/index.ts \
+  apps/backend/src/collectivites/import-collectivite-relations/perimetre-epci-a-fp.csv
+```
+
 ### 4. Transferts de compétences
 
-Peuple la table `collectivite_banatic_2025_transfert` pour un code compétence donné.
-À exécuter une fois par fichier de transfert disponible.
+Peuple la table `collectivite_banatic_2025_transfert` pour un code compétence donné
+(`nature_transfert` + `nb_communes_transferees`).
+À exécuter une fois par fichier de transfert disponible. Indépendant de l'étape 3bis.
 
 ```bash
 tsx apps/tools/src/migrations/banatic2025/import-banatic-2025-transferts/index.ts \
@@ -86,4 +108,5 @@ Les fichiers de seed pour ces tables se trouvent dans `data_layer/seed/` :
 | `banatic_2025_competence` | Référentiel des compétences (code 4 chiffres + intitulé) |
 | `banatic_2021_2025_crosswalk` | Correspondance codes 2021 → 2025 (one_to_one, split, no_equivalent) |
 | `collectivite_banatic_2025_competence` | Compétences exercées par collectivité |
-| `collectivite_banatic_2025_transfert` | Transferts de compétences vers groupements intermédiaires |
+| `collectivite_banatic_2025_transfert` | Transferts de compétences vers groupements intermédiaires (+ `nb_communes_transferees`) |
+| `collectivite_banatic_2025_perimetre` | Nombre de communes membres par EPCI (dénominateur délégation totale) |

--- a/apps/tools/src/migrations/banatic2025/import-banatic-2025-perimetre/__fixtures__/perimetre-sample.csv
+++ b/apps/tools/src/migrations/banatic2025/import-banatic-2025-perimetre/__fixtures__/perimetre-sample.csv
@@ -1,0 +1,8 @@
+dept;siren;raison_sociale;nature_juridique;mode_financ;nb_membres;total_pop_tot;total_pop_mun;dep_com;insee;siren_membre;nom_membre;ptot_2025;pmun_2025
+76;200023414;Métropole Rouen Normandie;METRO;FPU;3;500000;490000;76;76540;217605400;Rouen;115000;110000
+76;200023414;Métropole Rouen Normandie;METRO;FPU;3;500000;490000;76;76451;217604510;Petit-Quevilly;22000;21000
+76;200023414;Métropole Rouen Normandie;METRO;FPU;3;500000;490000;76;76575;217605753;Sotteville-lès-Rouen;29000;28000
+76;200023414;Métropole Rouen Normandie;METRO;FPU;3;500000;490000;76;76575;217605753;Sotteville-lès-Rouen;29000;28000
+63;200070407;CA Agglo Pays d'Issoire;CA;FPU;2;60000;58000;63;63158;216301589;Issoire;15000;14500
+63;200070407;CA Agglo Pays d'Issoire;CA;FPU;2;60000;58000;63;63005;216300052;Antoingt;120;110
+63;200099999;CC Sans Collectivité;CC;FPU;1;3000;2900;63;63999;216399999;Village-Test;500;480

--- a/apps/tools/src/migrations/banatic2025/import-banatic-2025-perimetre/index.ts
+++ b/apps/tools/src/migrations/banatic2025/import-banatic-2025-perimetre/index.ts
@@ -1,0 +1,114 @@
+#!/usr/bin/env tsx
+/**
+ * Import du périmètre Banatic 2025 des EPCI : nombre de communes membres.
+ *
+ * Source : fichier data.gouv « base nationale sur les intercommunalités »
+ * (EPCI ↔ communes, une ligne par (EPCI, commune), séparateur `;`).
+ * Téléchargement :
+ *   https://www.data.gouv.fr/api/1/datasets/r/6e05c448-62cc-4470-aa0f-4f31adea0bc4
+ *
+ * Sert de dénominateur à l'inférence de délégation totale d'une compétence :
+ * `nb_communes_transferees >= nb_communes_membres`.
+ * Le comptage n'applique AUCUN filtre de population (cf. plan 2026-06-30-001, §1.3).
+ *
+ * Prérequis :
+ * - Collectivités EPCI présentes en base
+ *   (lancer import-banatic-2025-collectivite-competences d'abord).
+ *
+ * Usage :
+ *   SUPABASE_DATABASE_URL="postgresql://..." \
+ *     tsx apps/tools/src/migrations/banatic2025/import-banatic-2025-perimetre/index.ts [path/to/perimetre-epci-communes.csv]
+ */
+
+import { collectiviteBanatic2025PerimetreTable } from '@tet/backend/collectivites/shared/models/collectivite-banatic-2025-perimetre.table';
+import { sql } from 'drizzle-orm';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import { findCollectiviteIdBySiren } from '../collectivite-db';
+import { getCsvPathFromArgv, parseCsvRecords, readCsvFile } from '../csv';
+import { getDatabase } from '../db';
+import {
+  collectDeclaredNbMembres,
+  countCommunesByEpci,
+  diffRecomptageVsDeclare,
+  parsePerimetreRecords,
+} from './utils';
+
+const USAGE =
+  'tsx apps/tools/src/migrations/banatic2025/import-banatic-2025-perimetre/index.ts [path/to/perimetre-epci-communes.csv]';
+
+const upsertPerimetre = async (
+  db: NodePgDatabase,
+  collectiviteId: number,
+  nbCommunesMembres: number
+): Promise<void> => {
+  await db
+    .insert(collectiviteBanatic2025PerimetreTable)
+    .values({ collectiviteId, nbCommunesMembres })
+    .onConflictDoUpdate({
+      target: [collectiviteBanatic2025PerimetreTable.collectiviteId],
+      set: {
+        nbCommunesMembres: sql.raw(
+          `excluded.${collectiviteBanatic2025PerimetreTable.nbCommunesMembres.name}`
+        ),
+      },
+    });
+};
+
+async function main() {
+  const csvPath = getCsvPathFromArgv(2, USAGE);
+  const fileContent = readCsvFile(csvPath);
+  const { db, pool } = getDatabase('import-banatic-2025-perimetre');
+
+  try {
+    const records = parseCsvRecords(fileContent, { delimiter: ';', bom: true });
+    const rows = parsePerimetreRecords(records);
+    const countByEpci = countCommunesByEpci(rows);
+
+    console.log(
+      `${records.length} lignes, ${rows.length} lignes exploitables, ${countByEpci.size} EPCI avec périmètre.`
+    );
+
+    // Contrôle : la colonne nb_membres du CSV doit correspondre au recomptage.
+    const ecarts = diffRecomptageVsDeclare(
+      countByEpci,
+      collectDeclaredNbMembres(records)
+    );
+    if (ecarts.length > 0) {
+      console.warn(
+        `⚠️  ${ecarts.length} écart(s) recomptage / nb_membres déclaré (le recomptage fait foi) :`
+      );
+      ecarts.forEach(({ epciSiren, recompte, declare }) =>
+        console.warn(`  - ${epciSiren} : ${recompte} recomptées vs ${declare}`)
+      );
+    }
+
+    let upserted = 0;
+    const notFound: string[] = [];
+
+    for (const [siren, nbCommunesMembres] of countByEpci) {
+      const collectiviteId = await findCollectiviteIdBySiren(db, siren);
+      if (collectiviteId === null) {
+        notFound.push(siren);
+        continue;
+      }
+      await upsertPerimetre(db, collectiviteId, nbCommunesMembres);
+      upserted++;
+    }
+
+    console.log(`   Upserted ${upserted} périmètre(s) EPCI.`);
+
+    if (notFound.length > 0) {
+      console.warn(`⚠️  SIREN EPCI non trouvés en base (${notFound.length}) :`);
+      notFound.forEach((s) => console.warn(`  - ${s}`));
+    }
+
+    console.log('✅ Done.');
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/tools/src/migrations/banatic2025/import-banatic-2025-perimetre/utils.test.ts
+++ b/apps/tools/src/migrations/banatic2025/import-banatic-2025-perimetre/utils.test.ts
@@ -1,0 +1,93 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { describe, expect, it } from 'vitest';
+import { parseCsvRecords } from '../csv';
+import {
+  collectDeclaredNbMembres,
+  countCommunesByEpci,
+  diffRecomptageVsDeclare,
+  parsePerimetreRecords,
+} from './utils';
+
+const fixturesDir = path.join(__dirname, '__fixtures__');
+
+const readFixture = (filename: string): string =>
+  fs.readFileSync(path.join(fixturesDir, filename), 'utf-8');
+
+describe('Banatic 2025 périmètre import', () => {
+  const rows = parsePerimetreRecords(
+    parseCsvRecords(readFixture('perimetre-sample.csv'), { delimiter: ';' })
+  );
+
+  it('compte les communes distinctes par SIREN d\'EPCI (dédoublonnage)', () => {
+    const countByEpci = countCommunesByEpci(rows);
+
+    // Rouen : 4 lignes dont 1 doublon -> 3 communes distinctes
+    expect(countByEpci.get('200023414')).toBe(3);
+  });
+
+  it('ne filtre pas les petites communes', () => {
+    const countByEpci = countCommunesByEpci(rows);
+
+    // CA Agglo Pays d'Issoire : Issoire + Antoingt (pmun 110) -> 2
+    expect(countByEpci.get('200070407')).toBe(2);
+  });
+
+  it('gère un EPCI à une seule commune', () => {
+    const countByEpci = countCommunesByEpci(rows);
+
+    expect(countByEpci.get('200099999')).toBe(1);
+  });
+
+  it('ignore les lignes sans SIREN EPCI ou sans code INSEE', () => {
+    const parsed = parsePerimetreRecords([
+      { siren: '200023414', insee: '76540' },
+      { siren: '', insee: '76451' },
+      { siren: '200023414', insee: '' },
+      { siren: '200023414', insee: '76575' },
+    ]);
+
+    expect(parsed).toHaveLength(2);
+    expect(countCommunesByEpci(parsed).get('200023414')).toBe(2);
+  });
+
+  describe('contrôle nb_membres déclaré', () => {
+    it('lit nb_membres une fois par EPCI (espaces tolérés)', () => {
+      const declare = collectDeclaredNbMembres([
+        { siren: '200023414', insee: '76540', nb_membres: '3' },
+        { siren: '200023414', insee: '76451', nb_membres: '3' },
+        { siren: '200099999', insee: '63999', nb_membres: '1 234' },
+      ]);
+
+      expect(declare.get('200023414')).toBe(3);
+      expect(declare.get('200099999')).toBe(1234);
+    });
+
+    it("la fixture est cohérente : aucun écart recomptage / nb_membres", () => {
+      const records = parseCsvRecords(readFixture('perimetre-sample.csv'), {
+        delimiter: ';',
+      });
+      const ecarts = diffRecomptageVsDeclare(
+        countCommunesByEpci(rows),
+        collectDeclaredNbMembres(records)
+      );
+
+      expect(ecarts).toEqual([]);
+    });
+
+    it('remonte un écart quand le recomptage diffère de nb_membres', () => {
+      const records = [
+        { siren: '200000001', insee: '11111', nb_membres: '3' },
+        { siren: '200000001', insee: '22222', nb_membres: '3' },
+      ];
+      const ecarts = diffRecomptageVsDeclare(
+        countCommunesByEpci(parsePerimetreRecords(records)),
+        collectDeclaredNbMembres(records)
+      );
+
+      expect(ecarts).toEqual([
+        { epciSiren: '200000001', recompte: 2, declare: 3 },
+      ]);
+    });
+  });
+});

--- a/apps/tools/src/migrations/banatic2025/import-banatic-2025-perimetre/utils.ts
+++ b/apps/tools/src/migrations/banatic2025/import-banatic-2025-perimetre/utils.ts
@@ -1,0 +1,97 @@
+import { z } from 'zod';
+
+/**
+ * Colonnes utiles du fichier data.gouv « base nationale sur les
+ * intercommunalités » (EPCI ↔ communes), une ligne par (EPCI, commune).
+ * cf. `epci-perimetre.schema.ts` côté backend.
+ */
+const HEADER = {
+  epciSiren: 'siren',
+  communeInsee: 'insee',
+  nbMembres: 'nb_membres',
+} as const;
+
+const rowSchema = z.object({
+  epciSiren: z.string().min(1),
+  communeInsee: z.string().min(1),
+});
+
+export type PerimetreRow = z.infer<typeof rowSchema>;
+
+export const parsePerimetreRecords = (
+  records: Record<string, string>[]
+): PerimetreRow[] =>
+  records
+    .map((record) => {
+      const parsed = rowSchema.safeParse({
+        epciSiren: (record[HEADER.epciSiren] ?? '').trim(),
+        communeInsee: (record[HEADER.communeInsee] ?? '').trim(),
+      });
+      return parsed.success ? parsed.data : null;
+    })
+    .filter((row): row is PerimetreRow => row !== null);
+
+/**
+ * Nombre de communes membres **distinctes** par SIREN d'EPCI.
+ *
+ * Aucun filtre de population : le dénominateur doit rester cohérent avec le
+ * numérateur `nb_communes_transferees` (issu du fichier transfert brut Banatic).
+ * cf. plan 2026-06-30-001, §1.3.
+ */
+export const countCommunesByEpci = (
+  rows: PerimetreRow[]
+): Map<string, number> => {
+  const communesByEpci = new Map<string, Set<string>>();
+
+  for (const row of rows) {
+    const communes = communesByEpci.get(row.epciSiren) ?? new Set<string>();
+    communes.add(row.communeInsee);
+    communesByEpci.set(row.epciSiren, communes);
+  }
+
+  return new Map(
+    Array.from(communesByEpci, ([siren, communes]) => [siren, communes.size])
+  );
+};
+
+/**
+ * Valeur `nb_membres` déclarée par data.gouv, par SIREN d'EPCI (répétée sur
+ * chaque ligne). Sert uniquement de contrôle du recomptage `countCommunesByEpci`
+ * — la valeur retenue en base reste le recomptage des communes distinctes.
+ */
+export const collectDeclaredNbMembres = (
+  records: Record<string, string>[]
+): Map<string, number> => {
+  const byEpci = new Map<string, number>();
+
+  for (const record of records) {
+    const siren = (record[HEADER.epciSiren] ?? '').trim();
+    if (!siren || byEpci.has(siren)) continue;
+
+    const declared = Number(
+      (record[HEADER.nbMembres] ?? '').replace(/\s+/g, '')
+    );
+    if (Number.isInteger(declared) && declared >= 0) {
+      byEpci.set(siren, declared);
+    }
+  }
+
+  return byEpci;
+};
+
+/** Écarts entre recomptage des communes distinctes et `nb_membres` déclaré. */
+export const diffRecomptageVsDeclare = (
+  recompteByEpci: Map<string, number>,
+  declareByEpci: Map<string, number>
+): { epciSiren: string; recompte: number; declare: number }[] => {
+  const ecarts: { epciSiren: string; recompte: number; declare: number }[] = [];
+
+  for (const [epciSiren, recompte] of recompteByEpci) {
+    const declare = declareByEpci.get(epciSiren);
+    if (declare !== undefined && declare !== recompte) {
+      ecarts.push({ epciSiren, recompte, declare });
+    }
+  }
+
+  return ecarts;
+};

--- a/apps/tools/src/migrations/banatic2025/import-banatic-2025-transferts/index.ts
+++ b/apps/tools/src/migrations/banatic2025/import-banatic-2025-transferts/index.ts
@@ -39,7 +39,8 @@ const upsertTransfert = async (
   db: NodePgDatabase,
   collectiviteId: number,
   competenceCode: number,
-  natureTransfert: string
+  natureTransfert: string,
+  nbCommunesTransferees: number
 ): Promise<void> => {
   await db
     .insert(collectiviteBanatic2025TransfertTable)
@@ -47,13 +48,14 @@ const upsertTransfert = async (
       collectiviteId,
       competenceCode,
       natureTransfert,
+      nbCommunesTransferees,
     })
     .onConflictDoUpdate({
       target: [
         collectiviteBanatic2025TransfertTable.collectiviteId,
         collectiviteBanatic2025TransfertTable.competenceCode,
       ],
-      set: { natureTransfert },
+      set: { natureTransfert, nbCommunesTransferees },
     });
 };
 
@@ -73,7 +75,13 @@ const processTransferts = async (
     }
 
     const natureTransfert = formatNatureTransfert(info);
-    await upsertTransfert(db, collectiviteId, competenceCode, natureTransfert);
+    await upsertTransfert(
+      db,
+      collectiviteId,
+      competenceCode,
+      natureTransfert,
+      info.communesTransferees.size
+    );
     inserted++;
   }
 

--- a/apps/tools/src/migrations/banatic2025/import-banatic-2025-transferts/utils.test.ts
+++ b/apps/tools/src/migrations/banatic2025/import-banatic-2025-transferts/utils.test.ts
@@ -51,6 +51,10 @@ describe('Banatic 2025 transferts import', () => {
 
       expect(transfertsByEpci.size).toBe(2);
 
+      // nb de communes transférées = communes distinctes, tous syndicats confondus
+      expect(transfertsByEpci.get('200070407')?.communesTransferees.size).toBe(2);
+      expect(transfertsByEpci.get('200069169')?.communesTransferees.size).toBe(3);
+
       // CA Agglo Pays d'Issoire -> SICTOM Issoire-Brioude (2 communes)
       const caAgglo = transfertsByEpci.get('200070407');
       if (!caAgglo) throw new Error('CA Agglo not found');
@@ -67,6 +71,26 @@ describe('Banatic 2025 transferts import', () => {
       expect(natureTransfert).toBe(
         'SM de collecte des déchets ménagers Dômes et Combrailles (1 commune), SMCTOM de la Haute Dordogne (2 communes)'
       );
+    });
+
+    it('compte une commune une seule fois même listée sous deux syndicats', () => {
+      const baseRow = {
+        communeName: '',
+        departementCode: '63',
+        epciSiren: '200070407',
+        epciName: "CA Agglo Pays d'Issoire",
+      };
+      const parsedRows: ParsedRow[] = [
+        { ...baseRow, communeCode: '63005', syndicatSiren: 'A', syndicatName: 'Syndicat A' },
+        { ...baseRow, communeCode: '63006', syndicatSiren: 'A', syndicatName: 'Syndicat A' },
+        // 63006 également rattachée au syndicat B (cas limite Banatic)
+        { ...baseRow, communeCode: '63006', syndicatSiren: 'B', syndicatName: 'Syndicat B' },
+      ];
+
+      const info = groupByEpci(parsedRows).get('200070407');
+      if (!info) throw new Error('EPCI not found');
+
+      expect(info.communesTransferees.size).toBe(2);
     });
   });
 });

--- a/apps/tools/src/migrations/banatic2025/import-banatic-2025-transferts/utils.ts
+++ b/apps/tools/src/migrations/banatic2025/import-banatic-2025-transferts/utils.ts
@@ -31,6 +31,8 @@ export type TransfertInfo = {
   epciSiren: string;
   epciName: string;
   syndicats: Map<string, SyndicatInfo>;
+  /** codes INSEE distincts des communes dont la compétence transite par l'EPCI */
+  communesTransferees: Set<string>;
 };
 
 const buildColumnIndices = (headerRow: string[]): ColumnIndices => {
@@ -99,6 +101,7 @@ export const groupByEpci = (rows: ParsedRow[]): Map<string, TransfertInfo> =>
       epciSiren: row.epciSiren,
       epciName: row.epciName,
       syndicats: new Map<string, SyndicatInfo>(),
+      communesTransferees: new Set<string>(),
     };
 
     const syndicatInfo = existing.syndicats.get(row.syndicatSiren) ?? {
@@ -110,6 +113,8 @@ export const groupByEpci = (rows: ParsedRow[]): Map<string, TransfertInfo> =>
       ...syndicatInfo,
       communeCount: syndicatInfo.communeCount + 1,
     });
+
+    existing.communesTransferees.add(row.communeCode);
 
     return acc.set(row.epciSiren, existing);
   }, new Map<string, TransfertInfo>());

--- a/data_layer/sqitch/deploy/referentiel/banatic_2025_perimetre.sql
+++ b/data_layer/sqitch/deploy/referentiel/banatic_2025_perimetre.sql
@@ -1,0 +1,23 @@
+-- Deploy tet:referentiel/banatic_2025_perimetre to pg
+-- requires: referentiel/banatic_2025
+
+BEGIN;
+
+-- Nombre de communes distinctes dont la compétence
+-- est transférée via l'EPCI vers un groupement intermédiaire (fichier transfert Banatic).
+alter table collectivite_banatic_2025_transfert
+    add column nb_communes_transferees integer;
+
+-- Périmètre de l'EPCI : nombre de communes membres.
+create table collectivite_banatic_2025_perimetre
+(
+    collectivite_id     integer primary key references collectivite (id) on delete cascade,
+    nb_communes_membres integer     not null check (nb_communes_membres >= 0),
+    created_at          timestamptz not null default now()
+);
+
+alter table collectivite_banatic_2025_perimetre
+    enable row level security;
+create policy allow_read_for_all on collectivite_banatic_2025_perimetre using (true);
+
+COMMIT;

--- a/data_layer/sqitch/revert/referentiel/banatic_2025_perimetre.sql
+++ b/data_layer/sqitch/revert/referentiel/banatic_2025_perimetre.sql
@@ -1,0 +1,10 @@
+-- Revert tet:referentiel/banatic_2025_perimetre from pg
+
+BEGIN;
+
+drop table if exists collectivite_banatic_2025_perimetre;
+
+alter table collectivite_banatic_2025_transfert
+    drop column if exists nb_communes_transferees;
+
+COMMIT;

--- a/data_layer/sqitch/sqitch.plan
+++ b/data_layer/sqitch/sqitch.plan
@@ -1057,3 +1057,5 @@ collectivite/service_etat_import [collectivite/type_add_dr_ademe_service_nationa
 demarche/pcaet_diagnostic_indicateur_source_metadonnee [demarche/pcaet_diagnostic indicateur/fusion] 2026-08-19T00:00:00Z System Administrator <root@localhost> # Lien PCAET ↔ source métadonnée pour les valeurs saisies
 
 demarche/pcaet_diagnostic_drop_referentiel_tables [demarche/pcaet_diagnostic_indicateur_source_metadonnee demarche/pcaet_diagnostic_ordre_reglementaire demarche/pcaet_vulnerabilite_thematique_socle_recadre] 2026-08-27T10:00:00Z Farnoux <farnoux@users.noreply.github.com> # Supprime le référentiel SQL du diagnostic PCAET (topics/state/snapshot) désormais porté par le package domain
+
+referentiel/banatic_2025_perimetre [referentiel/banatic_2025] 2026-08-31T10:58:47Z Marc Rutkowski <marc@attractive-media.fr> # Ajoute collectivite_banatic_2025_perimetre (nb_communes_membres par EPCI) et collectivite_banatic_2025_transfert.nb_communes_transferees pour l'inference de delegation totale

--- a/data_layer/sqitch/verify/referentiel/banatic_2025_perimetre.sql
+++ b/data_layer/sqitch/verify/referentiel/banatic_2025_perimetre.sql
@@ -1,0 +1,13 @@
+-- Verify tet:referentiel/banatic_2025_perimetre on pg
+
+BEGIN;
+
+select nb_communes_transferees
+from collectivite_banatic_2025_transfert
+where false;
+
+select collectivite_id, nb_communes_membres, created_at
+from collectivite_banatic_2025_perimetre
+where false;
+
+ROLLBACK;

--- a/doc/plans/2026-06-30-001-feat-delegation-totale-banatic-inference-plan.md
+++ b/doc/plans/2026-06-30-001-feat-delegation-totale-banatic-inference-plan.md
@@ -1,0 +1,342 @@
+---
+title: "feat: Inférence personnalisation Banatic — délégation totale au syndicat → Non pour l'EPCI"
+type: feat
+status: active
+date: 2026-06-30
+revised: 2026-08-31
+---
+
+# feat: Inférence personnalisation Banatic — délégation totale au syndicat → Non pour l'EPCI
+
+## Overview
+
+Pour une question binaire liée à une compétence Banatic (ex. `dechets_2` → 2085), inférer **« Non (réponse Banatic) »** uniquement quand la délégation au syndicat est **totale** : toutes les communes membres de l'EPCI délèguent cette compétence au syndicat.
+
+Conserver :
+
+- `exercice` brut Banatic en base (souvent `true` pour une métropole comme Rouen)
+- l'affichage **« Transfert vers … »** pour toute délégation (totale ou partielle)
+
+Cas de référence : **Métropole Rouen Normandie** (SIREN `200023414`) — C2085 = OUI dans Banatic, mais 71/71 communes déléguées au SMEDAR → inférence **Non** + ligne transfert.
+
+> **Vérif partielle (révision 2026-08-31)** : import du périmètre joué sur la base locale (seed, IDs identiques à staging) à partir de `perimetre-epci-a-fp.csv` → **Rouen = `collectivite_id` 5118, `nb_communes_membres` = 71**, et le recomptage des communes distinctes == `nb_membres` déclaré pour les 1255 EPCI du fichier (aucun écart). Reste à confirmer sur staging : `nb_communes_transferees` pour C2085 (fichier `3_transfert_code_2085.csv` non versionné) et la sortie API — cf. Tranche 5.
+
+## Problem Statement / Motivation
+
+Aujourd'hui, l'inférence binaire utilise uniquement `collectivite_banatic_2025_competence.exercice` (valeur OUI/NON du fichier `2_interco_competences_banatic.csv`). Le transfert (`collectivite_banatic_2025_transfert.nature_transfert`) est affiché mais **n'influence pas** `competenceExercee` ni la réponse inférée.
+
+Pour Rouen, Banatic marque la métropole **OUI** sur C2085 alors que le traitement est entièrement délégué au SMEDAR. Le besoin métier est :
+
+> Délégation totale au syndicat = **Non** pour l'EPCI (+ ligne transfert comme actuellement).
+
+Le code actuel (`personnalisation-reponses-effectives.repository.ts`) :
+
+```typescript
+competenceExercee: collectiviteBanatic2025CompetenceTable.exercice,
+// coalesce(reponse_binaire, competenceExercee)
+```
+
+## Règle métier cible (option B — stricte)
+
+```
+competenceExerceeEffective =
+  exercice_banatic
+  ET PAS (
+    nb_communes_transferees >= nb_communes_membres
+    ET nb_communes_membres > 0
+  )
+```
+
+| Cas | `exercice` | Transfert | `nb_transf` / `nb_membres` | Inférence |
+|-----|-----------|-----------|---------------------------|-----------|
+| Rouen → SMEDAR | `true` | oui | 71 / 71 | **Non** |
+| Délégation partielle | `true` | oui | 40 / 71 | **Oui** (+ ligne transfert) |
+| Pas de délégation | `true` | non | — | **Oui** |
+| Pas la compétence Banatic | `false` | — | — | **Non** |
+
+**Réponse effective** : `coalesce(reponse_binaire.explicite, competenceExerceeEffective)` (forme inchangée).
+
+**UI** : **pas de changement de code** (le backend renvoie déjà `competenceExercee` + `natureTransfert`), mais **changement d'affichage assumé** puisque `competenceExercee` passe de la valeur brute à la valeur effective :
+
+- `reponse-binaire.tsx` : le label `(réponse Banatic)` se déplace du bouton *Oui* vers le bouton *Non* pour un cas Rouen (délégation totale).
+- `justification.tsx` (`showLabelBanatic`, comparaison `competenceExercee !== reponseValue`) : le bandeau « réponse différente de Banatic » apparaît désormais pour une collectivité en délégation totale qui a répondu *Oui* explicitement.
+
+À faire : relire les *stories* / *snapshots* de ces deux composants. Option d'atténuation : exposer `exerciceBanatic` brut (Tranche 3.3) pour que l'UI distingue « pas la compétence » de « compétence transférée », ou faire dépendre le libellé de la présence de `natureTransfert`.
+
+## Principe d'architecture
+
+Séparer trois notions :
+
+| Concept | Stockage | Rôle |
+|---------|----------|------|
+| `exercice` | `collectivite_banatic_2025_competence` | Valeur brute Banatic (OUI/NON fichier `2_interco_…`) |
+| Périmètre EPCI | `collectivite_banatic_2025_perimetre` (nouvelle table) | `nb_communes_membres`, **source unique** du dénominateur |
+| Transfert | `collectivite_banatic_2025_transfert` enrichie | `nb_communes_transferees` + `nature_transfert` |
+| Inférence | calculée à la lecture (JOIN périmètre + transfert) | `competenceExerceeEffective` |
+
+La règle vit dans le **backend**, dans l'expression `CASE` SQL de la requête d'inférence (`getCompetenceSubquery`), couverte par les tests e2e.
+
+> **Décision (révision 2026-08-31)** : `nb_communes_membres` n'est stocké **que** dans `collectivite_banatic_2025_perimetre` et rejoint au moment de la lecture. Pas de dénormalisation dans la table `transfert`, pas de colonne générée `delegation_totale`. Un périmètre absent → `NULL` au JOIN → le `CASE` retombe automatiquement sur `exercice` (fallback sûr, sans code de garde à l'import).
+
+## Proposed Solution
+
+### Tranche 1 — Schéma de données (Sqitch)
+
+> **Nouvelle migration Sqitch, pas d'édition de l'existante.** `referentiel/banatic_2025` est déployée depuis le 2026-03-10 (`sqitch.plan:967`). Créer `sqitch add referentiel/banatic_2025_perimetre --requires referentiel/banatic_2025` → `deploy/` + `revert/` + `verify/` + entrée `sqitch.plan`. Ne **pas** modifier `deploy/referentiel/banatic_2025.sql`.
+
+#### 1.1 Enrichir `collectivite_banatic_2025_transfert`
+
+```sql
+ALTER TABLE collectivite_banatic_2025_transfert
+  ADD COLUMN nb_communes_transferees integer;
+```
+
+- `nb_communes_transferees` : communes **distinctes** du fichier transfert pour cet EPCI + compétence (numérateur).
+- Le dénominateur (`nb_communes_membres`) vit dans `collectivite_banatic_2025_perimetre` (§1.2) et est rejoint à la lecture — **pas** dupliqué ici.
+- Pas de colonne générée `delegation_totale` : la règle est calculée à la lecture (`CASE` SQL, cf. Tranche 3), donc pas besoin des deux compteurs sur la même ligne.
+
+#### 1.2 Nouvelle table `collectivite_banatic_2025_perimetre`
+
+```sql
+CREATE TABLE collectivite_banatic_2025_perimetre (
+  collectivite_id       integer PRIMARY KEY REFERENCES collectivite(id) ON DELETE CASCADE,
+  nb_communes_membres   integer NOT NULL CHECK (nb_communes_membres >= 0),
+  created_at            timestamptz NOT NULL DEFAULT now()
+);
+
+alter table collectivite_banatic_2025_perimetre enable row level security;
+create policy allow_read_for_all on collectivite_banatic_2025_perimetre using (true);
+```
+
+**Source du dénominateur** — ⚠️ point corrigé à la révision 2026-08-31 :
+
+- ❌ `2_interco_competences_banatic.csv` a **une ligne par EPCI** (confirmé par le README d'import, le seed `07-banatic_2025_competence_par_collectivite.sql` et le `firstRowPerSiren` défensif). Compter ses lignes par SIREN donne `1`, pas le nombre de communes membres. L'hypothèse « 71 adhésions dans le fichier 2 » est fausse.
+- ✅ Utiliser le fichier **data.gouv EPCI ↔ communes** déjà consommé par `ImportCollectiviteRelationsService` (`RELATIONS_EPCI_COMMUNES_URL` = `https://www.data.gouv.fr/api/1/datasets/r/6e05c448-62cc-4470-aa0f-4f31adea0bc4`), en comptant **toutes** les communes par SIREN d'EPCI.
+- ❌ Ne **pas** réutiliser `collectivite_relations` ni y appliquer `MIN_COMMUNE_POPULATION` (3000 hab.) : voir §1.3 cohérence.
+
+#### 1.3 Cohérence numérateur / dénominateur (invariant)
+
+`nb_communes_transferees` provient du CSV transfert **brut Banatic** (aucun filtre population). Le dénominateur `nb_communes_membres` doit donc lui aussi être **non filtré**, sinon une délégation partielle riche en petites communes serait classée « totale » à tort (`nb_transf >= nb_membres`). Conséquence pratique : dans l'import du périmètre, **ne pas reprendre** le garde `pmun_2025 < MIN_COMMUNE_POPULATION` de `ImportCollectiviteRelationsService`.
+
+Fichiers à toucher :
+
+- `data_layer/sqitch/deploy/referentiel/banatic_2025_perimetre.sql` + `revert/` + `verify/` + `sqitch.plan` (nouvelle change)
+- `apps/backend/src/collectivites/shared/models/collectivite-banatic-2025-transfert.table.ts` (ajout `nbCommunesTransferees`)
+- nouveau `apps/backend/src/collectivites/shared/models/collectivite-banatic-2025-perimetre.table.ts`
+
+### Tranche 2 — Imports Banatic
+
+#### 2.1 Nouvel import périmètre (`import-banatic-2025-perimetre`)
+
+Nouveau script, **indépendant de l'import compétences** (il ne fait qu'ajouter le dénominateur). Il lit le fichier data.gouv EPCI ↔ communes (même source que `ImportCollectiviteRelationsService`) :
+
+```typescript
+// pour chaque SIREN d'EPCI présent dans le CSV :
+//   nb_communes_membres = nombre de communes distinctes rattachées à ce SIREN
+//   AUCUN filtre pmun_2025 / MIN_COMMUNE_POPULATION (cf. §1.3)
+// résolution SIREN -> collectivite_id via findCollectiviteIdBySiren
+// upsert (onConflictDoUpdate) dans collectivite_banatic_2025_perimetre
+```
+
+- SIREN sans `collectivite_id` en base → **warning** + skip (comme l'import transferts).
+- Le comptage doit ignorer les doublons de lignes (`Set` de codes INSEE).
+- `firstRowPerSiren` de l'import compétences reste inchangé et ne sert **pas** ici.
+
+> Alternative envisagée : ajouter le comptage dans `ImportCollectiviteRelationsService` (déjà branché sur ce CSV) en exposant un total non filtré. Rejeté pour garder l'import Banatic autonome et re-jouable indépendamment.
+
+#### 2.2 Import transferts (`import-banatic-2025-transferts`)
+
+Enrichir `groupByEpci` dans `utils.ts` :
+
+```typescript
+type TransfertInfo = {
+  epciSiren: string;
+  epciName: string;
+  syndicats: Map<string, SyndicatInfo>;
+  communesTransferees: Set<string>; // codes INSEE distincts
+};
+```
+
+À l'upsert :
+
+- `nb_communes_transferees = info.communesTransferees.size` (seul ajout).
+- **Aucune** lecture du périmètre ici : le rapprochement numérateur/dénominateur se fait à la lecture (Tranche 3), pas à l'import. Supprime le besoin de warning / `null` et découple les deux imports.
+
+#### 2.3 Ordre d'exécution (README)
+
+```
+1. codes
+2. crosswalk
+3. compétences               (crée les collectivités EPCI manquantes)
+3bis. périmètre              ← nouveau, requiert les collectivités de l'étape 3
+4. transferts (par code)     ← enrichi (nb_communes_transferees), INDÉPENDANT du périmètre
+```
+
+L'étape 3bis et l'étape 4 peuvent tourner dans n'importe quel ordre après l'étape 3.
+
+#### 2.4 Re-import staging / prod
+
+1. re-run étape 3bis (périmètre) sur le CSV data.gouv EPCI ↔ communes
+2. pour chaque code compétence concerné (`2080`, `2085`, …) : re-run étape 4 sur chaque `3_transfert_code_<CODE>.csv`
+
+### Tranche 3 — Inférence personnalisation (backend)
+
+#### 3.1 Règle métier
+
+Logique (option B — stricte) :
+
+- `exercice === null` → `null`
+- `exercice === false` → `false`
+- `exercice === true` + délégation totale (`nbCommunesMembres > 0 && nbCommunesTransferees != null && nbCommunesTransferees >= nbCommunesMembres`) → `false`
+- sinon → `true`
+
+> **Décision d'implémentation (2026-08-31)** : `buildReponseUnionQuery` construit une seule requête `UNION` produisant directement la map `questionId → valeur` ; l'inférence doit donc s'exprimer en SQL. La règle vit dans l'expression `CASE` de `getCompetenceSubquery` (§3.2), couverte par les tests e2e (§4).
+
+#### 3.2 Repository
+
+Modifier `PersonnalisationReponsesEffectivesRepository.getCompetenceSubquery` :
+
+- ajouter un `leftJoin` sur `collectivite_banatic_2025_perimetre` (clé `collectivite_id`) en plus du `leftJoin` transfert existant
+- exposer `competenceExercee` = valeur **effective** via le `CASE` SQL ci-dessous
+- optionnel : exposer `exerciceBanatic` = `collectiviteBanatic2025CompetenceTable.exercice` brut (debug / UI, cf. 3.3)
+
+`buildReponseUnionQuery` : le `coalesce(reponseBinaire.reponse, competenceSubquery.competenceExercee)` reste inchangé — il consomme déjà `competenceExercee`, qui devient la valeur effective. Vérifier aussi le `or(isNotNull(reponseBinaire), isNotNull(competenceSubquery.competenceExercee))` du `where` : `competenceExercee` effectif peut être `false` (au lieu de `null`) pour une délégation totale, ce qui est bien la ligne qu'on veut inclure.
+
+**Expression SQL** (dans `getCompetenceSubquery`, `nb_communes_membres` venant du JOIN périmètre) :
+
+```sql
+CASE
+  WHEN cb.exercice IS NULL THEN NULL
+  WHEN cb.exercice = false THEN false
+  WHEN p.nb_communes_membres > 0
+    AND t.nb_communes_transferees >= p.nb_communes_membres THEN false
+  ELSE cb.exercice
+END
+-- p ou t absent (LEFT JOIN NULL) => la condition n'est pas vraie => ELSE cb.exercice (fallback sûr)
+```
+
+#### 3.3 Schéma API (`packages/domain/src/collectivites/personnalisations/reponse.schema.ts`)
+
+- `personnalisationReponseBaseSchema.competenceExercee` (`z.nullable(z.boolean())`) : inchangé côté type, porte désormais la valeur **effective**.
+- optionnel : ajouter `exerciceBanatic: z.nullable(z.boolean())` au `personnalisationReponseBaseSchema` pour la transparence (permet à l'UI de distinguer « pas la compétence » de « compétence transférée » sans deviner via `natureTransfert`). Propager depuis `getCompetenceSubquery` et `list-personnalisation-reponses.repository.ts`.
+
+### Tranche 4 — Tests
+
+#### Cas de la règle `CASE` SQL (couverts par les e2e ci-dessous)
+
+| Cas | `nbTransf` / `nbMembres` | Attendu |
+|-----|-------------------------|---------|
+| `exercice=true`, pas de transfert | `null` / `71` | `true` |
+| `exercice=true`, délégation totale | `71` / `71` | `false` |
+| `exercice=true`, sur-délégation | `72` / `71` | `false` (`>=`) |
+| `exercice=true`, délégation partielle | `40` / `71` | `true` |
+| `exercice=false` | `71` / `71` | `false` |
+| `nbMembres=null` (périmètre absent) | `71` / `null` | `true` (= `exercice` brut, fallback) |
+| `nbMembres=0` (garde-fou) | `0` / `0` | `true` (= `exercice`, pas de division par 0 implicite) |
+
+#### Import périmètre (`import-banatic-2025-perimetre` — nouveau `utils.test.ts`)
+
+- compter les communes **distinctes** par SIREN d'EPCI (`Set` de codes INSEE), pas de double comptage
+- **ne pas** filtrer sur `pmun_2025` / `MIN_COMMUNE_POPULATION`
+- SIREN non résolu en base → skip + warning, pas d'exception
+
+#### Import transferts (`import-banatic-2025-transferts/utils.test.ts`)
+
+- `communesTransferees` : `Set` de codes INSEE distincts ; EPCI multi-syndicats → taille du `Set` global (une commune comptée une fois même si listée sous deux syndicats)
+
+#### E2E backend (`personnalisation-reponses-effectives.repository.e2e-spec.ts`)
+
+- fixture Rouen-like : `exercice=true`, périmètre 71, transfert 71 → `payload = false`
+- fixture partielle : périmètre 71, transfert 40 → `payload = true` + `natureTransfert` présent
+- **fixtures à faire évoluer** dans `personnalisations.test-fixture.ts` :
+  - `addTestCollectiviteTransfertCompetence` (l. ~350) → accepter `nbCommunesTransferees`
+  - nouvelle `addTestCollectiviteBanaticPerimetre({ collectiviteId, nbCommunesMembres })`
+  - `addTestQuestionBanaticCompetencePourCollectivite` (l. ~612, aujourd'hui `exercice:true` + transfert `'transfert de test'`) : le test existant qui attend `true` reste valide tant qu'aucun périmètre total n'est posé — l'assertion ne change pas, mais ajouter un cas jumeau avec périmètre total attendant `false`.
+
+#### Non-régression scoring
+
+Vérifier `action-personnalisations` / règles `dechets_2` + `dechets_4` :
+
+- délégation totale → `dechets_2=NON` cohérent avec règles CAE EPCI
+- délégation partielle → `dechets_2=OUI` ; `dechets_4` reste la question de précision
+
+### Tranche 5 — Déploiement
+
+```mermaid
+flowchart TD
+  A[Migration Sqitch banatic_2025_perimetre] --> B[Deploy backend]
+  B --> C[Import périmètre EPCI - data.gouv]
+  B --> D[Import transferts par code]
+  C --> E[Vérif Rouen staging]
+  D --> E
+  E --> F[Deploy app si schéma API enrichi]
+```
+
+**Vérif Rouen** (staging — `collectivite_id` **à confirmer**, le plan citait `5118`) :
+
+```sql
+-- 0. retrouver l'id (SIREN Métropole Rouen Normandie = 200023414)
+SELECT id, nom, type FROM collectivite WHERE siren = '200023414';
+
+-- 1. données brutes + périmètre + transfert pour C2085
+SELECT
+  cb.exercice,
+  p.nb_communes_membres,
+  t.nb_communes_transferees,
+  t.nature_transfert
+FROM collectivite_banatic_2025_competence cb
+LEFT JOIN collectivite_banatic_2025_perimetre p
+  ON p.collectivite_id = cb.collectivite_id
+LEFT JOIN collectivite_banatic_2025_transfert t
+  ON t.collectivite_id = cb.collectivite_id AND t.competence_code = cb.competence_code
+WHERE cb.collectivite_id = :rouenId AND cb.competence_code = 2085;
+-- attendu : exercice=true, nb_communes_membres=71, nb_communes_transferees=71, nature_transfert='SMEDAR (71 communes)'
+```
+
+API `listPersonnalisationReponses` pour `dechets_2` :
+
+- `competenceExercee: false`
+- `reponse: false`
+- `natureTransfert: "SMEDAR (71 communes)"`
+- `exerciceBanatic: true` (si exposé, cf. 3.3)
+
+## Risques et décisions ouvertes
+
+| Sujet | Question | Recommandation |
+|-------|----------|----------------|
+| Périmètre absent | `nb_communes_membres` non importé pour un EPCI | LEFT JOIN → `NULL` → `CASE` retombe sur `exercice` brut. Aucun code de garde à l'import ; log de couverture après import périmètre. |
+| Source du dénominateur | D'où vient `nb_communes_membres` ? | Fichier data.gouv EPCI ↔ communes (`RELATIONS_EPCI_COMMUNES_URL`), **pas** `2_interco_…` (1 ligne/EPCI) ni `collectivite_relations` (filtré 3000 hab.). |
+| Cohérence num./dénom. | Filtre population asymétrique → faux « total » | Numérateur et dénominateur tous deux non filtrés (§1.3). |
+| Délégation partielle | `dechets_2=Oui` + transfert affiché — OK métier ? | Oui, aligné avec `dechets_4` pour la part syndicat. |
+| Multi-syndicats | Rouen = 1 syndicat ; d'autres EPCI en ont plusieurs | `Set` de codes INSEE sur **tous** les syndicats ; une commune comptée une fois. |
+| Codes compétence | Fichier transfert par code (`2080`, `2085`, …) | Documenter dans README ; pas seulement `1510`. |
+| Affichage UI | Label Banatic déplacé + bandeau « réponse différente » | Assumé (cf. §UI). Relire stories/snapshots `reponse-binaire` + `justification`. |
+| `exerciceBanatic` exposé | Utile pour support / debug / UI ? | Recommandé (permet à l'UI de distinguer « pas la compétence » de « transférée »), tranche 3.3. |
+| `id` Rouen staging | `5118` cité dans le plan initial | **Confirmé** sur base locale (seed) : `id` 5118, `nb_communes_membres` 71. Revalider sur staging avec le SQL §Tranche 5. |
+| Recomptage vs `nb_membres` | Le recomptage des INSEE distincts peut diverger de la colonne data.gouv | Sur le fichier actuel : 0 écart sur 1255 EPCI. L'import loggue tout écart, le recomptage fait foi. |
+
+## Ordre d'implémentation recommandé
+
+1. **Change Sqitch `banatic_2025_perimetre`** (deploy/revert/verify) + modèles Drizzle
+2. **Import périmètre** depuis le CSV data.gouv EPCI ↔ communes (non filtré) + `utils.test.ts`
+3. **Import transferts** : ajout `nb_communes_transferees` (`Set` INSEE) + `utils.test.ts`
+4. **Repository personnalisation** : JOIN périmètre + `CASE` effectif dans `getCompetenceSubquery` ; fixtures ; e2e
+5. **(optionnel)** exposer `exerciceBanatic` bout en bout ; ajustement libellés UI
+6. **Doc README** import + **vérif Rouen staging** (confirmer `id` + 71/71)
+
+## Fichiers clés existants
+
+| Fichier | Rôle actuel |
+|---------|-------------|
+| `apps/backend/src/collectivites/personnalisations/services/personnalisation-reponses-effectives.repository.ts` | Inférence `coalesce` + `competenceExercee` (`getCompetenceSubquery` / `buildReponseUnionQuery`) |
+| `apps/backend/src/collectivites/personnalisations/list-personnalisation-reponses/list-personnalisation-reponses.repository.ts` | Autre lecture exposant `competenceExercee` / `natureTransfert` (à propager si `exerciceBanatic`) |
+| `packages/domain/src/collectivites/personnalisations/reponse.schema.ts` | `personnalisationReponseBaseSchema` (`competenceExercee`, `natureTransfert`) |
+| `packages/domain/src/collectivites/personnalisations/competence-banatic.schema.ts` | Schéma compétence Banatic (`@tet/domain`) |
+| `apps/app/src/collectivites/personnalisations/question/reponse-binaire.tsx` | Label « (réponse Banatic) » sur Oui/Non (`showLabelBanatic`) |
+| `apps/app/src/collectivites/personnalisations/question/justification.tsx` | Ligne « Transfert vers … » + bandeau « réponse différente de Banatic » |
+| `apps/backend/src/collectivites/import-collectivite-relations/import-collectivite-relations.service.ts` | Consomme déjà le CSV data.gouv EPCI ↔ communes (`RELATIONS_EPCI_COMMUNES_URL`, garde `MIN_COMMUNE_POPULATION`) |
+| `apps/tools/src/migrations/banatic2025/import-banatic-2025-transferts/` | Import transferts (`groupByEpci`, `formatNatureTransfert`) |
+| `apps/tools/src/migrations/banatic2025/import-banatic-2025-collectivite-competences/` | Import exercice Banatic (`firstRowPerSiren`) |
+| `apps/tools/src/migrations/banatic2025/README.md` | Ordre d'exécution des imports |
+| `data_layer/sqitch/deploy/referentiel/banatic_2025.sql` | Schéma tables Banatic 2025 **existant** (ne pas éditer — cf. Tranche 1) |
+| `apps/backend/src/collectivites/personnalisations/personnalisations.test-fixture.ts` | Fixtures `addTestCollectiviteTransfertCompetence`, `addTestQuestionBanaticCompetencePourCollectivite` |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Nouvelles fonctionnalités**
  - Ajout de l’import du périmètre 2025 des EPCI et du nombre de communes membres.
  - Enrichissement des transferts avec le nombre de communes concernées.
  - Inférence automatique d’une délégation totale lorsqu’elle concerne toutes les communes membres.

- **Documentation**
  - Mise à jour de la documentation d’import Banatic 2025 et des étapes de traitement.

- **Tests**
  - Ajout de tests couvrant le comptage des communes, les écarts déclarés et les délégations totales ou partielles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->