### PR TITLE
refactor(labellisations): exprime en union l'acteur d'un remplacement de rapport

### DIFF
--- a/apps/app/src/referentiels/preuves/Bibliotheque/canUserUpdateAuditReport.ts
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/canUserUpdateAuditReport.ts
@@ -13,7 +13,7 @@ export const canUserUpdateAuditReport = (
     return false;
   }
   return canUpdateAuditReport({
-    isAuditeur: isUserAuditeurForAudit(user, preuve.audit.id),
+    editor: isUserAuditeurForAudit(user, preuve.audit.id) ? 'auditeur' : 'tiers',
     audit: {
       clos: preuve.audit.clos,
       valide: preuve.audit.valide,

--- a/apps/backend/src/referentiels/labellisations/update-audit-report/update-audit-report.service.ts
+++ b/apps/backend/src/referentiels/labellisations/update-audit-report/update-audit-report.service.ts
@@ -53,7 +53,7 @@ export class UpdateAuditReportService {
       }
 
       const allowed = canUpdateAuditReport({
-        isAuditeur: context.auditeur !== null,
+        editor: context.auditeur !== null ? 'auditeur' : 'tiers',
         audit: {
           clos: context.clos,
           valide: context.valide,

--- a/packages/domain/src/referentiels/labellisations/can-update-audit-report/can-update-audit-report.rule.spec.ts
+++ b/packages/domain/src/referentiels/labellisations/can-update-audit-report/can-update-audit-report.rule.spec.ts
@@ -7,15 +7,15 @@ const daysAgo = (days: number) =>
 
 describe('canUpdateAuditReport', () => {
   it("refuse une preuve sans rapport d'audit", () => {
-    expect(canUpdateAuditReport({ isAuditeur: true, audit: null, now })).toBe(
-      false
-    );
+    expect(
+      canUpdateAuditReport({ editor: 'auditeur', audit: null, now })
+    ).toBe(false);
   });
 
-  it("refuse si l'utilisateur n'est pas l'auditeur de cet audit", () => {
+  it("refuse un tiers à l'audit", () => {
     expect(
       canUpdateAuditReport({
-        isAuditeur: false,
+        editor: 'tiers',
         audit: { clos: false, valide: false, dateFin: null },
         now,
       })
@@ -25,7 +25,7 @@ describe('canUpdateAuditReport', () => {
   it("autorise l'auditeur tant que l'audit n'est pas valide", () => {
     expect(
       canUpdateAuditReport({
-        isAuditeur: true,
+        editor: 'auditeur',
         audit: { clos: false, valide: false, dateFin: null },
         now,
       })
@@ -35,7 +35,7 @@ describe('canUpdateAuditReport', () => {
   it('autorise dans les 15 jours suivant la validation', () => {
     expect(
       canUpdateAuditReport({
-        isAuditeur: true,
+        editor: 'auditeur',
         audit: { clos: false, valide: true, dateFin: daysAgo(14) },
         now,
       })
@@ -45,7 +45,7 @@ describe('canUpdateAuditReport', () => {
   it('refuse plus de 15 jours apres la validation', () => {
     expect(
       canUpdateAuditReport({
-        isAuditeur: true,
+        editor: 'auditeur',
         audit: { clos: false, valide: true, dateFin: daysAgo(16) },
         now,
       })
@@ -55,7 +55,7 @@ describe('canUpdateAuditReport', () => {
   it('autorise dans les 15 jours même si l’audit est clos', () => {
     expect(
       canUpdateAuditReport({
-        isAuditeur: true,
+        editor: 'auditeur',
         audit: { clos: true, valide: true, dateFin: daysAgo(14) },
         now,
       })
@@ -65,7 +65,7 @@ describe('canUpdateAuditReport', () => {
   it("refuse plus de 15 jours après la clôture, même si l'audit est clos", () => {
     expect(
       canUpdateAuditReport({
-        isAuditeur: true,
+        editor: 'auditeur',
         audit: { clos: true, valide: true, dateFin: daysAgo(16) },
         now,
       })
@@ -75,7 +75,7 @@ describe('canUpdateAuditReport', () => {
   it('refuse un audit valide sans date de fin', () => {
     expect(
       canUpdateAuditReport({
-        isAuditeur: true,
+        editor: 'auditeur',
         audit: { clos: false, valide: true, dateFin: null },
         now,
       })

--- a/packages/domain/src/referentiels/labellisations/can-update-audit-report/can-update-audit-report.rule.ts
+++ b/packages/domain/src/referentiels/labellisations/can-update-audit-report/can-update-audit-report.rule.ts
@@ -1,19 +1,17 @@
+import { match } from 'ts-pattern';
 import { AUDIT_REPORT_UPDATE_WINDOW_DAYS } from '../labellisation-audit.schema';
 
 const DAY_IN_MS = 24 * 60 * 60 * 1000;
 
-export function canUpdateAuditReport({
-  isAuditeur,
-  audit,
-  now,
-}: {
-  isAuditeur: boolean;
-  audit: { clos: boolean; valide: boolean; dateFin: Date | string | null } | null;
-  now: Date;
-}): boolean {
-  if (audit === null || !isAuditeur) {
-    return false;
-  }
+export type AuditReportEditor = 'auditeur' | 'tiers';
+
+type Audit = {
+  clos: boolean;
+  valide: boolean;
+  dateFin: Date | string | null;
+};
+
+function isAuditeurUpdateWindowOpen(audit: Audit, now: Date): boolean {
   if (!audit.valide && !audit.clos) {
     return true;
   }
@@ -23,4 +21,22 @@ export function canUpdateAuditReport({
   const editWindowStart =
     now.getTime() - AUDIT_REPORT_UPDATE_WINDOW_DAYS * DAY_IN_MS;
   return new Date(audit.dateFin).getTime() > editWindowStart;
+}
+
+export function canUpdateAuditReport({
+  editor,
+  audit,
+  now,
+}: {
+  editor: AuditReportEditor;
+  audit: Audit | null;
+  now: Date;
+}): boolean {
+  if (audit === null) {
+    return false;
+  }
+  return match(editor)
+    .with('auditeur', () => isAuditeurUpdateWindowOpen(audit, now))
+    .with('tiers', () => false)
+    .exhaustive();
 }


### PR DESCRIPTION
## Comportement

Aucun changement. Mêmes autorisations, mêmes refus, sur les mêmes audits.

## Ce qui change

`canUpdateAuditReport` recevait `isAuditeur: boolean`. La négation de ce booléen recouvrait deux situations distinctes — « ce n'est pas l'auditeur de cet audit » — et le type autorisait des combinaisons qui ne veulent rien dire dès qu'un second acteur apparaît.

La règle reçoit désormais **l'acteur lui-même** :

```ts
export type AuditReportEditor = 'auditeur' | 'tiers';
```

résolu par `ts-pattern` avec `.exhaustive()`, comme `start-new-audit-cycle.rules.ts` le fait déjà dans le même dossier. La fenêtre d'édition de l'auditeur sort dans une fonction qui nomme ce qu'elle décide, `isAuditeurUpdateWindowOpen`, au lieu d'être une suite de gardes dans le corps de la règle.

## Surface de review

Un commit, 4 fichiers, ~15 lignes de logique déplacée et 0 ligne de comportement nouveau.

Le seul endroit à regarder est **`can-update-audit-report.rule.ts`** : c'est là que la forme change. Les trois autres fichiers en découlent mécaniquement.

- `update-audit-report.service.ts` — une ligne, `context.auditeur !== null ? 'auditeur' : 'tiers'`
- `canUserUpdateAuditReport.ts` — une ligne, la même résolution depuis `isUserAuditeurForAudit`
- la spec — les huit cas sont conservés tels quels, seule l'entrée change de forme

`packages/domain/src/referentiels/index.ts` n'est pas touché : le module est déjà réexporté par `export *`, le type suit.

Ces deux appelants sont les **seuls** consommateurs de la règle dans le dépôt, vérifié par recherche sur `apps/` et `packages/`.

## Vérification

Le comportement identique n'est pas affirmé par relecture, il est tenu par les tests existants :

- spec domaine `can-update-audit-report` : 8/8, cas inchangés
- e2e backend `update-audit-report` : 7/7, spec non modifiée par cette PR
- typecheck `backend` et `app` : 0 erreur — c'est le typecheck front qui garantit qu'aucun consommateur n'est resté sur l'ancienne signature
- lint `domain`, `backend`, `app` : 0 erreur

## Pourquoi maintenant

Cette PR prépare l'arrivée d'un troisième acteur — le support, qui pourra remplacer un rapport hors de la fenêtre de l'auditeur. Elle est livrée seule et en amont pour que ce changement de forme soit reviewable sans se mélanger à un changement d'autorisation.

Le membre `'super-admin'` n'est **pas** ajouté ici : un membre d'union sans producteur serait une branche morte.

## Ce que ça n'inclut pas

`audit` reste nullable dans la signature, alors qu'aucun des deux appelants ne peut produire `null` à cet endroit — le backend fait un `innerJoin`, le front garde en amont. Le resserrer est une autre intention, et cette PR n'en porte qu'une.

## Plan

PR 2 de la stack `2026-09-03-001-feat-super-admin-remplacement-rapport-audit` (plan local, non commité). Indépendante de la PR 1 (#4942), qui touche d'autres lignes des mêmes fichiers backend.
