### PR TITLE
refactor(indicateurs): isolate permissions sources and relation persistence

### DIFF
--- a/.github/actions/compute-affected-scope/action.yml
+++ b/.github/actions/compute-affected-scope/action.yml
@@ -89,7 +89,7 @@ runs:
         fi
 
         run_db_deploy=false
-        if grep -Eq '^(data_layer/|supabase/|sqitch\.conf$|\.github/actions/sqitch/|\.github/actions/sqitch-local/|\.github/workflows/prepare-test-db\.yml$|\.github/workflows/test-db-deploy\.yml$)' <<<"$changed_files"; then
+        if grep -Eq '^(Makefile$|Earthfile$|data_layer/|supabase/|sqitch\.conf$|\.github/actions/sqitch/|\.github/actions/sqitch-local/|\.github/workflows/(backup-database|cd-periodicite-contract|cd-restore-preprod|prepare-test-db|test-db-deploy)\.yml$)' <<<"$changed_files"; then
           run_db_deploy=true
         fi
 

--- a/.github/actions/sqitch-local/action.yml
+++ b/.github/actions/sqitch-local/action.yml
@@ -1,17 +1,19 @@
 name: sqitch-local
-description: Run sqitch (for local dev)
+description: |
+  Run sqitch for local development.
+  Docker actions preserve the standard libpq PGOPTIONS variable supplied by the calling step.
 
 inputs:
   command:
-    description: "Command to run"
+    description: 'Command to run'
     required: true
   target:
-    description: "Target"
+    description: 'Target'
     required: true
 
 runs:
-  using: "docker"
-  image: "Dockerfile"
+  using: 'docker'
+  image: 'Dockerfile'
   args:
     - ${{ inputs.command }}
     - ${{ inputs.target }}

--- a/.github/actions/sqitch-local/entrypoint.sh
+++ b/.github/actions/sqitch-local/entrypoint.sh
@@ -1,8 +1,18 @@
 #!/bin/bash
 
+set -euo pipefail
+
+if (( $# != 2 )) || [[ -z "$1" || -z "$2" ]]; then
+  echo 'sqitch-local requires a non-empty command and target' >&2
+  exit 2
+fi
+
 # Split the command input into an array by space
 IFS=' ' read -r -a cmd_array <<< "$1"
+if (( ${#cmd_array[@]} == 0 )); then
+  echo 'sqitch-local command cannot be empty' >&2
+  exit 2
+fi
 
 # Execute sqitch with the array
 sqitch "${cmd_array[@]}" --target "$2"
-

--- a/.github/actions/sqitch/action.yml
+++ b/.github/actions/sqitch/action.yml
@@ -1,21 +1,21 @@
 name: sqitch
 description: |
   Run sqitch into a container with a prebuilt image to allow passing the --network option.
-
+  The standard libpq PGOPTIONS environment variable is forwarded unchanged when callers set it.
 
 inputs:
   command:
-    description: "Command to run"
+    description: 'Command to run'
     required: true
   target:
-    description: "Target"
+    description: 'Target'
     required: true
   network:
     description: Docker network
     required: true
 
 runs:
-  using: "composite"
+  using: 'composite'
 
   steps:
     - name: Get image path
@@ -39,12 +39,24 @@ runs:
 
     - name: Execute command within image
       shell: bash
-      run: >
-        docker run
-        --rm
-        --network ${{ inputs.network }}
-        -v ./sqitch.conf:/sqitch.conf
-        -v ./data_layer/sqitch:/data_layer/sqitch
-        ${{ steps.get_image_path.outputs.path }}
-        ${{ inputs.command }}
-        --target ${{ inputs.target }}
+      env:
+        SQITCH_COMMAND: ${{ inputs.command }}
+        SQITCH_IMAGE: ${{ steps.get_image_path.outputs.path }}
+        SQITCH_NETWORK: ${{ inputs.network }}
+        SQITCH_TARGET: ${{ inputs.target }}
+      run: |
+        IFS=' ' read -r -a sqitch_command <<< "$SQITCH_COMMAND"
+        if (( ${#sqitch_command[@]} == 0 )); then
+          echo '::error::La commande Sqitch ne peut pas être vide.'
+          exit 2
+        fi
+
+        docker run \
+          --rm \
+          --network "$SQITCH_NETWORK" \
+          --env PGOPTIONS \
+          -v ./sqitch.conf:/sqitch.conf \
+          -v ./data_layer/sqitch:/data_layer/sqitch \
+          "$SQITCH_IMAGE" \
+          "${sqitch_command[@]}" \
+          --target "$SQITCH_TARGET"

--- a/.github/workflows/backup-database.yml
+++ b/.github/workflows/backup-database.yml
@@ -15,9 +15,14 @@ jobs:
     environment: prod
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    concurrency:
+      group: database-maintenance-prod
+      cancel-in-progress: false
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install PostgreSQL client
         run: |
@@ -63,11 +68,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     concurrency:
-      group: restore-staging
+      group: database-maintenance-staging
       cancel-in-progress: false
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install PostgreSQL client
         run: |
@@ -76,7 +83,7 @@ jobs:
 
       - name: Install yq
         run: |
-          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.53.2/yq_linux_amd64
           sudo chmod +x /usr/local/bin/yq
 
       - name: Install AWS CLI
@@ -104,11 +111,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     concurrency:
-      group: restore-preprod
+      group: database-maintenance-preprod
       cancel-in-progress: false
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install PostgreSQL client
         run: |
@@ -117,7 +126,7 @@ jobs:
 
       - name: Install yq
         run: |
-          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.53.2/yq_linux_amd64
           sudo chmod +x /usr/local/bin/yq
 
       - name: Install AWS CLI
@@ -143,4 +152,5 @@ jobs:
           BACKUP_BUCKET: ${{ vars.BACKUP_BUCKET }}
           BACKUP_REGION: ${{ vars.BACKUP_REGION }}
           BACKUP_ENDPOINT_URL: ${{ vars.BACKUP_ENDPOINT_URL }}
-        run: bash data_layer/backup/restore.sh "${{ steps.dminus1.outputs.date }}"
+          RESTORE_ARGUMENT: ${{ steps.dminus1.outputs.date }}
+        run: bash data_layer/backup/restore.sh "$RESTORE_ARGUMENT"

--- a/.github/workflows/cd-restore-preprod.yml
+++ b/.github/workflows/cd-restore-preprod.yml
@@ -20,11 +20,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     concurrency:
-      group: restore-preprod
+      group: database-maintenance-preprod
       cancel-in-progress: false
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install PostgreSQL client
         run: |
@@ -33,7 +35,7 @@ jobs:
 
       - name: Install yq
         run: |
-          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.53.2/yq_linux_amd64
           sudo chmod +x /usr/local/bin/yq
 
       - name: Install AWS CLI
@@ -75,4 +77,5 @@ jobs:
           BACKUP_BUCKET: ${{ vars.BACKUP_BUCKET }}
           BACKUP_REGION: ${{ vars.BACKUP_REGION }}
           BACKUP_ENDPOINT_URL: ${{ vars.BACKUP_ENDPOINT_URL }}
-        run: bash data_layer/backup/restore.sh "${{ steps.restore_arg.outputs.restore_arg }}"
+          RESTORE_ARGUMENT: ${{ steps.restore_arg.outputs.restore_arg }}
+        run: bash data_layer/backup/restore.sh "$RESTORE_ARGUMENT"

--- a/.github/workflows/test-db-deploy.yml
+++ b/.github/workflows/test-db-deploy.yml
@@ -7,13 +7,13 @@ permissions:
 on:
   workflow_call:
 
-
 env:
   # le tag sqitch jusqu'où on test les revert/deploy
   tag: v4.0.0
 
 jobs:
   test-db-deploy:
+    name: Test database deployment lifecycle
     runs-on: ubuntu-latest
     environment: ci
 
@@ -21,6 +21,13 @@ jobs:
       - uses: actions/checkout@v7.0.1
         with:
           persist-credentials: false
+
+      - name: Test database deployment guards
+        run: |
+          node --test data_layer/scripts/validate-database-url.spec.mjs
+          bash data_layer/backup/check-restore-compatibility.spec.sh
+          bash data_layer/tests/indicateur/periodicite-migration-lifecycle-database.spec.sh
+
       - uses: ./.github/actions/docker-login
         if: ${{ !env.ACT }}
         with:
@@ -33,30 +40,212 @@ jobs:
           network: ${{ vars.SUPABASE_NETWORK }}
           pull: ${{ !env.ACT }}
 
+      - name: Bind database tests to the local Supabase container
+        id: local-supabase
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@supabase_db_tet:5432/postgres
+          SUPABASE_NETWORK: ${{ vars.SUPABASE_NETWORK }}
+        run: |
+          set -euo pipefail
+
+          node data_layer/scripts/validate-database-url.mjs local-supabase-ci
+
+          container_id="$(docker inspect --format '{{.Id}}' supabase_db_tet)"
+          if [[ "$(docker inspect --format '{{.State.Running}}' supabase_db_tet)" != 'true' ]]; then
+            echo "::error::Le conteneur Supabase local n'est pas démarré."
+            exit 2
+          fi
+
+          attached_container_ip=''
+          while IFS='|' read -r attached_container_id attached_container_cidr; do
+            if [[ "$attached_container_id" == "$container_id" ]]; then
+              attached_container_ip="${attached_container_cidr%%/*}"
+              break
+            fi
+          done < <(
+            docker network inspect \
+              --format '{{range $id, $container := .Containers}}{{$id}}|{{$container.IPv4Address}}{{"\n"}}{{end}}' \
+              "$SUPABASE_NETWORK"
+          )
+          if [[ -z "$attached_container_ip" ]]; then
+            echo "::error::Le conteneur Supabase local n'est pas rattaché au réseau $SUPABASE_NETWORK."
+            exit 2
+          fi
+
+          postgres_image="$(docker inspect --format '{{.Config.Image}}' supabase_db_tet)"
+          connection_identity="$(
+            docker run \
+              --rm \
+              --network "$SUPABASE_NETWORK" \
+              --env DATABASE_URL \
+              --entrypoint psql \
+              "$postgres_image" \
+              "$DATABASE_URL" \
+              --no-psqlrc \
+              --tuples-only \
+              --no-align \
+              --set ON_ERROR_STOP=1 \
+              --command "select current_database() || '|' || host(inet_server_addr())"
+          )"
+          if [[ "$connection_identity" != "postgres|$attached_container_ip" ]]; then
+            echo '::error::La cible PostgreSQL ne correspond pas au conteneur Supabase local démarré.'
+            exit 2
+          fi
+
+          echo "database-url=$DATABASE_URL" >> "$GITHUB_OUTPUT"
+          echo "sqitch-target=db:$DATABASE_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Test restore guard with a real Sqitch archive
+        env:
+          DATABASE_TARGET: ${{ steps.local-supabase.outputs.sqitch-target }}
+          SUPABASE_NETWORK: ${{ vars.SUPABASE_NETWORK }}
+        run: |
+          database_url="${DATABASE_TARGET#db:}"
+          postgres_image="$(docker inspect --format '{{.Config.Image}}' supabase_db_tet)"
+          docker run \
+            --rm \
+            --network "$SUPABASE_NETWORK" \
+            --env "RESTORE_GUARD_TEST_DATABASE_URL=$database_url" \
+            --volume "$GITHUB_WORKSPACE:/workspace:ro" \
+            --workdir /workspace \
+            --entrypoint bash \
+            "$postgres_image" \
+            -c '
+              set -euo pipefail
+              dump_file=$(mktemp)
+              trap '\''rm -f "$dump_file"'\'' EXIT
+              pg_dump "$RESTORE_GUARD_TEST_DATABASE_URL" \
+                --format=custom \
+                --data-only \
+                --table=sqitch.changes \
+                --table=migration.indicateur_valeur_periodicite_audit \
+                --table=private.indicateur_reconciliation_formule \
+                --file="$dump_file"
+              phase=$(TO_DB_URL="$RESTORE_GUARD_TEST_DATABASE_URL" \
+                bash data_layer/backup/check-restore-compatibility.sh "$dump_file")
+              test "$phase" = expand
+            '
+
+      - name: Define isolated periodicity lifecycle database
+        id: periodicite-lifecycle-database
+        env:
+          PERIODICITE_MIGRATION_ADMIN_DATABASE_URL: ${{ steps.local-supabase.outputs.database-url }}
+          PERIODICITE_MIGRATION_DATABASE_NAME: periodicite_migration_lifecycle_test_${{ github.run_id }}_${{ github.run_attempt }}
+        run: |
+          set -euo pipefail
+          database_script='data_layer/tests/indicateur/periodicite-migration-lifecycle-database.sh'
+          database_url="$(bash "$database_script" database-url)"
+          echo "::add-mask::$database_url"
+          {
+            echo "database-name=$PERIODICITE_MIGRATION_DATABASE_NAME"
+            echo "database-url=$database_url"
+            echo "sqitch-target=db:$database_url"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create isolated pre-expand database
+        id: create-periodicite-lifecycle-database
+        env:
+          PERIODICITE_MIGRATION_ADMIN_DATABASE_URL: ${{ steps.local-supabase.outputs.database-url }}
+          PERIODICITE_MIGRATION_DATABASE_NAME: ${{ steps.periodicite-lifecycle-database.outputs.database-name }}
+        run: |
+          set -euo pipefail
+          database_script='data_layer/tests/indicateur/periodicite-migration-lifecycle-database.sh'
+          docker exec \
+            --interactive \
+            --env PERIODICITE_MIGRATION_ADMIN_DATABASE_URL \
+            --env PERIODICITE_MIGRATION_DATABASE_NAME \
+            supabase_db_tet \
+            bash -s -- create < "$database_script"
+          echo 'created=true' >> "$GITHUB_OUTPUT"
+
+      - name: Revert isolated database to periodicity base (ci)
+        if: ${{ !env.ACT }}
+        uses: ./.github/actions/sqitch
+        with:
+          command: 'revert --to @indicateur-periodicite-base --y'
+          target: ${{ steps.periodicite-lifecycle-database.outputs.sqitch-target }}
+          network: ${{ vars.SUPABASE_NETWORK }}
+
+      - name: Revert isolated database to periodicity base (local)
+        if: ${{ env.ACT }}
+        uses: ./.github/actions/sqitch-local
+        with:
+          command: 'revert --to @indicateur-periodicite-base --y'
+          target: ${{ steps.periodicite-lifecycle-database.outputs.sqitch-target }}
+
+      - name: Assert isolated database is exactly pre-expand
+        env:
+          PERIODICITE_MIGRATION_ADMIN_DATABASE_URL: ${{ steps.local-supabase.outputs.database-url }}
+          PERIODICITE_MIGRATION_DATABASE_NAME: ${{ steps.periodicite-lifecycle-database.outputs.database-name }}
+        run: |
+          set -euo pipefail
+          database_script='data_layer/tests/indicateur/periodicite-migration-lifecycle-database.sh'
+          docker exec \
+            --interactive \
+            --env PERIODICITE_MIGRATION_ADMIN_DATABASE_URL \
+            --env PERIODICITE_MIGRATION_DATABASE_NAME \
+            supabase_db_tet \
+            bash -s -- assert-pre-expand < "$database_script"
+
+      - name: Test expand periodicity migration lifecycle
+        env:
+          LIFECYCLE_DATABASE_URL: ${{ steps.periodicite-lifecycle-database.outputs.database-url }}
+          SUPABASE_NETWORK: ${{ vars.SUPABASE_NETWORK }}
+        run: |
+          set -euo pipefail
+
+          postgres_image="$(docker inspect --format '{{.Config.Image}}' supabase_db_tet)"
+          docker run \
+            --rm \
+            --network "$SUPABASE_NETWORK" \
+            --env "PERIODICITE_MIGRATION_TEST_DATABASE_URL=$LIFECYCLE_DATABASE_URL" \
+            --volume "$GITHUB_WORKSPACE:/workspace:ro" \
+            --workdir /workspace \
+            --entrypoint bash \
+            "$postgres_image" \
+            data_layer/tests/indicateur/periodicite-migration-lifecycle.sh
+
+      - name: Drop isolated periodicity lifecycle database
+        if: ${{ always() && steps.create-periodicite-lifecycle-database.outputs.created == 'true' }}
+        env:
+          PERIODICITE_MIGRATION_ADMIN_DATABASE_URL: ${{ steps.local-supabase.outputs.database-url }}
+          PERIODICITE_MIGRATION_DATABASE_NAME: ${{ steps.periodicite-lifecycle-database.outputs.database-name }}
+        run: |
+          set -euo pipefail
+          database_script='data_layer/tests/indicateur/periodicite-migration-lifecycle-database.sh'
+          docker exec \
+            --interactive \
+            --env PERIODICITE_MIGRATION_ADMIN_DATABASE_URL \
+            --env PERIODICITE_MIGRATION_DATABASE_NAME \
+            supabase_db_tet \
+            bash -s -- drop < "$database_script"
+
       - name: Sqitch revert to ${{ env.tag }}
         if: ${{ !env.ACT }}
         uses: ./.github/actions/sqitch
         with:
-          command: "revert --to @${{ env.tag }} --y"
-          target: ${{ vars.SQITCH_TARGET }}
+          command: 'revert --to @${{ env.tag }} --y'
+          target: ${{ steps.local-supabase.outputs.sqitch-target }}
           network: ${{ vars.SUPABASE_NETWORK }}
 
       - name: Sqitch deploy/verify
         if: ${{ !env.ACT }}
         uses: ./.github/actions/sqitch
         with:
-          command: "deploy --mode change --verify"
-          target: ${{ vars.SQITCH_TARGET }}
+          command: 'deploy --mode all --verify --to @indicateur-periodicite-expand'
+          target: ${{ steps.local-supabase.outputs.sqitch-target }}
           network: ${{ vars.SUPABASE_NETWORK }}
 
       - name: Sqitch revert to ${{ env.tag }} (local)
         if: ${{ env.ACT }}
         uses: ./.github/actions/sqitch-local
         with:
-          command: "revert --to @${{ env.tag }} --y"
+          command: 'revert --to @${{ env.tag }} --y'
+          target: ${{ steps.local-supabase.outputs.sqitch-target }}
 
       - name: Sqitch deploy/verify (local)
         if: ${{ env.ACT }}
         uses: ./.github/actions/sqitch-local
         with:
-          command: "deploy --mode change --verify"
+          command: 'deploy --mode all --verify --to @indicateur-periodicite-expand'
+          target: ${{ steps.local-supabase.outputs.sqitch-target }}

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ env_target = $(if $(app),apps/$(app)/.env,$$(node scripts/pick-env-file.mts))
         infra-up services-scoped-up worktree worktree-env worktree-prune guard-main warn-shared-db \
         up services-up node-base heal-db stop down cache-clean workflow-graph logs ps tui \
         preflight-inotify preflight-env-keys ensure-deps inotify-persist \
-        db-init db-migrate db-seed db-reset db-shell db-import-referentiels db-restore-local-from-prod-backup seeds_rebuild_from_source \
+        db-init db-migrate db-migrate-periodicite-expand db-test-deployment-guards db-test-periodicite-migration db-seed db-reset db-shell db-import-referentiels db-restore-local-from-prod-backup seeds_rebuild_from_source \
         cms-pull cms-pull-local
 
 help: ## Affiche cette aide
@@ -258,8 +258,18 @@ tui: ensure-deps ## Tableau de bord interactif de la stack : statuts, URLs, logs
 db-init: guard-main preflight-env-keys services-up db-migrate db-import-referentiels db-seed ## Initialise la base de zéro : services + migrations + référentiels + données de test
 	@echo "✓ base prête — lancez les apps avec make dev (host) ou make up (docker)"
 
-db-migrate: warn-shared-db ## Applique les migrations sqitch
-	$(COMPOSE) --profile dbtools --profile supabase run --rm --build -T sqitch deploy --mode change
+db-migrate: db-migrate-periodicite-expand ## Déploie la phase compatible de périodicité
+
+db-migrate-periodicite-expand: warn-shared-db ## Déploie les quatre changements expand dans une transaction vérifiée
+	$(COMPOSE) --profile dbtools --profile supabase run --rm --build -T sqitch deploy --mode all --verify --to @indicateur-periodicite-expand
+
+db-test-deployment-guards: ## Teste les politiques d'URL, backup/schéma et base de migration jetable
+	node --test data_layer/scripts/validate-database-url.spec.mjs
+	bash data_layer/backup/check-restore-compatibility.spec.sh
+	bash data_layer/tests/indicateur/periodicite-migration-lifecycle-database.spec.sh
+
+db-test-periodicite-migration: ## Teste le cycle expand sur PERIODICITE_MIGRATION_TEST_DATABASE_URL (base jetable)
+	bash data_layer/tests/indicateur/periodicite-migration-lifecycle.sh
 
 # Comme en CI, les seeds supposent les référentiels déjà importés (les tables
 # banatic_2025_competence, action…, remplies par db-import-referentiels).

--- a/apps/backend/src/indicateurs/indicateurs.module.ts
+++ b/apps/backend/src/indicateurs/indicateurs.module.ts
@@ -1,3 +1,8 @@
+import { IndicateurSourcesRepository } from './sources/indicateur-sources.repository';
+import { HandleDefinitionFichesRepository } from './indicateurs/handle-definition-fiches/handle-definition-fiches.repository';
+import { HandleDefinitionPilotesRepository } from './indicateurs/handle-definition-pilotes/handle-definition-pilotes.repository';
+import { HandleDefinitionServicesRepository } from './indicateurs/handle-definition-services/handle-definition-services.repository';
+import { HandleDefinitionThematiquesRepository } from './indicateurs/handle-definition-thematiques/handle-definition-thematiques.repository';
 import { Module } from '@nestjs/common';
 import CreateDefinitionService from '@tet/backend/indicateurs/definitions/mutate-definition/create-definition.service';
 import { MutateDefinitionRouter } from '@tet/backend/indicateurs/definitions/mutate-definition/mutate-definition.router';
@@ -11,6 +16,7 @@ import { PersonnalisationsModule } from '../collectivites/personnalisations/pers
 import { ReferentielsCoreModule } from '../referentiels/referentiels-core.module';
 import { UsersModule } from '../users/users.module';
 import { SheetModule } from '../utils/google-sheets/sheet.module';
+import { TransactionModule } from '../utils/transaction/transaction.module';
 import { IndicateurChartService } from './charts/indicateur-chart.service';
 import { ListCollectiviteDefinitionsRepository } from './definitions/list-collectivite-definitions/list-collectivite-definitions.repository';
 import { ListPlatformDefinitionsController } from './definitions/list-platform-definitions/list-platform-definitions.controller';
@@ -69,8 +75,14 @@ const DEFINITIONS_PROVIDERS = [
     SheetModule,
     PersonnalisationsModule,
     ReferentielsCoreModule,
+    TransactionModule,
   ],
   providers: [
+    IndicateurSourcesRepository,
+    HandleDefinitionFichesRepository,
+    HandleDefinitionPilotesRepository,
+    HandleDefinitionServicesRepository,
+    HandleDefinitionThematiquesRepository,
     ExportIndicateursService,
     IndicateurSourcesService,
     IndicateurSourcesService,

--- a/apps/backend/src/indicateurs/indicateurs/handle-definition-fiches/handle-definition-fiches.repository.spec.ts
+++ b/apps/backend/src/indicateurs/indicateurs/handle-definition-fiches/handle-definition-fiches.repository.spec.ts
@@ -1,0 +1,26 @@
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { HandleDefinitionFichesRepository } from './handle-definition-fiches.repository';
+
+describe('HandleDefinitionFichesRepository', () => {
+  it('writes through the selected database without opening a transaction', async () => {
+    const database = {
+      transaction: vi.fn(),
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({ where: vi.fn(() => ({})) })),
+      })),
+      delete: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+    };
+    const repository = new HandleDefinitionFichesRepository({
+      db: database,
+    } as unknown as DatabaseService);
+
+    await repository.upsertIndicateurFiches({
+      indicateurId: 1,
+      collectiviteId: 2,
+      ficheIds: [],
+    });
+
+    expect(database.delete).toHaveBeenCalledOnce();
+    expect(database.transaction).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/indicateurs/indicateurs/handle-definition-fiches/handle-definition-fiches.repository.ts
+++ b/apps/backend/src/indicateurs/indicateurs/handle-definition-fiches/handle-definition-fiches.repository.ts
@@ -1,0 +1,74 @@
+import { Injectable } from '@nestjs/common';
+import { ficheActionIndicateurTable } from '@tet/backend/plans/fiches/shared/models/fiche-action-indicateur.table';
+import { ficheActionTable } from '@tet/backend/plans/fiches/shared/models/fiche-action.table';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { and, eq, inArray, notInArray } from 'drizzle-orm';
+
+type UpsertIndicateurFiches = Readonly<{
+  indicateurId: number;
+  collectiviteId: number;
+  ficheIds: number[];
+}>;
+
+@Injectable()
+export class HandleDefinitionFichesRepository {
+  constructor(private readonly databaseService: DatabaseService) {}
+
+  async areFichesOwnedByCollectivite(
+    ficheIds: number[],
+    collectiviteId: number,
+    tx?: Transaction
+  ): Promise<boolean> {
+    const uniqueFicheIds = [...new Set(ficheIds)];
+    if (uniqueFicheIds.length === 0) {
+      return true;
+    }
+
+    const fiches = await (tx ?? this.databaseService.db)
+      .select({ id: ficheActionTable.id })
+      .from(ficheActionTable)
+      .where(
+        and(
+          inArray(ficheActionTable.id, uniqueFicheIds),
+          eq(ficheActionTable.collectiviteId, collectiviteId)
+        )
+      );
+
+    return fiches.length === uniqueFicheIds.length;
+  }
+
+  async upsertIndicateurFiches(
+    { indicateurId, collectiviteId, ficheIds }: UpsertIndicateurFiches,
+    tx?: Transaction
+  ): Promise<void> {
+    const writeDb = tx ?? this.databaseService.db;
+    const deleteConditions = [
+      eq(ficheActionIndicateurTable.indicateurId, indicateurId),
+      inArray(
+        ficheActionIndicateurTable.ficheId,
+        writeDb
+          .select({ id: ficheActionTable.id })
+          .from(ficheActionTable)
+          .where(eq(ficheActionTable.collectiviteId, collectiviteId))
+      ),
+    ];
+
+    if (ficheIds.length > 0) {
+      deleteConditions.push(
+        notInArray(ficheActionIndicateurTable.ficheId, ficheIds)
+      );
+    }
+
+    await writeDb
+      .delete(ficheActionIndicateurTable)
+      .where(and(...deleteConditions));
+
+    if (ficheIds.length > 0) {
+      await writeDb
+        .insert(ficheActionIndicateurTable)
+        .values(ficheIds.map((ficheId) => ({ ficheId, indicateurId })))
+        .onConflictDoNothing();
+    }
+  }
+}

--- a/apps/backend/src/indicateurs/indicateurs/handle-definition-fiches/handle-definition-fiches.service.spec.ts
+++ b/apps/backend/src/indicateurs/indicateurs/handle-definition-fiches/handle-definition-fiches.service.spec.ts
@@ -1,0 +1,63 @@
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { TransactionManager } from '@tet/backend/utils/transaction/transaction-manager.service';
+import { HandleDefinitionFichesRepository } from './handle-definition-fiches.repository';
+import { HandleDefinitionFichesService } from './handle-definition-fiches.service';
+
+describe('HandleDefinitionFichesService', () => {
+  it('delegates transaction ownership and reuses the caller transaction', async () => {
+    const repository = {
+      areFichesOwnedByCollectivite: vi.fn().mockResolvedValue(true),
+      upsertIndicateurFiches: vi.fn().mockResolvedValue(undefined),
+    } as unknown as HandleDefinitionFichesRepository;
+    const tx = {} as Transaction;
+    const transactionManager = {
+      executeSingle: vi.fn(
+        async (
+          operation: (currentTx: Transaction) => Promise<unknown>,
+          currentTx?: Transaction
+        ) => operation(currentTx ?? tx)
+      ),
+    } as unknown as TransactionManager;
+    const service = new HandleDefinitionFichesService(
+      repository,
+      transactionManager
+    );
+
+    const input = { indicateurId: 1, collectiviteId: 2, ficheIds: [] };
+
+    await service.upsertIndicateurFiches(input, tx);
+
+    expect(transactionManager.executeSingle).toHaveBeenCalledWith(
+      expect.any(Function),
+      tx
+    );
+    expect(repository.upsertIndicateurFiches).toHaveBeenCalledWith(input, tx);
+  });
+
+  it("refuse une fiche qui n'appartient pas à la collectivité", async () => {
+    const repository = {
+      areFichesOwnedByCollectivite: vi.fn().mockResolvedValue(false),
+      upsertIndicateurFiches: vi.fn(),
+    } as unknown as HandleDefinitionFichesRepository;
+    const tx = {} as Transaction;
+    const transactionManager = {
+      executeSingle: vi.fn(
+        async (operation: (currentTx: Transaction) => Promise<unknown>) =>
+          operation(tx)
+      ),
+    } as unknown as TransactionManager;
+    const service = new HandleDefinitionFichesService(
+      repository,
+      transactionManager
+    );
+
+    await expect(
+      service.upsertIndicateurFiches({
+        indicateurId: 1,
+        collectiviteId: 2,
+        ficheIds: [3],
+      })
+    ).rejects.toThrow(/fiches doivent appartenir/i);
+    expect(repository.upsertIndicateurFiches).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/indicateurs/indicateurs/handle-definition-fiches/handle-definition-fiches.service.ts
+++ b/apps/backend/src/indicateurs/indicateurs/handle-definition-fiches/handle-definition-fiches.service.ts
@@ -1,64 +1,59 @@
-import { Injectable, Logger } from '@nestjs/common';
-import { ficheActionIndicateurTable } from '@tet/backend/plans/fiches/shared/models/fiche-action-indicateur.table';
-import { ficheActionTable } from '@tet/backend/plans/fiches/shared/models/fiche-action.table';
-import { DatabaseService } from '@tet/backend/utils/database/database.service';
-import { and, eq, inArray, notInArray } from 'drizzle-orm';
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { success } from '@tet/backend/utils/result.type';
+import { TransactionManager } from '@tet/backend/utils/transaction/transaction-manager.service';
+import { HandleDefinitionFichesRepository } from './handle-definition-fiches.repository';
 
 @Injectable()
 export class HandleDefinitionFichesService {
   private readonly logger = new Logger(HandleDefinitionFichesService.name);
 
-  constructor(private readonly databaseService: DatabaseService) {}
+  constructor(
+    private readonly repository: HandleDefinitionFichesRepository,
+    private readonly transactionManager: TransactionManager
+  ) {}
 
-  async upsertIndicateurFiches({
-    indicateurId,
-    collectiviteId,
-    ficheIds,
-  }: {
-    indicateurId: number;
-    collectiviteId: number;
-    ficheIds: number[];
-  }) {
+  async upsertIndicateurFiches(
+    {
+      indicateurId,
+      collectiviteId,
+      ficheIds,
+    }: {
+      indicateurId: number;
+      collectiviteId: number;
+      ficheIds: number[];
+    },
+    tx?: Transaction
+  ): Promise<void> {
     this.logger.log(
       `Mise à jour des fiches liées de l'indicateur dont l'id est ${indicateurId}`
     );
 
-    await this.databaseService.db.transaction(async (tx) => {
-      const deleteConditions = [
-        eq(ficheActionIndicateurTable.indicateurId, indicateurId),
-        inArray(
-          ficheActionIndicateurTable.ficheId,
-          // subquery to filter by collectiviteId
-          tx
-            .select({ id: ficheActionTable.id })
-            .from(ficheActionTable)
-            .where(eq(ficheActionTable.collectiviteId, collectiviteId))
-        ),
-      ];
-
-      // Do not delete fiches that may still exist in the new list
-      if (ficheIds.length > 0) {
-        deleteConditions.push(
-          notInArray(ficheActionIndicateurTable.ficheId, ficheIds)
+    const transactionResult = await this.transactionManager.executeSingle<
+      void,
+      unknown
+    >(async (transaction) => {
+      const fichesBelongToCollectivite =
+        await this.repository.areFichesOwnedByCollectivite(
+          ficheIds,
+          collectiviteId,
+          transaction
+        );
+      if (!fichesBelongToCollectivite) {
+        throw new BadRequestException(
+          `Toutes les fiches doivent appartenir à la collectivité ${collectiviteId}`
         );
       }
 
-      await tx
-        .delete(ficheActionIndicateurTable)
-        .where(and(...deleteConditions));
+      await this.repository.upsertIndicateurFiches(
+        { indicateurId, collectiviteId, ficheIds },
+        transaction
+      );
+      return success(undefined);
+    }, tx);
 
-      // Insert new fiches
-      if (ficheIds.length > 0) {
-        await tx
-          .insert(ficheActionIndicateurTable)
-          .values(
-            ficheIds.map((ficheId) => ({
-              ficheId,
-              indicateurId,
-            }))
-          )
-          .onConflictDoNothing();
-      }
-    });
+    if (!transactionResult.success) {
+      throw transactionResult.cause ?? transactionResult.error;
+    }
   }
 }

--- a/apps/backend/src/indicateurs/indicateurs/handle-definition-pilotes/handle-definition-pilotes.repository.spec.ts
+++ b/apps/backend/src/indicateurs/indicateurs/handle-definition-pilotes/handle-definition-pilotes.repository.spec.ts
@@ -1,0 +1,52 @@
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { HandleDefinitionPilotesRepository } from './handle-definition-pilotes.repository';
+
+describe('HandleDefinitionPilotesRepository', () => {
+  it('writes through the selected database without opening a transaction', async () => {
+    const database = {
+      transaction: vi.fn(),
+      delete: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+    };
+    const repository = new HandleDefinitionPilotesRepository({
+      db: database,
+    } as unknown as DatabaseService);
+
+    await repository.upsertIndicateurPilotes({
+      indicateurId: 1,
+      collectiviteId: 2,
+      pilotes: [],
+    });
+
+    expect(database.delete).toHaveBeenCalledOnce();
+    expect(database.transaction).not.toHaveBeenCalled();
+  });
+
+  it('removes stale tag and user pilotes independently despite nullable columns', async () => {
+    const where = vi.fn().mockResolvedValue(undefined);
+    const onConflictDoNothing = vi.fn().mockResolvedValue(undefined);
+    const database = {
+      delete: vi.fn(() => ({ where })),
+      insert: vi.fn(() => ({
+        values: vi.fn(() => ({ onConflictDoNothing })),
+      })),
+    };
+    const repository = new HandleDefinitionPilotesRepository({
+      db: database,
+    } as unknown as DatabaseService);
+
+    await repository.upsertIndicateurPilotes({
+      indicateurId: 1,
+      collectiviteId: 2,
+      pilotes: [{ tagId: 10 }, { userId: crypto.randomUUID() }],
+    });
+
+    const deletionCondition = where.mock.calls[0][0];
+    const query = new PgDialect().sqlToQuery(deletionCondition);
+    expect(query.sql).toContain('"tag_id" is not null');
+    expect(query.sql).toContain('"tag_id" not in');
+    expect(query.sql).toContain('"user_id" is not null');
+    expect(query.sql).toContain('"user_id" not in');
+    expect(query.sql).toContain(' or ');
+  });
+});

--- a/apps/backend/src/indicateurs/indicateurs/handle-definition-pilotes/handle-definition-pilotes.repository.ts
+++ b/apps/backend/src/indicateurs/indicateurs/handle-definition-pilotes/handle-definition-pilotes.repository.ts
@@ -1,0 +1,185 @@
+import { Injectable } from '@nestjs/common';
+import { personneTagTable } from '@tet/backend/collectivites/tags/personnes/personne-tag.table';
+import { indicateurPiloteTable } from '@tet/backend/indicateurs/shared/models/indicateur-pilote.table';
+import { dcpTable } from '@tet/backend/users/models/dcp.table';
+import { utilisateurCollectiviteAccessTable } from '@tet/backend/users/authorizations/utilisateur-collectivite-access.table';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import {
+  and,
+  eq,
+  getTableColumns,
+  isNotNull,
+  isNull,
+  inArray,
+  notInArray,
+  or,
+  sql,
+} from 'drizzle-orm';
+
+type IndicateurPilotesScope = Readonly<{
+  indicateurId: number;
+  collectiviteId: number;
+}>;
+
+type UpsertIndicateurPilotes = IndicateurPilotesScope &
+  Readonly<{
+    pilotes: Array<
+      Readonly<{
+        userId?: string | null;
+        tagId?: number | null;
+      }>
+    >;
+  }>;
+
+@Injectable()
+export class HandleDefinitionPilotesRepository {
+  constructor(private readonly databaseService: DatabaseService) {}
+
+  async arePilotesInCollectivite(
+    pilotes: UpsertIndicateurPilotes['pilotes'],
+    collectiviteId: number,
+    tx?: Transaction
+  ): Promise<boolean> {
+    const tagIds = [
+      ...new Set(
+        pilotes
+          .map(({ tagId }) => tagId)
+          .filter((tagId): tagId is number => tagId != null)
+      ),
+    ];
+    const userIds = [
+      ...new Set(
+        pilotes
+          .map(({ userId }) => userId)
+          .filter((userId): userId is string => userId != null)
+      ),
+    ];
+    const readDb = tx ?? this.databaseService.db;
+
+    const tags =
+      tagIds.length === 0
+        ? []
+        : await readDb
+            .select({ id: personneTagTable.id })
+            .from(personneTagTable)
+            .where(
+              and(
+                inArray(personneTagTable.id, tagIds),
+                eq(personneTagTable.collectiviteId, collectiviteId)
+              )
+            );
+    const users =
+      userIds.length === 0
+        ? []
+        : await readDb
+            .select({ id: utilisateurCollectiviteAccessTable.userId })
+            .from(utilisateurCollectiviteAccessTable)
+            .where(
+              and(
+                inArray(utilisateurCollectiviteAccessTable.userId, userIds),
+                eq(
+                  utilisateurCollectiviteAccessTable.collectiviteId,
+                  collectiviteId
+                ),
+                eq(utilisateurCollectiviteAccessTable.isActive, true)
+              )
+            );
+
+    return tags.length === tagIds.length && users.length === userIds.length;
+  }
+
+  listIndicateurPilotes({
+    indicateurId,
+    collectiviteId,
+  }: IndicateurPilotesScope) {
+    return this.databaseService.db
+      .select({
+        ...getTableColumns(indicateurPiloteTable),
+        nom: sql<string>`
+          CASE
+            WHEN ${indicateurPiloteTable.userId} IS NOT NULL THEN
+              CONCAT(${dcpTable.prenom}, ' ', ${dcpTable.nom})
+            WHEN ${indicateurPiloteTable.tagId} IS NOT NULL THEN
+              ${personneTagTable.nom}
+          END
+        `.as('nom'),
+      })
+      .from(indicateurPiloteTable)
+      .leftJoin(dcpTable, eq(dcpTable.id, indicateurPiloteTable.userId))
+      .leftJoin(
+        personneTagTable,
+        eq(personneTagTable.id, indicateurPiloteTable.tagId)
+      )
+      .where(
+        and(
+          eq(indicateurPiloteTable.indicateurId, indicateurId),
+          eq(indicateurPiloteTable.collectiviteId, collectiviteId)
+        )
+      )
+      .groupBy(
+        indicateurPiloteTable.id,
+        dcpTable.prenom,
+        dcpTable.nom,
+        personneTagTable.nom
+      );
+  }
+
+  async upsertIndicateurPilotes(
+    { indicateurId, collectiviteId, pilotes }: UpsertIndicateurPilotes,
+    tx?: Transaction
+  ): Promise<void> {
+    const writeDb = tx ?? this.databaseService.db;
+    const { userIds, tagIds } = pilotes.reduce(
+      (acc, pilote) => {
+        if (pilote.userId) {
+          acc.userIds.push(pilote.userId);
+        } else if (pilote.tagId) {
+          acc.tagIds.push(pilote.tagId);
+        }
+        return acc;
+      },
+      { userIds: [] as string[], tagIds: [] as number[] }
+    );
+
+    await writeDb
+      .delete(indicateurPiloteTable)
+      .where(
+        and(
+          eq(indicateurPiloteTable.indicateurId, indicateurId),
+          eq(indicateurPiloteTable.collectiviteId, collectiviteId),
+          or(
+            and(
+              isNotNull(indicateurPiloteTable.tagId),
+              tagIds.length > 0
+                ? notInArray(indicateurPiloteTable.tagId, tagIds)
+                : undefined
+            ),
+            and(
+              isNotNull(indicateurPiloteTable.userId),
+              userIds.length > 0
+                ? notInArray(indicateurPiloteTable.userId, userIds)
+                : undefined
+            ),
+            and(
+              isNull(indicateurPiloteTable.tagId),
+              isNull(indicateurPiloteTable.userId)
+            )
+          )
+        )
+      );
+
+    if (pilotes.length > 0) {
+      await writeDb
+        .insert(indicateurPiloteTable)
+        .values(
+          pilotes.map((pilote) => ({
+            ...pilote,
+            indicateurId,
+            collectiviteId,
+          }))
+        )
+        .onConflictDoNothing();
+    }
+  }
+}

--- a/apps/backend/src/indicateurs/indicateurs/handle-definition-pilotes/handle-definition-pilotes.service.spec.ts
+++ b/apps/backend/src/indicateurs/indicateurs/handle-definition-pilotes/handle-definition-pilotes.service.spec.ts
@@ -1,0 +1,70 @@
+import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { TransactionManager } from '@tet/backend/utils/transaction/transaction-manager.service';
+import { HandleDefinitionPilotesRepository } from './handle-definition-pilotes.repository';
+import { HandleDefinitionPilotesService } from './handle-definition-pilotes.service';
+
+describe('HandleDefinitionPilotesService', () => {
+  it('delegates transaction ownership and reuses the caller transaction', async () => {
+    const repository = {
+      arePilotesInCollectivite: vi.fn().mockResolvedValue(true),
+      upsertIndicateurPilotes: vi.fn().mockResolvedValue(undefined),
+    } as unknown as HandleDefinitionPilotesRepository;
+    const tx = {} as Transaction;
+    const transactionManager = {
+      executeSingle: vi.fn(
+        async (
+          operation: (currentTx: Transaction) => Promise<unknown>,
+          currentTx?: Transaction
+        ) => operation(currentTx ?? tx)
+      ),
+    } as unknown as TransactionManager;
+    const service = new HandleDefinitionPilotesService(
+      repository,
+      {} as PermissionService,
+      transactionManager
+    );
+
+    const input = {
+      indicateurId: 1,
+      collectiviteId: 2,
+      pilotes: [],
+    };
+
+    await service.upsertIndicateurPilotes(input, tx);
+
+    expect(transactionManager.executeSingle).toHaveBeenCalledWith(
+      expect.any(Function),
+      tx
+    );
+    expect(repository.upsertIndicateurPilotes).toHaveBeenCalledWith(input, tx);
+  });
+
+  it("refuse un pilote qui n'appartient pas à la collectivité", async () => {
+    const repository = {
+      arePilotesInCollectivite: vi.fn().mockResolvedValue(false),
+      upsertIndicateurPilotes: vi.fn(),
+    } as unknown as HandleDefinitionPilotesRepository;
+    const tx = {} as Transaction;
+    const transactionManager = {
+      executeSingle: vi.fn(
+        async (operation: (currentTx: Transaction) => Promise<unknown>) =>
+          operation(tx)
+      ),
+    } as unknown as TransactionManager;
+    const service = new HandleDefinitionPilotesService(
+      repository,
+      {} as PermissionService,
+      transactionManager
+    );
+
+    await expect(
+      service.upsertIndicateurPilotes({
+        indicateurId: 1,
+        collectiviteId: 2,
+        pilotes: [{ tagId: 3 }],
+      })
+    ).rejects.toThrow(/pilotes doivent appartenir/i);
+    expect(repository.upsertIndicateurPilotes).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/indicateurs/indicateurs/handle-definition-pilotes/handle-definition-pilotes.service.ts
+++ b/apps/backend/src/indicateurs/indicateurs/handle-definition-pilotes/handle-definition-pilotes.service.ts
@@ -1,21 +1,21 @@
-import { Injectable, Logger } from '@nestjs/common';
-import { personneTagTable } from '@tet/backend/collectivites/tags/personnes/personne-tag.table';
-import { indicateurPiloteTable } from '@tet/backend/indicateurs/shared/models/indicateur-pilote.table';
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
 import { AuthUser } from '@tet/backend/users/models/auth.models';
-import { dcpTable } from '@tet/backend/users/models/dcp.table';
-import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { success } from '@tet/backend/utils/result.type';
+import { TransactionManager } from '@tet/backend/utils/transaction/transaction-manager.service';
 import { ResourceType } from '@tet/domain/users';
-import { and, eq, getTableColumns, inArray, not, sql } from 'drizzle-orm';
 import { UpsertIndicateurDefinitionPilotesInput } from './handle-definition-pilotes.input';
+import { HandleDefinitionPilotesRepository } from './handle-definition-pilotes.repository';
 
 @Injectable()
 export class HandleDefinitionPilotesService {
   private readonly logger = new Logger(HandleDefinitionPilotesService.name);
 
   constructor(
-    private readonly databaseService: DatabaseService,
-    private readonly permissionService: PermissionService
+    private readonly repository: HandleDefinitionPilotesRepository,
+    private readonly permissionService: PermissionService,
+    private readonly transactionManager: TransactionManager
   ) {}
 
   async listIndicateurPilotes({
@@ -38,103 +38,58 @@ export class HandleDefinitionPilotesService {
       `Récupération des pilotes de l'indicateur dont l'id est ${indicateurId}`
     );
 
-    const indicateurPilotes = await this.databaseService.db
-      .select({
-        ...getTableColumns(indicateurPiloteTable),
-        nom: sql<string>`
-
-                      CASE
-                        WHEN ${indicateurPiloteTable.userId} IS NOT NULL THEN
-                          CONCAT(${dcpTable.prenom}, ' ', ${dcpTable.nom})
-                        WHEN ${indicateurPiloteTable.tagId} IS NOT NULL THEN
-                          ${personneTagTable.nom}
-                      END
-
-                `.as('nom'),
-      })
-      .from(indicateurPiloteTable)
-      .leftJoin(dcpTable, eq(dcpTable.id, indicateurPiloteTable.userId))
-      .leftJoin(
-        personneTagTable,
-        eq(personneTagTable.id, indicateurPiloteTable.tagId)
-      )
-      .where(
-        and(
-          eq(indicateurPiloteTable.indicateurId, indicateurId),
-          eq(indicateurPiloteTable.collectiviteId, collectiviteId)
-        )
-      )
-      .groupBy(
-        indicateurPiloteTable.id,
-        dcpTable.prenom,
-        dcpTable.nom,
-        personneTagTable.nom
-      );
-    return indicateurPilotes;
+    return this.repository.listIndicateurPilotes({
+      indicateurId,
+      collectiviteId,
+    });
   }
 
-  async upsertIndicateurPilotes({
-    indicateurId,
-    collectiviteId,
-    pilotes,
-  }: {
-    indicateurId: number;
-    collectiviteId: number;
-    pilotes: UpsertIndicateurDefinitionPilotesInput[];
-  }) {
+  async upsertIndicateurPilotes(
+    {
+      indicateurId,
+      collectiviteId,
+      pilotes,
+    }: {
+      indicateurId: number;
+      collectiviteId: number;
+      pilotes: UpsertIndicateurDefinitionPilotesInput[];
+    },
+    tx?: Transaction
+  ): Promise<void> {
     this.logger.log(
       `Mise à jour des pilotes de l'indicateur dont l'id est ${indicateurId}`
     );
 
-    await this.databaseService.db.transaction(async (tx) => {
-      const { userIds, tagIds } = pilotes.reduce(
-        (acc, pilote) => {
-          if (pilote.userId) {
-            return { ...acc, userIds: [...acc.userIds, pilote.userId] };
-          }
-          if (pilote.tagId) {
-            return { ...acc, tagIds: [...acc.tagIds, pilote.tagId] };
-          }
-          return acc;
-        },
-        {
-          userIds: new Array<string>(),
-          tagIds: new Array<number>(),
-        }
+    const transactionResult = await this.transactionManager.executeSingle<
+      void,
+      unknown
+    >(async (transaction) => {
+      const hasExactlyOneIdentity = pilotes.every(
+        ({ tagId, userId }) =>
+          Number(tagId != null) + Number(userId != null) === 1
       );
-
-      const keepExistingPiloteTagsCondition =
-        tagIds.length > 0
-          ? not(inArray(indicateurPiloteTable.tagId, tagIds))
-          : undefined;
-
-      const keepExistingPiloteUserIdsCondition =
-        userIds.length > 0
-          ? not(inArray(indicateurPiloteTable.userId, userIds))
-          : undefined;
-
-      const deleteConditions = [
-        eq(indicateurPiloteTable.indicateurId, indicateurId),
-        eq(indicateurPiloteTable.collectiviteId, collectiviteId),
-        keepExistingPiloteTagsCondition,
-        keepExistingPiloteUserIdsCondition,
-      ];
-
-      await tx.delete(indicateurPiloteTable).where(and(...deleteConditions));
-
-      // Insert new pilotes (PostgreSQL will ignore duplicates due to unique constraints)
-      if (pilotes.length > 0) {
-        await tx
-          .insert(indicateurPiloteTable)
-          .values(
-            pilotes.map((indicateurPilote) => ({
-              ...indicateurPilote,
-              indicateurId,
-              collectiviteId,
-            }))
-          )
-          .onConflictDoNothing();
+      const pilotesBelongToCollectivite =
+        hasExactlyOneIdentity &&
+        (await this.repository.arePilotesInCollectivite(
+          pilotes,
+          collectiviteId,
+          transaction
+        ));
+      if (!pilotesBelongToCollectivite) {
+        throw new BadRequestException(
+          `Tous les pilotes doivent appartenir à la collectivité ${collectiviteId}`
+        );
       }
-    });
+
+      await this.repository.upsertIndicateurPilotes(
+        { indicateurId, collectiviteId, pilotes },
+        transaction
+      );
+      return success(undefined);
+    }, tx);
+
+    if (!transactionResult.success) {
+      throw transactionResult.cause ?? transactionResult.error;
+    }
   }
 }

--- a/apps/backend/src/indicateurs/indicateurs/handle-definition-services/handle-definition-services.repository.spec.ts
+++ b/apps/backend/src/indicateurs/indicateurs/handle-definition-services/handle-definition-services.repository.spec.ts
@@ -1,0 +1,23 @@
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { HandleDefinitionServicesRepository } from './handle-definition-services.repository';
+
+describe('HandleDefinitionServicesRepository', () => {
+  it('writes through the selected database without opening a transaction', async () => {
+    const database = {
+      transaction: vi.fn(),
+      delete: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+    };
+    const repository = new HandleDefinitionServicesRepository({
+      db: database,
+    } as unknown as DatabaseService);
+
+    await repository.upsertIndicateurServices({
+      indicateurId: 1,
+      collectiviteId: 2,
+      serviceIds: [],
+    });
+
+    expect(database.delete).toHaveBeenCalledOnce();
+    expect(database.transaction).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/indicateurs/indicateurs/handle-definition-services/handle-definition-services.repository.ts
+++ b/apps/backend/src/indicateurs/indicateurs/handle-definition-services/handle-definition-services.repository.ts
@@ -1,0 +1,111 @@
+import { Injectable } from '@nestjs/common';
+import { serviceTagTable } from '@tet/backend/collectivites/tags/service-tag.table';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { ServiceTag } from '@tet/domain/collectivites';
+import { and, eq, inArray, notInArray, sql } from 'drizzle-orm';
+import { indicateurServiceTagTable } from './indicateur-service-tag.table';
+
+type IndicateurServicesScope = Readonly<{
+  indicateurId: number;
+  collectiviteId: number;
+}>;
+
+type UpsertIndicateurServices = IndicateurServicesScope &
+  Readonly<{ serviceIds: number[] }>;
+
+@Injectable()
+export class HandleDefinitionServicesRepository {
+  constructor(private readonly databaseService: DatabaseService) {}
+
+  async areServicesOwnedByCollectivite(
+    serviceIds: number[],
+    collectiviteId: number,
+    tx?: Transaction
+  ): Promise<boolean> {
+    const uniqueServiceIds = [...new Set(serviceIds)];
+    if (uniqueServiceIds.length === 0) {
+      return true;
+    }
+
+    const services = await (tx ?? this.databaseService.db)
+      .select({ id: serviceTagTable.id })
+      .from(serviceTagTable)
+      .where(
+        and(
+          inArray(serviceTagTable.id, uniqueServiceIds),
+          eq(serviceTagTable.collectiviteId, collectiviteId)
+        )
+      );
+
+    return services.length === uniqueServiceIds.length;
+  }
+
+  listIndicateurServices({
+    indicateurId,
+    collectiviteId,
+  }: IndicateurServicesScope): Promise<ServiceTag[]> {
+    return this.databaseService.db
+      .select({
+        id: indicateurServiceTagTable.serviceTagId,
+        collectiviteId: indicateurServiceTagTable.collectiviteId,
+        nom: sql<string>`
+          CASE
+            WHEN ${serviceTagTable.nom} IS NOT NULL THEN ${serviceTagTable.nom}
+            ELSE ''
+          END
+        `.as('nom'),
+      })
+      .from(indicateurServiceTagTable)
+      .leftJoin(
+        serviceTagTable,
+        eq(serviceTagTable.id, indicateurServiceTagTable.serviceTagId)
+      )
+      .where(
+        and(
+          eq(indicateurServiceTagTable.indicateurId, indicateurId),
+          eq(indicateurServiceTagTable.collectiviteId, collectiviteId)
+        )
+      )
+      .groupBy(
+        indicateurServiceTagTable.indicateurId,
+        indicateurServiceTagTable.collectiviteId,
+        indicateurServiceTagTable.serviceTagId,
+        serviceTagTable.nom
+      );
+  }
+
+  async upsertIndicateurServices(
+    { indicateurId, collectiviteId, serviceIds }: UpsertIndicateurServices,
+    tx?: Transaction
+  ): Promise<void> {
+    const writeDb = tx ?? this.databaseService.db;
+    const scope = and(
+      eq(indicateurServiceTagTable.indicateurId, indicateurId),
+      eq(indicateurServiceTagTable.collectiviteId, collectiviteId)
+    );
+    await writeDb
+      .delete(indicateurServiceTagTable)
+      .where(
+        serviceIds.length > 0
+          ? and(
+              scope,
+              notInArray(indicateurServiceTagTable.serviceTagId, serviceIds)
+            )
+          : scope
+      );
+
+    if (serviceIds.length > 0) {
+      await writeDb
+        .insert(indicateurServiceTagTable)
+        .values(
+          serviceIds.map((serviceTagId) => ({
+            serviceTagId,
+            indicateurId,
+            collectiviteId,
+          }))
+        )
+        .onConflictDoNothing();
+    }
+  }
+}

--- a/apps/backend/src/indicateurs/indicateurs/handle-definition-services/handle-definition-services.service.spec.ts
+++ b/apps/backend/src/indicateurs/indicateurs/handle-definition-services/handle-definition-services.service.spec.ts
@@ -1,0 +1,66 @@
+import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { TransactionManager } from '@tet/backend/utils/transaction/transaction-manager.service';
+import { HandleDefinitionServicesRepository } from './handle-definition-services.repository';
+import { HandleDefinitionServicesService } from './handle-definition-services.service';
+
+describe('HandleDefinitionServicesService', () => {
+  it('delegates transaction ownership and reuses the caller transaction', async () => {
+    const repository = {
+      areServicesOwnedByCollectivite: vi.fn().mockResolvedValue(true),
+      upsertIndicateurServices: vi.fn().mockResolvedValue(undefined),
+    } as unknown as HandleDefinitionServicesRepository;
+    const tx = {} as Transaction;
+    const transactionManager = {
+      executeSingle: vi.fn(
+        async (
+          operation: (currentTx: Transaction) => Promise<unknown>,
+          currentTx?: Transaction
+        ) => operation(currentTx ?? tx)
+      ),
+    } as unknown as TransactionManager;
+    const service = new HandleDefinitionServicesService(
+      repository,
+      {} as PermissionService,
+      transactionManager
+    );
+
+    const input = { indicateurId: 1, collectiviteId: 2, serviceIds: [] };
+
+    await service.upsertIndicateurServices(input, tx);
+
+    expect(transactionManager.executeSingle).toHaveBeenCalledWith(
+      expect.any(Function),
+      tx
+    );
+    expect(repository.upsertIndicateurServices).toHaveBeenCalledWith(input, tx);
+  });
+
+  it("refuse un service qui n'appartient pas à la collectivité", async () => {
+    const repository = {
+      areServicesOwnedByCollectivite: vi.fn().mockResolvedValue(false),
+      upsertIndicateurServices: vi.fn(),
+    } as unknown as HandleDefinitionServicesRepository;
+    const tx = {} as Transaction;
+    const transactionManager = {
+      executeSingle: vi.fn(
+        async (operation: (currentTx: Transaction) => Promise<unknown>) =>
+          operation(tx)
+      ),
+    } as unknown as TransactionManager;
+    const service = new HandleDefinitionServicesService(
+      repository,
+      {} as PermissionService,
+      transactionManager
+    );
+
+    await expect(
+      service.upsertIndicateurServices({
+        indicateurId: 1,
+        collectiviteId: 2,
+        serviceIds: [3],
+      })
+    ).rejects.toThrow(/services doivent appartenir/i);
+    expect(repository.upsertIndicateurServices).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/indicateurs/indicateurs/handle-definition-services/handle-definition-services.service.ts
+++ b/apps/backend/src/indicateurs/indicateurs/handle-definition-services/handle-definition-services.service.ts
@@ -1,20 +1,21 @@
-import { Injectable, Logger } from '@nestjs/common';
-import { serviceTagTable } from '@tet/backend/collectivites/tags/service-tag.table';
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
 import { AuthUser } from '@tet/backend/users/models/auth.models';
-import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { success } from '@tet/backend/utils/result.type';
+import { TransactionManager } from '@tet/backend/utils/transaction/transaction-manager.service';
 import { ServiceTag } from '@tet/domain/collectivites';
 import { ResourceType } from '@tet/domain/users';
-import { and, eq, notInArray, sql } from 'drizzle-orm';
-import { indicateurServiceTagTable } from './indicateur-service-tag.table';
+import { HandleDefinitionServicesRepository } from './handle-definition-services.repository';
 
 @Injectable()
 export class HandleDefinitionServicesService {
   private readonly logger = new Logger(HandleDefinitionServicesService.name);
 
   constructor(
-    private readonly databaseService: DatabaseService,
-    private readonly permissionService: PermissionService
+    private readonly repository: HandleDefinitionServicesRepository,
+    private readonly permissionService: PermissionService,
+    private readonly transactionManager: TransactionManager
   ) {}
 
   async listIndicateurServices({
@@ -37,86 +38,53 @@ export class HandleDefinitionServicesService {
       `Récupération des services pilotes de l'indicateur dont l'id est ${indicateurId}`
     );
 
-    const indicateurServicesPilotes = await this.databaseService.db
-      .select({
-        id: indicateurServiceTagTable.serviceTagId,
-        collectiviteId: indicateurServiceTagTable.collectiviteId,
-        nom: sql<string>`
-          CASE
-              WHEN ${serviceTagTable.nom} IS NOT NULL THEN ${serviceTagTable.nom}
-              ELSE ''
-          END
-        `.as('nom'),
-      })
-      .from(indicateurServiceTagTable)
-      .leftJoin(
-        serviceTagTable,
-        eq(serviceTagTable.id, indicateurServiceTagTable.serviceTagId)
-      )
-      .where(
-        and(
-          eq(indicateurServiceTagTable.indicateurId, indicateurId),
-          eq(indicateurServiceTagTable.collectiviteId, collectiviteId)
-        )
-      )
-      .groupBy(
-        indicateurServiceTagTable.indicateurId,
-        indicateurServiceTagTable.collectiviteId,
-        indicateurServiceTagTable.serviceTagId,
-        serviceTagTable.nom
-      );
-
-    return indicateurServicesPilotes;
+    return this.repository.listIndicateurServices({
+      indicateurId,
+      collectiviteId,
+    });
   }
 
-  async upsertIndicateurServices({
-    indicateurId,
-    collectiviteId,
-    serviceIds,
-  }: {
-    indicateurId: number;
-    collectiviteId: number;
-    serviceIds: number[];
-  }) {
+  async upsertIndicateurServices(
+    {
+      indicateurId,
+      collectiviteId,
+      serviceIds,
+    }: {
+      indicateurId: number;
+      collectiviteId: number;
+      serviceIds: number[];
+    },
+    tx?: Transaction
+  ): Promise<void> {
     this.logger.log(
       `Mise à jour des servicespilotes de l'indicateur dont l'id est ${indicateurId}`
     );
 
-    await this.databaseService.db.transaction(async (tx) => {
-      // Delete all services not in the new list
-      const indicateurIdCondition = eq(
-        indicateurServiceTagTable.indicateurId,
-        indicateurId
-      );
-      const collectiviteIdCondition = eq(
-        indicateurServiceTagTable.collectiviteId,
-        collectiviteId
-      );
-
-      const deleteConditions =
-        serviceIds.length > 0
-          ? and(
-              indicateurIdCondition,
-              collectiviteIdCondition,
-              notInArray(indicateurServiceTagTable.serviceTagId, serviceIds)
-            )
-          : and(indicateurIdCondition, collectiviteIdCondition);
-
-      await tx.delete(indicateurServiceTagTable).where(deleteConditions);
-
-      // Insert all services (PostgreSQL will ignore duplicates)
-      if (serviceIds.length > 0) {
-        await tx
-          .insert(indicateurServiceTagTable)
-          .values(
-            serviceIds.map((serviceTagId) => ({
-              serviceTagId,
-              indicateurId,
-              collectiviteId,
-            }))
-          )
-          .onConflictDoNothing();
+    const transactionResult = await this.transactionManager.executeSingle<
+      void,
+      unknown
+    >(async (transaction) => {
+      const servicesBelongToCollectivite =
+        await this.repository.areServicesOwnedByCollectivite(
+          serviceIds,
+          collectiviteId,
+          transaction
+        );
+      if (!servicesBelongToCollectivite) {
+        throw new BadRequestException(
+          `Tous les services doivent appartenir à la collectivité ${collectiviteId}`
+        );
       }
-    });
+
+      await this.repository.upsertIndicateurServices(
+        { indicateurId, collectiviteId, serviceIds },
+        transaction
+      );
+      return success(undefined);
+    }, tx);
+
+    if (!transactionResult.success) {
+      throw transactionResult.cause ?? transactionResult.error;
+    }
   }
 }

--- a/apps/backend/src/indicateurs/indicateurs/handle-definition-thematiques/handle-definition-thematiques.repository.spec.ts
+++ b/apps/backend/src/indicateurs/indicateurs/handle-definition-thematiques/handle-definition-thematiques.repository.spec.ts
@@ -1,0 +1,22 @@
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { HandleDefinitionThematiquesRepository } from './handle-definition-thematiques.repository';
+
+describe('HandleDefinitionThematiquesRepository', () => {
+  it('writes through the selected database without opening a transaction', async () => {
+    const database = {
+      transaction: vi.fn(),
+      delete: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+    };
+    const repository = new HandleDefinitionThematiquesRepository({
+      db: database,
+    } as unknown as DatabaseService);
+
+    await repository.upsertIndicateurThematiques({
+      indicateurId: 1,
+      thematiqueIds: [],
+    });
+
+    expect(database.delete).toHaveBeenCalledOnce();
+    expect(database.transaction).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/indicateurs/indicateurs/handle-definition-thematiques/handle-definition-thematiques.repository.ts
+++ b/apps/backend/src/indicateurs/indicateurs/handle-definition-thematiques/handle-definition-thematiques.repository.ts
@@ -1,0 +1,59 @@
+import { Injectable } from '@nestjs/common';
+import { indicateurThematiqueTable } from '@tet/backend/indicateurs/shared/models/indicateur-thematique.table';
+import { thematiqueTable } from '@tet/backend/shared/thematiques/thematique.table';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { Thematique } from '@tet/domain/shared';
+import { and, asc, eq, notInArray } from 'drizzle-orm';
+
+type UpsertIndicateurThematiques = Readonly<{
+  indicateurId: number;
+  thematiqueIds: number[];
+}>;
+
+@Injectable()
+export class HandleDefinitionThematiquesRepository {
+  constructor(private readonly databaseService: DatabaseService) {}
+
+  listIndicateurThematiques(indicateurId: number): Promise<Thematique[]> {
+    return this.databaseService.db
+      .select({ id: thematiqueTable.id, nom: thematiqueTable.nom })
+      .from(thematiqueTable)
+      .leftJoin(
+        indicateurThematiqueTable,
+        eq(thematiqueTable.id, indicateurThematiqueTable.thematiqueId)
+      )
+      .where(eq(indicateurThematiqueTable.indicateurId, indicateurId))
+      .orderBy(asc(thematiqueTable.nom));
+  }
+
+  async upsertIndicateurThematiques(
+    { indicateurId, thematiqueIds }: UpsertIndicateurThematiques,
+    tx?: Transaction
+  ): Promise<void> {
+    const writeDb = tx ?? this.databaseService.db;
+    const scope = eq(indicateurThematiqueTable.indicateurId, indicateurId);
+    await writeDb
+      .delete(indicateurThematiqueTable)
+      .where(
+        thematiqueIds.length > 0
+          ? and(
+              scope,
+              notInArray(indicateurThematiqueTable.thematiqueId, thematiqueIds)
+            )
+          : scope
+      );
+
+    if (thematiqueIds.length > 0) {
+      await writeDb
+        .insert(indicateurThematiqueTable)
+        .values(
+          thematiqueIds.map((thematiqueId) => ({
+            thematiqueId,
+            indicateurId,
+          }))
+        )
+        .onConflictDoNothing();
+    }
+  }
+}

--- a/apps/backend/src/indicateurs/indicateurs/handle-definition-thematiques/handle-definition-thematiques.service.spec.ts
+++ b/apps/backend/src/indicateurs/indicateurs/handle-definition-thematiques/handle-definition-thematiques.service.spec.ts
@@ -1,0 +1,40 @@
+import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { TransactionManager } from '@tet/backend/utils/transaction/transaction-manager.service';
+import { HandleDefinitionThematiquesRepository } from './handle-definition-thematiques.repository';
+import { HandleDefinitionThematiquesService } from './handle-definition-thematiques.service';
+
+describe('HandleDefinitionThematiquesService', () => {
+  it('delegates transaction ownership and reuses the caller transaction', async () => {
+    const repository = {
+      upsertIndicateurThematiques: vi.fn().mockResolvedValue(undefined),
+    } as unknown as HandleDefinitionThematiquesRepository;
+    const tx = {} as Transaction;
+    const transactionManager = {
+      executeSingle: vi.fn(
+        async (
+          operation: (currentTx: Transaction) => Promise<unknown>,
+          currentTx?: Transaction
+        ) => operation(currentTx ?? tx)
+      ),
+    } as unknown as TransactionManager;
+    const service = new HandleDefinitionThematiquesService(
+      repository,
+      {} as PermissionService,
+      transactionManager
+    );
+
+    const input = { indicateurId: 1, thematiqueIds: [] };
+
+    await service.upsertIndicateurThematiques(input, tx);
+
+    expect(transactionManager.executeSingle).toHaveBeenCalledWith(
+      expect.any(Function),
+      tx
+    );
+    expect(repository.upsertIndicateurThematiques).toHaveBeenCalledWith(
+      input,
+      tx
+    );
+  });
+});

--- a/apps/backend/src/indicateurs/indicateurs/handle-definition-thematiques/handle-definition-thematiques.service.ts
+++ b/apps/backend/src/indicateurs/indicateurs/handle-definition-thematiques/handle-definition-thematiques.service.ts
@@ -1,20 +1,21 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { indicateurThematiqueTable } from '@tet/backend/indicateurs/shared/models/indicateur-thematique.table';
-import { thematiqueTable } from '@tet/backend/shared/thematiques/thematique.table';
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
 import { AuthUser } from '@tet/backend/users/models/auth.models';
-import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { success } from '@tet/backend/utils/result.type';
+import { TransactionManager } from '@tet/backend/utils/transaction/transaction-manager.service';
 import { Thematique } from '@tet/domain/shared';
 import { ResourceType } from '@tet/domain/users';
-import { and, asc, eq, notInArray } from 'drizzle-orm';
+import { HandleDefinitionThematiquesRepository } from './handle-definition-thematiques.repository';
 
 @Injectable()
 export class HandleDefinitionThematiquesService {
   private readonly logger = new Logger(HandleDefinitionThematiquesService.name);
 
   constructor(
-    private readonly databaseService: DatabaseService,
-    private readonly permissionService: PermissionService
+    private readonly repository: HandleDefinitionThematiquesRepository,
+    private readonly permissionService: PermissionService,
+    private readonly transactionManager: TransactionManager
   ) {}
 
   async listIndicateurThematiques({
@@ -37,59 +38,36 @@ export class HandleDefinitionThematiquesService {
       `Récupération des thematiques de l'indicateur dont l'id est ${indicateurId}`
     );
 
-    const indicateurThematiques = await this.databaseService.db
-      .select({ id: thematiqueTable.id, nom: thematiqueTable.nom })
-      .from(thematiqueTable)
-      .leftJoin(
-        indicateurThematiqueTable,
-        eq(thematiqueTable.id, indicateurThematiqueTable.thematiqueId)
-      )
-      .where(eq(indicateurThematiqueTable.indicateurId, indicateurId))
-      .orderBy(asc(thematiqueTable.nom));
-
-    return indicateurThematiques;
+    return this.repository.listIndicateurThematiques(indicateurId);
   }
 
-  async upsertIndicateurThematiques({
-    indicateurId,
-    thematiqueIds,
-  }: {
-    indicateurId: number;
-    thematiqueIds: number[];
-  }) {
+  async upsertIndicateurThematiques(
+    {
+      indicateurId,
+      thematiqueIds,
+    }: {
+      indicateurId: number;
+      thematiqueIds: number[];
+    },
+    tx?: Transaction
+  ): Promise<void> {
     this.logger.log(
       `Mise à jour des thematiques de l'indicateur dont l'id est ${indicateurId}`
     );
 
-    await this.databaseService.db.transaction(async (tx) => {
-      // Delete all thematiques not in the new list
-      const indicateurIdCondition = eq(
-        indicateurThematiqueTable.indicateurId,
-        indicateurId
+    const transactionResult = await this.transactionManager.executeSingle<
+      void,
+      unknown
+    >(async (transaction) => {
+      await this.repository.upsertIndicateurThematiques(
+        { indicateurId, thematiqueIds },
+        transaction
       );
+      return success(undefined);
+    }, tx);
 
-      const deleteConditions =
-        thematiqueIds.length > 0
-          ? and(
-              indicateurIdCondition,
-              notInArray(indicateurThematiqueTable.thematiqueId, thematiqueIds)
-            )
-          : indicateurIdCondition;
-
-      await tx.delete(indicateurThematiqueTable).where(deleteConditions);
-
-      // Insert all thematiques (PostgreSQL will ignore duplicates)
-      if (thematiqueIds.length > 0) {
-        await tx
-          .insert(indicateurThematiqueTable)
-          .values(
-            thematiqueIds.map((thematiqueId) => ({
-              thematiqueId,
-              indicateurId,
-            }))
-          )
-          .onConflictDoNothing();
-      }
-    });
+    if (!transactionResult.success) {
+      throw transactionResult.cause ?? transactionResult.error;
+    }
   }
 }

--- a/apps/backend/src/indicateurs/sources/indicateur-sources.repository.spec.ts
+++ b/apps/backend/src/indicateurs/sources/indicateur-sources.repository.spec.ts
@@ -1,0 +1,40 @@
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import type { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { IndicateurSourcesRepository } from './indicateur-sources.repository';
+
+describe('IndicateurSourcesRepository', () => {
+  it('utilise la transaction fournie pour partager le snapshot des métadonnées', async () => {
+    const metadonnees = [{ id: 1 }];
+    const from = vi.fn().mockResolvedValue(metadonnees);
+    const select = vi.fn(() => ({ from }));
+    const baseSelect = vi.fn();
+    const repository = new IndicateurSourcesRepository({
+      db: { select: baseSelect },
+    } as unknown as DatabaseService);
+    const tx = { select } as unknown as Transaction;
+
+    await expect(repository.listMetadonnees(tx)).resolves.toBe(metadonnees);
+    expect(select).toHaveBeenCalledOnce();
+    expect(baseSelect).not.toHaveBeenCalled();
+  });
+
+  it('borne les sources disponibles aux valeurs renseignées de la collectivité et de l’indicateur', () => {
+    const repository = new IndicateurSourcesRepository({
+      db: drizzle.mock(),
+    } as unknown as DatabaseService);
+
+    const query = repository.listAvailableSources({
+      collectiviteId: 42,
+      indicateurId: 7,
+    });
+    const compiled = query.toSQL();
+
+    expect(compiled.sql).toContain('"metadonnee_id" is not null');
+    expect(compiled.sql).toContain('"collectivite_id" =');
+    expect(compiled.sql).toContain('"indicateur_id" =');
+    expect(compiled.sql).toContain('"resultat" is not null');
+    expect(compiled.sql).toContain('"objectif" is not null');
+    expect(compiled.params).toEqual([42, 7]);
+  });
+});

--- a/apps/backend/src/indicateurs/sources/indicateur-sources.repository.ts
+++ b/apps/backend/src/indicateurs/sources/indicateur-sources.repository.ts
@@ -1,0 +1,113 @@
+import { Injectable } from '@nestjs/common';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import {
+  IndicateurSourceCreate,
+  IndicateurSourceMetadonnee,
+  IndicateurSourceMetadonneeCreate,
+} from '@tet/domain/indicateurs';
+import { and, asc, eq, inArray, isNotNull, or } from 'drizzle-orm';
+import { indicateurSourceMetadonneeTable } from '../shared/models/indicateur-source-metadonnee.table';
+import { indicateurSourceTable } from '../shared/models/indicateur-source.table';
+import { indicateurValeurTable } from '../valeurs/indicateur-valeur.table';
+
+type IndicateurAvailableSourcesScope = Readonly<{
+  collectiviteId: number;
+  indicateurId: number;
+}>;
+
+@Injectable()
+export class IndicateurSourcesRepository {
+  constructor(private readonly databaseService: DatabaseService) {}
+
+  async createMetadonnee(
+    metadonnee: IndicateurSourceMetadonneeCreate,
+    tx?: Transaction
+  ) {
+    const [created] = await (tx ?? this.databaseService.db)
+      .insert(indicateurSourceMetadonneeTable)
+      .values(metadonnee)
+      .onConflictDoNothing()
+      .returning();
+    return created;
+  }
+
+  listMetadonnees(tx?: Transaction): Promise<IndicateurSourceMetadonnee[]> {
+    return (tx ?? this.databaseService.db)
+      .select()
+      .from(indicateurSourceMetadonneeTable);
+  }
+
+  async getMetadonnee(
+    sourceId: string,
+    dateVersion: string,
+    tx?: Transaction
+  ): Promise<IndicateurSourceMetadonnee | null> {
+    const [metadonnee] = await (tx ?? this.databaseService.db)
+      .select()
+      .from(indicateurSourceMetadonneeTable)
+      .where(
+        and(
+          eq(indicateurSourceMetadonneeTable.sourceId, sourceId),
+          eq(indicateurSourceMetadonneeTable.dateVersion, dateVersion)
+        )
+      )
+      .limit(1);
+    return metadonnee ?? null;
+  }
+
+  upsertSource(source: IndicateurSourceCreate, tx?: Transaction) {
+    return (tx ?? this.databaseService.db)
+      .insert(indicateurSourceTable)
+      .values(source)
+      .onConflictDoUpdate({
+        target: indicateurSourceTable.id,
+        set: { libelle: source.libelle },
+      });
+  }
+
+  listSources(tx?: Transaction) {
+    return (tx ?? this.databaseService.db)
+      .select()
+      .from(indicateurSourceTable)
+      .orderBy(
+        asc(indicateurSourceTable.ordreAffichage),
+        asc(indicateurSourceTable.libelle)
+      );
+  }
+
+  listAvailableSources(
+    { collectiviteId, indicateurId }: IndicateurAvailableSourcesScope,
+    tx?: Transaction
+  ) {
+    const database = tx ?? this.databaseService.db;
+    const metadonneeIds = database
+      .select({ id: indicateurValeurTable.metadonneeId })
+      .from(indicateurValeurTable)
+      .where(
+        and(
+          isNotNull(indicateurValeurTable.metadonneeId),
+          eq(indicateurValeurTable.collectiviteId, collectiviteId),
+          eq(indicateurValeurTable.indicateurId, indicateurId),
+          or(
+            isNotNull(indicateurValeurTable.resultat),
+            isNotNull(indicateurValeurTable.objectif)
+          )
+        )
+      );
+
+    const sourceIds = database
+      .selectDistinct({ sourceId: indicateurSourceMetadonneeTable.sourceId })
+      .from(indicateurSourceMetadonneeTable)
+      .where(inArray(indicateurSourceMetadonneeTable.id, metadonneeIds));
+
+    return database
+      .select()
+      .from(indicateurSourceTable)
+      .where(inArray(indicateurSourceTable.id, sourceIds))
+      .orderBy(
+        asc(indicateurSourceTable.ordreAffichage),
+        asc(indicateurSourceTable.libelle)
+      );
+  }
+}

--- a/apps/backend/src/indicateurs/sources/indicateur-sources.router.ts
+++ b/apps/backend/src/indicateurs/sources/indicateur-sources.router.ts
@@ -16,8 +16,8 @@ export class IndicateurSourcesRouter {
     }),
     available: this.trpc.authedProcedure
       .input(getAvailableSourcesRequestSchema)
-      .query(({ input }) => {
-        return this.service.getAvailableSources(input);
+      .query(({ ctx, input }) => {
+        return this.service.getAvailableSources(input, { user: ctx.user });
       }),
   });
 }

--- a/apps/backend/src/indicateurs/sources/indicateur-sources.service.spec.ts
+++ b/apps/backend/src/indicateurs/sources/indicateur-sources.service.spec.ts
@@ -1,0 +1,98 @@
+import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { ResourceType } from '@tet/domain/users';
+import { IndicateurSourcesRepository } from './indicateur-sources.repository';
+import IndicateurSourcesService from './indicateur-sources.service';
+
+describe('IndicateurSourcesService', () => {
+  const input = { collectiviteId: 42, indicateurId: 7 };
+  const user = { id: 'user-id' } as AuthenticatedUser;
+
+  it('authorizes the collectivity before loading available sources', async () => {
+    const sources = [{ id: 'territoire', libelle: 'Territoire' }];
+    const repository = {
+      listAvailableSources: vi.fn().mockResolvedValue(sources),
+    } as unknown as IndicateurSourcesRepository;
+    const permissionService = {
+      assertAllowed: vi.fn().mockResolvedValue(undefined),
+    } as unknown as PermissionService;
+    const service = new IndicateurSourcesService(repository, permissionService);
+
+    await expect(service.getAvailableSources(input, { user })).resolves.toBe(
+      sources
+    );
+    expect(permissionService.assertAllowed).toHaveBeenCalledWith(
+      user,
+      'indicateurs.valeurs.read',
+      ResourceType.COLLECTIVITE,
+      { collectiviteId: input.collectiviteId }
+    );
+    expect(repository.listAvailableSources).toHaveBeenCalledWith(input);
+  });
+
+  it('does not query persistence when authorization is denied', async () => {
+    const repository = {
+      listAvailableSources: vi.fn(),
+    } as unknown as IndicateurSourcesRepository;
+    const denial = new Error('Droits insuffisants');
+    const permissionService = {
+      assertAllowed: vi.fn().mockRejectedValue(denial),
+    } as unknown as PermissionService;
+    const service = new IndicateurSourcesService(repository, permissionService);
+
+    await expect(service.getAvailableSources(input, { user })).rejects.toBe(
+      denial
+    );
+    expect(repository.listAvailableSources).not.toHaveBeenCalled();
+  });
+
+  it('forwards a computation transaction when listing metadata', async () => {
+    const tx = {} as Transaction;
+    const repository = {
+      listMetadonnees: vi.fn().mockResolvedValue([]),
+    } as unknown as IndicateurSourcesRepository;
+    const service = new IndicateurSourcesService(
+      repository,
+      {} as PermissionService
+    );
+
+    await service.getAllIndicateurSourceMetadonnees(tx);
+
+    expect(repository.listMetadonnees).toHaveBeenCalledWith(tx);
+  });
+
+  it('délègue les commandes et lectures de catalogue au repository', async () => {
+    const createdMetadonnee = { id: 1 };
+    const foundMetadonnee = { id: 2 };
+    const sources = [{ id: 'insee', libelle: 'INSEE' }];
+    const repository = {
+      createMetadonnee: vi.fn().mockResolvedValue(createdMetadonnee),
+      getMetadonnee: vi.fn().mockResolvedValue(foundMetadonnee),
+      upsertSource: vi.fn().mockResolvedValue(undefined),
+      listSources: vi.fn().mockResolvedValue(sources),
+    } as unknown as IndicateurSourcesRepository;
+    const service = new IndicateurSourcesService(
+      repository,
+      {} as PermissionService
+    );
+    const metadonnee = { sourceId: 'insee', dateVersion: '2026' } as never;
+    const source = { id: 'insee', libelle: 'INSEE' } as never;
+
+    await expect(
+      service.createIndicateurSourceMetadonnee(metadonnee)
+    ).resolves.toBe(createdMetadonnee);
+    await expect(
+      service.getIndicateurSourceMetadonnee('insee', '2026')
+    ).resolves.toBe(foundMetadonnee);
+    await expect(
+      service.upsertIndicateurSource(source)
+    ).resolves.toBeUndefined();
+    await expect(service.getAllSources()).resolves.toBe(sources);
+
+    expect(repository.createMetadonnee).toHaveBeenCalledWith(metadonnee);
+    expect(repository.getMetadonnee).toHaveBeenCalledWith('insee', '2026');
+    expect(repository.upsertSource).toHaveBeenCalledWith(source);
+    expect(repository.listSources).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/backend/src/indicateurs/sources/indicateur-sources.service.ts
+++ b/apps/backend/src/indicateurs/sources/indicateur-sources.service.ts
@@ -1,21 +1,24 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { ServiceSecondArg } from '@tet/backend/utils/nest/service-second-arg.utils';
 import {
   IndicateurSourceCreate,
   IndicateurSourceMetadonnee,
   IndicateurSourceMetadonneeCreate,
 } from '@tet/domain/indicateurs';
-import { and, asc, eq, inArray, isNotNull, or } from 'drizzle-orm';
-import { DatabaseService } from '../../utils/database/database.service';
-import { indicateurSourceMetadonneeTable } from '../shared/models/indicateur-source-metadonnee.table';
-import { indicateurSourceTable } from '../shared/models/indicateur-source.table';
-import { indicateurValeurTable } from '../valeurs/indicateur-valeur.table';
+import { ResourceType } from '@tet/domain/users';
 import { GetAvailableSourcesRequestSchemaRequestType } from './get-available-sources.request';
+import { IndicateurSourcesRepository } from './indicateur-sources.repository';
 
 @Injectable()
 export default class IndicateurSourcesService {
   private readonly logger = new Logger(IndicateurSourcesService.name);
 
-  constructor(private readonly databaseService: DatabaseService) {}
+  constructor(
+    private readonly repository: IndicateurSourcesRepository,
+    private readonly permissionService: PermissionService
+  ) {}
 
   async createIndicateurSourceMetadonnee(
     indicateurSourceMetadonneeType: IndicateurSourceMetadonneeCreate
@@ -23,22 +26,16 @@ export default class IndicateurSourcesService {
     this.logger.log(
       `Création de la metadonnees pour la source d'indicateur ${indicateurSourceMetadonneeType.sourceId} et la date ${indicateurSourceMetadonneeType.dateVersion}`
     );
-    const request = this.databaseService.db
-      .insert(indicateurSourceMetadonneeTable)
-      .values(indicateurSourceMetadonneeType)
-      .onConflictDoNothing();
-
-    const [model] = await request.returning();
-    return model;
+    return this.repository.createMetadonnee(indicateurSourceMetadonneeType);
   }
 
-  async getAllIndicateurSourceMetadonnees(): Promise<
-    IndicateurSourceMetadonnee[]
-  > {
+  async getAllIndicateurSourceMetadonnees(
+    tx?: Transaction
+  ): Promise<IndicateurSourceMetadonnee[]> {
     this.logger.log(`Get all metadonnees for indicateur sources`);
-    const indicateurSourceMetadonnees = await this.databaseService.db
-      .select()
-      .from(indicateurSourceMetadonneeTable);
+    const indicateurSourceMetadonnees = await this.repository.listMetadonnees(
+      tx
+    );
 
     this.logger.log(
       `Found ${indicateurSourceMetadonnees.length} metadonnees for indicateur sources`
@@ -53,78 +50,34 @@ export default class IndicateurSourcesService {
     this.logger.log(
       `Récupération de la metadonnees pour la source d'indicateur ${sourceId} et la date ${dateVersion}`
     );
-    const indicateurSourceMetadonnees = await this.databaseService.db
-      .select()
-      .from(indicateurSourceMetadonneeTable)
-      .where(
-        and(
-          eq(indicateurSourceMetadonneeTable.sourceId, sourceId),
-          eq(indicateurSourceMetadonneeTable.dateVersion, dateVersion)
-        )
-      )
-      .limit(1);
-    return indicateurSourceMetadonnees.length > 0
-      ? indicateurSourceMetadonnees[0]
-      : null;
+    return this.repository.getMetadonnee(sourceId, dateVersion);
   }
 
   async upsertIndicateurSource(indicateurSource: IndicateurSourceCreate) {
     this.logger.log(`Upsert de la source d'indicateur ${indicateurSource.id}`);
-    return this.databaseService.db
-      .insert(indicateurSourceTable)
-      .values(indicateurSource)
-      .onConflictDoUpdate({
-        target: indicateurSourceTable.id,
-        set: { libelle: indicateurSource.libelle },
-      });
+    return this.repository.upsertSource(indicateurSource);
   }
 
   async getAllSources() {
     this.logger.log('Liste toutes les sources de données');
-    return this.databaseService.db
-      .select()
-      .from(indicateurSourceTable)
-      .orderBy(
-        asc(indicateurSourceTable.ordreAffichage),
-        asc(indicateurSourceTable.libelle)
-      );
+    return this.repository.listSources();
   }
 
   async getAvailableSources(
-    input: GetAvailableSourcesRequestSchemaRequestType
+    input: GetAvailableSourcesRequestSchemaRequestType,
+    { user }: Pick<ServiceSecondArg, 'user'>
   ) {
     const { collectiviteId, indicateurId } = input;
+    await this.permissionService.assertAllowed(
+      user,
+      'indicateurs.valeurs.read',
+      ResourceType.COLLECTIVITE,
+      { collectiviteId }
+    );
+
     this.logger.log(
       `Liste les sources de données disponibles pour l'indicateur ${indicateurId} et la collectivité ${collectiviteId}`
     );
-
-    const metadonneeIds = this.databaseService.db
-      .select({ id: indicateurValeurTable.metadonneeId })
-      .from(indicateurValeurTable)
-      .where(
-        and(
-          isNotNull(indicateurValeurTable.metadonneeId),
-          eq(indicateurValeurTable.collectiviteId, collectiviteId),
-          eq(indicateurValeurTable.indicateurId, indicateurId),
-          or(
-            isNotNull(indicateurValeurTable.resultat),
-            isNotNull(indicateurValeurTable.objectif)
-          )
-        )
-      );
-
-    const sourceId = this.databaseService.db
-      .selectDistinct({ sourceId: indicateurSourceMetadonneeTable.sourceId })
-      .from(indicateurSourceMetadonneeTable)
-      .where(inArray(indicateurSourceMetadonneeTable.id, metadonneeIds));
-
-    return this.databaseService.db
-      .select()
-      .from(indicateurSourceTable)
-      .where(inArray(indicateurSourceTable.id, sourceId))
-      .orderBy(
-        asc(indicateurSourceTable.ordreAffichage),
-        asc(indicateurSourceTable.libelle)
-      );
+    return this.repository.listAvailableSources(input);
   }
 }

--- a/apps/backend/src/users/authorizations/permission.repository.spec.ts
+++ b/apps/backend/src/users/authorizations/permission.repository.spec.ts
@@ -1,0 +1,64 @@
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { describe, expect, it, vi } from 'vitest';
+import { PermissionRepository } from './permission.repository';
+
+function createSelectQuery(
+  rows: Array<{ collectiviteId: number; referentielId: string }>
+) {
+  const limit = vi.fn().mockResolvedValue(rows);
+  const where = vi.fn(() => ({ limit }));
+  const from = vi.fn(() => ({ where }));
+  const select = vi.fn(() => ({ from }));
+
+  return { select, from, where, limit };
+}
+
+describe('PermissionRepository', () => {
+  it('loads the referentiel context of an audit', async () => {
+    const query = createSelectQuery([
+      { collectiviteId: 12, referentielId: 'cae' },
+    ]);
+    const repository = new PermissionRepository({
+      db: { select: query.select },
+    } as unknown as DatabaseService);
+
+    await expect(repository.getAuditPermissionContext(42)).resolves.toEqual({
+      collectiviteId: 12,
+      referentielId: 'cae',
+    });
+    expect(query.where).toHaveBeenCalledOnce();
+    expect(query.limit).toHaveBeenCalledWith(1);
+  });
+
+  it('returns null when the audit does not exist', async () => {
+    const query = createSelectQuery([]);
+    const repository = new PermissionRepository({
+      db: { select: query.select },
+    } as unknown as DatabaseService);
+
+    await expect(repository.getAuditPermissionContext(404)).resolves.toBeNull();
+  });
+
+  it('uses the transaction supplied by the application service', async () => {
+    const databaseSelect = vi.fn();
+    const transactionQuery = createSelectQuery([
+      { collectiviteId: 12, referentielId: 'eci' },
+    ]);
+    const repository = new PermissionRepository({
+      db: { select: databaseSelect },
+    } as unknown as DatabaseService);
+    const tx = {
+      select: transactionQuery.select,
+    } as unknown as Transaction;
+
+    await expect(repository.getAuditPermissionContext(42, tx)).resolves.toEqual(
+      {
+        collectiviteId: 12,
+        referentielId: 'eci',
+      }
+    );
+    expect(transactionQuery.select).toHaveBeenCalledOnce();
+    expect(databaseSelect).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/users/authorizations/permission.repository.ts
+++ b/apps/backend/src/users/authorizations/permission.repository.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@nestjs/common';
+import { auditTable } from '@tet/backend/referentiels/labellisations/audit.table';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import type { ReferentielId } from '@tet/domain/referentiels';
+import { eq } from 'drizzle-orm';
+
+type AuditPermissionContext = {
+  collectiviteId: number;
+  referentielId: ReferentielId;
+};
+
+@Injectable()
+export class PermissionRepository {
+  constructor(private readonly databaseService: DatabaseService) {}
+
+  async getAuditPermissionContext(
+    auditId: number,
+    tx?: Transaction
+  ): Promise<AuditPermissionContext | null> {
+    const [audit] = await (tx ?? this.databaseService.db)
+      .select({
+        collectiviteId: auditTable.collectiviteId,
+        referentielId: auditTable.referentielId,
+      })
+      .from(auditTable)
+      .where(eq(auditTable.id, auditId))
+      .limit(1);
+
+    if (!audit) {
+      return null;
+    }
+
+    return {
+      collectiviteId: audit.collectiviteId,
+      referentielId: audit.referentielId as ReferentielId,
+    };
+  }
+}

--- a/apps/backend/src/users/authorizations/permission.service.spec.ts
+++ b/apps/backend/src/users/authorizations/permission.service.spec.ts
@@ -1,0 +1,119 @@
+import { ForbiddenException } from '@nestjs/common';
+import { AuthRole, AuthUser } from '@tet/backend/users/models/auth.models';
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { success } from '@tet/backend/utils/result.type';
+import { defaultCollectivitePreferences } from '@tet/domain/collectivites';
+import { ResourceType, UserRolesAndPermissions } from '@tet/domain/users';
+import { describe, expect, it, vi } from 'vitest';
+import { PermissionService } from './permission.service';
+
+const service = new PermissionService({} as never, {} as never, {} as never);
+
+const humanUser = {
+  id: '00000000-0000-0000-0000-000000000001',
+  role: AuthRole.AUTHENTICATED,
+  isAnonymous: false,
+  jwtPayload: { role: AuthRole.AUTHENTICATED },
+} satisfies AuthUser<AuthRole.AUTHENTICATED>;
+
+describe('PermissionService.assertApiKeyPermission', () => {
+  it('does not constrain a human session without an API-key allow-list', () => {
+    expect(() =>
+      service.assertApiKeyPermission(humanUser, 'indicateurs.valeurs.mutate')
+    ).not.toThrow();
+  });
+
+  it('rejects an operation absent from a restricted API-key allow-list', () => {
+    const readOnlyApiKeyUser = {
+      ...humanUser,
+      jwtPayload: {
+        ...humanUser.jwtPayload,
+        client_id: 'read-only-key',
+        permissions: ['indicateurs.valeurs.read'],
+      },
+    } satisfies AuthUser<AuthRole.AUTHENTICATED>;
+
+    expect(() =>
+      service.assertApiKeyPermission(
+        readOnlyApiKeyUser,
+        'indicateurs.valeurs.mutate'
+      )
+    ).toThrow(ForbiddenException);
+  });
+
+  it('allows an operation present in a restricted API-key allow-list', () => {
+    const writableApiKeyUser = {
+      ...humanUser,
+      jwtPayload: {
+        ...humanUser.jwtPayload,
+        client_id: 'writable-key',
+        permissions: ['indicateurs.valeurs.mutate'],
+      },
+    } satisfies AuthUser<AuthRole.AUTHENTICATED>;
+
+    expect(() =>
+      service.assertApiKeyPermission(
+        writableApiKeyUser,
+        'indicateurs.valeurs.mutate'
+      )
+    ).not.toThrow();
+  });
+
+  it('keeps service-role integrations unrestricted', () => {
+    const serviceRoleUser = {
+      id: null,
+      role: AuthRole.SERVICE_ROLE,
+      isAnonymous: true,
+      jwtPayload: { role: AuthRole.SERVICE_ROLE, permissions: [] },
+    } satisfies AuthUser<AuthRole.SERVICE_ROLE>;
+
+    expect(() =>
+      service.assertApiKeyPermission(
+        serviceRoleUser,
+        'indicateurs.valeurs.mutate'
+      )
+    ).not.toThrow();
+  });
+});
+
+describe('PermissionService.isAllowed', () => {
+  it('delegates the audit fallback lookup to the repository with the current transaction', async () => {
+    const tx = {} as Transaction;
+    const userPermissions = {
+      roles: [],
+      permissions: ['referentiels.read'],
+      collectivites: [],
+    } satisfies UserRolesAndPermissions;
+    const getUserRolesAndPermissions = vi
+      .fn()
+      .mockResolvedValue(success(userPermissions));
+    const getPreferencesByCollectiviteId = vi
+      .fn()
+      .mockResolvedValue(success(defaultCollectivitePreferences));
+    const getAuditPermissionContext = vi.fn().mockResolvedValue({
+      collectiviteId: 12,
+      referentielId: 'cae',
+    });
+    const auditPermissionService = new PermissionService(
+      { getUserRolesAndPermissions } as never,
+      { getPreferencesByCollectiviteId } as never,
+      { getAuditPermissionContext } as never
+    );
+
+    await expect(
+      auditPermissionService.isAllowed(
+        humanUser,
+        'referentiels.read',
+        ResourceType.AUDIT,
+        { auditId: 42 },
+        tx
+      )
+    ).resolves.toEqual(success(undefined));
+    expect(getUserRolesAndPermissions).toHaveBeenCalledWith({
+      userId: humanUser.id,
+      tx,
+    });
+    expect(getAuditPermissionContext).toHaveBeenCalledWith(42, tx);
+    expect(getPreferencesByCollectiviteId).toHaveBeenCalledWith(12, { tx });
+  });
+});

--- a/apps/backend/src/users/authorizations/permission.service.ts
+++ b/apps/backend/src/users/authorizations/permission.service.ts
@@ -1,8 +1,6 @@
 import { ForbiddenException, Injectable, Logger } from '@nestjs/common';
 import { CollectivitePreferencesRepository } from '@tet/backend/collectivites/collectivite-preferences/collectivite-preferences.repository';
 import { REFERENTIEL_NOT_WRITABLE_MESSAGE } from '@tet/backend/collectivites/collectivite-referentiel-mode/referentiel-mode-guard.errors';
-import { auditTable } from '@tet/backend/referentiels/labellisations/audit.table';
-import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { Transaction } from '@tet/backend/utils/database/transaction.utils';
 import { failure, success, type Result } from '@tet/backend/utils/result.type';
 import {
@@ -17,24 +15,24 @@ import {
   ResourceType,
   type UserRolesAndPermissions,
 } from '@tet/domain/users';
-import { eq } from 'drizzle-orm';
 import { AuthRole, AuthUser } from '../models/auth.models';
 import { GetUserRolesAndPermissionsService } from './get-user-roles-and-permissions/get-user-roles-and-permissions.service';
+import { PermissionRepository } from './permission.repository';
 
-export type ReferentielPermissionResource = {
+type ReferentielPermissionResource = {
   collectiviteId: number;
   referentielId: ReferentielId;
 };
 
-export type AuditPermissionResource = {
+type AuditPermissionResource = {
   auditId: number;
 };
 
-export type CollectivitePermissionResource = {
+type CollectivitePermissionResource = {
   collectiviteId: number;
 };
 
-export type PermissionResourceId =
+type PermissionResourceId =
   | ReferentielPermissionResource
   | AuditPermissionResource
   | CollectivitePermissionResource
@@ -50,7 +48,7 @@ export type NonReferentielPermissionOperation = Exclude<
   ReferentielPermissionOperation
 >;
 
-export type PermissionDenial = 'UNAUTHORIZED' | 'REFERENTIEL_NOT_WRITABLE';
+type PermissionDenial = 'UNAUTHORIZED' | 'REFERENTIEL_NOT_WRITABLE';
 
 function isAuditPermissionResource(
   resourceId: PermissionResourceId
@@ -121,7 +119,7 @@ export class PermissionService {
   constructor(
     private readonly getUserPermissionsService: GetUserRolesAndPermissionsService,
     private readonly collectivitePreferencesRepository: CollectivitePreferencesRepository,
-    private readonly databaseService: DatabaseService
+    private readonly permissionRepository: PermissionRepository
   ) {}
 
   hasServiceRole(
@@ -139,6 +137,32 @@ export class PermissionService {
     } else {
       return true;
     }
+  }
+
+  /**
+   * Enforce the operation allow-list carried by restricted API-key JWTs.
+   *
+   * Human sessions do not carry this claim, so their collectivity role (and
+   * feature-specific fallbacks such as "piloted by me") remains authoritative.
+   * Service-role tokens keep their existing unrestricted integration access.
+   */
+  assertApiKeyPermission(user: AuthUser, operation: PermissionOperation): void {
+    if (!this.hasApiKeyPermission(user, operation)) {
+      throw new ForbiddenException(
+        `Droits insuffisants, la clé d'api n'a pas l'autorisation ${operation}.`
+      );
+    }
+  }
+
+  private hasApiKeyPermission(
+    user: AuthUser,
+    operation: PermissionOperation
+  ): boolean {
+    return (
+      user.role === AuthRole.SERVICE_ROLE ||
+      !user.jwtPayload?.permissions ||
+      user.jwtPayload.permissions.includes(operation)
+    );
   }
 
   throwForbiddenException(
@@ -274,14 +298,7 @@ export class PermissionService {
       throw new ForbiddenException(REFERENTIEL_NOT_WRITABLE_MESSAGE);
     }
 
-    if (
-      user.jwtPayload?.permissions &&
-      !user.jwtPayload.permissions.includes(operation)
-    ) {
-      throw new ForbiddenException(
-        `Droits insuffisants, la clé d'api n'a pas l'autorisation ${operation}.`
-      );
-    }
+    this.assertApiKeyPermission(user, operation);
 
     this.throwForbiddenException(user, operation, resourceType, resourceId);
   }
@@ -301,7 +318,7 @@ export class PermissionService {
       this.logger.log(
         `Checking restricted permissions for client_id ${user.jwtPayload.client_id}`
       );
-      if (!user.jwtPayload.permissions.includes(operation)) {
+      if (!this.hasApiKeyPermission(user, operation)) {
         this.logger.log(
           `La clé d'api n'a pas l'autorisation ${operation}: permissions ${user.jwtPayload.permissions.join(
             ', '
@@ -342,7 +359,11 @@ export class PermissionService {
         findAuditPermissionContext(
           userPermissionsResult.data,
           resourceId.auditId
-        ) ?? (await this.loadAuditPermissionContext(resourceId.auditId, tx));
+        ) ??
+        (await this.permissionRepository.getAuditPermissionContext(
+          resourceId.auditId,
+          tx
+        ));
 
       if (!auditContext) {
         this.logger.warn(
@@ -483,29 +504,5 @@ export class PermissionService {
     }
 
     return success(undefined);
-  }
-
-  private async loadAuditPermissionContext(
-    auditId: number,
-    tx?: Transaction
-  ): Promise<ReferentielPermissionResource | null> {
-    const db = tx ?? this.databaseService.db;
-    const [audit] = await db
-      .select({
-        collectiviteId: auditTable.collectiviteId,
-        referentielId: auditTable.referentielId,
-      })
-      .from(auditTable)
-      .where(eq(auditTable.id, auditId))
-      .limit(1);
-
-    if (!audit) {
-      return null;
-    }
-
-    return {
-      collectiviteId: audit.collectiviteId,
-      referentielId: audit.referentielId as ReferentielId,
-    };
   }
 }

--- a/apps/backend/src/users/users.module.ts
+++ b/apps/backend/src/users/users.module.ts
@@ -6,6 +6,7 @@ import { ApikeysController } from '@tet/backend/users/apikeys/apikeys.controller
 import { ApikeysRouter } from '@tet/backend/users/apikeys/apikeys.router';
 import { ApikeysService } from '@tet/backend/users/apikeys/apikeys.service';
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
+import { PermissionRepository } from '@tet/backend/users/authorizations/permission.repository';
 import { ListUsersController } from '@tet/backend/users/users/list-users/list-users.controller';
 import { EmailService } from '@tet/backend/utils/email/email.service';
 import { NestjsFormDataModule } from 'nestjs-form-data';
@@ -71,6 +72,7 @@ import { TransactionModule } from '@tet/backend/utils/transaction/transaction.mo
       useClass: AuthGuard,
     },
     CollectivitePreferencesRepository,
+    PermissionRepository,
     PermissionService,
     GetUserRolesAndPermissionsService,
     GetUserRolesAndPermissionsRepository,

--- a/data_layer/README.md
+++ b/data_layer/README.md
@@ -83,3 +83,24 @@ il faut mettre à jour les variables d'environnement :
   - le websocket `wss://{ID}.supabase.co`
   - la clé privée **service_role**
   - l'url postgres `postgresql://postgres:{PASSWORD}@db.{ID}.supabase.co:5432/postgres`
+
+## Déploiement de la périodicité : phase expand
+
+`make db-migrate-periodicite-expand` déploie ensemble les quatre changements compatibles,
+jusqu'au tag `@indicateur-periodicite-expand`, dans une transaction vérifiée. La colonne
+`periodicite` garde son défaut `annuelle` et reste nullable pour les anciennes applications.
+Les dates historiques sans collision sont normalisées sous audit réversible ; les collisions
+restent dans `migration.indicateur_valeur_periodicite_audit` avec le statut `conflit`.
+
+Avant de déployer les futurs lecteurs et writers qui exigent une date canonique, résoudre
+chaque conflit et vérifier que toutes les valeurs ont une date canonique. Cette étape précède
+la bascule applicative ; elle ne doit pas être reportée au retrait de la compatibilité.
+
+Le passage à la contrainte obligatoire et le retrait du défaut seront livrés séparément,
+après migration de tous les consommateurs et arrêt des anciennes instances. Ne pas activer
+la saisie mensuelle tant que les consommateurs correspondants ne sont pas déployés.
+
+`make db-test-deployment-guards` vérifie les garde-fous sans toucher à la base.
+`make db-test-periodicite-migration` exige une URL `PERIODICITE_MIGRATION_TEST_DATABASE_URL`
+vers une base locale jetable nommée `periodicite_migration_lifecycle_test_*`, préparée avant
+l'expand. Ce test y exerce le déploiement, la concurrence et le revert.

--- a/data_layer/backup/check-restore-compatibility.sh
+++ b/data_layer/backup/check-restore-compatibility.sh
@@ -1,0 +1,417 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: TO_DB_URL=... $0 <backup.dump>" >&2
+    exit 2
+fi
+
+if [ -z "${TO_DB_URL:-}" ]; then
+    echo "Missing TO_DB_URL environment variable" >&2
+    exit 2
+fi
+
+DUMP_FILE="$1"
+EXPAND_CHANGE="indicateur/periodicite"
+EXPAND_IMPORT_CHANGE="indicateur/import_emt_valeur"
+EXPAND_RECONCILIATION_CHANGE="indicateur/reconciliation_formules"
+EXPAND_DEPENDENCIES_CHANGE="indicateur/dependances_formules"
+TARGET_CONTRACT_CHANGE="indicateur/periodicite_obligatoire"
+SOURCE_FORMULA_CHANGE="indicateur/periodicite_formules"
+SOURCE_FINAL_CHANGE="stats/report_indicateur_resultat_periode"
+SQITCH_PROJECT="tet"
+
+# The registry identifies the intended phase, while the physical object checks
+# below prove that the target can safely execute that phase's restore path.
+# This includes the column contract and the exact phase-specific write guard;
+# an object with the right name but the wrong trigger semantics is drift. A
+# connection, registry or schema-drift error must stop the restore before any
+# table is truncated. In pg_trigger.tgtype, 23 is ROW + BEFORE + INSERT + UPDATE.
+target_phase=$(psql \
+    --dbname "$TO_DB_URL" \
+    --no-psqlrc \
+    --tuples-only \
+    --no-align \
+    --set ON_ERROR_STOP=1 \
+    --command "
+        WITH registry_phase AS (
+            SELECT CASE
+                WHEN count(*) FILTER (
+                    WHERE change = '$EXPAND_CHANGE'
+                ) > 0
+                 AND count(*) FILTER (
+                    WHERE change = '$EXPAND_IMPORT_CHANGE'
+                ) > 0
+                 AND count(*) FILTER (
+                    WHERE change = '$EXPAND_RECONCILIATION_CHANGE'
+                ) > 0
+                 AND count(*) FILTER (
+                    WHERE change = '$EXPAND_DEPENDENCIES_CHANGE'
+                ) > 0
+                 AND count(*) FILTER (
+                    WHERE change = '$TARGET_CONTRACT_CHANGE'
+                ) > 0
+                 AND count(*) FILTER (
+                    WHERE change = '$SOURCE_FORMULA_CHANGE'
+                ) > 0
+                 AND count(*) FILTER (
+                    WHERE change = '$SOURCE_FINAL_CHANGE'
+                ) > 0
+                    THEN 'contract'
+                WHEN count(*) FILTER (
+                    WHERE change IN (
+                        '$TARGET_CONTRACT_CHANGE',
+                        '$SOURCE_FORMULA_CHANGE',
+                        '$SOURCE_FINAL_CHANGE'
+                    )
+                ) > 0
+                    THEN 'partial-contract'
+                WHEN count(*) FILTER (
+                    WHERE change = '$EXPAND_CHANGE'
+                ) > 0
+                 AND count(*) FILTER (
+                    WHERE change = '$EXPAND_IMPORT_CHANGE'
+                ) > 0
+                 AND count(*) FILTER (
+                    WHERE change = '$EXPAND_RECONCILIATION_CHANGE'
+                ) > 0
+                 AND count(*) FILTER (
+                    WHERE change = '$EXPAND_DEPENDENCIES_CHANGE'
+                ) > 0
+                    THEN 'expand'
+                WHEN count(*) FILTER (
+                    WHERE change IN (
+                        '$EXPAND_CHANGE',
+                        '$EXPAND_IMPORT_CHANGE',
+                        '$EXPAND_RECONCILIATION_CHANGE',
+                        '$EXPAND_DEPENDENCIES_CHANGE'
+                    )
+                ) > 0
+                    THEN 'partial-expand'
+                ELSE 'legacy'
+            END AS phase,
+            count(*) > 0 AS registry_seen
+            FROM sqitch.changes
+            WHERE project = '$SQITCH_PROJECT'
+        ),
+        physical_state AS (
+            SELECT
+                to_regclass(
+                    'public.indicateur_periodicite'
+                ) IS NOT NULL AS periodicity_catalog_exists,
+                EXISTS (
+                    SELECT 1
+                    FROM information_schema.columns
+                    WHERE table_schema = 'public'
+                      AND table_name = 'indicateur_definition'
+                      AND column_name = 'periodicite'
+                ) AS periodicity_column_exists,
+                EXISTS (
+                    SELECT 1
+                    FROM information_schema.columns
+                    WHERE table_schema = 'public'
+                      AND table_name = 'indicateur_definition'
+                      AND column_name = 'periodicite'
+                      AND data_type = 'text'
+                      AND is_nullable = 'YES'
+                      AND column_default = '''annuelle''::text'
+                ) AS periodicity_column_is_expand_compatible,
+                EXISTS (
+                    SELECT 1
+                    FROM information_schema.columns
+                    WHERE table_schema = 'public'
+                      AND table_name = 'indicateur_definition'
+                      AND column_name = 'periodicite'
+                      AND data_type = 'text'
+                      AND is_nullable = 'NO'
+                      AND column_default IS NULL
+                ) AS periodicity_column_is_contract_compatible,
+                to_regprocedure(
+                    'public.indicateur_date_debut_periode(text,date)'
+                ) IS NOT NULL AS canonical_date_function_exists,
+                to_regclass(
+                    'migration.indicateur_valeur_periodicite_audit'
+                ) IS NOT NULL AS audit_table_exists,
+                to_regclass(
+                    'private.indicateur_reconciliation_formule'
+                ) IS NOT NULL AS reconciliation_queue_exists,
+                to_regclass(
+                    'private.indicateur_definition_dependance_calcul'
+                ) IS NOT NULL AS dependency_projection_exists,
+                to_regprocedure(
+                    'private.extraire_dependances_formule_indicateur(text)'
+                ) IS NOT NULL AS dependency_extractor_exists,
+                to_regprocedure(
+                    'private.verifier_periodicite_dependances_formule(integer,text[])'
+                ) IS NOT NULL AS dependency_verifier_exists,
+                to_regprocedure(
+                    'migration.auditer_et_normaliser_dates_indicateur()'
+                ) IS NOT NULL AS audit_function_exists,
+                to_regprocedure(
+                    'migration.auditer_et_normaliser_date_indicateur_en_transition()'
+                ) IS NOT NULL AS transition_date_function_exists,
+                EXISTS (
+                    SELECT 1
+                    FROM pg_trigger
+                    WHERE tgrelid = to_regclass('public.indicateur_valeur')
+                      AND tgname =
+                          'auditer_et_normaliser_date_indicateur_en_transition'
+                      AND NOT tgisinternal
+                ) AS transition_date_trigger_exists,
+                EXISTS (
+                    SELECT 1
+                    FROM pg_trigger trigger_state
+                    WHERE trigger_state.tgrelid =
+                          to_regclass('public.indicateur_valeur')
+                      AND trigger_state.tgname =
+                          'auditer_et_normaliser_date_indicateur_en_transition'
+                      AND trigger_state.tgenabled = 'O'
+                      AND NOT trigger_state.tgisinternal
+                      AND trigger_state.tgconstraint = 0
+                      AND trigger_state.tgtype::integer = 23
+                      AND trigger_state.tgfoid = to_regprocedure(
+                          'migration.auditer_et_normaliser_date_indicateur_en_transition()'
+                      )
+                      AND (
+                          SELECT array_agg(
+                              attribute.attname
+                              ORDER BY attribute.attname
+                          )
+                          FROM unnest(
+                              trigger_state.tgattr::smallint[]
+                          ) AS updated(attnum)
+                          JOIN pg_attribute attribute
+                            ON attribute.attrelid = trigger_state.tgrelid
+                           AND attribute.attnum = updated.attnum
+                      ) = ARRAY[
+                          'collectivite_id',
+                          'date_valeur',
+                          'indicateur_id',
+                          'metadonnee_id'
+                      ]::name[]
+                ) AS transition_date_trigger_is_valid,
+                to_regprocedure(
+                    'public.verifier_date_valeur_selon_periodicite()'
+                ) IS NOT NULL AS strict_date_function_exists,
+                EXISTS (
+                    SELECT 1
+                    FROM pg_trigger
+                    WHERE tgrelid = to_regclass('public.indicateur_valeur')
+                      AND tgname = 'verifier_date_valeur_selon_periodicite'
+                      AND NOT tgisinternal
+                ) AS strict_date_trigger_exists,
+                EXISTS (
+                    SELECT 1
+                    FROM pg_trigger trigger_state
+                    WHERE trigger_state.tgrelid =
+                          to_regclass('public.indicateur_valeur')
+                      AND trigger_state.tgname =
+                          'verifier_date_valeur_selon_periodicite'
+                      AND trigger_state.tgenabled = 'O'
+                      AND NOT trigger_state.tgisinternal
+                      AND trigger_state.tgconstraint = 0
+                      AND trigger_state.tgtype::integer = 23
+                      AND trigger_state.tgfoid = to_regprocedure(
+                          'public.verifier_date_valeur_selon_periodicite()'
+                      )
+                      AND (
+                          SELECT array_agg(
+                              attribute.attname
+                              ORDER BY attribute.attname
+                          )
+                          FROM unnest(
+                              trigger_state.tgattr::smallint[]
+                          ) AS updated(attnum)
+                          JOIN pg_attribute attribute
+                            ON attribute.attrelid = trigger_state.tgrelid
+                           AND attribute.attnum = updated.attnum
+                      ) = ARRAY[
+                          'date_valeur',
+                          'indicateur_id'
+                      ]::name[]
+                ) AS strict_date_trigger_is_valid
+        )
+        SELECT CASE
+            WHEN NOT registry_seen
+                THEN 'missing-registry'
+            WHEN phase = 'legacy'
+             AND NOT periodicity_catalog_exists
+             AND NOT periodicity_column_exists
+             AND NOT canonical_date_function_exists
+             AND NOT audit_table_exists
+             AND NOT reconciliation_queue_exists
+             AND NOT dependency_projection_exists
+             AND NOT dependency_extractor_exists
+             AND NOT dependency_verifier_exists
+             AND NOT audit_function_exists
+             AND NOT transition_date_function_exists
+             AND NOT transition_date_trigger_exists
+             AND NOT strict_date_function_exists
+             AND NOT strict_date_trigger_exists
+                THEN 'legacy'
+            WHEN phase = 'expand'
+             AND periodicity_catalog_exists
+             AND periodicity_column_is_expand_compatible
+             AND canonical_date_function_exists
+             AND audit_table_exists
+             AND reconciliation_queue_exists
+             AND dependency_extractor_exists
+             AND audit_function_exists
+             AND transition_date_function_exists
+             AND transition_date_trigger_is_valid
+             AND NOT strict_date_function_exists
+             AND NOT strict_date_trigger_exists
+             AND NOT dependency_projection_exists
+             AND NOT dependency_verifier_exists
+                THEN 'expand'
+            WHEN phase = 'contract'
+             AND periodicity_catalog_exists
+             AND periodicity_column_is_contract_compatible
+             AND canonical_date_function_exists
+             AND audit_table_exists
+             AND reconciliation_queue_exists
+             AND dependency_projection_exists
+             AND dependency_extractor_exists
+             AND dependency_verifier_exists
+             AND NOT audit_function_exists
+             AND NOT transition_date_function_exists
+             AND NOT transition_date_trigger_exists
+             AND strict_date_function_exists
+             AND strict_date_trigger_is_valid
+                THEN 'contract'
+            WHEN phase IN ('partial-expand', 'partial-contract')
+                THEN phase
+            ELSE 'physical-drift-' || phase
+        END
+        FROM registry_phase
+        CROSS JOIN physical_state;
+    ")
+
+case "$target_phase" in
+    legacy|expand|contract)
+        ;;
+    partial-expand)
+        echo "Refusing to restore: target is inside a partial periodicity expand." >&2
+        exit 1
+        ;;
+    partial-contract)
+        echo "Refusing to restore: target is inside a partial periodicity contract." >&2
+        exit 1
+        ;;
+    missing-registry)
+        echo "Refusing to restore: target has no Sqitch registry state." >&2
+        exit 1
+        ;;
+    physical-drift-*)
+        echo "Refusing to restore: target schema objects disagree with its Sqitch phase." >&2
+        exit 1
+        ;;
+    *)
+        echo "Refusing to restore: unexpected target periodicity phase." >&2
+        exit 1
+        ;;
+esac
+
+# pg_dump includes sqitch.changes in the same consistent snapshot as the
+# business data. Inspect that archived COPY stream instead of trusting mutable
+# metadata or a date supplied by the operator.
+source_phase=$(pg_restore \
+    --data-only \
+    --schema=sqitch \
+    --table=changes \
+    --file=- \
+    "$DUMP_FILE" \
+    | awk -F '\t' \
+        -v expand_change="$EXPAND_CHANGE" \
+        -v import_change="$EXPAND_IMPORT_CHANGE" \
+        -v reconciliation_change="$EXPAND_RECONCILIATION_CHANGE" \
+        -v dependencies_change="$EXPAND_DEPENDENCIES_CHANGE" \
+        -v mandatory_change="$TARGET_CONTRACT_CHANGE" \
+        -v formula_change="$SOURCE_FORMULA_CHANGE" \
+        -v final_change="$SOURCE_FINAL_CHANGE" \
+        -v project="$SQITCH_PROJECT" '
+        $4 == project { registry_seen = 1 }
+        $3 == expand_change && $4 == project { expand_applied = 1 }
+        $3 == import_change && $4 == project { import_applied = 1 }
+        $3 == reconciliation_change && $4 == project { reconciliation_applied = 1 }
+        $3 == dependencies_change && $4 == project { dependencies_applied = 1 }
+        $3 == mandatory_change && $4 == project { mandatory_applied = 1 }
+        $3 == formula_change && $4 == project { formula_applied = 1 }
+        $3 == final_change && $4 == project { final_applied = 1 }
+        END {
+            expand_complete = expand_applied && import_applied \
+                && reconciliation_applied && dependencies_applied
+            if (!registry_seen) {
+                print "missing-registry"
+            } else if (expand_complete && mandatory_applied && formula_applied && final_applied) {
+                print "contract"
+            } else if (mandatory_applied || formula_applied || final_applied) {
+                print "partial-contract"
+            } else if (expand_complete) {
+                print "expand"
+            } else if (expand_applied || import_applied \
+                       || reconciliation_applied || dependencies_applied) {
+                print "partial-expand"
+            } else {
+                print "legacy"
+            }
+        }
+    ')
+
+case "$source_phase" in
+    legacy|expand|contract)
+        ;;
+    partial-expand)
+        echo "Refusing to restore: backup is inside a partial periodicity expand." >&2
+        exit 1
+        ;;
+    partial-contract)
+        echo "Refusing to restore: backup is inside a partial periodicity contract." >&2
+        exit 1
+        ;;
+    missing-registry)
+        echo "Refusing to restore: backup has no Sqitch registry state." >&2
+        exit 1
+        ;;
+    *)
+        echo "Refusing to restore: unexpected backup periodicity phase." >&2
+        exit 1
+        ;;
+esac
+
+archive_has_table_data() {
+    local schema="$1"
+    local table="$2"
+
+    pg_restore --list "$DUMP_FILE" \
+        | awk -v schema="$schema" -v table="$table" '
+            $4 == "TABLE" && $5 == "DATA" \
+                && $6 == schema && $7 == table { found = 1 }
+            END { exit !found }
+        '
+}
+
+# Both rows sets are durable domain/migration state in expand and contract.
+# Without their TABLE DATA entries, the table-by-table restore would truncate
+# valid target state and could otherwise treat a selective archive as empty.
+if [ "$source_phase" != "legacy" ]; then
+    if ! archive_has_table_data \
+        migration indicateur_valeur_periodicite_audit; then
+        echo "Refusing to restore: backup lacks periodicity audit data." >&2
+        exit 1
+    fi
+    if ! archive_has_table_data \
+        private indicateur_reconciliation_formule; then
+        echo "Refusing to restore: backup lacks formula reconciliation data." >&2
+        exit 1
+    fi
+fi
+
+if [ "$source_phase" != "$target_phase" ]; then
+    echo "Refusing to restore: periodicity phases differ" >&2
+    echo "(backup: $source_phase, target: $target_phase)." >&2
+    exit 1
+fi
+
+echo "Restore compatibility: source and target phase is $target_phase." >&2
+printf '%s\n' "$target_phase"

--- a/data_layer/backup/check-restore-compatibility.spec.sh
+++ b/data_layer/backup/check-restore-compatibility.spec.sh
@@ -1,0 +1,226 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-restore-compatibility.sh"
+TEST_DIRECTORY=$(mktemp -d)
+FAKE_BIN="$TEST_DIRECTORY/bin"
+DUMP_FILE="$TEST_DIRECTORY/backup.dump"
+
+cleanup() {
+    rm -rf "$TEST_DIRECTORY"
+}
+trap cleanup EXIT
+
+mkdir -p "$FAKE_BIN"
+printf 'test archive\n' > "$DUMP_FILE"
+
+printf '%s\n' \
+    '#!/bin/bash' \
+    'if [ "${TARGET_QUERY_FAILS:-false}" = "true" ]; then exit 1; fi' \
+    'case "${TARGET_SCHEMA_DRIFT:-}" in' \
+    '  expand-*) printf "physical-drift-expand\n" ;;' \
+    '  contract-*) printf "physical-drift-contract\n" ;;' \
+    '  *) printf "%s\n" "${TARGET_PHASE:-legacy}" ;;' \
+    'esac' \
+    > "$FAKE_BIN/psql"
+
+printf '%s\n' \
+    '#!/bin/bash' \
+    'if [ "${ARCHIVE_READ_FAILS:-false}" = "true" ]; then exit 1; fi' \
+    'if [[ " $* " == *" --list "* ]]; then' \
+    '  printf "1; 0 1 TABLE DATA sqitch changes owner\\n"' \
+    '  if [ "${ARCHIVE_AUDIT_TABLE_MISSING:-false}" != "true" ]; then' \
+    '    printf "2; 0 2 TABLE DATA migration indicateur_valeur_periodicite_audit owner\\n"' \
+    '  fi' \
+    '  if [ "${ARCHIVE_QUEUE_TABLE_MISSING:-false}" != "true" ]; then' \
+    '    printf "3; 0 3 TABLE DATA private indicateur_reconciliation_formule owner\\n"' \
+    '  fi' \
+    '  exit 0' \
+    'fi' \
+    'if [ "${SOURCE_PHASE:-legacy}" != "missing-registry" ]; then' \
+    '  printf "change-id\\thash\\tbaseline/change\\ttet\\tnote\\n"' \
+    'fi' \
+    'if [ "${SOURCE_PHASE:-legacy}" = "partial-expand" ]; then' \
+    '  printf "change-id\\thash\\tindicateur/periodicite\\ttet\\tnote\\n"' \
+    'fi' \
+    'if [ "${SOURCE_PHASE:-legacy}" = "expand" ] || [ "${SOURCE_PHASE:-legacy}" = "partial-contract" ] || [ "${SOURCE_PHASE:-legacy}" = "contract" ]; then' \
+    '  printf "change-id\\thash\\tindicateur/periodicite\\ttet\\tnote\\n"' \
+    '  printf "change-id\\thash\\tindicateur/import_emt_valeur\\ttet\\tnote\\n"' \
+    '  printf "change-id\\thash\\tindicateur/reconciliation_formules\\ttet\\tnote\\n"' \
+    '  printf "change-id\\thash\\tindicateur/dependances_formules\\ttet\\tnote\\n"' \
+    'fi' \
+    'if [ "${SOURCE_PHASE:-legacy}" = "partial-contract" ] || [ "${SOURCE_PHASE:-legacy}" = "contract" ]; then' \
+    '  printf "change-id\\thash\\tindicateur/periodicite_obligatoire\\ttet\\tnote\\n"' \
+    'fi' \
+    'if [ "${SOURCE_PHASE:-legacy}" = "contract" ]; then' \
+    '  printf "change-id\\thash\\tindicateur/periodicite_formules\\ttet\\tnote\\n"' \
+    '  printf "change-id\\thash\\tstats/report_indicateur_resultat_periode\\ttet\\tnote\\n"' \
+    'fi' \
+    > "$FAKE_BIN/pg_restore"
+
+chmod +x "$FAKE_BIN/psql" "$FAKE_BIN/pg_restore"
+
+assert_success() {
+    local description="$1"
+    shift
+
+    if ! env PATH="$FAKE_BIN:/usr/bin:/bin" TO_DB_URL="postgresql://target/db" "$@" >/dev/null 2>&1; then
+        echo "FAIL: $description" >&2
+        exit 1
+    fi
+}
+
+assert_failure() {
+    local description="$1"
+    shift
+
+    if env PATH="$FAKE_BIN:/usr/bin:/bin" TO_DB_URL="postgresql://target/db" "$@" >/dev/null 2>&1; then
+        echo "FAIL: $description" >&2
+        exit 1
+    fi
+}
+
+assert_failure_with_message() {
+    local description="$1"
+    local expected_message="$2"
+    shift 2
+    local output_file="$TEST_DIRECTORY/failure-output"
+
+    if env PATH="$FAKE_BIN:/usr/bin:/bin" TO_DB_URL="postgresql://target/db" \
+        "$@" >"$output_file" 2>&1; then
+        echo "FAIL: $description" >&2
+        exit 1
+    fi
+
+    if ! grep --fixed-strings --quiet "$expected_message" "$output_file"; then
+        echo "FAIL: $description (unexpected error)" >&2
+        cat "$output_file" >&2
+        exit 1
+    fi
+}
+
+assert_success \
+    "a legacy target accepts a legacy backup" \
+    env TARGET_PHASE=legacy SOURCE_PHASE=legacy \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+assert_success \
+    "an expand target accepts an expand backup" \
+    env TARGET_PHASE=expand SOURCE_PHASE=expand \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+assert_success \
+    "a post-contract target accepts a post-contract backup" \
+    env TARGET_PHASE=contract SOURCE_PHASE=contract \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+assert_failure \
+    "a contract target rejects an older expand backup" \
+    env TARGET_PHASE=contract SOURCE_PHASE=expand \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+assert_failure \
+    "an expand target rejects a newer contract backup" \
+    env TARGET_PHASE=expand SOURCE_PHASE=contract \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+assert_failure \
+    "a partial-contract target rejects every backup" \
+    env TARGET_PHASE=partial-contract SOURCE_PHASE=contract \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+assert_failure \
+    "a partial-contract backup is rejected" \
+    env TARGET_PHASE=contract SOURCE_PHASE=partial-contract \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+assert_failure \
+    "a partial-expand target rejects every backup" \
+    env TARGET_PHASE=partial-expand SOURCE_PHASE=expand \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+assert_failure \
+    "a partial-expand backup is rejected" \
+    env TARGET_PHASE=expand SOURCE_PHASE=partial-expand \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+assert_failure \
+    "a target registry read failure is fail-closed" \
+    env TARGET_QUERY_FAILS=true SOURCE_PHASE=contract \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+assert_failure \
+    "an unexpected target registry result is fail-closed" \
+    env TARGET_PHASE=unexpected SOURCE_PHASE=contract \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+assert_failure \
+    "a target without the Sqitch registry is fail-closed" \
+    env TARGET_PHASE=missing-registry SOURCE_PHASE=legacy \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+assert_failure \
+    "physical target drift is fail-closed" \
+    env TARGET_PHASE=physical-drift-contract SOURCE_PHASE=contract \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+physical_drift_message="target schema objects disagree with its Sqitch phase"
+
+assert_failure_with_message \
+    "an expand target rejects a NOT NULL periodicite column" \
+    "$physical_drift_message" \
+    env TARGET_SCHEMA_DRIFT=expand-not-null SOURCE_PHASE=expand \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+assert_failure_with_message \
+    "an expand target rejects a missing compatibility default" \
+    "$physical_drift_message" \
+    env TARGET_SCHEMA_DRIFT=expand-missing-default SOURCE_PHASE=expand \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+assert_failure_with_message \
+    "an expand target rejects the strict guard in place of the transition guard" \
+    "$physical_drift_message" \
+    env TARGET_SCHEMA_DRIFT=expand-strict-guard SOURCE_PHASE=expand \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+assert_failure_with_message \
+    "a contract target rejects a nullable periodicite column" \
+    "$physical_drift_message" \
+    env TARGET_SCHEMA_DRIFT=contract-nullable SOURCE_PHASE=contract \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+assert_failure_with_message \
+    "a contract target rejects the expand compatibility default" \
+    "$physical_drift_message" \
+    env TARGET_SCHEMA_DRIFT=contract-default SOURCE_PHASE=contract \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+assert_failure_with_message \
+    "a contract target rejects the transition guard in place of the strict guard" \
+    "$physical_drift_message" \
+    env TARGET_SCHEMA_DRIFT=contract-transition-guard SOURCE_PHASE=contract \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+assert_failure \
+    "an archive registry read failure is fail-closed" \
+    env TARGET_PHASE=contract ARCHIVE_READ_FAILS=true \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+assert_failure \
+    "an archive without the Sqitch registry is fail-closed" \
+    env TARGET_PHASE=legacy SOURCE_PHASE=missing-registry \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+assert_failure \
+    "an expand archive without its audit table data is fail-closed" \
+    env TARGET_PHASE=expand SOURCE_PHASE=expand ARCHIVE_AUDIT_TABLE_MISSING=true \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+assert_failure \
+    "an expand archive without its reconciliation queue data is fail-closed" \
+    env TARGET_PHASE=expand SOURCE_PHASE=expand ARCHIVE_QUEUE_TABLE_MISSING=true \
+    bash "$CHECK_SCRIPT" "$DUMP_FILE"
+
+echo "Restore compatibility checks passed."

--- a/data_layer/backup/rebuild-indicateur-formula-state.sql
+++ b/data_layer/backup/rebuild-indicateur-formula-state.sql
@@ -1,0 +1,105 @@
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+-- Les services et les triggers du graphe prennent ce verrou avant celui de la
+-- table. La restauration reconstruit ainsi sa projection sur un catalogue
+-- immobile, selon le même ordre que le contract Sqitch.
+SELECT pg_advisory_xact_lock(
+    hashtextextended('indicateur-calculation-graph', 0)
+);
+LOCK TABLE public.indicateur_definition IN SHARE ROW EXCLUSIVE MODE;
+LOCK TABLE public.indicateur_valeur IN SHARE ROW EXCLUSIVE MODE;
+
+DO $rebuild$
+DECLARE
+    projection_exists boolean := to_regclass(
+        'private.indicateur_definition_dependance_calcul'
+    ) IS NOT NULL;
+    verifier_exists boolean := to_regprocedure(
+        'private.verifier_periodicite_dependances_formule(integer,text[])'
+    ) IS NOT NULL;
+    extractor_exists boolean := to_regprocedure(
+        'private.extraire_dependances_formule_indicateur(text)'
+    ) IS NOT NULL;
+    audit_exists boolean := to_regclass(
+        'migration.indicateur_valeur_periodicite_audit'
+    ) IS NOT NULL;
+    audit_function_exists boolean := to_regprocedure(
+        'migration.auditer_et_normaliser_dates_indicateur()'
+    ) IS NOT NULL;
+    contract_applied boolean := projection_exists;
+BEGIN
+    IF projection_exists IS DISTINCT FROM verifier_exists
+       OR (projection_exists AND NOT extractor_exists) THEN
+        RAISE EXCEPTION USING
+            ERRCODE = '55000',
+            MESSAGE = 'État contractuel partiel : impossible de reconstruire les dépendances de formule';
+    END IF;
+
+    IF projection_exists THEN
+        TRUNCATE private.indicateur_definition_dependance_calcul;
+
+        INSERT INTO private.indicateur_definition_dependance_calcul
+            (indicateur_id, source_identifiant)
+        SELECT definition.id, dependance.source_identifiant
+        FROM public.indicateur_definition definition
+        CROSS JOIN LATERAL private.extraire_dependances_formule_indicateur(
+            definition.valeur_calcule
+        ) AS dependance
+        WHERE definition.valeur_calcule IS NOT NULL
+          AND btrim(definition.valeur_calcule) <> '';
+
+        -- Cette validation appartient à la même transaction que le rebuild :
+        -- une formule inconnue ou inter-périodicité annule toute la projection.
+        PERFORM private.verifier_periodicite_dependances_formule();
+    END IF;
+
+    IF projection_exists AND NOT audit_exists THEN
+        RAISE EXCEPTION USING
+            ERRCODE = '55000',
+            MESSAGE = 'État contractuel partiel : l audit de périodicité manque';
+    ELSIF NOT projection_exists AND extractor_exists
+          AND (NOT audit_exists OR NOT audit_function_exists) THEN
+        RAISE EXCEPTION USING
+            ERRCODE = '55000',
+            MESSAGE = 'État expand partiel : impossible de rejouer l audit de périodicité';
+    ELSIF NOT projection_exists AND NOT extractor_exists
+          AND (audit_exists OR audit_function_exists) THEN
+        RAISE EXCEPTION USING
+            ERRCODE = '55000',
+            MESSAGE = 'État legacy incohérent : objets d audit de périodicité inattendus';
+    END IF;
+
+    IF NOT projection_exists AND extractor_exists THEN
+        -- Le snapshot restaure l'historique nécessaire au downgrade. Le rejeu
+        -- retire ses lignes obsolètes et audite toute valeur chargée sans que
+        -- les triggers de transition aient été exécutés par pg_restore.
+        ALTER TABLE public.indicateur_valeur DISABLE TRIGGER modified_at;
+        ALTER TABLE public.indicateur_valeur DISABLE TRIGGER modified_by;
+        PERFORM migration.auditer_et_normaliser_dates_indicateur();
+        ALTER TABLE public.indicateur_valeur ENABLE TRIGGER modified_by;
+        ALTER TABLE public.indicateur_valeur ENABLE TRIGGER modified_at;
+    END IF;
+
+    -- En phase contract la fonction d'audit transitoire a été retirée. Les
+    -- lignes d'audit restaurées appartiennent déjà au snapshot source ; on les
+    -- préserve et on valide directement l'invariant strict des dates.
+    IF contract_applied AND EXISTS (
+        SELECT 1
+        FROM public.indicateur_valeur valeur
+        JOIN public.indicateur_definition definition
+          ON definition.id = valeur.indicateur_id
+        WHERE valeur.date_valeur <> public.indicateur_date_debut_periode(
+            definition.periodicite,
+            valeur.date_valeur
+        )
+    ) THEN
+        RAISE EXCEPTION USING
+            ERRCODE = '23514',
+            MESSAGE = 'Le snapshot contractuel contient une date d indicateur non canonique';
+    END IF;
+END
+$rebuild$;
+
+COMMIT;

--- a/data_layer/backup/restore-config.yml
+++ b/data_layer/backup/restore-config.yml
@@ -145,6 +145,12 @@ groups:
     - indicateur_source_metadonnee
     - indicateur_valeur
 
+  # État durable propre aux phases expand/contract. restore.sh n'ajoute ce
+  # groupe que lorsque source et cible partagent exactement l'une de ces phases.
+  periodicite_group:
+    - migration.indicateur_valeur_periodicite_audit
+    - private.indicateur_reconciliation_formule
+
   pai_group:
     - action_impact_complexite
     - action_impact_typologie
@@ -197,7 +203,6 @@ groups:
     - historique.fiche_action
     - historique.fiche_action_pilote
     - plan_report_generation
-
 # Sensitive-data scrubbing rules formerly lived here as a `data_rules:` block
 # consumed by an inline scrubber in restore.sh. They moved to clean_data.sql
 # (in the same directory) for explicitness — adding a new scrubbed

--- a/data_layer/backup/restore.sh
+++ b/data_layer/backup/restore.sh
@@ -10,32 +10,43 @@ if [ -z "${TO_DB_URL:-}" ]; then
     fi
 fi
 
-# Allowlist of known non-prod restore targets.
-# Fail-closed: TO_DB_URL must match a localhost shape or one of these project IDs.
-# A misconfigured secret (e.g., accidentally pointing at production) is refused.
-ALLOWED_PROJECT_IDS=(
-    "qwbsrgwlypaqheoedxxq"  # staging
-    "xbrefnclajfcjlpnwyow"  # preprod
-)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DISABLED_TRIGGER_SCHEMA=''
+DISABLED_TRIGGER_TABLE=''
 
-is_allowed_target=false
-if [[ "$TO_DB_URL" =~ (localhost|127\.0\.0\.1|host\.docker\.internal) ]]; then
-    is_allowed_target=true
-else
-    for project_id in "${ALLOWED_PROJECT_IDS[@]}"; do
-        if [[ "$TO_DB_URL" == *"$project_id"* ]]; then
-            is_allowed_target=true
-            break
-        fi
-    done
-fi
+reenable_current_user_triggers() {
+    if [ -z "$DISABLED_TRIGGER_SCHEMA" ] || [ -z "$DISABLED_TRIGGER_TABLE" ]; then
+        return 0
+    fi
 
-if [ "$is_allowed_target" != true ]; then
-    masked_url=$(echo "$TO_DB_URL" | sed 's|://[^@]*@|://***@|')
-    echo "Refusing to restore: TO_DB_URL ($masked_url) does not match the allowlist."
-    echo "Allowed targets: localhost shape, or one of: ${ALLOWED_PROJECT_IDS[*]}"
-    exit 1
-fi
+    if ! psql -d "$TO_DB_URL" -c \
+        "ALTER TABLE \"$DISABLED_TRIGGER_SCHEMA\".\"$DISABLED_TRIGGER_TABLE\" ENABLE TRIGGER USER;"; then
+        return 1
+    fi
+
+    DISABLED_TRIGGER_SCHEMA=''
+    DISABLED_TRIGGER_TABLE=''
+}
+
+cleanup_disabled_user_triggers() {
+    if ! reenable_current_user_triggers; then
+        echo "WARNING: failed to re-enable USER triggers on $DISABLED_TRIGGER_SCHEMA.$DISABLED_TRIGGER_TABLE" >&2
+    fi
+}
+
+# A cancelled restore must not silently leave the current table's domain
+# triggers disabled. SIGKILL cannot be recovered from, but normal failures,
+# runner cancellation (TERM) and interactive interruption (INT) all retry the
+# compensating ALTER TABLE before exit.
+trap cleanup_disabled_user_triggers EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+# Parse the connection identity before any download or database access. Raw
+# substring matching is unsafe because credentials and query parameters can
+# contain an allowlisted project name without making it the actual host.
+DATABASE_URL="$TO_DB_URL" node \
+    "$SCRIPT_DIR/../scripts/validate-database-url.mjs" restore-target
 
 # Sanity-check RESTORE_ENCRYPTED_PASSWORD shape when set.
 # bcrypt hashes are exactly 60 chars and start with $2a$ / $2b$ / $2y$.
@@ -181,8 +192,14 @@ if [ ! -s "$DUMP_FILE" ]; then
 fi
 
 # --- Parse restore-config.yml for group/table definitions and data_rules ---
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RESTORE_CONFIG="$SCRIPT_DIR/restore-config.yml"
+
+# Validate the archive and its schema-contract compatibility before the first
+# destructive statement. Source and target must share the same complete phase;
+# partial phases, physical target drift and both mismatch directions are denied.
+pg_restore --list "$DUMP_FILE" > /dev/null
+PERIODICITE_RESTORE_PHASE=$(TO_DB_URL="$TO_DB_URL" \
+    bash "$SCRIPT_DIR/check-restore-compatibility.sh" "$DUMP_FILE")
 
 if [ ! -f "$RESTORE_CONFIG" ]; then
     echo "restore config not found: $RESTORE_CONFIG"
@@ -196,7 +213,8 @@ if ! command -v yq &> /dev/null; then
     exit 1
 fi
 
-# Group order: technical → stats → collectivites → indicateurs → referentiels → pai → plans
+# Group order: technical → stats → collectivites → indicateurs →
+# periodicite → referentiels → pai → plans
 # Restores foundational tables before tables that reference them. Truncation
 # runs in the reverse order (see below) so dependents come down first.
 GROUP_ORDER=(
@@ -204,6 +222,15 @@ GROUP_ORDER=(
   stats_group
   collectivites_group
   indicateurs_group
+)
+
+# Ces tables n'existent pas dans le schéma legacy. L'égalité de phase vérifiée
+# ci-dessus garantit qu'elles existent à la fois dans la cible et le snapshot.
+if [ "$PERIODICITE_RESTORE_PHASE" != "legacy" ]; then
+    GROUP_ORDER+=(periodicite_group)
+fi
+
+GROUP_ORDER+=(
   referentiels_group
   pai_group
   plans_group
@@ -304,11 +331,17 @@ for group in "${GROUP_ORDER[@]}"; do
             psql -d "$TO_DB_URL" -c "TRUNCATE TABLE \"$schema\".\"$table_name\" CASCADE;"
         fi
 
-        # Disable user triggers before restore.
+        # Disable user triggers before restore. Record the table first so the
+        # EXIT trap can compensate even if the process is interrupted between
+        # the ALTER TABLE and the normal re-enable step.
         # ALTER TABLE ... DISABLE TRIGGER USER requires table ownership.
         # On tables we don't own (e.g. auth.users), this fails — log a warning.
+        DISABLED_TRIGGER_SCHEMA="$schema"
+        DISABLED_TRIGGER_TABLE="$table_name"
         if ! psql -d "$TO_DB_URL" -c "ALTER TABLE \"$schema\".\"$table_name\" DISABLE TRIGGER USER;" 2>/dev/null; then
             echo -n " (warning: could not disable triggers — not table owner)"
+            DISABLED_TRIGGER_SCHEMA=''
+            DISABLED_TRIGGER_TABLE=''
         fi
 
         # Don't use --exit-on-error or --single-transaction: pg_restore executes
@@ -329,9 +362,12 @@ for group in "${GROUP_ORDER[@]}"; do
         restore_exit=$?
         set -e
 
-        # Re-enable user triggers after restore
-        if ! psql -d "$TO_DB_URL" -c "ALTER TABLE \"$schema\".\"$table_name\" ENABLE TRIGGER USER;" 2>/dev/null; then
-            true # Already warned above, no need to repeat
+        # Re-enable only when the disable succeeded. A failure here is unsafe:
+        # retain the recorded table for the EXIT retry and abort the restore.
+        if ! reenable_current_user_triggers; then
+            echo ""
+            echo "  FAILED: could not re-enable USER triggers on $schema.$table_name"
+            exit 1
         fi
 
         if [ -n "$restore_stderr" ]; then
@@ -342,7 +378,7 @@ for group in "${GROUP_ORDER[@]}"; do
         if [ $restore_exit -ne 0 ]; then
             # Filter out known harmless errors (transaction_timeout on PG < 17)
             real_errors=$(echo "$restore_stderr" | grep -i "error:" | grep -v "transaction_timeout" || true)
-            if [ -n "$real_errors" ]; then
+            if [ -n "$real_errors" ] || ! grep -qi "transaction_timeout" <<< "$restore_stderr"; then
                 echo "  FAILED"
                 exit 1
             fi
@@ -370,6 +406,13 @@ echo "Tables restored: $TOTAL_RESTORED"
 echo "Tables skipped (duplicates): $TOTAL_SKIPPED"
 echo "Total time: ${TOTAL_MINUTES}m${TOTAL_SECONDS}s"
 echo "Done!"
+
+# --- Post-restore: rebuild formula-derived state skipped with USER triggers ---
+echo ""
+echo "=== Rebuilding indicator formula state ==="
+psql -d "$TO_DB_URL" --no-psqlrc --set ON_ERROR_STOP=1 \
+    -f "$SCRIPT_DIR/rebuild-indicateur-formula-state.sql"
+echo "Indicator formula state rebuilt and validated."
 
 # --- Post-restore: reset sequences to match restored data ---
 echo ""

--- a/data_layer/scripts/validate-database-url.mjs
+++ b/data_layer/scripts/validate-database-url.mjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+
+const policy = process.argv[2];
+const rawDatabaseUrl = process.env.DATABASE_URL;
+const loopbackHosts = new Set(['localhost', '127.0.0.1', '[::1]']);
+const secureSslModes = new Set(['require', 'verify-ca', 'verify-full']);
+const restoreProjectRefs = new Set([
+  'qwbsrgwlypaqheoedxxq', // staging
+  'xbrefnclajfcjlpnwyow', // preprod
+]);
+
+function fail(message) {
+  console.error(`URL PostgreSQL refusée : ${message}`);
+  process.exit(2);
+}
+
+function decodeUrlComponent(component, label) {
+  try {
+    return decodeURIComponent(component);
+  } catch {
+    fail(`${label} contient un encodage invalide`);
+  }
+}
+
+function getSupabaseProjectRef(url) {
+  const directHostMatch = url.hostname.match(
+    /^db\.([a-z0-9-]+)\.supabase\.co$/
+  );
+  if (directHostMatch) {
+    return directHostMatch[1];
+  }
+
+  if (/^[a-z0-9-]+\.pooler\.supabase\.com$/.test(url.hostname)) {
+    const username = decodeUrlComponent(url.username, "le nom d'utilisateur");
+    if (username.startsWith('postgres.')) {
+      return username.slice('postgres.'.length);
+    }
+  }
+
+  return undefined;
+}
+
+function assertSupabaseConnectionShape(url) {
+  if (url.port && url.port !== '5432') {
+    fail(
+      'la connexion doit être directe ou utiliser un pooler de session sur le port 5432'
+    );
+  }
+  if (decodeUrlComponent(url.pathname, 'le nom de base') !== '/postgres') {
+    fail(
+      'la connexion doit cibler explicitement la base postgres du projet Supabase'
+    );
+  }
+
+  const configuredSslMode = url.searchParams.get('sslmode');
+  if (configuredSslMode && !secureSslModes.has(configuredSslMode)) {
+    fail(`le mode TLS ${configuredSslMode} n'est pas assez strict`);
+  }
+}
+
+function assertDisposableLocalDatabase(url) {
+  if (!loopbackHosts.has(url.hostname)) {
+    fail('un test destructif exige une adresse loopback');
+  }
+
+  const pathname = decodeUrlComponent(url.pathname, 'le nom de base');
+  const databaseNameMatch = pathname.match(/^\/([a-z0-9_]+)$/);
+  const databaseName = databaseNameMatch?.[1];
+  if (
+    !databaseName ||
+    !/(?:^|_)(?:test|temp|tmp|disposable)(?:_|$)/.test(databaseName)
+  ) {
+    fail(
+      'un test destructif exige un nom de base jetable contenant test, temp, tmp ou disposable'
+    );
+  }
+}
+
+function assertLocalSupabaseCiDatabase(url) {
+  const username = decodeUrlComponent(url.username, "le nom d'utilisateur");
+  const password = decodeUrlComponent(url.password, 'le mot de passe');
+  const databaseName = decodeUrlComponent(url.pathname, 'le nom de base');
+
+  if (
+    url.hostname !== 'supabase_db_tet' ||
+    url.port !== '5432' ||
+    databaseName !== '/postgres' ||
+    username !== 'postgres' ||
+    password !== 'postgres'
+  ) {
+    fail(
+      'un test CI destructif doit cibler exactement la base postgres du conteneur Supabase local'
+    );
+  }
+
+  if ([...url.searchParams].length !== 0) {
+    fail("la cible Supabase locale CI n'accepte aucun paramètre de connexion");
+  }
+}
+
+if (!rawDatabaseUrl) {
+  fail('DATABASE_URL est absente');
+}
+
+let databaseUrl;
+try {
+  databaseUrl = new URL(rawDatabaseUrl);
+} catch {
+  fail("le format de l'URL est invalide");
+}
+
+if (!['postgres:', 'postgresql:'].includes(databaseUrl.protocol)) {
+  fail('le protocole doit être postgres ou postgresql');
+}
+if (databaseUrl.hash) {
+  fail('les fragments sont interdits');
+}
+
+// libpq permet aux paramètres nommés de remplacer l'autorité de l'URI et le
+// dernier doublon gagne. Une URL de déploiement reste donc volontairement
+// minimale : seul sslmode peut apparaître, une seule fois.
+const connectionParameters = [...databaseUrl.searchParams.entries()];
+if (
+  connectionParameters.some(([name]) => name !== 'sslmode') ||
+  connectionParameters.length > 1
+) {
+  fail('seul un unique paramètre sslmode est autorisé');
+}
+
+if (policy === 'local-bootstrap') {
+  if (!loopbackHosts.has(databaseUrl.hostname)) {
+    fail('le bootstrap Earthly exige une adresse loopback');
+  }
+  process.exit(0);
+}
+
+if (policy === 'local-disposable') {
+  assertDisposableLocalDatabase(databaseUrl);
+  process.exit(0);
+}
+
+if (policy === 'local-supabase-ci') {
+  assertLocalSupabaseCiDatabase(databaseUrl);
+  process.exit(0);
+}
+
+if (policy === 'supabase-contract') {
+  const expectedProjectRef = process.env.EXPECTED_SUPABASE_PROJECT_REF;
+
+  if (!expectedProjectRef) {
+    fail('EXPECTED_SUPABASE_PROJECT_REF est absente');
+  }
+  assertSupabaseConnectionShape(databaseUrl);
+
+  const actualProjectRef = getSupabaseProjectRef(databaseUrl);
+  if (!actualProjectRef || actualProjectRef !== expectedProjectRef) {
+    fail(
+      "la cible ne correspond pas au projet Supabase déclaré pour l'environnement"
+    );
+  }
+  process.exit(0);
+}
+
+if (policy === 'restore-target') {
+  if (
+    loopbackHosts.has(databaseUrl.hostname) ||
+    databaseUrl.hostname === 'host.docker.internal'
+  ) {
+    process.exit(0);
+  }
+
+  assertSupabaseConnectionShape(databaseUrl);
+  if (!databaseUrl.searchParams.has('sslmode')) {
+    fail('une restauration distante doit expliciter un mode TLS strict');
+  }
+  const actualProjectRef = getSupabaseProjectRef(databaseUrl);
+  if (!actualProjectRef || !restoreProjectRefs.has(actualProjectRef)) {
+    fail('la restauration distante doit cibler exactement staging ou preprod');
+  }
+  process.exit(0);
+}
+
+fail(`la politique ${policy ?? '(absente)'} est inconnue`);

--- a/data_layer/scripts/validate-database-url.spec.mjs
+++ b/data_layer/scripts/validate-database-url.spec.mjs
@@ -1,0 +1,212 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const scriptPath = fileURLToPath(
+  new URL('./validate-database-url.mjs', import.meta.url)
+);
+
+function validate(policy, databaseUrl, expectedProjectRef) {
+  return spawnSync(process.execPath, [scriptPath, policy], {
+    encoding: 'utf8',
+    env: {
+      DATABASE_URL: databaseUrl,
+      EXPECTED_SUPABASE_PROJECT_REF: expectedProjectRef ?? '',
+    },
+  });
+}
+
+test('accepts loopback URLs for a local bootstrap', () => {
+  assert.equal(
+    validate(
+      'local-bootstrap',
+      'postgresql://postgres:postgres@127.0.0.1:54322/postgres'
+    ).status,
+    0
+  );
+});
+
+test('rejects remote and query-overridden local bootstrap targets', () => {
+  assert.notEqual(
+    validate(
+      'local-bootstrap',
+      'postgresql://postgres:secret@db.example.com:5432/postgres'
+    ).status,
+    0
+  );
+  assert.notEqual(
+    validate(
+      'local-bootstrap',
+      'postgresql://postgres:postgres@127.0.0.1:54322/postgres?host=db.example.com'
+    ).status,
+    0
+  );
+});
+
+test('accepts only explicitly disposable loopback databases for destructive tests', () => {
+  assert.equal(
+    validate(
+      'local-disposable',
+      'postgresql://postgres:postgres@127.0.0.1:54322/periodicite_contract_test_20260904'
+    ).status,
+    0
+  );
+  assert.equal(
+    validate(
+      'local-disposable',
+      'postgresql://postgres:postgres@localhost:5432/tmp'
+    ).status,
+    0
+  );
+
+  for (const databaseUrl of [
+    'postgresql://postgres:postgres@127.0.0.1:54322/postgres',
+    'postgresql://postgres:postgres@127.0.0.1:54322/contest',
+    'postgresql://postgres:secret@db.example.com:5432/migration_test',
+  ]) {
+    assert.notEqual(validate('local-disposable', databaseUrl).status, 0);
+  }
+});
+
+test('accepts only the exact internal Supabase database for destructive CI tests', () => {
+  assert.equal(
+    validate(
+      'local-supabase-ci',
+      'postgresql://postgres:postgres@supabase_db_tet:5432/postgres'
+    ).status,
+    0
+  );
+
+  for (const databaseUrl of [
+    'postgresql://postgres:postgres@127.0.0.1:54322/postgres',
+    'postgresql://postgres:postgres@supabase_db_tet/postgres',
+    'postgresql://postgres:postgres@supabase_db_tet:5432/production',
+    'postgresql://admin:postgres@supabase_db_tet:5432/postgres',
+    'postgresql://postgres:secret@supabase_db_tet:5432/postgres',
+    'postgresql://postgres:postgres@supabase_db_tet:5432/postgres?sslmode=disable',
+    'postgresql://postgres:postgres@database.example:5432/postgres',
+  ]) {
+    assert.notEqual(validate('local-supabase-ci', databaseUrl).status, 0);
+  }
+});
+
+test('accepts direct and session-pooler URLs for the expected Supabase project', () => {
+  assert.equal(
+    validate(
+      'supabase-contract',
+      'postgresql://postgres:secret@db.project-ref.supabase.co:5432/postgres?sslmode=verify-full',
+      'project-ref'
+    ).status,
+    0
+  );
+  assert.equal(
+    validate(
+      'supabase-contract',
+      'postgresql://postgres.project-ref:secret@aws-0-eu-west-3.pooler.supabase.com:5432/postgres',
+      'project-ref'
+    ).status,
+    0
+  );
+});
+
+test('rejects wrong projects, transaction poolers and insecure TLS', () => {
+  assert.notEqual(
+    validate(
+      'supabase-contract',
+      'postgresql://postgres:secret@db.other-project.supabase.co:5432/postgres',
+      'project-ref'
+    ).status,
+    0
+  );
+  assert.notEqual(
+    validate(
+      'supabase-contract',
+      'postgresql://postgres.project-ref:secret@aws-0-eu-west-3.pooler.supabase.com:6543/postgres',
+      'project-ref'
+    ).status,
+    0
+  );
+  assert.notEqual(
+    validate(
+      'supabase-contract',
+      'postgresql://postgres:secret@db.project-ref.supabase.co:5432/postgres?sslmode=disable',
+      'project-ref'
+    ).status,
+    0
+  );
+});
+
+test('rejects libpq identity overrides and duplicate connection parameters', () => {
+  assert.notEqual(
+    validate(
+      'supabase-contract',
+      'postgresql://postgres:secret@db.project-ref.supabase.co:5432/postgres?host=db.other-project.supabase.co',
+      'project-ref'
+    ).status,
+    0
+  );
+  assert.notEqual(
+    validate(
+      'supabase-contract',
+      'postgresql://postgres:secret@db.project-ref.supabase.co:5432/postgres?sslmode=require&sslmode=disable',
+      'project-ref'
+    ).status,
+    0
+  );
+});
+
+test('accepts only exact local, staging and preprod restore targets', () => {
+  assert.equal(
+    validate(
+      'restore-target',
+      'postgresql://postgres:postgres@host.docker.internal:54322/postgres'
+    ).status,
+    0
+  );
+  assert.equal(
+    validate(
+      'restore-target',
+      'postgresql://postgres:secret@db.qwbsrgwlypaqheoedxxq.supabase.co:5432/postgres?sslmode=require'
+    ).status,
+    0
+  );
+  assert.equal(
+    validate(
+      'restore-target',
+      'postgresql://postgres.xbrefnclajfcjlpnwyow:secret@aws-0-eu-west-3.pooler.supabase.com:5432/postgres?sslmode=require'
+    ).status,
+    0
+  );
+});
+
+test('rejects restore allowlist values outside the parsed target identity', () => {
+  assert.notEqual(
+    validate(
+      'restore-target',
+      'postgresql://localhost:secret@db.example.com:5432/postgres'
+    ).status,
+    0
+  );
+  assert.notEqual(
+    validate(
+      'restore-target',
+      'postgresql://postgres:qwbsrgwlypaqheoedxxq@db.example.com:5432/postgres'
+    ).status,
+    0
+  );
+  assert.notEqual(
+    validate(
+      'restore-target',
+      'postgresql://postgres:secret@db.qwbsrgwlypaqheoedxxq.supabase.co.attacker.example:5432/postgres'
+    ).status,
+    0
+  );
+  assert.notEqual(
+    validate(
+      'restore-target',
+      'postgresql://postgres:secret@db.qwbsrgwlypaqheoedxxq.supabase.co:5432/postgres'
+    ).status,
+    0
+  );
+});

--- a/data_layer/seed/content/23-indicateur_referentiel.sql
+++ b/data_layer/seed/content/23-indicateur_referentiel.sql
@@ -1372,9 +1372,9 @@ Préciser si possible les moyennes nationale et/ou locale, le cas échéant cont
 
         insert into public.indicateur_definition
         (identifiant_referentiel, titre, titre_long, unite, participation_score,
-         sans_valeur_utilisateur, modified_at, created_at, description)
+         sans_valeur_utilisateur, periodicite, modified_at, created_at, description)
         select id as identifiant_referentiel, nom as titre, titre_long, unite, participation_score,
-               sans_valeur as sans_valeur_utilisateur, modified_at, modified_at as created_at, description
+               sans_valeur as sans_valeur_utilisateur, 'annuelle', modified_at, modified_at as created_at, description
         from indicateur_def on conflict do nothing;
 
         insert into public.indicateur_thematique (indicateur_id, thematique_id)

--- a/data_layer/seed/fakes/15-insert_fake_indicateurs.sql
+++ b/data_layer/seed/fakes/15-insert_fake_indicateurs.sql
@@ -1,5 +1,5 @@
-insert into public.indicateur_definition (collectivite_id, titre, unite, modified_by, description)
-values (1, 'Mon indicateur perso', 'm2/hab', '17440546-f389-4d4f-bfdb-b0c94a1bd0f9', 'Description');
+insert into public.indicateur_definition (collectivite_id, titre, unite, periodicite, modified_by, description)
+values (1, 'Mon indicateur perso', 'm2/hab', 'annuelle', '17440546-f389-4d4f-bfdb-b0c94a1bd0f9', 'Description');
 
 insert into public.indicateur_collectivite (indicateur_id, collectivite_id, commentaire)
 values ((select id from indicateur_definition where identifiant_referentiel = 'cae_8' limit 1),
@@ -53,8 +53,8 @@ INSERT INTO public.indicateur_source_metadonnee (id, source_id, date_version, no
 VALUES (5, 'insee', '2020-01-01 00:00:00.000', '', 'CGDD', '', '', '');
 
 -- Insertion de la valeur de population
-insert into public.indicateur_definition(identifiant_referentiel, titre, unite, description) values (
-    'terr_1', 'Population', 'nombre', 'Nombre d habitants par an.') ON CONFLICT DO NOTHING;
+insert into public.indicateur_definition(identifiant_referentiel, titre, unite, periodicite, description) values (
+    'terr_1', 'Population', 'nombre', 'annuelle', 'Nombre d habitants par an.') ON CONFLICT DO NOTHING;
 
 insert into public.indicateur_valeur (indicateur_id, collectivite_id, date_valeur, metadonnee_id, resultat,
                                       resultat_commentaire, objectif, objectif_commentaire)

--- a/data_layer/sqitch/deploy/indicateur/dependances_formules.sql
+++ b/data_layer/sqitch/deploy/indicateur/dependances_formules.sql
@@ -1,0 +1,37 @@
+-- Deploy tet:indicateur/dependances_formules to pg
+-- requires: private_schema
+
+BEGIN;
+
+-- La grammaire applicative interdit chaînes et commentaires. Un identifiant
+-- est [a-zA-Z_][a-zA-Z_0-9.-]* et les quatre appels ci-dessous sont les seuls
+-- qui référencent un indicateur. Cette extraction ne prétend pas valider
+-- l'expression complète : elle projette exhaustivement les références de
+-- toute formule acceptée par le parseur applicatif.
+--
+-- La fonction appartient à l'expand : le préflight et le contract partagent
+-- ainsi exactement le même parseur de dépendances, sans dupliquer sa regex.
+CREATE FUNCTION private.extraire_dependances_formule_indicateur(formule text)
+    RETURNS TABLE (source_identifiant text)
+    LANGUAGE sql
+    IMMUTABLE
+    STRICT
+    PARALLEL SAFE
+    SET search_path = pg_catalog
+AS $$
+    SELECT DISTINCT lower(captures[3])
+    FROM regexp_matches(
+        formule,
+        '(^|[^[:alnum:]_.-])(opt_val|val|cible|limite)[[:space:]]*[(][[:space:]]*([[:alpha:]_][[:alnum:]_.-]*)',
+        'g'
+    ) AS captures;
+$$;
+
+COMMENT ON FUNCTION private.extraire_dependances_formule_indicateur(text) IS
+    'Extrait les identifiants référencés par une formule indicateur acceptée par la grammaire applicative.';
+
+REVOKE EXECUTE
+    ON FUNCTION private.extraire_dependances_formule_indicateur(text)
+    FROM PUBLIC, anon, authenticated, service_role;
+
+COMMIT;

--- a/data_layer/sqitch/deploy/indicateur/import_emt_valeur.sql
+++ b/data_layer/sqitch/deploy/indicateur/import_emt_valeur.sql
@@ -1,0 +1,237 @@
+-- Deploy tet:indicateur/import_emt_valeur to pg
+-- requires: indicateur/periodicite
+
+BEGIN;
+
+-- Frontière transactionnelle de l'ancien import EMT. Le classeur ne porte
+-- que des années : cette fonction refuse donc toute autre cadence et garde le
+-- contrôle des définitions, des verrous de période et de toutes les écritures
+-- du classeur dans une transaction PostgreSQL unique.
+CREATE FUNCTION public.import_indicateur_emt_valeurs(
+    collectivite_id_a_ecrire integer,
+    valeurs_a_ecrire jsonb
+)
+    RETURNS integer
+    LANGUAGE plpgsql
+    SECURITY DEFINER
+    SET search_path = pg_catalog, public
+AS $$
+DECLARE
+    valeur_a_ecrire record;
+    periodicite_effective text;
+    valeur_existante public.indicateur_valeur%ROWTYPE;
+    valeurs_ecrites integer := 0;
+BEGIN
+    IF collectivite_id_a_ecrire IS NULL OR collectivite_id_a_ecrire < 1 THEN
+        RAISE EXCEPTION USING
+            ERRCODE = '23514',
+            MESSAGE = format(
+                'Collectivité EMT invalide : %s',
+                COALESCE(collectivite_id_a_ecrire::text, 'NULL')
+            );
+    END IF;
+
+    IF valeurs_a_ecrire IS NULL
+       OR jsonb_typeof(valeurs_a_ecrire) IS DISTINCT FROM 'array'
+    THEN
+        RAISE EXCEPTION USING
+            ERRCODE = '23514',
+            MESSAGE = 'Les valeurs EMT doivent former un tableau JSON';
+    END IF;
+
+    -- Même ordre que les writers applicatifs : graphe, définition, période.
+    -- La prise de ce verrou avant tout traitement stabilise les cadences pour
+    -- la totalité du lot.
+    PERFORM pg_advisory_xact_lock_shared(
+        hashtextextended('indicateur-calculation-graph', 0)
+    );
+
+    PERFORM 1
+    FROM public.collectivite
+    WHERE id = collectivite_id_a_ecrire
+    FOR KEY SHARE;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION USING
+            ERRCODE = '23503',
+            MESSAGE = format(
+                'Collectivité EMT introuvable : %s',
+                collectivite_id_a_ecrire
+            );
+    END IF;
+
+    -- Valide et verrouille d'abord toutes les définitions, dans l'ordre de
+    -- leur identifiant. Aucun verrou de période ni aucune écriture n'est pris
+    -- tant que le lot complet n'est pas valide.
+    FOR valeur_a_ecrire IN
+        SELECT valeur.*, element.ordinality
+        FROM jsonb_array_elements(valeurs_a_ecrire)
+            WITH ORDINALITY AS element(payload, ordinality)
+        CROSS JOIN LATERAL jsonb_to_record(element.payload) AS valeur(
+            indicateur_id integer,
+            periodicite text,
+            date_debut date,
+            resultat double precision,
+            commentaire text
+        )
+        ORDER BY valeur.indicateur_id, valeur.date_debut, element.ordinality
+    LOOP
+        IF valeur_a_ecrire.periodicite IS DISTINCT FROM 'annuelle' THEN
+            RAISE EXCEPTION USING
+                ERRCODE = '23514',
+                MESSAGE = format(
+                    'L''import EMT exige une périodicité annuelle, reçu : %s',
+                    COALESCE(valeur_a_ecrire.periodicite, 'NULL')
+                );
+        END IF;
+
+        SELECT definition.periodicite
+        INTO periodicite_effective
+        FROM public.indicateur_definition definition
+        WHERE definition.id = valeur_a_ecrire.indicateur_id
+          AND definition.collectivite_id IS NULL
+          AND definition.groupement_id IS NULL
+          AND definition.identifiant_referentiel IS NOT NULL
+        FOR SHARE;
+
+        IF NOT FOUND THEN
+            RAISE EXCEPTION USING
+                ERRCODE = '23503',
+                MESSAGE = format(
+                    'Définition EMT prédéfinie introuvable : %s',
+                    COALESCE(valeur_a_ecrire.indicateur_id::text, 'NULL')
+                );
+        END IF;
+
+        IF periodicite_effective IS DISTINCT FROM valeur_a_ecrire.periodicite THEN
+            RAISE EXCEPTION USING
+                ERRCODE = '23514',
+                MESSAGE = format(
+                    'La périodicité de l''indicateur %s a changé : attendu %s, trouvé %s',
+                    valeur_a_ecrire.indicateur_id,
+                    valeur_a_ecrire.periodicite,
+                    periodicite_effective
+                );
+        END IF;
+
+        IF valeur_a_ecrire.date_debut IS NULL
+           OR valeur_a_ecrire.date_debut IS DISTINCT FROM
+              public.indicateur_date_debut_periode(
+                  periodicite_effective,
+                  valeur_a_ecrire.date_debut
+              )
+        THEN
+            RAISE EXCEPTION USING
+                ERRCODE = '23514',
+                MESSAGE = format(
+                    'Date EMT non canonique pour l''indicateur %s : %s',
+                    valeur_a_ecrire.indicateur_id,
+                    COALESCE(valeur_a_ecrire.date_debut::text, 'NULL')
+                );
+        END IF;
+
+    END LOOP;
+
+    -- La clé de concurrence des valeurs ne contient pas l'indicateur. Trier
+    -- le lot par indicateur ne suffit donc pas : deux lots peuvent parcourir
+    -- les mêmes dates dans un ordre opposé. Les clés distinctes sont prises
+    -- ici dans le même ordre lexicographique global que le repository NestJS.
+    PERFORM pg_advisory_xact_lock(
+        hashtextextended(verrou.lock_key, 0)
+    )
+    FROM (
+        SELECT DISTINCT format(
+            'indicateur-valeur:%s:%s',
+            collectivite_id_a_ecrire,
+            to_char(valeur.date_debut, 'YYYY-MM-DD')
+        ) AS lock_key
+        FROM jsonb_array_elements(valeurs_a_ecrire) AS element(payload)
+        CROSS JOIN LATERAL jsonb_to_record(element.payload) AS valeur(
+            date_debut date
+        )
+        ORDER BY lock_key
+    ) AS verrou;
+
+    FOR valeur_a_ecrire IN
+        SELECT valeur.*, element.ordinality
+        FROM jsonb_array_elements(valeurs_a_ecrire)
+            WITH ORDINALITY AS element(payload, ordinality)
+        CROSS JOIN LATERAL jsonb_to_record(element.payload) AS valeur(
+            indicateur_id integer,
+            periodicite text,
+            date_debut date,
+            resultat double precision,
+            commentaire text
+        )
+        ORDER BY valeur.indicateur_id, valeur.date_debut, element.ordinality
+    LOOP
+
+        SELECT valeur.*
+        INTO valeur_existante
+        FROM public.indicateur_valeur valeur
+        WHERE valeur.indicateur_id = valeur_a_ecrire.indicateur_id
+          AND valeur.collectivite_id = collectivite_id_a_ecrire
+          AND valeur.date_valeur = valeur_a_ecrire.date_debut
+          AND valeur.metadonnee_id IS NULL
+        FOR UPDATE;
+
+        -- Le comportement historique ne remplace jamais un résultat manuel
+        -- déjà présent. Il ajoute seulement le commentaire du classeur.
+        IF FOUND THEN
+            IF NULLIF(valeur_a_ecrire.commentaire, '') IS NOT NULL THEN
+                UPDATE public.indicateur_valeur
+                SET resultat_commentaire = CASE
+                        WHEN NULLIF(
+                            valeur_existante.resultat_commentaire,
+                            ''
+                        ) IS NULL
+                            THEN valeur_a_ecrire.commentaire
+                        ELSE valeur_a_ecrire.commentaire || E'\n---\n'
+                             || valeur_existante.resultat_commentaire
+                    END
+                WHERE id = valeur_existante.id;
+                valeurs_ecrites := valeurs_ecrites + 1;
+            END IF;
+            CONTINUE;
+        END IF;
+
+        IF valeur_a_ecrire.resultat IS NULL
+           AND NULLIF(valeur_a_ecrire.commentaire, '') IS NULL
+        THEN
+            CONTINUE;
+        END IF;
+
+        INSERT INTO public.indicateur_valeur (
+            indicateur_id,
+            collectivite_id,
+            date_valeur,
+            metadonnee_id,
+            resultat,
+            resultat_commentaire,
+            calcul_auto,
+            calcul_auto_identifiants_manquants
+        ) VALUES (
+            valeur_a_ecrire.indicateur_id,
+            collectivite_id_a_ecrire,
+            valeur_a_ecrire.date_debut,
+            NULL,
+            valeur_a_ecrire.resultat,
+            NULLIF(valeur_a_ecrire.commentaire, ''),
+            false,
+            NULL
+        );
+        valeurs_ecrites := valeurs_ecrites + 1;
+    END LOOP;
+
+    RETURN valeurs_ecrites;
+END;
+$$;
+
+COMMENT ON FUNCTION public.import_indicateur_emt_valeurs(integer, jsonb) IS
+    'Importe atomiquement un lot de valeurs EMT annuelles après verrouillage et revalidation des périodicités.';
+
+REVOKE ALL ON FUNCTION public.import_indicateur_emt_valeurs(integer, jsonb)
+FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.import_indicateur_emt_valeurs(integer, jsonb)
+TO service_role;
+
+COMMIT;

--- a/data_layer/sqitch/deploy/indicateur/periodicite.sql
+++ b/data_layer/sqitch/deploy/indicateur/periodicite.sql
@@ -1,0 +1,735 @@
+-- Deploy tet:indicateur/periodicite to pg
+-- requires: indicateur/referentiel
+-- requires: indicateur/indicateurs_gaz_effet_serre
+-- requires: demarche/pcaet_diagnostic_drop_referentiel_tables
+-- requires: migration_schema
+
+BEGIN;
+
+-- Fige d'abord les définitions puis leurs valeurs. Cet ordre laisse finir une
+-- ancienne suppression de définition et sa cascade avant que la migration ne
+-- détienne le verrou de la table de valeurs.
+LOCK TABLE public.indicateur_definition IN SHARE ROW EXCLUSIVE MODE;
+LOCK TABLE public.indicateur_valeur IN SHARE ROW EXCLUSIVE MODE;
+
+-- Une périodicité est une description de cadence immuable, et non une série
+-- de branches recopiées dans chaque consommateur. Les deux périodicités
+-- livrées utilisent la même famille calendaire fondée sur le mois.
+CREATE TABLE public.indicateur_periodicite
+(
+    code               text     PRIMARY KEY,
+    unite_calendaire   text     NOT NULL
+        CHECK (unite_calendaire IN ('mois', 'semaine', 'jour')),
+    nombre_unites      integer  NOT NULL CHECK (nombre_unites > 0),
+    date_ancrage       date     NOT NULL
+        CONSTRAINT indicateur_periodicite_date_ancrage_supported_check
+        CHECK (date_ancrage BETWEEN DATE '0001-01-01' AND DATE '9999-12-31'),
+    CONSTRAINT indicateur_periodicite_mois_valides_check
+        CHECK (
+            unite_calendaire <> 'mois'
+            OR (
+                EXTRACT(DAY FROM date_ancrage) = 1
+                AND MOD(12, nombre_unites) = 0
+            )
+        )
+);
+
+COMMENT ON TABLE public.indicateur_periodicite IS
+    'Catalogue en lecture seule des cadences applicables aux indicateurs. Une politique publiée est immuable ; changer son sens exige un nouveau code.';
+COMMENT ON COLUMN public.indicateur_periodicite.date_ancrage IS
+    'Début d''une période de référence utilisé pour aligner toutes les occurrences de la cadence.';
+
+INSERT INTO public.indicateur_periodicite
+    (code, unite_calendaire, nombre_unites, date_ancrage)
+VALUES
+    ('annuelle', 'mois', 12, DATE '2000-01-01'),
+    ('mensuelle', 'mois', 1, DATE '2000-01-01');
+
+-- Catalogue public en lecture, mais administré uniquement par migration. Sans
+-- cette frontière un client REST pourrait ajouter une cadence inconnue du
+-- registre TypeScript ou modifier une ligne pas encore utilisée.
+ALTER TABLE public.indicateur_periodicite ENABLE ROW LEVEL SECURITY;
+CREATE POLICY indicateur_periodicite_allow_read
+    ON public.indicateur_periodicite
+    FOR SELECT
+    USING (true);
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER
+    ON public.indicateur_periodicite
+    FROM PUBLIC, anon, authenticated, service_role;
+GRANT SELECT ON public.indicateur_periodicite
+    TO anon, authenticated, service_role;
+
+-- Unique implémentation SQL de l'arithmétique des cadences. Ajouter une
+-- cadence utilisant une famille existante ne requiert qu'une ligne de
+-- catalogue ; une nouvelle famille est ajoutée ici et nulle part ailleurs.
+CREATE FUNCTION public.indicateur_date_debut_periode(
+    periodicite_code text,
+    date_a_classer date
+)
+    RETURNS date
+    LANGUAGE plpgsql
+    STABLE
+    STRICT
+    SECURITY DEFINER
+    SET search_path = pg_catalog, public
+AS $$
+DECLARE
+    periodicite public.indicateur_periodicite%ROWTYPE;
+    ecart_unites integer;
+    index_periode integer;
+    date_debut date;
+BEGIN
+    -- Garde la base et le value object TypeScript sur le même domaine de
+    -- dates. Sans cette borne, PostgreSQL accepterait des dates impossibles à
+    -- hydrater par l'application (années à cinq chiffres ou dates av. J.-C.).
+    IF date_a_classer NOT BETWEEN DATE '0001-01-01' AND DATE '9999-12-31' THEN
+        RAISE EXCEPTION USING
+            ERRCODE = '23514',
+            MESSAGE = format(
+                'Date hors du calendrier pris en charge pour les périodes d''indicateur : %s',
+                date_a_classer
+            );
+    END IF;
+
+    SELECT catalogue.*
+    INTO periodicite
+    FROM public.indicateur_periodicite catalogue
+    WHERE catalogue.code = periodicite_code;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION USING
+            ERRCODE = '23514',
+            MESSAGE = format('Périodicité d''indicateur inconnue : %s', periodicite_code);
+    END IF;
+
+    IF periodicite.unite_calendaire = 'mois' THEN
+        ecart_unites :=
+            (EXTRACT(YEAR FROM date_a_classer)::integer * 12
+             + EXTRACT(MONTH FROM date_a_classer)::integer)
+            - (EXTRACT(YEAR FROM periodicite.date_ancrage)::integer * 12
+               + EXTRACT(MONTH FROM periodicite.date_ancrage)::integer);
+        index_periode :=
+            floor(ecart_unites::numeric / periodicite.nombre_unites)::integer;
+        date_debut := (
+            date_trunc('month', periodicite.date_ancrage)::date
+            + index_periode * periodicite.nombre_unites * INTERVAL '1 month'
+        )::date;
+    ELSIF periodicite.unite_calendaire = 'semaine' THEN
+        ecart_unites := date_a_classer - periodicite.date_ancrage;
+        index_periode :=
+            floor(ecart_unites::numeric / (periodicite.nombre_unites * 7))::integer;
+        date_debut := periodicite.date_ancrage
+            + index_periode * periodicite.nombre_unites * 7;
+    ELSIF periodicite.unite_calendaire = 'jour' THEN
+        ecart_unites := date_a_classer - periodicite.date_ancrage;
+        index_periode :=
+            floor(ecart_unites::numeric / periodicite.nombre_unites)::integer;
+        date_debut := periodicite.date_ancrage
+            + index_periode * periodicite.nombre_unites;
+    ELSE
+        RAISE EXCEPTION USING
+            ERRCODE = '23514',
+            MESSAGE = format(
+                'Unité calendaire non prise en charge pour la périodicité %s',
+                periodicite_code
+            );
+    END IF;
+
+    IF date_debut NOT BETWEEN DATE '0001-01-01' AND DATE '9999-12-31' THEN
+        RAISE EXCEPTION USING
+            ERRCODE = '23514',
+            MESSAGE = format(
+                'Début de période hors du calendrier pris en charge : %s',
+                date_debut
+            );
+    END IF;
+
+    RETURN date_debut;
+END;
+$$;
+
+COMMENT ON FUNCTION public.indicateur_date_debut_periode(text, date) IS
+    'Retourne le début canonique de la période contenant une date, selon le catalogue des périodicités.';
+
+-- La colonne reste nullable pendant cette première étape de déploiement
+-- progressif. La clé étrangère remplace une liste de valeurs codée en dur.
+ALTER TABLE public.indicateur_definition
+    ADD COLUMN periodicite text DEFAULT 'annuelle',
+    ADD CONSTRAINT indicateur_definition_periodicite_fkey
+        FOREIGN KEY (periodicite)
+        REFERENCES public.indicateur_periodicite(code);
+
+-- Les définitions historiques ont été conçues et exposées comme annuelles. La
+-- classification ne se déduit jamais des dates déjà saisies.
+UPDATE public.indicateur_definition
+SET periodicite = 'annuelle'
+WHERE periodicite IS NULL;
+
+-- La fonction publique doit transporter la cadence avec chaque valeur. Elle
+-- ne projette pas elle-même une période sur une année : le consommateur peut
+-- ainsi appliquer explicitement sa capacité (annuelle aujourd'hui) et échouer
+-- fermé si une cadence incompatible lui parvient.
+CREATE OR REPLACE FUNCTION public.indicateurs_gaz_effet_serre(site_labellisation)
+    RETURNS jsonb
+    SECURITY DEFINER
+    LANGUAGE sql
+BEGIN ATOMIC
+SELECT to_jsonb(array_agg(d))
+FROM (
+    SELECT iri.date_valeur,
+           iri.resultat,
+           id.identifiant_referentiel AS identifiant,
+           id.periodicite,
+           src.libelle AS source
+    FROM indicateur_valeur iri
+    JOIN indicateur_definition id ON iri.indicateur_id = id.id
+    JOIN indicateur_source_metadonnee ism ON ism.id = iri.metadonnee_id
+    JOIN indicateur_source src ON src.id = ism.source_id
+    WHERE iri.collectivite_id = ($1).collectivite_id
+      AND iri.metadonnee_id IS NOT NULL
+      AND iri.resultat IS NOT NULL
+      AND src.id IN ('citepa')
+      AND id.identifiant_referentiel::text = ANY (
+          ARRAY [
+              'cae_1.g'::character varying,
+              'cae_1.f'::character varying,
+              'cae_1.h'::character varying,
+              'cae_1.j'::character varying,
+              'cae_1.i'::character varying,
+              'cae_1.c'::character varying,
+              'cae_1.e'::character varying,
+              'cae_1.d'::character varying,
+              'cae_1.a'::character varying
+          ]::text[]
+      )
+) d;
+END;
+
+-- Le schéma historique ne sait représenter qu'une cadence annuelle. Ce garde
+-- partagé par les reverts du reporting et du catalogue empêche un downgrade
+-- partiel ou une perte silencieuse dès qu'une autre cadence est utilisée.
+CREATE FUNCTION migration.verifier_retrait_periodicite_indicateur()
+    RETURNS void
+    LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM public.indicateur_definition
+        WHERE COALESCE(periodicite, 'annuelle') <> 'annuelle'
+    ) THEN
+        RAISE EXCEPTION USING
+            ERRCODE = '23514',
+            MESSAGE = 'Impossible de retirer la périodicité tant que des définitions non annuelles existent ; effectuer d''abord une migration métier explicite';
+    END IF;
+END;
+$$;
+
+COMMENT ON FUNCTION migration.verifier_retrait_periodicite_indicateur() IS
+    'Refuse un retour au schéma annuel lorsque celui-ci perdrait le sens de définitions non annuelles.';
+
+-- Une politique publiée ne change jamais de sens, qu'elle soit déjà utilisée
+-- ou non. Toute évolution ajoute un nouveau code par migration ; cette règle
+-- inconditionnelle ferme aussi la course avec une attribution concurrente.
+CREATE FUNCTION public.empecher_modification_periodicite()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    SECURITY DEFINER
+    SET search_path = pg_catalog, public
+AS $$
+BEGIN
+    RAISE EXCEPTION USING
+        ERRCODE = '23514',
+        MESSAGE = format(
+            'La politique de périodicité %s est immuable ; créer un nouveau code',
+            OLD.code
+        );
+END;
+$$;
+
+CREATE TRIGGER empecher_modification_periodicite
+    BEFORE UPDATE OR DELETE
+    ON public.indicateur_periodicite
+    FOR EACH ROW
+    EXECUTE FUNCTION public.empecher_modification_periodicite();
+
+-- Conserve la date d'origine de chaque valeur non canonique. Les groupes qui
+-- convergeraient vers la même période sont seulement audités : les fusionner
+-- automatiquement ferait perdre une information métier sans règle explicite.
+CREATE TABLE migration.indicateur_valeur_periodicite_audit
+(
+    valeur_id             integer PRIMARY KEY,
+    indicateur_id         integer NOT NULL,
+    collectivite_id       integer NOT NULL,
+    metadonnee_id         integer,
+    periodicite           text NOT NULL,
+    date_valeur_avant     date NOT NULL,
+    date_valeur_canonique date NOT NULL,
+    statut                text NOT NULL
+        CHECK (statut IN ('normalisee', 'conflit')),
+    audited_at            timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+COMMENT ON TABLE migration.indicateur_valeur_periodicite_audit IS
+    'Audit réversible des dates non canoniques rencontrées lors de la migration de périodicité. Les conflits exigent une remédiation métier explicite.';
+
+-- Cette fonction est rejouée par l'étape de verrouillage afin de couvrir les
+-- écritures effectuées par une ancienne version entre les deux changements.
+CREATE FUNCTION migration.auditer_et_normaliser_dates_indicateur()
+    RETURNS void
+    LANGUAGE plpgsql
+AS $$
+BEGIN
+    -- Une ligne peut avoir été supprimée ou réaffectée depuis son audit. Dans
+    -- ce cas l'audit ne décrit plus son identité métier et ne doit jamais être
+    -- rejoué sur le nouveau tuple qui aurait réutilisé le même identifiant.
+    DELETE FROM migration.indicateur_valeur_periodicite_audit audit
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM public.indicateur_valeur valeur
+        WHERE valeur.id = audit.valeur_id
+          AND valeur.indicateur_id = audit.indicateur_id
+          AND valeur.collectivite_id = audit.collectivite_id
+          AND valeur.metadonnee_id IS NOT DISTINCT FROM audit.metadonnee_id
+    );
+
+    DELETE FROM migration.indicateur_valeur_periodicite_audit audit
+    WHERE audit.statut = 'conflit'
+      AND NOT EXISTS (
+          SELECT 1
+          FROM public.indicateur_valeur valeur
+          JOIN public.indicateur_definition definition
+            ON definition.id = valeur.indicateur_id
+          WHERE valeur.id = audit.valeur_id
+            AND valeur.date_valeur <> public.indicateur_date_debut_periode(
+                COALESCE(definition.periodicite, 'annuelle'),
+                valeur.date_valeur
+            )
+      );
+
+    INSERT INTO migration.indicateur_valeur_periodicite_audit
+        (valeur_id,
+         indicateur_id,
+         collectivite_id,
+         metadonnee_id,
+         periodicite,
+         date_valeur_avant,
+         date_valeur_canonique,
+         statut)
+    WITH valeurs_avec_date_canonique AS (
+        SELECT valeur.id AS valeur_id,
+               valeur.indicateur_id,
+               valeur.collectivite_id,
+               valeur.metadonnee_id,
+               COALESCE(definition.periodicite, 'annuelle') AS periodicite,
+               valeur.date_valeur AS date_valeur_avant,
+               public.indicateur_date_debut_periode(
+                   COALESCE(definition.periodicite, 'annuelle'),
+                   valeur.date_valeur
+               ) AS date_valeur_canonique
+        FROM public.indicateur_valeur valeur
+        JOIN public.indicateur_definition definition
+          ON definition.id = valeur.indicateur_id
+    ),
+    valeurs_non_canoniques AS (
+        SELECT *
+        FROM valeurs_avec_date_canonique
+        WHERE date_valeur_avant <> date_valeur_canonique
+    )
+    SELECT valeur.valeur_id,
+           valeur.indicateur_id,
+           valeur.collectivite_id,
+           valeur.metadonnee_id,
+           valeur.periodicite,
+           valeur.date_valeur_avant,
+           valeur.date_valeur_canonique,
+           CASE WHEN EXISTS (
+               SELECT 1
+               FROM public.indicateur_valeur autre
+               WHERE autre.id <> valeur.valeur_id
+                 AND autre.indicateur_id = valeur.indicateur_id
+                 AND autre.collectivite_id = valeur.collectivite_id
+                 AND autre.metadonnee_id IS NOT DISTINCT FROM valeur.metadonnee_id
+                 AND public.indicateur_date_debut_periode(
+                         valeur.periodicite,
+                         autre.date_valeur
+                     ) = valeur.date_valeur_canonique
+           ) THEN 'conflit' ELSE 'normalisee' END
+    FROM valeurs_non_canoniques valeur
+    ON CONFLICT (valeur_id) DO UPDATE
+    SET indicateur_id = EXCLUDED.indicateur_id,
+        collectivite_id = EXCLUDED.collectivite_id,
+        metadonnee_id = EXCLUDED.metadonnee_id,
+        periodicite = EXCLUDED.periodicite,
+        date_valeur_avant = EXCLUDED.date_valeur_avant,
+        date_valeur_canonique = EXCLUDED.date_valeur_canonique,
+        statut = EXCLUDED.statut,
+        audited_at = CURRENT_TIMESTAMP;
+
+    UPDATE public.indicateur_valeur valeur
+    SET date_valeur = audit.date_valeur_canonique
+    FROM migration.indicateur_valeur_periodicite_audit audit
+    WHERE audit.valeur_id = valeur.id
+      AND audit.statut = 'normalisee'
+      AND valeur.indicateur_id = audit.indicateur_id
+      AND valeur.collectivite_id = audit.collectivite_id
+      AND valeur.metadonnee_id IS NOT DISTINCT FROM audit.metadonnee_id
+      AND valeur.date_valeur = audit.date_valeur_avant;
+END;
+$$;
+
+ALTER TABLE public.indicateur_valeur DISABLE TRIGGER modified_at;
+ALTER TABLE public.indicateur_valeur DISABLE TRIGGER modified_by;
+SELECT migration.auditer_et_normaliser_dates_indicateur();
+ALTER TABLE public.indicateur_valeur ENABLE TRIGGER modified_by;
+ALTER TABLE public.indicateur_valeur ENABLE TRIGGER modified_at;
+
+-- Les valeurs peuvent être écrites concurremment, mais leur calcul doit voir
+-- un graphe de formules et de périodicités stable. Les triggers statement-level
+-- prennent le verrou avant tout verrou de ligne, y compris pour un writer SQL
+-- qui ne passe pas par les repositories applicatifs.
+CREATE FUNCTION public.verrouiller_graphe_calcul_indicateur_partage()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    SECURITY DEFINER
+    SET search_path = pg_catalog, public
+AS $$
+BEGIN
+    PERFORM pg_advisory_xact_lock_shared(
+        hashtextextended('indicateur-calculation-graph', 0)
+    );
+    RETURN NULL;
+END;
+$$;
+
+CREATE FUNCTION public.verrouiller_graphe_calcul_indicateur_exclusif()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    SECURITY DEFINER
+    SET search_path = pg_catalog, public
+AS $$
+BEGIN
+    PERFORM pg_advisory_xact_lock(
+        hashtextextended('indicateur-calculation-graph', 0)
+    );
+    RETURN NULL;
+END;
+$$;
+
+CREATE TRIGGER verrouiller_graphe_calcul_indicateur_valeur
+    BEFORE INSERT OR UPDATE OR DELETE
+    ON public.indicateur_valeur
+    FOR EACH STATEMENT
+    EXECUTE FUNCTION public.verrouiller_graphe_calcul_indicateur_partage();
+
+CREATE TRIGGER verrouiller_graphe_calcul_indicateur_definition
+    BEFORE INSERT OR DELETE
+    ON public.indicateur_definition
+    FOR EACH STATEMENT
+    EXECUTE FUNCTION public.verrouiller_graphe_calcul_indicateur_exclusif();
+
+CREATE TRIGGER verrouiller_graphe_calcul_indicateur_definition_update
+    BEFORE UPDATE OF id, collectivite_id, identifiant_referentiel,
+                     valeur_calcule, periodicite
+    ON public.indicateur_definition
+    FOR EACH STATEMENT
+    EXECUTE FUNCTION public.verrouiller_graphe_calcul_indicateur_exclusif();
+
+REVOKE EXECUTE
+    ON FUNCTION public.verrouiller_graphe_calcul_indicateur_partage(),
+                public.verrouiller_graphe_calcul_indicateur_exclusif()
+    FROM PUBLIC, anon, authenticated, service_role;
+
+-- À partir de cet instant, un audit normalisé ne reste réversible que tant
+-- que la ligne représente la même occurrence métier. Ce trigger est créé
+-- après la normalisation initiale et reste actif pendant les phases expand et
+-- contract. Son nom le fait exécuter avant le trigger d'audit transitoire.
+CREATE FUNCTION migration.assainir_audit_periodicite_indicateur()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    SECURITY DEFINER
+    SET search_path = pg_catalog, public
+AS $$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        DELETE FROM migration.indicateur_valeur_periodicite_audit
+        WHERE valeur_id = OLD.id;
+        RETURN OLD;
+    END IF;
+
+    IF TG_OP = 'INSERT' THEN
+        DELETE FROM migration.indicateur_valeur_periodicite_audit
+        WHERE valeur_id = NEW.id;
+        RETURN NEW;
+    END IF;
+
+    DELETE FROM migration.indicateur_valeur_periodicite_audit audit
+    WHERE audit.valeur_id = NEW.id
+      AND (
+          audit.indicateur_id IS DISTINCT FROM NEW.indicateur_id
+          OR audit.collectivite_id IS DISTINCT FROM NEW.collectivite_id
+          OR audit.metadonnee_id IS DISTINCT FROM NEW.metadonnee_id
+          OR audit.date_valeur_canonique IS DISTINCT FROM NEW.date_valeur
+      );
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER assainir_audit_periodicite_indicateur
+    BEFORE INSERT OR UPDATE OF indicateur_id, collectivite_id, date_valeur, metadonnee_id OR DELETE
+    ON public.indicateur_valeur
+    FOR EACH ROW
+    EXECUTE FUNCTION migration.assainir_audit_periodicite_indicateur();
+
+-- Pendant la fenêtre de déploiement, l'ancienne application peut encore
+-- envoyer une date annuelle quelconque. Le trigger l'audite et la normalise
+-- seulement en l'absence de collision.
+CREATE FUNCTION migration.auditer_et_normaliser_date_indicateur_en_transition()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    SECURITY DEFINER
+    SET search_path = pg_catalog, public
+AS $$
+DECLARE
+    definition_periodicite text;
+    date_canonique date;
+    statut_audit text;
+BEGIN
+    SELECT COALESCE(definition.periodicite, 'annuelle')
+    INTO definition_periodicite
+    FROM public.indicateur_definition definition
+    WHERE definition.id = NEW.indicateur_id
+    FOR SHARE;
+
+    IF NOT FOUND THEN
+        RETURN NEW;
+    END IF;
+
+    -- Un audit est attaché au tuple métier, pas seulement à l'identifiant
+    -- technique de la ligne. Une réaffectation canonique ne passe pas par la
+    -- normalisation ci-dessous : supprimer ici son ancien audit évite qu'un
+    -- futur rejeu de la migration ne le lui applique.
+    DELETE FROM migration.indicateur_valeur_periodicite_audit audit
+    WHERE audit.valeur_id = NEW.id
+      AND (
+          audit.indicateur_id IS DISTINCT FROM NEW.indicateur_id
+          OR audit.collectivite_id IS DISTINCT FROM NEW.collectivite_id
+          OR audit.metadonnee_id IS DISTINCT FROM NEW.metadonnee_id
+      );
+
+    date_canonique := public.indicateur_date_debut_periode(
+        definition_periodicite,
+        NEW.date_valeur
+    );
+
+    -- Même espace de verrou que les repositories applicatifs. Le verrou est
+    -- pris aussi pour une date déjà canonique : deux anciennes écritures de
+    -- la même période ne peuvent ainsi observer simultanément une clé métier
+    -- encore absente, puis se normaliser l'une sur l'autre.
+    PERFORM pg_advisory_xact_lock(
+        hashtextextended(
+            format(
+                'indicateur-valeur:%s:%s',
+                NEW.collectivite_id,
+                to_char(date_canonique, 'YYYY-MM-DD')
+            ),
+            0
+        )
+    );
+
+    IF NEW.date_valeur = date_canonique THEN
+        -- Un conflit corrigé explicitement n'est plus à remédier. Conserver en
+        -- revanche les audits normalisés du même tuple pour rendre possible
+        -- le revert de l'étape d'expansion.
+        DELETE FROM migration.indicateur_valeur_periodicite_audit audit
+        WHERE audit.valeur_id = NEW.id
+          AND audit.statut = 'conflit';
+        RETURN NEW;
+    END IF;
+
+    statut_audit := CASE WHEN EXISTS (
+        SELECT 1
+        FROM public.indicateur_valeur autre
+        WHERE autre.id <> NEW.id
+          AND autre.indicateur_id = NEW.indicateur_id
+          AND autre.collectivite_id = NEW.collectivite_id
+          AND autre.metadonnee_id IS NOT DISTINCT FROM NEW.metadonnee_id
+          AND public.indicateur_date_debut_periode(
+                  definition_periodicite,
+                  autre.date_valeur
+              ) = date_canonique
+    ) THEN 'conflit' ELSE 'normalisee' END;
+
+    -- Après l'audit initial, ne jamais laisser une ancienne instance créer
+    -- une nouvelle ligne que l'application canonique ne saurait hydrater. Un
+    -- conflit demande une décision métier ; l'écriture est donc atomiquement
+    -- refusée au lieu de persister une date ambiguë.
+    IF statut_audit = 'conflit' THEN
+        RAISE EXCEPTION USING
+            ERRCODE = '23505',
+            MESSAGE = format(
+                'La date %s entre en conflit avec une période %s existante pour l''indicateur %s',
+                NEW.date_valeur,
+                date_canonique,
+                NEW.indicateur_id
+            );
+    END IF;
+
+    INSERT INTO migration.indicateur_valeur_periodicite_audit
+        (valeur_id,
+         indicateur_id,
+         collectivite_id,
+         metadonnee_id,
+         periodicite,
+         date_valeur_avant,
+         date_valeur_canonique,
+         statut)
+    VALUES
+        (NEW.id,
+         NEW.indicateur_id,
+         NEW.collectivite_id,
+         NEW.metadonnee_id,
+         definition_periodicite,
+         NEW.date_valeur,
+         date_canonique,
+         statut_audit)
+    ON CONFLICT (valeur_id) DO UPDATE
+    SET indicateur_id = EXCLUDED.indicateur_id,
+        collectivite_id = EXCLUDED.collectivite_id,
+        metadonnee_id = EXCLUDED.metadonnee_id,
+        periodicite = EXCLUDED.periodicite,
+        date_valeur_avant = EXCLUDED.date_valeur_avant,
+        date_valeur_canonique = EXCLUDED.date_valeur_canonique,
+        statut = EXCLUDED.statut,
+        audited_at = CURRENT_TIMESTAMP;
+
+    IF statut_audit = 'normalisee' THEN
+        NEW.date_valeur := date_canonique;
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER auditer_et_normaliser_date_indicateur_en_transition
+    BEFORE INSERT OR UPDATE OF indicateur_id, collectivite_id, date_valeur, metadonnee_id
+    ON public.indicateur_valeur
+    FOR EACH ROW
+    EXECUTE FUNCTION migration.auditer_et_normaliser_date_indicateur_en_transition();
+
+-- L'immuabilité de la cadence ne dépend pas de NOT NULL : l'installer dès
+-- l'étape compatible ferme aussi la course avec l'écriture d'une valeur.
+CREATE FUNCTION public.empecher_changement_periodicite_indicateur()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    SECURITY DEFINER
+    SET search_path = pg_catalog, public
+AS $$
+BEGIN
+    IF COALESCE(OLD.periodicite, 'annuelle')
+           IS DISTINCT FROM COALESCE(NEW.periodicite, 'annuelle') THEN
+      IF EXISTS (
+           SELECT 1
+           FROM public.indicateur_valeur valeur
+           WHERE valeur.indicateur_id = OLD.id
+       ) THEN
+        RAISE EXCEPTION USING
+            ERRCODE = '23514',
+            MESSAGE = format(
+                'La périodicité de l''indicateur %s ne peut plus changer après sa première valeur',
+                OLD.id
+            );
+      END IF;
+
+      IF EXISTS (
+          SELECT 1
+          FROM public.indicateur_groupe groupe
+          JOIN public.indicateur_definition autre_definition
+            ON autre_definition.id = CASE
+                WHEN groupe.parent = OLD.id THEN groupe.enfant
+                ELSE groupe.parent
+            END
+          WHERE OLD.id IN (groupe.parent, groupe.enfant)
+            AND autre_definition.id <> OLD.id
+            AND COALESCE(autre_definition.periodicite, 'annuelle')
+                IS DISTINCT FROM COALESCE(NEW.periodicite, 'annuelle')
+      ) THEN
+          RAISE EXCEPTION USING
+              ERRCODE = '23514',
+              MESSAGE = format(
+                  'La périodicité de l''indicateur %s doit rester identique à celle de son groupe',
+                  OLD.id
+              );
+      END IF;
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public.empecher_changement_periodicite_indicateur() IS
+    'Interdit de réinterpréter les valeurs existantes en changeant la périodicité de leur définition.';
+
+CREATE TRIGGER empecher_changement_periodicite_indicateur
+    BEFORE UPDATE OF periodicite
+    ON public.indicateur_definition
+    FOR EACH ROW
+    EXECUTE FUNCTION public.empecher_changement_periodicite_indicateur();
+
+-- Un groupe est une agrégation, pas une règle implicite de conversion. Les
+-- deux définitions sont verrouillées dans l'ordre de leur identifiant afin
+-- de sérialiser ce contrôle avec une modification concurrente de cadence.
+CREATE FUNCTION public.verifier_periodicite_groupe_indicateur()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    SECURITY DEFINER
+    SET search_path = pg_catalog, public
+AS $$
+DECLARE
+    periodicite_parent text;
+    periodicite_enfant text;
+BEGIN
+    PERFORM 1
+    FROM public.indicateur_definition definition
+    WHERE definition.id IN (NEW.parent, NEW.enfant)
+    ORDER BY definition.id
+    FOR SHARE;
+
+    SELECT parent.periodicite, enfant.periodicite
+    INTO periodicite_parent, periodicite_enfant
+    FROM public.indicateur_definition parent
+    CROSS JOIN public.indicateur_definition enfant
+    WHERE parent.id = NEW.parent
+      AND enfant.id = NEW.enfant;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION USING
+            ERRCODE = '23503',
+            MESSAGE = 'Les deux définitions du groupe doivent exister';
+    END IF;
+
+    IF COALESCE(periodicite_parent, 'annuelle')
+           IS DISTINCT FROM COALESCE(periodicite_enfant, 'annuelle') THEN
+        RAISE EXCEPTION USING
+            ERRCODE = '23514',
+            MESSAGE = format(
+                'Le parent %s et l''enfant %s d''un groupe doivent avoir la même périodicité',
+                NEW.parent,
+                NEW.enfant
+            );
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER verifier_periodicite_groupe_indicateur
+    BEFORE INSERT OR UPDATE OF parent, enfant
+    ON public.indicateur_groupe
+    FOR EACH ROW
+    EXECUTE FUNCTION public.verifier_periodicite_groupe_indicateur();
+
+COMMENT ON COLUMN public.indicateur_definition.periodicite IS
+    'Cadence en cours de classification, référencée dans public.indicateur_periodicite.';
+
+COMMIT;

--- a/data_layer/sqitch/deploy/indicateur/reconciliation_formules.sql
+++ b/data_layer/sqitch/deploy/indicateur/reconciliation_formules.sql
@@ -1,0 +1,55 @@
+-- Deploy tet:indicateur/reconciliation_formules to pg
+-- requires: indicateur/periodicite
+-- requires: private_schema
+
+BEGIN;
+
+-- Source de vérité durable du recalcul déclenché par une mutation de formule.
+-- Une ligne est une unité de travail bornée : une cible, une génération et une
+-- collectivité. Elle n'est supprimée que dans la transaction qui a terminé le
+-- recalcul (ou constaté que sa génération est devenue obsolète).
+CREATE TABLE private.indicateur_reconciliation_formule
+(
+    id                  uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+    generation          uuid        NOT NULL,
+    indicateur_id       integer     NOT NULL
+        REFERENCES public.indicateur_definition(id) ON DELETE CASCADE,
+    collectivite_id     integer     NOT NULL
+        REFERENCES public.collectivite(id) ON DELETE CASCADE,
+    formule_attendue    text,
+    created_at          timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    next_attempt_at     timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    failure_count       integer     NOT NULL DEFAULT 0
+        CHECK (failure_count >= 0),
+    last_failed_at      timestamptz,
+    last_error          text,
+    CONSTRAINT indicateur_reconciliation_formule_generation_unique
+        UNIQUE (generation, indicateur_id, collectivite_id),
+    CONSTRAINT indicateur_reconciliation_formule_normalisee_check
+        CHECK (
+            formule_attendue IS NULL
+            OR (
+                formule_attendue <> ''
+                AND formule_attendue = lower(btrim(formule_attendue))
+            )
+        )
+);
+
+CREATE INDEX indicateur_reconciliation_formule_claim_idx
+    ON private.indicateur_reconciliation_formule
+        (next_attempt_at, failure_count, created_at,
+         indicateur_id, collectivite_id, id);
+
+CREATE INDEX indicateur_reconciliation_formule_target_idx
+    ON private.indicateur_reconciliation_formule
+        (indicateur_id, next_attempt_at, created_at, collectivite_id, id);
+
+COMMENT ON TABLE private.indicateur_reconciliation_formule IS
+    'File durable des recalculs de formules, revendiquée avec FOR UPDATE SKIP LOCKED et vidée transactionnellement.';
+COMMENT ON COLUMN private.indicateur_reconciliation_formule.formule_attendue IS
+    'Formule normalisée de la génération à réconcilier ; NULL représente explicitement le retrait de la formule.';
+
+REVOKE ALL ON TABLE private.indicateur_reconciliation_formule
+    FROM PUBLIC, anon, authenticated, service_role;
+
+COMMIT;

--- a/data_layer/sqitch/revert/indicateur/dependances_formules.sql
+++ b/data_layer/sqitch/revert/indicateur/dependances_formules.sql
@@ -1,0 +1,7 @@
+-- Revert tet:indicateur/dependances_formules from pg
+
+BEGIN;
+
+DROP FUNCTION private.extraire_dependances_formule_indicateur(text);
+
+COMMIT;

--- a/data_layer/sqitch/revert/indicateur/import_emt_valeur.sql
+++ b/data_layer/sqitch/revert/indicateur/import_emt_valeur.sql
@@ -1,0 +1,7 @@
+-- Revert tet:indicateur/import_emt_valeur from pg
+
+BEGIN;
+
+DROP FUNCTION public.import_indicateur_emt_valeurs(integer, jsonb);
+
+COMMIT;

--- a/data_layer/sqitch/revert/indicateur/periodicite.sql
+++ b/data_layer/sqitch/revert/indicateur/periodicite.sql
@@ -1,0 +1,146 @@
+-- Revert tet:indicateur/periodicite from pg
+
+BEGIN;
+
+-- Prendre le verrou du graphe avant les tables respecte le même ordre que les
+-- writers applicatifs et les triggers statement-level. Une fois exclusif, le
+-- revert peut retirer ces triggers sans qu'une écriture ne s'intercale.
+SELECT pg_advisory_xact_lock(
+    hashtextextended('indicateur-calculation-graph', 0)
+);
+LOCK TABLE public.indicateur_definition IN SHARE ROW EXCLUSIVE MODE;
+LOCK TABLE public.indicateur_valeur IN SHARE ROW EXCLUSIVE MODE;
+SELECT migration.verifier_retrait_periodicite_indicateur();
+
+DROP TRIGGER IF EXISTS verrouiller_graphe_calcul_indicateur_valeur
+    ON public.indicateur_valeur;
+DROP TRIGGER IF EXISTS verrouiller_graphe_calcul_indicateur_definition_update
+    ON public.indicateur_definition;
+DROP TRIGGER IF EXISTS verrouiller_graphe_calcul_indicateur_definition
+    ON public.indicateur_definition;
+DROP FUNCTION IF EXISTS public.verrouiller_graphe_calcul_indicateur_partage();
+DROP FUNCTION IF EXISTS public.verrouiller_graphe_calcul_indicateur_exclusif();
+
+-- Retire la dépendance de la fonction publique à la colonne avant de
+-- supprimer celle-ci, et restaure exactement le contrat antérieur : la
+-- cadence n'était pas encore transportée dans chaque entrée JSON.
+CREATE OR REPLACE FUNCTION public.indicateurs_gaz_effet_serre(site_labellisation)
+    RETURNS jsonb
+    SECURITY DEFINER
+    LANGUAGE sql
+BEGIN ATOMIC
+SELECT to_jsonb(array_agg(d))
+FROM (
+    SELECT iri.date_valeur,
+           iri.resultat,
+           id.identifiant_referentiel AS identifiant,
+           src.libelle AS source
+    FROM indicateur_valeur iri
+    JOIN indicateur_definition id ON iri.indicateur_id = id.id
+    JOIN indicateur_source_metadonnee ism ON ism.id = iri.metadonnee_id
+    JOIN indicateur_source src ON src.id = ism.source_id
+    WHERE iri.collectivite_id = ($1).collectivite_id
+      AND iri.metadonnee_id IS NOT NULL
+      AND iri.resultat IS NOT NULL
+      AND src.id IN ('citepa')
+      AND id.identifiant_referentiel::text = ANY (
+          ARRAY [
+              'cae_1.g'::character varying,
+              'cae_1.f'::character varying,
+              'cae_1.h'::character varying,
+              'cae_1.j'::character varying,
+              'cae_1.i'::character varying,
+              'cae_1.c'::character varying,
+              'cae_1.e'::character varying,
+              'cae_1.d'::character varying,
+              'cae_1.a'::character varying
+          ]::text[]
+      )
+) d;
+END;
+
+DROP TRIGGER IF EXISTS empecher_periodicite_non_annuelle_pendant_retrait
+    ON public.indicateur_definition;
+DROP FUNCTION IF EXISTS migration.empecher_periodicite_non_annuelle_pendant_retrait();
+
+DROP TRIGGER IF EXISTS auditer_et_normaliser_date_indicateur_en_transition
+    ON public.indicateur_valeur;
+DROP FUNCTION IF EXISTS migration.auditer_et_normaliser_date_indicateur_en_transition();
+
+-- Doit être retiré avant la restauration des dates, sinon cette restauration
+-- invaliderait précisément les audits qu'elle doit encore consommer.
+DROP TRIGGER IF EXISTS assainir_audit_periodicite_indicateur
+    ON public.indicateur_valeur;
+DROP FUNCTION IF EXISTS migration.assainir_audit_periodicite_indicateur();
+
+DROP TRIGGER IF EXISTS empecher_changement_periodicite_indicateur
+    ON public.indicateur_definition;
+DROP FUNCTION IF EXISTS public.empecher_changement_periodicite_indicateur();
+
+DROP TRIGGER IF EXISTS verifier_periodicite_groupe_indicateur
+    ON public.indicateur_groupe;
+DROP FUNCTION IF EXISTS public.verifier_periodicite_groupe_indicateur();
+
+-- Restaure uniquement les dates que le déploiement avait effectivement
+-- normalisées. Les conflits n'ont jamais été modifiés.
+-- Une écriture effectuée pendant la transition peut avoir repris exactement
+-- la date historique d'une ligne normalisée. Refuser explicitement le revert
+-- conserve alors tout l'état et indique la remédiation attendue, plutôt que de
+-- laisser la contrainte d'unicité produire une erreur opaque au milieu de la
+-- restauration.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM migration.indicateur_valeur_periodicite_audit audit
+        JOIN public.indicateur_valeur valeur
+          ON valeur.id = audit.valeur_id
+        JOIN public.indicateur_valeur autre
+          ON autre.id <> valeur.id
+         AND autre.indicateur_id = valeur.indicateur_id
+         AND autre.collectivite_id = valeur.collectivite_id
+         AND autre.metadonnee_id IS NOT DISTINCT FROM valeur.metadonnee_id
+         AND autre.date_valeur = audit.date_valeur_avant
+        WHERE audit.statut = 'normalisee'
+          AND valeur.indicateur_id = audit.indicateur_id
+          AND valeur.collectivite_id = audit.collectivite_id
+          AND valeur.metadonnee_id IS NOT DISTINCT FROM audit.metadonnee_id
+          AND valeur.date_valeur = audit.date_valeur_canonique
+    ) THEN
+        RAISE EXCEPTION USING
+            ERRCODE = '23505',
+            MESSAGE = 'Le revert de la périodicité restaurerait une date historique désormais occupée ; remédier les lignes listées dans migration.indicateur_valeur_periodicite_audit';
+    END IF;
+END $$;
+
+ALTER TABLE public.indicateur_valeur DISABLE TRIGGER modified_at;
+ALTER TABLE public.indicateur_valeur DISABLE TRIGGER modified_by;
+UPDATE public.indicateur_valeur valeur
+SET date_valeur = audit.date_valeur_avant
+FROM migration.indicateur_valeur_periodicite_audit audit
+WHERE audit.valeur_id = valeur.id
+  AND audit.statut = 'normalisee'
+  -- Une ligne peut avoir été volontairement réaffectée après la migration.
+  -- Dans ce cas, l'ancien tuple audité ne décrit plus son identité et sa date
+  -- historique ne doit surtout pas lui être réappliquée.
+  AND valeur.indicateur_id = audit.indicateur_id
+  AND valeur.collectivite_id = audit.collectivite_id
+  AND valeur.metadonnee_id IS NOT DISTINCT FROM audit.metadonnee_id
+  AND valeur.date_valeur = audit.date_valeur_canonique;
+ALTER TABLE public.indicateur_valeur ENABLE TRIGGER modified_by;
+ALTER TABLE public.indicateur_valeur ENABLE TRIGGER modified_at;
+
+DROP FUNCTION IF EXISTS migration.auditer_et_normaliser_dates_indicateur();
+DROP TABLE migration.indicateur_valeur_periodicite_audit;
+DROP FUNCTION migration.verifier_retrait_periodicite_indicateur();
+
+ALTER TABLE public.indicateur_definition
+    DROP COLUMN periodicite;
+
+DROP TRIGGER empecher_modification_periodicite
+    ON public.indicateur_periodicite;
+DROP FUNCTION public.empecher_modification_periodicite();
+DROP FUNCTION public.indicateur_date_debut_periode(text, date);
+DROP TABLE public.indicateur_periodicite;
+
+COMMIT;

--- a/data_layer/sqitch/revert/indicateur/reconciliation_formules.sql
+++ b/data_layer/sqitch/revert/indicateur/reconciliation_formules.sql
@@ -1,0 +1,28 @@
+-- Revert tet:indicateur/reconciliation_formules from pg
+
+BEGIN;
+
+-- Même ordre que les producteurs et consommateurs : le verrou du graphe
+-- interdit qu'une nouvelle intention soit validée entre le préflight et le
+-- DROP, puis ACCESS EXCLUSIVE attend la fin d'un éventuel claim en cours.
+SELECT pg_advisory_xact_lock(
+    hashtextextended('indicateur-calculation-graph', 0)
+);
+LOCK TABLE private.indicateur_reconciliation_formule
+    IN ACCESS EXCLUSIVE MODE;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM private.indicateur_reconciliation_formule
+    ) THEN
+        RAISE EXCEPTION USING
+            ERRCODE = '23514',
+            MESSAGE = 'Impossible de retirer la file de réconciliation tant que des formules restent à recalculer';
+    END IF;
+END $$;
+
+DROP TABLE private.indicateur_reconciliation_formule;
+
+COMMIT;

--- a/data_layer/sqitch/sqitch.plan
+++ b/data_layer/sqitch/sqitch.plan
@@ -1056,3 +1056,10 @@ demarches/pcaet_destinataires_dr_ademe_service_national [demarches/pcaet_avis_pr
 demarche/pcaet_diagnostic_indicateur_source_metadonnee [demarche/pcaet_diagnostic indicateur/fusion] 2026-08-19T00:00:00Z System Administrator <root@localhost> # Lien PCAET ↔ source métadonnée pour les valeurs saisies
 
 demarche/pcaet_diagnostic_drop_referentiel_tables [demarche/pcaet_diagnostic_indicateur_source_metadonnee demarche/pcaet_diagnostic_ordre_reglementaire demarche/pcaet_vulnerabilite_thematique_socle_recadre] 2026-08-27T10:00:00Z Farnoux <farnoux@users.noreply.github.com> # Supprime le référentiel SQL du diagnostic PCAET (topics/state/snapshot) désormais porté par le package domain
+
+@indicateur-periodicite-base 2026-09-03T15:59:59Z Emilien Escalle <emilien.escalle@escemi.com> # Frontière stable précédant la migration de périodicité
+indicateur/periodicite [indicateur/referentiel indicateur/indicateurs_gaz_effet_serre demarche/pcaet_diagnostic_drop_referentiel_tables migration_schema] 2026-09-03T16:00:00Z Emilien Escalle <emilien.escalle@escemi.com> # Ajoute le catalogue des politiques de périodicité et classifie les définitions
+indicateur/import_emt_valeur [indicateur/periodicite] 2026-09-03T16:00:15Z Emilien Escalle <emilien.escalle@escemi.com> # Sérialise l'import EMT annuel avec la périodicité de sa définition
+indicateur/reconciliation_formules [indicateur/periodicite private_schema] 2026-09-03T16:00:20Z Emilien Escalle <emilien.escalle@escemi.com> # Rend durable et bornée la réconciliation déclenchée par un changement de formule
+indicateur/dependances_formules [private_schema] 2026-09-03T16:00:25Z Emilien Escalle <emilien.escalle@escemi.com> # Centralise l'extraction des dépendances de formule dès la phase expand
+@indicateur-periodicite-expand 2026-09-03T16:00:30Z Emilien Escalle <emilien.escalle@escemi.com> # Frontière de déploiement expand avant activation de la contrainte stricte

--- a/data_layer/sqitch/verify/indicateur/dependances_formules.sql
+++ b/data_layer/sqitch/verify/indicateur/dependances_formules.sql
@@ -1,0 +1,46 @@
+-- Verify tet:indicateur/dependances_formules on pg
+
+BEGIN;
+
+DO $$
+BEGIN
+    ASSERT to_regprocedure(
+        'private.extraire_dependances_formule_indicateur(text)'
+    ) IS NOT NULL,
+        'La fonction canonique d extraction des dépendances doit exister';
+
+    ASSERT (
+        SELECT proisstrict
+               AND provolatile = 'i'
+               AND proparallel = 's'
+        FROM pg_proc
+        WHERE oid =
+            'private.extraire_dependances_formule_indicateur(text)'::regprocedure
+    ), 'L extraction doit être immutable, stricte et parallèle-safe';
+
+    ASSERT (
+        SELECT count(*) = 2
+               AND bool_and(
+                   source_identifiant IN ('source-a', 'source_b')
+               )
+        FROM private.extraire_dependances_formule_indicateur(
+            'val(Source-A) + cible(source_b) + val(source-a)'
+        )
+    ), 'L extraction doit normaliser et dédupliquer les dépendances';
+
+    ASSERT NOT has_function_privilege(
+        'anon',
+        'private.extraire_dependances_formule_indicateur(text)',
+        'EXECUTE'
+    ) AND NOT has_function_privilege(
+        'authenticated',
+        'private.extraire_dependances_formule_indicateur(text)',
+        'EXECUTE'
+    ) AND NOT has_function_privilege(
+        'service_role',
+        'private.extraire_dependances_formule_indicateur(text)',
+        'EXECUTE'
+    ), 'L extraction interne ne doit pas être exposée aux rôles API';
+END $$;
+
+ROLLBACK;

--- a/data_layer/sqitch/verify/indicateur/import_emt_valeur.sql
+++ b/data_layer/sqitch/verify/indicateur/import_emt_valeur.sql
@@ -1,0 +1,63 @@
+-- Verify tet:indicateur/import_emt_valeur on pg
+
+BEGIN;
+
+DO $$
+BEGIN
+    ASSERT to_regprocedure(
+        'public.import_indicateur_emt_valeurs(integer,jsonb)'
+    ) IS NOT NULL,
+        'La RPC transactionnelle par lot de l''import EMT doit exister';
+
+    ASSERT has_function_privilege(
+        'service_role',
+        'public.import_indicateur_emt_valeurs(integer,jsonb)',
+        'EXECUTE'
+    ), 'Le rôle de service doit pouvoir appeler la RPC EMT';
+
+    ASSERT NOT has_function_privilege(
+        'anon',
+        'public.import_indicateur_emt_valeurs(integer,jsonb)',
+        'EXECUTE'
+    ) AND NOT has_function_privilege(
+        'authenticated',
+        'public.import_indicateur_emt_valeurs(integer,jsonb)',
+        'EXECUTE'
+    ), 'La RPC EMT ne doit pas être exposée aux rôles utilisateurs';
+
+    ASSERT position(
+        'pg_advisory_xact_lock_shared' IN pg_get_functiondef(
+            'public.import_indicateur_emt_valeurs(integer,jsonb)'::regprocedure
+        )
+    ) > 0, 'La RPC EMT doit participer au verrou du graphe';
+
+    ASSERT position(
+        'jsonb_array_elements' IN pg_get_functiondef(
+            'public.import_indicateur_emt_valeurs(integer,jsonb)'::regprocedure
+        )
+    ) > 0, 'La RPC EMT doit traiter tout le classeur dans un appel par lot';
+
+    ASSERT position(
+        'to_char(valeur_a_ecrire.date_debut, ''YYYY-MM-DD'')'
+        IN pg_get_functiondef(
+            'public.import_indicateur_emt_valeurs(integer,jsonb)'::regprocedure
+        )
+    ) = 0, 'La RPC ne doit plus prendre ses verrous au fil des écritures';
+
+    ASSERT position(
+        'ORDER BY lock_key'
+        IN pg_get_functiondef(
+            'public.import_indicateur_emt_valeurs(integer,jsonb)'::regprocedure
+        )
+    ) > 0, 'Les clés de verrou EMT doivent suivre un ordre global stable';
+
+    ASSERT position(
+        'to_char(valeur.date_debut, ''YYYY-MM-DD'')'
+        IN pg_get_functiondef(
+            'public.import_indicateur_emt_valeurs(integer,jsonb)'::regprocedure
+        )
+    ) > 0, 'La clé de verrou EMT doit être indépendante de DateStyle';
+END;
+$$;
+
+ROLLBACK;

--- a/data_layer/sqitch/verify/indicateur/periodicite.sql
+++ b/data_layer/sqitch/verify/indicateur/periodicite.sql
@@ -1,0 +1,222 @@
+-- Verify tet:indicateur/periodicite on pg
+
+BEGIN;
+
+DO $$
+BEGIN
+    -- Le changement contractuel suivant retire le défaut de compatibilité :
+    -- cette vérification historique doit donc accepter les deux états.
+    ASSERT (
+        SELECT column_default = '''annuelle''::text' OR column_default IS NULL
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'indicateur_definition'
+          AND column_name = 'periodicite'
+          AND data_type = 'text'
+    ), 'indicateur_definition.periodicite doit exister et être de type text';
+
+    ASSERT to_regclass('migration.indicateur_valeur_periodicite_audit') IS NOT NULL,
+        'La table d''audit des dates historiques doit exister';
+
+    ASSERT to_regclass('public.indicateur_periodicite') IS NOT NULL,
+        'Le catalogue des périodicités doit exister';
+
+    ASSERT NOT EXISTS (
+        SELECT 1
+        FROM (VALUES
+            ('annuelle', 'mois', 12, DATE '2000-01-01'),
+            ('mensuelle', 'mois', 1, DATE '2000-01-01')
+        ) AS attendue(code, unite_calendaire, nombre_unites, date_ancrage)
+        LEFT JOIN public.indicateur_periodicite effective
+          USING (code, unite_calendaire, nombre_unites, date_ancrage)
+        WHERE effective.code IS NULL
+    ), 'Le catalogue doit conserver les politiques annuelle et mensuelle livrées';
+
+    ASSERT to_regprocedure(
+        'public.indicateur_date_debut_periode(text,date)'
+    ) IS NOT NULL, 'La fonction canonique des périodes doit exister';
+
+    ASSERT to_regprocedure(
+        'migration.verifier_retrait_periodicite_indicateur()'
+    ) IS NOT NULL, 'Le garde anti-perte du downgrade doit exister';
+
+    ASSERT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'indicateur_definition_periodicite_fkey'
+          AND conrelid = 'public.indicateur_definition'::regclass
+          AND contype = 'f'
+    ), 'La clé étrangère vers le catalogue doit protéger la colonne pendant la transition';
+
+    ASSERT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'indicateur_periodicite_date_ancrage_supported_check'
+          AND conrelid = 'public.indicateur_periodicite'::regclass
+          AND contype = 'c'
+    ), 'Les ancrages du catalogue doivent rester dans le calendrier partagé avec le domaine';
+
+    ASSERT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'indicateur_periodicite_mois_valides_check'
+          AND conrelid = 'public.indicateur_periodicite'::regclass
+          AND contype = 'c'
+    ), 'Les politiques mensuelles doivent partager les règles d''alignement du domaine';
+
+    ASSERT EXISTS (
+        SELECT 1
+        FROM pg_trigger
+        WHERE tgname = 'empecher_modification_periodicite'
+          AND tgrelid = 'public.indicateur_periodicite'::regclass
+          AND tgenabled = 'O'
+          AND NOT tgisinternal
+    ), 'Toute politique de périodicité publiée doit être immuable';
+
+    ASSERT (
+        SELECT relrowsecurity
+        FROM pg_class
+        WHERE oid = 'public.indicateur_periodicite'::regclass
+    ), 'Le catalogue public doit activer RLS';
+
+    ASSERT EXISTS (
+        SELECT 1
+        FROM pg_policies
+        WHERE schemaname = 'public'
+          AND tablename = 'indicateur_periodicite'
+          AND policyname = 'indicateur_periodicite_allow_read'
+          AND cmd = 'SELECT'
+    ), 'Le catalogue doit exposer uniquement une politique de lecture';
+
+    ASSERT has_table_privilege(
+        'anon', 'public.indicateur_periodicite', 'SELECT'
+    ) AND has_table_privilege(
+        'authenticated', 'public.indicateur_periodicite', 'SELECT'
+    ) AND has_table_privilege(
+        'service_role', 'public.indicateur_periodicite', 'SELECT'
+    ), 'Les rôles API doivent pouvoir lire le catalogue';
+
+    ASSERT NOT has_table_privilege(
+        'anon', 'public.indicateur_periodicite', 'INSERT'
+    ) AND NOT has_table_privilege(
+        'anon', 'public.indicateur_periodicite', 'UPDATE'
+    ) AND NOT has_table_privilege(
+        'anon', 'public.indicateur_periodicite', 'DELETE'
+    ) AND NOT has_table_privilege(
+        'authenticated', 'public.indicateur_periodicite', 'INSERT'
+    ) AND NOT has_table_privilege(
+        'authenticated', 'public.indicateur_periodicite', 'UPDATE'
+    ) AND NOT has_table_privilege(
+        'authenticated', 'public.indicateur_periodicite', 'DELETE'
+    ) AND NOT has_table_privilege(
+        'service_role', 'public.indicateur_periodicite', 'INSERT'
+    ) AND NOT has_table_privilege(
+        'service_role', 'public.indicateur_periodicite', 'UPDATE'
+    ) AND NOT has_table_privilege(
+        'service_role', 'public.indicateur_periodicite', 'DELETE'
+    ), 'Les rôles API ne doivent jamais modifier le catalogue';
+
+    ASSERT EXISTS (
+        SELECT 1
+        FROM pg_trigger
+        WHERE tgname = 'empecher_changement_periodicite_indicateur'
+          AND tgrelid = 'public.indicateur_definition'::regclass
+          AND tgenabled = 'O'
+          AND NOT tgisinternal
+    ), 'La périodicité effective doit être immuable dès la première valeur';
+
+    ASSERT EXISTS (
+        SELECT 1
+        FROM pg_trigger
+        WHERE tgname = 'verrouiller_graphe_calcul_indicateur_valeur'
+          AND tgrelid = 'public.indicateur_valeur'::regclass
+          AND tgenabled = 'O'
+          AND NOT tgisinternal
+          AND tgtype::integer = 30
+          AND tgfoid =
+              'public.verrouiller_graphe_calcul_indicateur_partage()'::regprocedure
+    ), 'Les écritures de valeurs doivent partager le verrou du graphe avant les lignes';
+
+    ASSERT (
+        SELECT count(*) = 2
+        FROM pg_trigger
+        WHERE tgname IN (
+            'verrouiller_graphe_calcul_indicateur_definition',
+            'verrouiller_graphe_calcul_indicateur_definition_update'
+        )
+          AND tgrelid = 'public.indicateur_definition'::regclass
+          AND tgenabled = 'O'
+          AND NOT tgisinternal
+          AND tgfoid =
+              'public.verrouiller_graphe_calcul_indicateur_exclusif()'::regprocedure
+          AND (
+              (
+                  tgname = 'verrouiller_graphe_calcul_indicateur_definition'
+                  AND tgtype::integer = 14
+              )
+              OR (
+                  tgname = 'verrouiller_graphe_calcul_indicateur_definition_update'
+                  AND tgtype::integer = 18
+                  AND (
+                      SELECT array_agg(attribute.attname ORDER BY attribute.attname)
+                      FROM unnest(tgattr::smallint[]) AS updated(attnum)
+                      JOIN pg_attribute attribute
+                        ON attribute.attrelid = pg_trigger.tgrelid
+                       AND attribute.attnum = updated.attnum
+                  ) = ARRAY[
+                      'collectivite_id',
+                      'id',
+                      'identifiant_referentiel',
+                      'periodicite',
+                      'valeur_calcule'
+                  ]::name[]
+              )
+          )
+    ), 'Les mutations du graphe doivent prendre le verrou exclusif avant les lignes';
+
+    ASSERT EXISTS (
+        SELECT 1
+        FROM pg_trigger
+        WHERE tgname = 'verifier_periodicite_groupe_indicateur'
+          AND tgrelid = 'public.indicateur_groupe'::regclass
+          AND tgenabled = 'O'
+          AND NOT tgisinternal
+    ), 'Les agrégations parent/enfant doivent conserver une périodicité homogène';
+
+    ASSERT to_regprocedure(
+        'public.indicateurs_gaz_effet_serre(site_labellisation)'
+    ) IS NOT NULL
+    AND position(
+        'id.periodicite'
+        IN pg_get_functiondef(
+            'public.indicateurs_gaz_effet_serre(site_labellisation)'::regprocedure
+        )
+    ) > 0,
+        'La fonction publique des GES doit transporter la périodicité';
+
+    -- Le changement suivant remplace le trigger compatible qui normalise et
+    -- audite par le trigger strict. L'un des deux doit toujours fermer la
+    -- fenêtre de course entre l'audit et les écritures.
+    ASSERT EXISTS (
+        SELECT 1
+        FROM pg_trigger
+        WHERE tgrelid = 'public.indicateur_valeur'::regclass
+          AND tgname IN (
+              'auditer_et_normaliser_date_indicateur_en_transition',
+              'verifier_date_valeur_selon_periodicite'
+          )
+          AND tgenabled = 'O'
+          AND NOT tgisinternal
+    ), 'Les écritures de valeurs doivent être auditées en transition ou strictement validées';
+
+    ASSERT EXISTS (
+        SELECT 1
+        FROM pg_trigger
+        WHERE tgname = 'assainir_audit_periodicite_indicateur'
+          AND tgrelid = 'public.indicateur_valeur'::regclass
+          AND tgenabled = 'O'
+          AND NOT tgisinternal
+    ), 'Le cycle de vie d''une ligne doit invalider son audit devenu obsolète';
+END $$;
+
+ROLLBACK;

--- a/data_layer/sqitch/verify/indicateur/reconciliation_formules.sql
+++ b/data_layer/sqitch/verify/indicateur/reconciliation_formules.sql
@@ -1,0 +1,87 @@
+-- Verify tet:indicateur/reconciliation_formules on pg
+
+BEGIN;
+
+DO $$
+DECLARE
+    claim_index_definition text;
+    target_index_definition text;
+BEGIN
+    ASSERT to_regclass('private.indicateur_reconciliation_formule') IS NOT NULL,
+        'La file durable de réconciliation des formules doit exister';
+
+    ASSERT (
+        SELECT COUNT(*) = 10
+        FROM information_schema.columns
+        WHERE table_schema = 'private'
+          AND table_name = 'indicateur_reconciliation_formule'
+          AND column_name IN (
+              'id', 'generation', 'indicateur_id', 'collectivite_id',
+              'formule_attendue', 'created_at', 'next_attempt_at', 'failure_count',
+              'last_failed_at', 'last_error'
+          )
+    ), 'La file doit exposer exactement les dix colonnes attendues';
+
+    ASSERT (
+        SELECT COUNT(*) = 3
+        FROM information_schema.columns
+        WHERE table_schema = 'private'
+          AND table_name = 'indicateur_reconciliation_formule'
+          AND column_name IN ('formule_attendue', 'last_failed_at', 'last_error')
+          AND is_nullable = 'YES'
+    ), 'Seules les informations de formule retirée et de dernier échec sont optionnelles';
+
+    ASSERT (
+        SELECT COUNT(*) = 7
+        FROM information_schema.columns
+        WHERE table_schema = 'private'
+          AND table_name = 'indicateur_reconciliation_formule'
+          AND column_name IN (
+              'id', 'generation', 'indicateur_id', 'collectivite_id',
+              'created_at', 'next_attempt_at', 'failure_count'
+          )
+          AND is_nullable = 'NO'
+    ), 'Toutes les autres colonnes de la file doivent être NOT NULL';
+
+    ASSERT (
+        SELECT COUNT(*) = 2
+        FROM information_schema.table_constraints
+        WHERE table_schema = 'private'
+          AND table_name = 'indicateur_reconciliation_formule'
+          AND constraint_type = 'FOREIGN KEY'
+    ), 'La cible et la collectivité doivent être protégées par des clés étrangères';
+
+    SELECT pg_get_indexdef(indexrelid)
+    INTO claim_index_definition
+    FROM pg_index
+    WHERE indexrelid =
+        'private.indicateur_reconciliation_formule_claim_idx'::regclass;
+
+    ASSERT claim_index_definition LIKE '%next_attempt_at%failure_count%created_at%indicateur_id%collectivite_id%id%',
+        'L''index de revendication doit porter l''ordre stable de traitement';
+
+    SELECT pg_get_indexdef(indexrelid)
+    INTO target_index_definition
+    FROM pg_index
+    WHERE indexrelid =
+        'private.indicateur_reconciliation_formule_target_idx'::regclass;
+
+    ASSERT target_index_definition LIKE '%indicateur_id%next_attempt_at%created_at%collectivite_id%id%',
+        'Le drain prioritaire d''un import doit disposer de son index par cible';
+
+    ASSERT NOT has_table_privilege(
+        'anon',
+        'private.indicateur_reconciliation_formule',
+        'SELECT'
+    ) AND NOT has_table_privilege(
+        'authenticated',
+        'private.indicateur_reconciliation_formule',
+        'SELECT'
+    ) AND NOT has_table_privilege(
+        'service_role',
+        'private.indicateur_reconciliation_formule',
+        'SELECT'
+    ), 'La file interne ne doit être lisible par aucun rôle API';
+END $$;
+
+ROLLBACK;

--- a/data_layer/tests/indicateur/periodicite-migration-lifecycle-database.sh
+++ b/data_layer/tests/indicateur/periodicite-migration-lifecycle-database.sh
@@ -1,0 +1,326 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly database_name_pattern='^periodicite_migration_lifecycle_test_[a-zA-Z0-9_]+$'
+
+fail() {
+  echo "ERREUR: $*" >&2
+  exit 2
+}
+
+normalize_database_url() {
+  local database_url="${1#db:}"
+
+  case "$database_url" in
+    pg://*) printf 'postgresql://%s\n' "${database_url#pg://}" ;;
+    postgres://* | postgresql://*) printf '%s\n' "$database_url" ;;
+    *) fail 'PERIODICITE_MIGRATION_ADMIN_DATABASE_URL doit être une URL PostgreSQL' ;;
+  esac
+}
+
+validate_database_name() {
+  local database_name="$1"
+
+  [[ "$database_name" =~ $database_name_pattern ]] ||
+    fail "nom de base de cycle de vie inattendu: '$database_name'"
+  ((${#database_name} <= 63)) ||
+    fail 'le nom de la base de cycle de vie dépasse 63 caractères'
+}
+
+validate_query() {
+  local query="$1"
+  local -a parameters=()
+  local parameter
+  local key
+
+  [[ -z "$query" ]] && return
+
+  IFS='&' read -r -a parameters <<<"$query"
+  for parameter in "${parameters[@]}"; do
+    [[ "$parameter" == *=* ]] || fail "paramètre de connexion mal formé: '$parameter'"
+    key="${parameter%%=*}"
+    case "$key" in
+      application_name | connect_timeout | sslmode) ;;
+      *) fail "paramètre de connexion non autorisé: '$key'" ;;
+    esac
+  done
+}
+
+build_database_url() {
+  local admin_database_url
+  local database_name="$2"
+  local database_url_without_query
+  local query=''
+
+  admin_database_url="$(normalize_database_url "$1")"
+  validate_database_name "$database_name"
+  [[ "$admin_database_url" != *'#'* ]] || fail "l'URL PostgreSQL ne doit pas contenir de fragment"
+
+  database_url_without_query="${admin_database_url%%\?*}"
+  if [[ "$admin_database_url" == *\?* ]]; then
+    query="${admin_database_url#*\?}"
+  fi
+
+  [[ "$database_url_without_query" =~ ^postgres(ql)?://.+/[^/?]+$ ]] ||
+    fail 'PERIODICITE_MIGRATION_ADMIN_DATABASE_URL doit être une URL PostgreSQL avec une base explicite'
+  validate_query "$query"
+
+  if [[ -n "$query" ]]; then
+    printf '%s/%s?%s\n' "${database_url_without_query%/*}" "$database_name" "$query"
+  else
+    printf '%s/%s\n' "${database_url_without_query%/*}" "$database_name"
+  fi
+}
+
+assert_local_disposable_url() {
+  local database_url="$1"
+  local database_name="$2"
+  local database_url_without_query="${database_url%%\?*}"
+  local authority_and_path="${database_url_without_query#*://}"
+  local authority="${authority_and_path%%/*}"
+  local host_and_port="${authority##*@}"
+  local url_database_name="${database_url_without_query##*/}"
+
+  validate_database_name "$database_name"
+  [[ "$url_database_name" == "$database_name" ]] ||
+    fail "l'URL ne cible pas la base jetable attendue '$database_name'"
+
+  if [[ ! "$host_and_port" =~ ^(localhost|127\.0\.0\.1|supabase_db_tet)(:[0-9]+)?$ ]] &&
+    [[ ! "$host_and_port" =~ ^\[::1\](:[0-9]+)?$ ]]; then
+    fail "le cycle destructif exige la base Supabase CI ou une adresse loopback, pas '$host_and_port'"
+  fi
+}
+
+clone_database_schema() {
+  local source_database_url="$1"
+  local target_database_name="$2"
+  local schema_archive
+  local schema_toc
+  local filtered_schema_toc
+  local registry_archive
+  local excluded_pg_cron_entries
+  local superuser_password="${POSTGRES_PASSWORD:-}"
+  local source_state
+  local target_state
+
+  [[ -n "$superuser_password" ]] ||
+    fail 'POSTGRES_PASSWORD est obligatoire pour restaurer le clone avec supabase_admin'
+
+  source_state="$(
+    psql \
+      --quiet \
+      --no-psqlrc \
+      --tuples-only \
+      --no-align \
+      --set=ON_ERROR_STOP=1 \
+      --dbname="$source_database_url" \
+      --command="
+        SELECT count(*) = 4
+        FROM sqitch.changes
+        WHERE project = 'tet'
+          AND change IN (
+            'indicateur/periodicite',
+            'indicateur/import_emt_valeur',
+            'indicateur/reconciliation_formules',
+            'indicateur/dependances_formules'
+          )
+      "
+  )"
+  [[ "$source_state" == 't' ]] ||
+    fail 'la base préparée ne contient pas le expand complet de périodicité'
+
+  schema_archive="$(mktemp)"
+  schema_toc="$(mktemp)"
+  filtered_schema_toc="$(mktemp)"
+  registry_archive="$(mktemp)"
+  trap 'rm -f "${schema_archive:-}" "${schema_toc:-}" "${filtered_schema_toc:-}" "${registry_archive:-}"' EXIT
+
+  pg_dump \
+    "$source_database_url" \
+    --format=custom \
+    --schema-only \
+    --exclude-schema=posthog \
+    --exclude-schema=graphql_public \
+    --file="$schema_archive"
+  pg_restore --list "$schema_archive" >"$schema_toc"
+
+  excluded_pg_cron_entries="$(
+    awk '
+      / EXTENSION - pg_cron[[:space:]]*$/ || / COMMENT - EXTENSION pg_cron[[:space:]]*$/ { count++ }
+      END { print count + 0 }
+    ' "$schema_toc"
+  )"
+  case "$excluded_pg_cron_entries" in
+    0 | 2) ;;
+    *) fail "archive inattendue: $excluded_pg_cron_entries entrées pg_cron trouvées" ;;
+  esac
+
+  # Extension-owned functions can leave ACL entries in the archive even when
+  # their schema is excluded. Keep the ACLs for all schemas restored below.
+  sed \
+    -e '/ EXTENSION - pg_cron[[:space:]]*$/d' \
+    -e '/ COMMENT - EXTENSION pg_cron[[:space:]]*$/d' \
+    -e '/ ACL - SCHEMA \(cron\|graphql_public\|posthog\)[[:space:]]/d' \
+    -e '/ ACL \(cron\|graphql_public\|posthog\) /d' \
+    -e '/ DEFAULT ACL \(cron\|graphql_public\|posthog\) /d' \
+    "$schema_toc" >"$filtered_schema_toc"
+
+  PGPASSWORD="$superuser_password" pg_restore \
+    --exit-on-error \
+    --use-list="$filtered_schema_toc" \
+    --username=supabase_admin \
+    --dbname="$target_database_name" \
+    "$schema_archive"
+
+  pg_dump \
+    "$source_database_url" \
+    --format=custom \
+    --data-only \
+    --schema=sqitch \
+    --file="$registry_archive"
+  PGPASSWORD="$superuser_password" pg_restore \
+    --exit-on-error \
+    --username=supabase_admin \
+    --dbname="$target_database_name" \
+    "$registry_archive"
+
+  # pg_dump restaure les vues matérialisées WITH NO DATA. Les scripts de
+  # reporting de la migration lisent celle-ci pendant le revert et le deploy.
+  PGPASSWORD="$superuser_password" psql \
+    --quiet \
+    --no-psqlrc \
+    --set=ON_ERROR_STOP=1 \
+    --username=supabase_admin \
+    --dbname="$target_database_name" \
+    --command='REFRESH MATERIALIZED VIEW stats.collectivite'
+
+  target_state="$(
+    PGPASSWORD="$superuser_password" psql \
+      --quiet \
+      --no-psqlrc \
+      --tuples-only \
+      --no-align \
+      --set=ON_ERROR_STOP=1 \
+      --dbname="$target_database_name" \
+      --username=supabase_admin \
+      --command="
+        SELECT concat_ws('|',
+          to_regclass('public.indicateur_periodicite'),
+          to_regclass('migration.indicateur_valeur_periodicite_audit'),
+          count(*) = 4
+        )
+        FROM sqitch.changes
+        WHERE project = 'tet'
+          AND change IN (
+            'indicateur/periodicite',
+            'indicateur/import_emt_valeur',
+            'indicateur/reconciliation_formules',
+            'indicateur/dependances_formules'
+          )
+      "
+  )"
+  [[ "$target_state" == 'indicateur_periodicite|migration.indicateur_valeur_periodicite_audit|t' ]] ||
+    fail "clone de schéma incomplet: '$target_state'"
+}
+
+assert_pre_expand() {
+  local database_url="$1"
+  local pre_expand_state
+
+  pre_expand_state="$(
+    psql \
+      --quiet \
+      --no-psqlrc \
+      --tuples-only \
+      --no-align \
+      --set=ON_ERROR_STOP=1 \
+      --dbname="$database_url" \
+      --command="
+        SELECT concat_ws('|',
+          to_regclass('public.indicateur_periodicite') IS NULL,
+          NOT EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'indicateur_definition'
+              AND column_name = 'periodicite'
+          ),
+          to_regclass('private.indicateur_reconciliation_formule') IS NULL,
+          to_regprocedure('private.extraire_dependances_formule_indicateur(text)') IS NULL,
+          NOT EXISTS (
+            SELECT 1
+            FROM sqitch.changes
+            WHERE project = 'tet'
+              AND change IN (
+                'indicateur/periodicite',
+                'indicateur/import_emt_valeur',
+                'indicateur/reconciliation_formules',
+                'indicateur/dependances_formules',
+                'indicateur/periodicite_obligatoire',
+                'indicateur/periodicite_formules',
+                'stats/report_indicateur_resultat_periode'
+              )
+          )
+        )
+      "
+  )"
+  [[ "$pre_expand_state" == 't|t|t|t|t' ]] ||
+    fail "la base jetable n'est pas exactement pré-expand: '$pre_expand_state'"
+}
+
+command="${1:-}"
+admin_database_url="${PERIODICITE_MIGRATION_ADMIN_DATABASE_URL:-}"
+database_name="${PERIODICITE_MIGRATION_DATABASE_NAME:-}"
+
+[[ -n "$command" ]] || fail 'commande attendue: database-url, assert-disposable-url, create, assert-pre-expand ou drop'
+[[ -n "$admin_database_url" ]] || fail 'PERIODICITE_MIGRATION_ADMIN_DATABASE_URL est obligatoire'
+[[ -n "$database_name" ]] || fail 'PERIODICITE_MIGRATION_DATABASE_NAME est obligatoire'
+
+database_url="$(build_database_url "$admin_database_url" "$database_name")"
+admin_database_url="$(normalize_database_url "$admin_database_url")"
+
+case "$command" in
+  database-url)
+    printf '%s\n' "$database_url"
+    ;;
+  assert-disposable-url)
+    assert_local_disposable_url "$admin_database_url" "$database_name"
+    ;;
+  create)
+    command -v createdb >/dev/null || fail 'createdb est introuvable'
+    command -v dropdb >/dev/null || fail 'dropdb est introuvable'
+    command -v awk >/dev/null || fail 'awk est introuvable'
+    command -v pg_dump >/dev/null || fail 'pg_dump est introuvable'
+    command -v pg_restore >/dev/null || fail 'pg_restore est introuvable'
+    command -v psql >/dev/null || fail 'psql est introuvable'
+    command -v sed >/dev/null || fail 'sed est introuvable'
+
+    createdb --maintenance-db="$admin_database_url" "$database_name"
+    # An `if ! clone...` condition disables errexit inside the whole function.
+    # Run the clone unconditionally so a failed restore stops before later ACLs
+    # or validation can make an incomplete database look successful. This trap
+    # belongs to the parent; the subshell owns its temporary-file cleanup.
+    trap 'echo "ERREUR: clone de schéma incomplet; suppression de la base jetable." >&2
+      dropdb \
+        --if-exists \
+        --force \
+        --maintenance-db="$admin_database_url" \
+        "$database_name" >/dev/null' ERR
+    (clone_database_schema "$admin_database_url" "$database_name")
+    trap - ERR
+    ;;
+  assert-pre-expand)
+    command -v psql >/dev/null || fail 'psql est introuvable'
+    assert_pre_expand "$database_url"
+    ;;
+  drop)
+    command -v dropdb >/dev/null || fail 'dropdb est introuvable'
+    dropdb \
+      --if-exists \
+      --force \
+      --maintenance-db="$admin_database_url" \
+      "$database_name"
+    ;;
+  *) fail "commande inconnue: '$command'" ;;
+esac

--- a/data_layer/tests/indicateur/periodicite-migration-lifecycle-database.spec.sh
+++ b/data_layer/tests/indicateur/periodicite-migration-lifecycle-database.spec.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+database_script="$script_dir/periodicite-migration-lifecycle-database.sh"
+valid_name='periodicite_migration_lifecycle_test_123_4'
+
+database_url="$({
+  PERIODICITE_MIGRATION_ADMIN_DATABASE_URL='db:postgresql://postgres:p%40ss@database:5432/postgres?sslmode=disable&connect_timeout=5'
+  PERIODICITE_MIGRATION_DATABASE_NAME="$valid_name"
+  export PERIODICITE_MIGRATION_ADMIN_DATABASE_URL PERIODICITE_MIGRATION_DATABASE_NAME
+  bash "$database_script" database-url
+})"
+
+expected_url="postgresql://postgres:p%40ss@database:5432/$valid_name?sslmode=disable&connect_timeout=5"
+if [[ "$database_url" != "$expected_url" ]]; then
+  echo "ÉCHEC: URL attendue '$expected_url', obtenue '$database_url'." >&2
+  exit 1
+fi
+
+normalized_pg_url="$({
+  PERIODICITE_MIGRATION_ADMIN_DATABASE_URL='db:pg://postgres:postgres@supabase_db_tet:5432/postgres'
+  PERIODICITE_MIGRATION_DATABASE_NAME="$valid_name"
+  export PERIODICITE_MIGRATION_ADMIN_DATABASE_URL PERIODICITE_MIGRATION_DATABASE_NAME
+  bash "$database_script" database-url
+})"
+expected_pg_url="postgresql://postgres:postgres@supabase_db_tet:5432/$valid_name"
+if [[ "$normalized_pg_url" != "$expected_pg_url" ]]; then
+  echo "ÉCHEC: URL pg normalisée attendue '$expected_pg_url', obtenue '$normalized_pg_url'." >&2
+  exit 1
+fi
+
+for local_url in \
+  "postgresql://postgres:postgres@127.0.0.1:54322/$valid_name" \
+  "postgresql://postgres:postgres@localhost/$valid_name" \
+  "db:pg://postgres:postgres@supabase_db_tet:5432/$valid_name"; do
+  PERIODICITE_MIGRATION_ADMIN_DATABASE_URL="$local_url" \
+    PERIODICITE_MIGRATION_DATABASE_NAME="$valid_name" \
+    bash "$database_script" assert-disposable-url
+done
+
+expect_rejection() {
+  local admin_database_url="$1"
+  local database_name="$2"
+  local command="${3:-database-url}"
+
+  if PERIODICITE_MIGRATION_ADMIN_DATABASE_URL="$admin_database_url" \
+    PERIODICITE_MIGRATION_DATABASE_NAME="$database_name" \
+    bash "$database_script" "$command" >/dev/null 2>&1; then
+    echo "ÉCHEC: la commande '$command' a accepté '$admin_database_url' / '$database_name'." >&2
+    exit 1
+  fi
+}
+
+expect_rejection 'https://database/postgres' "$valid_name"
+expect_rejection 'postgresql://database' "$valid_name"
+expect_rejection 'postgresql://database/postgres#fragment' "$valid_name"
+expect_rejection 'postgresql://database/postgres?dbname=postgres' "$valid_name"
+expect_rejection 'postgresql://database/postgres?host=elsewhere' "$valid_name"
+expect_rejection 'postgresql://database/postgres' 'postgres'
+expect_rejection 'postgresql://database/postgres' 'contest'
+expect_rejection 'postgresql://database/postgres' 'latest'
+expect_rejection 'postgresql://database/postgres' 'periodicite_migration_lifecycle_test_bad-name'
+expect_rejection 'postgresql://database/postgres' 'periodicite_migration_lifecycle_test_123_4' destroy
+expect_rejection "postgresql://postgres:secret@db.example.com/$valid_name" "$valid_name" assert-disposable-url
+expect_rejection "postgresql://postgres:secret@127.0.0.1/postgres" "$valid_name" assert-disposable-url
+expect_rejection "postgresql://postgres:secret@127.0.0.1/$valid_name?host=db.example.com" "$valid_name" assert-disposable-url
+
+echo 'Contrat du gestionnaire de base jetable de périodicité validé.'
+
+# Exercise the clone command as a separate shell, just like the CI docker exec.
+# In particular, a failed pg_restore must stop before the registry is restored.
+mock_directory="$(mktemp -d)"
+trap 'rm -rf "$mock_directory"' EXIT
+mkdir "$mock_directory/bin"
+cat > "$mock_directory/bin/postgres-test-command" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+command_name="${0##*/}"
+printf '%s\n' "$command_name" >> "$CLONE_TEST_TRACE"
+case "$command_name" in
+  psql)
+    if [[ "$*" == *'concat_ws'* ]]; then
+      echo 'indicateur_periodicite|migration.indicateur_valeur_periodicite_audit|t'
+    elif [[ "$*" == *'SELECT count(*)'* ]]; then
+      echo t
+    fi
+    ;;
+  pg_restore)
+    if [[ "${1:-}" == --list ]]; then
+      cat <<'TOC'
+1; 0 0 EXTENSION - pg_cron
+2; 0 0 COMMENT - EXTENSION pg_cron
+3; 0 0 ACL - SCHEMA cron supabase_admin
+4; 0 0 ACL cron TABLE job supabase_admin
+5; 0 0 DEFAULT ACL cron DEFAULT PRIVILEGES FOR TABLES supabase_admin
+6; 0 0 ACL - SCHEMA graphql_public supabase_admin
+7; 0 0 ACL graphql_public FUNCTION graphql(text, text, jsonb, jsonb) supabase_admin
+8; 0 0 DEFAULT ACL graphql_public DEFAULT PRIVILEGES FOR FUNCTIONS supabase_admin
+9; 0 0 ACL - SCHEMA posthog postgres
+10; 0 0 ACL posthog TABLE events postgres
+11; 0 0 DEFAULT ACL posthog DEFAULT PRIVILEGES FOR TABLES postgres
+12; 0 0 ACL storage TABLE buckets supabase_storage_admin
+TOC
+    else
+      for argument in "$@"; do
+        if [[ "$argument" == --use-list=* ]]; then
+          cat "${argument#--use-list=}" > "$CLONE_TEST_FILTERED_TOC"
+          if [[ "${CLONE_TEST_FAIL_RESTORE:-false}" == true ]]; then
+            echo 'forced schema pg_restore failure' >&2
+            exit 17
+          fi
+        fi
+      done
+    fi
+    ;;
+esac
+MOCK
+chmod +x "$mock_directory/bin/postgres-test-command"
+for postgres_command in createdb dropdb pg_dump pg_restore psql; do
+  ln -s postgres-test-command "$mock_directory/bin/$postgres_command"
+done
+
+export CLONE_TEST_TRACE="$mock_directory/commands.log"
+export CLONE_TEST_FILTERED_TOC="$mock_directory/filtered.toc"
+export PERIODICITE_MIGRATION_ADMIN_DATABASE_URL='postgresql://postgres:test-only@localhost/postgres'
+export PERIODICITE_MIGRATION_DATABASE_NAME="$valid_name"
+export POSTGRES_PASSWORD='test-only'
+
+if PATH="$mock_directory/bin:$PATH" CLONE_TEST_FAIL_RESTORE=true \
+  bash "$database_script" create >"$mock_directory/failure.log" 2>&1; then
+  echo 'ÉCHEC: une restauration de schéma échouée a été considérée comme réussie.' >&2
+  exit 1
+else
+  restore_status=$?
+fi
+[[ "$restore_status" == 17 ]] || {
+  cat "$mock_directory/failure.log" >&2
+  echo "ÉCHEC: le statut pg_restore n'a pas été propagé ($restore_status)." >&2
+  exit 1
+}
+[[ "$(awk '$0 == "dropdb" { count++ } END { print count + 0 }' "$CLONE_TEST_TRACE")" == 1 ]] || {
+  echo 'ÉCHEC: le clone incomplet doit être supprimé exactement une fois.' >&2
+  exit 1
+}
+[[ "$(awk '$0 == "pg_dump" { count++ } END { print count + 0 }' "$CLONE_TEST_TRACE")" == 1 ]] || {
+  echo 'ÉCHEC: le registre ne doit pas être copié après un échec de restauration du schéma.' >&2
+  exit 1
+}
+[[ "$(cat "$CLONE_TEST_FILTERED_TOC")" == '12; 0 0 ACL storage TABLE buckets supabase_storage_admin' ]] || {
+  echo 'ÉCHEC: seuls les ACL des schémas exclus doivent être retirés du TOC.' >&2
+  exit 1
+}
+
+: > "$CLONE_TEST_TRACE"
+PATH="$mock_directory/bin:$PATH" bash "$database_script" create
+if grep -q '^dropdb$' "$CLONE_TEST_TRACE"; then
+  echo 'ÉCHEC: le clone réussi ne doit pas être supprimé.' >&2
+  exit 1
+fi
+
+echo 'Échec de restauration, nettoyage du clone et filtrage des ACL exclus validés.'

--- a/data_layer/tests/indicateur/periodicite-migration-lifecycle.sh
+++ b/data_layer/tests/indicateur/periodicite-migration-lifecycle.sh
@@ -1,0 +1,340 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+database_url="${PERIODICITE_MIGRATION_TEST_DATABASE_URL:-}"
+if [[ -z "$database_url" ]]; then
+  echo "PERIODICITE_MIGRATION_TEST_DATABASE_URL doit cibler une base jetable déjà initialisée, avant la migration." >&2
+  exit 2
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repository_root="$(cd "$script_dir/../../.." && pwd)"
+database_manager="$script_dir/periodicite-migration-lifecycle-database.sh"
+
+psql_test() {
+  psql --quiet --no-psqlrc --set=ON_ERROR_STOP=1 --dbname="$database_url" "$@"
+}
+
+scalar() {
+  psql_test --tuples-only --no-align --command="$1"
+}
+
+assert_equal() {
+  local expected="$1"
+  local actual="$2"
+  local message="$3"
+  if [[ "$actual" != "$expected" ]]; then
+    echo "ÉCHEC: $message (attendu: $expected, obtenu: $actual)" >&2
+    exit 1
+  fi
+}
+
+apply_change() {
+  psql_test --file="$repository_root/$1" >/dev/null
+}
+
+expect_change_failure() {
+  local change="$1"
+  local message="$2"
+  if psql_test --file="$repository_root/$change" >/dev/null 2>&1; then
+    echo "ÉCHEC: $message" >&2
+    exit 1
+  fi
+}
+
+wait_for_sleeping_session() {
+  local application_name="$1"
+  local attempt
+  for attempt in {1..50}; do
+    if [[ "$(scalar "SELECT count(*) FROM pg_stat_activity WHERE application_name = '$application_name' AND wait_event = 'PgSleep'")" == "1" ]]; then
+      return
+    fi
+    sleep 0.1
+  done
+  echo "ÉCHEC: la session concurrente $application_name n'a pas atteint son point de synchronisation" >&2
+  exit 1
+}
+
+wait_for_advisory_lock_session() {
+  local application_name="$1"
+  local attempt
+  for attempt in {1..50}; do
+    if [[ "$(scalar "SELECT count(*) FROM pg_locks verrou JOIN pg_stat_activity session ON session.pid = verrou.pid WHERE session.application_name = '$application_name' AND verrou.locktype = 'advisory' AND NOT verrou.granted")" == "1" ]]; then
+      return
+    fi
+    sleep 0.1
+  done
+  echo "ÉCHEC: la session concurrente $application_name n'attend pas le verrou du graphe" >&2
+  exit 1
+}
+
+wait_for_relation_lock_session() {
+  local application_name="$1"
+  local attempt
+  for attempt in {1..50}; do
+    if [[ "$(scalar "SELECT count(*) FROM pg_locks verrou JOIN pg_stat_activity session ON session.pid = verrou.pid WHERE session.application_name = '$application_name' AND verrou.locktype = 'relation' AND NOT verrou.granted")" != "0" ]]; then
+      return
+    fi
+    sleep 0.1
+  done
+  echo "ÉCHEC: la session concurrente $application_name n'attend pas un verrou de table" >&2
+  exit 1
+}
+
+database_name="$(scalar 'SELECT current_database()')"
+PERIODICITE_MIGRATION_ADMIN_DATABASE_URL="$database_url" \
+  PERIODICITE_MIGRATION_DATABASE_NAME="$database_name" \
+  bash "$database_manager" assert-disposable-url
+
+assert_equal "" "$(scalar "SELECT to_regclass('public.indicateur_periodicite')")" \
+  "la base doit être positionnée avant l'étape expand"
+assert_equal "0" "$(scalar "SELECT count(*) FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'indicateur_definition' AND column_name = 'periodicite'")" \
+  "la colonne de périodicité ne doit pas encore exister"
+
+fixture_suffix="${BASHPID}-$(date +%s%N)"
+collectivite_id="$(scalar "INSERT INTO public.collectivite (nom, type) VALUES ('Cycle périodicité $fixture_suffix', 'epci') RETURNING id")"
+origin_id="$(scalar "INSERT INTO public.indicateur_definition (collectivite_id, titre, unite) VALUES ($collectivite_id, 'cycle-origin-$fixture_suffix', 'kWh') RETURNING id")"
+target_id="$(scalar "INSERT INTO public.indicateur_definition (collectivite_id, titre, unite) VALUES ($collectivite_id, 'cycle-target-$fixture_suffix', 'kWh') RETURNING id")"
+concurrency_id="$(scalar "INSERT INTO public.indicateur_definition (collectivite_id, titre, unite) VALUES ($collectivite_id, 'cycle-concurrence-$fixture_suffix', 'kWh') RETURNING id")"
+conflict_id="$(scalar "INSERT INTO public.indicateur_definition (collectivite_id, titre, unite) VALUES ($collectivite_id, 'cycle-conflit-$fixture_suffix', 'kWh') RETURNING id")"
+emt_id="$(scalar "INSERT INTO public.indicateur_definition (identifiant_referentiel, titre, unite) VALUES ('cycle-emt-$fixture_suffix', 'cycle-emt-$fixture_suffix', 'kWh') RETURNING id")"
+emt_second_id="$(scalar "INSERT INTO public.indicateur_definition (identifiant_referentiel, titre, unite) VALUES ('cycle-emt-second-$fixture_suffix', 'cycle-emt-second-$fixture_suffix', 'kWh') RETURNING id")"
+expand_delete_id="$(scalar "INSERT INTO public.indicateur_definition (collectivite_id, titre, unite) VALUES ($collectivite_id, 'cycle-expand-delete-$fixture_suffix', 'kWh') RETURNING id")"
+
+origin_value_id="$(scalar "INSERT INTO public.indicateur_valeur (indicateur_id, collectivite_id, date_valeur, resultat) VALUES ($origin_id, $collectivite_id, DATE '2020-02-01', 1) RETURNING id")"
+scalar "INSERT INTO public.indicateur_valeur (indicateur_id, collectivite_id, date_valeur, resultat) VALUES ($conflict_id, $collectivite_id, DATE '2019-02-01', 1), ($conflict_id, $collectivite_id, DATE '2019-03-01', 2)" >/dev/null
+scalar "INSERT INTO public.indicateur_valeur (indicateur_id, collectivite_id, date_valeur, resultat) VALUES ($expand_delete_id, $collectivite_id, DATE '2020-01-01', 1)" >/dev/null
+
+expand_migration_log="$(mktemp)"
+expand_delete_log="$(mktemp)"
+transition_log="$(mktemp)"
+graph_definition_log="$(mktemp)"
+graph_value_log="$(mktemp)"
+emt_definition_log="$(mktemp)"
+emt_writer_log="$(mktemp)"
+emt_lock_first_log="$(mktemp)"
+emt_lock_second_log="$(mktemp)"
+reconciliation_producer_log="$(mktemp)"
+reconciliation_revert_log="$(mktemp)"
+reconciliation_reader_log="$(mktemp)"
+trap 'rm -f "$expand_migration_log" "$expand_delete_log" "$transition_log" "$graph_definition_log" "$graph_value_log" "$emt_definition_log" "$emt_writer_log" "$emt_lock_first_log" "$emt_lock_second_log" "$reconciliation_producer_log" "$reconciliation_revert_log" "$reconciliation_reader_log"' EXIT
+
+# L'expand prend définition puis valeur. Une ancienne suppression avec cascade
+# arrivée ensuite attend donc sans détenir la table de valeurs : la migration
+# peut progresser, puis la suppression se termine sans interblocage.
+psql_test --command="SET application_name = 'periodicite-lifecycle-expand-migration'; BEGIN; LOCK TABLE public.indicateur_definition IN SHARE ROW EXCLUSIVE MODE; SELECT pg_sleep(3); LOCK TABLE public.indicateur_valeur IN SHARE ROW EXCLUSIVE MODE; COMMIT" >"$expand_migration_log" 2>&1 &
+expand_migration_pid=$!
+wait_for_sleeping_session periodicite-lifecycle-expand-migration
+psql_test --command="SET application_name = 'periodicite-lifecycle-expand-delete'; DELETE FROM public.indicateur_definition WHERE id = $expand_delete_id" >"$expand_delete_log" 2>&1 &
+expand_delete_pid=$!
+wait_for_relation_lock_session periodicite-lifecycle-expand-delete
+wait "$expand_migration_pid"
+wait "$expand_delete_pid"
+assert_equal "0" "$(scalar "SELECT count(*) FROM public.indicateur_definition WHERE id = $expand_delete_id")" \
+  "l'ordre définition puis valeur de l'expand doit laisser finir une ancienne suppression en cascade"
+
+apply_change data_layer/sqitch/deploy/indicateur/periodicite.sql
+apply_change data_layer/sqitch/verify/indicateur/periodicite.sql
+apply_change data_layer/sqitch/deploy/indicateur/import_emt_valeur.sql
+apply_change data_layer/sqitch/verify/indicateur/import_emt_valeur.sql
+apply_change data_layer/sqitch/deploy/indicateur/reconciliation_formules.sql
+apply_change data_layer/sqitch/verify/indicateur/reconciliation_formules.sql
+apply_change data_layer/sqitch/deploy/indicateur/dependances_formules.sql
+apply_change data_layer/sqitch/verify/indicateur/dependances_formules.sql
+assert_equal "2020-01-01|2020-02-01|normalisee" \
+  "$(scalar "SELECT valeur.date_valeur || '|' || audit.date_valeur_avant || '|' || audit.statut FROM public.indicateur_valeur valeur JOIN migration.indicateur_valeur_periodicite_audit audit ON audit.valeur_id = valeur.id WHERE valeur.id = $origin_value_id")" \
+  "l'expand doit normaliser et auditer une date historique sans collision"
+assert_equal "2" "$(scalar "SELECT count(*) FROM migration.indicateur_valeur_periodicite_audit WHERE indicateur_id = $conflict_id AND statut = 'conflit'")" \
+  "l'expand doit auditer sans fusionner les collisions historiques"
+
+scalar "DELETE FROM public.indicateur_valeur WHERE indicateur_id = $conflict_id AND date_valeur = DATE '2019-03-01'; UPDATE public.indicateur_valeur SET date_valeur = DATE '2019-01-01' WHERE indicateur_id = $conflict_id" >/dev/null
+assert_equal "0" "$(scalar "SELECT count(*) FROM migration.indicateur_valeur_periodicite_audit WHERE indicateur_id = $conflict_id")" \
+  "la remédiation explicite doit assainir les audits de conflit"
+
+# Simule indicateur_valeur restaurée sans triggers durant la phase expand. Le
+# post-traitement doit rejouer l'audit transitoire et conserver son historique.
+scalar "ALTER TABLE public.indicateur_valeur DISABLE TRIGGER USER" >/dev/null
+expand_restore_value_id="$(scalar "INSERT INTO public.indicateur_valeur (indicateur_id, collectivite_id, date_valeur, resultat) VALUES ($target_id, $collectivite_id, DATE '2025-02-01', 7) RETURNING id")"
+scalar "ALTER TABLE public.indicateur_valeur ENABLE TRIGGER USER" >/dev/null
+apply_change data_layer/backup/rebuild-indicateur-formula-state.sql
+assert_equal "2025-01-01|2025-02-01|normalisee" \
+  "$(scalar "SELECT valeur.date_valeur || '|' || audit.date_valeur_avant || '|' || audit.statut FROM public.indicateur_valeur valeur JOIN migration.indicateur_valeur_periodicite_audit audit ON audit.valeur_id = valeur.id WHERE valeur.id = $expand_restore_value_id")" \
+  "le post-traitement expand doit normaliser et auditer une valeur restaurée sans triggers"
+
+psql_test --command="SET application_name = 'periodicite-lifecycle-transition-writer'; BEGIN; INSERT INTO public.indicateur_valeur (indicateur_id, collectivite_id, date_valeur, resultat) VALUES ($concurrency_id, $collectivite_id, DATE '2021-02-01', 1); SELECT pg_sleep(3); COMMIT" >"$transition_log" 2>&1 &
+transition_pid=$!
+wait_for_sleeping_session periodicite-lifecycle-transition-writer
+if psql_test --command="INSERT INTO public.indicateur_valeur (indicateur_id, collectivite_id, date_valeur, resultat) VALUES ($concurrency_id, $collectivite_id, DATE '2021-03-01', 2)" >/dev/null 2>&1; then
+  echo "ÉCHEC: deux écritures historiques concurrentes ont occupé la même période canonique" >&2
+  exit 1
+fi
+wait "$transition_pid"
+assert_equal "1|2021-01-01" \
+  "$(scalar "SELECT count(*) || '|' || min(date_valeur) FROM public.indicateur_valeur WHERE indicateur_id = $concurrency_id AND resultat IN (1, 2)")" \
+  "les écritures de transition doivent se sérialiser sur la période canonique"
+
+# L'import EMT est déployable dès l'expand et participe au même ordre de
+# verrous que l'application. Si le changement de cadence gagne, l'import
+# attend puis refuse la définition devenue mensuelle sans écrire de valeur.
+psql_test --command="SET application_name = 'periodicite-lifecycle-emt-definition'; BEGIN; UPDATE public.indicateur_definition SET periodicite = 'mensuelle' WHERE id = $emt_id; SELECT pg_sleep(3); COMMIT" >"$emt_definition_log" 2>&1 &
+emt_definition_pid=$!
+wait_for_sleeping_session periodicite-lifecycle-emt-definition
+psql_test --command="SET application_name = 'periodicite-lifecycle-emt-writer'; SELECT public.import_indicateur_emt_valeurs($collectivite_id, jsonb_build_array(jsonb_build_object('indicateur_id', $emt_id, 'periodicite', 'annuelle', 'date_debut', '2030-01-01', 'resultat', 0, 'commentaire', 'cycle EMT')))" >"$emt_writer_log" 2>&1 &
+emt_writer_pid=$!
+wait_for_advisory_lock_session periodicite-lifecycle-emt-writer
+wait "$emt_definition_pid"
+if wait "$emt_writer_pid"; then
+  echo "ÉCHEC: l'import EMT a écrit après un changement concurrent vers mensuelle" >&2
+  exit 1
+fi
+assert_equal "mensuelle|0" \
+  "$(scalar "SELECT definition.periodicite || '|' || count(valeur.*) FROM public.indicateur_definition definition LEFT JOIN public.indicateur_valeur valeur ON valeur.indicateur_id = definition.id WHERE definition.id = $emt_id GROUP BY definition.periodicite")" \
+  "le changement de cadence validé en premier doit faire échouer l'import EMT"
+scalar "UPDATE public.indicateur_definition SET periodicite = 'annuelle' WHERE id = $emt_id" >/dev/null
+
+# Si le writer annuel gagne, il conserve son verrou partagé jusqu'au commit.
+# La mutation attend, puis le garde d'immuabilité voit la valeur et échoue.
+psql_test --command="SET application_name = 'periodicite-lifecycle-emt-writer'; BEGIN; SELECT pg_advisory_xact_lock_shared(hashtextextended('indicateur-calculation-graph', 0)); SELECT id FROM public.indicateur_definition WHERE id = $emt_id FOR SHARE; SELECT pg_sleep(3); SELECT public.import_indicateur_emt_valeurs($collectivite_id, jsonb_build_array(jsonb_build_object('indicateur_id', $emt_id, 'periodicite', 'annuelle', 'date_debut', '2030-01-01', 'resultat', 0, 'commentaire', 'cycle EMT'))); COMMIT" >"$emt_writer_log" 2>&1 &
+emt_writer_pid=$!
+wait_for_sleeping_session periodicite-lifecycle-emt-writer
+psql_test --command="SET application_name = 'periodicite-lifecycle-emt-definition'; UPDATE public.indicateur_definition SET periodicite = 'mensuelle' WHERE id = $emt_id" >"$emt_definition_log" 2>&1 &
+emt_definition_pid=$!
+wait_for_advisory_lock_session periodicite-lifecycle-emt-definition
+wait "$emt_writer_pid"
+if wait "$emt_definition_pid"; then
+  echo "ÉCHEC: un changement concurrent a invalidé la cadence d'une valeur EMT validée" >&2
+  exit 1
+fi
+assert_equal "annuelle|1|0" \
+  "$(scalar "SELECT definition.periodicite || '|' || count(valeur.*) || '|' || min(valeur.resultat) FROM public.indicateur_definition definition LEFT JOIN public.indicateur_valeur valeur ON valeur.indicateur_id = definition.id WHERE definition.id = $emt_id GROUP BY definition.periodicite")" \
+  "l'import EMT validé en premier doit conserver la cadence, la ligne et la valeur zéro"
+
+# Les verrous de valeur sont indexés par collectivité et date, pas par
+# indicateur. Une session retient volontairement 2035 pendant que l'autre lot
+# présente les mêmes dates dans l'ordre inverse de ses indicateurs. Avec une
+# pré-acquisition lexicographique, la seconde session n'emporte aucun verrou
+# ultérieur et les deux lots finissent sans interblocage.
+psql_test --command="SET application_name = 'periodicite-lifecycle-emt-lock-first'; BEGIN; SELECT pg_advisory_xact_lock(hashtextextended('indicateur-valeur:$collectivite_id:2035-01-01', 0)); SELECT pg_sleep(3); SELECT public.import_indicateur_emt_valeurs($collectivite_id, jsonb_build_array(jsonb_build_object('indicateur_id', $emt_id, 'periodicite', 'annuelle', 'date_debut', '2035-01-01', 'resultat', 1), jsonb_build_object('indicateur_id', $emt_second_id, 'periodicite', 'annuelle', 'date_debut', '2036-01-01', 'resultat', 2))); COMMIT" >"$emt_lock_first_log" 2>&1 &
+emt_lock_first_pid=$!
+wait_for_sleeping_session periodicite-lifecycle-emt-lock-first
+psql_test --command="SET application_name = 'periodicite-lifecycle-emt-lock-second'; SELECT public.import_indicateur_emt_valeurs($collectivite_id, jsonb_build_array(jsonb_build_object('indicateur_id', $emt_id, 'periodicite', 'annuelle', 'date_debut', '2036-01-01', 'resultat', 3), jsonb_build_object('indicateur_id', $emt_second_id, 'periodicite', 'annuelle', 'date_debut', '2035-01-01', 'resultat', 4)))" >"$emt_lock_second_log" 2>&1 &
+emt_lock_second_pid=$!
+wait_for_advisory_lock_session periodicite-lifecycle-emt-lock-second
+if ! wait "$emt_lock_first_pid"; then
+  cat "$emt_lock_first_log" >&2
+  echo "ÉCHEC: le premier lot EMT a échoué pendant la sérialisation multi-périodes" >&2
+  exit 1
+fi
+if ! wait "$emt_lock_second_pid"; then
+  cat "$emt_lock_second_log" >&2
+  echo "ÉCHEC: le second lot EMT a rencontré un interblocage multi-périodes" >&2
+  exit 1
+fi
+assert_equal "4" \
+  "$(scalar "SELECT count(*) FROM public.indicateur_valeur WHERE collectivite_id = $collectivite_id AND indicateur_id IN ($emt_id, $emt_second_id) AND date_valeur IN (DATE '2035-01-01', DATE '2036-01-01')")" \
+  "les lots EMT aux périodes croisées doivent tous deux être écrits"
+
+# Si un producteur de réconciliation valide son intention en premier, le
+# revert attend le verrou exclusif du graphe puis refuse de supprimer une file
+# non vide. Le contrôle de vacuité porte donc bien sur l'état commité.
+psql_test --command="SET application_name = 'periodicite-lifecycle-reconciliation-producer'; BEGIN; SELECT pg_advisory_xact_lock(hashtextextended('indicateur-calculation-graph', 0)); INSERT INTO private.indicateur_reconciliation_formule (generation, indicateur_id, collectivite_id, formule_attendue) VALUES (gen_random_uuid(), $target_id, $collectivite_id, '1'); SELECT pg_sleep(3); COMMIT" >"$reconciliation_producer_log" 2>&1 &
+reconciliation_producer_pid=$!
+wait_for_sleeping_session periodicite-lifecycle-reconciliation-producer
+psql_test \
+  --command="SET application_name = 'periodicite-lifecycle-reconciliation-revert'" \
+  --file="$repository_root/data_layer/sqitch/revert/indicateur/reconciliation_formules.sql" \
+  >"$reconciliation_revert_log" 2>&1 &
+reconciliation_revert_pid=$!
+wait_for_advisory_lock_session periodicite-lifecycle-reconciliation-revert
+wait "$reconciliation_producer_pid"
+if wait "$reconciliation_revert_pid"; then
+  echo "ÉCHEC: le revert a supprimé une file contenant une réconciliation validée" >&2
+  exit 1
+fi
+assert_equal "1" \
+  "$(scalar "SELECT count(*) FROM private.indicateur_reconciliation_formule WHERE indicateur_id = $target_id AND collectivite_id = $collectivite_id")" \
+  "le revert doit conserver la file et l'intention validée par le producteur"
+scalar "DELETE FROM private.indicateur_reconciliation_formule WHERE indicateur_id = $target_id AND collectivite_id = $collectivite_id" >/dev/null
+
+# Dans l'ordre inverse, un lecteur maintient provisoirement le revert entre le
+# verrou du graphe et son verrou ACCESS EXCLUSIVE. Un producteur arrivé ensuite
+# attend le graphe : il ne peut pas franchir le contrôle de vacuité avant le
+# DROP et échoue lorsque la relation a disparu.
+psql_test --command="SET application_name = 'periodicite-lifecycle-reconciliation-reader'; BEGIN; SELECT count(*) FROM private.indicateur_reconciliation_formule; SELECT pg_sleep(3); COMMIT" >"$reconciliation_reader_log" 2>&1 &
+reconciliation_reader_pid=$!
+wait_for_sleeping_session periodicite-lifecycle-reconciliation-reader
+psql_test \
+  --command="SET application_name = 'periodicite-lifecycle-reconciliation-revert'" \
+  --file="$repository_root/data_layer/sqitch/revert/indicateur/reconciliation_formules.sql" \
+  >"$reconciliation_revert_log" 2>&1 &
+reconciliation_revert_pid=$!
+wait_for_relation_lock_session periodicite-lifecycle-reconciliation-revert
+psql_test --command="SET application_name = 'periodicite-lifecycle-reconciliation-producer'; BEGIN; SELECT pg_advisory_xact_lock(hashtextextended('indicateur-calculation-graph', 0)); INSERT INTO private.indicateur_reconciliation_formule (generation, indicateur_id, collectivite_id, formule_attendue) VALUES (gen_random_uuid(), $target_id, $collectivite_id, '2'); COMMIT" >"$reconciliation_producer_log" 2>&1 &
+reconciliation_producer_pid=$!
+wait_for_advisory_lock_session periodicite-lifecycle-reconciliation-producer
+wait "$reconciliation_reader_pid"
+if ! wait "$reconciliation_revert_pid"; then
+  cat "$reconciliation_revert_log" >&2
+  echo "ÉCHEC: le revert n'a pas supprimé la file vide après avoir gagné la course" >&2
+  exit 1
+fi
+if wait "$reconciliation_producer_pid"; then
+  echo "ÉCHEC: un producteur a écrit dans la file après le contrôle de vacuité du revert" >&2
+  exit 1
+fi
+assert_equal "" \
+  "$(scalar "SELECT to_regclass('private.indicateur_reconciliation_formule')")" \
+  "le revert arrivé en premier doit supprimer entièrement la file"
+
+# Le changement doit rester rejouable après le scénario de rollback concurrent.
+apply_change data_layer/sqitch/deploy/indicateur/reconciliation_formules.sql
+apply_change data_layer/sqitch/verify/indicateur/reconciliation_formules.sql
+
+# Les triggers statement-level étendent le verrou du graphe aux écritures SQL
+# directes. Ils n'offrent toutefois ni le verrou applicatif par période, ni le
+# recalcul des dépendances. Ce test ne couvre que les deux ordres d'arrivée du
+# graphe et l'absence d'interblocage.
+psql_test --command="SET application_name = 'periodicite-lifecycle-graph-definition'; BEGIN; UPDATE public.indicateur_definition SET valeur_calcule = '1' WHERE id = $target_id; SELECT pg_sleep(3); COMMIT" >"$graph_definition_log" 2>&1 &
+graph_definition_pid=$!
+wait_for_sleeping_session periodicite-lifecycle-graph-definition
+psql_test --command="SET application_name = 'periodicite-lifecycle-graph-value'; INSERT INTO public.indicateur_valeur (indicateur_id, collectivite_id, date_valeur, resultat) VALUES ($concurrency_id, $collectivite_id, DATE '2023-01-01', 4)" >"$graph_value_log" 2>&1 &
+graph_value_pid=$!
+wait_for_advisory_lock_session periodicite-lifecycle-graph-value
+wait "$graph_definition_pid"
+wait "$graph_value_pid"
+assert_equal "1|1" \
+  "$(scalar "SELECT (SELECT count(*) FROM public.indicateur_valeur WHERE indicateur_id = $concurrency_id AND date_valeur = DATE '2023-01-01') || '|' || (SELECT valeur_calcule FROM public.indicateur_definition WHERE id = $target_id)")" \
+  "une mutation du graphe arrivée en premier doit précéder l'écriture de valeur"
+
+psql_test --command="SET application_name = 'periodicite-lifecycle-graph-value'; BEGIN; INSERT INTO public.indicateur_valeur (indicateur_id, collectivite_id, date_valeur, resultat) VALUES ($concurrency_id, $collectivite_id, DATE '2024-01-01', 5); SELECT pg_sleep(3); COMMIT" >"$graph_value_log" 2>&1 &
+graph_value_pid=$!
+wait_for_sleeping_session periodicite-lifecycle-graph-value
+psql_test --command="SET application_name = 'periodicite-lifecycle-graph-definition'; UPDATE public.indicateur_definition SET valeur_calcule = '2' WHERE id = $target_id" >"$graph_definition_log" 2>&1 &
+graph_definition_pid=$!
+wait_for_advisory_lock_session periodicite-lifecycle-graph-definition
+wait "$graph_value_pid"
+wait "$graph_definition_pid"
+assert_equal "1|2" \
+  "$(scalar "SELECT (SELECT count(*) FROM public.indicateur_valeur WHERE indicateur_id = $concurrency_id AND date_valeur = DATE '2024-01-01') || '|' || (SELECT valeur_calcule FROM public.indicateur_definition WHERE id = $target_id)")" \
+  "une écriture de valeur arrivée en premier doit précéder la mutation du graphe"
+
+apply_change data_layer/sqitch/revert/indicateur/dependances_formules.sql
+apply_change data_layer/sqitch/revert/indicateur/reconciliation_formules.sql
+apply_change data_layer/sqitch/revert/indicateur/import_emt_valeur.sql
+apply_change data_layer/sqitch/revert/indicateur/periodicite.sql
+assert_equal "0" \
+  "$(scalar "SELECT position('id.periodicite' IN pg_get_functiondef('public.indicateurs_gaz_effet_serre(site_labellisation)'::regprocedure))")" \
+  "le revert doit restaurer la projection GES sans dépendance à la colonne supprimée"
+assert_equal "2020-02-01" "$(scalar "SELECT date_valeur FROM public.indicateur_valeur WHERE id = $origin_value_id")" \
+  "le revert restaure la date historique auditée"
+assert_equal "1" "$(scalar "SELECT count(*) FROM public.indicateur_valeur WHERE indicateur_id = $concurrency_id AND date_valeur = DATE '2021-02-01'")" \
+  "le revert doit restaurer une date dont l'audit est toujours valide"
+assert_equal "" "$(scalar "SELECT to_regclass('public.indicateur_periodicite')")" \
+  "le revert complet doit retirer le catalogue"
+assert_equal "" "$(scalar "SELECT to_regclass('private.indicateur_reconciliation_formule')")" \
+  "le revert complet doit retirer la file de réconciliation"
+assert_equal "" "$(scalar "SELECT to_regprocedure('private.extraire_dependances_formule_indicateur(text)')")" \
+  "le revert complet doit retirer l'extracteur de dépendances"
+
+echo "Cycle Sqitch de périodicité validé sur la base jetable '$database_name'."

--- a/data_layer/tests/indicateur/periodicite.sql
+++ b/data_layer/tests/indicateur/periodicite.sql
@@ -1,0 +1,802 @@
+BEGIN;
+
+SELECT plan(61);
+
+CREATE TEMPORARY TABLE test_collectivite_periodicite AS
+WITH collectivite AS (
+    INSERT INTO public.collectivite (nom, type)
+    VALUES ('Collectivité périodicité indicateur', 'epci')
+    RETURNING id
+)
+SELECT id AS collectivite_id
+FROM collectivite;
+
+CREATE TEMPORARY TABLE test_indicateur_periodicite AS
+WITH indicateurs AS (
+    INSERT INTO public.indicateur_definition
+        (collectivite_id, identifiant_referentiel, titre, unite, periodicite)
+    SELECT collectivite.collectivite_id,
+           donnees.referentiel_id,
+           donnees.code,
+           'kWh',
+           donnees.periodicite
+    FROM test_collectivite_periodicite collectivite
+    CROSS JOIN (VALUES
+        ('test-annuel', NULL, 'annuelle'),
+        ('test-audit-reaffectation', NULL, 'annuelle'),
+        ('test-a-convertir-en-mensuel', NULL, 'annuelle')
+    ) AS donnees(code, referentiel_id, periodicite)
+    RETURNING id, titre, periodicite
+)
+SELECT id, titre AS code, periodicite
+FROM indicateurs;
+
+CREATE TEMPORARY TABLE test_indicateur_emt_periodicite AS
+WITH indicateurs AS (
+    INSERT INTO public.indicateur_definition
+        (identifiant_referentiel, titre, unite, periodicite)
+    VALUES
+        ('test_emt_annuel_pg_tap', 'test-emt-annuel', 'kWh', 'annuelle'),
+        ('test_emt_mensuel_pg_tap', 'test-emt-mensuel', 'kWh', 'annuelle')
+    RETURNING id, titre
+)
+SELECT id, titre AS code
+FROM indicateurs;
+
+SELECT ok(
+    to_regprocedure(
+        'public.import_indicateur_emt_valeurs(integer,jsonb)'
+    ) IS NOT NULL,
+    'La frontière transactionnelle de l''import EMT est déployée'
+);
+
+SELECT ok(
+    has_function_privilege(
+        'service_role',
+        'public.import_indicateur_emt_valeurs(integer,jsonb)',
+        'EXECUTE'
+    )
+    AND NOT has_function_privilege(
+        'anon',
+        'public.import_indicateur_emt_valeurs(integer,jsonb)',
+        'EXECUTE'
+    )
+    AND NOT has_function_privilege(
+        'authenticated',
+        'public.import_indicateur_emt_valeurs(integer,jsonb)',
+        'EXECUTE'
+    ),
+    'Seul le rôle de service peut appeler la RPC EMT'
+);
+
+SELECT lives_ok(
+    format(
+        $$ SELECT public.import_indicateur_emt_valeurs(
+               %s,
+               jsonb_build_array(jsonb_build_object(
+                   'indicateur_id', %s,
+                   'periodicite', 'annuelle',
+                   'date_debut', '2031-01-01',
+                   'resultat', 0,
+                   'commentaire', 'commentaire initial'
+               ))
+           ) $$,
+        (SELECT collectivite_id FROM test_collectivite_periodicite),
+        (SELECT id FROM test_indicateur_emt_periodicite WHERE code = 'test-emt-annuel')
+    ),
+    'La RPC EMT accepte une valeur annuelle canonique, y compris zéro'
+);
+
+SELECT is(
+    (
+        SELECT resultat
+        FROM public.indicateur_valeur
+        WHERE indicateur_id = (
+            SELECT id
+            FROM test_indicateur_emt_periodicite
+            WHERE code = 'test-emt-annuel'
+        )
+          AND date_valeur = DATE '2031-01-01'
+    ),
+    0::double precision,
+    'La valeur zéro de l''import EMT n''est pas assimilée à une absence'
+);
+
+SELECT lives_ok(
+    format(
+        $$ SELECT public.import_indicateur_emt_valeurs(
+               %s,
+               jsonb_build_array(jsonb_build_object(
+                   'indicateur_id', %s,
+                   'periodicite', 'annuelle',
+                   'date_debut', '2031-01-01',
+                   'resultat', 99,
+                   'commentaire', 'nouveau commentaire'
+               ))
+           ) $$,
+        (SELECT collectivite_id FROM test_collectivite_periodicite),
+        (SELECT id FROM test_indicateur_emt_periodicite WHERE code = 'test-emt-annuel')
+    ),
+    'Un second import EMT traite la ligne existante sans la remplacer'
+);
+
+SELECT is(
+    (
+        SELECT resultat
+        FROM public.indicateur_valeur
+        WHERE indicateur_id = (
+            SELECT id
+            FROM test_indicateur_emt_periodicite
+            WHERE code = 'test-emt-annuel'
+        )
+          AND date_valeur = DATE '2031-01-01'
+    ),
+    0::double precision,
+    'Un import EMT ne remplace pas un résultat manuel existant'
+);
+
+SELECT is(
+    (
+        SELECT resultat_commentaire
+        FROM public.indicateur_valeur
+        WHERE indicateur_id = (
+            SELECT id
+            FROM test_indicateur_emt_periodicite
+            WHERE code = 'test-emt-annuel'
+        )
+          AND date_valeur = DATE '2031-01-01'
+    ),
+    E'nouveau commentaire\n---\ncommentaire initial',
+    'Un import EMT préserve l''historique des commentaires'
+);
+
+UPDATE public.indicateur_definition
+SET periodicite = 'mensuelle'
+WHERE id = (
+    SELECT id
+    FROM test_indicateur_emt_periodicite
+    WHERE code = 'test-emt-mensuel'
+);
+
+SELECT throws_ok(
+    format(
+        $$ SELECT public.import_indicateur_emt_valeurs(
+               %s,
+               jsonb_build_array(jsonb_build_object(
+                   'indicateur_id', %s,
+                   'periodicite', 'annuelle',
+                   'date_debut', '2031-01-01',
+                   'resultat', 1,
+                   'commentaire', NULL
+               ))
+           ) $$,
+        (SELECT collectivite_id FROM test_collectivite_periodicite),
+        (SELECT id FROM test_indicateur_emt_periodicite WHERE code = 'test-emt-mensuel')
+    ),
+    23514,
+    NULL,
+    'La RPC EMT refuse une définition devenue mensuelle'
+);
+
+SELECT is_empty(
+    $$ SELECT 1
+       FROM public.indicateur_valeur
+       WHERE indicateur_id = (
+           SELECT id
+           FROM test_indicateur_emt_periodicite
+           WHERE code = 'test-emt-mensuel'
+       ) $$,
+    'Le refus d''une définition mensuelle ne laisse aucune valeur EMT'
+);
+
+SELECT throws_ok(
+    format(
+        $$ SELECT public.import_indicateur_emt_valeurs(
+               %s,
+               jsonb_build_array(
+                   jsonb_build_object(
+                       'indicateur_id', %s,
+                       'periodicite', 'annuelle',
+                       'date_debut', '2032-01-01',
+                       'resultat', 12
+                   ),
+                   jsonb_build_object(
+                       'indicateur_id', %s,
+                       'periodicite', 'annuelle',
+                       'date_debut', '2032-01-01',
+                       'resultat', 24
+                   )
+               )
+           ) $$,
+        (SELECT collectivite_id FROM test_collectivite_periodicite),
+        (SELECT id FROM test_indicateur_emt_periodicite WHERE code = 'test-emt-annuel'),
+        (SELECT id FROM test_indicateur_emt_periodicite WHERE code = 'test-emt-mensuel')
+    ),
+    23514,
+    NULL,
+    'Une cadence invalide annule le lot EMT complet'
+);
+
+SELECT is_empty(
+    $$ SELECT 1
+       FROM public.indicateur_valeur
+       WHERE indicateur_id = (
+           SELECT id
+           FROM test_indicateur_emt_periodicite
+           WHERE code = 'test-emt-annuel'
+       )
+         AND date_valeur = DATE '2032-01-01' $$,
+    'Une erreur tardive ne laisse pas la première valeur du lot'
+);
+
+UPDATE public.indicateur_definition
+SET periodicite = 'annuelle'
+WHERE id = (
+    SELECT id
+    FROM test_indicateur_emt_periodicite
+    WHERE code = 'test-emt-mensuel'
+);
+
+SELECT is(
+    public.import_indicateur_emt_valeurs(
+        (SELECT collectivite_id FROM test_collectivite_periodicite),
+        jsonb_build_array(
+            jsonb_build_object(
+                'indicateur_id', (
+                    SELECT id
+                    FROM test_indicateur_emt_periodicite
+                    WHERE code = 'test-emt-annuel'
+                ),
+                'periodicite', 'annuelle',
+                'date_debut', '2033-01-01',
+                'resultat', 1
+            ),
+            jsonb_build_object(
+                'indicateur_id', (
+                    SELECT id
+                    FROM test_indicateur_emt_periodicite
+                    WHERE code = 'test-emt-mensuel'
+                ),
+                'periodicite', 'annuelle',
+                'date_debut', '2033-01-01',
+                'resultat', 2
+            )
+        )
+    ),
+    2,
+    'La RPC retourne le nombre d''écritures effectives du lot'
+);
+
+SELECT lives_ok(
+    format(
+        $$ INSERT INTO public.indicateur_definition
+               (collectivite_id, titre, unite, periodicite)
+           VALUES (%s, 'test-periodicite-absente', 'kWh', NULL) $$,
+        (SELECT collectivite_id FROM test_collectivite_periodicite)
+    ),
+    'Une ancienne création avec périodicité NULL reste acceptée pendant expand'
+);
+
+SELECT is(
+    (SELECT count(*)::integer FROM public.indicateur_periodicite),
+    2,
+    'Le catalogue ne livre que les politiques annuelle et mensuelle'
+);
+
+SELECT ok(
+    has_table_privilege('anon', 'public.indicateur_periodicite', 'SELECT'),
+    'Le rôle anonyme peut lire le catalogue'
+);
+
+SELECT ok(
+    has_table_privilege('authenticated', 'public.indicateur_periodicite', 'SELECT'),
+    'Le rôle authentifié peut lire le catalogue'
+);
+
+SELECT ok(
+    NOT has_table_privilege('anon', 'public.indicateur_periodicite', 'INSERT')
+    AND NOT has_table_privilege('anon', 'public.indicateur_periodicite', 'UPDATE')
+    AND NOT has_table_privilege('anon', 'public.indicateur_periodicite', 'DELETE'),
+    'Le rôle anonyme ne peut pas modifier le catalogue'
+);
+
+SELECT ok(
+    NOT has_table_privilege('authenticated', 'public.indicateur_periodicite', 'INSERT')
+    AND NOT has_table_privilege('authenticated', 'public.indicateur_periodicite', 'UPDATE')
+    AND NOT has_table_privilege('authenticated', 'public.indicateur_periodicite', 'DELETE'),
+    'Le rôle authentifié ne peut pas modifier le catalogue'
+);
+
+SELECT ok(
+    has_table_privilege('service_role', 'public.indicateur_periodicite', 'SELECT')
+    AND NOT has_table_privilege('service_role', 'public.indicateur_periodicite', 'INSERT')
+    AND NOT has_table_privilege('service_role', 'public.indicateur_periodicite', 'UPDATE')
+    AND NOT has_table_privilege('service_role', 'public.indicateur_periodicite', 'DELETE'),
+    'Le rôle de service peut lire le catalogue sans pouvoir le modifier'
+);
+
+SELECT ok(
+    EXISTS (
+        SELECT 1
+        FROM pg_trigger
+        WHERE tgname = 'verrouiller_graphe_calcul_indicateur_valeur'
+          AND tgrelid = 'public.indicateur_valeur'::regclass
+          AND tgenabled = 'O'
+          AND NOT tgisinternal
+          AND tgtype::integer = 30
+          AND tgfoid =
+              'public.verrouiller_graphe_calcul_indicateur_partage()'::regprocedure
+    ),
+    'Les écritures de valeurs prennent le bon verrou partagé BEFORE STATEMENT sur tous les événements'
+);
+
+SELECT is(
+    (
+        SELECT count(*)::integer
+        FROM pg_trigger
+        WHERE tgname IN (
+            'verrouiller_graphe_calcul_indicateur_definition',
+            'verrouiller_graphe_calcul_indicateur_definition_update'
+        )
+          AND tgrelid = 'public.indicateur_definition'::regclass
+          AND tgenabled = 'O'
+          AND NOT tgisinternal
+          AND tgfoid =
+              'public.verrouiller_graphe_calcul_indicateur_exclusif()'::regprocedure
+          AND (
+              (
+                  tgname = 'verrouiller_graphe_calcul_indicateur_definition'
+                  AND tgtype::integer = 14
+              )
+              OR (
+                  tgname = 'verrouiller_graphe_calcul_indicateur_definition_update'
+                  AND tgtype::integer = 18
+                  AND (
+                      SELECT array_agg(attribute.attname ORDER BY attribute.attname)
+                      FROM unnest(tgattr::smallint[]) AS updated(attnum)
+                      JOIN pg_attribute attribute
+                        ON attribute.attrelid = pg_trigger.tgrelid
+                       AND attribute.attnum = updated.attnum
+                  ) = ARRAY[
+                      'collectivite_id',
+                      'id',
+                      'identifiant_referentiel',
+                      'periodicite',
+                      'valeur_calcule'
+                  ]::name[]
+              )
+          )
+    ),
+    2,
+    'Les mutations du graphe prennent le bon verrou exclusif BEFORE STATEMENT avec un masque exhaustif'
+);
+
+SELECT is(
+    public.indicateur_date_debut_periode('annuelle', DATE '2028-04-03'),
+    DATE '2028-01-01',
+    'La politique SQL annuelle calcule le début canonique sans branche dans le consommateur'
+);
+
+SELECT is(
+    public.indicateur_date_debut_periode('mensuelle', DATE '2028-04-03'),
+    DATE '2028-04-01',
+    'La politique SQL mensuelle calcule le début canonique sans branche dans le consommateur'
+);
+
+SELECT is(
+    public.indicateur_date_debut_periode('annuelle', DATE '1999-12-31'),
+    DATE '1999-01-01',
+    'La politique SQL annuelle reste alignée avant sa date d''ancrage'
+);
+
+SELECT is(
+    public.indicateur_date_debut_periode('mensuelle', DATE '1999-12-31'),
+    DATE '1999-12-01',
+    'La politique SQL mensuelle reste alignée avant sa date d''ancrage'
+);
+
+SELECT ok(
+    position(
+        'id.periodicite'
+        IN pg_get_functiondef(
+            'public.indicateurs_gaz_effet_serre(site_labellisation)'::regprocedure
+        )
+    ) > 0,
+    'La projection publique des GES transporte explicitement la périodicité'
+);
+
+SELECT throws_ok(
+    $$ SELECT public.indicateur_date_debut_periode('inconnue', DATE '2028-04-03') $$,
+    23514,
+    NULL,
+    'Une politique inconnue est refusée sans fallback implicite'
+);
+
+SELECT throws_ok(
+    $$ SELECT public.indicateur_date_debut_periode('annuelle', DATE '10000-01-01') $$,
+    23514,
+    NULL,
+    'Une date postérieure au calendrier du value object est refusée en base'
+);
+
+SELECT throws_ok(
+    $$ SELECT public.indicateur_date_debut_periode('annuelle', DATE '0001-01-01 BC') $$,
+    23514,
+    NULL,
+    'Une date antérieure au calendrier du value object est refusée en base'
+);
+
+SELECT throws_ok(
+    $$ INSERT INTO public.indicateur_periodicite
+           (code, unite_calendaire, nombre_unites, date_ancrage)
+       VALUES ('ancrage-hors-bornes', 'jour', 1, DATE '10000-01-01') $$,
+    23514,
+    NULL,
+    'Une politique ne peut pas introduire un ancrage hors du calendrier partagé'
+);
+
+SELECT throws_ok(
+    $$ INSERT INTO public.indicateur_periodicite
+           (code, unite_calendaire, nombre_unites, date_ancrage)
+       VALUES ('ancrage-mensuel-invalide', 'mois', 3, DATE '2000-01-02') $$,
+    23514,
+    NULL,
+    'Une politique fondée sur les mois commence le premier jour et utilise un pas divisant l''année'
+);
+
+SELECT throws_ok(
+    $$ UPDATE public.indicateur_periodicite
+       SET nombre_unites = 6
+       WHERE code = 'annuelle' $$,
+    23514,
+    NULL,
+    'La description d''une cadence utilisée est immuable'
+);
+
+INSERT INTO public.indicateur_periodicite
+    (code, unite_calendaire, nombre_unites, date_ancrage)
+VALUES ('politique-immuable-test', 'jour', 2, DATE '2000-01-01');
+
+SELECT throws_ok(
+    $$ UPDATE public.indicateur_periodicite
+       SET nombre_unites = 3
+       WHERE code = 'politique-immuable-test' $$,
+    23514,
+    NULL,
+    'Même une politique inutilisée ne peut pas changer de sens'
+);
+
+SELECT throws_ok(
+    $$ DELETE FROM public.indicateur_periodicite
+       WHERE code = 'politique-immuable-test' $$,
+    23514,
+    NULL,
+    'Une politique publiée ne peut pas être supprimée'
+);
+
+SELECT lives_ok(
+    format(
+        $$ INSERT INTO public.indicateur_valeur
+               (indicateur_id, collectivite_id, date_valeur, resultat)
+           VALUES (%s, %s, DATE '2027-01-01', 1) $$,
+        (SELECT id FROM test_indicateur_periodicite WHERE code = 'test-annuel'),
+        (SELECT collectivite_id FROM test_collectivite_periodicite)
+    ),
+    'Une valeur annuelle au 1er janvier est acceptée directement en base'
+);
+
+SELECT lives_ok(
+    $$ SELECT migration.verifier_retrait_periodicite_indicateur() $$,
+    'Le downgrade reste possible tant que toutes les définitions sont annuelles'
+);
+
+INSERT INTO migration.indicateur_valeur_periodicite_audit
+    (valeur_id,
+     indicateur_id,
+     collectivite_id,
+     metadonnee_id,
+     periodicite,
+     date_valeur_avant,
+     date_valeur_canonique,
+     statut)
+SELECT valeur.id,
+       valeur.indicateur_id,
+       valeur.collectivite_id,
+       valeur.metadonnee_id,
+       'annuelle',
+       DATE '2027-06-01',
+       valeur.date_valeur,
+       'normalisee'
+FROM public.indicateur_valeur valeur
+WHERE valeur.indicateur_id = (
+    SELECT id FROM test_indicateur_periodicite WHERE code = 'test-annuel'
+);
+
+SELECT lives_ok(
+    format(
+        $$ UPDATE public.indicateur_valeur
+           SET indicateur_id = %s
+           WHERE indicateur_id = %s;
+           UPDATE public.indicateur_valeur
+           SET indicateur_id = %s
+           WHERE indicateur_id = %s $$,
+        (SELECT id FROM test_indicateur_periodicite WHERE code = 'test-audit-reaffectation'),
+        (SELECT id FROM test_indicateur_periodicite WHERE code = 'test-annuel'),
+        (SELECT id FROM test_indicateur_periodicite WHERE code = 'test-annuel'),
+        (SELECT id FROM test_indicateur_periodicite WHERE code = 'test-audit-reaffectation')
+    ),
+    'Une ligne normalisée peut être réaffectée puis replacée sur sa définition initiale'
+);
+
+SELECT is_empty(
+    $$ SELECT 1
+       FROM migration.indicateur_valeur_periodicite_audit audit
+       JOIN public.indicateur_valeur valeur ON valeur.id = audit.valeur_id
+       WHERE valeur.indicateur_id = (
+           SELECT id FROM test_indicateur_periodicite WHERE code = 'test-annuel'
+       ) $$,
+    'La première réaffectation invalide définitivement son ancien audit de normalisation'
+);
+
+SELECT lives_ok(
+    format(
+        $$ INSERT INTO public.indicateur_valeur
+               (indicateur_id, collectivite_id, date_valeur, resultat)
+           VALUES (%s, %s, DATE '2028-04-03', 2) $$,
+        (SELECT id FROM test_indicateur_periodicite WHERE code = 'test-annuel'),
+        (SELECT collectivite_id FROM test_collectivite_periodicite)
+    ),
+    'Une ancienne date annuelle est normalisée pendant la transition'
+);
+
+SELECT lives_ok(
+    format(
+        $$ UPDATE public.indicateur_valeur
+           SET date_valeur = DATE '2027-02-01'
+           WHERE indicateur_id = %s AND date_valeur = DATE '2027-01-01' $$,
+        (SELECT id FROM test_indicateur_periodicite WHERE code = 'test-annuel')
+    ),
+    'Une modification annuelle historique reste compatible pendant la transition'
+);
+
+SELECT throws_ok(
+    format(
+        $$ UPDATE public.indicateur_definition
+           SET periodicite = 'mensuelle'
+           WHERE id = %s $$,
+        (SELECT id FROM test_indicateur_periodicite WHERE code = 'test-annuel')
+    ),
+    23514,
+    NULL,
+    'La périodicité ne change plus après la première valeur'
+);
+
+SELECT lives_ok(
+    format(
+        $$ UPDATE public.indicateur_definition
+           SET periodicite = 'annuelle'
+           WHERE id = %s $$,
+        (SELECT id FROM test_indicateur_periodicite WHERE code = 'test-annuel')
+    ),
+    'Réécrire la même périodicité reste autorisé'
+);
+
+SELECT lives_ok(
+    format(
+        $$ INSERT INTO public.indicateur_groupe (parent, enfant)
+           VALUES (%s, %s) $$,
+        (SELECT id FROM test_indicateur_periodicite WHERE code = 'test-audit-reaffectation'),
+        (SELECT id FROM test_indicateur_periodicite WHERE code = 'test-a-convertir-en-mensuel')
+    ),
+    'Un groupe de définitions annuelles homogènes est accepté'
+);
+
+SELECT throws_ok(
+    format(
+        $$ UPDATE public.indicateur_definition
+           SET periodicite = 'mensuelle'
+           WHERE id = %s $$,
+        (SELECT id FROM test_indicateur_periodicite WHERE code = 'test-a-convertir-en-mensuel')
+    ),
+    23514,
+    NULL,
+    'Une définition liée ne peut pas rendre son groupe hétérogène'
+);
+
+SELECT lives_ok(
+    format(
+        $$ DELETE FROM public.indicateur_groupe
+           WHERE parent = %1$s AND enfant = %2$s;
+           UPDATE public.indicateur_definition
+           SET periodicite = 'mensuelle'
+           WHERE id IN (%1$s, %2$s);
+           INSERT INTO public.indicateur_groupe (parent, enfant)
+           VALUES (%1$s, %2$s);
+           DELETE FROM public.indicateur_groupe
+           WHERE parent = %1$s AND enfant = %2$s;
+           UPDATE public.indicateur_definition
+           SET periodicite = 'annuelle'
+           WHERE id IN (%1$s, %2$s);
+           INSERT INTO public.indicateur_groupe (parent, enfant)
+           VALUES (%1$s, %2$s) $$,
+        (SELECT id FROM test_indicateur_periodicite WHERE code = 'test-audit-reaffectation'),
+        (SELECT id FROM test_indicateur_periodicite WHERE code = 'test-a-convertir-en-mensuel')
+    ),
+    'Un import peut remplacer atomiquement un graphe homogène sans état intermédiaire invalide'
+);
+
+DELETE FROM public.indicateur_groupe
+WHERE parent = (
+    SELECT id FROM test_indicateur_periodicite WHERE code = 'test-audit-reaffectation'
+)
+  AND enfant = (
+    SELECT id FROM test_indicateur_periodicite WHERE code = 'test-a-convertir-en-mensuel'
+  );
+
+SELECT lives_ok(
+    format(
+        $$ UPDATE public.indicateur_definition
+           SET periodicite = 'mensuelle'
+           WHERE id = %s $$,
+        (SELECT id FROM test_indicateur_periodicite WHERE code = 'test-a-convertir-en-mensuel')
+    ),
+    'Une définition sans valeur peut encore changer de périodicité'
+);
+
+SELECT throws_ok(
+    format(
+        $$ INSERT INTO public.indicateur_groupe (parent, enfant)
+           VALUES (%s, %s) $$,
+        (SELECT id FROM test_indicateur_periodicite WHERE code = 'test-audit-reaffectation'),
+        (SELECT id FROM test_indicateur_periodicite WHERE code = 'test-a-convertir-en-mensuel')
+    ),
+    23514,
+    NULL,
+    'Un groupe ne peut pas agréger des définitions de périodicités différentes'
+);
+
+SELECT lives_ok(
+    format(
+        $$ INSERT INTO public.indicateur_valeur
+               (indicateur_id, collectivite_id, date_valeur, resultat)
+           VALUES (%s, %s, DATE '2027-01-01', 10) $$,
+        (SELECT id FROM test_indicateur_periodicite WHERE code = 'test-a-convertir-en-mensuel'),
+        (SELECT collectivite_id FROM test_collectivite_periodicite)
+    ),
+    'Le premier jour de janvier est accepté pour un indicateur mensuel'
+);
+
+SELECT lives_ok(
+    format(
+        $$ INSERT INTO public.indicateur_valeur
+               (indicateur_id, collectivite_id, date_valeur, resultat)
+           VALUES (%s, %s, DATE '2027-02-01', 20) $$,
+        (SELECT id FROM test_indicateur_periodicite WHERE code = 'test-a-convertir-en-mensuel'),
+        (SELECT collectivite_id FROM test_collectivite_periodicite)
+    ),
+    'Le premier jour de février est accepté pour un indicateur mensuel'
+);
+
+SELECT throws_ok(
+    $$ SELECT migration.verifier_retrait_periodicite_indicateur() $$,
+    23514,
+    NULL,
+    'Le downgrade refuse de perdre le sens d''une définition mensuelle'
+);
+
+SELECT is(
+    (
+        SELECT count(*)::integer
+        FROM public.indicateur_valeur
+        WHERE indicateur_id = (
+            SELECT id
+            FROM test_indicateur_periodicite
+            WHERE code = 'test-a-convertir-en-mensuel'
+        )
+    ),
+    2,
+    'Janvier et février restent deux valeurs indépendantes'
+);
+
+SELECT lives_ok(
+    format(
+        $$ INSERT INTO public.indicateur_valeur
+               (indicateur_id, collectivite_id, date_valeur, resultat)
+           VALUES (%s, %s, DATE '2027-03-02', 30) $$,
+        (SELECT id FROM test_indicateur_periodicite WHERE code = 'test-a-convertir-en-mensuel'),
+        (SELECT collectivite_id FROM test_collectivite_periodicite)
+    ),
+    'Une date mensuelle est normalisée pendant la transition'
+);
+
+SELECT throws_ok(
+    format(
+        $$ UPDATE public.indicateur_definition
+           SET periodicite = 'annuelle'
+           WHERE id = %s $$,
+        (SELECT id FROM test_indicateur_periodicite WHERE code = 'test-a-convertir-en-mensuel')
+    ),
+    23514,
+    NULL,
+    'Une définition mensuelle alimentée ne peut pas devenir annuelle'
+);
+
+SELECT throws_ok(
+    format(
+        $$ UPDATE public.indicateur_valeur
+           SET indicateur_id = %s
+           WHERE indicateur_id = %s
+             AND date_valeur = DATE '2027-02-01' $$,
+        (SELECT id FROM test_indicateur_periodicite WHERE code = 'test-annuel'),
+        (SELECT id FROM test_indicateur_periodicite WHERE code = 'test-a-convertir-en-mensuel')
+    ),
+    23505,
+    NULL,
+    'Un déplacement qui entrerait en collision après normalisation est refusé'
+);
+
+SELECT is_empty(
+    $$
+        SELECT valeur.id
+        FROM public.indicateur_valeur valeur
+        JOIN public.indicateur_definition definition
+          ON definition.id = valeur.indicateur_id
+        LEFT JOIN migration.indicateur_valeur_periodicite_audit audit
+          ON audit.valeur_id = valeur.id
+         AND audit.statut = 'conflit'
+        WHERE valeur.date_valeur <> public.indicateur_date_debut_periode(
+            definition.periodicite,
+            valeur.date_valeur
+        )
+          AND audit.valeur_id IS NULL
+    $$,
+    'Aucune date non canonique ne peut échapper à l''audit historique'
+);
+
+SELECT is_empty(
+    $$
+        SELECT valeur_id
+        FROM migration.indicateur_valeur_periodicite_audit
+        WHERE statut = 'conflit'
+    $$,
+    'La périodicité obligatoire ne laisse aucun conflit historique non remédié'
+);
+
+SELECT is(
+    (SELECT is_nullable FROM information_schema.columns
+     WHERE table_schema = 'public' AND table_name = 'indicateur_definition'
+       AND column_name = 'periodicite'),
+    'YES',
+    'La phase expand conserve la colonne nullable pour les anciens writers'
+);
+
+SELECT lives_ok(
+    $$ INSERT INTO public.indicateur_definition (titre, unite)
+       VALUES ('test-ancien-writer-periodicite', 'kWh') $$,
+    'Une ancienne création de définition sans périodicité reste acceptée'
+);
+
+SELECT is(
+    (SELECT periodicite FROM public.indicateur_definition
+     WHERE titre = 'test-ancien-writer-periodicite'),
+    'annuelle',
+    'Le défaut annuel classe explicitement les anciennes créations'
+);
+
+SELECT is(
+    (SELECT date_valeur FROM public.indicateur_valeur
+     WHERE indicateur_id = (SELECT id FROM test_indicateur_periodicite WHERE code = 'test-annuel')
+       AND resultat = 2),
+    DATE '2028-01-01',
+    'Une date historique annuelle est persistée au début canonique de sa période'
+);
+
+SELECT is(
+    (SELECT date_valeur FROM public.indicateur_valeur
+     WHERE indicateur_id = (SELECT id FROM test_indicateur_periodicite WHERE code = 'test-a-convertir-en-mensuel')
+       AND resultat = 30),
+    DATE '2027-03-01',
+    'Une date historique mensuelle est persistée au début canonique de sa période'
+);
+
+ROLLBACK;

--- a/doc/adr/0016-strategie-backup-database.md
+++ b/doc/adr/0016-strategie-backup-database.md
@@ -55,6 +55,18 @@ Cette approche garantit que le schéma de la base cible est toujours celui du co
 
 Pour faciliter la vérification de compatibilité, un fichier **metadata** (`backup-YYYY-MM-DD.metadata.json`) est uploadé avec chaque backup. Il contient la version du backend, le commit et l'environnement au moment de la sauvegarde. Cela permet à l'opérateur de vérifier que le backup est compatible avec le code déployé sur l'environnement cible avant de lancer la restauration.
 
+Cette information humaine ne constitue pas le garde de schéma. Avant sa première troncature,
+`restore.sh` lit la phase de périodicité dans le registre Sqitch de la cible et dans la table
+`sqitch.changes` archivée par `pg_dump` dans le même snapshot que les données. Les phases reconnues
+sont `legacy`, `expand` et `contract`; elles doivent être strictement identiques. L'expand exige ses
+quatre changements `periodicite`, `import_emt_valeur`, `reconciliation_formules` et
+`dependances_formules`. Le contract exige en plus `periodicite_obligatoire`,
+`periodicite_formules` et `report_indicateur_resultat_periode`. Toute combinaison partielle est
+refusée, côté source comme côté cible. Cette matrice conservatrice bloque aussi bien un vieux backup
+sur un schéma contracté qu'un backup mensuel sur un ancien schéma ou reporting. Une source ou cible
+privée du registre Sqitch, ou une archive illisible, est toujours refusée. Le contrôle ne dépend ni
+du nom daté de l'archive ni d'un fichier metadata modifiable séparément.
+
 ### 2. Restauration table par table pilotée par `restore-config.yml`
 
 Le fichier `data_layer/backup/restore-config.yml` définit la liste des tables et leur regroupement logique (groupes : technical, stats, collectivites, indicateurs, referentiels, pai, plans). Il sert d'unique source de vérité consommée par `restore.sh` pour orchestrer la restauration. Les règles d'anonymisation, elles, sont écrites en SQL dans `clean_data.sql` (cf. §7).
@@ -96,23 +108,66 @@ Ce remplacement du job historique `validate-restore` par deux jobs supprime la n
 Chaque job :
 
 1. Télécharge le backup depuis S3 (valide le roundtrip complet : backup → upload → download → restore)
-2. Tronque les tables cibles dans l'ordre inverse des dépendances
-3. Restaure table par table à partir du dump
-4. Réinitialise les séquences PostgreSQL via `reset_sequences.sql`
-5. Exécute `clean_data.sql` (cf. §7) pour anonymiser les colonnes sensibles et asserter la garantie post-scrub
-6. Vérifie les sanity checks de présence de données (`collectivite`, `dcp`, `indicateur_valeur`, `action_statut`, `score_snapshot`)
+2. Vérifie l'intégrité de l'archive et sa compatibilité Sqitch avec la cible, avant toute mutation
+3. Tronque les tables cibles dans l'ordre inverse des dépendances
+4. Restaure table par table à partir du dump
+5. Restaure l'audit de migration et les intentions de réconciliation durables du même snapshot
+6. Reconstruit et valide atomiquement la projection dérivée des dépendances de formules, puis rejoue
+   l'audit de dates sous verrou
+7. Réinitialise les séquences PostgreSQL via `reset_sequences.sql`
+8. Exécute `clean_data.sql` (cf. §7) pour anonymiser les colonnes sensibles et asserter la garantie post-scrub
+9. Vérifie les sanity checks de présence de données (`collectivite`, `dcp`, `indicateur_valeur`, `action_statut`, `score_snapshot`)
 
-Chaque job a son propre groupe de concurrence (`restore-staging` et `restore-preprod`), un timeout de 90 minutes pour borner les runs runaway, et utilise respectivement `STAGING_DB_URL` et `PREPROD_DB_URL` (les deux secrets pré-existants, hérités du fonctionnement pgsync). `clean_data.sql` lit `RESTORE_ENCRYPTED_PASSWORD` via `psql -v` pour la mise à jour de `encrypted_password`.
+Chaque job a son propre groupe de concurrence par base (`database-maintenance-staging` et
+`database-maintenance-preprod`), partagé avec le workflow contractuel de périodicité. Une
+restauration et ce changement de schéma exceptionnel ne peuvent donc pas s'exécuter simultanément
+sur une même cible depuis GitHub Actions. Les jobs gardent un timeout de 90 minutes pour borner les
+runs runaway et utilisent respectivement `STAGING_DB_URL` et `PREPROD_DB_URL` (les deux secrets
+pré-existants, hérités du fonctionnement pgsync). `clean_data.sql` lit
+`RESTORE_ENCRYPTED_PASSWORD` via `psql -v` pour la mise à jour de `encrypted_password`.
 
 ### 5. Restauration manuelle à la demande
 
 En complément de la restauration nocturne, un workflow GitHub Actions séparé (`cd-restore-preprod.yml`) permet de restaurer **à la demande** la preprod à partir d'un backup S3 de prod. Déclenchable manuellement via `workflow_dispatch`, il accepte un paramètre optionnel `backup_date` au format ISO (`YYYY-MM-DD`) : si une date est fournie, le backup correspondant (`backup-YYYY-MM-DD.dump`) est téléchargé et restauré ; si le champ est laissé vide, le workflow délègue à `restore.sh latest` qui liste le bucket S3 et sélectionne automatiquement le backup le plus récent disponible.
 
-Ce mode `latest` est exposé par `restore.sh` lui-même (et non dans le workflow) pour rester utilisable en local (`./restore.sh latest`). Le workflow manuel utilise le secret `PREPROD_DB_URL` (consolidé avec celui du job `restore-preprod` nocturne) et partage le même verrou de concurrence (`restore-preprod`), sérialisant les restaurations concurrentes (manuelles ou planifiées) sur la preprod partagée. `clean_data.sql` (§7) s'applique automatiquement, comme pour le job nocturne. Le garde-fou de protection production (allowlist, §6) reste actif puisqu'il est implémenté dans `restore.sh` et donc commun à tous les appelants.
+Ce mode `latest` est exposé par `restore.sh` lui-même (et non dans le workflow) pour rester utilisable en local (`./restore.sh latest`). Le workflow manuel utilise le secret `PREPROD_DB_URL` (consolidé avec celui du job `restore-preprod` nocturne) et partage le même verrou de concurrence (`database-maintenance-preprod`), sérialisant les restaurations concurrentes (manuelles ou planifiées) et le contract de périodicité sur la preprod partagée. `clean_data.sql` (§7) s'applique automatiquement, comme pour le job nocturne. Le garde-fou de protection production (allowlist, §6) reste actif puisqu'il est implémenté dans `restore.sh` et donc commun à tous les appelants.
 
 ### 6. Sécurité
 
-- **Protection production (allowlist fail-closed)** : `restore.sh` refuse toute restauration sauf si `TO_DB_URL` correspond à une URL en localhost ou à l'un des identifiants de projet Supabase explicitement autorisés (staging, preprod). Toute URL inattendue (y compris production) est rejetée avec un message clair et l'URL masquée. Cette approche remplace l'ancien denylist (un seul identifiant prod) qui était fragile en cas d'ajout d'un second projet de production.
+- **Protection production (allowlist fail-closed)** : `restore.sh` parse `TO_DB_URL` et refuse toute
+  restauration sauf si son hostname effectif est local ou si l'identité Supabase extraite correspond
+  exactement à staging ou preprod. Les paramètres libpq capables de remplacer l'autorité de l'URL
+  sont interdits. Une valeur autorisée placée dans le mot de passe, la query string ou un suffixe de
+  domaine ne peut donc pas autoriser une autre cible. Toute URL inattendue, dont production, est
+  rejetée sans journaliser ses credentials. Toute cible Supabase distante doit en plus déclarer
+  explicitement `sslmode=require`, `verify-ca` ou `verify-full` dans son secret de connexion.
+- **Compatibilité fail-closed avant troncature** : les phases Sqitch de la source et de la cible
+  doivent être exactement égales, et toute phase `expand` ou `contract` partielle est rejetée. La
+  cible doit aussi posséder les tables et fonctions physiques attendues par sa phase déclarée ; le
+  registre Sqitch seul ne peut pas masquer une dérive de schéma. Les restaurations nocturnes
+  resteront donc volontairement en échec pendant chaque décalage de rollout entre production et
+  staging/preprod, dans les deux directions. En `expand` et `contract`, l'archive doit aussi contenir
+  les entrées `TABLE DATA` de l'audit et de la file de réconciliation ; une archive sélective ne peut
+  pas les vider silencieusement.
+- **État dérivé restauré explicitement** : `indicateur_definition` est chargé avec ses triggers USER
+  désactivés. La projection `private.indicateur_definition_dependance_calcul` est donc reconstruite
+  avec l'extracteur canonique, puis validée sous les verrous du graphe et du catalogue. En revanche,
+  `migration.indicateur_valeur_periodicite_audit` et
+  `private.indicateur_reconciliation_formule` sont des états durables restaurés depuis le même
+  snapshot : ils portent respectivement l'historique de downgrade et les recalculs encore dus. Le
+  rejeu de l'audit en phase `expand` écarte les entrées devenues incohérentes et traite les valeurs
+  chargées sans triggers. En phase `contract`, la fonction transitoire ayant été retirée, les dates
+  sont validées directement. Une validation en échec annule atomiquement les post-traitements.
+- **Exclusion mutuelle des maintenances** : les restaurations planifiées et manuelles partagent leur
+  groupe de concurrence par base avec le workflow contractuel. Le backup de production partage de
+  même `database-maintenance-prod`, afin de ne jamais capturer un snapshot au milieu du contract.
+  Une invocation hors GitHub Actions reste une opération de maintenance et doit respecter le même
+  gel opératoire.
+- **Réactivation des triggers** : pendant la restauration table par table, la table dont les
+  triggers USER ont effectivement été désactivés reste mémorisée. Toute sortie normale, erreur,
+  interruption ou annulation par `TERM` tente de les réactiver ; un échec de réactivation arrête le
+  restore au lieu de publier silencieusement une table sans invariants. Seul un arrêt non
+  interceptable (`SIGKILL` ou panne de la cible) nécessite encore une vérification opérateur.
 - **Délai de confirmation** : un `sleep 10` permet à l'opérateur de vérifier l'URL cible avant la restauration (désactivé en CI via `$CI`)
 - **Masquage des credentials** : l'URL de connexion est masquée dans les logs (`postgresql://***@host/db`)
 - **Secrets GitHub** : tous les credentials sont passés via des variables d'environnement (secrets GitHub), jamais en arguments CLI
@@ -124,12 +179,12 @@ Après `reset_sequences.sql` et avant les sanity checks, `restore.sh` exécute `
 
 **Colonnes scrubbées (état actuel)** :
 
-| Cible                                       | Action                                                        |
-| ------------------------------------------- | ------------------------------------------------------------- |
-| `auth.users.phone`                          | `NULL`                                                        |
-| `auth.users.encrypted_password`             | `:'pwd'` si non vide, sinon laissé tel quel                   |
-| `public.dcp.telephone`                      | `NULL` (cf. interaction trigger ci-dessous)                   |
-| `config.service_configurations.token`       | `NULL` — empêche staging/preprod d'avoir des tokens API live  |
+| Cible                                 | Action                                                       |
+| ------------------------------------- | ------------------------------------------------------------ |
+| `auth.users.phone`                    | `NULL`                                                       |
+| `auth.users.encrypted_password`       | `:'pwd'` si non vide, sinon laissé tel quel                  |
+| `public.dcp.telephone`                | `NULL` (cf. interaction trigger ci-dessous)                  |
+| `config.service_configurations.token` | `NULL` — empêche staging/preprod d'avoir des tokens API live |
 
 **Substitution du mot de passe** : `restore.sh` passe `-v pwd="${RESTORE_ENCRYPTED_PASSWORD:-}"` à `psql`. La variable peut être vide (env var non définie en local) — l'`UPDATE` correspondant et son assertion sont alors no-op (clauses `WHERE :'pwd' <> ''`). Le hash bcrypt n'est ainsi jamais stocké dans le repo ; la rotation se fait en mettant à jour le secret GitHub Actions `RESTORE_ENCRYPTED_PASSWORD`.
 
@@ -202,6 +257,8 @@ Supabase propose ses propres backups (Point-in-Time Recovery). Non retenu comme 
 │  └─────────────┘          │           └─────────────────────────┘ │
 │                           ▼                                        │
 │                Each restore.sh: pg_restore table-by-table          │
+│                              ↓ restore audit + reconciliation      │
+│                              ↓ rebuild/validate formula projection │
 │                              ↓ reset_sequences.sql                 │
 │                              ↓ clean_data.sql (auth.users.phone +  │
 │                                  encrypted_password, dcp.telephone,│
@@ -215,16 +272,18 @@ Supabase propose ses propres backups (Point-in-Time Recovery). Non retenu comme 
 
 ## Fichiers et scripts
 
-| Fichier                                    | Rôle                                                                                              |
-| ------------------------------------------ | ------------------------------------------------------------------------------------------------- |
-| `data_layer/backup/backup.sh`              | Dump production + upload S3 + metadata                                                            |
-| `data_layer/backup/restore.sh`             | Download S3 + truncate + restore table/table + reset sequences + clean_data.sql + sanity          |
-| `data_layer/backup/cleanup.sh`             | Nettoyage des backups obsolètes selon la politique de rétention                                  |
-| `data_layer/backup/reset_sequences.sql`    | Réinitialisation des séquences après restore data-only                                            |
-| `data_layer/backup/clean_data.sql`         | Anonymisation des colonnes sensibles (cf. §7) + assertions intégrées                              |
-| `data_layer/backup/restore-config.yml`     | Source de vérité : liste des tables et groupes restaurés par `restore.sh`                         |
-| `.github/workflows/backup-database.yml`    | Orchestration CI : backup-production + restore-staging (latest) + restore-preprod (D-1) + cleanup |
-| `.github/workflows/cd-restore-preprod.yml` | Restauration manuelle à la demande de la preprod (date ISO ou `latest`)                           |
+| Fichier                                                  | Rôle                                                                                              |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `data_layer/backup/backup.sh`                            | Dump production + upload S3 + metadata                                                            |
+| `data_layer/backup/restore.sh`                           | Contrôle de phase + restore ordonné + post-traitements + sanity                                   |
+| `data_layer/backup/check-restore-compatibility.sh`       | Classification Sqitch source/cible et matrice de compatibilité fail-closed                        |
+| `data_layer/backup/rebuild-indicateur-formula-state.sql` | Rebuild/validation du graphe dérivé et rejeu d'audit après restore                                |
+| `data_layer/backup/cleanup.sh`                           | Nettoyage des backups obsolètes selon la politique de rétention                                   |
+| `data_layer/backup/reset_sequences.sql`                  | Réinitialisation des séquences après restore data-only                                            |
+| `data_layer/backup/clean_data.sql`                       | Anonymisation des colonnes sensibles (cf. §7) + assertions intégrées                              |
+| `data_layer/backup/restore-config.yml`                   | Source de vérité : liste des tables et groupes restaurés par `restore.sh`                         |
+| `.github/workflows/backup-database.yml`                  | Orchestration CI : backup-production + restore-staging (latest) + restore-preprod (D-1) + cleanup |
+| `.github/workflows/cd-restore-preprod.yml`               | Restauration manuelle à la demande de la preprod (date ISO ou `latest`)                           |
 
 ## Opérations courantes
 

--- a/packages/api/src/database.types.ts
+++ b/packages/api/src/database.types.ts
@@ -7396,6 +7396,7 @@ export type Database = {
           modified_at: string;
           modified_by: string | null;
           participation_score: boolean;
+          periodicite: string | null;
           precision: number;
           sans_valeur_utilisateur: boolean;
           titre: string;
@@ -7427,6 +7428,7 @@ export type Database = {
           modified_at?: string;
           modified_by?: string | null;
           participation_score?: boolean;
+          periodicite?: string | null;
           precision?: number;
           sans_valeur_utilisateur?: boolean;
           titre: string;
@@ -7452,6 +7454,7 @@ export type Database = {
           modified_at?: string;
           modified_by?: string | null;
           participation_score?: boolean;
+          periodicite?: string | null;
           precision?: number;
           sans_valeur_utilisateur?: boolean;
           titre?: string;
@@ -7657,6 +7660,13 @@ export type Database = {
             isOneToOne: false;
             referencedRelation: 'groupement';
             referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'indicateur_definition_periodicite_fkey';
+            columns: ['periodicite'];
+            isOneToOne: false;
+            referencedRelation: 'indicateur_periodicite';
+            referencedColumns: ['code'];
           }
         ];
       };
@@ -7736,6 +7746,27 @@ export type Database = {
             referencedColumns: ['id'];
           }
         ];
+      };
+      indicateur_periodicite: {
+        Row: {
+          code: string;
+          date_ancrage: string;
+          nombre_unites: number;
+          unite_calendaire: string;
+        };
+        Insert: {
+          code: string;
+          date_ancrage: string;
+          nombre_unites: number;
+          unite_calendaire: string;
+        };
+        Update: {
+          code?: string;
+          date_ancrage?: string;
+          nombre_unites?: number;
+          unite_calendaire?: string;
+        };
+        Relationships: [];
       };
       indicateur_pilote: {
         Row: {
@@ -19911,6 +19942,10 @@ export type Database = {
           total: number;
         }[];
       };
+      indicateur_date_debut_periode: {
+        Args: { date_a_classer: string; periodicite_code: string };
+        Returns: string;
+      };
       indicateur_enfants: {
         Args: {
           '': Database['public']['Tables']['indicateur_definition']['Row'];
@@ -19931,6 +19966,7 @@ export type Database = {
           modified_at: string;
           modified_by: string | null;
           participation_score: boolean;
+          periodicite: string | null;
           precision: number;
           sans_valeur_utilisateur: boolean;
           titre: string;
@@ -19961,6 +19997,7 @@ export type Database = {
           modified_at: string;
           modified_by: string | null;
           participation_score: boolean;
+          periodicite: string | null;
           precision: number;
           sans_valeur_utilisateur: boolean;
           titre: string;
@@ -20683,6 +20720,13 @@ export type Database = {
       unaccent_init: {
         Args: { '': unknown };
         Returns: unknown;
+      };
+      import_indicateur_emt_valeurs: {
+        Args: {
+          collectivite_id_a_ecrire: number;
+          valeurs_a_ecrire: Json;
+        };
+        Returns: number;
       };
       update_bibliotheque_fichier_confidentiel: {
         Args: { collectivite_id: number; hash: string; confidentiel: boolean };

--- a/supabase/functions/_shared/database.types.ts
+++ b/supabase/functions/_shared/database.types.ts
@@ -7402,6 +7402,7 @@ export type Database = {
           modified_at: string;
           modified_by: string | null;
           participation_score: boolean;
+          periodicite: string | null;
           precision: number;
           sans_valeur_utilisateur: boolean;
           titre: string;
@@ -7433,6 +7434,7 @@ export type Database = {
           modified_at?: string;
           modified_by?: string | null;
           participation_score?: boolean;
+          periodicite?: string | null;
           precision?: number;
           sans_valeur_utilisateur?: boolean;
           titre: string;
@@ -7458,6 +7460,7 @@ export type Database = {
           modified_at?: string;
           modified_by?: string | null;
           participation_score?: boolean;
+          periodicite?: string | null;
           precision?: number;
           sans_valeur_utilisateur?: boolean;
           titre?: string;
@@ -7663,6 +7666,13 @@ export type Database = {
             isOneToOne: false;
             referencedRelation: 'groupement';
             referencedColumns: ['id'];
+          },
+          {
+            foreignKeyName: 'indicateur_definition_periodicite_fkey';
+            columns: ['periodicite'];
+            isOneToOne: false;
+            referencedRelation: 'indicateur_periodicite';
+            referencedColumns: ['code'];
           }
         ];
       };
@@ -7742,6 +7752,27 @@ export type Database = {
             referencedColumns: ['id'];
           }
         ];
+      };
+      indicateur_periodicite: {
+        Row: {
+          code: string;
+          date_ancrage: string;
+          nombre_unites: number;
+          unite_calendaire: string;
+        };
+        Insert: {
+          code: string;
+          date_ancrage: string;
+          nombre_unites: number;
+          unite_calendaire: string;
+        };
+        Update: {
+          code?: string;
+          date_ancrage?: string;
+          nombre_unites?: number;
+          unite_calendaire?: string;
+        };
+        Relationships: [];
       };
       indicateur_pilote: {
         Row: {
@@ -19917,6 +19948,10 @@ export type Database = {
           total: number;
         }[];
       };
+      indicateur_date_debut_periode: {
+        Args: { date_a_classer: string; periodicite_code: string };
+        Returns: string;
+      };
       indicateur_enfants: {
         Args: {
           '': Database['public']['Tables']['indicateur_definition']['Row'];
@@ -19937,6 +19972,7 @@ export type Database = {
           modified_at: string;
           modified_by: string | null;
           participation_score: boolean;
+          periodicite: string | null;
           precision: number;
           sans_valeur_utilisateur: boolean;
           titre: string;
@@ -19967,6 +20003,7 @@ export type Database = {
           modified_at: string;
           modified_by: string | null;
           participation_score: boolean;
+          periodicite: string | null;
           precision: number;
           sans_valeur_utilisateur: boolean;
           titre: string;
@@ -20689,6 +20726,13 @@ export type Database = {
       unaccent_init: {
         Args: { '': unknown };
         Returns: unknown;
+      };
+      import_indicateur_emt_valeurs: {
+        Args: {
+          collectivite_id_a_ecrire: number;
+          valeurs_a_ecrire: Json;
+        };
+        Returns: number;
       };
       update_bibliotheque_fichier_confidentiel: {
         Args: { collectivite_id: number; hash: string; confidentiel: boolean };


### PR DESCRIPTION
Superseded by [PR 3/10](https://github.com/incubateur-ademe/territoires-en-transitions/pull/4966) in the consolidated 10-PR stack. Review and merge using the [updated index](https://github.com/incubateur-ademe/territoires-en-transitions/pull/4959). This PR is closed without merging; its changes are included in the replacement.

---

Move indicator permission, source and definition-relation persistence behind focused repositories. Application services retain the existing authorization and business behavior, while the source-list endpoint passes its authenticated context explicitly.

This is a prerequisite for later transaction-aware writes. It does not activate monthly creation or replace the calculation engine.

Validation completed: 26 focused tests passed; backend app and test TypeScript builds passed.

Stack base: `split/03-schema-expand`. Review against that branch; after its PR merges, restack this branch onto main and rerun checks before merging.

TransactionModule is registered with the first services that inject TransactionManager. Actual Nest provider-resolution smoke checks and the focused pilotes tests pass.
