### PR TITLE
fix(labellisations): enregistre l'auteur et la date du remplacement d'un rapport d'audit

### DIFF
--- a/apps/backend/src/referentiels/labellisations/update-audit-report/update-audit-report.router.e2e-spec.ts
+++ b/apps/backend/src/referentiels/labellisations/update-audit-report/update-audit-report.router.e2e-spec.ts
@@ -114,12 +114,25 @@ describe('UpdateAuditReportRouter', () => {
     };
 
     return {
+      audit,
       auditeurUser,
       otherUser,
       preuve,
       newFichier,
       cleanup: cleanupAll,
     };
+  };
+
+  const getPreuveTrace = async (preuveId: number) => {
+    const [row] = await databaseService.db
+      .select({
+        fichierId: preuveAuditTable.fichierId,
+        modifiedBy: preuveAuditTable.modifiedBy,
+        modifiedAt: preuveAuditTable.modifiedAt,
+      })
+      .from(preuveAuditTable)
+      .where(eq(preuveAuditTable.id, preuveId));
+    return row;
   };
 
   const getPreuveFichierId = async (preuveId: number) => {
@@ -145,6 +158,43 @@ describe('UpdateAuditReportRouter', () => {
     });
 
     expect(await getPreuveFichierId(preuve.id)).toBe(newFichier.id);
+  });
+
+  test('le remplacement enregistre son auteur et sa date', async () => {
+    const { audit, otherUser, preuve, newFichier, cleanup } = await seedReport({
+      clos: false,
+      valide: false,
+    });
+    onTestFinished(cleanup);
+
+    const secondAuditeurPermission = await addAuditeurPermission({
+      databaseService,
+      auditId: audit.id,
+      userId: otherUser.id,
+    });
+    onTestFinished(secondAuditeurPermission.cleanup);
+
+    const traceBeforeReplacement = await getPreuveTrace(preuve.id);
+
+    const caller = router.createCaller({ user: await getAuthUser(otherUser) });
+    await caller.referentiels.labellisations.updateAuditReport({
+      preuveId: preuve.id,
+      fichierId: newFichier.id,
+    });
+
+    const trace = await getPreuveTrace(preuve.id);
+
+    expect({
+      fichierId: trace.fichierId,
+      modifiedBy: trace.modifiedBy,
+      isModifiedAtRefreshed:
+        new Date(trace.modifiedAt) >
+        new Date(traceBeforeReplacement.modifiedAt),
+    }).toEqual({
+      fichierId: newFichier.id,
+      modifiedBy: otherUser.id,
+      isModifiedAtRefreshed: true,
+    });
   });
 
   test("l'auditeur remplace le rapport d'un audit pas encore valide", async () => {

--- a/apps/backend/src/referentiels/labellisations/update-audit-report/update-audit-report.service.ts
+++ b/apps/backend/src/referentiels/labellisations/update-audit-report/update-audit-report.service.ts
@@ -88,7 +88,11 @@ export class UpdateAuditReportService {
 
       await this.databaseService.db
         .update(preuveAuditTable)
-        .set({ fichierId })
+        .set({
+          fichierId,
+          modifiedBy: user.id,
+          modifiedAt: new Date().toISOString(),
+        })
         .where(eq(preuveAuditTable.id, preuveId));
 
       return { success: true, data: { preuveId } };


### PR DESCRIPTION
## Comportement

Quand le fichier d'un rapport d'audit est remplacé, la preuve enregistre désormais **qui** a posé le fichier courant et **quand**. Jusqu'ici elle continuait de désigner le déposant initial et la date du dépôt initial : la carte de document attribuait le nouveau fichier à la mauvaise personne.

## Le mode de défaillance

`UpdateAuditReportService` n'écrivait que `fichierId`. Les colonnes `modified_by` / `modified_at` de `preuve_audit` n'ont que des DEFAULT — `auth.uid()` et `CURRENT_TIMESTAMP` — honorés à la seule insertion : `public.preuve_audit` a été recréée par `labellisation/audit@v2.14` sans les triggers que `preuve_v2@v1.16.0` posait sur les tables de preuves antérieures, `like preuve_base` ne copiant pas les triggers. Vérifié en base : `pg_trigger` ne renvoie aucune ligne non interne pour cette table.

Poser les triggers manquants aurait été le contraire d'un correctif. `utilisateur.update_modified_by()` affecte `auth.uid()`, soit **NULL** sous le service-role du backend : l'auteur aurait été effacé au lieu d'être rafraîchi. Le correctif appartient au service, seul à connaître l'utilisateur authentifié.

## Surface de review

Deux commits, deux fichiers, ~4 lignes de logique nouvelle.

| commit | contenu |
|---|---|
| `a9b172a8e2` | le test de régression — **rouge sur `main`** |
| `17e5df5254` | le fix |

Le test rouge échouait sur les deux champs simultanément : `modifiedBy` restait l'identifiant du premier déposant, et `isModifiedAtRefreshed` valait `false`.

Les deux endroits à regarder :

- **`update-audit-report.service.ts`** — le `set` du `UPDATE`. Le patron `modifiedBy: user.id` + `modifiedAt: new Date().toISOString()` est celui qu'emploie déjà `upsert-axe-base.repository.ts`.
- **`update-audit-report.router.e2e-spec.ts`** — le test met **deux auditeurs** sur le même audit et fait remplacer par le second. Sans ce second acteur, une assertion sur `modifiedBy` ne distinguerait pas un champ figé d'un champ correctement réécrit.

Le reste du diff est mécanique : `seedReport` rend désormais l'`audit` pour permettre le rattachement du second auditeur, et `getPreuveFichierId` est doublé d'un `getPreuveTrace` qui lit aussi les deux colonnes de traçabilité.

## Vérification

- `nx test backend 'update-audit-report'` : 8/8 au vert, dont les 7 tests préexistants inchangés.
- `nx run backend:typecheck` : 0 erreur.
- `nx run backend:lint` : 0 erreur (les 154 warnings sont préexistants, aucun dans les fichiers touchés).
- Le rouge du commit 1 a été constaté avant écriture du fix, pas déduit.

## Anti-duplication

Aucune utility, aucun helper, aucun composant créé. Recherche menée avant d'écrire le fix : un patron d'écriture de `modifiedBy` / `modifiedAt` sur une mise à jour existe déjà dans le dépôt (`upsert-axe-base.repository.ts`, `panier-checkout.repository.ts`) — il est réutilisé tel quel, y compris la sérialisation ISO imposée par `TIMESTAMP_OPTIONS` en `mode: 'string'`.

## Ce que ça n'inclut pas

- **Les autres chemins d'écriture sur les tables `preuve_*`** peuvent souffrir du même défaut. Ils n'ont pas été audités et ne sont pas touchés : ce serait une autre PR, avec ses propres tests rouges.
- **Aucun changement d'autorisation.** Qui peut remplacer un rapport, et dans quelle fenêtre, reste strictement inchangé.

## Plan

PR 1 de la stack `2026-09-03-001-feat-super-admin-remplacement-rapport-audit` (plan local, non commité). Ce fix y est en tête de stack parce qu'il corrige un défaut préexistant, indépendant de la feature qui suit — un remplacement de rapport par le support sur un audit clos ne serait pas acceptable sans trace.
