### PR TITLE
fix(database): guard restores across periodicity rollout phases

### DIFF
--- a/.github/actions/compute-affected-scope/action.yml
+++ b/.github/actions/compute-affected-scope/action.yml
@@ -89,7 +89,7 @@ runs:
         fi
 
         run_db_deploy=false
-        if grep -Eq '^(data_layer/|supabase/|sqitch\.conf$|\.github/actions/sqitch/|\.github/actions/sqitch-local/|\.github/workflows/prepare-test-db\.yml$|\.github/workflows/test-db-deploy\.yml$)' <<<"$changed_files"; then
+        if grep -Eq '^(Makefile$|Earthfile$|data_layer/|supabase/|sqitch\.conf$|\.github/actions/sqitch/|\.github/actions/sqitch-local/|\.github/workflows/(backup-database|cd-periodicite-contract|cd-restore-preprod|prepare-test-db|test-db-deploy)\.yml$)' <<<"$changed_files"; then
           run_db_deploy=true
         fi
 

--- a/.github/workflows/backup-database.yml
+++ b/.github/workflows/backup-database.yml
@@ -15,9 +15,14 @@ jobs:
     environment: prod
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    concurrency:
+      group: database-maintenance-prod
+      cancel-in-progress: false
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install PostgreSQL client
         run: |
@@ -63,11 +68,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     concurrency:
-      group: restore-staging
+      group: database-maintenance-staging
       cancel-in-progress: false
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install PostgreSQL client
         run: |
@@ -76,7 +83,7 @@ jobs:
 
       - name: Install yq
         run: |
-          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.53.2/yq_linux_amd64
           sudo chmod +x /usr/local/bin/yq
 
       - name: Install AWS CLI
@@ -104,11 +111,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     concurrency:
-      group: restore-preprod
+      group: database-maintenance-preprod
       cancel-in-progress: false
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install PostgreSQL client
         run: |
@@ -117,7 +126,7 @@ jobs:
 
       - name: Install yq
         run: |
-          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.53.2/yq_linux_amd64
           sudo chmod +x /usr/local/bin/yq
 
       - name: Install AWS CLI
@@ -143,4 +152,5 @@ jobs:
           BACKUP_BUCKET: ${{ vars.BACKUP_BUCKET }}
           BACKUP_REGION: ${{ vars.BACKUP_REGION }}
           BACKUP_ENDPOINT_URL: ${{ vars.BACKUP_ENDPOINT_URL }}
-        run: bash data_layer/backup/restore.sh "${{ steps.dminus1.outputs.date }}"
+          RESTORE_ARGUMENT: ${{ steps.dminus1.outputs.date }}
+        run: bash data_layer/backup/restore.sh "$RESTORE_ARGUMENT"

--- a/.github/workflows/cd-restore-preprod.yml
+++ b/.github/workflows/cd-restore-preprod.yml
@@ -20,11 +20,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     concurrency:
-      group: restore-preprod
+      group: database-maintenance-preprod
       cancel-in-progress: false
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install PostgreSQL client
         run: |
@@ -33,7 +35,7 @@ jobs:
 
       - name: Install yq
         run: |
-          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.53.2/yq_linux_amd64
           sudo chmod +x /usr/local/bin/yq
 
       - name: Install AWS CLI
@@ -75,4 +77,5 @@ jobs:
           BACKUP_BUCKET: ${{ vars.BACKUP_BUCKET }}
           BACKUP_REGION: ${{ vars.BACKUP_REGION }}
           BACKUP_ENDPOINT_URL: ${{ vars.BACKUP_ENDPOINT_URL }}
-        run: bash data_layer/backup/restore.sh "${{ steps.restore_arg.outputs.restore_arg }}"
+          RESTORE_ARGUMENT: ${{ steps.restore_arg.outputs.restore_arg }}
+        run: bash data_layer/backup/restore.sh "$RESTORE_ARGUMENT"

--- a/data_layer/backup/check-restore-compatibility.sh
+++ b/data_layer/backup/check-restore-compatibility.sh
@@ -1,0 +1,417 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: TO_DB_URL=... $0 <backup.dump>" >&2
+    exit 2
+fi
+
+if [ -z "${TO_DB_URL:-}" ]; then
+    echo "Missing TO_DB_URL environment variable" >&2
+    exit 2
+fi
+
+DUMP_FILE="$1"
+EXPAND_CHANGE="indicateur/periodicite"
+EXPAND_IMPORT_CHANGE="indicateur/import_emt_valeur"
+EXPAND_RECONCILIATION_CHANGE="indicateur/reconciliation_formules"
+EXPAND_DEPENDENCIES_CHANGE="indicateur/dependances_formules"
+TARGET_CONTRACT_CHANGE="indicateur/periodicite_obligatoire"
+SOURCE_FORMULA_CHANGE="indicateur/periodicite_formules"
+SOURCE_FINAL_CHANGE="stats/report_indicateur_resultat_periode"
+SQITCH_PROJECT="tet"
+
+# The registry identifies the intended phase, while the physical object checks
+# below prove that the target can safely execute that phase's restore path.
+# This includes the column contract and the exact phase-specific write guard;
+# an object with the right name but the wrong trigger semantics is drift. A
+# connection, registry or schema-drift error must stop the restore before any
+# table is truncated. In pg_trigger.tgtype, 23 is ROW + BEFORE + INSERT + UPDATE.
+target_phase=$(psql \
+    --dbname "$TO_DB_URL" \
+    --no-psqlrc \
+    --tuples-only \
+    --no-align \
+    --set ON_ERROR_STOP=1 \
+    --command "
+        WITH registry_phase AS (
+            SELECT CASE
+                WHEN count(*) FILTER (
+                    WHERE change = '$EXPAND_CHANGE'
+                ) > 0
+                 AND count(*) FILTER (
+                    WHERE change = '$EXPAND_IMPORT_CHANGE'
+                ) > 0
+                 AND count(*) FILTER (
+                    WHERE change = '$EXPAND_RECONCILIATION_CHANGE'
+                ) > 0
+                 AND count(*) FILTER (
+                    WHERE change = '$EXPAND_DEPENDENCIES_CHANGE'
+                ) > 0
+                 AND count(*) FILTER (
+                    WHERE change = '$TARGET_CONTRACT_CHANGE'
+                ) > 0
+                 AND count(*) FILTER (
+                    WHERE change = '$SOURCE_FORMULA_CHANGE'
+                ) > 0
+                 AND count(*) FILTER (
+                    WHERE change = '$SOURCE_FINAL_CHANGE'
+                ) > 0
+                    THEN 'contract'
+                WHEN count(*) FILTER (
+                    WHERE change IN (
+                        '$TARGET_CONTRACT_CHANGE',
+                        '$SOURCE_FORMULA_CHANGE',
+                        '$SOURCE_FINAL_CHANGE'
+                    )
+                ) > 0
+                    THEN 'partial-contract'
+                WHEN count(*) FILTER (
+                    WHERE change = '$EXPAND_CHANGE'
+                ) > 0
+                 AND count(*) FILTER (
+                    WHERE change = '$EXPAND_IMPORT_CHANGE'
+                ) > 0
+                 AND count(*) FILTER (
+                    WHERE change = '$EXPAND_RECONCILIATION_CHANGE'
+                ) > 0
+                 AND count(*) FILTER (
+                    WHERE change = '$EXPAND_DEPENDENCIES_CHANGE'
+                ) > 0
+                    THEN 'expand'
+                WHEN count(*) FILTER (
+                    WHERE change IN (
+                        '$EXPAND_CHANGE',
+                        '$EXPAND_IMPORT_CHANGE',
+                        '$EXPAND_RECONCILIATION_CHANGE',
+                        '$EXPAND_DEPENDENCIES_CHANGE'
+                    )
+                ) > 0
+                    THEN 'partial-expand'
+                ELSE 'legacy'
+            END AS phase,
+            count(*) > 0 AS registry_seen
+            FROM sqitch.changes
+            WHERE project = '$SQITCH_PROJECT'
+        ),
+        physical_state AS (
+            SELECT
+                to_regclass(
+                    'public.indicateur_periodicite'
+                ) IS NOT NULL AS periodicity_catalog_exists,
+                EXISTS (
+                    SELECT 1
+                    FROM information_schema.columns
+                    WHERE table_schema = 'public'
+                      AND table_name = 'indicateur_definition'
+                      AND column_name = 'periodicite'
+                ) AS periodicity_column_exists,
+                EXISTS (
+                    SELECT 1
+                    FROM information_schema.columns
+                    WHERE table_schema = 'public'
+                      AND table_name = 'indicateur_definition'
+                      AND column_name = 'periodicite'
+                      AND data_type = 'text'
+                      AND is_nullable = 'YES'
+                      AND column_default = '''annuelle''::text'
+                ) AS periodicity_column_is_expand_compatible,
+                EXISTS (
+                    SELECT 1
+                    FROM information_schema.columns
+                    WHERE table_schema = 'public'
+                      AND table_name = 'indicateur_definition'
+                      AND column_name = 'periodicite'
+                      AND data_type = 'text'
+                      AND is_nullable = 'NO'
+                      AND column_default IS NULL
+                ) AS periodicity_column_is_contract_compatible,
+                to_regprocedure(
+                    'public.indicateur_date_debut_periode(text,date)'
+                ) IS NOT NULL AS canonical_date_function_exists,
+                to_regclass(
+                    'migration.indicateur_valeur_periodicite_audit'
+                ) IS NOT NULL AS audit_table_exists,
+                to_regclass(
+                    'private.indicateur_reconciliation_formule'
+                ) IS NOT NULL AS reconciliation_queue_exists,
+                to_regclass(
+                    'private.indicateur_definition_dependance_calcul'
+                ) IS NOT NULL AS dependency_projection_exists,
+                to_regprocedure(
+                    'private.extraire_dependances_formule_indicateur(text)'
+                ) IS NOT NULL AS dependency_extractor_exists,
+                to_regprocedure(
+                    'private.verifier_periodicite_dependances_formule(integer,text[])'
+                ) IS NOT NULL AS dependency_verifier_exists,
+                to_regprocedure(
+                    'migration.auditer_et_normaliser_dates_indicateur()'
+                ) IS NOT NULL AS audit_function_exists,
+                to_regprocedure(
+                    'migration.auditer_et_normaliser_date_indicateur_en_transition()'
+                ) IS NOT NULL AS transition_date_function_exists,
+                EXISTS (
+                    SELECT 1
+                    FROM pg_trigger
+                    WHERE tgrelid = to_regclass('public.indicateur_valeur')
+                      AND tgname =
+                          'auditer_et_normaliser_date_indicateur_en_transition'
+                      AND NOT tgisinternal
+                ) AS transition_date_trigger_exists,
+                EXISTS (
+                    SELECT 1
+                    FROM pg_trigger trigger_state
+                    WHERE trigger_state.tgrelid =
+                          to_regclass('public.indicateur_valeur')
+                      AND trigger_state.tgname =
+                          'auditer_et_normaliser_date_indicateur_en_transition'
+                      AND trigger_state.tgenabled = 'O'
+                      AND NOT trigger_state.tgisinternal
+                      AND trigger_state.tgconstraint = 0
+                      AND trigger_state.tgtype::integer = 23
+                      AND trigger_state.tgfoid = to_regprocedure(
+                          'migration.auditer_et_normaliser_date_indicateur_en_transition()'
+                      )
+                      AND (
+                          SELECT array_agg(
+                              attribute.attname
+                              ORDER BY attribute.attname
+                          )
+                          FROM unnest(
+                              trigger_state.tgattr::smallint[]
+                          ) AS updated(attnum)
+                          JOIN pg_attribute attribute
+                            ON attribute.attrelid = trigger_state.tgrelid
+                           AND attribute.attnum = updated.attnum
+                      ) = ARRAY[
+                          'collectivite_id',
+                          'date_valeur',
+                          'indicateur_id',
+                          'metadonnee_id'
+                      ]::name[]
+                ) AS transition_date_trigger_is_valid,
+                to_regprocedure(
+                    'public.verifier_date_valeur_selon_periodicite()'
+                ) IS NOT NULL AS strict_date_function_exists,
+                EXISTS (
+                    SELECT 1
+                    FROM pg_trigger
+                    WHERE tgrelid = to_regclass('public.indicateur_valeur')
+                      AND tgname = 'verifier_date_valeur_selon_periodicite'
+                      AND NOT tgisinternal
+                ) AS strict_date_trigger_exists,
+                EXISTS (
+                    SELECT 1
+                    FROM pg_trigger trigger_state
+                    WHERE trigger_state.tgrelid =
+                          to_regclass('public.indicateur_valeur')
+                      AND trigger_state.tgname =
+                          'verifier_date_valeur_selon_periodicite'
+                      AND trigger_state.tgenabled = 'O'
+                      AND NOT trigger_state.tgisinternal
+                      AND trigger_state.tgconstraint = 0
+                      AND trigger_state.tgtype::integer = 23
+                      AND trigger_state.tgfoid = to_regprocedure(
+                          'public.verifier_date_valeur_selon_periodicite()'
+                      )
+                      AND (
+                          SELECT array_agg(
+                              attribute.attname
+                              ORDER BY attribute.attname
+                          )
+                          FROM unnest(
+                              trigger_state.tgattr::smallint[]
+                          ) AS updated(attnum)
+                          JOIN pg_attribute attribute
+                            ON attribute.attrelid = trigger_state.tgrelid
+                           AND attribute.attnum = updated.attnum
+                      ) = ARRAY[
+                          'date_valeur',
+                          'indicateur_id'
+                      ]::name[]
+                ) AS strict_date_trigger_is_valid
+        )
+        SELECT CASE
+            WHEN NOT registry_seen
+                THEN 'missing-registry'
+            WHEN phase = 'legacy'
+             AND NOT periodicity_catalog_exists
+             AND NOT periodicity_column_exists
+             AND NOT canonical_date_function_exists
+             AND NOT audit_table_exists
+             AND NOT reconciliation_queue_exists
+             AND NOT dependency_projection_exists
+             AND NOT dependency_extractor_exists
+             AND NOT dependency_verifier_exists
+             AND NOT audit_function_exists
+             AND NOT transition_date_function_exists
+             AND NOT transition_date_trigger_exists
+             AND NOT strict_date_function_exists
+             AND NOT strict_date_trigger_exists
+                THEN 'legacy'
+            WHEN phase = 'expand'
+             AND periodicity_catalog_exists
+             AND periodicity_column_is_expand_compatible
+             AND canonical_date_function_exists
+             AND audit_table_exists
+             AND reconciliation_queue_exists
+             AND dependency_extractor_exists
+             AND audit_function_exists
+             AND transition_date_function_exists
+             AND transition_date_trigger_is_valid
+             AND NOT strict_date_function_exists
+             AND NOT strict_date_trigger_exists
+             AND NOT dependency_projection_exists
+             AND NOT dependency_verifier_exists
+                THEN 'expand'
+            WHEN phase = 'contract'
+             AND periodicity_catalog_exists
+             AND periodicity_column_is_contract_compatible
+             AND canonical_date_function_exists
+             AND audit_table_exists
+             AND reconciliation_queue_exists
+             AND dependency_projection_exists
+             AND dependency_extractor_exists
+             AND dependency_verifier_exists
+             AND NOT audit_function_exists
+             AND NOT transition_date_function_exists
+             AND NOT transition_date_trigger_exists
+             AND strict_date_function_exists
+             AND strict_date_trigger_is_valid
+                THEN 'contract'
+            WHEN phase IN ('partial-expand', 'partial-contract')
+                THEN phase
+            ELSE 'physical-drift-' || phase
+        END
+        FROM registry_phase
+        CROSS JOIN physical_state;
+    ")
+
+case "$target_phase" in
+    legacy|expand|contract)
+        ;;
+    partial-expand)
+        echo "Refusing to restore: target is inside a partial periodicity expand." >&2
+        exit 1
+        ;;
+    partial-contract)
+        echo "Refusing to restore: target is inside a partial periodicity contract." >&2
+        exit 1
+        ;;
+    missing-registry)
+        echo "Refusing to restore: target has no Sqitch registry state." >&2
+        exit 1
+        ;;
+    physical-drift-*)
+        echo "Refusing to restore: target schema objects disagree with its Sqitch phase." >&2
+        exit 1
+        ;;
+    *)
+        echo "Refusing to restore: unexpected target periodicity phase." >&2
+        exit 1
+        ;;
+esac
+
+# pg_dump includes sqitch.changes in the same consistent snapshot as the
+# business data. Inspect that archived COPY stream instead of trusting mutable
+# metadata or a date supplied by the operator.
+source_phase=$(pg_restore \
+    --data-only \
+    --schema=sqitch \
+    --table=changes \
+    --file=- \
+    "$DUMP_FILE" \
+    | awk -F '\t' \
+        -v expand_change="$EXPAND_CHANGE" \
+        -v import_change="$EXPAND_IMPORT_CHANGE" \
+        -v reconciliation_change="$EXPAND_RECONCILIATION_CHANGE" \
+        -v dependencies_change="$EXPAND_DEPENDENCIES_CHANGE" \
+        -v mandatory_change="$TARGET_CONTRACT_CHANGE" \
+        -v formula_change="$SOURCE_FORMULA_CHANGE" \
+        -v final_change="$SOURCE_FINAL_CHANGE" \
+        -v project="$SQITCH_PROJECT" '
+        $4 == project { registry_seen = 1 }
+        $3 == expand_change && $4 == project { expand_applied = 1 }
+        $3 == import_change && $4 == project { import_applied = 1 }
+        $3 == reconciliation_change && $4 == project { reconciliation_applied = 1 }
+        $3 == dependencies_change && $4 == project { dependencies_applied = 1 }
+        $3 == mandatory_change && $4 == project { mandatory_applied = 1 }
+        $3 == formula_change && $4 == project { formula_applied = 1 }
+        $3 == final_change && $4 == project { final_applied = 1 }
+        END {
+            expand_complete = expand_applied && import_applied \
+                && reconciliation_applied && dependencies_applied
+            if (!registry_seen) {
+                print "missing-registry"
+            } else if (expand_complete && mandatory_applied && formula_applied && final_applied) {
+                print "contract"
+            } else if (mandatory_applied || formula_applied || final_applied) {
+                print "partial-contract"
+            } else if (expand_complete) {
+                print "expand"
+            } else if (expand_applied || import_applied \
+                       || reconciliation_applied || dependencies_applied) {
+                print "partial-expand"
+            } else {
+                print "legacy"
+            }
+        }
+    ')
+
+case "$source_phase" in
+    legacy|expand|contract)
+        ;;
+    partial-expand)
+        echo "Refusing to restore: backup is inside a partial periodicity expand." >&2
+        exit 1
+        ;;
+    partial-contract)
+        echo "Refusing to restore: backup is inside a partial periodicity contract." >&2
+        exit 1
+        ;;
+    missing-registry)
+        echo "Refusing to restore: backup has no Sqitch registry state." >&2
+        exit 1
+        ;;
+    *)
+        echo "Refusing to restore: unexpected backup periodicity phase." >&2
+        exit 1
+        ;;
+esac
+
+archive_has_table_data() {
+    local schema="$1"
+    local table="$2"
+
+    pg_restore --list "$DUMP_FILE" \
+        | awk -v schema="$schema" -v table="$table" '
+            $4 == "TABLE" && $5 == "DATA" \
+                && $6 == schema && $7 == table { found = 1 }
+            END { exit !found }
+        '
+}
+
+# Both rows sets are durable domain/migration state in expand and contract.
+# Without their TABLE DATA entries, the table-by-table restore would truncate
+# valid target state and could otherwise treat a selective archive as empty.
+if [ "$source_phase" != "legacy" ]; then
+    if ! archive_has_table_data \
+        migration indicateur_valeur_periodicite_audit; then
+        echo "Refusing to restore: backup lacks periodicity audit data." >&2
+        exit 1
+    fi
+    if ! archive_has_table_data \
+        private indicateur_reconciliation_formule; then
+        echo "Refusing to restore: backup lacks formula reconciliation data." >&2
+        exit 1
+    fi
+fi
+
+if [ "$source_phase" != "$target_phase" ]; then
+    echo "Refusing to restore: periodicity phases differ" >&2
+    echo "(backup: $source_phase, target: $target_phase)." >&2
+    exit 1
+fi
+
+echo "Restore compatibility: source and target phase is $target_phase." >&2
+printf '%s\n' "$target_phase"

--- a/data_layer/backup/check-restore-compatibility.spec.sh
+++ b/data_layer/backup/check-restore-compatibility.spec.sh
@@ -1,0 +1,226 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-restore-compatibility.sh"
+TEST_DIRECTORY=$(mktemp -d)
+FAKE_BIN="$TEST_DIRECTORY/bin"
+DUMP_FILE="$TEST_DIRECTORY/backup.dump"
+
+cleanup() {
+    rm -rf "$TEST_DIRECTORY"
+}
+trap cleanup EXIT
+
+mkdir -p "$FAKE_BIN"
+printf 'test archive\n' > "$DUMP_FILE"
+
+printf '%s\n' \
+    '#!/bin/bash' \
+    'if [ "${TARGET_QUERY_FAILS:-false}" = "true" ]; then exit 1; fi' \
+    'case "${TARGET_SCHEMA_DRIFT:-}" in' \
+    '  expand-*) printf "physical-drift-expand\n" ;;' \
+    '  contract-*) printf "physical-drift-contract\n" ;;' \
+    '  *) printf "%s\n" "${TARGET_PHASE:-legacy}" ;;' \
+    'esac' \
+    > "$FAKE_BIN/psql"
+
+printf '%s\n' \
+    '#!/bin/bash' \
+    'if [ "${ARCHIVE_READ_FAILS:-false}" = "true" ]; then exit 1; fi' \
+    'if [[ " $* " == *" --list "* ]]; then' \
+    '  printf "1; 0 1 TABLE DATA sqitch changes owner\\n"' \
+    '  if [ "${ARCHIVE_AUDIT_TABLE_MISSING:-false}" != "true" ]; then' \
+    '    printf "2; 0 2 TABLE DATA migration indicateur_valeur_periodicite_audit owner\\n"' \
+    '  fi' \
+    '  if [ "${ARCHIVE_QUEUE_TABLE_MISSING:-false}" != "true" ]; then' \
+    '    printf "3; 0 3 TABLE DATA private indicateur_reconciliation_formule owner\\n"' \
+    '  fi' \
+    '  exit 0' \
+    'fi' \
+    'if [ "${SOURCE_PHASE:-legacy}" != "missing-registry" ]; then' \
+    '  printf "change-id\\thash\\tbaseline/change\\ttet\\tnote\\n"' \
+    'fi' \
+    'if [ "${SOURCE_PHASE:-legacy}" = "partial-expand" ]; then' \
+    '  printf "change-id\\thash\\tindicateur/periodicite\\ttet\\tnote\\n"' \
+    'fi' \
+    'if [ "${SOURCE_PHASE:-legacy}" = "expand" ] || [ "${SOURCE_PHASE:-legacy}" = "partial-contract" ] || [ "${SOURCE_PHASE:-legacy}" = "contract" ]; then' \
+    '  printf "change-id\\thash\\tindicateur/periodicite\\ttet\\tnote\\n"' \
+    '  printf "change-id\\thash\\tindicateur/import_emt_valeur\\ttet\\tnote\\n"' \
+    '  printf "change-id\\thash\\tindicateur/reconciliation_formules\\ttet\\tnote\\n"' \
+    '  printf "change-id\\thash\\tindicateur/dependances_formules\\ttet\\tnote\\n"' \
+    'fi' \
+    'if [ "${SOURCE_PHASE:-legacy}" = "partial-contract" ] || [ "${SOURCE_PHASE:-legacy}" = "contract" ]; then' \
+    '  printf "change-id\\thash\\tindicateur/periodicite_obligatoire\\ttet\\tnote\\n"' \
+    'fi' \
+    'if [ "${SOURCE_PHASE:-legacy}" = "contract" ]; then' \
+    '  printf "change-id\\thash\\tindicateur/periodicite_formules\\ttet\\tnote\\n"' \
+    '  printf "change-id\\thash\\tstats/report_indicateur_resultat_periode\\ttet\\tnote\\n"' \
+    'fi' \
+    > "$FAKE_BIN/pg_restore"
+
+chmod +x "$FAKE_BIN/psql" "$FAKE_BIN/pg_restore"
+
+assert_success() {
+    local description="$1"
+    shift
+
+    if ! env PATH="$FAKE_BIN:/usr/bin:/bin" TO_DB_URL="postgresql://target/db" "$@" >/dev/null 2>&1; then
+        echo "FAIL: $description" >&2
+        exit 1
+    fi
+}
+
+assert_failure() {
+    local description="$1"
+    shift
+
+    if env PATH="$FAKE_BIN:/usr/bin:/bin" TO_DB_URL="postgresql://target/db" "$@" >/dev/null 2>&1; then
+        echo "FAIL: $description" >&2
+        exit 1
+    fi
+}
+
+assert_failure_with_message() {
+    local description="$1"
+    local expected_message="$2"
+    shift 2
+    local output_file="$TEST_DIRECTORY/failure-output"
+
+    if env PATH="$FAKE_BIN:/usr/bin:/bin" TO_DB_URL="postgresql://target/db" \
+        "$@" >"$output_file" 2>&1; then
+        echo "FAIL: $description" >&2
+        exit 1
+    fi
+
+    if ! grep --fixed-strings --quiet "$expected_message" "$output_file"; then
+        echo "FAIL: $description (unexpected error)" >&2
+        cat "$output_file" >&2
+        exit 1
+    fi
+}
+
+assert_success \
+    "a legacy target accepts a legacy backup" \
+    env TARGET_PHASE=legacy SOURCE_PHASE=legacy \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+assert_success \
+    "an expand target accepts an expand backup" \
+    env TARGET_PHASE=expand SOURCE_PHASE=expand \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+assert_success \
+    "a post-contract target accepts a post-contract backup" \
+    env TARGET_PHASE=contract SOURCE_PHASE=contract \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+assert_failure \
+    "a contract target rejects an older expand backup" \
+    env TARGET_PHASE=contract SOURCE_PHASE=expand \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+assert_failure \
+    "an expand target rejects a newer contract backup" \
+    env TARGET_PHASE=expand SOURCE_PHASE=contract \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+assert_failure \
+    "a partial-contract target rejects every backup" \
+    env TARGET_PHASE=partial-contract SOURCE_PHASE=contract \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+assert_failure \
+    "a partial-contract backup is rejected" \
+    env TARGET_PHASE=contract SOURCE_PHASE=partial-contract \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+assert_failure \
+    "a partial-expand target rejects every backup" \
+    env TARGET_PHASE=partial-expand SOURCE_PHASE=expand \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+assert_failure \
+    "a partial-expand backup is rejected" \
+    env TARGET_PHASE=expand SOURCE_PHASE=partial-expand \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+assert_failure \
+    "a target registry read failure is fail-closed" \
+    env TARGET_QUERY_FAILS=true SOURCE_PHASE=contract \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+assert_failure \
+    "an unexpected target registry result is fail-closed" \
+    env TARGET_PHASE=unexpected SOURCE_PHASE=contract \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+assert_failure \
+    "a target without the Sqitch registry is fail-closed" \
+    env TARGET_PHASE=missing-registry SOURCE_PHASE=legacy \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+assert_failure \
+    "physical target drift is fail-closed" \
+    env TARGET_PHASE=physical-drift-contract SOURCE_PHASE=contract \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+physical_drift_message="target schema objects disagree with its Sqitch phase"
+
+assert_failure_with_message \
+    "an expand target rejects a NOT NULL periodicite column" \
+    "$physical_drift_message" \
+    env TARGET_SCHEMA_DRIFT=expand-not-null SOURCE_PHASE=expand \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+assert_failure_with_message \
+    "an expand target rejects a missing compatibility default" \
+    "$physical_drift_message" \
+    env TARGET_SCHEMA_DRIFT=expand-missing-default SOURCE_PHASE=expand \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+assert_failure_with_message \
+    "an expand target rejects the strict guard in place of the transition guard" \
+    "$physical_drift_message" \
+    env TARGET_SCHEMA_DRIFT=expand-strict-guard SOURCE_PHASE=expand \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+assert_failure_with_message \
+    "a contract target rejects a nullable periodicite column" \
+    "$physical_drift_message" \
+    env TARGET_SCHEMA_DRIFT=contract-nullable SOURCE_PHASE=contract \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+assert_failure_with_message \
+    "a contract target rejects the expand compatibility default" \
+    "$physical_drift_message" \
+    env TARGET_SCHEMA_DRIFT=contract-default SOURCE_PHASE=contract \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+assert_failure_with_message \
+    "a contract target rejects the transition guard in place of the strict guard" \
+    "$physical_drift_message" \
+    env TARGET_SCHEMA_DRIFT=contract-transition-guard SOURCE_PHASE=contract \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+assert_failure \
+    "an archive registry read failure is fail-closed" \
+    env TARGET_PHASE=contract ARCHIVE_READ_FAILS=true \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+assert_failure \
+    "an archive without the Sqitch registry is fail-closed" \
+    env TARGET_PHASE=legacy SOURCE_PHASE=missing-registry \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+assert_failure \
+    "an expand archive without its audit table data is fail-closed" \
+    env TARGET_PHASE=expand SOURCE_PHASE=expand ARCHIVE_AUDIT_TABLE_MISSING=true \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+assert_failure \
+    "an expand archive without its reconciliation queue data is fail-closed" \
+    env TARGET_PHASE=expand SOURCE_PHASE=expand ARCHIVE_QUEUE_TABLE_MISSING=true \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+echo "Restore compatibility checks passed."

--- a/data_layer/backup/rebuild-indicateur-formula-state.sql
+++ b/data_layer/backup/rebuild-indicateur-formula-state.sql
@@ -1,0 +1,105 @@
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+-- Les services et les triggers du graphe prennent ce verrou avant celui de la
+-- table. La restauration reconstruit ainsi sa projection sur un catalogue
+-- immobile, selon le même ordre que le contract Sqitch.
+SELECT pg_advisory_xact_lock(
+    hashtextextended('indicateur-calculation-graph', 0)
+);
+LOCK TABLE public.indicateur_definition IN SHARE ROW EXCLUSIVE MODE;
+LOCK TABLE public.indicateur_valeur IN SHARE ROW EXCLUSIVE MODE;
+
+DO $rebuild$
+DECLARE
+    projection_exists boolean := to_regclass(
+        'private.indicateur_definition_dependance_calcul'
+    ) IS NOT NULL;
+    verifier_exists boolean := to_regprocedure(
+        'private.verifier_periodicite_dependances_formule(integer,text[])'
+    ) IS NOT NULL;
+    extractor_exists boolean := to_regprocedure(
+        'private.extraire_dependances_formule_indicateur(text)'
+    ) IS NOT NULL;
+    audit_exists boolean := to_regclass(
+        'migration.indicateur_valeur_periodicite_audit'
+    ) IS NOT NULL;
+    audit_function_exists boolean := to_regprocedure(
+        'migration.auditer_et_normaliser_dates_indicateur()'
+    ) IS NOT NULL;
+    contract_applied boolean := projection_exists;
+BEGIN
+    IF projection_exists IS DISTINCT FROM verifier_exists
+       OR (projection_exists AND NOT extractor_exists) THEN
+        RAISE EXCEPTION USING
+            ERRCODE = '55000',
+            MESSAGE = 'État contractuel partiel : impossible de reconstruire les dépendances de formule';
+    END IF;
+
+    IF projection_exists THEN
+        TRUNCATE private.indicateur_definition_dependance_calcul;
+
+        INSERT INTO private.indicateur_definition_dependance_calcul
+            (indicateur_id, source_identifiant)
+        SELECT definition.id, dependance.source_identifiant
+        FROM public.indicateur_definition definition
+        CROSS JOIN LATERAL private.extraire_dependances_formule_indicateur(
+            definition.valeur_calcule
+        ) AS dependance
+        WHERE definition.valeur_calcule IS NOT NULL
+          AND btrim(definition.valeur_calcule) <> '';
+
+        -- Cette validation appartient à la même transaction que le rebuild :
+        -- une formule inconnue ou inter-périodicité annule toute la projection.
+        PERFORM private.verifier_periodicite_dependances_formule();
+    END IF;
+
+    IF projection_exists AND NOT audit_exists THEN
+        RAISE EXCEPTION USING
+            ERRCODE = '55000',
+            MESSAGE = 'État contractuel partiel : l audit de périodicité manque';
+    ELSIF NOT projection_exists AND extractor_exists
+          AND (NOT audit_exists OR NOT audit_function_exists) THEN
+        RAISE EXCEPTION USING
+            ERRCODE = '55000',
+            MESSAGE = 'État expand partiel : impossible de rejouer l audit de périodicité';
+    ELSIF NOT projection_exists AND NOT extractor_exists
+          AND (audit_exists OR audit_function_exists) THEN
+        RAISE EXCEPTION USING
+            ERRCODE = '55000',
+            MESSAGE = 'État legacy incohérent : objets d audit de périodicité inattendus';
+    END IF;
+
+    IF NOT projection_exists AND extractor_exists THEN
+        -- Le snapshot restaure l'historique nécessaire au downgrade. Le rejeu
+        -- retire ses lignes obsolètes et audite toute valeur chargée sans que
+        -- les triggers de transition aient été exécutés par pg_restore.
+        ALTER TABLE public.indicateur_valeur DISABLE TRIGGER modified_at;
+        ALTER TABLE public.indicateur_valeur DISABLE TRIGGER modified_by;
+        PERFORM migration.auditer_et_normaliser_dates_indicateur();
+        ALTER TABLE public.indicateur_valeur ENABLE TRIGGER modified_by;
+        ALTER TABLE public.indicateur_valeur ENABLE TRIGGER modified_at;
+    END IF;
+
+    -- En phase contract la fonction d'audit transitoire a été retirée. Les
+    -- lignes d'audit restaurées appartiennent déjà au snapshot source ; on les
+    -- préserve et on valide directement l'invariant strict des dates.
+    IF contract_applied AND EXISTS (
+        SELECT 1
+        FROM public.indicateur_valeur valeur
+        JOIN public.indicateur_definition definition
+          ON definition.id = valeur.indicateur_id
+        WHERE valeur.date_valeur <> public.indicateur_date_debut_periode(
+            definition.periodicite,
+            valeur.date_valeur
+        )
+    ) THEN
+        RAISE EXCEPTION USING
+            ERRCODE = '23514',
+            MESSAGE = 'Le snapshot contractuel contient une date d indicateur non canonique';
+    END IF;
+END
+$rebuild$;
+
+COMMIT;

--- a/data_layer/backup/restore-config.yml
+++ b/data_layer/backup/restore-config.yml
@@ -145,6 +145,12 @@ groups:
     - indicateur_source_metadonnee
     - indicateur_valeur
 
+  # État durable propre aux phases expand/contract. restore.sh n'ajoute ce
+  # groupe que lorsque source et cible partagent exactement l'une de ces phases.
+  periodicite_group:
+    - migration.indicateur_valeur_periodicite_audit
+    - private.indicateur_reconciliation_formule
+
   pai_group:
     - action_impact_complexite
     - action_impact_typologie
@@ -197,7 +203,6 @@ groups:
     - historique.fiche_action
     - historique.fiche_action_pilote
     - plan_report_generation
-
 # Sensitive-data scrubbing rules formerly lived here as a `data_rules:` block
 # consumed by an inline scrubber in restore.sh. They moved to clean_data.sql
 # (in the same directory) for explicitness — adding a new scrubbed

--- a/data_layer/backup/restore.sh
+++ b/data_layer/backup/restore.sh
@@ -10,32 +10,43 @@ if [ -z "${TO_DB_URL:-}" ]; then
     fi
 fi
 
-# Allowlist of known non-prod restore targets.
-# Fail-closed: TO_DB_URL must match a localhost shape or one of these project IDs.
-# A misconfigured secret (e.g., accidentally pointing at production) is refused.
-ALLOWED_PROJECT_IDS=(
-    "qwbsrgwlypaqheoedxxq"  # staging
-    "xbrefnclajfcjlpnwyow"  # preprod
-)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DISABLED_TRIGGER_SCHEMA=''
+DISABLED_TRIGGER_TABLE=''
 
-is_allowed_target=false
-if [[ "$TO_DB_URL" =~ (localhost|127\.0\.0\.1|host\.docker\.internal) ]]; then
-    is_allowed_target=true
-else
-    for project_id in "${ALLOWED_PROJECT_IDS[@]}"; do
-        if [[ "$TO_DB_URL" == *"$project_id"* ]]; then
-            is_allowed_target=true
-            break
-        fi
-    done
-fi
+reenable_current_user_triggers() {
+    if [ -z "$DISABLED_TRIGGER_SCHEMA" ] || [ -z "$DISABLED_TRIGGER_TABLE" ]; then
+        return 0
+    fi
 
-if [ "$is_allowed_target" != true ]; then
-    masked_url=$(echo "$TO_DB_URL" | sed 's|://[^@]*@|://***@|')
-    echo "Refusing to restore: TO_DB_URL ($masked_url) does not match the allowlist."
-    echo "Allowed targets: localhost shape, or one of: ${ALLOWED_PROJECT_IDS[*]}"
-    exit 1
-fi
+    if ! psql -d "$TO_DB_URL" -c \
+        "ALTER TABLE \"$DISABLED_TRIGGER_SCHEMA\".\"$DISABLED_TRIGGER_TABLE\" ENABLE TRIGGER USER;"; then
+        return 1
+    fi
+
+    DISABLED_TRIGGER_SCHEMA=''
+    DISABLED_TRIGGER_TABLE=''
+}
+
+cleanup_disabled_user_triggers() {
+    if ! reenable_current_user_triggers; then
+        echo "WARNING: failed to re-enable USER triggers on $DISABLED_TRIGGER_SCHEMA.$DISABLED_TRIGGER_TABLE" >&2
+    fi
+}
+
+# A cancelled restore must not silently leave the current table's domain
+# triggers disabled. SIGKILL cannot be recovered from, but normal failures,
+# runner cancellation (TERM) and interactive interruption (INT) all retry the
+# compensating ALTER TABLE before exit.
+trap cleanup_disabled_user_triggers EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+# Parse the connection identity before any download or database access. Raw
+# substring matching is unsafe because credentials and query parameters can
+# contain an allowlisted project name without making it the actual host.
+DATABASE_URL="$TO_DB_URL" node \
+    "$SCRIPT_DIR/../scripts/validate-database-url.mjs" restore-target
 
 # Sanity-check RESTORE_ENCRYPTED_PASSWORD shape when set.
 # bcrypt hashes are exactly 60 chars and start with $2a$ / $2b$ / $2y$.
@@ -181,8 +192,14 @@ if [ ! -s "$DUMP_FILE" ]; then
 fi
 
 # --- Parse restore-config.yml for group/table definitions and data_rules ---
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RESTORE_CONFIG="$SCRIPT_DIR/restore-config.yml"
+
+# Validate the archive and its schema-contract compatibility before the first
+# destructive statement. Source and target must share the same complete phase;
+# partial phases, physical target drift and both mismatch directions are denied.
+pg_restore --list "$DUMP_FILE" > /dev/null
+PERIODICITE_RESTORE_PHASE=$(TO_DB_URL="$TO_DB_URL" \
+    bash "$SCRIPT_DIR/check-restore-compatibility.sh" "$DUMP_FILE")
 
 if [ ! -f "$RESTORE_CONFIG" ]; then
     echo "restore config not found: $RESTORE_CONFIG"
@@ -196,7 +213,8 @@ if ! command -v yq &> /dev/null; then
     exit 1
 fi
 
-# Group order: technical → stats → collectivites → indicateurs → referentiels → pai → plans
+# Group order: technical → stats → collectivites → indicateurs →
+# periodicite → referentiels → pai → plans
 # Restores foundational tables before tables that reference them. Truncation
 # runs in the reverse order (see below) so dependents come down first.
 GROUP_ORDER=(
@@ -204,6 +222,15 @@ GROUP_ORDER=(
   stats_group
   collectivites_group
   indicateurs_group
+)
+
+# Ces tables n'existent pas dans le schéma legacy. L'égalité de phase vérifiée
+# ci-dessus garantit qu'elles existent à la fois dans la cible et le snapshot.
+if [ "$PERIODICITE_RESTORE_PHASE" != "legacy" ]; then
+    GROUP_ORDER+=(periodicite_group)
+fi
+
+GROUP_ORDER+=(
   referentiels_group
   pai_group
   plans_group
@@ -304,11 +331,17 @@ for group in "${GROUP_ORDER[@]}"; do
             psql -d "$TO_DB_URL" -c "TRUNCATE TABLE \"$schema\".\"$table_name\" CASCADE;"
         fi
 
-        # Disable user triggers before restore.
+        # Disable user triggers before restore. Record the table first so the
+        # EXIT trap can compensate even if the process is interrupted between
+        # the ALTER TABLE and the normal re-enable step.
         # ALTER TABLE ... DISABLE TRIGGER USER requires table ownership.
         # On tables we don't own (e.g. auth.users), this fails — log a warning.
+        DISABLED_TRIGGER_SCHEMA="$schema"
+        DISABLED_TRIGGER_TABLE="$table_name"
         if ! psql -d "$TO_DB_URL" -c "ALTER TABLE \"$schema\".\"$table_name\" DISABLE TRIGGER USER;" 2>/dev/null; then
             echo -n " (warning: could not disable triggers — not table owner)"
+            DISABLED_TRIGGER_SCHEMA=''
+            DISABLED_TRIGGER_TABLE=''
         fi
 
         # Don't use --exit-on-error or --single-transaction: pg_restore executes
@@ -329,9 +362,12 @@ for group in "${GROUP_ORDER[@]}"; do
         restore_exit=$?
         set -e
 
-        # Re-enable user triggers after restore
-        if ! psql -d "$TO_DB_URL" -c "ALTER TABLE \"$schema\".\"$table_name\" ENABLE TRIGGER USER;" 2>/dev/null; then
-            true # Already warned above, no need to repeat
+        # Re-enable only when the disable succeeded. A failure here is unsafe:
+        # retain the recorded table for the EXIT retry and abort the restore.
+        if ! reenable_current_user_triggers; then
+            echo ""
+            echo "  FAILED: could not re-enable USER triggers on $schema.$table_name"
+            exit 1
         fi
 
         if [ -n "$restore_stderr" ]; then
@@ -342,7 +378,7 @@ for group in "${GROUP_ORDER[@]}"; do
         if [ $restore_exit -ne 0 ]; then
             # Filter out known harmless errors (transaction_timeout on PG < 17)
             real_errors=$(echo "$restore_stderr" | grep -i "error:" | grep -v "transaction_timeout" || true)
-            if [ -n "$real_errors" ]; then
+            if [ -n "$real_errors" ] || ! grep -qi "transaction_timeout" <<< "$restore_stderr"; then
                 echo "  FAILED"
                 exit 1
             fi
@@ -370,6 +406,13 @@ echo "Tables restored: $TOTAL_RESTORED"
 echo "Tables skipped (duplicates): $TOTAL_SKIPPED"
 echo "Total time: ${TOTAL_MINUTES}m${TOTAL_SECONDS}s"
 echo "Done!"
+
+# --- Post-restore: rebuild formula-derived state skipped with USER triggers ---
+echo ""
+echo "=== Rebuilding indicator formula state ==="
+psql -d "$TO_DB_URL" --no-psqlrc --set ON_ERROR_STOP=1 \
+    -f "$SCRIPT_DIR/rebuild-indicateur-formula-state.sql"
+echo "Indicator formula state rebuilt and validated."
 
 # --- Post-restore: reset sequences to match restored data ---
 echo ""

--- a/data_layer/scripts/validate-database-url.mjs
+++ b/data_layer/scripts/validate-database-url.mjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+
+const policy = process.argv[2];
+const rawDatabaseUrl = process.env.DATABASE_URL;
+const loopbackHosts = new Set(['localhost', '127.0.0.1', '[::1]']);
+const secureSslModes = new Set(['require', 'verify-ca', 'verify-full']);
+const restoreProjectRefs = new Set([
+  'qwbsrgwlypaqheoedxxq', // staging
+  'xbrefnclajfcjlpnwyow', // preprod
+]);
+
+function fail(message) {
+  console.error(`URL PostgreSQL refusée : ${message}`);
+  process.exit(2);
+}
+
+function decodeUrlComponent(component, label) {
+  try {
+    return decodeURIComponent(component);
+  } catch {
+    fail(`${label} contient un encodage invalide`);
+  }
+}
+
+function getSupabaseProjectRef(url) {
+  const directHostMatch = url.hostname.match(
+    /^db\.([a-z0-9-]+)\.supabase\.co$/
+  );
+  if (directHostMatch) {
+    return directHostMatch[1];
+  }
+
+  if (/^[a-z0-9-]+\.pooler\.supabase\.com$/.test(url.hostname)) {
+    const username = decodeUrlComponent(url.username, "le nom d'utilisateur");
+    if (username.startsWith('postgres.')) {
+      return username.slice('postgres.'.length);
+    }
+  }
+
+  return undefined;
+}
+
+function assertSupabaseConnectionShape(url) {
+  if (url.port && url.port !== '5432') {
+    fail(
+      'la connexion doit être directe ou utiliser un pooler de session sur le port 5432'
+    );
+  }
+  if (decodeUrlComponent(url.pathname, 'le nom de base') !== '/postgres') {
+    fail(
+      'la connexion doit cibler explicitement la base postgres du projet Supabase'
+    );
+  }
+
+  const configuredSslMode = url.searchParams.get('sslmode');
+  if (configuredSslMode && !secureSslModes.has(configuredSslMode)) {
+    fail(`le mode TLS ${configuredSslMode} n'est pas assez strict`);
+  }
+}
+
+function assertDisposableLocalDatabase(url) {
+  if (!loopbackHosts.has(url.hostname)) {
+    fail('un test destructif exige une adresse loopback');
+  }
+
+  const pathname = decodeUrlComponent(url.pathname, 'le nom de base');
+  const databaseNameMatch = pathname.match(/^\/([a-z0-9_]+)$/);
+  const databaseName = databaseNameMatch?.[1];
+  if (
+    !databaseName ||
+    !/(?:^|_)(?:test|temp|tmp|disposable)(?:_|$)/.test(databaseName)
+  ) {
+    fail(
+      'un test destructif exige un nom de base jetable contenant test, temp, tmp ou disposable'
+    );
+  }
+}
+
+function assertLocalSupabaseCiDatabase(url) {
+  const username = decodeUrlComponent(url.username, "le nom d'utilisateur");
+  const password = decodeUrlComponent(url.password, 'le mot de passe');
+  const databaseName = decodeUrlComponent(url.pathname, 'le nom de base');
+
+  if (
+    url.hostname !== 'supabase_db_tet' ||
+    url.port !== '5432' ||
+    databaseName !== '/postgres' ||
+    username !== 'postgres' ||
+    password !== 'postgres'
+  ) {
+    fail(
+      'un test CI destructif doit cibler exactement la base postgres du conteneur Supabase local'
+    );
+  }
+
+  if ([...url.searchParams].length !== 0) {
+    fail("la cible Supabase locale CI n'accepte aucun paramètre de connexion");
+  }
+}
+
+if (!rawDatabaseUrl) {
+  fail('DATABASE_URL est absente');
+}
+
+let databaseUrl;
+try {
+  databaseUrl = new URL(rawDatabaseUrl);
+} catch {
+  fail("le format de l'URL est invalide");
+}
+
+if (!['postgres:', 'postgresql:'].includes(databaseUrl.protocol)) {
+  fail('le protocole doit être postgres ou postgresql');
+}
+if (databaseUrl.hash) {
+  fail('les fragments sont interdits');
+}
+
+// libpq permet aux paramètres nommés de remplacer l'autorité de l'URI et le
+// dernier doublon gagne. Une URL de déploiement reste donc volontairement
+// minimale : seul sslmode peut apparaître, une seule fois.
+const connectionParameters = [...databaseUrl.searchParams.entries()];
+if (
+  connectionParameters.some(([name]) => name !== 'sslmode') ||
+  connectionParameters.length > 1
+) {
+  fail('seul un unique paramètre sslmode est autorisé');
+}
+
+if (policy === 'local-bootstrap') {
+  if (!loopbackHosts.has(databaseUrl.hostname)) {
+    fail('le bootstrap Earthly exige une adresse loopback');
+  }
+  process.exit(0);
+}
+
+if (policy === 'local-disposable') {
+  assertDisposableLocalDatabase(databaseUrl);
+  process.exit(0);
+}
+
+if (policy === 'local-supabase-ci') {
+  assertLocalSupabaseCiDatabase(databaseUrl);
+  process.exit(0);
+}
+
+if (policy === 'supabase-contract') {
+  const expectedProjectRef = process.env.EXPECTED_SUPABASE_PROJECT_REF;
+
+  if (!expectedProjectRef) {
+    fail('EXPECTED_SUPABASE_PROJECT_REF est absente');
+  }
+  assertSupabaseConnectionShape(databaseUrl);
+
+  const actualProjectRef = getSupabaseProjectRef(databaseUrl);
+  if (!actualProjectRef || actualProjectRef !== expectedProjectRef) {
+    fail(
+      "la cible ne correspond pas au projet Supabase déclaré pour l'environnement"
+    );
+  }
+  process.exit(0);
+}
+
+if (policy === 'restore-target') {
+  if (
+    loopbackHosts.has(databaseUrl.hostname) ||
+    databaseUrl.hostname === 'host.docker.internal'
+  ) {
+    process.exit(0);
+  }
+
+  assertSupabaseConnectionShape(databaseUrl);
+  if (!databaseUrl.searchParams.has('sslmode')) {
+    fail('une restauration distante doit expliciter un mode TLS strict');
+  }
+  const actualProjectRef = getSupabaseProjectRef(databaseUrl);
+  if (!actualProjectRef || !restoreProjectRefs.has(actualProjectRef)) {
+    fail('la restauration distante doit cibler exactement staging ou preprod');
+  }
+  process.exit(0);
+}
+
+fail(`la politique ${policy ?? '(absente)'} est inconnue`);

--- a/data_layer/scripts/validate-database-url.spec.mjs
+++ b/data_layer/scripts/validate-database-url.spec.mjs
@@ -1,0 +1,212 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const scriptPath = fileURLToPath(
+  new URL('./validate-database-url.mjs', import.meta.url)
+);
+
+function validate(policy, databaseUrl, expectedProjectRef) {
+  return spawnSync(process.execPath, [scriptPath, policy], {
+    encoding: 'utf8',
+    env: {
+      DATABASE_URL: databaseUrl,
+      EXPECTED_SUPABASE_PROJECT_REF: expectedProjectRef ?? '',
+    },
+  });
+}
+
+test('accepts loopback URLs for a local bootstrap', () => {
+  assert.equal(
+    validate(
+      'local-bootstrap',
+      'postgresql://postgres:postgres@127.0.0.1:54322/postgres'
+    ).status,
+    0
+  );
+});
+
+test('rejects remote and query-overridden local bootstrap targets', () => {
+  assert.notEqual(
+    validate(
+      'local-bootstrap',
+      'postgresql://postgres:secret@db.example.com:5432/postgres'
+    ).status,
+    0
+  );
+  assert.notEqual(
+    validate(
+      'local-bootstrap',
+      'postgresql://postgres:postgres@127.0.0.1:54322/postgres?host=db.example.com'
+    ).status,
+    0
+  );
+});
+
+test('accepts only explicitly disposable loopback databases for destructive tests', () => {
+  assert.equal(
+    validate(
+      'local-disposable',
+      'postgresql://postgres:postgres@127.0.0.1:54322/periodicite_contract_test_20260904'
+    ).status,
+    0
+  );
+  assert.equal(
+    validate(
+      'local-disposable',
+      'postgresql://postgres:postgres@localhost:5432/tmp'
+    ).status,
+    0
+  );
+
+  for (const databaseUrl of [
+    'postgresql://postgres:postgres@127.0.0.1:54322/postgres',
+    'postgresql://postgres:postgres@127.0.0.1:54322/contest',
+    'postgresql://postgres:secret@db.example.com:5432/migration_test',
+  ]) {
+    assert.notEqual(validate('local-disposable', databaseUrl).status, 0);
+  }
+});
+
+test('accepts only the exact internal Supabase database for destructive CI tests', () => {
+  assert.equal(
+    validate(
+      'local-supabase-ci',
+      'postgresql://postgres:postgres@supabase_db_tet:5432/postgres'
+    ).status,
+    0
+  );
+
+  for (const databaseUrl of [
+    'postgresql://postgres:postgres@127.0.0.1:54322/postgres',
+    'postgresql://postgres:postgres@supabase_db_tet/postgres',
+    'postgresql://postgres:postgres@supabase_db_tet:5432/production',
+    'postgresql://admin:postgres@supabase_db_tet:5432/postgres',
+    'postgresql://postgres:secret@supabase_db_tet:5432/postgres',
+    'postgresql://postgres:postgres@supabase_db_tet:5432/postgres?sslmode=disable',
+    'postgresql://postgres:postgres@database.example:5432/postgres',
+  ]) {
+    assert.notEqual(validate('local-supabase-ci', databaseUrl).status, 0);
+  }
+});
+
+test('accepts direct and session-pooler URLs for the expected Supabase project', () => {
+  assert.equal(
+    validate(
+      'supabase-contract',
+      'postgresql://postgres:secret@db.project-ref.supabase.co:5432/postgres?sslmode=verify-full',
+      'project-ref'
+    ).status,
+    0
+  );
+  assert.equal(
+    validate(
+      'supabase-contract',
+      'postgresql://postgres.project-ref:secret@aws-0-eu-west-3.pooler.supabase.com:5432/postgres',
+      'project-ref'
+    ).status,
+    0
+  );
+});
+
+test('rejects wrong projects, transaction poolers and insecure TLS', () => {
+  assert.notEqual(
+    validate(
+      'supabase-contract',
+      'postgresql://postgres:secret@db.other-project.supabase.co:5432/postgres',
+      'project-ref'
+    ).status,
+    0
+  );
+  assert.notEqual(
+    validate(
+      'supabase-contract',
+      'postgresql://postgres.project-ref:secret@aws-0-eu-west-3.pooler.supabase.com:6543/postgres',
+      'project-ref'
+    ).status,
+    0
+  );
+  assert.notEqual(
+    validate(
+      'supabase-contract',
+      'postgresql://postgres:secret@db.project-ref.supabase.co:5432/postgres?sslmode=disable',
+      'project-ref'
+    ).status,
+    0
+  );
+});
+
+test('rejects libpq identity overrides and duplicate connection parameters', () => {
+  assert.notEqual(
+    validate(
+      'supabase-contract',
+      'postgresql://postgres:secret@db.project-ref.supabase.co:5432/postgres?host=db.other-project.supabase.co',
+      'project-ref'
+    ).status,
+    0
+  );
+  assert.notEqual(
+    validate(
+      'supabase-contract',
+      'postgresql://postgres:secret@db.project-ref.supabase.co:5432/postgres?sslmode=require&sslmode=disable',
+      'project-ref'
+    ).status,
+    0
+  );
+});
+
+test('accepts only exact local, staging and preprod restore targets', () => {
+  assert.equal(
+    validate(
+      'restore-target',
+      'postgresql://postgres:postgres@host.docker.internal:54322/postgres'
+    ).status,
+    0
+  );
+  assert.equal(
+    validate(
+      'restore-target',
+      'postgresql://postgres:secret@db.qwbsrgwlypaqheoedxxq.supabase.co:5432/postgres?sslmode=require'
+    ).status,
+    0
+  );
+  assert.equal(
+    validate(
+      'restore-target',
+      'postgresql://postgres.xbrefnclajfcjlpnwyow:secret@aws-0-eu-west-3.pooler.supabase.com:5432/postgres?sslmode=require'
+    ).status,
+    0
+  );
+});
+
+test('rejects restore allowlist values outside the parsed target identity', () => {
+  assert.notEqual(
+    validate(
+      'restore-target',
+      'postgresql://localhost:secret@db.example.com:5432/postgres'
+    ).status,
+    0
+  );
+  assert.notEqual(
+    validate(
+      'restore-target',
+      'postgresql://postgres:qwbsrgwlypaqheoedxxq@db.example.com:5432/postgres'
+    ).status,
+    0
+  );
+  assert.notEqual(
+    validate(
+      'restore-target',
+      'postgresql://postgres:secret@db.qwbsrgwlypaqheoedxxq.supabase.co.attacker.example:5432/postgres'
+    ).status,
+    0
+  );
+  assert.notEqual(
+    validate(
+      'restore-target',
+      'postgresql://postgres:secret@db.qwbsrgwlypaqheoedxxq.supabase.co:5432/postgres'
+    ).status,
+    0
+  );
+});

--- a/doc/adr/0016-strategie-backup-database.md
+++ b/doc/adr/0016-strategie-backup-database.md
@@ -55,6 +55,18 @@ Cette approche garantit que le schéma de la base cible est toujours celui du co
 
 Pour faciliter la vérification de compatibilité, un fichier **metadata** (`backup-YYYY-MM-DD.metadata.json`) est uploadé avec chaque backup. Il contient la version du backend, le commit et l'environnement au moment de la sauvegarde. Cela permet à l'opérateur de vérifier que le backup est compatible avec le code déployé sur l'environnement cible avant de lancer la restauration.
 
+Cette information humaine ne constitue pas le garde de schéma. Avant sa première troncature,
+`restore.sh` lit la phase de périodicité dans le registre Sqitch de la cible et dans la table
+`sqitch.changes` archivée par `pg_dump` dans le même snapshot que les données. Les phases reconnues
+sont `legacy`, `expand` et `contract`; elles doivent être strictement identiques. L'expand exige ses
+quatre changements `periodicite`, `import_emt_valeur`, `reconciliation_formules` et
+`dependances_formules`. Le contract exige en plus `periodicite_obligatoire`,
+`periodicite_formules` et `report_indicateur_resultat_periode`. Toute combinaison partielle est
+refusée, côté source comme côté cible. Cette matrice conservatrice bloque aussi bien un vieux backup
+sur un schéma contracté qu'un backup mensuel sur un ancien schéma ou reporting. Une source ou cible
+privée du registre Sqitch, ou une archive illisible, est toujours refusée. Le contrôle ne dépend ni
+du nom daté de l'archive ni d'un fichier metadata modifiable séparément.
+
 ### 2. Restauration table par table pilotée par `restore-config.yml`
 
 Le fichier `data_layer/backup/restore-config.yml` définit la liste des tables et leur regroupement logique (groupes : technical, stats, collectivites, indicateurs, referentiels, pai, plans). Il sert d'unique source de vérité consommée par `restore.sh` pour orchestrer la restauration. Les règles d'anonymisation, elles, sont écrites en SQL dans `clean_data.sql` (cf. §7).
@@ -96,23 +108,66 @@ Ce remplacement du job historique `validate-restore` par deux jobs supprime la n
 Chaque job :
 
 1. Télécharge le backup depuis S3 (valide le roundtrip complet : backup → upload → download → restore)
-2. Tronque les tables cibles dans l'ordre inverse des dépendances
-3. Restaure table par table à partir du dump
-4. Réinitialise les séquences PostgreSQL via `reset_sequences.sql`
-5. Exécute `clean_data.sql` (cf. §7) pour anonymiser les colonnes sensibles et asserter la garantie post-scrub
-6. Vérifie les sanity checks de présence de données (`collectivite`, `dcp`, `indicateur_valeur`, `action_statut`, `score_snapshot`)
+2. Vérifie l'intégrité de l'archive et sa compatibilité Sqitch avec la cible, avant toute mutation
+3. Tronque les tables cibles dans l'ordre inverse des dépendances
+4. Restaure table par table à partir du dump
+5. Restaure l'audit de migration et les intentions de réconciliation durables du même snapshot
+6. Reconstruit et valide atomiquement la projection dérivée des dépendances de formules, puis rejoue
+   l'audit de dates sous verrou
+7. Réinitialise les séquences PostgreSQL via `reset_sequences.sql`
+8. Exécute `clean_data.sql` (cf. §7) pour anonymiser les colonnes sensibles et asserter la garantie post-scrub
+9. Vérifie les sanity checks de présence de données (`collectivite`, `dcp`, `indicateur_valeur`, `action_statut`, `score_snapshot`)
 
-Chaque job a son propre groupe de concurrence (`restore-staging` et `restore-preprod`), un timeout de 90 minutes pour borner les runs runaway, et utilise respectivement `STAGING_DB_URL` et `PREPROD_DB_URL` (les deux secrets pré-existants, hérités du fonctionnement pgsync). `clean_data.sql` lit `RESTORE_ENCRYPTED_PASSWORD` via `psql -v` pour la mise à jour de `encrypted_password`.
+Chaque job a son propre groupe de concurrence par base (`database-maintenance-staging` et
+`database-maintenance-preprod`), partagé avec le workflow contractuel de périodicité. Une
+restauration et ce changement de schéma exceptionnel ne peuvent donc pas s'exécuter simultanément
+sur une même cible depuis GitHub Actions. Les jobs gardent un timeout de 90 minutes pour borner les
+runs runaway et utilisent respectivement `STAGING_DB_URL` et `PREPROD_DB_URL` (les deux secrets
+pré-existants, hérités du fonctionnement pgsync). `clean_data.sql` lit
+`RESTORE_ENCRYPTED_PASSWORD` via `psql -v` pour la mise à jour de `encrypted_password`.
 
 ### 5. Restauration manuelle à la demande
 
 En complément de la restauration nocturne, un workflow GitHub Actions séparé (`cd-restore-preprod.yml`) permet de restaurer **à la demande** la preprod à partir d'un backup S3 de prod. Déclenchable manuellement via `workflow_dispatch`, il accepte un paramètre optionnel `backup_date` au format ISO (`YYYY-MM-DD`) : si une date est fournie, le backup correspondant (`backup-YYYY-MM-DD.dump`) est téléchargé et restauré ; si le champ est laissé vide, le workflow délègue à `restore.sh latest` qui liste le bucket S3 et sélectionne automatiquement le backup le plus récent disponible.
 
-Ce mode `latest` est exposé par `restore.sh` lui-même (et non dans le workflow) pour rester utilisable en local (`./restore.sh latest`). Le workflow manuel utilise le secret `PREPROD_DB_URL` (consolidé avec celui du job `restore-preprod` nocturne) et partage le même verrou de concurrence (`restore-preprod`), sérialisant les restaurations concurrentes (manuelles ou planifiées) sur la preprod partagée. `clean_data.sql` (§7) s'applique automatiquement, comme pour le job nocturne. Le garde-fou de protection production (allowlist, §6) reste actif puisqu'il est implémenté dans `restore.sh` et donc commun à tous les appelants.
+Ce mode `latest` est exposé par `restore.sh` lui-même (et non dans le workflow) pour rester utilisable en local (`./restore.sh latest`). Le workflow manuel utilise le secret `PREPROD_DB_URL` (consolidé avec celui du job `restore-preprod` nocturne) et partage le même verrou de concurrence (`database-maintenance-preprod`), sérialisant les restaurations concurrentes (manuelles ou planifiées) et le contract de périodicité sur la preprod partagée. `clean_data.sql` (§7) s'applique automatiquement, comme pour le job nocturne. Le garde-fou de protection production (allowlist, §6) reste actif puisqu'il est implémenté dans `restore.sh` et donc commun à tous les appelants.
 
 ### 6. Sécurité
 
-- **Protection production (allowlist fail-closed)** : `restore.sh` refuse toute restauration sauf si `TO_DB_URL` correspond à une URL en localhost ou à l'un des identifiants de projet Supabase explicitement autorisés (staging, preprod). Toute URL inattendue (y compris production) est rejetée avec un message clair et l'URL masquée. Cette approche remplace l'ancien denylist (un seul identifiant prod) qui était fragile en cas d'ajout d'un second projet de production.
+- **Protection production (allowlist fail-closed)** : `restore.sh` parse `TO_DB_URL` et refuse toute
+  restauration sauf si son hostname effectif est local ou si l'identité Supabase extraite correspond
+  exactement à staging ou preprod. Les paramètres libpq capables de remplacer l'autorité de l'URL
+  sont interdits. Une valeur autorisée placée dans le mot de passe, la query string ou un suffixe de
+  domaine ne peut donc pas autoriser une autre cible. Toute URL inattendue, dont production, est
+  rejetée sans journaliser ses credentials. Toute cible Supabase distante doit en plus déclarer
+  explicitement `sslmode=require`, `verify-ca` ou `verify-full` dans son secret de connexion.
+- **Compatibilité fail-closed avant troncature** : les phases Sqitch de la source et de la cible
+  doivent être exactement égales, et toute phase `expand` ou `contract` partielle est rejetée. La
+  cible doit aussi posséder les tables et fonctions physiques attendues par sa phase déclarée ; le
+  registre Sqitch seul ne peut pas masquer une dérive de schéma. Les restaurations nocturnes
+  resteront donc volontairement en échec pendant chaque décalage de rollout entre production et
+  staging/preprod, dans les deux directions. En `expand` et `contract`, l'archive doit aussi contenir
+  les entrées `TABLE DATA` de l'audit et de la file de réconciliation ; une archive sélective ne peut
+  pas les vider silencieusement.
+- **État dérivé restauré explicitement** : `indicateur_definition` est chargé avec ses triggers USER
+  désactivés. La projection `private.indicateur_definition_dependance_calcul` est donc reconstruite
+  avec l'extracteur canonique, puis validée sous les verrous du graphe et du catalogue. En revanche,
+  `migration.indicateur_valeur_periodicite_audit` et
+  `private.indicateur_reconciliation_formule` sont des états durables restaurés depuis le même
+  snapshot : ils portent respectivement l'historique de downgrade et les recalculs encore dus. Le
+  rejeu de l'audit en phase `expand` écarte les entrées devenues incohérentes et traite les valeurs
+  chargées sans triggers. En phase `contract`, la fonction transitoire ayant été retirée, les dates
+  sont validées directement. Une validation en échec annule atomiquement les post-traitements.
+- **Exclusion mutuelle des maintenances** : les restaurations planifiées et manuelles partagent leur
+  groupe de concurrence par base avec le workflow contractuel. Le backup de production partage de
+  même `database-maintenance-prod`, afin de ne jamais capturer un snapshot au milieu du contract.
+  Une invocation hors GitHub Actions reste une opération de maintenance et doit respecter le même
+  gel opératoire.
+- **Réactivation des triggers** : pendant la restauration table par table, la table dont les
+  triggers USER ont effectivement été désactivés reste mémorisée. Toute sortie normale, erreur,
+  interruption ou annulation par `TERM` tente de les réactiver ; un échec de réactivation arrête le
+  restore au lieu de publier silencieusement une table sans invariants. Seul un arrêt non
+  interceptable (`SIGKILL` ou panne de la cible) nécessite encore une vérification opérateur.
 - **Délai de confirmation** : un `sleep 10` permet à l'opérateur de vérifier l'URL cible avant la restauration (désactivé en CI via `$CI`)
 - **Masquage des credentials** : l'URL de connexion est masquée dans les logs (`postgresql://***@host/db`)
 - **Secrets GitHub** : tous les credentials sont passés via des variables d'environnement (secrets GitHub), jamais en arguments CLI
@@ -124,12 +179,12 @@ Après `reset_sequences.sql` et avant les sanity checks, `restore.sh` exécute `
 
 **Colonnes scrubbées (état actuel)** :
 
-| Cible                                       | Action                                                        |
-| ------------------------------------------- | ------------------------------------------------------------- |
-| `auth.users.phone`                          | `NULL`                                                        |
-| `auth.users.encrypted_password`             | `:'pwd'` si non vide, sinon laissé tel quel                   |
-| `public.dcp.telephone`                      | `NULL` (cf. interaction trigger ci-dessous)                   |
-| `config.service_configurations.token`       | `NULL` — empêche staging/preprod d'avoir des tokens API live  |
+| Cible                                 | Action                                                       |
+| ------------------------------------- | ------------------------------------------------------------ |
+| `auth.users.phone`                    | `NULL`                                                       |
+| `auth.users.encrypted_password`       | `:'pwd'` si non vide, sinon laissé tel quel                  |
+| `public.dcp.telephone`                | `NULL` (cf. interaction trigger ci-dessous)                  |
+| `config.service_configurations.token` | `NULL` — empêche staging/preprod d'avoir des tokens API live |
 
 **Substitution du mot de passe** : `restore.sh` passe `-v pwd="${RESTORE_ENCRYPTED_PASSWORD:-}"` à `psql`. La variable peut être vide (env var non définie en local) — l'`UPDATE` correspondant et son assertion sont alors no-op (clauses `WHERE :'pwd' <> ''`). Le hash bcrypt n'est ainsi jamais stocké dans le repo ; la rotation se fait en mettant à jour le secret GitHub Actions `RESTORE_ENCRYPTED_PASSWORD`.
 
@@ -202,6 +257,8 @@ Supabase propose ses propres backups (Point-in-Time Recovery). Non retenu comme 
 │  └─────────────┘          │           └─────────────────────────┘ │
 │                           ▼                                        │
 │                Each restore.sh: pg_restore table-by-table          │
+│                              ↓ restore audit + reconciliation      │
+│                              ↓ rebuild/validate formula projection │
 │                              ↓ reset_sequences.sql                 │
 │                              ↓ clean_data.sql (auth.users.phone +  │
 │                                  encrypted_password, dcp.telephone,│
@@ -215,16 +272,18 @@ Supabase propose ses propres backups (Point-in-Time Recovery). Non retenu comme 
 
 ## Fichiers et scripts
 
-| Fichier                                    | Rôle                                                                                              |
-| ------------------------------------------ | ------------------------------------------------------------------------------------------------- |
-| `data_layer/backup/backup.sh`              | Dump production + upload S3 + metadata                                                            |
-| `data_layer/backup/restore.sh`             | Download S3 + truncate + restore table/table + reset sequences + clean_data.sql + sanity          |
-| `data_layer/backup/cleanup.sh`             | Nettoyage des backups obsolètes selon la politique de rétention                                  |
-| `data_layer/backup/reset_sequences.sql`    | Réinitialisation des séquences après restore data-only                                            |
-| `data_layer/backup/clean_data.sql`         | Anonymisation des colonnes sensibles (cf. §7) + assertions intégrées                              |
-| `data_layer/backup/restore-config.yml`     | Source de vérité : liste des tables et groupes restaurés par `restore.sh`                         |
-| `.github/workflows/backup-database.yml`    | Orchestration CI : backup-production + restore-staging (latest) + restore-preprod (D-1) + cleanup |
-| `.github/workflows/cd-restore-preprod.yml` | Restauration manuelle à la demande de la preprod (date ISO ou `latest`)                           |
+| Fichier                                                  | Rôle                                                                                              |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `data_layer/backup/backup.sh`                            | Dump production + upload S3 + metadata                                                            |
+| `data_layer/backup/restore.sh`                           | Contrôle de phase + restore ordonné + post-traitements + sanity                                   |
+| `data_layer/backup/check-restore-compatibility.sh`       | Classification Sqitch source/cible et matrice de compatibilité fail-closed                        |
+| `data_layer/backup/rebuild-indicateur-formula-state.sql` | Rebuild/validation du graphe dérivé et rejeu d'audit après restore                                |
+| `data_layer/backup/cleanup.sh`                           | Nettoyage des backups obsolètes selon la politique de rétention                                   |
+| `data_layer/backup/reset_sequences.sql`                  | Réinitialisation des séquences après restore data-only                                            |
+| `data_layer/backup/clean_data.sql`                       | Anonymisation des colonnes sensibles (cf. §7) + assertions intégrées                              |
+| `data_layer/backup/restore-config.yml`                   | Source de vérité : liste des tables et groupes restaurés par `restore.sh`                         |
+| `.github/workflows/backup-database.yml`                  | Orchestration CI : backup-production + restore-staging (latest) + restore-preprod (D-1) + cleanup |
+| `.github/workflows/cd-restore-preprod.yml`               | Restauration manuelle à la demande de la preprod (date ISO ou `latest`)                           |
 
 ## Opérations courantes
 


### PR DESCRIPTION
Superseded by [PR 2/10](https://github.com/incubateur-ademe/territoires-en-transitions/pull/4961) in the consolidated 10-PR stack. Review and merge using the [updated index](https://github.com/incubateur-ademe/territoires-en-transitions/pull/4959). This PR is closed without merging; its changes are included in the replacement.

---

Protect backup restoration while indicator periodicity is deployed in several steps. Restore checks identify legacy, expanded and contracted schemas, reject incompatible archives, and rebuild formula-derived state only when its tables exist.

Validation: restore compatibility shell tests and database URL validation tests passed.

Merge after the calendar-period primitives. This safeguard precedes every schema change in the stack.
