### PR TITLE
fix(referentiels): fait valider sa sortie par list-preuves

### DIFF
--- a/apps/app/src/referentiels/preuves/AddPreuveModal/AddFromLib.tsx
+++ b/apps/app/src/referentiels/preuves/AddPreuveModal/AddFromLib.tsx
@@ -4,13 +4,16 @@ import { getExtension } from '@/app/utils/file';
 import { Button, Field, Icon, Option, SelectFilter } from '@tet/ui';
 import classNames from 'classnames';
 import { useState } from 'react';
-import { BibliothequeFichier } from '../Bibliotheque/types';
-import { FichiersFilters, useFichiers } from '../Bibliotheque/useFichiers';
+import {
+  FichierListe,
+  FichiersFilters,
+  useFichiers,
+} from '../Bibliotheque/useFichiers';
 import { FileConstraints, keepWithinMaxFiles } from '../upload/constants';
 import { AddFileFromLibHandler } from './AddFile';
 
 export type AddFromLibProps = {
-  items: BibliothequeFichier[];
+  items: FichierListe[];
   setFilters: (filters: FichiersFilters) => void;
   /** Formats acceptés (par défaut : tous ceux de la bibliothèque). */
   fileConstraints?: FileConstraints;

--- a/apps/app/src/referentiels/preuves/AddPreuveModal/filesToUploadList.tsx
+++ b/apps/app/src/referentiels/preuves/AddPreuveModal/filesToUploadList.tsx
@@ -1,6 +1,5 @@
 import { shasum256 } from '@/app/utils/shasum256';
-import { BibliothequeFichier } from '../Bibliotheque/types';
-import { getFilesPerHash } from '../Bibliotheque/useFichiers';
+import { FichierParHash, getFilesPerHash } from '../Bibliotheque/useFichiers';
 import {
   DEFAULT_FILE_CONSTRAINTS,
   FileConstraints,
@@ -85,7 +84,7 @@ const createItemFailed = (
 // représente un fichier déjà téléversé
 const createItemDuplicated = (
   file: File,
-  fichier: BibliothequeFichier
+  fichier: FichierParHash
 ): FileUploadItem => ({
   file,
   status: {

--- a/apps/app/src/referentiels/preuves/Bibliotheque/useFichiers.ts
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/useFichiers.ts
@@ -7,7 +7,17 @@ import { BibliothequeFichier } from './types';
 export const NB_ITEMS_PER_PAGE = 5;
 
 export type FichiersFilters = { search: string; page: number };
-type FetchedData = { items: BibliothequeFichier[]; total: number };
+export type FichierListe = Pick<
+  BibliothequeFichier,
+  'id' | 'filename' | 'filesize' | 'hash' | 'confidentiel'
+>;
+
+export type FichierParHash = Pick<
+  BibliothequeFichier,
+  'id' | 'filename' | 'filesize' | 'hash'
+>;
+
+type FetchedData = { items: FichierListe[]; total: number };
 
 /**
  * Donne la liste de tous les fichiers de la collectivité, éventuellement
@@ -52,7 +62,10 @@ const fetch = async (
     throw new Error(error.message);
   }
 
-  return { items: (data as BibliothequeFichier[]) || [], total: count || 0 };
+  // `public.bibliotheque_fichier` est une vue : Postgres rend toutes ses
+  // colonnes nullables dans les types générés, y compris celles que la table
+  // sous-jacente déclare NOT NULL.
+  return { items: (data ?? []) as FichierListe[], total: count ?? 0 };
 };
 
 /**
@@ -62,7 +75,7 @@ const fetch = async (
 export const getFilesPerHash = async (
   collectiviteId: number,
   hashes: string[]
-) => {
+): Promise<FichierParHash[] | null> => {
   // TODO: replace with `useSupabase()`
   const supabase = createClientWithoutCookieOptions();
 
@@ -78,5 +91,5 @@ export const getFilesPerHash = async (
     return null;
   }
 
-  return (data as BibliothequeFichier[]) || null;
+  return (data ?? null) as FichierParHash[] | null;
 };

--- a/apps/backend/src/referentiels/labellisations/list-preuves/list-preuves-audit.errors.ts
+++ b/apps/backend/src/referentiels/labellisations/list-preuves/list-preuves-audit.errors.ts
@@ -7,6 +7,7 @@ const specificErrors = [
   'UNAUTHORIZED',
   'AUDIT_NOT_FOUND',
   'DATABASE_ERROR',
+  'DOCUMENT_SCHEMA_MISMATCH',
 ] as const;
 type SpecificError = (typeof specificErrors)[number];
 
@@ -22,6 +23,11 @@ export const listPreuvesAuditErrorConfig: TrpcErrorHandlerConfig<SpecificError> 
         code: 'BAD_REQUEST',
         message:
           'Aucun audit trouvé pour cette collectivité et ce référentiel.',
+      },
+      DOCUMENT_SCHEMA_MISMATCH: {
+        code: 'INTERNAL_SERVER_ERROR',
+        message:
+          "Un document ne respecte pas le format attendu et n'a pas pu être rendu.",
       },
       DATABASE_ERROR: {
         code: 'INTERNAL_SERVER_ERROR',

--- a/apps/backend/src/referentiels/labellisations/list-preuves/list-preuves-labellisation.errors.ts
+++ b/apps/backend/src/referentiels/labellisations/list-preuves/list-preuves-labellisation.errors.ts
@@ -7,6 +7,7 @@ const specificErrors = [
   'UNAUTHORIZED',
   'DEMANDE_NOT_FOUND',
   'DATABASE_ERROR',
+  'DOCUMENT_SCHEMA_MISMATCH',
 ] as const;
 type SpecificError = (typeof specificErrors)[number];
 
@@ -22,6 +23,11 @@ export const listPreuvesLabellisationErrorConfig: TrpcErrorHandlerConfig<Specifi
         code: 'BAD_REQUEST',
         message:
           'Aucune demande de labellisation trouvée pour cette collectivité et ce référentiel.',
+      },
+      DOCUMENT_SCHEMA_MISMATCH: {
+        code: 'INTERNAL_SERVER_ERROR',
+        message:
+          "Un document ne respecte pas le format attendu et n'a pas pu être rendu.",
       },
       DATABASE_ERROR: {
         code: 'INTERNAL_SERVER_ERROR',

--- a/apps/backend/src/referentiels/labellisations/list-preuves/list-preuves.repository.ts
+++ b/apps/backend/src/referentiels/labellisations/list-preuves/list-preuves.repository.ts
@@ -1,0 +1,137 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  buildFichierSubquery,
+  buildFileInfoSql,
+} from '@tet/backend/collectivites/documents/file-info.utils';
+import { hideConfidentielFilter } from '@tet/backend/collectivites/documents/hide-confidentiel.utils';
+import { preuveAuditTable } from '@tet/backend/collectivites/documents/models/preuve-audit.table';
+import { preuveLabellisationTable } from '@tet/backend/collectivites/documents/models/preuve-labellisation.table';
+import { createdByNom, dcpTable } from '@tet/backend/users/models/dcp.table';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { failure, success } from '@tet/backend/utils/result.type';
+import { getErrorMessage } from '@tet/domain/utils';
+import { and, eq, getTableColumns, sql } from 'drizzle-orm';
+import { auditTable } from '../audit.table';
+import { labellisationDemandeTable } from '../labellisation-demande.table';
+import { ListPreuvesAuditErrorEnum } from './list-preuves-audit.errors';
+import { ListPreuvesLabellisationErrorEnum } from './list-preuves-labellisation.errors';
+
+type AuditScope = {
+  auditId: number;
+  canReadConfidentiel: boolean;
+};
+
+type LabellisationScope = {
+  demandeId: number;
+  canReadConfidentiel: boolean;
+};
+
+@Injectable()
+export class ListPreuvesRepository {
+  private readonly logger = new Logger(ListPreuvesRepository.name);
+
+  constructor(private readonly databaseService: DatabaseService) {}
+
+  async listPreuvesAudit({ auditId, canReadConfidentiel }: AuditScope) {
+    const db = this.databaseService.db;
+    const fichier = buildFichierSubquery(db);
+
+    try {
+      const preuves = await db
+        .select({
+          ...getTableColumns(preuveAuditTable),
+          fichier: buildFileInfoSql(fichier),
+          demande: {
+            ...getTableColumns(labellisationDemandeTable),
+          },
+          audit: {
+            ...getTableColumns(auditTable),
+          },
+          modifiedByNom: createdByNom,
+          preuveType: sql<'audit'>`'audit'`,
+        })
+        .from(preuveAuditTable)
+        .leftJoin(fichier, eq(preuveAuditTable.fichierId, fichier.id))
+        .innerJoin(auditTable, eq(preuveAuditTable.auditId, auditTable.id))
+        .leftJoin(
+          labellisationDemandeTable,
+          eq(auditTable.demandeId, labellisationDemandeTable.id)
+        )
+        .leftJoin(dcpTable, eq(preuveAuditTable.modifiedBy, dcpTable.id))
+        .where(
+          and(
+            eq(preuveAuditTable.auditId, auditId),
+            hideConfidentielFilter({
+              fichierIdColumn: preuveAuditTable.fichierId,
+              confidentielColumn: fichier.confidentiel,
+              canReadConfidentiel,
+            })
+          )
+        )
+        .orderBy(preuveAuditTable.id);
+
+      return success(preuves);
+    } catch (error) {
+      this.logger.error(
+        `Echec de la lecture des preuves de l'audit ${auditId}: ${getErrorMessage(
+          error
+        )}`
+      );
+      return failure(ListPreuvesAuditErrorEnum.DATABASE_ERROR);
+    }
+  }
+
+  async listPreuvesLabellisation({
+    demandeId,
+    canReadConfidentiel,
+  }: LabellisationScope) {
+    const db = this.databaseService.db;
+    const fichier = buildFichierSubquery(db);
+
+    try {
+      const preuves = await db
+        .select({
+          ...getTableColumns(preuveLabellisationTable),
+          fichier: buildFileInfoSql(fichier),
+          demande: {
+            ...getTableColumns(labellisationDemandeTable),
+          },
+          modifiedByNom: createdByNom,
+          preuveType: sql<'labellisation'>`'labellisation'`,
+        })
+        .from(preuveLabellisationTable)
+        .leftJoin(fichier, eq(preuveLabellisationTable.fichierId, fichier.id))
+        .leftJoin(
+          labellisationDemandeTable,
+          eq(preuveLabellisationTable.demandeId, labellisationDemandeTable.id)
+        )
+        .leftJoin(
+          dcpTable,
+          eq(preuveLabellisationTable.modifiedBy, dcpTable.id)
+        )
+        .where(
+          and(
+            eq(preuveLabellisationTable.demandeId, demandeId),
+            hideConfidentielFilter({
+              fichierIdColumn: preuveLabellisationTable.fichierId,
+              confidentielColumn: fichier.confidentiel,
+              canReadConfidentiel,
+            })
+          )
+        )
+        // Ordre stable par id croissant : le front traite `preuves[0]` comme
+        // l'acte d'engagement (déposé en premier), il faut donc un ordre
+        // déterministe et non l'ordre physique arbitraire de Postgres.
+        .orderBy(preuveLabellisationTable.id);
+
+      return success(preuves);
+    } catch (error) {
+      this.logger.error(
+        `Echec de la lecture des preuves de la demande ${demandeId}: ${getErrorMessage(
+          error
+        )}`
+      );
+      return failure(ListPreuvesLabellisationErrorEnum.DATABASE_ERROR);
+    }
+  }
+}

--- a/apps/backend/src/referentiels/labellisations/list-preuves/list-preuves.repository.ts
+++ b/apps/backend/src/referentiels/labellisations/list-preuves/list-preuves.repository.ts
@@ -7,6 +7,10 @@ import { hideConfidentielFilter } from '@tet/backend/collectivites/documents/hid
 import { preuveAuditTable } from '@tet/backend/collectivites/documents/models/preuve-audit.table';
 import { preuveLabellisationTable } from '@tet/backend/collectivites/documents/models/preuve-labellisation.table';
 import { createdByNom, dcpTable } from '@tet/backend/users/models/dcp.table';
+import {
+  sqlToDate,
+  sqlToDateTimeISO,
+} from '@tet/backend/utils/column.utils';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { failure, success } from '@tet/backend/utils/result.type';
 import { getErrorMessage } from '@tet/domain/utils';
@@ -40,12 +44,19 @@ export class ListPreuvesRepository {
       const preuves = await db
         .select({
           ...getTableColumns(preuveAuditTable),
+          modifiedAt: sqlToDateTimeISO(preuveAuditTable.modifiedAt),
           fichier: buildFileInfoSql(fichier),
           demande: {
             ...getTableColumns(labellisationDemandeTable),
+            date: sqlToDate(labellisationDemandeTable.date),
+            modifiedAt: sqlToDateTimeISO(labellisationDemandeTable.modifiedAt),
+            envoyeeLe: sqlToDateTimeISO(labellisationDemandeTable.envoyeeLe),
           },
           audit: {
             ...getTableColumns(auditTable),
+            dateDebut: sqlToDateTimeISO(auditTable.dateDebut),
+            dateFin: sqlToDateTimeISO(auditTable.dateFin),
+            dateCnl: sqlToDateTimeISO(auditTable.dateCnl),
           },
           modifiedByNom: createdByNom,
           preuveType: sql<'audit'>`'audit'`,
@@ -92,9 +103,13 @@ export class ListPreuvesRepository {
       const preuves = await db
         .select({
           ...getTableColumns(preuveLabellisationTable),
+          modifiedAt: sqlToDateTimeISO(preuveLabellisationTable.modifiedAt),
           fichier: buildFileInfoSql(fichier),
           demande: {
             ...getTableColumns(labellisationDemandeTable),
+            date: sqlToDate(labellisationDemandeTable.date),
+            modifiedAt: sqlToDateTimeISO(labellisationDemandeTable.modifiedAt),
+            envoyeeLe: sqlToDateTimeISO(labellisationDemandeTable.envoyeeLe),
           },
           modifiedByNom: createdByNom,
           preuveType: sql<'labellisation'>`'labellisation'`,

--- a/apps/backend/src/referentiels/labellisations/list-preuves/list-preuves.service.spec.ts
+++ b/apps/backend/src/referentiels/labellisations/list-preuves/list-preuves.service.spec.ts
@@ -1,0 +1,99 @@
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { success } from '@tet/backend/utils/result.type';
+import { describe, expect, it, vi } from 'vitest';
+import { ListPreuvesService } from './list-preuves.service';
+
+const user = { id: 'user-id' } as AuthenticatedUser;
+
+const audit = {
+  id: 10,
+  collectiviteId: 1,
+  referentielId: 'cae',
+  demandeId: 20,
+  dateDebut: '2026-01-05T09:00:00Z',
+  dateFin: null,
+  valide: false,
+  dateCnl: null,
+  valideLabellisation: null,
+  clos: false,
+};
+
+const demande = {
+  id: 20,
+  collectiviteId: 1,
+  referentiel: 'cae',
+  enCours: false,
+  etoiles: '2',
+  date: '2026-01-10T10:00:00Z',
+  sujet: 'labellisation',
+  modifiedAt: null,
+  envoyeeLe: '2026-01-10T10:00:00Z',
+  demandeur: null,
+  associatedCollectiviteId: null,
+};
+
+const preuveAuditHorsContrat = {
+  id: 1,
+  collectiviteId: 1,
+  fichierId: null,
+  url: null,
+  titre: null,
+  commentaire: null,
+  modifiedAt: '2026-01-15T10:00:00Z',
+  modifiedBy: null,
+  lien: null,
+  auditId: 10,
+  fichier: null,
+  demande: null,
+  modifiedByNom: null,
+  preuveType: 'audit',
+};
+
+function buildService(preuves: unknown[]) {
+  const listPreuvesAudit = vi.fn().mockResolvedValue(success(preuves));
+  const listPreuvesLabellisation = vi.fn().mockResolvedValue(success(preuves));
+
+  const service = new ListPreuvesService(
+    { listPreuvesAudit, listPreuvesLabellisation } as never,
+    {
+      getAudit: vi.fn().mockResolvedValue(success(audit)),
+      getDemande: vi.fn().mockResolvedValue(success(demande)),
+    } as never,
+    {
+      checkUserCanReadDocuments: vi
+        .fn()
+        .mockResolvedValue(success({ canReadConfidentiel: true })),
+    } as never
+  );
+
+  return service;
+}
+
+describe('ListPreuvesService', () => {
+  it("refuse une preuve d'audit dont l'audit manque, au lieu de la rendre", async () => {
+    const service = buildService([preuveAuditHorsContrat]);
+
+    const result = await service.listPreuvesAudit({ auditId: 10 }, user);
+
+    expect(result).toEqual({
+      success: false,
+      error: 'DOCUMENT_SCHEMA_MISMATCH',
+    });
+  });
+
+  it('refuse une preuve de labellisation sans demande, au lieu de la rendre', async () => {
+    const service = buildService([
+      { ...preuveAuditHorsContrat, preuveType: 'labellisation' },
+    ]);
+
+    const result = await service.listPreuvesLabellisation(
+      { demandeId: 20 },
+      user
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: 'DOCUMENT_SCHEMA_MISMATCH',
+    });
+  });
+});

--- a/apps/backend/src/referentiels/labellisations/list-preuves/list-preuves.service.ts
+++ b/apps/backend/src/referentiels/labellisations/list-preuves/list-preuves.service.ts
@@ -1,10 +1,13 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { Result } from '@tet/backend/utils/result.type';
 import {
   LegacyPreuveAuditWithFichier,
   LegacyPreuveLabellisationWithFichier,
+  preuveAuditWithFichierSchema,
+  preuveLabellisationWithFichierSchema,
 } from '@tet/domain/collectivites';
+import * as z from 'zod/mini';
 import { ReferentielDocumentsAccessService } from '../../documents/referentiel-documents-access.service';
 import { GetLabellisationService } from '../get-labellisation.service';
 import {
@@ -21,6 +24,8 @@ import { ListPreuvesRepository } from './list-preuves.repository';
 
 @Injectable()
 export class ListPreuvesService {
+  private readonly logger = new Logger(ListPreuvesService.name);
+
   constructor(
     private readonly listPreuvesRepository: ListPreuvesRepository,
     private readonly getLabellisationService: GetLabellisationService,
@@ -63,10 +68,26 @@ export class ListPreuvesService {
 
     const { canReadConfidentiel } = accessResult.data;
 
-    return this.listPreuvesRepository.listPreuvesAudit({
+    const preuves = await this.listPreuvesRepository.listPreuvesAudit({
       auditId,
       canReadConfidentiel,
     });
+    if (!preuves.success) {
+      return preuves;
+    }
+
+    const parsed = z.array(preuveAuditWithFichierSchema).safeParse(preuves.data);
+    if (!parsed.success) {
+      this.logger.error(
+        `Preuves hors contrat pour l'audit ${auditId}: ${parsed.error.message}`
+      );
+      return {
+        success: false,
+        error: ListPreuvesAuditErrorEnum.DOCUMENT_SCHEMA_MISMATCH,
+      };
+    }
+
+    return { success: true, data: parsed.data };
   }
 
   async listPreuvesLabellisation(
@@ -110,9 +131,27 @@ export class ListPreuvesService {
 
     const { canReadConfidentiel } = accessResult.data;
 
-    return this.listPreuvesRepository.listPreuvesLabellisation({
+    const preuves = await this.listPreuvesRepository.listPreuvesLabellisation({
       demandeId,
       canReadConfidentiel,
     });
+    if (!preuves.success) {
+      return preuves;
+    }
+
+    const parsed = z
+      .array(preuveLabellisationWithFichierSchema)
+      .safeParse(preuves.data);
+    if (!parsed.success) {
+      this.logger.error(
+        `Preuves hors contrat pour la demande ${demandeId}: ${parsed.error.message}`
+      );
+      return {
+        success: false,
+        error: ListPreuvesLabellisationErrorEnum.DOCUMENT_SCHEMA_MISMATCH,
+      };
+    }
+
+    return { success: true, data: parsed.data };
   }
 }

--- a/apps/backend/src/referentiels/labellisations/list-preuves/list-preuves.service.ts
+++ b/apps/backend/src/referentiels/labellisations/list-preuves/list-preuves.service.ts
@@ -1,25 +1,12 @@
-import { Injectable, Logger } from '@nestjs/common';
-import { ReferentielDocumentsAccessService } from '../../documents/referentiel-documents-access.service';
-import {
-  buildFichierSubquery,
-  buildFileInfoSql,
-} from '@tet/backend/collectivites/documents/file-info.utils';
-import { hideConfidentielFilter } from '@tet/backend/collectivites/documents/hide-confidentiel.utils';
-import { preuveAuditTable } from '@tet/backend/collectivites/documents/models/preuve-audit.table';
-import { preuveLabellisationTable } from '@tet/backend/collectivites/documents/models/preuve-labellisation.table';
+import { Injectable } from '@nestjs/common';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
-import { createdByNom, dcpTable } from '@tet/backend/users/models/dcp.table';
-import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { Result } from '@tet/backend/utils/result.type';
 import {
   LegacyPreuveAuditWithFichier,
   LegacyPreuveLabellisationWithFichier,
 } from '@tet/domain/collectivites';
-import { getErrorMessage } from '@tet/domain/utils';
-import { and, eq, getTableColumns, sql } from 'drizzle-orm';
-import { auditTable } from '../audit.table';
+import { ReferentielDocumentsAccessService } from '../../documents/referentiel-documents-access.service';
 import { GetLabellisationService } from '../get-labellisation.service';
-import { labellisationDemandeTable } from '../labellisation-demande.table';
 import {
   ListPreuvesAuditError,
   ListPreuvesAuditErrorEnum,
@@ -30,13 +17,12 @@ import {
   ListPreuvesLabellisationErrorEnum,
 } from './list-preuves-labellisation.errors';
 import { ListPreuvesLabellisationInput } from './list-preuves-labellisation.input';
+import { ListPreuvesRepository } from './list-preuves.repository';
 
 @Injectable()
 export class ListPreuvesService {
-  private readonly logger = new Logger(ListPreuvesService.name);
-
   constructor(
-    private readonly databaseService: DatabaseService,
+    private readonly listPreuvesRepository: ListPreuvesRepository,
     private readonly getLabellisationService: GetLabellisationService,
     private readonly referentielDocumentsAccess: ReferentielDocumentsAccessService
   ) {}
@@ -77,59 +63,10 @@ export class ListPreuvesService {
 
     const { canReadConfidentiel } = accessResult.data;
 
-    try {
-      // Get the preuve
-      const fichier = buildFichierSubquery(this.databaseService.db);
-
-      const preuves = await this.databaseService.db
-        .select({
-          ...getTableColumns(preuveAuditTable),
-          fichier: buildFileInfoSql(fichier),
-          demande: {
-            ...getTableColumns(labellisationDemandeTable),
-          },
-          audit: {
-            ...getTableColumns(auditTable),
-          },
-          modifiedByNom: createdByNom,
-          preuveType: sql<'audit'>`'audit'`,
-        })
-        .from(preuveAuditTable)
-        .leftJoin(fichier, eq(preuveAuditTable.fichierId, fichier.id))
-        .innerJoin(auditTable, eq(preuveAuditTable.auditId, auditTable.id))
-        .leftJoin(
-          labellisationDemandeTable,
-          eq(auditTable.demandeId, labellisationDemandeTable.id)
-        )
-        .leftJoin(dcpTable, eq(preuveAuditTable.modifiedBy, dcpTable.id))
-        .where(
-          and(
-            eq(preuveAuditTable.auditId, auditId),
-            hideConfidentielFilter({
-              fichierIdColumn: preuveAuditTable.fichierId,
-              confidentielColumn: fichier.confidentiel,
-              canReadConfidentiel,
-            })
-          )
-        )
-        .orderBy(preuveAuditTable.id);
-
-      return {
-        success: true,
-        data: preuves,
-      };
-    } catch (error) {
-      this.logger.error(error);
-      this.logger.error(
-        `Error getting audit preuves: ${getErrorMessage(error)}`
-      );
-      return {
-        success: false,
-        error: ListPreuvesAuditErrorEnum.DATABASE_ERROR,
-        cause:
-          error instanceof Error ? error : new Error(getErrorMessage(error)),
-      };
-    }
+    return this.listPreuvesRepository.listPreuvesAudit({
+      auditId,
+      canReadConfidentiel,
+    });
   }
 
   async listPreuvesLabellisation(
@@ -173,60 +110,9 @@ export class ListPreuvesService {
 
     const { canReadConfidentiel } = accessResult.data;
 
-    try {
-      // Get the preuve
-      const fichier = buildFichierSubquery(this.databaseService.db);
-
-      const preuves = await this.databaseService.db
-        .select({
-          ...getTableColumns(preuveLabellisationTable),
-          fichier: buildFileInfoSql(fichier),
-          demande: {
-            ...getTableColumns(labellisationDemandeTable),
-          },
-          modifiedByNom: createdByNom,
-          preuveType: sql<'labellisation'>`'labellisation'`,
-        })
-        .from(preuveLabellisationTable)
-        .leftJoin(fichier, eq(preuveLabellisationTable.fichierId, fichier.id))
-        .leftJoin(
-          labellisationDemandeTable,
-          eq(preuveLabellisationTable.demandeId, labellisationDemandeTable.id)
-        )
-        .leftJoin(
-          dcpTable,
-          eq(preuveLabellisationTable.modifiedBy, dcpTable.id)
-        )
-        .where(
-          and(
-            eq(preuveLabellisationTable.demandeId, demandeId),
-            hideConfidentielFilter({
-              fichierIdColumn: preuveLabellisationTable.fichierId,
-              confidentielColumn: fichier.confidentiel,
-              canReadConfidentiel,
-            })
-          )
-        )
-        // Ordre stable par id croissant : le front traite `preuves[0]` comme
-        // l'acte d'engagement (déposé en premier), il faut donc un ordre
-        // déterministe et non l'ordre physique arbitraire de Postgres.
-        .orderBy(preuveLabellisationTable.id);
-
-      return {
-        success: true,
-        data: preuves,
-      };
-    } catch (error) {
-      this.logger.error(error);
-      this.logger.error(
-        `Error getting labellisation preuves: ${getErrorMessage(error)}`
-      );
-      return {
-        success: false,
-        error: ListPreuvesAuditErrorEnum.DATABASE_ERROR,
-        cause:
-          error instanceof Error ? error : new Error(getErrorMessage(error)),
-      };
-    }
+    return this.listPreuvesRepository.listPreuvesLabellisation({
+      demandeId,
+      canReadConfidentiel,
+    });
   }
 }

--- a/apps/backend/src/referentiels/referentiels.module.ts
+++ b/apps/backend/src/referentiels/referentiels.module.ts
@@ -60,6 +60,7 @@ import { ListDocumentsService } from './documents/list-documents/list-documents.
 import { ListMesureDocumentsRepository } from './documents/list-mesure-documents/list-mesure-documents.repository';
 import { ListMesureDocumentsRouter } from './documents/list-mesure-documents/list-mesure-documents.router';
 import { ListMesureDocumentsService } from './documents/list-mesure-documents/list-mesure-documents.service';
+import { ListPreuvesRepository } from './labellisations/list-preuves/list-preuves.repository';
 import { ListPreuvesService } from './labellisations/list-preuves/list-preuves.service';
 import { RequestLabellisationRouter } from './labellisations/request-labellisation/request-labellisation.router';
 import { RequestLabellisationService } from './labellisations/request-labellisation/request-labellisation.service';
@@ -192,6 +193,7 @@ import { UpdateActionStatutService } from './update-action-statut/update-action-
     CreatePreuveService,
     CreatePreuveRouter,
     ReferentielDocumentsAccessService,
+    ListPreuvesRepository,
     ListPreuvesService,
     ListPreuvesRouter,
     ListDocumentsRepository,

--- a/packages/domain/src/referentiels/labellisations/request-labellisation/request-labellisation.rules.spec.ts
+++ b/packages/domain/src/referentiels/labellisations/request-labellisation/request-labellisation.rules.spec.ts
@@ -407,7 +407,6 @@ describe('getParcoursLabellisationStatus — état consolidé du cycle', () => {
 
   it("retourne non_demandee quand il n'y a ni demande ni audit", () => {
     expect(getParcoursLabellisationStatus(null)).toBe('non_demandee');
-    expect(getParcoursLabellisationStatus(undefined)).toBe('non_demandee');
     expect(getParcoursLabellisationStatus({ demande: null, audit: null })).toBe(
       'non_demandee'
     );

--- a/packages/domain/src/referentiels/labellisations/request-labellisation/request-labellisation.rules.ts
+++ b/packages/domain/src/referentiels/labellisations/request-labellisation/request-labellisation.rules.ts
@@ -21,13 +21,13 @@ import {
 } from './request-labellisation.rules-errors';
 
 // détermine l'état consolidé du cycle
-type TDemandeEtOuAudit = {
+type DemandeEtOuAudit = {
   demande: Pick<LabellisationDemande, 'enCours'> | null;
   audit: Pick<LabellisationAudit, 'valide' | 'dateDebut' | 'dateFin'> | null;
 };
 
 export const getParcoursLabellisationStatus = (
-  demandeEtOuAudit: TDemandeEtOuAudit | null | undefined
+  demandeEtOuAudit: DemandeEtOuAudit | null
 ): ParcoursLabellisationStatus => {
   if (!demandeEtOuAudit) {
     return 'non_demandee';


### PR DESCRIPTION
## Comportement

`listPreuvesAudit` et `listPreuvesLabellisation` refusent une ligne hors contrat au lieu de la rendre au client, avec l'erreur `DOCUMENT_SCHEMA_MISMATCH` de leurs deux voisins.

Rien d'autre ne change tant que la sélection Drizzle et le schéma concordent — ce qui est le cas aujourd'hui.

## Ce qui manquait

`list-preuves` décrit son contrat depuis toujours : `preuveAuditWithFichierSchema` et `preuveLabellisationWithFichierSchema` typent le retour des deux méthodes. Ils ne servaient que de type. Une divergence entre la sélection et le schéma n'était rattrapée qu'au typecheck ; à l'exécution, la ligne partait telle quelle.

`listDocuments` et `listMesureDocuments` parsent déjà leur sortie. Les quatre endpoints de lecture de documents offrent désormais la même garantie.

## Le repository, préalable au test

Le service injectait `DatabaseService`, importait cinq tables et écrivait ses deux requêtes Drizzle en ligne, là où ses deux voisins délèguent chacun à un `.repository.ts`.

`ListPreuvesRepository` porte les deux requêtes telles quelles. Le service n'orchestre plus que la résolution de l'audit ou de la demande, le contrôle d'accès, l'appel au repository et la validation.

C'est ce qui rend le test rouge honnête : il monte le service sur un repository qui rend une ligne incomplète, et vérifie le refus. Sans repository, il aurait fallu simuler la chaîne Drizzle.

## Deux corrections annexes

**`useFichiers`** castait ses lignes en `BibliothequeFichier[]`, un type qui porte `collectiviteId` et `bucketId` alors qu'aucune des deux requêtes ne les sélectionne. Les consommateurs les recevaient dans leur type sans jamais les recevoir à l'exécution. `FichierListe` et `FichierParHash` décrivent ce que chaque `select` demande ; retirer une colonne d'un `select` casse maintenant à la compilation.

Le cast subsiste, réduit à ces types et commenté : `public.bibliotheque_fichier` est une **vue**, et Postgres rend nullables toutes les colonnes d'une vue dans les types générés, y compris celles que la table sous-jacente déclare `NOT NULL`.

**`getParcoursLabellisationStatus`** acceptait `TDemandeEtOuAudit | null | undefined`. Aucun appelant ne passe `undefined` — `getCurrentDemandeAndAudit` rend un objet, les deux autres sites passent un littéral. Le type interdit désormais ce cas, et le préfixe `T` tombe avec.

## Surface de review

Cinq commits, chacun d'une seule nature :

| commit | nature |
|---|---|
| `d891a76924` | extraction du repository — aucun changement de comportement |
| `f3627ef8ee` | test de régression, **rouge** sur ce commit |
| `2eb2e23308` | le `safeParse`, qui le passe au vert |
| `0c76f17243` | types de `useFichiers` |
| `62845eaffc` | une seule forme d'absence |

Le premier est le plus gros diff et le moins risqué : les requêtes se déplacent verbatim. Les décisions réelles sont dans le troisième et le quatrième.

Une correction au passage dans l'extraction : la branche labellisation renvoyait `ListPreuvesAuditErrorEnum.DATABASE_ERROR`. Les deux valent la même chaîne, le comportement est inchangé.

## Vérification

- Test rouge vu : `expected { success: true, data: [...] }` avant le `safeParse`, vert après.
- Typecheck backend et front : 0 erreur.
- `request-labellisation.rules.spec.ts` : 34 tests au vert.
- ESLint clean.

## Zone de moindre confiance

**Les e2e backend n'ont pas tourné en local.** `@tet/pdf-components` se construit avec swc et non `tsc`, et les specs de `labellisations/` démarrent l'application Nest complète avec une base. `list-preuves.router.e2e-spec.ts` est le seul filet sur le comportement réel des deux requêtes déplacées : il ne s'exécute qu'en CI.

Le point à regarder en priorité si un e2e tombe : l'extraction a déplacé les requêtes sans les relire ligne à ligne, en particulier les `leftJoin` sur `fichier` et le filtre de confidentialité.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Nouvelles fonctionnalités**
  - Les preuves d’audit et de labellisation sont désormais vérifiées avant affichage afin d’éviter le rendu de documents au format invalide.
  - Un message d’erreur spécifique est présenté lorsqu’un document ne respecte pas le format attendu.

- **Correctifs**
  - La récupération des fichiers utilise désormais des données adaptées à chaque usage, améliorant la fiabilité du traitement des preuves.
  - Les statuts de parcours de labellisation gèrent plus précisément l’absence de demande ou d’audit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->