### PR TITLE
refactor(referentiels): nomme les documents d'une mesure par ce qu'ils sont

### DIFF
--- a/apps/app/src/referentiels/actions/action-documents.download-button.tsx
+++ b/apps/app/src/referentiels/actions/action-documents.download-button.tsx
@@ -1,7 +1,10 @@
 import { appLabels } from '@/app/labels/catalog';
 import { saveBlob } from '@/app/referentiels/preuves/Bibliotheque/saveBlob';
 import { Fichier, Preuve } from '@/app/referentiels/preuves/Bibliotheque/types';
-import { useListMesureDocuments } from '@/app/referentiels/preuves/data/use-list-mesure-documents';
+import {
+  MesureDocumentsState,
+  useListMesureDocuments,
+} from '@/app/referentiels/preuves/data/use-list-mesure-documents';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { DBClient, useSupabase } from '@tet/api';
 import {
@@ -59,15 +62,13 @@ export const DownloadDocs = ({ action, className }: TDownloadDocsProps) => {
   );
 };
 
-const flattenMesureDocuments = (
-  documentsQuery: ReturnType<typeof useListMesureDocuments>
-): Preuve[] => {
-  if (documentsQuery.status !== 'loaded') {
+const flattenMesureDocuments = (documents: MesureDocumentsState): Preuve[] => {
+  if (documents.status !== 'loaded') {
     return [];
   }
   return [
-    ...documentsQuery.attendus.flatMap((attendu) => attendu.documents),
-    ...documentsQuery.complementaires,
+    ...documents.attendus.flatMap((attendu) => attendu.documents),
+    ...documents.complementaires,
   ];
 };
 
@@ -78,13 +79,13 @@ const useDownloadDocs = (action: ActionListItem) => {
   const { nom } = collectivite || {};
 
   const collectiviteId = useCollectiviteId();
-  const documentsQuery = useListMesureDocuments({
+  const documents = useListMesureDocuments({
     collectiviteId,
     actionId: action.actionId,
     withSubActions: true,
   });
 
-  const preuves = flattenMesureDocuments(documentsQuery);
+  const preuves = flattenMesureDocuments(documents);
 
   const fichiers: Fichier[] = Object.values(
     preuves.reduce((filenameByHash, { fichier }) => {

--- a/apps/app/src/referentiels/actions/action-preuve.panel.tsx
+++ b/apps/app/src/referentiels/actions/action-preuve.panel.tsx
@@ -1,7 +1,7 @@
 import { appLabels } from '@/app/labels/catalog';
 import { useListMesureDocuments } from '@/app/referentiels/preuves/data/use-list-mesure-documents';
 import { PreuvesAction } from '@/app/referentiels/preuves/PreuvesAction';
-import { ActionDef } from './use-list-actions';
+import { ActionIdentity } from './use-list-actions';
 import SpinnerLoader from '@/app/ui/shared/SpinnerLoader';
 import { useCollectiviteId } from '@tet/api/collectivites';
 import { Alert } from '@tet/ui';
@@ -10,7 +10,7 @@ import { ComponentPropsWithoutRef } from 'react';
 export interface TActionPreuvePanelProps
   extends ComponentPropsWithoutRef<'div'> {
   /** Identifiant de l'action ou de la sous-action concernée */
-  action: ActionDef;
+  action: ActionIdentity;
   /** indique si les preuves associées aux sous-actions sont également chargées */
   withSubActions?: boolean;
   /** indique si l'avertissement "toutes les preuves ajoutées seront
@@ -35,17 +35,17 @@ const ActionPreuvePanel = (props: TActionPreuvePanelProps) => {
     ...otherProps
   } = props;
   const collectiviteId = useCollectiviteId();
-  const documentsQuery = useListMesureDocuments({
+  const documents = useListMesureDocuments({
     collectiviteId,
     actionId: action.actionId,
     withSubActions,
   });
 
-  if (documentsQuery.status === 'loading') {
+  if (documents.status === 'loading') {
     return <SpinnerLoader className="m-auto" />;
   }
 
-  if (documentsQuery.status === 'error') {
+  if (documents.status === 'error') {
     return <Alert state="error" title={appLabels.erreurChargementDocuments} />;
   }
 
@@ -53,8 +53,8 @@ const ActionPreuvePanel = (props: TActionPreuvePanelProps) => {
     <PreuvesAction
       action={action}
       withSubActions={withSubActions}
-      attendus={documentsQuery.attendus}
-      complementaires={documentsQuery.complementaires}
+      attendus={documents.attendus}
+      complementaires={documents.complementaires}
       showWarning={showWarning}
       hideIdentifier={hideIdentifier}
       displayInPanel={displayInPanel}

--- a/apps/app/src/referentiels/actions/use-list-actions.ts
+++ b/apps/app/src/referentiels/actions/use-list-actions.ts
@@ -10,7 +10,7 @@ import { useListActionsGroupedById } from './use-list-actions-grouped-by-id';
 export type ActionListItem =
   RouterOutput['referentiels']['actions']['listActionsGroupedById']['actionsById'][ActionId];
 
-export type ActionDef = Pick<
+export type ActionIdentity = Pick<
   ActionListItem,
   'actionId' | 'identifiant' | 'referentiel'
 >;

--- a/apps/app/src/referentiels/preuves/AddPreuveComplementaire.tsx
+++ b/apps/app/src/referentiels/preuves/AddPreuveComplementaire.tsx
@@ -1,5 +1,5 @@
 import { appLabels } from '@/app/labels/catalog';
-import { ActionDef } from '@/app/referentiels/actions/use-list-actions';
+import { ActionIdentity } from '@/app/referentiels/actions/use-list-actions';
 import { useCurrentCollectivite } from '@tet/api/collectivites';
 import { getReferentielIdFromActionId } from '@tet/domain/referentiels';
 import { Button, Field, Modal, Select } from '@tet/ui';
@@ -10,7 +10,7 @@ import type { OnDuplicatedDocumentsAdded } from './AddPreuveModal/types';
 import { useAddPreuveComplementaireToAction } from './useAddPreuveToAction';
 
 export type AddPreuveComplementaireProps = {
-  action: ActionDef;
+  action: ActionIdentity;
   addToSubAction?: boolean;
   onDuplicatedDocumentsAdded?: OnDuplicatedDocumentsAdded;
 };
@@ -79,7 +79,7 @@ const SelectSubAction = ({
   action,
   setSubaction,
 }: {
-  action: ActionDef;
+  action: ActionIdentity;
   setSubaction: (value: string) => void;
 }) => {
   const children = useGetActionChildren({

--- a/apps/app/src/referentiels/preuves/PreuvesAction.tsx
+++ b/apps/app/src/referentiels/preuves/PreuvesAction.tsx
@@ -9,10 +9,10 @@ import PreuveDoc from './Bibliotheque/PreuveDoc';
 import { PreuveReglementaire } from './Bibliotheque/PreuveReglementaire';
 import { DocumentAttendu, PreuveComplementaire } from './Bibliotheque/types';
 import { useDuplicatedDocumentState } from './duplicated-document-state.utils';
-import { ActionDef } from '../actions/use-list-actions';
+import { ActionIdentity } from '../actions/use-list-actions';
 
 export interface PreuvesActionProps extends ComponentPropsWithoutRef<'div'> {
-  action: ActionDef;
+  action: ActionIdentity;
   withSubActions?: boolean;
   showWarning?: boolean;
   hideIdentifier?: boolean;

--- a/apps/app/src/referentiels/preuves/data/use-list-mesure-documents.ts
+++ b/apps/app/src/referentiels/preuves/data/use-list-mesure-documents.ts
@@ -4,7 +4,7 @@ import { RouterOutput, useTRPC } from '@tet/api';
 type MesureDocuments =
   RouterOutput['referentiels']['documents']['listMesureDocuments'];
 
-type MesureDocumentsQuery =
+export type MesureDocumentsState =
   | { status: 'loading' }
   | { status: 'error' }
   | ({ status: 'loaded' } & MesureDocuments);
@@ -17,7 +17,7 @@ export const useListMesureDocuments = ({
   collectiviteId: number;
   actionId: string;
   withSubActions?: boolean;
-}): MesureDocumentsQuery => {
+}): MesureDocumentsState => {
   const trpc = useTRPC();
 
   const { data, isError } = useQuery(


### PR DESCRIPTION
Empilée sur #4929. Renommage seul, aucun changement de comportement.

- `documentsQuery` → `documents` : la valeur rendue par `useListMesureDocuments` n'est pas une query mais l'état des documents de la mesure (chargement / erreur / chargés).
- `MesureDocumentsQuery` → `MesureDocumentsState`, exporté pour remplacer le `ReturnType<typeof useListMesureDocuments>` du helper d'aplatissement.
- `ActionDef` → `ActionIdentity` : le type ne porte que `actionId`, `identifiant` et `referentiel`.

6 fichiers, renommage mécanique. Typecheck + lint 0 erreur, 717 tests app au vert.

https://claude.ai/code/session_01A3uLgXFJLL94AmxRGWbndW