### PR TITLE
fix(referentiels): annonce une modification et non un ajout sur une carte document

### DIFF
--- a/apps/app/src/labels/referentiels.labels.ts
+++ b/apps/app/src/labels/referentiels.labels.ts
@@ -52,6 +52,21 @@ export const referentielsLabels = {
   commentaires: plural({ one: 'commentaire', other: 'commentaires' }),
   pasDocumentAttenduAction:
     'Aucun document attendu pour cette mesure du référentiel',
+  documentDerniereModification: ({
+    date,
+    auteur,
+  }: {
+    date?: string;
+    auteur?: string;
+  }): string => {
+    if (date && auteur) {
+      return `Modifié le ${date} par ${auteur}`;
+    }
+    if (date) {
+      return `Modifié le ${date}`;
+    }
+    return auteur ? `Modifié par ${auteur}` : '';
+  },
 
   /** Sous-mesures */
   phaseBases: "S'engager",

--- a/apps/app/src/referentiels/preuves/Bibliotheque/utils.spec.ts
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/utils.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'vitest';
+import { getAuthorAndDate } from './utils';
+
+// La date rendue par les contrats de documents est celle de derniere
+// modification : preuve_labellisation, preuve_audit et preuve_rapport
+// exposent tous modifiedAt, qu'ils aliasaient en createdAt.
+describe('getAuthorAndDate', () => {
+  test('annonce une modification, pas un ajout', () => {
+    expect(getAuthorAndDate('2026-09-02T10:00:00Z', 'Yolo Dodo')).toBe(
+      'Modifié le 2 sept. 2026 par Yolo Dodo'
+    );
+  });
+
+  test("se passe de l'auteur quand il est inconnu", () => {
+    expect(getAuthorAndDate('2026-09-02T10:00:00Z', null)).toBe(
+      'Modifié le 2 sept. 2026'
+    );
+  });
+
+  test('se passe de la date quand elle est inconnue', () => {
+    expect(getAuthorAndDate(null, 'Yolo Dodo')).toBe('Modifié par Yolo Dodo');
+  });
+
+  test("ne rend rien quand ni la date ni l'auteur ne sont connus", () => {
+    expect(getAuthorAndDate(null, null)).toBeNull();
+  });
+});

--- a/apps/app/src/referentiels/preuves/Bibliotheque/utils.ts
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/utils.ts
@@ -1,3 +1,4 @@
+import { appLabels } from '@/app/labels/catalog';
 import { formatFileSize, getExtension } from '@/app/utils/file';
 import { getTextFormattedDate } from '@/app/utils/formatUtils';
 import { Preuve } from './types';
@@ -18,15 +19,13 @@ export const getFormattedTitle = (preuve: Preuve) => {
 export const getAuthorAndDate = (
   date: string | null,
   author: string | null
-) => {
-  const formattedDate = date
-    ? getTextFormattedDate({ date: date, shortMonth: true })
-    : null;
-
-  if (date || author) {
-    return `Ajouté${date ? ` le ${formattedDate}` : ''}${
-      author ? ` par ${author}` : ''
-    }`;
+): string | null => {
+  if (!date && !author) {
+    return null;
   }
-  return null;
+
+  return appLabels.documentDerniereModification({
+    date: date ? getTextFormattedDate({ date, shortMonth: true }) : undefined,
+    auteur: author ?? undefined,
+  });
 };


### PR DESCRIPTION
## Comportement

Une carte document affiche désormais **« Modifié le … par … »** au lieu de « Ajouté le … par … ».

## Pourquoi

`preuve_labellisation`, `preuve_audit` et `preuve_rapport` ne portent **pas de date de création** : leur seule colonne temporelle est `modified_at`. Les contrats la rendent sous son vrai nom depuis #4920, et `list-preuves` l'aliase encore en `createdAt`.

Le libellé était donc faux dès qu'un document était renommé ou commenté : il annonçait un ajout en montrant la date de la dernière modification. Sur un document fraîchement déposé les deux coïncident, ce qui masquait l'erreur.

Corriger la donnée n'est pas possible — la date de création n'existe nulle part. C'est le libellé qui doit dire la vérité.

## Contenu

`getAuthorAndDate` construisait sa phrase en dur, en français, dans un util de composant. Elle passe par `appLabels.documentDerniereModification`, ajouté au catalogue `referentiels` — la phrase reste entière, avec ses variables en argument, comme le prescrit le CLAUDE.md du front.

Les deux appelants en bénéficient : la carte d'un document de mesure ou de labellisation, et la carte de rapport d'audit.

## Tests

Commit 1 : les 4 tests, dont **3 échouent sur le code pré-fix** (`Ajouté le 2 sept. 2026 par Yolo Dodo` au lieu de `Modifié le …`). Commit 2 : le correctif, les 4 passent.

## Vérification

`nx run app:typecheck` (les deux tsconfig) et `nx run app:lint` verts.
