### PR TITLE
fix(llm): conserve le chemin et le code de l'issue zod dans invalid_json

### DIFF
--- a/apps/backend/src/utils/llm/llm.errors.ts
+++ b/apps/backend/src/utils/llm/llm.errors.ts
@@ -1,5 +1,10 @@
+export type SchemaIssue = {
+  path: (string | number)[];
+  code: string;
+};
+
 export type LlmError =
   | { kind: 'rate_limited' }
   | { kind: 'truncated' }
-  | { kind: 'invalid_json'; rawTextLength: number }
+  | { kind: 'invalid_json'; rawTextLength: number; schemaIssue?: SchemaIssue }
   | { kind: 'api_error'; httpStatus: number | null };

--- a/apps/backend/src/utils/llm/parse-json-response.spec.ts
+++ b/apps/backend/src/utils/llm/parse-json-response.spec.ts
@@ -50,8 +50,8 @@ describe('parseStructuredResponse', () => {
     });
   });
 
-  it('renvoie invalid_json quand le JSON ne respecte pas le schema', () => {
-    const text = JSON.stringify({ titre: 'Action', score: 'pas un nombre' });
+  it('renvoie invalid_json sans detail de schema quand le texte n est pas du JSON', () => {
+    const text = 'pas du json {';
     const result = parseStructuredResponse({
       completed: true,
       text,
@@ -61,5 +61,53 @@ describe('parseStructuredResponse', () => {
       success: false,
       error: { kind: 'invalid_json', rawTextLength: text.length },
     });
+  });
+
+  it('porte le chemin et le code de la premiere issue quand le JSON ne respecte pas le schema', () => {
+    const text = JSON.stringify({ titre: 'Action', score: 'pas un nombre' });
+    const result = parseStructuredResponse({
+      completed: true,
+      text,
+      schema,
+    });
+    expect(result).toEqual({
+      success: false,
+      error: {
+        kind: 'invalid_json',
+        rawTextLength: text.length,
+        schemaIssue: { path: ['score'], code: 'invalid_type' },
+      },
+    });
+  });
+
+  it('porte le chemin complet d une issue imbriquee', () => {
+    const schemaImbrique = z.object({
+      volets: z.array(z.object({ levier: z.string() })),
+    });
+    const text = JSON.stringify({ volets: [{ levier: 12 }] });
+    const result = parseStructuredResponse({
+      completed: true,
+      text,
+      schema: schemaImbrique,
+    });
+    expect(result).toEqual({
+      success: false,
+      error: {
+        kind: 'invalid_json',
+        rawTextLength: text.length,
+        schemaIssue: { path: ['volets', 0, 'levier'], code: 'invalid_type' },
+      },
+    });
+  });
+
+  it('ne laisse pas fuiter la valeur recue du modele dans l erreur', () => {
+    const contenuDeFiche = 'renovation-thermique-des-ecoles-du-quartier-nord';
+    const text = JSON.stringify({ titre: 'Action', score: contenuDeFiche });
+    const result = parseStructuredResponse({
+      completed: true,
+      text,
+      schema,
+    });
+    expect(JSON.stringify(result)).not.toContain(contenuDeFiche);
   });
 });

--- a/apps/backend/src/utils/llm/parse-json-response.ts
+++ b/apps/backend/src/utils/llm/parse-json-response.ts
@@ -1,6 +1,6 @@
 import { failure, Result, success } from '@tet/backend/utils/result.type';
-import { z, ZodType } from 'zod';
-import { LlmError } from './llm.errors';
+import { z, ZodError, ZodType } from 'zod';
+import { LlmError, SchemaIssue } from './llm.errors';
 
 export const parseStructuredResponse = <Schema extends ZodType>(args: {
   completed: boolean;
@@ -24,10 +24,26 @@ export const parseStructuredResponse = <Schema extends ZodType>(args: {
 
   const validated = schema.safeParse(parsed.data);
   if (!validated.success) {
-    return failure({ kind: 'invalid_json', rawTextLength: text.length });
+    return failure({
+      kind: 'invalid_json',
+      rawTextLength: text.length,
+      schemaIssue: toSchemaIssue(validated.error),
+    });
   }
 
   return success(validated.data);
+};
+
+const isJsonPathSegment = (
+  segment: PropertyKey
+): segment is string | number => typeof segment !== 'symbol';
+
+const toSchemaIssue = (error: ZodError): SchemaIssue | undefined => {
+  const [issue] = error.issues;
+  if (!issue) {
+    return undefined;
+  }
+  return { path: issue.path.filter(isJsonPathSegment), code: issue.code };
 };
 
 const tryParseJson = (text: string): Result<unknown, 'invalid'> => {


### PR DESCRIPTION
## Le problème

Quand le modèle renvoie un JSON syntaxiquement valide mais hors schéma, `parseStructuredResponse` ne remonte que `rawTextLength`. Impossible de savoir quel champ a échoué : un mismatch de schéma en production n'est pas diagnosticable sans rejouer l'appel.

Ça devient bloquant dès qu'on contraint une sortie par une énumération fermée — le cas de la classification IA des fiches à venir, où le premier écart doit pouvoir être compris depuis un log.

## Ce que ça change

`LlmError` gagne un `schemaIssue` optionnel, renseigné **uniquement** quand un JSON valide sort du schéma :

```ts
export type SchemaIssue = { path: (string | number)[]; code: string };

| { kind: 'invalid_json'; rawTextLength: number; schemaIssue?: SchemaIssue }
```

Un texte non parsable ou vide ne porte pas de `schemaIssue` — l'absence de la clé dit l'absence de diagnostic de schéma.

## Ce qui n'y entre jamais

**Ni `issue.message`, ni `issue.received`.** Le message zod d'un échec de `z.enum` contient la valeur reçue, c'est-à-dire du texte produit par le modèle — potentiellement un écho du contenu d'une fiche. Or les erreurs partent automatiquement vers Sentry via `AllExceptionsFilter` et le hook `onError` de tRPC.

Le chemin et le code suffisent au diagnostic. Un test dédié le verrouille : il injecte une valeur reconnaissable dans le payload et vérifie qu'elle n'apparaît nulle part dans l'erreur sérialisée.

## Détail d'implémentation

Le filtrage des segments de chemin passe par un prédicat plutôt qu'une assertion : zod 4 type `issue.path` en `PropertyKey[]`, qui admet `symbol`, alors qu'un objet issu de `JSON.parse` n'a jamais de clé symbole.

## Ce que ça ne change pas

La politique de retry. `invalid_json` reste non transitoire, `isTransientError` est inchangé.

## Vérifications

- **Tests** : 16 verts sur `utils/llm/`. Les deux commits sont séparés — le premier ajoute les tests et **est rouge** (2 échecs, `schemaIssue` absent), le second les fait passer.
- **Typecheck** : aucune erreur introduite.
- **Lint** : propre.

https://claude.ai/code/session_01SfuG57CHgUMgKi5wwBurUz
