### PR TITLE
refactor(plans): applique la convention ServiceSecondArg aux services du domaine

### DIFF
--- a/apps/backend/src/demarches/pcaet/create-and-link-plan/create-and-link-plan.service.ts
+++ b/apps/backend/src/demarches/pcaet/create-and-link-plan/create-and-link-plan.service.ts
@@ -130,8 +130,7 @@ export class CreateAndLinkPlanService {
           dateDebut: input.dateDebut,
           dateFin: input.dateFin,
         },
-        user,
-        transaction
+        { user, tx: transaction }
       );
       if (!planResult.success) {
         return failure(

--- a/apps/backend/src/metrics/collectivites/collectivites-modules.service.ts
+++ b/apps/backend/src/metrics/collectivites/collectivites-modules.service.ts
@@ -190,7 +190,7 @@ export class CollectivitesModulesService {
     } else if (request.defaultKey) {
       const planActionIdsResult = await this.listPlansService.listPlans(
         { collectiviteId: request.collectiviteId },
-        authUser
+        { user: authUser }
       );
       const planActionIds = planActionIdsResult.success
         ? planActionIdsResult.data.plans.map((plan) => plan.id)
@@ -219,7 +219,7 @@ export class CollectivitesModulesService {
   ) {
     const planActionIdsResult = await this.listPlansService.listPlans(
       { collectiviteId },
-      authUser
+      { user: authUser }
     );
 
     const planActionIds = planActionIdsResult.success

--- a/apps/backend/src/plans/axes/delete-axe/delete-axe.router.ts
+++ b/apps/backend/src/plans/axes/delete-axe/delete-axe.router.ts
@@ -18,8 +18,8 @@ export class DeleteAxeRouter {
   router = this.trpc.router({
     delete: this.trpc.authedProcedure
       .input(deleteAxeInputSchema)
-      .mutation(async ({ input, ctx }) => {
-        const result = await this.deleteAxeService.deleteAxe(input, ctx.user);
+      .mutation(async ({ input, ctx: { user } }) => {
+        const result = await this.deleteAxeService.deleteAxe(input, { user });
         return this.getResultDataOrThrowError(result);
       }),
   });

--- a/apps/backend/src/plans/axes/delete-axe/delete-axe.service.ts
+++ b/apps/backend/src/plans/axes/delete-axe/delete-axe.service.ts
@@ -1,7 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
-import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
-import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { ServiceSecondArg } from '@tet/backend/utils/nest/service-second-arg.utils';
 import { Result } from '@tet/backend/utils/result.type';
 import { PermissionOperationEnum, ResourceType } from '@tet/domain/users';
 import { GetAxeErrorEnum } from '../get-axe/get-axe.errors';
@@ -24,14 +23,12 @@ export class DeleteAxeService {
 
   async deleteAxe(
     input: DeleteAxeInput,
-    user: AuthenticatedUser,
-    tx?: Transaction
+    { user, tx }: ServiceSecondArg
   ): Promise<Result<void, DeleteAxeError>> {
     // Récupérer l'axe pour obtenir le collectiviteId
     const axeResult = await this.getAxeService.getAxe(
       { axeId: input.axeId },
-      user,
-      tx
+      { user, tx }
     );
 
     if (!axeResult.success) {

--- a/apps/backend/src/plans/axes/get-axe/get-axe.router.ts
+++ b/apps/backend/src/plans/axes/get-axe/get-axe.router.ts
@@ -18,8 +18,8 @@ export class GetAxeRouter {
   router = this.trpc.router({
     get: this.trpc.authedProcedure
       .input(getAxeInputSchema)
-      .query(async ({ input, ctx }) => {
-        const result = await this.getAxeService.getAxe(input, ctx.user);
+      .query(async ({ input, ctx: { user } }) => {
+        const result = await this.getAxeService.getAxe(input, { user });
         return this.getResultDataOrThrowError(result);
       }),
   });

--- a/apps/backend/src/plans/axes/get-axe/get-axe.service.ts
+++ b/apps/backend/src/plans/axes/get-axe/get-axe.service.ts
@@ -4,6 +4,7 @@ import { PermissionService } from '@tet/backend/users/authorizations/permission.
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { ServiceSecondArg } from '@tet/backend/utils/nest/service-second-arg.utils';
 import { Result } from '@tet/backend/utils/result.type';
 import { ResourceType } from '@tet/domain/users';
 import { AxeLight } from '@tet/domain/plans';
@@ -25,8 +26,7 @@ export class GetAxeService {
 
   async getAxe(
     input: GetAxeInput,
-    user: AuthenticatedUser,
-    tx?: Transaction
+    { user, tx }: ServiceSecondArg
   ): Promise<Result<GetAxeOutput, GetAxeError>> {
     const executeInTransaction = async (
       transaction: Transaction
@@ -81,8 +81,7 @@ export class GetAxeService {
 
   async getAxesChemins(
     axeIds: number[],
-    user: AuthenticatedUser,
-    tx?: Transaction
+    { user, tx }: ServiceSecondArg
   ): Promise<Result<Record<number, AxeLight[]>, GetAxeError>> {
     if (axeIds.length === 0) {
       return { success: true, data: {} };

--- a/apps/backend/src/plans/axes/list-axes/list-axes.router.ts
+++ b/apps/backend/src/plans/axes/list-axes/list-axes.router.ts
@@ -18,16 +18,16 @@ export class ListAxesRouter {
   router = this.trpc.router({
     list: this.trpc.authedProcedure
       .input(listAxesInputSchema)
-      .query(async ({ input, ctx }) => {
-        const result = await this.listAxesService.listAxes(input, ctx.user);
+      .query(async ({ input, ctx: { user } }) => {
+        const result = await this.listAxesService.listAxes(input, { user });
         return this.getResultDataOrThrowError(result);
       }),
     listRecursively: this.trpc.authedProcedure
       .input(listAxesInputSchema)
-      .query(async ({ input, ctx }) => {
+      .query(async ({ input, ctx: { user } }) => {
         const result = await this.listAxesService.listAxesRecursively(
           input,
-          ctx.user
+          user
         );
         return this.getResultDataOrThrowError(result);
       }),

--- a/apps/backend/src/plans/axes/list-axes/list-axes.service.ts
+++ b/apps/backend/src/plans/axes/list-axes/list-axes.service.ts
@@ -3,6 +3,7 @@ import CollectivitesService from '@tet/backend/collectivites/services/collectivi
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { ServiceSecondArg } from '@tet/backend/utils/nest/service-second-arg.utils';
 import { Result } from '@tet/backend/utils/result.type';
 import { PlanNode } from '@tet/domain/plans';
 import { ResourceType } from '@tet/domain/users';
@@ -22,10 +23,12 @@ export class ListAxesService {
 
   async listAxes(
     input: ListAxesInput,
-    user: AuthenticatedUser,
-    tx?: Transaction
+    { user, tx }: ServiceSecondArg
   ): Promise<Result<ListAxesOutput, ListAxesError>> {
-    const permissionResult = await this.checkPermission(input.collectiviteId, user);
+    const permissionResult = await this.checkPermission(
+      input.collectiviteId,
+      user
+    );
     if (!permissionResult) {
       return {
         success: false,
@@ -42,7 +45,10 @@ export class ListAxesService {
     tx?: Transaction
   ): Promise<Result<PlanNode[], ListAxesError>> {
     if (user) {
-      const permissionResult = await this.checkPermission(input.collectiviteId, user);
+      const permissionResult = await this.checkPermission(
+        input.collectiviteId,
+        user
+      );
       if (!permissionResult) {
         return {
           success: false,

--- a/apps/backend/src/plans/axes/upsert-axe/upsert-axe.router.ts
+++ b/apps/backend/src/plans/axes/upsert-axe/upsert-axe.router.ts
@@ -18,14 +18,14 @@ export class UpsertAxeRouter {
   router = this.trpc.router({
     create: this.trpc.authedProcedure
       .input(createAxeSchema)
-      .mutation(async ({ input, ctx }) => {
-        const result = await this.upsertAxeService.upsertAxe(input, ctx.user);
+      .mutation(async ({ input, ctx: { user } }) => {
+        const result = await this.upsertAxeService.upsertAxe(input, { user });
         return this.getResultDataOrThrowError(result);
       }),
     update: this.trpc.authedProcedure
       .input(updateAxeSchema)
-      .mutation(async ({ input, ctx }) => {
-        const result = await this.upsertAxeService.upsertAxe(input, ctx.user);
+      .mutation(async ({ input, ctx: { user } }) => {
+        const result = await this.upsertAxeService.upsertAxe(input, { user });
         return this.getResultDataOrThrowError(result);
       }),
   });

--- a/apps/backend/src/plans/axes/upsert-axe/upsert-axe.service.ts
+++ b/apps/backend/src/plans/axes/upsert-axe/upsert-axe.service.ts
@@ -1,8 +1,8 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
-import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { ServiceSecondArg } from '@tet/backend/utils/nest/service-second-arg.utils';
 import { Result } from '@tet/backend/utils/result.type';
 import { AxeLight } from '@tet/domain/plans';
 import { PermissionOperationEnum, ResourceType } from '@tet/domain/users';
@@ -26,8 +26,7 @@ export class UpsertAxeService {
 
   async upsertAxe(
     axe: UpsertAxeInput,
-    user: AuthenticatedUser,
-    tx?: Transaction
+    { user, tx }: ServiceSecondArg
   ): Promise<Result<AxeLight, UpsertAxeError>> {
     const permissionResult = await this.permissionService.isAllowed(
       user,

--- a/apps/backend/src/plans/fiches/add-annexe/add-annexe.router.ts
+++ b/apps/backend/src/plans/fiches/add-annexe/add-annexe.router.ts
@@ -19,7 +19,7 @@ export class AddAnnexeRouter {
       .input(addAnnexeInputSchema)
       .output(annexeSchema)
       .mutation(async ({ input, ctx: { user } }) => {
-        const result = await this.addAnnexeService.addAnnexe(input, user);
+        const result = await this.addAnnexeService.addAnnexe(input, { user });
         return this.getResultDataOrThrowError(result);
       }),
   });

--- a/apps/backend/src/plans/fiches/add-annexe/add-annexe.service.ts
+++ b/apps/backend/src/plans/fiches/add-annexe/add-annexe.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import FicheActionPermissionsService from '@tet/backend/plans/fiches/fiche-action-permissions.service';
-import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { ServiceSecondArg } from '@tet/backend/utils/nest/service-second-arg.utils';
 import { failure, Result } from '@tet/backend/utils/result.type';
 import { CommonErrorEnum } from '@tet/backend/utils/trpc/common-errors';
 import { Annexe } from '@tet/domain/collectivites';
@@ -22,7 +22,7 @@ export class AddAnnexeService {
 
   async addAnnexe(
     input: AddAnnexeInput,
-    user: AuthenticatedUser
+    { user }: ServiceSecondArg
   ): Promise<Result<Annexe, AddAnnexeError>> {
     const { ficheId } = input;
 

--- a/apps/backend/src/plans/fiches/duplicate-fiche/duplicate-fiche.router.ts
+++ b/apps/backend/src/plans/fiches/duplicate-fiche/duplicate-fiche.router.ts
@@ -19,8 +19,8 @@ export class DuplicateFicheRouter {
   router = this.trpc.router({
     duplicate: this.trpc.authedProcedure
       .input(duplicateFicheInputSchema)
-      .mutation(async ({ input, ctx }) => {
-        const result = await this.service.duplicate(input, ctx.user);
+      .mutation(async ({ input, ctx: { user } }) => {
+        const result = await this.service.duplicate(input, { user });
         return this.getResultDataOrThrowError(result);
       }),
   });

--- a/apps/backend/src/plans/fiches/duplicate-fiche/duplicate-fiche.service.ts
+++ b/apps/backend/src/plans/fiches/duplicate-fiche/duplicate-fiche.service.ts
@@ -9,6 +9,7 @@ import { Transaction } from '@tet/backend/utils/database/transaction.utils';
 import { failure, Result, success } from '@tet/backend/utils/result.type';
 import { TransactionManager } from '@tet/backend/utils/transaction/transaction-manager.service';
 import { AxeIdRemapping } from '@tet/backend/plans/plans/duplicate-plan/duplicated-fiche.mapper';
+import { ServiceSecondArg } from '@tet/backend/utils/nest/service-second-arg.utils';
 import { FicheWithRelations } from '@tet/domain/plans';
 import {
   DuplicateFicheError,
@@ -39,8 +40,7 @@ export class DuplicateFicheService {
 
   async duplicate(
     { ficheId }: DuplicateFicheInput,
-    user: AuthenticatedUser,
-    tx?: Transaction
+    { user, tx }: ServiceSecondArg
   ): Promise<Result<{ ficheId: number }, DuplicateFicheError>> {
     return this.transactionManager.executeSingle<
       { ficheId: number },

--- a/apps/backend/src/plans/fiches/fiche-action-budget/fiche-action-budget.router.ts
+++ b/apps/backend/src/plans/fiches/fiche-action-budget/fiche-action-budget.router.ts
@@ -17,18 +17,18 @@ export class FicheActionBudgetRouter {
     budgets: {
       upsert: this.trpc.authedProcedure
         .input(z.array(ficheBudgetCreateSchema))
-        .mutation(({ ctx, input }) => {
-          return this.service.upsert(input, ctx.user);
+        .mutation(({ ctx: { user }, input }) => {
+          return this.service.upsert(input, { user });
         }),
       delete: this.trpc.authedProcedure
         .input(deleteBudgetsInputSchema)
-        .mutation(({ ctx, input }) => {
-          return this.service.delete(input.ficheId, input.budgetsIds, ctx.user);
+        .mutation(({ ctx: { user }, input }) => {
+          return this.service.delete(input.ficheId, input.budgetsIds, { user });
         }),
       list: this.trpc.authedProcedure
         .input(getBudgetsRequestSchema)
-        .query(({ ctx, input }) => {
-          return this.service.listBudgets(input, ctx.user);
+        .query(({ ctx: { user }, input }) => {
+          return this.service.listBudgets(input, user);
         }),
     },
   });

--- a/apps/backend/src/plans/fiches/fiche-action-budget/fiche-action-budget.service.ts
+++ b/apps/backend/src/plans/fiches/fiche-action-budget/fiche-action-budget.service.ts
@@ -3,12 +3,10 @@ import { ficheActionBudgetTable } from '@tet/backend/plans/fiches/fiche-action-b
 import { getBudgetsRequest } from '@tet/backend/plans/fiches/fiche-action-budget/get-budgets.request';
 import FicheActionPermissionsService from '@tet/backend/plans/fiches/fiche-action-permissions.service';
 import { ficheActionTable } from '@tet/backend/plans/fiches/shared/models/fiche-action.table';
-import {
-  AuthenticatedUser,
-  AuthUser,
-} from '@tet/backend/users/models/auth.models';
+import { AuthUser } from '@tet/backend/users/models/auth.models';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { ServiceSecondArg } from '@tet/backend/utils/nest/service-second-arg.utils';
 import { failure, Result, success } from '@tet/backend/utils/result.type';
 import {
   assertNoDuplicateBudgets,
@@ -120,7 +118,7 @@ export class FicheActionBudgetService {
 
   async upsert(
     budgets: FicheBudgetCreate[],
-    user: AuthenticatedUser
+    { user }: ServiceSecondArg
   ): Promise<FicheBudget[]> {
     if (budgets.length === 0) {
       return [];
@@ -163,7 +161,11 @@ export class FicheActionBudgetService {
     }
   }
 
-  async delete(ficheId: number, budgetsIds: number[], user: AuthenticatedUser) {
+  async delete(
+    ficheId: number,
+    budgetsIds: number[],
+    { user }: ServiceSecondArg
+  ) {
     if (budgetsIds.length === 0) {
       return;
     }

--- a/apps/backend/src/plans/fiches/fiche-action-pdf-export/fiche-export-payload.service.ts
+++ b/apps/backend/src/plans/fiches/fiche-action-pdf-export/fiche-export-payload.service.ts
@@ -86,7 +86,7 @@ export class FicheExportPayloadService {
       return [];
     }
 
-    const result = await this.getAxeService.getAxesChemins(axeIds, user);
+    const result = await this.getAxeService.getAxesChemins(axeIds, { user });
     if (!result.success) {
       this.logger.warn(
         `Impossible de charger les chemins pour la fiche ${fiche.id} : ${result.error}`
@@ -181,7 +181,7 @@ export class FicheExportPayloadService {
         collectiviteId: fiche.collectiviteId,
         ficheIds: [fiche.id],
       },
-      user
+      { user }
     );
     if (!result.success) {
       this.logger.warn(

--- a/apps/backend/src/plans/fiches/fiche-annexes/fiche-annexes.router.ts
+++ b/apps/backend/src/plans/fiches/fiche-annexes/fiche-annexes.router.ts
@@ -18,8 +18,8 @@ export class FicheAnnexesRouter {
     ficheAnnexes: this.trpc.authedProcedure
       .input(ficheAnnexesInputSchema)
       .output(ficheAnnexesOutputSchema)
-      .query(async ({ input, ctx }) => {
-        const result = await this.service.listForFiches(input, ctx.user);
+      .query(async ({ input, ctx: { user } }) => {
+        const result = await this.service.listForFiches(input, { user });
         return this.getResultDataOrThrowError(result);
       }),
   });

--- a/apps/backend/src/plans/fiches/fiche-annexes/fiche-annexes.service.ts
+++ b/apps/backend/src/plans/fiches/fiche-annexes/fiche-annexes.service.ts
@@ -6,7 +6,7 @@ import {
 } from '@nestjs/common';
 import FicheActionPermissionsService from '@tet/backend/plans/fiches/fiche-action-permissions.service';
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
-import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { ServiceSecondArg } from '@tet/backend/utils/nest/service-second-arg.utils';
 import { failure, Result, success } from '@tet/backend/utils/result.type';
 import {
   CommonError,
@@ -34,7 +34,7 @@ export class FicheAnnexesService {
 
   async listForFiches(
     input: FicheAnnexesInput,
-    user: AuthenticatedUser
+    { user }: ServiceSecondArg
   ): Promise<Result<FicheAnnexesOutput, CommonError>> {
     const permissionResult = await this.permissionService.isAllowed(
       user,

--- a/apps/backend/src/plans/paniers/checkout/checkout.router.ts
+++ b/apps/backend/src/plans/paniers/checkout/checkout.router.ts
@@ -18,8 +18,8 @@ export class CheckoutRouter {
   router = this.trpc.router({
     checkout: this.trpc.authedProcedure
       .input(checkoutInputSchema)
-      .mutation(async ({ input, ctx }) => {
-        const result = await this.checkoutService.execute(input, ctx.user);
+      .mutation(async ({ input, ctx: { user } }) => {
+        const result = await this.checkoutService.execute(input, { user });
         return this.getResultDataOrThrowError(result);
       }),
   });

--- a/apps/backend/src/plans/paniers/checkout/checkout.service.ts
+++ b/apps/backend/src/plans/paniers/checkout/checkout.service.ts
@@ -6,6 +6,7 @@ import { UpsertPlanService } from '@tet/backend/plans/plans/upsert-plan/upsert-p
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { ServiceSecondArg } from '@tet/backend/utils/nest/service-second-arg.utils';
 import {
   combineResults,
   failure,
@@ -36,8 +37,7 @@ export class CheckoutService {
 
   async execute(
     input: CheckoutInput,
-    user: AuthenticatedUser,
-    tx?: Transaction
+    { user, tx }: ServiceSecondArg
   ): Promise<Result<{ planId: number }, CheckoutError>> {
     const permissionResult = await this.permissionService.isAllowed(
       user,
@@ -183,8 +183,7 @@ export class CheckoutService {
     }
     const planResult = await this.upsertPlanService.upsertPlan(
       { nom: "Plan d'action à impact", collectiviteId: input.collectiviteId },
-      user,
-      tx
+      { user, tx }
     );
     if (!planResult.success) {
       this.logger.error(

--- a/apps/backend/src/plans/plans/create-plan-aggregate/create-plan-aggregate.service.spec.ts
+++ b/apps/backend/src/plans/plans/create-plan-aggregate/create-plan-aggregate.service.spec.ts
@@ -311,8 +311,7 @@ describe('CreatePlanAggregateService', () => {
           pilotes: [{ userId: 'pilot-1', tagId: null }],
           referents: [{ userId: null, tagId: 100 }],
         },
-        mockUser,
-        mockTransaction
+        { user: mockUser, tx: mockTransaction }
       );
     });
 
@@ -583,11 +582,7 @@ describe('CreatePlanAggregateService', () => {
           count: refetchedFiches.length,
         });
 
-        const result = await service.create(
-          request,
-          mockUser,
-          mockTransaction
-        );
+        const result = await service.create(request, mockUser, mockTransaction);
 
         expect(result.success).toBe(true);
         expect(
@@ -619,11 +614,7 @@ describe('CreatePlanAggregateService', () => {
           new Error('webhook endpoint down')
         );
 
-        const result = await service.create(
-          request,
-          mockUser,
-          mockTransaction
-        );
+        const result = await service.create(request, mockUser, mockTransaction);
 
         expect(result.success).toBe(true);
       });

--- a/apps/backend/src/plans/plans/create-plan-aggregate/create-plan-aggregate.service.ts
+++ b/apps/backend/src/plans/plans/create-plan-aggregate/create-plan-aggregate.service.ts
@@ -133,8 +133,7 @@ export class CreatePlanAggregateService {
           pilotes: request.pilotes,
           referents: request.referents,
         },
-        user,
-        tx
+        { user, tx }
       );
       if (!createPlanResult.success) return createPlanResult;
 
@@ -233,8 +232,7 @@ export class CreatePlanAggregateService {
       const nom = axe.path[axe.path.length - 1];
       const createdAxe = await this.upsertAxeService.upsertAxe(
         { planId, parent: parentIdResult.data, collectiviteId, nom },
-        user,
-        tx
+        { user, tx }
       );
       if (!createdAxe.success) return createdAxe;
 

--- a/apps/backend/src/plans/plans/delete-plan/delete-plan.router.ts
+++ b/apps/backend/src/plans/plans/delete-plan/delete-plan.router.ts
@@ -19,8 +19,8 @@ export class DeletePlanRouter {
   router = this.trpc.router({
     delete: this.trpc.authedProcedure
       .input(deletePlanInputSchema)
-      .mutation(async ({ input, ctx }) => {
-        const result = await this.deletePlanService.deletePlan(input, ctx.user);
+      .mutation(async ({ input, ctx: { user } }) => {
+        const result = await this.deletePlanService.deletePlan(input, { user });
         return this.getResultDataOrThrowError(result);
       }),
   });

--- a/apps/backend/src/plans/plans/delete-plan/delete-plan.service.ts
+++ b/apps/backend/src/plans/plans/delete-plan/delete-plan.service.ts
@@ -1,8 +1,8 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
-import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { ServiceSecondArg } from '@tet/backend/utils/nest/service-second-arg.utils';
 import { Result } from '@tet/backend/utils/result.type';
 import { PermissionOperationEnum, ResourceType } from '@tet/domain/users';
 import { DeleteFicheService } from '../../fiches/delete-fiche/delete-fiche.service';
@@ -26,8 +26,7 @@ export class DeletePlanService {
 
   async deletePlan(
     input: DeletePlanInput,
-    user: AuthenticatedUser,
-    tx?: Transaction
+    { user, tx }: ServiceSecondArg
   ): Promise<Result<void, DeletePlanError>> {
     const executeInTransaction = async (
       transaction: Transaction

--- a/apps/backend/src/plans/plans/duplicate-plan/duplicate-plan.router.ts
+++ b/apps/backend/src/plans/plans/duplicate-plan/duplicate-plan.router.ts
@@ -19,11 +19,8 @@ export class DuplicatePlanRouter {
   router = this.trpc.router({
     duplicate: this.trpc.authedProcedure
       .input(duplicatePlanInputSchema)
-      .mutation(async ({ input, ctx }) => {
-        const result = await this.duplicatePlanService.duplicate(
-          input,
-          ctx.user
-        );
+      .mutation(async ({ input, ctx: { user } }) => {
+        const result = await this.duplicatePlanService.duplicate(input, { user });
         return this.getResultDataOrThrowError(result);
       }),
   });

--- a/apps/backend/src/plans/plans/duplicate-plan/duplicate-plan.service.ts
+++ b/apps/backend/src/plans/plans/duplicate-plan/duplicate-plan.service.ts
@@ -5,6 +5,7 @@ import ListFichesService from '@tet/backend/plans/fiches/list-fiches/list-fiches
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { ServiceSecondArg } from '@tet/backend/utils/nest/service-second-arg.utils';
 import { failure, Result, success } from '@tet/backend/utils/result.type';
 import { TransactionManager } from '@tet/backend/utils/transaction/transaction-manager.service';
 import { Personne, PersonneId } from '@tet/domain/collectivites';
@@ -62,8 +63,7 @@ export class DuplicatePlanService {
 
   async duplicate(
     { planId, nom }: DuplicatePlanInput,
-    user: AuthenticatedUser,
-    tx?: Transaction
+    { user, tx }: ServiceSecondArg
   ): Promise<Result<{ planId: number }, DuplicatePlanError>> {
     return this.transactionManager.executeSingle<
       { planId: number },
@@ -104,8 +104,7 @@ export class DuplicatePlanService {
           dateDebut: source.dateDebut,
           dateFin: source.dateFin,
         },
-        user,
-        transaction
+        { user, tx: transaction }
       );
       if (!newPlanResult.success) {
         return failure(
@@ -222,9 +221,13 @@ export class DuplicatePlanService {
       }
 
       const createdAxe = await this.upsertAxeService.upsertAxe(
-        { planId: newPlanId, parent: parentNewId, collectiviteId, nom: axe.nom },
-        user,
-        tx
+        {
+          planId: newPlanId,
+          parent: parentNewId,
+          collectiviteId,
+          nom: axe.nom,
+        },
+        { user, tx }
       );
       if (!createdAxe.success) {
         return failure(DuplicatePlanErrorEnum.DUPLICATE_PLAN_ERROR);

--- a/apps/backend/src/plans/plans/get-plan/get-plan.service.ts
+++ b/apps/backend/src/plans/plans/get-plan/get-plan.service.ts
@@ -48,7 +48,10 @@ export class GetPlanService {
       const plan = planResult.data;
 
       if (user) {
-        const isAllowed = await this.checkPermission(plan.collectiviteId, user);
+        const isAllowed = await this.checkPermission(
+          plan.collectiviteId,
+          user
+        );
         if (!isAllowed) {
           return {
             success: false,

--- a/apps/backend/src/plans/plans/list-plans/list-plans.router.ts
+++ b/apps/backend/src/plans/plans/list-plans/list-plans.router.ts
@@ -18,8 +18,8 @@ export class ListPlansRouter {
   router = this.trpc.router({
     list: this.trpc.authedProcedure
       .input(listPlansInputSchema)
-      .query(async ({ input, ctx }) => {
-        const result = await this.listPlansService.listPlans(input, ctx.user);
+      .query(async ({ input, ctx: { user } }) => {
+        const result = await this.listPlansService.listPlans(input, { user });
         return this.getResultDataOrThrowError(result);
       }),
   });

--- a/apps/backend/src/plans/plans/list-plans/list-plans.service.ts
+++ b/apps/backend/src/plans/plans/list-plans/list-plans.service.ts
@@ -1,6 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
-import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { ServiceSecondArg } from '@tet/backend/utils/nest/service-second-arg.utils';
 import { Result } from '@tet/backend/utils/result.type';
 import { Plan } from '@tet/domain/plans';
 import { ListAxesService } from '../../axes/list-axes/list-axes.service';
@@ -24,8 +23,7 @@ export class ListPlansService {
 
   async listPlans(
     input: ListPlansInput,
-    user: AuthenticatedUser,
-    tx?: Transaction
+    { user, tx }: ServiceSecondArg
   ): Promise<Result<ListPlansOutput, ListPlansError>> {
     const isAllowed = await this.getPlanService.checkPermission(
       input.collectiviteId,

--- a/apps/backend/src/plans/plans/upsert-plan/upsert-plan.router.ts
+++ b/apps/backend/src/plans/plans/upsert-plan/upsert-plan.router.ts
@@ -25,23 +25,23 @@ export class UpsertPlanRouter {
   router = this.trpc.router({
     create: this.trpc.authedProcedure
       .input(createPlanSchema)
-      .mutation(async ({ input, ctx }) => {
-        const result = await this.upsertPlanService.upsertPlan(input, ctx.user);
+      .mutation(async ({ input, ctx: { user } }) => {
+        const result = await this.upsertPlanService.upsertPlan(input, { user });
         return this.getResultDataOrThrowError(result);
       }),
     update: this.trpc.authedProcedure
       .input(updatePlanSchema)
-      .mutation(async ({ input, ctx }) => {
-        const result = await this.upsertPlanService.upsertPlan(input, ctx.user);
+      .mutation(async ({ input, ctx: { user } }) => {
+        const result = await this.upsertPlanService.upsertPlan(input, { user });
         return this.getResultDataOrThrowError(result);
       }),
     setFichesPrivate: this.trpc.authedProcedure
       .input(setFichesPrivateSchema)
-      .mutation(async ({ input, ctx }) => {
+      .mutation(async ({ input, ctx: { user } }) => {
         const result = await this.upsertPlanService.setFichesPrivate({
           planId: input.planId,
           isPrivate: input.isPrivate,
-          user: ctx.user,
+          user,
         });
         return this.getResultDataOrThrowError(result);
       }),

--- a/apps/backend/src/plans/plans/upsert-plan/upsert-plan.service.ts
+++ b/apps/backend/src/plans/plans/upsert-plan/upsert-plan.service.ts
@@ -3,6 +3,7 @@ import { PermissionService } from '@tet/backend/users/authorizations/permission.
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { ServiceSecondArg } from '@tet/backend/utils/nest/service-second-arg.utils';
 import { Result } from '@tet/backend/utils/result.type';
 import { AxeLight } from '@tet/domain/plans';
 import { PermissionOperationEnum, ResourceType } from '@tet/domain/users';
@@ -26,8 +27,7 @@ export class UpsertPlanService {
 
   async upsertPlan(
     plan: UpsertPlanInput,
-    user: AuthenticatedUser,
-    tx?: Transaction
+    { user, tx }: ServiceSecondArg
   ): Promise<Result<AxeLight, UpsertPlanError>> {
     const permissionResult = await this.permissionService.isAllowed(
       user,

--- a/apps/backend/src/plans/reports/generate-plan-report-pptx/generate-reports.application-service.ts
+++ b/apps/backend/src/plans/reports/generate-plan-report-pptx/generate-reports.application-service.ts
@@ -3,7 +3,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { StoreDocumentService } from '@tet/backend/collectivites/documents/store-document/store-document.service';
 import CollectivitesService from '@tet/backend/collectivites/services/collectivites.service';
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
-import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { ServiceSecondArg } from '@tet/backend/utils/nest/service-second-arg.utils';
 import { Result } from '@tet/backend/utils/result.type';
 import { CollectiviteAvecType } from '@tet/domain/collectivites';
 import {
@@ -147,7 +147,7 @@ export class GenerateReportsApplicationService {
 
   async get(
     reportId: string,
-    user: AuthenticatedUser
+    { user }: ServiceSecondArg
   ): Promise<Result<ReportGeneration, GenerateReportError>> {
     const reportGenerationResult = await this.reportGenerationRepository.get(
       reportId
@@ -188,7 +188,7 @@ export class GenerateReportsApplicationService {
 
   async createPendingPlanReportGeneration(
     request: GenerateReportInput,
-    user: AuthenticatedUser
+    { user }: ServiceSecondArg
   ): Promise<Result<ReportGeneration, GenerateReportError>> {
     this.logger.log(
       `Creating pending plan report generation for plan ${request.planId} with template ${request.templateKey}`

--- a/apps/backend/src/plans/reports/generate-plan-report-pptx/generate-reports.router.ts
+++ b/apps/backend/src/plans/reports/generate-plan-report-pptx/generate-reports.router.ts
@@ -20,20 +20,20 @@ export class GenerateReportsRouter {
   router = this.trpc.router({
     create: this.trpc.authedProcedure
       .input(generateReportInputSchema)
-      .mutation(async ({ input, ctx }) => {
+      .mutation(async ({ input, ctx: { user } }) => {
         const result =
           await this.generateReportsApplicationService.createPendingPlanReportGeneration(
             input,
-            ctx.user
+            { user }
           );
         return this.getResultDataOrThrowError(result);
       }),
     get: this.trpc.authedProcedure
       .input(z.object({ reportId: z.string() }))
-      .query(async ({ input, ctx }) => {
+      .query(async ({ input, ctx: { user } }) => {
         const result = await this.generateReportsApplicationService.get(
           input.reportId,
-          ctx.user
+          { user }
         );
         return this.getResultDataOrThrowError(result);
       }),


### PR DESCRIPTION
## Ce que ça change

`apps/backend/CLAUDE.md` pose la règle : « Services always take context `{ user, isUserTrusted?, tx? }` as last parameter ». 47 fichiers du dépôt la suivent ; le domaine `plans` la suit désormais aussi.

```ts
// avant
async listPlans(input: ListPlansInput, user: AuthenticatedUser, tx?: Transaction)
// après
async listPlans(input: ListPlansInput, { user, tx }: ServiceSecondArg)
```

Les routers destructurent `ctx`, ce qui ramène chaque appel à une ligne :

```ts
.query(async ({ input, ctx: { user } }) => {
  const result = await this.listPlansService.listPlans(input, { user });
```

**Le compilateur garantit l'exhaustivité** : passer d'un paramètre positionnel à un objet nommé casse la compilation chez tous les appelants. Aucun site ne peut être oublié en silence — contrairement à un réordonnancement de positionnels, qui compilerait.

## Un seul type pour tous les points d'entrée

Six signatures destructurent `{ user }` seul et ignorent le reste. Elles gardent malgré tout `ServiceSecondArg`, pour que la convention se lise de la même façon partout.

Le prix est assumé : elles acceptent alors un `tx` sans l'honorer, là où la signature positionnelle rendait l'erreur impossible à compiler. Cela concerne notamment `FicheActionBudgetService.upsert` et `delete`, qui ouvrent leur propre transaction. Aucun appelant ne passe de `tx` aujourd'hui.

## Ce qui reste hors de cette passe

Quatre contrats que le type ne sait pas encore dire, et qui ne sont donc pas des oublis :

| contrat | exemple | pourquoi |
|---|---|---|
| `user` optionnel | `getPlan`, `listAxesRecursively` | `ServiceSecondArg.user` est requis ; il ne dit pas « anonyme admis » |
| transaction obligatoire | `create`, `resolveFicheEntities` | `ServiceSecondArg.tx` est optionnel ; migrer perdrait la garantie |
| `user: AuthUser` | `listBudgets` | type plus large ; migrer rétrécirait ce qui est accepté |
| utilisateur dans l'objet d'entrée | `setFichesPrivate` | forme différente, pas un second argument |

Trois de ces contrats sont **déjà exprimés ailleurs dans le dépôt**, en inline : `ServiceSecondArg & { tx: Transaction }` dans `migrate-collectivite-data.service.ts`, `{ user?: AuthenticatedUser; tx?: Transaction }` dans `list-tags`, `list-membres` et `list-pending-invitations`. Ce qui manque n'est pas la possibilité, c'est le nom — et la triple duplication le signale. Nommer ces variants relève d'une décision sur la convention, pas de cette migration.

Les **helpers privés** gardent leur paramètre nu : la règle vise l'API du service, et emballer pour un appel interne n'apporte rien.

## Ce que le périmètre laisse dans `plans`

Cette passe suit le motif syntaxique `(input, user, tx?)`, pas le contrat. Restent donc à traiter dans le domaine, sans que ce soit un oubli :

- `canWriteFiche` et `canDeleteFiche` (`fiche-action-permissions.service.ts`) — publiques, avec un booléen positionnel en quatrième position ;
- `import` (`import-excel-plan.application-service.ts`) — neuf paramètres positionnels, utilisateur en premier ;
- `createFiche` — déjà la bonne forme, déclarée inline.

## Surface de review

34 fichiers, +109/−119. La quasi-totalité du diff est signature ou site d'appel ; le diff a été passé au crible d'une comparaison insensible aux espaces pour qu'aucun hunk de pur reformatage ne subsiste.

Le point à regarder : `duplicate-plan.service.ts` et `create-and-link-plan.service.ts` écrivent `{ user, tx: transaction }` en toutes lettres plutôt que le raccourci. C'est nécessaire — `{ user, tx }` y capturerait le `tx?` du paramètre externe au lieu de la transaction ouverte par `executeSingle`.

## Constat consigné hors périmètre

`isUserTrusted` est déclaré sur `ServiceSecondArg`, donc sur environ 65 signatures, pour **un seul** service qui le consomme (`mutate-tag.service.ts`). Il gagnerait à être déclaré localement là où il sert.
