### PR TITLE
feat(labellisations): autorise le super admin à remplacer un rapport d'audit

### DIFF
--- a/apps/app/src/referentiels/preuves/Bibliotheque/canUserUpdateAuditReport.ts
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/canUserUpdateAuditReport.ts
@@ -1,5 +1,6 @@
 import { canUpdateAuditReport } from '@tet/domain/referentiels';
 import {
+  hasPermission,
   isUserAuditeurForAudit,
   UserRolesAndPermissions,
 } from '@tet/domain/users';
@@ -14,6 +15,11 @@ export const canUserUpdateAuditReport = (
   }
   return canUpdateAuditReport({
     isAuditeur: isUserAuditeurForAudit(user, preuve.audit.id),
+    canUpdateAnyAuditReport: hasPermission(
+      user,
+      'referentiels.labellisations.mutate_documents',
+      { collectiviteId: preuve.collectiviteId }
+    ),
     audit: {
       clos: preuve.audit.clos,
       valide: preuve.audit.valide,

--- a/apps/backend/src/referentiels/labellisations/update-audit-report/update-audit-report.errors.ts
+++ b/apps/backend/src/referentiels/labellisations/update-audit-report/update-audit-report.errors.ts
@@ -25,7 +25,7 @@ export const updateAuditReportErrorConfig: TrpcErrorHandlerConfig<SpecificError>
       UPDATE_NOT_ALLOWED: {
         code: 'UNAUTHORIZED',
         message:
-          "Seul l'auditeur de cet audit peut remplacer le rapport, et uniquement dans les 15 jours suivant la clôture.",
+          "Le remplacement du rapport est réservé à l'auditeur de cet audit, dans les 15 jours suivant la clôture.",
       },
       DATABASE_ERROR: {
         code: 'INTERNAL_SERVER_ERROR',

--- a/apps/backend/src/referentiels/labellisations/update-audit-report/update-audit-report.router.e2e-spec.ts
+++ b/apps/backend/src/referentiels/labellisations/update-audit-report/update-audit-report.router.e2e-spec.ts
@@ -7,7 +7,16 @@ import {
   addAuditeurPermission,
   createAudit,
 } from '@tet/backend/referentiels/labellisations/labellisations.test-fixture';
-import { getAuthUser, getTestApp } from '@tet/backend/test';
+import {
+  getAuthUser,
+  getAuthUserFromUserCredentials,
+  getTestApp,
+} from '@tet/backend/test';
+import {
+  addAndEnableUserSuperAdminMode,
+  addTestUser,
+  addUserRoleSupport,
+} from '@tet/backend/users/users/users.test-fixture';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
 import { ReferentielIdEnum } from '@tet/domain/referentiels';
@@ -280,6 +289,60 @@ describe('UpdateAuditReportRouter', () => {
     });
 
     expect(await getPreuveFichierId(preuve.id)).toBe(newFichier.id);
+  });
+
+  test("autorise le super admin en mode support sur un audit clos hors fenêtre", async () => {
+    const { preuve, newFichier, cleanup } = await seedReport({
+      clos: true,
+      valide: true,
+      dateFin: new Date(Date.now() - 16 * DAY_IN_MS).toISOString(),
+    });
+    onTestFinished(cleanup);
+
+    const { user, cleanup: cleanupUser } = await addTestUser(databaseService);
+    onTestFinished(cleanupUser);
+    const superAdmin = getAuthUserFromUserCredentials(user);
+    const caller = router.createCaller({ user: superAdmin });
+    const superAdminMode = await addAndEnableUserSuperAdminMode({
+      app,
+      caller,
+      userId: superAdmin.id,
+    });
+    onTestFinished(superAdminMode.cleanup);
+
+    await caller.referentiels.labellisations.updateAuditReport({
+      preuveId: preuve.id,
+      fichierId: newFichier.id,
+    });
+
+    expect(await getPreuveFichierId(preuve.id)).toBe(newFichier.id);
+  });
+
+  test('refuse le super admin dont le mode support est éteint', async () => {
+    const { preuve, newFichier, cleanup } = await seedReport({
+      clos: true,
+      valide: true,
+      dateFin: new Date(Date.now() - 16 * DAY_IN_MS).toISOString(),
+    });
+    onTestFinished(cleanup);
+
+    const { user, cleanup: cleanupUser } = await addTestUser(databaseService);
+    onTestFinished(cleanupUser);
+    const supportUser = getAuthUserFromUserCredentials(user);
+    const roleSupport = await addUserRoleSupport({
+      databaseService,
+      userId: supportUser.id,
+    });
+    onTestFinished(roleSupport.cleanup);
+
+    const caller = router.createCaller({ user: supportUser });
+
+    await expect(
+      caller.referentiels.labellisations.updateAuditReport({
+        preuveId: preuve.id,
+        fichierId: newFichier.id,
+      })
+    ).rejects.toThrow(/réservé à l'auditeur/);
   });
 
   test("refuse un fichier appartenant à une autre collectivité", async () => {

--- a/apps/backend/src/referentiels/labellisations/update-audit-report/update-audit-report.service.ts
+++ b/apps/backend/src/referentiels/labellisations/update-audit-report/update-audit-report.service.ts
@@ -2,10 +2,12 @@ import { Injectable, Logger } from '@nestjs/common';
 import { bibliothequeFichierTable } from '@tet/backend/collectivites/documents/models/bibliotheque-fichier.table';
 import { preuveAuditTable } from '@tet/backend/collectivites/documents/models/preuve-audit.table';
 import { auditeurTable } from '@tet/backend/referentiels/labellisations/auditeur.table';
+import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { Result } from '@tet/backend/utils/result.type';
 import { canUpdateAuditReport } from '@tet/domain/referentiels';
+import { PermissionOperationEnum, ResourceType } from '@tet/domain/users';
 import { getErrorMessage } from '@tet/domain/utils';
 import { and, eq } from 'drizzle-orm';
 import { auditTable } from '../audit.table';
@@ -19,7 +21,25 @@ import { UpdateAuditReportInput } from './update-audit-report.input';
 export class UpdateAuditReportService {
   private readonly logger = new Logger(UpdateAuditReportService.name);
 
-  constructor(private readonly databaseService: DatabaseService) {}
+  constructor(
+    private readonly databaseService: DatabaseService,
+    private readonly permissions: PermissionService
+  ) {}
+
+  private async canUpdateAnyAuditReport(
+    user: AuthenticatedUser,
+    collectiviteId: number
+  ): Promise<boolean> {
+    const permissionResult = await this.permissions.isAllowed(
+      user,
+      PermissionOperationEnum[
+        'REFERENTIELS.LABELLISATIONS.MUTATE_DOCUMENTS'
+      ],
+      ResourceType.COLLECTIVITE,
+      { collectiviteId }
+    );
+    return permissionResult.success;
+  }
 
   async updateAuditReport(
     { preuveId, fichierId }: UpdateAuditReportInput,
@@ -54,6 +74,10 @@ export class UpdateAuditReportService {
 
       const allowed = canUpdateAuditReport({
         isAuditeur: context.auditeur !== null,
+        canUpdateAnyAuditReport: await this.canUpdateAnyAuditReport(
+          user,
+          context.collectiviteId
+        ),
         audit: {
           clos: context.clos,
           valide: context.valide,

--- a/e2e/tests/referentiels/labellisations/rapport-audit-bibliotheque.spec.ts
+++ b/e2e/tests/referentiels/labellisations/rapport-audit-bibliotheque.spec.ts
@@ -117,6 +117,35 @@ test.describe("Rapport d'audit dans la bibliothèque", () => {
     await expect(page.getByTitle('Remplacer le fichier')).toHaveCount(0);
   });
 
+  test('le super admin en mode support voit le bouton « Remplacer le fichier » une fois la fenêtre dépassée', async ({
+    page,
+    collectivites,
+    referentiels,
+    closedAuditReport,
+  }) => {
+    const { collectiviteId } = closedAuditReport;
+
+    await referentiels.expireAuditReportEditWindow({
+      collectiviteId,
+      referentielId: referentiel,
+    });
+
+    const { user: superAdminUser } = await collectivites.addCollectiviteAndUser({
+      userArgs: {
+        autoLogin: true,
+        isSupport: true,
+        isSuperAdminRoleEnabled: true,
+      },
+    });
+
+    await superAdminUser.login();
+    await page.goto(
+      `/collectivite/${collectiviteId}/referentiel/eci/documents`
+    );
+    await expect(page.getByText('document_test.pdf').first()).toBeVisible();
+    await expect(page.getByTitle('Remplacer le fichier')).toHaveCount(1);
+  });
+
   test('un visiteur en lecture seule ne voit pas le bouton « Remplacer le fichier »', async ({
     page,
     closedAuditReport,

--- a/packages/domain/src/referentiels/labellisations/can-update-audit-report/can-update-audit-report.rule.spec.ts
+++ b/packages/domain/src/referentiels/labellisations/can-update-audit-report/can-update-audit-report.rule.spec.ts
@@ -5,17 +5,19 @@ const now = new Date('2026-06-22T12:00:00.000Z');
 const daysAgo = (days: number) =>
   new Date(now.getTime() - days * 24 * 60 * 60 * 1000).toISOString();
 
+const auditeur = { isAuditeur: true, canUpdateAnyAuditReport: false };
+const tiers = { isAuditeur: false, canUpdateAnyAuditReport: false };
+const porteurPermission = { isAuditeur: false, canUpdateAnyAuditReport: true };
+
 describe('canUpdateAuditReport', () => {
   it("refuse une preuve sans rapport d'audit", () => {
-    expect(canUpdateAuditReport({ isAuditeur: true, audit: null, now })).toBe(
-      false
-    );
+    expect(canUpdateAuditReport({ ...auditeur, audit: null, now })).toBe(false);
   });
 
-  it("refuse si l'utilisateur n'est pas l'auditeur de cet audit", () => {
+  it("refuse un tiers à l'audit", () => {
     expect(
       canUpdateAuditReport({
-        isAuditeur: false,
+        ...tiers,
         audit: { clos: false, valide: false, dateFin: null },
         now,
       })
@@ -25,7 +27,7 @@ describe('canUpdateAuditReport', () => {
   it("autorise l'auditeur tant que l'audit n'est pas valide", () => {
     expect(
       canUpdateAuditReport({
-        isAuditeur: true,
+        ...auditeur,
         audit: { clos: false, valide: false, dateFin: null },
         now,
       })
@@ -35,7 +37,7 @@ describe('canUpdateAuditReport', () => {
   it('autorise dans les 15 jours suivant la validation', () => {
     expect(
       canUpdateAuditReport({
-        isAuditeur: true,
+        ...auditeur,
         audit: { clos: false, valide: true, dateFin: daysAgo(14) },
         now,
       })
@@ -45,7 +47,7 @@ describe('canUpdateAuditReport', () => {
   it('refuse plus de 15 jours apres la validation', () => {
     expect(
       canUpdateAuditReport({
-        isAuditeur: true,
+        ...auditeur,
         audit: { clos: false, valide: true, dateFin: daysAgo(16) },
         now,
       })
@@ -55,7 +57,7 @@ describe('canUpdateAuditReport', () => {
   it('autorise dans les 15 jours même si l’audit est clos', () => {
     expect(
       canUpdateAuditReport({
-        isAuditeur: true,
+        ...auditeur,
         audit: { clos: true, valide: true, dateFin: daysAgo(14) },
         now,
       })
@@ -65,7 +67,7 @@ describe('canUpdateAuditReport', () => {
   it("refuse plus de 15 jours après la clôture, même si l'audit est clos", () => {
     expect(
       canUpdateAuditReport({
-        isAuditeur: true,
+        ...auditeur,
         audit: { clos: true, valide: true, dateFin: daysAgo(16) },
         now,
       })
@@ -75,10 +77,47 @@ describe('canUpdateAuditReport', () => {
   it('refuse un audit valide sans date de fin', () => {
     expect(
       canUpdateAuditReport({
-        isAuditeur: true,
+        ...auditeur,
         audit: { clos: false, valide: true, dateFin: null },
         now,
       })
+    ).toBe(false);
+  });
+
+  it("autorise la permission sur un audit clos depuis plus de 15 jours", () => {
+    expect(
+      canUpdateAuditReport({
+        ...porteurPermission,
+        audit: { clos: true, valide: true, dateFin: daysAgo(16) },
+        now,
+      })
+    ).toBe(true);
+  });
+
+  it('autorise la permission sur un audit valide sans date de fin', () => {
+    expect(
+      canUpdateAuditReport({
+        ...porteurPermission,
+        audit: { clos: false, valide: true, dateFin: null },
+        now,
+      })
+    ).toBe(true);
+  });
+
+  it("autorise l'auditeur hors fenêtre qui détient aussi la permission", () => {
+    expect(
+      canUpdateAuditReport({
+        isAuditeur: true,
+        canUpdateAnyAuditReport: true,
+        audit: { clos: true, valide: true, dateFin: daysAgo(16) },
+        now,
+      })
+    ).toBe(true);
+  });
+
+  it("refuse la permission quand la preuve n'a pas de rapport d'audit", () => {
+    expect(
+      canUpdateAuditReport({ ...porteurPermission, audit: null, now })
     ).toBe(false);
   });
 });

--- a/packages/domain/src/referentiels/labellisations/can-update-audit-report/can-update-audit-report.rule.ts
+++ b/packages/domain/src/referentiels/labellisations/can-update-audit-report/can-update-audit-report.rule.ts
@@ -2,18 +2,13 @@ import { AUDIT_REPORT_UPDATE_WINDOW_DAYS } from '../labellisation-audit.schema';
 
 const DAY_IN_MS = 24 * 60 * 60 * 1000;
 
-export function canUpdateAuditReport({
-  isAuditeur,
-  audit,
-  now,
-}: {
-  isAuditeur: boolean;
-  audit: { clos: boolean; valide: boolean; dateFin: Date | string | null } | null;
-  now: Date;
-}): boolean {
-  if (audit === null || !isAuditeur) {
-    return false;
-  }
+type Audit = {
+  clos: boolean;
+  valide: boolean;
+  dateFin: Date | string | null;
+};
+
+function isAuditeurUpdateWindowOpen(audit: Audit, now: Date): boolean {
   if (!audit.valide && !audit.clos) {
     return true;
   }
@@ -23,4 +18,24 @@ export function canUpdateAuditReport({
   const editWindowStart =
     now.getTime() - AUDIT_REPORT_UPDATE_WINDOW_DAYS * DAY_IN_MS;
   return new Date(audit.dateFin).getTime() > editWindowStart;
+}
+
+export function canUpdateAuditReport({
+  isAuditeur,
+  canUpdateAnyAuditReport,
+  audit,
+  now,
+}: {
+  isAuditeur: boolean;
+  canUpdateAnyAuditReport: boolean;
+  audit: Audit | null;
+  now: Date;
+}): boolean {
+  if (audit === null) {
+    return false;
+  }
+  if (canUpdateAnyAuditReport) {
+    return true;
+  }
+  return isAuditeur && isAuditeurUpdateWindowOpen(audit, now);
 }

--- a/packages/domain/src/users/authorizations/permission-operation.enum.schema.ts
+++ b/packages/domain/src/users/authorizations/permission-operation.enum.schema.ts
@@ -30,6 +30,7 @@ export const PermissionOperations = [
   'referentiels.labellisations.start_audit',
   'referentiels.labellisations.validate_audit',
   'referentiels.labellisations.mutate_action_audit_statut',
+  'referentiels.labellisations.mutate_documents',
   'referentiels.discussions.read',
   'referentiels.discussions.mutate',
 

--- a/packages/domain/src/users/authorizations/permission.models.spec.ts
+++ b/packages/domain/src/users/authorizations/permission.models.spec.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { permissionsByRole } from './permission.models';
+import { PlatformRole } from './user-role.enum.schema';
+
+describe('permissionsByRole', () => {
+  it("n'accorde la modification des documents de labellisation qu'au super admin", () => {
+    const rolesGranting = Object.entries(permissionsByRole)
+      .filter(([, permissions]) =>
+        permissions.includes('referentiels.labellisations.mutate_documents')
+      )
+      .map(([role]) => role);
+
+    expect(rolesGranting).toEqual([PlatformRole.SUPER_ADMIN]);
+  });
+});

--- a/packages/domain/src/users/authorizations/permission.models.ts
+++ b/packages/domain/src/users/authorizations/permission.models.ts
@@ -72,6 +72,7 @@ export const permissionsByRole: Record<UserRole, PermissionOperation[]> = {
     'collectivites.documents.mutate_objet',
     'collectivites.mutate',
     'plans.fiches.import',
+    'referentiels.labellisations.mutate_documents',
     'utils.banner.mutate',
   ],
   [PlatformRole.ADEME]: [


### PR DESCRIPTION
## Comportement

Passé 15 jours après la date de fin d'un audit, plus personne ne pouvait corriger un rapport erroné. L'auditeur était hors fenêtre, et le support n'avait aucun recours — ni par l'interface, ni par l'API.

Un **super admin en mode support** peut désormais remplacer le fichier d'un rapport d'audit, quel que soit l'état de l'audit. Sur la carte du document, il obtient les mêmes actions qu'un auditeur dans sa fenêtre — c'est déjà ce qu'il a sur les cartes de preuves de labellisation voisines, où `referentiels.mutate` lui répond vrai.

Toggle du mode support éteint, il est refusé comme n'importe quel tiers. Les droits de l'auditeur ne changent pas.

## La règle

```
peut remplacer  ⟺  détient la permission
                ∨  (auditeur de CET audit  ∧  fenêtre de 15 jours ouverte)
```

L'appartenance à l'audit est scopée, pas seulement typée : le `leftJoin` sur `audit_auditeur` porte `auditId = preuveAudit.auditId AND auditeur = user.id`, donc un auditeur d'un *autre* audit ressort `null`. Côté front, `isUserAuditeurForAudit` filtre sur le même identifiant.

## Surface de review

Un commit, 10 fichiers, ~60 lignes de logique nouvelle. Il est d'un seul tenant parce que le changement de signature de la règle traverse ses deux appelants.

Les endroits à regarder :

- **`permission.models.ts`** — une ligne de diff, une portée de sécurité. `referentiels.labellisations.mutate_documents` n'est accordée qu'à `SUPER_ADMIN`, et un test verrouille cette liste. Son nom couvre **les documents d'un cycle de labellisation**, pas le seul rapport d'audit : le besoin métier est « le support peut réparer les documents d'un cycle », et le découper par table (`preuve_audit` d'un côté, `preuve_labellisation` de l'autre) produirait deux permissions à maintenir cohérentes pour une seule intention. Cette PR n'en exerce qu'une part.
- **`update-audit-report.service.ts`** — `canUpdateAnyAuditReport` renvoie le résultat d'`isAllowed` et s'arrête là. Le scope est `COLLECTIVITE` : `AUDIT` et `REFERENTIEL` appliqueraient le mode du référentiel via `checkReferentielMode`, or un audit clos appartient souvent à un référentiel archivé — soit précisément le cas visé.
- **`can-update-audit-report.rule.ts`** — la règle reçoit deux faits indépendants, `isAuditeur` et `canUpdateAnyAuditReport`. Ils coexistent : un super admin peut être par ailleurs l'auditeur de l'audit.

Le front tient en six lignes : `canUserUpdateAuditReport` passe le second fait à la règle. Aucun composant n'est modifié.

## Vérification

| | |
|---|---|
| domaine `can-update-audit-report` | 12/12 |
| domaine `permission.models` | 1/1 |
| e2e backend `update-audit-report` | 10/10 |
| typecheck `backend` / `app` / `e2e` | 0 erreur |
| lint `domain` / `backend` / `app` / `e2e` | 0 erreur |

Ce que les tests couvrent, et ce qu'ils ne couvrent pas :

- `autorise le super admin en mode support sur un audit clos hors fenêtre` (e2e backend) — **vu rouge** avant le changement de production : `TRPCError: Le remplacement du rapport est réservé à l'auditeur… / UPDATE_NOT_ALLOWED`.
- `refuse le super admin dont le mode support est éteint` — **était vert avant**, il ne démontre donc aucun bug. Il discrimine « rôle `SUPPORT` » de « mode support actif » : un gate sur `hasRole(SUPPORT)` le ferait passer au rouge.
- `autorise l'auditeur hors fenêtre qui détient aussi la permission` — documente la combinaison des deux faits.
- Le contrat de permissions assert que la liste des rôles portant la permission vaut **exactement** `[SUPER_ADMIN]`, et non « `SUPER_ADMIN` l'a », qui laisserait passer une fuite vers un autre rôle.
- **Le test Playwright n'a pas été exécuté en local** : il vise `localhost:3000`, occupé par un dev server sur une autre branche, donc le lancer aurait testé un code sans le changement. Typecheck et lint passent dessus ; la CI le tranchera.

## Point de vigilance

La permission doit être vérifiée en scope `COLLECTIVITE`. Les trois surcharges d'`isAllowed` étant légales, **le type ne tient pas cet invariant** — un futur appelant qui passerait `REFERENTIEL` ou `AUDIT` la resoumettrait au mode du référentiel et casserait le cas visé, sans erreur de compilation. Il n'y a qu'un appelant aujourd'hui.

## Anti-duplication

Aucune utility, aucun composant, aucun libellé créé. Recherche menée avant écriture :

- le patron « permission réservée au super admin sur un document » existe — `collectivites.documents.mutate_objet`, accordée au seul `SUPER_ADMIN`, vérifiée en scope `COLLECTIVITE` dans `edit-preuve-document.service.ts`. Repris à l'identique.
- la mécanique de révélation d'action existe — `allowedActions` / `isActionCarriedBy` — et n'a pas eu besoin d'être touchée.
- la modale de remplacement, le hook de mutation et le libellé « Remplacer le fichier » existent tous et ne sont pas modifiés.
- les fixtures de test existent — `addAndEnableUserSuperAdminMode`, `addUserRoleSupport`, `addAuditeurPermission`, `expireAuditReportEditWindow`.

Un seul fichier neuf, sans équivalent : `permission.models.spec.ts`.

## Ce que ça n'inclut pas

- **L'ajout d'un rapport quand l'audit n'en a aucun.** Ce chemin (`useAddPreuveAudit`) est un `insert` Supabase direct dont la policy RLS exige `est_auditeur` ; l'ouvrir supposerait de le passer backend.
- **La suppression d'un rapport**, aujourd'hui interdite à tous sur les preuves d'audit, et qui le reste.

La traçabilité du remplacement, elle, **est acquise** : `main` porte désormais le correctif qui enregistre l'auteur et la date, donc un remplacement par le support laisse une trace visible sur la carte du document.

## Plan

Stack `2026-09-03-001-feat-super-admin-remplacement-rapport-audit` (plan local, non commité).
