### PR TITLE
fix(referentiels): cloisonne par collectivité la lecture des documents d'audit et de demande

### DIFF
--- a/apps/backend/src/referentiels/documents/documents-labellisation.test-fixture.ts
+++ b/apps/backend/src/referentiels/documents/documents-labellisation.test-fixture.ts
@@ -68,6 +68,7 @@ export const createCollectiviteAvecCycle = async ({
     collectiviteId: collectivite.id,
     auditId: audit.id,
     demandeId: demande.id,
+    membreId: membre.id,
     membreCaller,
 
     deposeUnDocumentDeDemande: (document?: {
@@ -106,6 +107,8 @@ export const createCollectiviteAvecCycle = async ({
         commentaire: '',
         modifiedBy: membre.id,
       });
+
+      return fichier;
     },
   };
 };

--- a/apps/backend/src/referentiels/documents/list-documents-audit/list-documents-audit.repository.ts
+++ b/apps/backend/src/referentiels/documents/list-documents-audit/list-documents-audit.repository.ts
@@ -16,6 +16,7 @@ import { labellisationDemandeTable } from '../../labellisations/labellisation-de
 import { ListDocumentsAuditErrorEnum } from './list-documents-audit.errors';
 
 type AuditScope = {
+  collectiviteId: number;
   auditId: number;
   canReadConfidentiel: boolean;
 };
@@ -26,7 +27,11 @@ export class ListDocumentsAuditRepository {
 
   constructor(private readonly databaseService: DatabaseService) {}
 
-  async listDocumentsAudit({ auditId, canReadConfidentiel }: AuditScope) {
+  async listDocumentsAudit({
+    collectiviteId,
+    auditId,
+    canReadConfidentiel,
+  }: AuditScope) {
     const db = this.databaseService.db;
     const fichier = buildFichierSubquery(db);
 
@@ -52,7 +57,13 @@ export class ListDocumentsAuditRepository {
           preuveType: sql<'audit'>`'audit'`,
         })
         .from(preuveAuditTable)
-        .leftJoin(fichier, eq(preuveAuditTable.fichierId, fichier.id))
+        .leftJoin(
+          fichier,
+          and(
+            eq(preuveAuditTable.fichierId, fichier.id),
+            eq(fichier.collectiviteId, collectiviteId)
+          )
+        )
         .innerJoin(auditTable, eq(preuveAuditTable.auditId, auditTable.id))
         .leftJoin(
           labellisationDemandeTable,
@@ -62,6 +73,7 @@ export class ListDocumentsAuditRepository {
         .where(
           and(
             eq(preuveAuditTable.auditId, auditId),
+            eq(preuveAuditTable.collectiviteId, collectiviteId),
             hideConfidentielFilter({
               fichierIdColumn: preuveAuditTable.fichierId,
               confidentielColumn: fichier.confidentiel,

--- a/apps/backend/src/referentiels/documents/list-documents-audit/list-documents-audit.router.e2e-spec.ts
+++ b/apps/backend/src/referentiels/documents/list-documents-audit/list-documents-audit.router.e2e-spec.ts
@@ -7,6 +7,7 @@ import {
   getTestDatabase,
 } from '@tet/backend/test';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { preuveAuditTable } from '@tet/backend/collectivites/documents/models/preuve-audit.table';
 import { addTestUser } from '@tet/backend/users/users/users.test-fixture';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
@@ -77,6 +78,53 @@ describe('List Documents Audit Router', () => {
     ).rejects.toThrow(
       "Vous n'avez pas les permissions nécessaires pour lister les documents de cet audit."
     );
+  });
+
+  test("n'expose pas le document d'une autre collectivite reference par une preuve d'audit", async () => {
+    const cycle = await createCollectiviteAvecCycle({
+      db,
+      router,
+      app,
+      accesRestreint: false,
+    });
+    const otherCycle = await createCollectiviteAvecCycle({
+      db,
+      router,
+      app,
+      accesRestreint: false,
+    });
+
+    await cycle.deposeUnDocumentDAudit({ fileName: 'audit-legitime.pdf' });
+    const fichierFromOtherCollectivite = await otherCycle.deposeUnDocumentDAudit({
+      fileName: 'audit-autre-collectivite.pdf',
+      sampleFileName: OTHER_PDF_SAMPLE_FILE,
+    });
+
+    await db.db.insert(preuveAuditTable).values([
+      {
+        collectiviteId: cycle.collectiviteId,
+        auditId: cycle.auditId,
+        fichierId: fichierFromOtherCollectivite.id,
+        commentaire: '',
+        modifiedBy: cycle.membreId,
+      },
+      {
+        collectiviteId: otherCycle.collectiviteId,
+        auditId: cycle.auditId,
+        fichierId: fichierFromOtherCollectivite.id,
+        commentaire: '',
+        modifiedBy: otherCycle.membreId,
+      },
+    ]);
+
+    const documents =
+      await cycle.membreCaller.referentiels.documents.listDocumentsAudit({
+        auditId: cycle.auditId,
+      });
+
+    const filenames = documents.map((document) => document.fichier?.filename);
+    expect(filenames).toContain('audit-legitime.pdf');
+    expect(filenames).not.toContain('audit-autre-collectivite.pdf');
   });
 
   test("masque les documents d'audit confidentiels a un utilisateur non membre", async () => {

--- a/apps/backend/src/referentiels/documents/list-documents-audit/list-documents-audit.service.spec.ts
+++ b/apps/backend/src/referentiels/documents/list-documents-audit/list-documents-audit.service.spec.ts
@@ -36,8 +36,9 @@ const documentSansAudit = {
 };
 
 function buildService(documents: unknown[]) {
-  return new ListDocumentsAuditService(
-    { listDocumentsAudit: vi.fn().mockResolvedValue(success(documents)) } as never,
+  const listDocumentsAudit = vi.fn().mockResolvedValue(success(documents));
+  const service = new ListDocumentsAuditService(
+    { listDocumentsAudit } as never,
     { getAudit: vi.fn().mockResolvedValue(success(audit)) } as never,
     {
       checkUserCanReadDocuments: vi
@@ -45,11 +46,25 @@ function buildService(documents: unknown[]) {
         .mockResolvedValue(success({ canReadConfidentiel: true })),
     } as never
   );
+
+  return { service, listDocumentsAudit };
 }
 
 describe('ListDocumentsAuditService', () => {
+  it("transmet au repository la collectivité portée par l'audit chargé", async () => {
+    const { service, listDocumentsAudit } = buildService([]);
+
+    await service.listDocumentsAudit({ auditId: 10 }, user);
+
+    expect(listDocumentsAudit).toHaveBeenCalledWith({
+      collectiviteId: audit.collectiviteId,
+      auditId: 10,
+      canReadConfidentiel: true,
+    });
+  });
+
   it("refuse un document d'audit dont l'audit manque, au lieu de le rendre", async () => {
-    const service = buildService([documentSansAudit]);
+    const { service } = buildService([documentSansAudit]);
 
     const result = await service.listDocumentsAudit({ auditId: 10 }, user);
 

--- a/apps/backend/src/referentiels/documents/list-documents-audit/list-documents-audit.service.ts
+++ b/apps/backend/src/referentiels/documents/list-documents-audit/list-documents-audit.service.ts
@@ -62,7 +62,11 @@ export class ListDocumentsAuditService {
     const { canReadConfidentiel } = accessResult.data;
 
     const documents = await this.listDocumentsAuditRepository.listDocumentsAudit(
-      { auditId, canReadConfidentiel }
+      {
+        collectiviteId: auditData.collectiviteId,
+        auditId,
+        canReadConfidentiel,
+      }
     );
     if (!documents.success) {
       return documents;

--- a/apps/backend/src/referentiels/documents/list-documents-demande-labellisation/list-documents-demande-labellisation.repository.ts
+++ b/apps/backend/src/referentiels/documents/list-documents-demande-labellisation/list-documents-demande-labellisation.repository.ts
@@ -15,6 +15,7 @@ import { labellisationDemandeTable } from '../../labellisations/labellisation-de
 import { ListDocumentsDemandeLabellisationErrorEnum } from './list-documents-demande-labellisation.errors';
 
 type DemandeScope = {
+  collectiviteId: number;
   demandeId: number;
   canReadConfidentiel: boolean;
 };
@@ -28,6 +29,7 @@ export class ListDocumentsDemandeLabellisationRepository {
   constructor(private readonly databaseService: DatabaseService) {}
 
   async listDocumentsDemandeLabellisation({
+    collectiviteId,
     demandeId,
     canReadConfidentiel,
   }: DemandeScope) {
@@ -50,7 +52,13 @@ export class ListDocumentsDemandeLabellisationRepository {
           preuveType: sql<'labellisation'>`'labellisation'`,
         })
         .from(preuveLabellisationTable)
-        .leftJoin(fichier, eq(preuveLabellisationTable.fichierId, fichier.id))
+        .leftJoin(
+          fichier,
+          and(
+            eq(preuveLabellisationTable.fichierId, fichier.id),
+            eq(fichier.collectiviteId, collectiviteId)
+          )
+        )
         .leftJoin(
           labellisationDemandeTable,
           eq(preuveLabellisationTable.demandeId, labellisationDemandeTable.id)
@@ -62,6 +70,7 @@ export class ListDocumentsDemandeLabellisationRepository {
         .where(
           and(
             eq(preuveLabellisationTable.demandeId, demandeId),
+            eq(preuveLabellisationTable.collectiviteId, collectiviteId),
             hideConfidentielFilter({
               fichierIdColumn: preuveLabellisationTable.fichierId,
               confidentielColumn: fichier.confidentiel,

--- a/apps/backend/src/referentiels/documents/list-documents-demande-labellisation/list-documents-demande-labellisation.router.e2e-spec.ts
+++ b/apps/backend/src/referentiels/documents/list-documents-demande-labellisation/list-documents-demande-labellisation.router.e2e-spec.ts
@@ -9,6 +9,7 @@ import {
   signInWith,
 } from '@tet/backend/test';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { preuveLabellisationTable } from '@tet/backend/collectivites/documents/models/preuve-labellisation.table';
 import { addTestUser } from '@tet/backend/users/users/users.test-fixture';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
@@ -111,6 +112,55 @@ describe('List Documents Demande Labellisation Router', () => {
     ).rejects.toThrow(
       "Vous n'avez pas les permissions nécessaires pour lister les documents de cette demande."
     );
+  });
+
+  test("n'expose pas le document d'une autre collectivite reference par une preuve de demande", async () => {
+    const cycle = await createCollectiviteAvecCycle({
+      db,
+      router,
+      app,
+      accesRestreint: false,
+    });
+    const otherCycle = await createCollectiviteAvecCycle({
+      db,
+      router,
+      app,
+      accesRestreint: false,
+    });
+
+    await cycle.deposeUnDocumentDeDemande({ fileName: 'demande-legitime.pdf' });
+    const preuveFromOtherCollectivite = await otherCycle.deposeUnDocumentDeDemande(
+      {
+        fileName: 'demande-autre-collectivite.pdf',
+        sampleFileName: OTHER_PDF_SAMPLE_FILE,
+      }
+    );
+
+    await db.db.insert(preuveLabellisationTable).values([
+      {
+        collectiviteId: cycle.collectiviteId,
+        demandeId: cycle.demandeId,
+        fichierId: preuveFromOtherCollectivite.fichierId,
+        commentaire: '',
+        modifiedBy: cycle.membreId,
+      },
+      {
+        collectiviteId: otherCycle.collectiviteId,
+        demandeId: cycle.demandeId,
+        fichierId: preuveFromOtherCollectivite.fichierId,
+        commentaire: '',
+        modifiedBy: otherCycle.membreId,
+      },
+    ]);
+
+    const documents =
+      await cycle.membreCaller.referentiels.documents.listDocumentsDemandeLabellisation(
+        { demandeId: cycle.demandeId }
+      );
+
+    const filenames = documents.map((document) => document.fichier?.filename);
+    expect(filenames).toContain('demande-legitime.pdf');
+    expect(filenames).not.toContain('demande-autre-collectivite.pdf');
   });
 
   test('masque les documents confidentiels a un utilisateur non membre', async () => {

--- a/apps/backend/src/referentiels/documents/list-documents-demande-labellisation/list-documents-demande-labellisation.service.spec.ts
+++ b/apps/backend/src/referentiels/documents/list-documents-demande-labellisation/list-documents-demande-labellisation.service.spec.ts
@@ -36,12 +36,11 @@ const documentSansDemande = {
 };
 
 function buildService(documents: unknown[]) {
-  return new ListDocumentsDemandeLabellisationService(
-    {
-      listDocumentsDemandeLabellisation: vi
-        .fn()
-        .mockResolvedValue(success(documents)),
-    } as never,
+  const listDocumentsDemandeLabellisation = vi
+    .fn()
+    .mockResolvedValue(success(documents));
+  const service = new ListDocumentsDemandeLabellisationService(
+    { listDocumentsDemandeLabellisation } as never,
     { getDemande: vi.fn().mockResolvedValue(success(demande)) } as never,
     {
       checkUserCanReadDocuments: vi
@@ -49,11 +48,25 @@ function buildService(documents: unknown[]) {
         .mockResolvedValue(success({ canReadConfidentiel: true })),
     } as never
   );
+
+  return { service, listDocumentsDemandeLabellisation };
 }
 
 describe('ListDocumentsDemandeLabellisationService', () => {
+  it('transmet au repository la collectivité portée par la demande chargée', async () => {
+    const { service, listDocumentsDemandeLabellisation } = buildService([]);
+
+    await service.listDocumentsDemandeLabellisation({ demandeId: 20 }, user);
+
+    expect(listDocumentsDemandeLabellisation).toHaveBeenCalledWith({
+      collectiviteId: demande.collectiviteId,
+      demandeId: 20,
+      canReadConfidentiel: true,
+    });
+  });
+
   it('refuse un document de labellisation sans demande, au lieu de le rendre', async () => {
-    const service = buildService([documentSansDemande]);
+    const { service } = buildService([documentSansDemande]);
 
     const result = await service.listDocumentsDemandeLabellisation(
       { demandeId: 20 },

--- a/apps/backend/src/referentiels/documents/list-documents-demande-labellisation/list-documents-demande-labellisation.service.ts
+++ b/apps/backend/src/referentiels/documents/list-documents-demande-labellisation/list-documents-demande-labellisation.service.ts
@@ -72,7 +72,11 @@ export class ListDocumentsDemandeLabellisationService {
 
     const documents =
       await this.listDocumentsDemandeLabellisationRepository.listDocumentsDemandeLabellisation(
-        { demandeId, canReadConfidentiel }
+        {
+          collectiviteId: demande.collectiviteId,
+          demandeId,
+          canReadConfidentiel,
+        }
       );
     if (!documents.success) {
       return documents;


### PR DESCRIPTION
## Le problème

`listDocumentsAudit` et `listDocumentsDemandeLabellisation` joignent la sous-requête `fichier` sans prédicat de collectivité, et ne filtrent la table de preuve que sur `auditId` / `demandeId`. Le backend interroge la base en service role, donc sans RLS.

```ts
.leftJoin(fichier, eq(preuveAuditTable.fichierId, fichier.id))   // aucun prédicat
.where(and(
  eq(preuveAuditTable.auditId, auditId),                          // seul filtre
  hideConfidentielFilter({ ... })
))
```

`list-documents-mesure.repository.ts` et `list-documents-referentiel.repository.ts` portent tous deux les prédicats. Ces deux-là ne les ont jamais eus.

## Le chemin d'attaque

Aucune clé étrangère, aucun `CHECK`, aucun trigger ne contraint `preuve_audit.fichier_id` — `document.basetable.ts` le dit lui-même (« référence indirectement »). Et la policy d'insertion ne le contrôle pas :

```sql
allow_insert on preuve_audit with check (
  have_edition_acces(collectivite_id) or est_auditeur_audit(audit_id))
```

Le schéma `public` est exposé à PostgREST et le front insère en direct (`useAddPreuves.ts:92-103`). Un utilisateur en accès édition sur la collectivité A poste donc `{ collectivite_id: A, audit_id: <audit de A>, fichier_id: N }`, puis appelle `listDocumentsAudit`. L'autorisation porte sur la collectivité de l'audit — A — et passe légitimement. La réponse contient `filename`, `hash`, `bucketId`, `filesize` et `confidentiel` du fichier `N`, **quelle que soit sa collectivité**.

`labellisation.bibliotheque_fichier.id` est un `serial` : `N` est énumérable. C'était un oracle sur toute la table, contournant les deux clauses de sécurité de la vue `public.bibliotheque_fichier` — `can_read_acces_restreint` et le filtre `confidentiel`.

Les octets, eux, restent hors d'atteinte : `DocumentService.downloadFile` filtre sur la collectivité du chemin et refait l'`assertAllowed`. La fuite porte sur les **métadonnées**, dont les noms de fichiers — rarement anodins sur des pièces d'audit.

## Le correctif

Les deux prédicats, sur le modèle de `list-documents-mesure` :

```ts
.leftJoin(fichier, and(
  eq(preuveAuditTable.fichierId, fichier.id),
  eq(fichier.collectiviteId, collectiviteId)
))
.where(and(
  eq(preuveAuditTable.auditId, auditId),
  eq(preuveAuditTable.collectiviteId, collectiviteId),
  hideConfidentielFilter({ ... })
))
```

Celui du `WHERE` n'est pas redondant : il ferme une seconde voie. La branche `est_auditeur_audit(audit_id)` de la policy ne vérifie que l'audit, donc un auditeur peut insérer une ligne portant un `collectivite_id` arbitraire. Il satisfait au passage la règle IDOR d'`apps/backend/CLAUDE.md`.

Le `collectiviteId` descend de l'entité déjà chargée par le service — `auditData.collectiviteId`, `demande.collectiviteId` — c'est-à-dire celle sur laquelle porte le contrôle d'accès. Il ne vient jamais de l'appelant, et aucune signature d'entrée ne change.

## Tests

Un e2e par endpoint. Chacun monte deux collectivités, dépose un document légitime dans la première, puis injecte **deux** preuves empoisonnées pointant vers le fichier de la seconde : l'une avec le `collectivite_id` de la collectivité testée — vecteur de la jointure — l'autre avec celui de l'étrangère — vecteur du `WHERE`. Chaque test vérifie que le document légitime est présent **et** que le nom du document étranger ne l'est pas.

Une garde unitaire par service assert l'objet d'appel exact transmis au repository. Elle échoue sur l'appel d'avant le correctif, à qui il manque le `collectiviteId`.

Deux ajouts au fixture `createCollectiviteAvecCycle` : il expose `membreId`, et `deposeUnDocumentDAudit` rend le fichier déposé au lieu de le jeter.

## Constat consigné hors périmètre

Une preuve dont la jointure fichier échoue **reste dans la liste** avec `fichier: null` — les schémas zod déclarent `fichier` nullable. Cela vaut pour les sept requêtes bâties sur `buildFichierSubquery`, et a une conséquence réelle côté demande, où le front traite `preuves[0]` comme l'acte d'engagement.

Le correctif évident — `or(isNull(fichierId), isNotNull(fichier.id))` — masquerait aussi les documents légitimes dont l'objet de stockage a disparu, ce que #4946 vient précisément de rendre visible. Le prédicat devrait porter sur l'existence de la ligne `bibliotheque_fichier` de la collectivité, pas sur la résolution en stockage. Consigné dans `DISCOVERED` plutôt que traité ici.

## Vérification locale

Les e2e de ces deux fichiers ne tournent pas en local, y compris les préexistants : `signInWith` rend une session vide car `dotenvx` ne déchiffre pas `SUPABASE_ANON_KEY` ni `SUPABASE_JWT_SECRET`, et l'upload répond `401`. La CI est la seule boucle de feedback sur ces tests.
