### PR TITLE
refactor(referentiels): fait lire l'archive par les helpers de fichier partagés

### DIFF
--- a/apps/backend/src/referentiels/preuves-archive/collect-audit-preuves/collect-audit-preuves.service.spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/collect-audit-preuves/collect-audit-preuves.service.spec.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type {
   CollectedFilePreuve,
   CollectedLinkPreuve,
+  MissingFilePreuve,
 } from './collect-preuves.repository';
 import { CollectAuditPreuvesService } from './collect-audit-preuves.service';
 
@@ -20,10 +21,11 @@ const baseInput = {
   user,
 };
 
-const empty = { files: [], links: [] };
+const empty = { files: [], missingFiles: [], links: [] };
 
 type PreuvesPayload = {
   files: CollectedFilePreuve[];
+  missingFiles: MissingFilePreuve[];
   links: CollectedLinkPreuve[];
 };
 
@@ -125,10 +127,12 @@ describe('CollectAuditPreuvesService', () => {
     const { service } = buildService({
       complementaire: {
         files: [makeFile({ actionId: 'cae_1.1.1', filename: 'comp.pdf' })],
+        missingFiles: [],
         links: [],
       },
       reglementaire: {
         files: [makeFile({ actionId: 'cae_1.1.1', filename: 'regl.pdf' })],
+        missingFiles: [],
         links: [],
       },
     });

--- a/apps/backend/src/referentiels/preuves-archive/collect-audit-preuves/collect-audit-preuves.service.ts
+++ b/apps/backend/src/referentiels/preuves-archive/collect-audit-preuves/collect-audit-preuves.service.ts
@@ -11,19 +11,13 @@ import {
 } from '../preuves-archive.errors';
 import {
   CollectPreuvesRepository,
-  type CollectedFilePreuve,
-  type CollectedLinkPreuve,
+  type CollectedPreuves,
 } from './collect-preuves.repository';
 
-export interface PreuvesSource {
-  files: CollectedFilePreuve[];
-  links: CollectedLinkPreuve[];
-}
-
 export interface PreuvesByOrigin {
-  mesure: PreuvesSource;
-  demande: PreuvesSource;
-  audit: PreuvesSource;
+  mesure: CollectedPreuves;
+  demande: CollectedPreuves;
+  audit: CollectedPreuves;
 }
 
 export interface CollectAuditPreuvesInput {
@@ -89,6 +83,10 @@ export class CollectAuditPreuvesService {
       return success({
         mesure: {
           files: [...complementaire.data.files, ...reglementaire.data.files],
+          missingFiles: [
+            ...complementaire.data.missingFiles,
+            ...reglementaire.data.missingFiles,
+          ],
           links: [...complementaire.data.links, ...reglementaire.data.links],
         },
         demande: labellisation.data,

--- a/apps/backend/src/referentiels/preuves-archive/collect-audit-preuves/collect-preuves.repository.e2e-spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/collect-audit-preuves/collect-preuves.repository.e2e-spec.ts
@@ -1,6 +1,7 @@
 import { INestApplication } from '@nestjs/common';
 import { addTestCollectiviteAndUser } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
 import { bibliothequeFichierTable } from '@tet/backend/collectivites/documents/models/bibliotheque-fichier.table';
+import { preuveAuditTable } from '@tet/backend/collectivites/documents/models/preuve-audit.table';
 import { preuveComplementaireTable } from '@tet/backend/collectivites/documents/models/preuve-complementaire.table';
 import { storageObjectTable } from '@tet/backend/collectivites/documents/models/storage-object.table';
 import { collectiviteBucketTable } from '@tet/backend/collectivites/shared/models/collectivite-bucket.table';
@@ -14,6 +15,7 @@ import { Collectivite } from '@tet/domain/collectivites';
 import { CollectiviteRole } from '@tet/domain/users';
 import { and, eq, like } from 'drizzle-orm';
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { createAudit } from '../../labellisations/labellisations.test-fixture';
 import { PREUVES_ARCHIVES_BUCKET } from '../preuves-archive.constants';
 import { CollectPreuvesRepository } from './collect-preuves.repository';
 
@@ -29,6 +31,12 @@ describe('CollectPreuvesRepository - filtre confidentiel (SQL réel)', () => {
 
   let publicHash: string;
   let confidentielHash: string;
+
+  let collectiviteEtrangere: Collectivite;
+  let cleanupEtrangere: () => Promise<void>;
+  let hashEtranger: string;
+  let auditId: number;
+  let cleanupAudit: () => Promise<void>;
 
   beforeAll(async () => {
     app = await getTestApp();
@@ -67,6 +75,8 @@ describe('CollectPreuvesRepository - filtre confidentiel (SQL réel)', () => {
       ])
       .returning();
 
+    const [fichierPublic] = fichiers;
+
     await db.db.insert(storageObjectTable).values(
       fichiers.map((fichier) => ({
         bucketId: PREUVES_ARCHIVES_BUCKET,
@@ -90,12 +100,83 @@ describe('CollectPreuvesRepository - filtre confidentiel (SQL réel)', () => {
         modifiedBy: adminUserId,
       },
     ]);
+
+    const fixtureEtrangere = await addTestCollectiviteAndUser(db, {
+      user: { role: CollectiviteRole.ADMIN },
+    });
+    collectiviteEtrangere = fixtureEtrangere.collectivite;
+    cleanupEtrangere = fixtureEtrangere.cleanup;
+    hashEtranger = `hash-etranger-${collectiviteEtrangere.id}`;
+
+    await db.db.insert(collectiviteBucketTable).values({
+      bucketId: PREUVES_ARCHIVES_BUCKET,
+      collectiviteId: collectiviteEtrangere.id,
+    });
+
+    const [fichierEtranger] = await db.db
+      .insert(bibliothequeFichierTable)
+      .values({
+        collectiviteId: collectiviteEtrangere.id,
+        hash: hashEtranger,
+        filename: 'document-d-une-autre-collectivite.pdf',
+        confidentiel: false,
+      })
+      .returning();
+
+    await db.db.insert(storageObjectTable).values({
+      bucketId: PREUVES_ARCHIVES_BUCKET,
+      name: fichierEtranger.hash,
+      metadata: { size: 2048 },
+    });
+
+    const auditFixture = await createAudit({
+      databaseService: db,
+      collectiviteId: collectivite.id,
+      referentielId: 'cae',
+      withDemande: true,
+    });
+    auditId = auditFixture.audit.id;
+    cleanupAudit = auditFixture.cleanup;
+
+    await db.db.insert(preuveComplementaireTable).values({
+      collectiviteId: collectivite.id,
+      actionId: ACTION_ID,
+      fichierId: fichierEtranger.id,
+      modifiedBy: adminUserId,
+    });
+
+    await db.db.insert(preuveAuditTable).values([
+      {
+        collectiviteId: collectivite.id,
+        auditId,
+        fichierId: fichierPublic.id,
+        modifiedBy: adminUserId,
+      },
+      {
+        collectiviteId: collectivite.id,
+        auditId,
+        fichierId: fichierEtranger.id,
+        modifiedBy: adminUserId,
+      },
+    ]);
   });
 
   afterAll(async () => {
+    await cleanupAudit();
     await db.db
-      .delete(preuveComplementaireTable)
-      .where(eq(preuveComplementaireTable.collectiviteId, collectivite.id));
+      .delete(storageObjectTable)
+      .where(
+        and(
+          eq(storageObjectTable.bucketId, PREUVES_ARCHIVES_BUCKET),
+          eq(storageObjectTable.name, hashEtranger)
+        )
+      );
+    await db.db
+      .delete(bibliothequeFichierTable)
+      .where(
+        eq(bibliothequeFichierTable.collectiviteId, collectiviteEtrangere.id)
+      );
+    await cleanupEtrangere();
     await db.db
       .delete(storageObjectTable)
       .where(
@@ -109,6 +190,34 @@ describe('CollectPreuvesRepository - filtre confidentiel (SQL réel)', () => {
       .where(eq(bibliothequeFichierTable.collectiviteId, collectivite.id));
     await cleanupCollectivite();
     await app.close();
+  });
+
+  test("une preuve pointant vers le fichier d'une autre collectivite n'entre pas dans l'archive", async () => {
+    const result = await repository.getComplementairePreuves({
+      collectiviteId: collectivite.id,
+      referentielId: 'cae',
+      canReadConfidentiel: true,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const hashes = result.data.files.map((file) => file.hash);
+    expect(hashes).toContain(publicHash);
+    expect(hashes).not.toContain(hashEtranger);
+  });
+
+  test("une preuve d'audit pointant vers le fichier d'une autre collectivite n'entre pas dans l'archive", async () => {
+    const result = await repository.getAuditPreuves({
+      collectiviteId: collectivite.id,
+      auditId,
+      canReadConfidentiel: true,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const hashes = result.data.files.map((file) => file.hash);
+    expect(hashes).toContain(publicHash);
+    expect(hashes).not.toContain(hashEtranger);
   });
 
   test('canReadConfidentiel=true : expose le fichier public ET le confidentiel', async () => {

--- a/apps/backend/src/referentiels/preuves-archive/collect-audit-preuves/collect-preuves.repository.e2e-spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/collect-audit-preuves/collect-preuves.repository.e2e-spec.ts
@@ -2,7 +2,11 @@ import { INestApplication } from '@nestjs/common';
 import { addTestCollectiviteAndUser } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
 import { bibliothequeFichierTable } from '@tet/backend/collectivites/documents/models/bibliotheque-fichier.table';
 import { preuveAuditTable } from '@tet/backend/collectivites/documents/models/preuve-audit.table';
+import { preuveActionTable } from '@tet/backend/collectivites/documents/models/preuve-action.table';
 import { preuveComplementaireTable } from '@tet/backend/collectivites/documents/models/preuve-complementaire.table';
+import { preuveLabellisationTable } from '@tet/backend/collectivites/documents/models/preuve-labellisation.table';
+import { preuveReglementaireDefinitionTable } from '@tet/backend/collectivites/documents/models/preuve-reglementaire-definition.table';
+import { preuveReglementaireTable } from '@tet/backend/collectivites/documents/models/preuve-reglementaire.table';
 import { storageObjectTable } from '@tet/backend/collectivites/documents/models/storage-object.table';
 import { collectiviteBucketTable } from '@tet/backend/collectivites/shared/models/collectivite-bucket.table';
 import {
@@ -13,13 +17,14 @@ import {
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { Collectivite } from '@tet/domain/collectivites';
 import { CollectiviteRole } from '@tet/domain/users';
-import { and, eq, like } from 'drizzle-orm';
+import { and, eq, inArray, like } from 'drizzle-orm';
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import { createAudit } from '../../labellisations/labellisations.test-fixture';
 import { PREUVES_ARCHIVES_BUCKET } from '../preuves-archive.constants';
 import { CollectPreuvesRepository } from './collect-preuves.repository';
 
 const ACTION_ID = 'cae_1.1.3';
+const PREUVE_REGLEMENTAIRE_ID = 'preuve-reglementaire-cloisonnement';
 
 describe('CollectPreuvesRepository - filtre confidentiel (SQL réel)', () => {
   let app: INestApplication;
@@ -31,11 +36,14 @@ describe('CollectPreuvesRepository - filtre confidentiel (SQL réel)', () => {
 
   let publicHash: string;
   let confidentielHash: string;
+  let purgeHash: string;
+  let purgeConfidentielHash: string;
 
-  let collectiviteEtrangere: Collectivite;
-  let cleanupEtrangere: () => Promise<void>;
-  let hashEtranger: string;
+  let otherCollectivite: Collectivite;
+  let cleanupOtherCollectivite: () => Promise<void>;
+  let otherCollectiviteHash: string;
   let auditId: number;
+  let demandeId: number;
   let cleanupAudit: () => Promise<void>;
 
   beforeAll(async () => {
@@ -43,15 +51,17 @@ describe('CollectPreuvesRepository - filtre confidentiel (SQL réel)', () => {
     db = await getTestDatabase(app);
     repository = app.get(CollectPreuvesRepository);
 
-    const fixture = await addTestCollectiviteAndUser(db, {
+    const collectiviteFixture = await addTestCollectiviteAndUser(db, {
       user: { role: CollectiviteRole.ADMIN },
     });
-    collectivite = fixture.collectivite;
-    adminUserId = getAuthUserFromUserCredentials(fixture.user).id;
-    cleanupCollectivite = fixture.cleanup;
+    collectivite = collectiviteFixture.collectivite;
+    adminUserId = getAuthUserFromUserCredentials(collectiviteFixture.user).id;
+    cleanupCollectivite = collectiviteFixture.cleanup;
 
     publicHash = `hash-public-${collectivite.id}`;
     confidentielHash = `hash-confidentiel-${collectivite.id}`;
+    purgeHash = `hash-purge-${collectivite.id}`;
+    purgeConfidentielHash = `hash-purge-confidentiel-${collectivite.id}`;
 
     await db.db
       .insert(collectiviteBucketTable)
@@ -72,17 +82,35 @@ describe('CollectPreuvesRepository - filtre confidentiel (SQL réel)', () => {
           filename: 'secret.pdf',
           confidentiel: true,
         },
+        {
+          collectiviteId: collectivite.id,
+          hash: purgeHash,
+          filename: 'avis-technique-purge.pdf',
+          confidentiel: false,
+        },
+        {
+          collectiviteId: collectivite.id,
+          hash: purgeConfidentielHash,
+          filename: 'secret-purge.pdf',
+          confidentiel: true,
+        },
       ])
       .returning();
 
     const [fichierPublic] = fichiers;
 
     await db.db.insert(storageObjectTable).values(
-      fichiers.map((fichier) => ({
-        bucketId: PREUVES_ARCHIVES_BUCKET,
-        name: fichier.hash,
-        metadata: { size: 1024 },
-      }))
+      fichiers
+        .filter(
+          (fichier) =>
+            fichier.hash !== purgeHash &&
+            fichier.hash !== purgeConfidentielHash
+        )
+        .map((fichier) => ({
+          bucketId: PREUVES_ARCHIVES_BUCKET,
+          name: fichier.hash,
+          metadata: { size: 1024 },
+        }))
     );
 
     await db.db.insert(preuveComplementaireTable).values([
@@ -101,23 +129,23 @@ describe('CollectPreuvesRepository - filtre confidentiel (SQL réel)', () => {
       },
     ]);
 
-    const fixtureEtrangere = await addTestCollectiviteAndUser(db, {
+    const otherCollectiviteFixture = await addTestCollectiviteAndUser(db, {
       user: { role: CollectiviteRole.ADMIN },
     });
-    collectiviteEtrangere = fixtureEtrangere.collectivite;
-    cleanupEtrangere = fixtureEtrangere.cleanup;
-    hashEtranger = `hash-etranger-${collectiviteEtrangere.id}`;
+    otherCollectivite = otherCollectiviteFixture.collectivite;
+    cleanupOtherCollectivite = otherCollectiviteFixture.cleanup;
+    otherCollectiviteHash = `hash-autre-collectivite-${otherCollectivite.id}`;
 
     await db.db.insert(collectiviteBucketTable).values({
       bucketId: PREUVES_ARCHIVES_BUCKET,
-      collectiviteId: collectiviteEtrangere.id,
+      collectiviteId: otherCollectivite.id,
     });
 
-    const [fichierEtranger] = await db.db
+    const [otherCollectiviteFichier] = await db.db
       .insert(bibliothequeFichierTable)
       .values({
-        collectiviteId: collectiviteEtrangere.id,
-        hash: hashEtranger,
+        collectiviteId: otherCollectivite.id,
+        hash: otherCollectiviteHash,
         filename: 'document-d-une-autre-collectivite.pdf',
         confidentiel: false,
       })
@@ -125,7 +153,7 @@ describe('CollectPreuvesRepository - filtre confidentiel (SQL réel)', () => {
 
     await db.db.insert(storageObjectTable).values({
       bucketId: PREUVES_ARCHIVES_BUCKET,
-      name: fichierEtranger.hash,
+      name: otherCollectiviteFichier.hash,
       metadata: { size: 2048 },
     });
 
@@ -137,11 +165,57 @@ describe('CollectPreuvesRepository - filtre confidentiel (SQL réel)', () => {
     });
     auditId = auditFixture.audit.id;
     cleanupAudit = auditFixture.cleanup;
+    const { demande } = auditFixture;
+    if (!demande) {
+      throw new Error('createAudit with withDemande must produce a demande');
+    }
+    demandeId = demande.id;
+
+    await db.db.insert(preuveReglementaireDefinitionTable).values({
+      id: PREUVE_REGLEMENTAIRE_ID,
+      nom: 'Preuve réglementaire de cloisonnement',
+      description: '',
+    });
+
+    await db.db.insert(preuveActionTable).values({
+      preuveId: PREUVE_REGLEMENTAIRE_ID,
+      actionId: ACTION_ID,
+    });
+
+    await db.db.insert(preuveReglementaireTable).values([
+      {
+        collectiviteId: collectivite.id,
+        preuveId: PREUVE_REGLEMENTAIRE_ID,
+        fichierId: fichierPublic.id,
+        modifiedBy: adminUserId,
+      },
+      {
+        collectiviteId: collectivite.id,
+        preuveId: PREUVE_REGLEMENTAIRE_ID,
+        fichierId: otherCollectiviteFichier.id,
+        modifiedBy: adminUserId,
+      },
+    ]);
+
+    await db.db.insert(preuveLabellisationTable).values([
+      {
+        collectiviteId: collectivite.id,
+        demandeId,
+        fichierId: fichierPublic.id,
+        modifiedBy: adminUserId,
+      },
+      {
+        collectiviteId: collectivite.id,
+        demandeId,
+        fichierId: otherCollectiviteFichier.id,
+        modifiedBy: adminUserId,
+      },
+    ]);
 
     await db.db.insert(preuveComplementaireTable).values({
       collectiviteId: collectivite.id,
       actionId: ACTION_ID,
-      fichierId: fichierEtranger.id,
+      fichierId: otherCollectiviteFichier.id,
       modifiedBy: adminUserId,
     });
 
@@ -155,7 +229,7 @@ describe('CollectPreuvesRepository - filtre confidentiel (SQL réel)', () => {
       {
         collectiviteId: collectivite.id,
         auditId,
-        fichierId: fichierEtranger.id,
+        fichierId: otherCollectiviteFichier.id,
         modifiedBy: adminUserId,
       },
     ]);
@@ -164,25 +238,31 @@ describe('CollectPreuvesRepository - filtre confidentiel (SQL réel)', () => {
   afterAll(async () => {
     await cleanupAudit();
     await db.db
+      .delete(preuveActionTable)
+      .where(eq(preuveActionTable.preuveId, PREUVE_REGLEMENTAIRE_ID));
+    await db.db
+      .delete(preuveReglementaireDefinitionTable)
+      .where(eq(preuveReglementaireDefinitionTable.id, PREUVE_REGLEMENTAIRE_ID));
+    await db.db
       .delete(storageObjectTable)
       .where(
         and(
           eq(storageObjectTable.bucketId, PREUVES_ARCHIVES_BUCKET),
-          eq(storageObjectTable.name, hashEtranger)
+          eq(storageObjectTable.name, otherCollectiviteHash)
         )
       );
     await db.db
       .delete(bibliothequeFichierTable)
       .where(
-        eq(bibliothequeFichierTable.collectiviteId, collectiviteEtrangere.id)
+        eq(bibliothequeFichierTable.collectiviteId, otherCollectivite.id)
       );
-    await cleanupEtrangere();
+    await cleanupOtherCollectivite();
     await db.db
       .delete(storageObjectTable)
       .where(
         and(
           eq(storageObjectTable.bucketId, PREUVES_ARCHIVES_BUCKET),
-          like(storageObjectTable.name, `%${collectivite.id}`)
+          inArray(storageObjectTable.name, [publicHash, confidentielHash])
         )
       );
     await db.db
@@ -192,7 +272,7 @@ describe('CollectPreuvesRepository - filtre confidentiel (SQL réel)', () => {
     await app.close();
   });
 
-  test("une preuve pointant vers le fichier d'une autre collectivite n'entre pas dans l'archive", async () => {
+  test("une preuve complémentaire pointant vers le fichier d'une autre collectivité n'entre pas dans l'archive", async () => {
     const result = await repository.getComplementairePreuves({
       collectiviteId: collectivite.id,
       referentielId: 'cae',
@@ -203,10 +283,10 @@ describe('CollectPreuvesRepository - filtre confidentiel (SQL réel)', () => {
     if (!result.success) return;
     const hashes = result.data.files.map((file) => file.hash);
     expect(hashes).toContain(publicHash);
-    expect(hashes).not.toContain(hashEtranger);
+    expect(hashes).not.toContain(otherCollectiviteHash);
   });
 
-  test("une preuve d'audit pointant vers le fichier d'une autre collectivite n'entre pas dans l'archive", async () => {
+  test("une preuve d'audit pointant vers le fichier d'une autre collectivité n'entre pas dans l'archive", async () => {
     const result = await repository.getAuditPreuves({
       collectiviteId: collectivite.id,
       auditId,
@@ -217,7 +297,86 @@ describe('CollectPreuvesRepository - filtre confidentiel (SQL réel)', () => {
     if (!result.success) return;
     const hashes = result.data.files.map((file) => file.hash);
     expect(hashes).toContain(publicHash);
-    expect(hashes).not.toContain(hashEtranger);
+    expect(hashes).not.toContain(otherCollectiviteHash);
+  });
+
+  test("une preuve réglementaire pointant vers le fichier d'une autre collectivité n'entre pas dans l'archive", async () => {
+    const result = await repository.getReglementairePreuves({
+      collectiviteId: collectivite.id,
+      referentielId: 'cae',
+      canReadConfidentiel: true,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const hashes = result.data.files.map((file) => file.hash);
+    expect(hashes).toContain(publicHash);
+    expect(hashes).not.toContain(otherCollectiviteHash);
+  });
+
+  test("une preuve de labellisation pointant vers le fichier d'une autre collectivité n'entre pas dans l'archive", async () => {
+    const result = await repository.getLabellisationPreuves({
+      collectiviteId: collectivite.id,
+      demandeId,
+      canReadConfidentiel: true,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const hashes = result.data.files.map((file) => file.hash);
+    expect(hashes).toContain(publicHash);
+    expect(hashes).not.toContain(otherCollectiviteHash);
+  });
+
+  test("une preuve dont l'objet de stockage a disparu ressort en fichier manquant", async () => {
+    const result = await repository.getComplementairePreuves({
+      collectiviteId: collectivite.id,
+      referentielId: 'cae',
+      canReadConfidentiel: true,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.files.map((file) => file.hash)).not.toContain(purgeHash);
+    expect(result.data.missingFiles).toContainEqual({
+      hash: purgeHash,
+      filename: 'avis-technique-purge.pdf',
+      actionId: ACTION_ID,
+    });
+    expect(result.data.missingFiles.map((file) => file.hash)).toContain(
+      purgeConfidentielHash
+    );
+  });
+
+  test("un fichier public dont l'objet a disparu reste signalé sans droit confidentiel", async () => {
+    const result = await repository.getComplementairePreuves({
+      collectiviteId: collectivite.id,
+      referentielId: 'cae',
+      canReadConfidentiel: false,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.missingFiles.map((file) => file.hash)).toContain(
+      purgeHash
+    );
+  });
+
+  test("un fichier confidentiel dont l'objet a disparu ne fuite pas son nom sans droit confidentiel", async () => {
+    const result = await repository.getComplementairePreuves({
+      collectiviteId: collectivite.id,
+      referentielId: 'cae',
+      canReadConfidentiel: false,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.missingFiles.map((file) => file.hash)).not.toContain(
+      purgeConfidentielHash
+    );
+    expect(result.data.missingFiles.map((file) => file.filename)).not.toContain(
+      'secret-purge.pdf'
+    );
   });
 
   test('canReadConfidentiel=true : expose le fichier public ET le confidentiel', async () => {

--- a/apps/backend/src/referentiels/preuves-archive/collect-audit-preuves/collect-preuves.repository.ts
+++ b/apps/backend/src/referentiels/preuves-archive/collect-audit-preuves/collect-preuves.repository.ts
@@ -2,9 +2,9 @@ import { Injectable, Logger } from '@nestjs/common';
 import {
   buildFichierSubquery,
   buildFileInfoSql,
-  type FichierSubquery,
 } from '@tet/backend/collectivites/documents/file-info.utils';
 import { hideConfidentielFilter } from '@tet/backend/collectivites/documents/hide-confidentiel.utils';
+import { bibliothequeFichierTable } from '@tet/backend/collectivites/documents/models/bibliotheque-fichier.table';
 import { preuveActionTable } from '@tet/backend/collectivites/documents/models/preuve-action.table';
 import { preuveAuditTable } from '@tet/backend/collectivites/documents/models/preuve-audit.table';
 import { preuveComplementaireTable } from '@tet/backend/collectivites/documents/models/preuve-complementaire.table';
@@ -13,10 +13,9 @@ import { preuveReglementaireTable } from '@tet/backend/collectivites/documents/m
 import { actionDefinitionTable } from '@tet/backend/referentiels/models/action-definition.table';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { failure, success, type Result } from '@tet/backend/utils/result.type';
-import { ReferentielId } from '@tet/domain/referentiels';
+import { ActionId, ReferentielId } from '@tet/domain/referentiels';
 import { getErrorMessage } from '@tet/domain/utils';
-import { and, eq, sql, type SQL } from 'drizzle-orm';
-import { type PgColumn } from 'drizzle-orm/pg-core';
+import { and, eq, sql } from 'drizzle-orm';
 import {
   PreuvesArchiveErrorEnum,
   type PreuvesArchiveError,
@@ -25,55 +24,111 @@ import {
 export interface CollectedFilePreuve {
   bucketId: string;
   hash: string;
-  filename: string;
+  filename: string | null;
   filesize: number | null;
-  actionId: string | null;
+  actionId: ActionId | null;
 }
+
+export type MissingFilePreuve = Pick<
+  CollectedFilePreuve,
+  'hash' | 'filename' | 'actionId'
+>;
 
 export interface CollectedLinkPreuve {
   url: string;
   titre: string | null;
   commentaire: string | null;
-  actionId: string | null;
+  actionId: ActionId | null;
 }
 
-type CollectedPreuves = {
+export type CollectedPreuves = {
   files: CollectedFilePreuve[];
+  missingFiles: MissingFilePreuve[];
   links: CollectedLinkPreuve[];
 };
 
-type CollectedRow = {
-  actionId: string | null;
+type CollectedRow = Pick<CollectedFilePreuve, 'actionId' | 'filename'> & {
+  fichierId: number | null;
+  hash: string | null;
   url: string | null;
   titre: string | null;
   commentaire: string | null;
   fichier: {
     bucketId: string;
-    hash: string;
-    filename: string;
     filesize: number | null;
   } | null;
 };
 
-const AUCUNE_MESURE = sql<string | null>`null`;
+type TriagedPreuve =
+  | { kind: 'file'; file: CollectedFilePreuve }
+  | { kind: 'missingFile'; missingFile: MissingFilePreuve }
+  | { kind: 'link'; link: CollectedLinkPreuve };
 
-const splitFilesAndLinks = (rows: CollectedRow[]): CollectedPreuves => ({
-  files: rows.flatMap((row) =>
-    row.fichier ? [{ ...row.fichier, actionId: row.actionId }] : []
-  ),
-  links: rows.flatMap((row) =>
-    !row.fichier && row.url
-      ? [
-          {
-            url: row.url,
-            titre: row.titre,
-            commentaire: row.commentaire,
-            actionId: row.actionId,
-          },
-        ]
-      : []
-  ),
-});
+type PreuveKind =
+  | 'complementaire'
+  | 'reglementaire'
+  | 'labellisation'
+  | 'audit';
+
+function triagePreuve(row: CollectedRow): TriagedPreuve[] {
+  const { actionId, fichierId, hash, filename, fichier, url } = row;
+
+  const isLinkPreuve = fichierId === null;
+  if (isLinkPreuve) {
+    if (!url) {
+      return [];
+    }
+    return [
+      {
+        kind: 'link',
+        link: {
+          url,
+          titre: row.titre,
+          commentaire: row.commentaire,
+          actionId,
+        },
+      },
+    ];
+  }
+
+  const belongsToAnotherCollectivite = hash === null;
+  if (belongsToAnotherCollectivite) {
+    return [];
+  }
+
+  if (!fichier) {
+    return [{ kind: 'missingFile', missingFile: { hash, filename, actionId } }];
+  }
+
+  return [
+    {
+      kind: 'file',
+      file: {
+        bucketId: fichier.bucketId,
+        filesize: fichier.filesize,
+        hash,
+        filename,
+        actionId,
+      },
+    },
+  ];
+}
+
+function splitByKind(rows: CollectedRow[]): CollectedPreuves {
+  const triaged = rows.flatMap(triagePreuve);
+
+  return {
+    files: triaged.flatMap((entry) =>
+      entry.kind === 'file' ? [entry.file] : []
+    ),
+    missingFiles: triaged.flatMap((entry) =>
+      entry.kind === 'missingFile' ? [entry.missingFile] : []
+    ),
+    links: triaged.flatMap((entry) =>
+      entry.kind === 'link' ? [entry.link] : []
+    ),
+  };
+}
 
 @Injectable()
 export class CollectPreuvesRepository {
@@ -94,6 +149,9 @@ export class CollectPreuvesRepository {
       const rows = await this.db
         .select({
           actionId: preuveComplementaireTable.actionId,
+          fichierId: preuveComplementaireTable.fichierId,
+          hash: bibliothequeFichierTable.hash,
+          filename: bibliothequeFichierTable.filename,
           url: preuveComplementaireTable.url,
           titre: preuveComplementaireTable.titre,
           commentaire: preuveComplementaireTable.commentaire,
@@ -111,26 +169,27 @@ export class CollectPreuvesRepository {
           )
         )
         .leftJoin(
-          fichier,
+          bibliothequeFichierTable,
           and(
-            eq(preuveComplementaireTable.fichierId, fichier.id),
-            eq(fichier.collectiviteId, collectiviteId)
+            eq(preuveComplementaireTable.fichierId, bibliothequeFichierTable.id),
+            eq(bibliothequeFichierTable.collectiviteId, collectiviteId)
           )
         )
+        .leftJoin(fichier, eq(fichier.id, bibliothequeFichierTable.id))
         .where(
           and(
             eq(preuveComplementaireTable.collectiviteId, collectiviteId),
-            this.masqueLesConfidentiels(
-              preuveComplementaireTable.fichierId,
-              fichier,
-              canReadConfidentiel
-            )
+            hideConfidentielFilter({
+              fichierIdColumn: preuveComplementaireTable.fichierId,
+              confidentielColumn: bibliothequeFichierTable.confidentiel,
+              canReadConfidentiel,
+            })
           )
         );
 
-      return success(splitFilesAndLinks(rows));
+      return success(splitByKind(rows));
     } catch (error) {
-      return this.echecDeCollecte('complémentaires', error);
+      return this.collectFailure('complementaire', error);
     }
   }
 
@@ -146,6 +205,9 @@ export class CollectPreuvesRepository {
       const rows = await this.db
         .select({
           actionId: preuveActionTable.actionId,
+          fichierId: preuveReglementaireTable.fichierId,
+          hash: bibliothequeFichierTable.hash,
+          filename: bibliothequeFichierTable.filename,
           url: preuveReglementaireTable.url,
           titre: preuveReglementaireTable.titre,
           commentaire: preuveReglementaireTable.commentaire,
@@ -164,26 +226,27 @@ export class CollectPreuvesRepository {
           )
         )
         .leftJoin(
-          fichier,
+          bibliothequeFichierTable,
           and(
-            eq(preuveReglementaireTable.fichierId, fichier.id),
-            eq(fichier.collectiviteId, collectiviteId)
+            eq(preuveReglementaireTable.fichierId, bibliothequeFichierTable.id),
+            eq(bibliothequeFichierTable.collectiviteId, collectiviteId)
           )
         )
+        .leftJoin(fichier, eq(fichier.id, bibliothequeFichierTable.id))
         .where(
           and(
             eq(preuveReglementaireTable.collectiviteId, collectiviteId),
-            this.masqueLesConfidentiels(
-              preuveReglementaireTable.fichierId,
-              fichier,
-              canReadConfidentiel
-            )
+            hideConfidentielFilter({
+              fichierIdColumn: preuveReglementaireTable.fichierId,
+              confidentielColumn: bibliothequeFichierTable.confidentiel,
+              canReadConfidentiel,
+            })
           )
         );
 
-      return success(splitFilesAndLinks(rows));
+      return success(splitByKind(rows));
     } catch (error) {
-      return this.echecDeCollecte('réglementaires', error);
+      return this.collectFailure('reglementaire', error);
     }
   }
 
@@ -198,7 +261,10 @@ export class CollectPreuvesRepository {
     try {
       const rows = await this.db
         .select({
-          actionId: AUCUNE_MESURE,
+          actionId: sql<null>`null`,
+          fichierId: preuveLabellisationTable.fichierId,
+          hash: bibliothequeFichierTable.hash,
+          filename: bibliothequeFichierTable.filename,
           url: preuveLabellisationTable.url,
           titre: preuveLabellisationTable.titre,
           commentaire: preuveLabellisationTable.commentaire,
@@ -206,27 +272,28 @@ export class CollectPreuvesRepository {
         })
         .from(preuveLabellisationTable)
         .leftJoin(
-          fichier,
+          bibliothequeFichierTable,
           and(
-            eq(preuveLabellisationTable.fichierId, fichier.id),
-            eq(fichier.collectiviteId, collectiviteId)
+            eq(preuveLabellisationTable.fichierId, bibliothequeFichierTable.id),
+            eq(bibliothequeFichierTable.collectiviteId, collectiviteId)
           )
         )
+        .leftJoin(fichier, eq(fichier.id, bibliothequeFichierTable.id))
         .where(
           and(
             eq(preuveLabellisationTable.demandeId, demandeId),
             eq(preuveLabellisationTable.collectiviteId, collectiviteId),
-            this.masqueLesConfidentiels(
-              preuveLabellisationTable.fichierId,
-              fichier,
-              canReadConfidentiel
-            )
+            hideConfidentielFilter({
+              fichierIdColumn: preuveLabellisationTable.fichierId,
+              confidentielColumn: bibliothequeFichierTable.confidentiel,
+              canReadConfidentiel,
+            })
           )
         );
 
-      return success(splitFilesAndLinks(rows));
+      return success(splitByKind(rows));
     } catch (error) {
-      return this.echecDeCollecte('de labellisation', error);
+      return this.collectFailure('labellisation', error);
     }
   }
 
@@ -241,7 +308,10 @@ export class CollectPreuvesRepository {
     try {
       const rows = await this.db
         .select({
-          actionId: AUCUNE_MESURE,
+          actionId: sql<null>`null`,
+          fichierId: preuveAuditTable.fichierId,
+          hash: bibliothequeFichierTable.hash,
+          filename: bibliothequeFichierTable.filename,
           url: preuveAuditTable.url,
           titre: preuveAuditTable.titre,
           commentaire: preuveAuditTable.commentaire,
@@ -249,52 +319,40 @@ export class CollectPreuvesRepository {
         })
         .from(preuveAuditTable)
         .leftJoin(
-          fichier,
+          bibliothequeFichierTable,
           and(
-            eq(preuveAuditTable.fichierId, fichier.id),
-            eq(fichier.collectiviteId, collectiviteId)
+            eq(preuveAuditTable.fichierId, bibliothequeFichierTable.id),
+            eq(bibliothequeFichierTable.collectiviteId, collectiviteId)
           )
         )
+        .leftJoin(fichier, eq(fichier.id, bibliothequeFichierTable.id))
         .where(
           and(
             eq(preuveAuditTable.auditId, auditId),
             eq(preuveAuditTable.collectiviteId, collectiviteId),
-            this.masqueLesConfidentiels(
-              preuveAuditTable.fichierId,
-              fichier,
-              canReadConfidentiel
-            )
+            hideConfidentielFilter({
+              fichierIdColumn: preuveAuditTable.fichierId,
+              confidentielColumn: bibliothequeFichierTable.confidentiel,
+              canReadConfidentiel,
+            })
           )
         );
 
-      return success(splitFilesAndLinks(rows));
+      return success(splitByKind(rows));
     } catch (error) {
-      return this.echecDeCollecte("d'audit", error);
+      return this.collectFailure('audit', error);
     }
   }
 
-  private masqueLesConfidentiels(
-    fichierIdColumn: PgColumn,
-    fichier: FichierSubquery,
-    canReadConfidentiel: boolean
-  ): SQL | undefined {
-    return hideConfidentielFilter({
-      fichierIdColumn,
-      confidentielColumn: fichier.confidentiel,
-      canReadConfidentiel,
-    });
-  }
-
-  private echecDeCollecte(
-    nature: string,
+  private collectFailure(
+    kind: PreuveKind,
     error: unknown
   ): Result<never, PreuvesArchiveError> {
     this.logger.error(
-      `Collecte des preuves ${nature}: ${getErrorMessage(error)}`
+      `Failed to collect preuves ${kind}: ${getErrorMessage(error)}`
     );
-    return failure(
-      PreuvesArchiveErrorEnum.COLLECT_PREUVES_ERROR,
-      error instanceof Error ? error : new Error(getErrorMessage(error))
-    );
+    const cause =
+      error instanceof Error ? error : new Error(getErrorMessage(error));
+    return failure(PreuvesArchiveErrorEnum.COLLECT_PREUVES_ERROR, cause);
   }
 }

--- a/apps/backend/src/referentiels/preuves-archive/collect-audit-preuves/collect-preuves.repository.ts
+++ b/apps/backend/src/referentiels/preuves-archive/collect-audit-preuves/collect-preuves.repository.ts
@@ -1,33 +1,31 @@
 import { Injectable, Logger } from '@nestjs/common';
+import {
+  buildFichierSubquery,
+  buildFileInfoSql,
+  type FichierSubquery,
+} from '@tet/backend/collectivites/documents/file-info.utils';
 import { hideConfidentielFilter } from '@tet/backend/collectivites/documents/hide-confidentiel.utils';
-import { bibliothequeFichierTable } from '@tet/backend/collectivites/documents/models/bibliotheque-fichier.table';
 import { preuveActionTable } from '@tet/backend/collectivites/documents/models/preuve-action.table';
 import { preuveAuditTable } from '@tet/backend/collectivites/documents/models/preuve-audit.table';
 import { preuveComplementaireTable } from '@tet/backend/collectivites/documents/models/preuve-complementaire.table';
 import { preuveLabellisationTable } from '@tet/backend/collectivites/documents/models/preuve-labellisation.table';
 import { preuveReglementaireTable } from '@tet/backend/collectivites/documents/models/preuve-reglementaire.table';
-import { storageObjectTable } from '@tet/backend/collectivites/documents/models/storage-object.table';
-import { collectiviteBucketTable } from '@tet/backend/collectivites/shared/models/collectivite-bucket.table';
 import { actionDefinitionTable } from '@tet/backend/referentiels/models/action-definition.table';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { failure, success, type Result } from '@tet/backend/utils/result.type';
 import { ReferentielId } from '@tet/domain/referentiels';
 import { getErrorMessage } from '@tet/domain/utils';
-import { and, eq, inArray, sql, type SQL } from 'drizzle-orm';
-import { z } from 'zod';
+import { and, eq, sql, type SQL } from 'drizzle-orm';
+import { type PgColumn } from 'drizzle-orm/pg-core';
 import {
   PreuvesArchiveErrorEnum,
   type PreuvesArchiveError,
 } from '../preuves-archive.errors';
 
-const storageMetadataSchema = z.object({
-  size: z.union([z.number(), z.string()]),
-});
-
 export interface CollectedFilePreuve {
-  bucketId: string | null;
+  bucketId: string;
   hash: string;
-  filename: string | null;
+  filename: string;
   filesize: number | null;
   actionId: string | null;
 }
@@ -44,6 +42,39 @@ type CollectedPreuves = {
   links: CollectedLinkPreuve[];
 };
 
+type CollectedRow = {
+  actionId: string | null;
+  url: string | null;
+  titre: string | null;
+  commentaire: string | null;
+  fichier: {
+    bucketId: string;
+    hash: string;
+    filename: string;
+    filesize: number | null;
+  } | null;
+};
+
+const AUCUNE_MESURE = sql<string | null>`null`;
+
+const splitFilesAndLinks = (rows: CollectedRow[]): CollectedPreuves => ({
+  files: rows.flatMap((row) =>
+    row.fichier ? [{ ...row.fichier, actionId: row.actionId }] : []
+  ),
+  links: rows.flatMap((row) =>
+    !row.fichier && row.url
+      ? [
+          {
+            url: row.url,
+            titre: row.titre,
+            commentaire: row.commentaire,
+            actionId: row.actionId,
+          },
+        ]
+      : []
+  ),
+});
+
 @Injectable()
 export class CollectPreuvesRepository {
   private readonly db = this.database.db;
@@ -57,18 +88,16 @@ export class CollectPreuvesRepository {
     canReadConfidentiel: boolean;
   }): Promise<Result<CollectedPreuves, PreuvesArchiveError>> {
     const { collectiviteId, referentielId, canReadConfidentiel } = input;
+    const fichier = buildFichierSubquery(this.db);
+
     try {
       const rows = await this.db
         .select({
           actionId: preuveComplementaireTable.actionId,
-          fichierId: preuveComplementaireTable.fichierId,
           url: preuveComplementaireTable.url,
           titre: preuveComplementaireTable.titre,
           commentaire: preuveComplementaireTable.commentaire,
-          bucketId: storageObjectTable.bucketId,
-          hash: bibliothequeFichierTable.hash,
-          filename: bibliothequeFichierTable.filename,
-          metadata: storageObjectTable.metadata,
+          fichier: buildFileInfoSql(fichier),
         })
         .from(preuveComplementaireTable)
         .innerJoin(
@@ -82,42 +111,26 @@ export class CollectPreuvesRepository {
           )
         )
         .leftJoin(
-          bibliothequeFichierTable,
+          fichier,
           and(
-            eq(
-              preuveComplementaireTable.fichierId,
-              bibliothequeFichierTable.id
-            ),
-            eq(bibliothequeFichierTable.collectiviteId, collectiviteId)
-          )
-        )
-        .leftJoin(
-          storageObjectTable,
-          and(
-            eq(storageObjectTable.name, bibliothequeFichierTable.hash),
-            this.storageObjectInCollectiviteBuckets(collectiviteId)
+            eq(preuveComplementaireTable.fichierId, fichier.id),
+            eq(fichier.collectiviteId, collectiviteId)
           )
         )
         .where(
           and(
             eq(preuveComplementaireTable.collectiviteId, collectiviteId),
-            hideConfidentielFilter({
-              fichierIdColumn: preuveComplementaireTable.fichierId,
-              confidentielColumn: bibliothequeFichierTable.confidentiel,
-              canReadConfidentiel,
-            })
+            this.masqueLesConfidentiels(
+              preuveComplementaireTable.fichierId,
+              fichier,
+              canReadConfidentiel
+            )
           )
         );
 
-      return success(this.splitFilesAndLinks(rows));
+      return success(splitFilesAndLinks(rows));
     } catch (error) {
-      this.logger.error(
-        `Collecte des preuves complémentaires: ${getErrorMessage(error)}`
-      );
-      return failure(
-        PreuvesArchiveErrorEnum.COLLECT_PREUVES_ERROR,
-        error instanceof Error ? error : new Error(getErrorMessage(error))
-      );
+      return this.echecDeCollecte('complémentaires', error);
     }
   }
 
@@ -127,23 +140,21 @@ export class CollectPreuvesRepository {
     canReadConfidentiel: boolean;
   }): Promise<Result<CollectedPreuves, PreuvesArchiveError>> {
     const { collectiviteId, referentielId, canReadConfidentiel } = input;
+    const fichier = buildFichierSubquery(this.db);
+
     try {
       const rows = await this.db
         .select({
           actionId: preuveActionTable.actionId,
-          fichierId: preuveReglementaireTable.fichierId,
           url: preuveReglementaireTable.url,
           titre: preuveReglementaireTable.titre,
           commentaire: preuveReglementaireTable.commentaire,
-          bucketId: storageObjectTable.bucketId,
-          hash: bibliothequeFichierTable.hash,
-          filename: bibliothequeFichierTable.filename,
-          metadata: storageObjectTable.metadata,
+          fichier: buildFileInfoSql(fichier),
         })
         .from(preuveReglementaireTable)
         .innerJoin(
           preuveActionTable,
-          eq(preuveReglementaireTable.preuveId, preuveActionTable.preuveId)
+          eq(preuveActionTable.preuveId, preuveReglementaireTable.preuveId)
         )
         .innerJoin(
           actionDefinitionTable,
@@ -153,39 +164,26 @@ export class CollectPreuvesRepository {
           )
         )
         .leftJoin(
-          bibliothequeFichierTable,
+          fichier,
           and(
-            eq(preuveReglementaireTable.fichierId, bibliothequeFichierTable.id),
-            eq(bibliothequeFichierTable.collectiviteId, collectiviteId)
-          )
-        )
-        .leftJoin(
-          storageObjectTable,
-          and(
-            eq(storageObjectTable.name, bibliothequeFichierTable.hash),
-            this.storageObjectInCollectiviteBuckets(collectiviteId)
+            eq(preuveReglementaireTable.fichierId, fichier.id),
+            eq(fichier.collectiviteId, collectiviteId)
           )
         )
         .where(
           and(
             eq(preuveReglementaireTable.collectiviteId, collectiviteId),
-            hideConfidentielFilter({
-              fichierIdColumn: preuveReglementaireTable.fichierId,
-              confidentielColumn: bibliothequeFichierTable.confidentiel,
-              canReadConfidentiel,
-            })
+            this.masqueLesConfidentiels(
+              preuveReglementaireTable.fichierId,
+              fichier,
+              canReadConfidentiel
+            )
           )
         );
 
-      return success(this.splitFilesAndLinks(rows));
+      return success(splitFilesAndLinks(rows));
     } catch (error) {
-      this.logger.error(
-        `Collecte des preuves réglementaires: ${getErrorMessage(error)}`
-      );
-      return failure(
-        PreuvesArchiveErrorEnum.COLLECT_PREUVES_ERROR,
-        error instanceof Error ? error : new Error(getErrorMessage(error))
-      );
+      return this.echecDeCollecte('réglementaires', error);
     }
   }
 
@@ -195,55 +193,40 @@ export class CollectPreuvesRepository {
     canReadConfidentiel: boolean;
   }): Promise<Result<CollectedPreuves, PreuvesArchiveError>> {
     const { collectiviteId, demandeId, canReadConfidentiel } = input;
+    const fichier = buildFichierSubquery(this.db);
+
     try {
       const rows = await this.db
         .select({
-          actionId: sql<string | null>`null`,
-          fichierId: preuveLabellisationTable.fichierId,
+          actionId: AUCUNE_MESURE,
           url: preuveLabellisationTable.url,
           titre: preuveLabellisationTable.titre,
           commentaire: preuveLabellisationTable.commentaire,
-          bucketId: storageObjectTable.bucketId,
-          hash: bibliothequeFichierTable.hash,
-          filename: bibliothequeFichierTable.filename,
-          metadata: storageObjectTable.metadata,
+          fichier: buildFileInfoSql(fichier),
         })
         .from(preuveLabellisationTable)
         .leftJoin(
-          bibliothequeFichierTable,
+          fichier,
           and(
-            eq(preuveLabellisationTable.fichierId, bibliothequeFichierTable.id),
-            eq(bibliothequeFichierTable.collectiviteId, collectiviteId)
-          )
-        )
-        .leftJoin(
-          storageObjectTable,
-          and(
-            eq(storageObjectTable.name, bibliothequeFichierTable.hash),
-            this.storageObjectInCollectiviteBuckets(collectiviteId)
+            eq(preuveLabellisationTable.fichierId, fichier.id),
+            eq(fichier.collectiviteId, collectiviteId)
           )
         )
         .where(
           and(
             eq(preuveLabellisationTable.demandeId, demandeId),
             eq(preuveLabellisationTable.collectiviteId, collectiviteId),
-            hideConfidentielFilter({
-              fichierIdColumn: preuveLabellisationTable.fichierId,
-              confidentielColumn: bibliothequeFichierTable.confidentiel,
-              canReadConfidentiel,
-            })
+            this.masqueLesConfidentiels(
+              preuveLabellisationTable.fichierId,
+              fichier,
+              canReadConfidentiel
+            )
           )
         );
 
-      return success(this.splitFilesAndLinks(rows));
+      return success(splitFilesAndLinks(rows));
     } catch (error) {
-      this.logger.error(
-        `Collecte des preuves de labellisation: ${getErrorMessage(error)}`
-      );
-      return failure(
-        PreuvesArchiveErrorEnum.COLLECT_PREUVES_ERROR,
-        error instanceof Error ? error : new Error(getErrorMessage(error))
-      );
+      return this.echecDeCollecte('de labellisation', error);
     }
   }
 
@@ -253,119 +236,65 @@ export class CollectPreuvesRepository {
     canReadConfidentiel: boolean;
   }): Promise<Result<CollectedPreuves, PreuvesArchiveError>> {
     const { collectiviteId, auditId, canReadConfidentiel } = input;
+    const fichier = buildFichierSubquery(this.db);
+
     try {
       const rows = await this.db
         .select({
-          actionId: sql<string | null>`null`,
-          fichierId: preuveAuditTable.fichierId,
+          actionId: AUCUNE_MESURE,
           url: preuveAuditTable.url,
           titre: preuveAuditTable.titre,
           commentaire: preuveAuditTable.commentaire,
-          bucketId: storageObjectTable.bucketId,
-          hash: bibliothequeFichierTable.hash,
-          filename: bibliothequeFichierTable.filename,
-          metadata: storageObjectTable.metadata,
+          fichier: buildFileInfoSql(fichier),
         })
         .from(preuveAuditTable)
         .leftJoin(
-          bibliothequeFichierTable,
+          fichier,
           and(
-            eq(preuveAuditTable.fichierId, bibliothequeFichierTable.id),
-            eq(bibliothequeFichierTable.collectiviteId, collectiviteId)
-          )
-        )
-        .leftJoin(
-          storageObjectTable,
-          and(
-            eq(storageObjectTable.name, bibliothequeFichierTable.hash),
-            this.storageObjectInCollectiviteBuckets(collectiviteId)
+            eq(preuveAuditTable.fichierId, fichier.id),
+            eq(fichier.collectiviteId, collectiviteId)
           )
         )
         .where(
           and(
             eq(preuveAuditTable.auditId, auditId),
             eq(preuveAuditTable.collectiviteId, collectiviteId),
-            hideConfidentielFilter({
-              fichierIdColumn: preuveAuditTable.fichierId,
-              confidentielColumn: bibliothequeFichierTable.confidentiel,
-              canReadConfidentiel,
-            })
+            this.masqueLesConfidentiels(
+              preuveAuditTable.fichierId,
+              fichier,
+              canReadConfidentiel
+            )
           )
         );
 
-      return success(this.splitFilesAndLinks(rows));
+      return success(splitFilesAndLinks(rows));
     } catch (error) {
-      this.logger.error(
-        `Collecte des preuves d'audit: ${getErrorMessage(error)}`
-      );
-      return failure(
-        PreuvesArchiveErrorEnum.COLLECT_PREUVES_ERROR,
-        error instanceof Error ? error : new Error(getErrorMessage(error))
-      );
+      return this.echecDeCollecte("d'audit", error);
     }
   }
 
-  private storageObjectInCollectiviteBuckets(collectiviteId: number): SQL {
-    return inArray(
-      storageObjectTable.bucketId,
-      this.db
-        .select({ bucketId: collectiviteBucketTable.bucketId })
-        .from(collectiviteBucketTable)
-        .where(eq(collectiviteBucketTable.collectiviteId, collectiviteId))
+  private masqueLesConfidentiels(
+    fichierIdColumn: PgColumn,
+    fichier: FichierSubquery,
+    canReadConfidentiel: boolean
+  ): SQL | undefined {
+    return hideConfidentielFilter({
+      fichierIdColumn,
+      confidentielColumn: fichier.confidentiel,
+      canReadConfidentiel,
+    });
+  }
+
+  private echecDeCollecte(
+    nature: string,
+    error: unknown
+  ): Result<never, PreuvesArchiveError> {
+    this.logger.error(
+      `Collecte des preuves ${nature}: ${getErrorMessage(error)}`
     );
-  }
-
-  private splitFilesAndLinks(
-    rows: Array<{
-      actionId: string | null;
-      fichierId: number | null;
-      url: string | null;
-      titre: string | null;
-      commentaire: string | null;
-      bucketId: string | null;
-      hash: string | null;
-      filename: string | null;
-      metadata: unknown;
-    }>
-  ): CollectedPreuves {
-    const files = rows
-      .filter(
-        (
-          row
-        ): row is typeof row & {
-          fichierId: number;
-          hash: string;
-        } => row.fichierId !== null && row.hash !== null
-      )
-      .map((row) => ({
-        bucketId: row.bucketId,
-        hash: row.hash,
-        filename: row.filename,
-        filesize: this.readFilesize(row.metadata),
-        actionId: row.actionId,
-      }));
-
-    const links = rows
-      .filter(
-        (row): row is typeof row & { url: string } =>
-          row.fichierId === null && row.url !== null && row.url !== ''
-      )
-      .map((row) => ({
-        url: row.url,
-        titre: row.titre,
-        commentaire: row.commentaire,
-        actionId: row.actionId,
-      }));
-
-    return { files, links };
-  }
-
-  private readFilesize(metadata: unknown): number | null {
-    const parsed = storageMetadataSchema.safeParse(metadata);
-    if (!parsed.success) {
-      return null;
-    }
-    const size = Number(parsed.data.size);
-    return Number.isFinite(size) ? size : null;
+    return failure(
+      PreuvesArchiveErrorEnum.COLLECT_PREUVES_ERROR,
+      error instanceof Error ? error : new Error(getErrorMessage(error))
+    );
   }
 }

--- a/apps/backend/src/referentiels/preuves-archive/generate-preuves-archive/generate-archive-folder-arborescence.spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/generate-preuves-archive/generate-archive-folder-arborescence.spec.ts
@@ -202,7 +202,7 @@ describe('generateArchiveFolderArborescence', () => {
     });
   });
 
-  it('ignore un fichier introuvable dans le stockage', () => {
+  it('ignore un fichier dont la taille est inconnue', () => {
     const result = generateArchiveFolderArborescence(
       buildInput({
         mesure: {
@@ -223,7 +223,7 @@ describe('generateArchiveFolderArborescence', () => {
     expect(result.data.files).toEqual([]);
     expect(result.data.skippedFiles[0]).toMatchObject({
       filename: 'sans-taille.pdf',
-      raison: 'Fichier introuvable dans le stockage',
+      raison: 'Taille du fichier inconnue',
     });
   });
 

--- a/apps/backend/src/referentiels/preuves-archive/generate-preuves-archive/generate-archive-folder-arborescence.spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/generate-preuves-archive/generate-archive-folder-arborescence.spec.ts
@@ -1,9 +1,10 @@
 import { ActionTypeEnum } from '@tet/domain/referentiels';
 import { describe, expect, it } from 'vitest';
-import type { PreuvesByOrigin, PreuvesSource } from '../collect-audit-preuves/collect-audit-preuves.service';
+import type { PreuvesByOrigin } from '../collect-audit-preuves/collect-audit-preuves.service';
 import type {
   CollectedFilePreuve,
   CollectedLinkPreuve,
+  CollectedPreuves,
 } from '../collect-audit-preuves/collect-preuves.repository';
 import {
   generateArchiveFolderArborescence,
@@ -83,17 +84,16 @@ function makeLink(
   };
 }
 
-const empty: PreuvesSource = { files: [], links: [] };
+const empty: CollectedPreuves = { files: [], missingFiles: [], links: [] };
 
 function buildInput(
-  preuves: Partial<PreuvesByOrigin> = {}
+  preuves: Partial<Record<keyof PreuvesByOrigin, Partial<CollectedPreuves>>> = {}
 ): GenerateArchiveFolderArborescenceInput {
   return {
     preuves: {
-      mesure: empty,
-      demande: empty,
-      audit: empty,
-      ...preuves,
+      mesure: { ...empty, ...preuves.mesure },
+      demande: { ...empty, ...preuves.demande },
+      audit: { ...empty, ...preuves.audit },
     },
     referentielTree,
   };
@@ -200,6 +200,76 @@ describe('generateArchiveFolderArborescence', () => {
       filename: 'gros.zip',
       emplacement: 'mesures/1 Axe un/1.1 Sous-axe un/1.1.1 Mesure un',
     });
+  });
+
+  it('consigne un fichier absent du stockage dans le dossier de sa mesure', () => {
+    const result = generateArchiveFolderArborescence(
+      buildInput({
+        mesure: {
+          missingFiles: [
+            {
+              hash: 'hash-purge',
+              filename: 'avis-technique.pdf',
+              actionId: 'cae_1.1.1',
+            },
+          ],
+        },
+      })
+    );
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.files).toEqual([]);
+    expect(result.data.skippedFiles).toEqual([
+      {
+        filename: 'avis-technique.pdf',
+        emplacement: 'mesures/1 Axe un/1.1 Sous-axe un/1.1.1 Mesure un',
+        raison: 'Fichier introuvable dans le stockage',
+      },
+    ]);
+  });
+
+  it('consigne un fichier absent du stockage sans filename sous son hash', () => {
+    const result = generateArchiveFolderArborescence(
+      buildInput({
+        audit: {
+          missingFiles: [
+            { hash: 'hash-sans-nom', filename: null, actionId: null },
+          ],
+        },
+      })
+    );
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.skippedFiles).toEqual([
+      {
+        filename: 'hash-sans-nom',
+        emplacement: 'cycle-labellisation/audit',
+        raison: 'Fichier introuvable dans le stockage',
+      },
+    ]);
+  });
+
+  it('nomme un fichier sans filename par son hash', () => {
+    const result = generateArchiveFolderArborescence(
+      buildInput({
+        mesure: {
+          files: [
+            makeFile({
+              actionId: 'cae_1.1.1',
+              filename: null,
+              hash: 'hash-sans-nom',
+            }),
+          ],
+          links: [],
+        },
+      })
+    );
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.files[0].filename).toBe('hash-sans-nom');
   });
 
   it('ignore un fichier dont la taille est inconnue', () => {

--- a/apps/backend/src/referentiels/preuves-archive/generate-preuves-archive/generate-archive-folder-arborescence.ts
+++ b/apps/backend/src/referentiels/preuves-archive/generate-preuves-archive/generate-archive-folder-arborescence.ts
@@ -9,6 +9,7 @@ import {
 import type {
   CollectedFilePreuve,
   CollectedLinkPreuve,
+  MissingFilePreuve,
 } from '../collect-audit-preuves/collect-preuves.repository';
 import type { LienPreuve } from '../build-archive/build-liens-csv';
 
@@ -74,13 +75,32 @@ type LinkWithFolder = {
   folderSegments: string[];
 };
 
+type MissingFileWithFolder = {
+  missingFile: MissingFilePreuve;
+  folderSegments: string[];
+};
+
+const FILE_MISSING_FROM_STORAGE = 'Fichier introuvable dans le stockage';
+const FILE_SIZE_UNKNOWN = 'Taille du fichier inconnue';
+
+function toSkippedMissingFile({
+  missingFile,
+  folderSegments,
+}: MissingFileWithFolder): SkippedFile {
+  return {
+    filename: missingFile.filename ?? missingFile.hash,
+    emplacement: folderSegments.join('/'),
+    raison: FILE_MISSING_FROM_STORAGE,
+  };
+}
+
 type FileTriage =
   | { kind: 'collected'; file: ArchiveFile }
   | { kind: 'skipped'; entry: SkippedFile };
 
 function triageFile({ file, folderSegments }: FileWithFolder): FileTriage {
   const emplacement = folderSegments.join('/');
-  const { filename } = file;
+  const filename = file.filename ?? file.hash;
 
   if (file.filesize === null) {
     return {
@@ -88,7 +108,7 @@ function triageFile({ file, folderSegments }: FileWithFolder): FileTriage {
       entry: {
         filename,
         emplacement,
-        raison: 'Taille du fichier inconnue',
+        raison: FILE_SIZE_UNKNOWN,
       },
     };
   }
@@ -216,6 +236,21 @@ export function generateArchiveFolderArborescence(
     folderSegments: [CYCLE_FOLDER, AUDIT_FOLDER],
   }));
 
+  const mesureMissingFiles = preuves.mesure.missingFiles.map((missingFile) => ({
+    missingFile,
+    folderSegments: mesureFolderSegments(missingFile.actionId, mesureFolders),
+  }));
+  const demandeMissingFiles = preuves.demande.missingFiles.map(
+    (missingFile) => ({
+      missingFile,
+      folderSegments: [CYCLE_FOLDER, DEMANDE_FOLDER],
+    })
+  );
+  const auditMissingFiles = preuves.audit.missingFiles.map((missingFile) => ({
+    missingFile,
+    folderSegments: [CYCLE_FOLDER, AUDIT_FOLDER],
+  }));
+
   const mesureLinks = preuves.mesure.links.map((link) => ({
     link,
     folderSegments: mesureFolderSegments(link.actionId, mesureFolders),
@@ -233,9 +268,16 @@ export function generateArchiveFolderArborescence(
   const collectedFiles = triaged.flatMap((entry) =>
     entry.kind === 'collected' ? [entry.file] : []
   );
-  const skippedFiles = triaged.flatMap((entry) =>
-    entry.kind === 'skipped' ? [entry.entry] : []
-  );
+  const skippedFiles = [
+    ...triaged.flatMap((entry) =>
+      entry.kind === 'skipped' ? [entry.entry] : []
+    ),
+    ...[
+      ...mesureMissingFiles,
+      ...demandeMissingFiles,
+      ...auditMissingFiles,
+    ].map(toSkippedMissingFile),
+  ];
 
   const limits = checkArchiveLimits(collectedFiles);
   if (!limits.success) {

--- a/apps/backend/src/referentiels/preuves-archive/generate-preuves-archive/generate-archive-folder-arborescence.ts
+++ b/apps/backend/src/referentiels/preuves-archive/generate-preuves-archive/generate-archive-folder-arborescence.ts
@@ -80,15 +80,15 @@ type FileTriage =
 
 function triageFile({ file, folderSegments }: FileWithFolder): FileTriage {
   const emplacement = folderSegments.join('/');
-  const filename = file.filename ?? file.hash;
+  const { filename } = file;
 
-  if (file.filesize === null || file.bucketId === null) {
+  if (file.filesize === null) {
     return {
       kind: 'skipped',
       entry: {
         filename,
         emplacement,
-        raison: 'Fichier introuvable dans le stockage',
+        raison: 'Taille du fichier inconnue',
       },
     };
   }

--- a/apps/backend/src/referentiels/preuves-archive/generate-preuves-archive/generate-preuves-archive.service.spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/generate-preuves-archive/generate-preuves-archive.service.spec.ts
@@ -88,9 +88,9 @@ function buildService({
   const collectAuditPreuves = {
     collect: vi.fn().mockResolvedValue(
       success({
-        mesure: { files: [], links: [] },
-        demande: { files: [], links: [] },
-        audit: { files: [], links: [] },
+        mesure: { files: [], missingFiles: [], links: [] },
+        demande: { files: [], missingFiles: [], links: [] },
+        audit: { files: [], missingFiles: [], links: [] },
       })
     ),
   } as unknown;


### PR DESCRIPTION
## Comportement

Aucun changement visible sur le contenu de l'archive. Deux corrections d'intégrité, décrites plus bas : un document sans nom d'origine ne fait plus planter la génération, et un document public dont l'objet de stockage a disparu est de nouveau signalé dans le manifeste même sans droit confidentiel.

## Ce que ça supprime

Les quatre méthodes de `CollectPreuvesRepository` résolvent le bucket et la taille du fichier via `buildFichierSubquery` et `buildFileInfoSql` — les helpers SQL déjà partagés par les trois lecteurs de documents — au lieu de rejoindre `collectivite_bucket` et `storage.objects` à la main puis de reparser la taille en TypeScript avec un zod maison.

Cette duplication est la source du produit cartésien des buckets que documente l'assertion de garde à la fin de `preuves-archive.full-pipeline.e2e-spec.ts`. La classe de bug disparaît avec elle.

## Identité et résolution sont deux choses distinctes

`buildFichierSubquery` fait des `innerJoin` sur `collectivite_bucket` et `storage.objects` : quand l'objet manque, la ligne ne remonte plus rien — ni hash, ni nom. Une trace « fichier id 4821 » ne dit pas à l'auditeur quel document manque.

Le repository sépare donc les deux :

- une jointure directe sur `bibliotheque_fichier`, scopée par `collectiviteId`, porte **l'identité** du document et **le cloisonnement** ;
- la sous-requête partagée porte **la résolution en stockage** : `bucketId` et `filesize`.

Le tri est une union discriminée à trois branches — `file`, `missingFile`, `link` — construite sur `fichierId`, pas sur la réussite d'une jointure. « C'est un lien » et « le fichier est introuvable » sont deux faits différents ; les confondre fait disparaître un document sans trace.

## Ce que le repository garde : ses propres requêtes

Le partage s'arrête au fragment de requête. Les quatre méthodes gardent leur `WHERE`, leur projection et leurs tests.

- **Les prédicats `collectiviteId` appartiennent à l'archive.** Les repositories des trois lecteurs d'écran ne les portent pas. Sans eux, une ligne `preuve_audit` pointant vers le `fichier_id` d'une autre collectivité ferait entrer son contenu dans le ZIP, puisque le worker télécharge avec le service role. La policy RLS d'insertion ne contrôle pas `fichier_id`, et le front l'insère directement via PostgREST.
- **La projection est celle de l'écran.** Cinq colonnes suffisent au ZIP ; les lecteurs rendent la ligne entière, la jointure `dcp` et des dates converties que l'archive ne lit jamais. Et une pagination ajoutée un jour pour l'écran tronquerait l'archive en silence.
- **La duplication entre les quatre méthodes est délibérée.** Chacune épelle ses deux prédicats de cloisonnement. Les factoriser les rendrait implicites — exactement le glissement à éviter ici.

## Le cloisonnement est verrouillé par quatre tests

`collect-preuves.repository.e2e-spec.ts` crée une seconde collectivité **rattachée au même bucket**, puis empoisonne la collectivité testée avec des preuves pointant vers le `fichier_id` de l'étrangère — ce que la policy RLS d'insertion laisse passer. Le bucket commun rend le test strictement plus fort : l'isolation ne peut pas venir du bucket, seulement du prédicat.

Les quatre méthodes sont couvertes. Chaque test vérifie que le hash étranger n'entre pas dans le résultat **et** que le fichier légitime y est, sans quoi il passerait à vide si le fixture se cassait.

Le prédicat est portant, vérifiable en SQL nu :

| jointure | résultat |
| --- | --- |
| `on pc.fichier_id = bf.id` | le fichier de l'autre collectivité |
| `on pc.fichier_id = bf.id and bf.collectivite_id = 1` | aucun fichier |

## Deux corrections d'intégrité

**`filename` est nullable.** `labellisation.bibliotheque_fichier.filename` est `text` sans `not null` (`fichier_preuve@v1.8.0.sql:28`), et le modèle Drizzle le reflète. `buildFileInfoSql` affirme pourtant `BibliothequeFichier`, dont le zod déclare `z.string()` — un `sql<T>` est un cast, pas un parse. En aval, `sanitizeSegment(null)` appelle `null.normalize()` et fait échouer tout le job, relancé par BullMQ jusqu'à épuisement. Le repli `file.filename ?? file.hash` est conservé, et `CollectedFilePreuve.filename` est typé `string | null`. Le reste du dépôt se défend au même endroit : `document.service.ts:124` fait `fichier[0].filename || hashId`.

**Le filtre de confidentialité ne fait pas office de filtre d'existence.** `hideConfidentielFilter` lit `bibliotheque_fichier.confidentiel`, qui résout même sans objet de stockage, plutôt que la colonne de la sous-requête — dont la valeur `NULL` rendrait le prédicat `NULL` et éliminerait la ligne. Un document **public** dont l'objet a disparu reste donc signalé sans droit confidentiel ; un document confidentiel reste masqué, nom compris, vérifié par un test dédié.

## Surface de review

7 fichiers, +567/−198.

- **`collect-preuves.repository.ts`** — les quatre requêtes et le tri discriminé.
- **`collect-preuves.repository.e2e-spec.ts`** — cloisonnement des quatre méthodes, documents absents du stockage, non-fuite du confidentiel.
- **`generate-archive-folder-arborescence.ts`** — les `missingFiles` rejoignent `skippedFiles`.
- **`collect-audit-preuves.service.ts`** — `PreuvesSource` disparaît au profit de `CollectedPreuves` exporté par le repository.

Le point à regarder si quelque chose tombe : la résolution du bucket passe d'un `inArray` sur les buckets de la collectivité à une jointure sur `collectivite_bucket.collectiviteId = bibliotheque_fichier.collectiviteId`.

## Constats consignés hors périmètre

Trois faiblesses préexistantes, sans rapport avec cette PR, consignées dans `DISCOVERED` :

- `listDocumentsAudit` et `listDocumentsDemandeLabellisation` joignent `fichier` sans prédicat `collectiviteId` — fuite de métadonnées inter-collectivités par le même helper ;
- une collectivité sans ligne `collectivite_bucket` produit une archive vide, sans manifeste, avec un job en succès ;
- `(metadata->>'size')::integer` lève au-delà de 2,1 Go et fait échouer l'archive entière au lieu d'écarter un fichier.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Améliorations**
  * Les documents dont le fichier est introuvable dans le stockage sont de nouveau consignés dans le manifeste de l'archive.
  * Les fichiers dont la taille est inconnue sont ignorés, avec un motif explicite.
  * Un fichier sans nom d'origine est classé sous son empreinte au lieu de faire échouer la génération.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
