### PR TITLE
fix(ui): aligne les extrémités du header sur la gouttière des pages

### DIFF
--- a/packages/ui/src/design-system/Header/header-desktop/header-desktop.tsx
+++ b/packages/ui/src/design-system/Header/header-desktop/header-desktop.tsx
@@ -27,9 +27,13 @@ const HeaderDesktop = ({
       {/** Partie supérieure du header */}
       <HeaderContainer className={cn('justify-between py-2', className)}>
         {/** Lien vers la page d'accueil */}
+        {/* Le bloc-marque porte sa zone de protection dans son propre SVG : 20
+            unités de vide à gauche d'un `viewBox` de 151 de haut, soit ~10px à
+            la hauteur rendue (h-20). On les reprend pour que la Marianne tombe
+            sur la gouttière, comme la navigation et le contenu. */}
         <Link
           href={rootUrl ?? '/'}
-          className="bg-none hover:!bg-primary-1 rounded-lg"
+          className="-ml-[10px] bg-none hover:!bg-primary-1 rounded-lg"
         >
           <div className="flex gap-4">
             <RepubliqueFrancaiseLogo className="h-20" />
@@ -40,7 +44,9 @@ const HeaderDesktop = ({
         </Link>
         {/** Navigation secondaire */}
         {!!secondaryNav && (
-          <nav className="flex gap-2">
+          /* Comme la navigation principale : le `px-4` du dernier item est
+             repris, pour que le sur-menu s'aligne sur le bord droit. */
+          <nav className="flex gap-2 -mr-4">
             {secondaryNav.map((item, i) => (
               <HeaderDesktopSecondaryNavItem
                 key={i}
@@ -58,15 +64,22 @@ const HeaderDesktop = ({
             id={HEADER_MAIN_NAV_ID}
             className={cn('text-sm text-primary-9', className)}
           >
+            {/* Les items portent un `p-4` qui les décollerait de la gouttière du
+                conteneur : le premier est ramené dessus, pour que la navigation
+                tombe sur la même verticale que le logo, le titre de page et les
+                bandeaux. Le dernier item de droite est traité de même. */}
             {mainNav.startItems.map((item, i) => (
               <HeaderDesktopMainNavItem
                 key={i}
-                item={item}
+                item={{
+                  ...item,
+                  className: cn(i === 0 && '-ml-4', item.className),
+                }}
                 pathname={pathname}
               />
             ))}
             {mainNav.endItems && (
-              <div className="ml-auto flex items-center">
+              <div className="ml-auto flex items-center -mr-4">
                 {mainNav.endItems.map((item, i) => (
                   <HeaderDesktopMainNavItem
                     key={i}


### PR DESCRIPTION
Le logo, le premier item de navigation et le sur-menu ne tombaient pas sur la verticale que suivent le contenu des pages et les bandeaux — alors que les trois conteneurs partagent déjà `max-w-8xl mx-auto px-6`.

Deux causes, internes aux éléments eux-mêmes :

- les items de navigation portent un `p-4`, qui décalait de 16 px le premier item à gauche et le dernier à droite : l'icône Home commençait à 40 px du bord au lieu de 24 ;
- le bloc-marque République Française embarque sa zone de protection dans son propre SVG — 20 unités de vide à gauche d'un `viewBox` de 151 de haut, soit ≈ 10 px à la hauteur rendue (`h-20`).

Ces marges sont reprises là où elles sont introduites, plutôt que de décaler le contenu de toutes les pages pour rejoindre le header.

| Avant | Après |
|--------|--------|
| <img width="1395" height="349" alt="image" src="https://github.com/user-attachments/assets/a5c6e4a1-ed6d-4037-ae89-0c0bc76e102c" /> | <img width="1395" height="349" alt="image" src="https://github.com/user-attachments/assets/a049bac4-577b-43fd-b4e7-af2fc905a3e7" /> | 

## À savoir

Le décalage négatif du logo emporte aussi son fond de survol, qui dépasse donc de 10 px à gauche de la gouttière. Volontairement laissé tel quel : le compenser demanderait de dissocier le fond du contenu du lien.

<img width="129" height="163" alt="image" src="https://github.com/user-attachments/assets/3c12ae4c-2a1d-41dd-846d-5289022bdfdd" />


Le header mobile n'est pas concerné — il n'a pas de gouttière, ses logos sont déjà au bord.

1 fichier, CSS seul, aucun changement de comportement. `ui:typecheck` et `ui:lint` à 0 erreur.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Ajustement de l’alignement horizontal des éléments de l’en-tête desktop afin de mieux respecter la gouttière du conteneur.
  * Amélioration du positionnement du lien d’accueil et des navigations principale et secondaire.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->