### PR TITLE
refactor(indicateurs): prepare input and query helpers for periods

### DIFF
--- a/apps/app/src/app/pages/collectivite/Indicateurs/data/use-delete-indicateur-valeur.ts
+++ b/apps/app/src/app/pages/collectivite/Indicateurs/data/use-delete-indicateur-valeur.ts
@@ -1,3 +1,4 @@
+import { invalidateIndicateurValeursQueries } from '@/app/indicateurs/valeurs/invalidate-indicateur-valeurs-queries';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTRPC } from '@tet/api';
 
@@ -7,27 +8,12 @@ export const useDeleteIndicateurValeur = () => {
 
   return useMutation(
     trpc.indicateurs.valeurs.delete.mutationOptions({
-      onSuccess: (_, variables) => {
-        const { collectiviteId, indicateurId } = variables;
-        if (collectiviteId && indicateurId) {
-          // recharge les infos complémentaires associées à l'indicateur
-          queryClient.invalidateQueries({
-            queryKey: trpc.indicateurs.indicateurs.list.queryKey({
-              collectiviteId,
-            }),
-          });
-          queryClient.invalidateQueries({
-            queryKey: trpc.indicateurs.valeurs.list.queryKey({
-              collectiviteId,
-              indicateurIds: [indicateurId],
-            }),
-          });
-          queryClient.invalidateQueries({
-            queryKey: trpc.referentiels.actions.getValeursUtilisables.queryKey({
-              collectiviteId,
-            }),
-          });
-        }
+      onSuccess: async (_, { collectiviteId }) => {
+        await invalidateIndicateurValeursQueries({
+          queryClient,
+          trpc,
+          collectiviteId,
+        });
       },
       meta: {
         success: 'La valeur a été supprimée',

--- a/apps/app/src/app/pages/collectivite/Indicateurs/data/use-indicateur-sources.ts
+++ b/apps/app/src/app/pages/collectivite/Indicateurs/data/use-indicateur-sources.ts
@@ -1,6 +1,7 @@
 import { PALETTE } from '@/app/ui/charts/echarts';
 import { useQuery } from '@tanstack/react-query';
 import { RouterInput, useTRPC } from '@tet/api';
+import { useCallback, useMemo } from 'react';
 import { LAYERS as LAYERS_TRAJECTOIRE } from '../../Trajectoire/graphes/layer-parameters';
 import { LAYERS as INDICATEUR_LAYERS } from '../chart/layer-parameters';
 import { SourceType } from '../types';
@@ -29,28 +30,33 @@ export const useIndicateurAvailableSources = (
 /** Attribut une couleur à chaque source de données  */
 export const useColorBySourceId = () => {
   const { data: sources } = useIndicateurSources();
-  const colorBySourceId: Record<string, string> = {};
-  (sources ?? [])
-    // on enlève la source snbc pour que l'index dans la palette ne soit pas utilisé
-    // la couleur pour cette source étant attribuée dans `useGetColorBySourceId`
-    .filter((s) => s.id !== 'snbc')
-    .forEach((source, index) => {
-      colorBySourceId[source.id] = PALETTE[index % PALETTE.length];
-    });
-  return colorBySourceId;
+  return useMemo(() => {
+    const colorBySourceId: Record<string, string> = {};
+    let paletteIndex = 0;
+    for (const source of sources ?? []) {
+      // La source SNBC a sa couleur dédiée et ne consomme pas d'index.
+      if (source.id === 'snbc') continue;
+      colorBySourceId[source.id] = PALETTE[paletteIndex % PALETTE.length];
+      paletteIndex += 1;
+    }
+    return colorBySourceId;
+  }, [sources]);
 };
 
 /** Fourni une fonction permettant d'obtenir la couleur associée à une source de données */
 export const useGetColorBySourceId = () => {
   const colorBySourceId = useColorBySourceId();
-  return (sourceId: string | null, type: SourceType) => {
-    if (!sourceId || sourceId === 'collectivite') {
-      return LAYERS[`${type}s`].color;
-    }
-    if (sourceId === 'snbc') return LAYERS.trajectoire.color;
-    if (sourceId === 'moyenne') return LAYERS.moyenne.color;
-    return colorBySourceId[sourceId];
-  };
+  return useCallback(
+    (sourceId: string | null, type: SourceType) => {
+      if (!sourceId || sourceId === 'collectivite') {
+        return LAYERS[`${type}s`].color;
+      }
+      if (sourceId === 'snbc') return LAYERS.trajectoire.color;
+      if (sourceId === 'moyenne') return LAYERS.moyenne.color;
+      return colorBySourceId[sourceId];
+    },
+    [colorBySourceId]
+  );
 };
 
 export type GetColorBySourceId = ReturnType<typeof useGetColorBySourceId>;

--- a/apps/app/src/app/pages/collectivite/Indicateurs/data/use-source-filter.spec.ts
+++ b/apps/app/src/app/pages/collectivite/Indicateurs/data/use-source-filter.spec.ts
@@ -1,0 +1,81 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useSourceFilter } from './use-source-filter';
+
+const mocks = vi.hoisted(() => ({
+  availableSources: vi.fn(),
+  moyenne: vi.fn(),
+  reference: vi.fn(),
+}));
+
+vi.mock('./use-indicateur-sources', () => ({
+  useIndicateurAvailableSources: mocks.availableSources,
+}));
+
+vi.mock('./use-indicateur-moyenne', () => ({
+  useIndicateurMoyenne: mocks.moyenne,
+}));
+
+vi.mock('./use-indicateur-reference', () => ({
+  useIndicateurReference: mocks.reference,
+  hasValeurCible: (reference?: {
+    cible: number | null;
+    objectifs?: unknown[] | null;
+  }) =>
+    Boolean(
+      reference &&
+        (reference.cible !== null || Boolean(reference.objectifs?.length))
+    ),
+  hasValeurSeuil: (reference?: { seuil: number | null }) =>
+    Boolean(reference && reference.seuil !== null),
+}));
+
+describe('useSourceFilter', () => {
+  beforeEach(() => {
+    mocks.availableSources.mockReturnValue({
+      data: [{ id: 'snbc' }, { id: 'pcaet' }, { id: 'citepa' }],
+      isLoading: false,
+    });
+    mocks.moyenne.mockReturnValue({
+      data: { valeurs: [{ valeur: 12 }] },
+      isLoading: false,
+    });
+    mocks.reference.mockReturnValue({
+      data: {
+        cible: 20,
+        objectifs: null,
+        seuil: 10,
+        libelle: 'Référence',
+        drom: false,
+      },
+      isLoading: false,
+    });
+  });
+
+  it('mémorise son résultat tant que les données et les filtres sont stables', () => {
+    const input = { collectiviteId: 42, indicateurId: 7 };
+    const { result, rerender } = renderHook(() => useSourceFilter(input));
+    const initialResult = result.current;
+
+    rerender();
+
+    expect(result.current).toBe(initialResult);
+  });
+
+  it('déplie le filtre open data sans perdre les autres filtres', () => {
+    const input = { collectiviteId: 42, indicateurId: 7 };
+    const { result, rerender } = renderHook(() => useSourceFilter(input));
+
+    act(() => result.current.setFiltresSource(['opendata', 'cible']));
+
+    expect(result.current.sources).toEqual(['citepa', 'cible']);
+    expect(result.current.valeursReference).toMatchObject({
+      cible: 20,
+      seuil: null,
+    });
+
+    const filteredResult = result.current;
+    rerender();
+    expect(result.current).toBe(filteredResult);
+  });
+});

--- a/apps/app/src/app/pages/collectivite/Indicateurs/data/use-source-filter.ts
+++ b/apps/app/src/app/pages/collectivite/Indicateurs/data/use-source-filter.ts
@@ -1,5 +1,5 @@
 import { appLabels } from '@/app/labels/catalog';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useIndicateurMoyenne } from './use-indicateur-moyenne';
 import {
   hasValeurCible,
@@ -53,91 +53,81 @@ export const useSourceFilter = (input: GetAvailableSourcesInput) => {
 
   const { data: references, isLoading: isLoadingReference } =
     useIndicateurReference(input);
-  const avecValeurCible = hasValeurCible(references);
-  const avecValeurSeuil = hasValeurSeuil(references);
 
-  const options: FiltresSource[] = [];
-  if (data?.length) {
-    const availableSourceIds = data.map((s) => s.id);
-    if (availableSourceIds.includes('snbc')) {
-      options.push('snbc');
-    }
-    if (availableSourceIds.includes('pcaet')) {
-      options.push('pcaet');
-    }
-    if (availableSourceIds.length > options.length) {
-      options.push('opendata');
-    }
-  }
-  options.push('collectivite');
-  if (moyenne?.valeurs?.length) {
-    options.push('moyenne');
-  }
-  if (avecValeurCible) {
-    options.push('cible');
-  }
-  if (avecValeurSeuil) {
-    options.push('seuil');
-  }
+  return useMemo(() => {
+    const avecValeurCible = hasValeurCible(references);
+    const avecValeurSeuil = hasValeurSeuil(references);
+    const options: FiltresSource[] = [];
 
-  const availableOptions = options.map((value) => ({
-    value,
-    label: filtreToLabel(value),
-  }));
+    if (data?.length) {
+      const availableSourceIds = data.map((source) => source.id);
+      if (availableSourceIds.includes('snbc')) options.push('snbc');
+      if (availableSourceIds.includes('pcaet')) options.push('pcaet');
+      if (availableSourceIds.length > options.length) options.push('opendata');
+    }
+    options.push('collectivite');
+    if (moyenne?.valeurs?.length) options.push('moyenne');
+    if (avecValeurCible) options.push('cible');
+    if (avecValeurSeuil) options.push('seuil');
 
-  const sources: Array<string> = [];
-  if (filtresSource.length) {
+    const sources: string[] = [];
     if (filtresSource.includes('opendata')) {
       if (data?.length) {
-        const openSourcesId = data
-          .filter((s) => !FILTRES_SOURCE.includes(s.id as FiltresSource))
-          .map((s) => s.id);
         sources.push(
-          ...openSourcesId,
-          ...filtresSource.filter((s) => s !== 'opendata')
+          ...data
+            .filter(
+              (source) => !FILTRES_SOURCE.includes(source.id as FiltresSource)
+            )
+            .map((source) => source.id),
+          ...filtresSource.filter((source) => source !== 'opendata')
         );
       }
     } else {
       sources.push(...filtresSource);
     }
-  }
 
-  const avecDonneesCollectivite =
-    !sources.length || sources.includes('collectivite');
-
-  const avecSecteursSNBC =
-    filtresSource.length === 1 && filtresSource[0] === 'snbc';
-
-  const valeursReference = !filtresSource.length
-    ? references
-    : {
-        cible: filtresSource.includes('cible')
-          ? references?.cible ?? null
-          : null,
-        objectifs: filtresSource.includes('cible')
-          ? references?.objectifs ?? null
-          : null,
-        seuil: filtresSource.includes('seuil')
-          ? references?.seuil ?? null
-          : null,
-        libelle: references?.libelle ?? null,
-        drom: references?.drom ?? false,
-      };
-
-  return {
-    isLoading: isLoadingSources || isLoadingMoyenne || isLoadingReference,
-    availableOptions,
+    return {
+      isLoading: isLoadingSources || isLoadingMoyenne || isLoadingReference,
+      availableOptions: options.map((value) => ({
+        value,
+        label: filtreToLabel(value),
+      })),
+      filtresSource,
+      setFiltresSource,
+      sources: sources.length ? sources : undefined,
+      avecDonneesCollectivite:
+        !sources.length || sources.includes('collectivite'),
+      avecSecteursSNBC:
+        filtresSource.length === 1 && filtresSource[0] === 'snbc',
+      moyenne:
+        !filtresSource.length || filtresSource.includes('moyenne')
+          ? moyenne
+          : undefined,
+      valeursReference: !filtresSource.length
+        ? references
+        : {
+            cible: filtresSource.includes('cible')
+              ? references?.cible ?? null
+              : null,
+            objectifs: filtresSource.includes('cible')
+              ? references?.objectifs ?? null
+              : null,
+            seuil: filtresSource.includes('seuil')
+              ? references?.seuil ?? null
+              : null,
+            libelle: references?.libelle ?? null,
+            drom: references?.drom ?? false,
+          },
+    };
+  }, [
+    data,
     filtresSource,
-    setFiltresSource,
-    sources: sources.length ? sources : undefined,
-    avecDonneesCollectivite,
-    avecSecteursSNBC,
-    moyenne:
-      !filtresSource.length || filtresSource.includes('moyenne')
-        ? moyenne
-        : undefined,
-    valeursReference,
-  };
+    isLoadingMoyenne,
+    isLoadingReference,
+    isLoadingSources,
+    moyenne,
+    references,
+  ]);
 };
 
 export type SourceFilter = ReturnType<typeof useSourceFilter>;

--- a/apps/app/src/indicateurs/valeurs/grid/__tests__/parse-cell-number.spec.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/__tests__/parse-cell-number.spec.ts
@@ -22,5 +22,7 @@ describe('parseCellNumber', () => {
   it('rend null pour une saisie non numerique', () => {
     expect(parseCellNumber('abc')).toBe(null);
     expect(parseCellNumber('1.2.3')).toBe(null);
+    expect(parseCellNumber('Infinity')).toBe(null);
+    expect(parseCellNumber('1e309')).toBe(null);
   });
 });

--- a/apps/app/src/indicateurs/valeurs/grid/parse-cell-number.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/parse-cell-number.ts
@@ -4,5 +4,5 @@ export const parseCellNumber = (raw: string): number | null => {
     return null;
   }
   const parsed = Number(normalized);
-  return Number.isNaN(parsed) ? null : parsed;
+  return Number.isFinite(parsed) ? parsed : null;
 };

--- a/apps/app/src/indicateurs/valeurs/grid/use-cell-edit.spec.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/use-cell-edit.spec.ts
@@ -2,6 +2,8 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { useCellEdit } from './use-cell-edit';
 
+const ok = true;
+
 describe('useCellEdit', () => {
   it('re-enregistre le dernier draft saisi pendant une sauvegarde en vol', async () => {
     let resolveFirst: (result: boolean) => void = () => undefined;
@@ -13,14 +15,14 @@ describe('useCellEdit', () => {
             resolveFirst = resolve;
           })
       )
-      .mockResolvedValue(true);
+      .mockResolvedValue(ok);
 
     const { result } = renderHook(() =>
       useCellEdit({ currentValue: null, onSave })
     );
 
     act(() => result.current.onChange('5'));
-    let firstSave: Promise<void> = Promise.resolve();
+    let firstSave: Promise<boolean> = Promise.resolve(true);
     act(() => {
       firstSave = result.current.save();
     });
@@ -30,7 +32,7 @@ describe('useCellEdit', () => {
     });
 
     await act(async () => {
-      resolveFirst(true);
+      resolveFirst(ok);
       await firstSave;
     });
 
@@ -49,7 +51,7 @@ describe('useCellEdit', () => {
             resolveFirst = resolve;
           })
       )
-      .mockResolvedValue(true);
+      .mockResolvedValue(ok);
 
     const { result, rerender } = renderHook(
       ({ currentValue }: { currentValue: number | null }) =>
@@ -58,7 +60,7 @@ describe('useCellEdit', () => {
     );
 
     act(() => result.current.onChange('20'));
-    let firstSave: Promise<void> = Promise.resolve();
+    let firstSave: Promise<boolean> = Promise.resolve(true);
     act(() => {
       firstSave = result.current.save();
     });
@@ -71,37 +73,154 @@ describe('useCellEdit', () => {
     });
 
     await act(async () => {
-      resolveFirst(true);
+      resolveFirst(ok);
       await firstSave;
     });
 
     await waitFor(() => expect(onSave).toHaveBeenCalledWith(10));
   });
 
-  it("garde la valeur saisie apres sauvegarde tant que la valeur courante n'est pas rafraichie", async () => {
-    const onSave = vi.fn().mockResolvedValue(true);
+  it('re-enregistre la valeur initiale ressaisie sans attendre le rafraichissement', async () => {
+    let resolveFirst: (result: boolean) => void = () => undefined;
+    const onSave = vi
+      .fn<(resultat: number | null) => Promise<boolean>>()
+      .mockImplementationOnce(
+        () =>
+          new Promise<boolean>((resolve) => {
+            resolveFirst = resolve;
+          })
+      )
+      .mockResolvedValue(ok);
+    const { result } = renderHook(() =>
+      useCellEdit({ currentValue: 10, onSave })
+    );
+
+    act(() => result.current.onChange('20'));
+    let saveResult: Promise<boolean> = Promise.resolve(true);
+    act(() => {
+      saveResult = result.current.save();
+    });
+    act(() => result.current.onChange('10'));
+
+    await act(async () => {
+      resolveFirst(ok);
+      await saveResult;
+    });
+
+    expect(onSave).toHaveBeenCalledTimes(2);
+    expect(onSave).toHaveBeenNthCalledWith(1, 20);
+    expect(onSave).toHaveBeenNthCalledWith(2, 10);
+  });
+
+  it('met en file une nouvelle édition après Escape pendant une sauvegarde', async () => {
+    let resolveFirst: (result: boolean) => void = () => undefined;
+    const onSave = vi
+      .fn<(resultat: number | null) => Promise<boolean>>()
+      .mockImplementationOnce(
+        () =>
+          new Promise<boolean>((resolve) => {
+            resolveFirst = resolve;
+          })
+      )
+      .mockResolvedValue(ok);
+    const { result } = renderHook(() =>
+      useCellEdit({ currentValue: 10, onSave })
+    );
+
+    act(() => result.current.onChange('20'));
+    let firstSave: Promise<boolean> = Promise.resolve(true);
+    act(() => {
+      firstSave = result.current.save();
+    });
+    act(() => result.current.cancel());
+    act(() => result.current.onChange('30'));
+    let secondSave: Promise<boolean> = Promise.resolve(true);
+    act(() => {
+      secondSave = result.current.save();
+    });
+
+    expect(secondSave).not.toBe(firstSave);
+    expect(onSave).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      resolveFirst(ok);
+      await secondSave;
+    });
+
+    expect(onSave).toHaveBeenCalledTimes(2);
+    expect(onSave).toHaveBeenNthCalledWith(1, 20);
+    expect(onSave).toHaveBeenNthCalledWith(2, 30);
+  });
+
+  it("réécrit la valeur initiale après Escape si l'écriture précédente a abouti", async () => {
+    let resolveFirst: (result: boolean) => void = () => undefined;
+    const onSave = vi
+      .fn<(resultat: number | null) => Promise<boolean>>()
+      .mockImplementationOnce(
+        () =>
+          new Promise<boolean>((resolve) => {
+            resolveFirst = resolve;
+          })
+      )
+      .mockResolvedValue(ok);
+    const { result } = renderHook(() =>
+      useCellEdit({ currentValue: 10, onSave })
+    );
+
+    act(() => result.current.onChange('20'));
+    act(() => {
+      void result.current.save();
+    });
+    act(() => result.current.cancel());
+    act(() => result.current.onChange('10'));
+    let secondSave: Promise<boolean> = Promise.resolve(true);
+    act(() => {
+      secondSave = result.current.save();
+    });
+
+    await act(async () => {
+      resolveFirst(ok);
+      await secondSave;
+    });
+
+    expect(onSave).toHaveBeenCalledTimes(2);
+    expect(onSave).toHaveBeenNthCalledWith(1, 20);
+    expect(onSave).toHaveBeenNthCalledWith(2, 10);
+  });
+
+  it('affiche la valeur normalisee meme si le rafraichissement arrive avant la fin de la mutation', async () => {
+    let resolveSave: (result: boolean) => void = () => undefined;
+    const onSave = vi.fn(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveSave = resolve;
+        })
+    );
     const { result, rerender } = renderHook(
       ({ currentValue }: { currentValue: number | null }) =>
         useCellEdit({ currentValue, onSave }),
       { initialProps: { currentValue: 10 as number | null } }
     );
 
-    act(() => result.current.onChange('12'));
-    await act(async () => {
-      await result.current.save();
+    act(() => result.current.onChange('1,6'));
+    let saveResult: Promise<boolean> = Promise.resolve(false);
+    act(() => {
+      saveResult = result.current.save();
     });
 
-    expect(result.current.text).toBe('12');
+    // Le serveur applique ici une précision 0 et renvoie 2 lors du refetch
+    // effectué par le callback onSuccess de la mutation.
+    rerender({ currentValue: 2 });
+    await act(async () => {
+      resolveSave(ok);
+      await saveResult;
+    });
 
-    rerender({ currentValue: 12 });
-    expect(result.current.text).toBe('12');
-
-    rerender({ currentValue: 30 });
-    expect(result.current.text).toBe('30');
+    expect(result.current.text).toBe('2');
+    expect(result.current.status).toBe('saved');
   });
 
   it('vide une cellule renseignee en enregistrant null', async () => {
-    const onSave = vi.fn().mockResolvedValue(true);
+    const onSave = vi.fn().mockResolvedValue(ok);
     const { result } = renderHook(() =>
       useCellEdit({ currentValue: 12, onSave })
     );
@@ -114,18 +233,39 @@ describe('useCellEdit', () => {
     expect(onSave).toHaveBeenCalledWith(null);
   });
 
-  it('n’enregistre pas après annulation même si save est rappelé tout de suite', async () => {
-    const onSave = vi.fn().mockResolvedValue(true);
+  it('garde le draft et refuse la fermeture quand le serveur rejette la valeur', async () => {
+    const onSave = vi.fn().mockResolvedValue(false);
     const { result } = renderHook(() =>
       useCellEdit({ currentValue: 12, onSave })
     );
 
-    act(() => result.current.onChange('42'));
-    act(() => result.current.cancel());
+    act(() => result.current.onChange('15'));
+    let canClose = true;
     await act(async () => {
-      await result.current.save();
+      canClose = await result.current.save();
     });
 
+    expect(canClose).toBe(false);
+    expect(result.current.text).toBe('15');
+    expect(result.current.status).toBe('error');
+    expect(result.current.error).toBe('save');
+  });
+
+  it('garde un draft non numerique et refuse la fermeture sans requete', async () => {
+    const onSave = vi.fn().mockResolvedValue(ok);
+    const { result } = renderHook(() =>
+      useCellEdit({ currentValue: 12, onSave })
+    );
+
+    act(() => result.current.onChange('-'));
+    let canClose = true;
+    await act(async () => {
+      canClose = await result.current.save();
+    });
+
+    expect(canClose).toBe(false);
+    expect(result.current.text).toBe('-');
+    expect(result.current.error).toBe('invalid');
     expect(onSave).not.toHaveBeenCalled();
   });
 });

--- a/apps/app/src/indicateurs/valeurs/grid/use-cell-edit.ts
+++ b/apps/app/src/indicateurs/valeurs/grid/use-cell-edit.ts
@@ -2,12 +2,15 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { parseCellNumber } from './parse-cell-number';
 
 export type CellEditStatus = 'idle' | 'saving' | 'saved' | 'error';
+type CellEditError = 'invalid' | 'save';
 
 export type CellEdit = {
   text: string;
   status: CellEditStatus;
+  error: CellEditError | null;
   onChange: (raw: string) => void;
-  save: () => Promise<void>;
+  /** `true` autorise la fermeture de l'éditeur. */
+  save: () => Promise<boolean>;
   cancel: () => void;
 };
 
@@ -23,13 +26,14 @@ export const useCellEdit = ({
 }): CellEdit => {
   const [draftValue, setDraftValue] = useState<string | null>(null);
   const [status, setStatus] = useState<CellEditStatus>('idle');
-  const isSaving = useRef(false);
-  const hasPendingSave = useRef(false);
-  const pendingSavedRaw = useRef<string | undefined>(undefined);
+  const [error, setError] = useState<CellEditError | null>(null);
+  const savePromiseRef = useRef<{
+    editVersion: number;
+    promise: Promise<boolean>;
+  } | null>(null);
+  const editVersionRef = useRef(0);
   const draftValueRef = useRef<string | null>(null);
-  draftValueRef.current = draftValue;
-  const currentValueRef = useRef(currentValue);
-  currentValueRef.current = currentValue;
+  const persistedValueRef = useRef(currentValue);
 
   const currentText = currentValue === null ? '' : String(currentValue);
   const text = draftValue ?? currentText;
@@ -43,69 +47,122 @@ export const useCellEdit = ({
   }, [status]);
 
   useEffect(() => {
-    const savedRaw = pendingSavedRaw.current;
-    const currentValueReflectsSave =
-      savedRaw !== undefined &&
-      draftValueRef.current === savedRaw &&
-      currentValue === parseCellNumber(savedRaw);
-    if (currentValueReflectsSave) {
-      pendingSavedRaw.current = undefined;
-      setDraftValue(null);
-    }
+    persistedValueRef.current = currentValue;
   }, [currentValue]);
 
   const onChange = useCallback((raw: string) => {
-    setDraftValue(raw.replace(DISALLOWED_CHARS, ''));
+    const sanitized = raw.replace(DISALLOWED_CHARS, '');
+    // La ref est mise à jour dans le même événement : une validation au clavier
+    // déclenchée avant le prochain rendu lit bien le dernier caractère saisi.
+    draftValueRef.current = sanitized;
+    setDraftValue(sanitized);
     setStatus('idle');
+    setError(null);
   }, []);
 
   const cancel = useCallback(() => {
+    editVersionRef.current += 1;
     draftValueRef.current = null;
     setDraftValue(null);
     setStatus('idle');
+    setError(null);
   }, []);
 
-  const save = useCallback(async () => {
-    if (isSaving.current) {
-      hasPendingSave.current = true;
-      return;
-    }
-    const savedRaw = draftValueRef.current;
-    if (savedRaw === null) {
-      return;
-    }
-    const parsedValue = parseCellNumber(savedRaw);
-    const isUnparseable = savedRaw.trim() !== '' && parsedValue === null;
-    if (isUnparseable) {
-      setStatus('error');
-      return;
-    }
-    const isUnchanged = parsedValue === currentValueRef.current;
-    if (isUnchanged) {
-      setDraftValue(null);
-      setStatus('idle');
-      return;
-    }
-    isSaving.current = true;
-    setStatus('saving');
-    try {
-      const writeResult = await onSave(parsedValue);
-      if (writeResult) {
-        pendingSavedRaw.current = savedRaw;
-        setStatus((current) => (current === 'saving' ? 'saved' : current));
-      } else {
-        setStatus('error');
-      }
-    } catch {
-      setStatus('error');
-    } finally {
-      isSaving.current = false;
-      if (hasPendingSave.current) {
-        hasPendingSave.current = false;
-        void save();
-      }
-    }
-  }, [onSave]);
+  const runSave = useCallback(
+    async (editVersion: number): Promise<boolean> => {
+      // Une saisie peut encore changer pendant l'appel réseau. Dans ce cas, le
+      // premier résultat est acquitté puis le dernier draft est enregistré avant
+      // d'autoriser la fermeture.
+      while (true) {
+        if (editVersion !== editVersionRef.current) {
+          return true;
+        }
+        const savedRaw = draftValueRef.current;
+        if (savedRaw === null) {
+          return true;
+        }
+        const parsedValue = parseCellNumber(savedRaw);
+        const isUnparseable = savedRaw.trim() !== '' && parsedValue === null;
+        if (isUnparseable) {
+          setStatus('error');
+          setError('invalid');
+          return false;
+        }
+        if (parsedValue === persistedValueRef.current) {
+          draftValueRef.current = null;
+          setDraftValue(null);
+          setStatus('idle');
+          setError(null);
+          return true;
+        }
 
-  return { text, status, onChange, save, cancel };
+        setStatus('saving');
+        setError(null);
+        try {
+          const writeResult = await onSave(parsedValue);
+          if (writeResult) {
+            // Conserver l'écriture acquittée même si Escape a ouvert une
+            // nouvelle génération d'édition pendant la requête. La sauvegarde
+            // mise en file doit se comparer au dernier état réellement écrit,
+            // et non à la prop qui pouvait encore contenir l'ancienne valeur.
+            persistedValueRef.current = parsedValue;
+          }
+          // Escape peut fermer l'éditeur pendant que la requête se termine. Son
+          // reset ne doit alors pas être remplacé par un acquittement tardif.
+          if (editVersion !== editVersionRef.current) {
+            return true;
+          }
+          if (!writeResult) {
+            setStatus('error');
+            setError('save');
+            return false;
+          }
+        } catch {
+          if (editVersion !== editVersionRef.current) {
+            return true;
+          }
+          setStatus('error');
+          setError('save');
+          return false;
+        }
+
+        if (draftValueRef.current !== savedRaw) {
+          continue;
+        }
+
+        // `onSave` attend l'invalidation des requêtes. On libère donc le draft
+        // après son succès : la valeur rendue vient de la réponse serveur, y
+        // compris lorsqu'elle a été normalisée ou arrondie.
+        draftValueRef.current = null;
+        setDraftValue(null);
+        setStatus('saved');
+        setError(null);
+        return true;
+      }
+    },
+    [onSave]
+  );
+
+  const save = useCallback((): Promise<boolean> => {
+    const editVersion = editVersionRef.current;
+    const activeSave = savePromiseRef.current;
+    if (activeSave?.editVersion === editVersion) {
+      return activeSave.promise;
+    }
+
+    // Après Escape, une nouvelle édition doit attendre l'écriture déjà en vol
+    // pour conserver l'ordre serveur, tout en ayant sa propre promesse.
+    const run = () => runSave(editVersion);
+    const promise = (
+      activeSave ? activeSave.promise.then(run, run) : run()
+    ).finally(() => {
+      if (savePromiseRef.current?.promise === promise) {
+        savePromiseRef.current = null;
+      }
+    });
+    savePromiseRef.current = { editVersion, promise };
+    return promise;
+  }, [runSave]);
+
+  return { text, status, error, onChange, save, cancel };
 };

--- a/apps/app/src/indicateurs/valeurs/invalidate-indicateur-valeurs-queries.spec.ts
+++ b/apps/app/src/indicateurs/valeurs/invalidate-indicateur-valeurs-queries.spec.ts
@@ -1,0 +1,70 @@
+import type { QueryClient } from '@tanstack/react-query';
+import { describe, expect, it, vi } from 'vitest';
+import { invalidateIndicateurValeursQueries } from './invalidate-indicateur-valeurs-queries';
+
+describe('invalidateIndicateurValeursQueries', () => {
+  it('attend le rafraichissement de toutes les projections', async () => {
+    let resolveValues: () => void = () => undefined;
+    const invalidateQueries = vi
+      .fn()
+      .mockResolvedValue(undefined)
+      .mockImplementationOnce(() => Promise.resolve())
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveValues = resolve;
+          })
+      );
+    const queryKey = (name: string) => (input: unknown) => [name, input];
+    const pathKey = (name: string) => () => [name];
+    const trpc = {
+      indicateurs: {
+        indicateurs: { list: { queryKey: queryKey('indicateurs') } },
+        valeurs: {
+          list: { queryKey: queryKey('valeurs') },
+          average: { queryKey: queryKey('average') },
+        },
+      },
+      referentiels: {
+        actions: {
+          getValeursUtilisables: { queryKey: queryKey('referentiels') },
+          getScoreIndicatif: { pathKey: pathKey('score-indicatif') },
+        },
+      },
+      demarches: {
+        pcaet: {
+          get: { pathKey: pathKey('demarche-pcaet') },
+          diagnostic: {
+            get: { pathKey: pathKey('diagnostic-pcaet') },
+          },
+        },
+      },
+    };
+
+    let settled = false;
+    const invalidation = invalidateIndicateurValeursQueries({
+      queryClient: { invalidateQueries } as unknown as QueryClient,
+      trpc: trpc as never,
+      collectiviteId: 12,
+    }).then(() => {
+      settled = true;
+    });
+
+    await Promise.resolve();
+    expect(invalidateQueries).toHaveBeenCalledTimes(7);
+    expect(invalidateQueries.mock.calls).toEqual([
+      [{ queryKey: ['indicateurs', { collectiviteId: 12 }] }],
+      [{ queryKey: ['valeurs', { collectiviteId: 12 }] }],
+      [{ queryKey: ['average', { collectiviteId: 12 }] }],
+      [{ queryKey: ['referentiels', { collectiviteId: 12 }] }],
+      [{ queryKey: ['score-indicatif'] }],
+      [{ queryKey: ['diagnostic-pcaet'] }],
+      [{ queryKey: ['demarche-pcaet'] }],
+    ]);
+    expect(settled).toBe(false);
+
+    resolveValues();
+    await invalidation;
+    expect(settled).toBe(true);
+  });
+});

--- a/apps/app/src/indicateurs/valeurs/invalidate-indicateur-valeurs-queries.ts
+++ b/apps/app/src/indicateurs/valeurs/invalidate-indicateur-valeurs-queries.ts
@@ -1,0 +1,52 @@
+import type { QueryClient } from '@tanstack/react-query';
+import type { useTRPC } from '@tet/api';
+
+type TRPCClient = ReturnType<typeof useTRPC>;
+
+/**
+ * Rafraîchit toutes les projections alimentées par une valeur d'indicateur.
+ * La promesse ne se résout qu'une fois les requêtes actives rechargées : les
+ * éditeurs peuvent alors abandonner leur draft au profit de la valeur serveur
+ * normalisée.
+ */
+export const invalidateIndicateurValeursQueries = async ({
+  queryClient,
+  trpc,
+  collectiviteId,
+}: {
+  queryClient: QueryClient;
+  trpc: TRPCClient;
+  collectiviteId: number;
+}): Promise<void> => {
+  await Promise.all([
+    queryClient.invalidateQueries({
+      queryKey: trpc.indicateurs.indicateurs.list.queryKey({
+        collectiviteId,
+      }),
+    }),
+    queryClient.invalidateQueries({
+      queryKey: trpc.indicateurs.valeurs.list.queryKey({
+        collectiviteId,
+      }),
+    }),
+    queryClient.invalidateQueries({
+      queryKey: trpc.indicateurs.valeurs.average.queryKey({
+        collectiviteId,
+      }),
+    }),
+    queryClient.invalidateQueries({
+      queryKey: trpc.referentiels.actions.getValeursUtilisables.queryKey({
+        collectiviteId,
+      }),
+    }),
+    queryClient.invalidateQueries({
+      queryKey: trpc.referentiels.actions.getScoreIndicatif.pathKey(),
+    }),
+    queryClient.invalidateQueries({
+      queryKey: trpc.demarches.pcaet.diagnostic.get.pathKey(),
+    }),
+    queryClient.invalidateQueries({
+      queryKey: trpc.demarches.pcaet.get.pathKey(),
+    }),
+  ]);
+};

--- a/apps/app/src/indicateurs/valeurs/use-upsert-indicateur-valeur.ts
+++ b/apps/app/src/indicateurs/valeurs/use-upsert-indicateur-valeur.ts
@@ -1,7 +1,7 @@
-import { useToastContext } from '@/app/utils/toast/toast-context';
+import { appLabels } from '@/app/labels/catalog';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { RouterInput, useTRPC } from '@tet/api';
-import { ListIndicateurValeurOuput } from './use-list-indicateur-valeurs';
+import { invalidateIndicateurValeursQueries } from './invalidate-indicateur-valeurs-queries';
 
 export type UpsertIndicateurValeurInput =
   RouterInput['indicateurs']['valeurs']['upsert'];
@@ -9,50 +9,19 @@ export type UpsertIndicateurValeurInput =
 export const useUpsertIndicateurValeur = () => {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
-  const { setToast } = useToastContext();
 
   return useMutation(
     trpc.indicateurs.valeurs.upsert.mutationOptions({
-      onSuccess: (_, variables) => {
-        const { collectiviteId, indicateurId } = variables;
-        if (!variables.id) {
-          setToast('success', 'La valeur a été ajoutée');
-        }
-
-        // recharge les infos complémentaires associées à l'indicateur
-        queryClient.invalidateQueries({
-          queryKey: trpc.indicateurs.indicateurs.list.queryKey({
-            collectiviteId,
-          }),
-        });
-
-        queryClient
-          .getQueriesData<ListIndicateurValeurOuput>({
-            queryKey: trpc.indicateurs.valeurs.list.queryKey({
-              collectiviteId,
-            }),
-          })
-          .forEach(([queryKey, queryResult]) => {
-            if (
-              queryResult?.indicateurs.some(
-                (indicateur) => indicateur.definition.id === indicateurId
-              )
-            ) {
-              queryClient.invalidateQueries({ queryKey });
-            }
-          });
-
-        queryClient.invalidateQueries({
-          queryKey: trpc.referentiels.actions.getValeursUtilisables.queryKey({
-            collectiviteId,
-          }),
+      onSuccess: async (_, { collectiviteId }) => {
+        await invalidateIndicateurValeursQueries({
+          queryClient,
+          trpc,
+          collectiviteId,
         });
       },
-      onError: (_, variables) => {
-        setToast(
-          'error',
-          `La valeur n'a pas pu être ${variables.id ? 'modifiée' : 'ajoutée'}`
-        );
+      meta: {
+        success: appLabels.indicateurValeurEnregistree,
+        error: appLabels.mutationError,
       },
     })
   );

--- a/apps/app/src/ui/charts/echarts/utils.spec.ts
+++ b/apps/app/src/ui/charts/echarts/utils.spec.ts
@@ -1,0 +1,71 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { makeOption } from './utils';
+
+describe('makeOption', () => {
+  const initialTimeZone = process.env.TZ;
+
+  beforeAll(() => {
+    process.env.TZ = 'Europe/Paris';
+  });
+
+  afterAll(() => {
+    if (initialTimeZone === undefined) {
+      delete process.env.TZ;
+    } else {
+      process.env.TZ = initialTimeZone;
+    }
+  });
+
+  it('conserve le calendrier local des graphiques génériques', () => {
+    const option = makeOption({ option: {} });
+    const tooltip = option.tooltip as {
+      axisPointer: {
+        label: { formatter: (params: unknown) => string };
+      };
+    };
+    const localNewYear = new Date(2030, 0, 1).getTime();
+    expect(new Date(localNewYear).toISOString().startsWith('2029-')).toBe(true);
+
+    expect(
+      tooltip.axisPointer.label.formatter({
+        axisDimension: 'x',
+        value: localNewYear,
+      })
+    ).toBe('2030');
+    expect(option).not.toHaveProperty('useUTC');
+  });
+
+  it('applique la stratégie temporelle au graphique et à son curseur', () => {
+    const formatter = (value: number) => `période-${value}`;
+    const option = makeOption({
+      option: {},
+      timeAxis: {
+        useUTC: true,
+        minInterval: 10,
+        maxInterval: 20,
+        formatter,
+      },
+    });
+    const xAxis = option.xAxis as {
+      minInterval: number;
+      maxInterval: number;
+      axisLabel: { formatter: typeof formatter };
+    };
+    const tooltip = option.tooltip as {
+      axisPointer: {
+        label: { formatter: (params: unknown) => string };
+      };
+    };
+
+    expect(option.useUTC).toBe(true);
+    expect(xAxis.minInterval).toBe(10);
+    expect(xAxis.maxInterval).toBe(20);
+    expect(xAxis.axisLabel.formatter).toBe(formatter);
+    expect(
+      tooltip.axisPointer.label.formatter({
+        axisDimension: 'x',
+        value: 123,
+      })
+    ).toBe('période-123');
+  });
+});

--- a/apps/app/src/ui/charts/echarts/utils.ts
+++ b/apps/app/src/ui/charts/echarts/utils.ts
@@ -148,10 +148,18 @@ export const makeLegendData = (
         }
   );
 
+export type TimeAxisOptions = {
+  useUTC?: boolean;
+  minInterval?: number;
+  maxInterval?: number;
+  formatter?: (value: number) => string;
+};
+
 type OptionsProps = {
   option: EChartsOption;
   titre?: string;
   unite?: string;
+  timeAxis?: TimeAxisOptions;
   disableToolbox?: boolean;
   hideMinMaxLabel?: boolean;
 };
@@ -190,6 +198,7 @@ export const makeOption = ({
   option = {},
   titre,
   unite,
+  timeAxis,
   disableToolbox = false,
   hideMinMaxLabel = false,
 }: OptionsProps): EChartsOption => {
@@ -206,6 +215,7 @@ export const makeOption = ({
   } = option;
 
   return {
+    ...(timeAxis?.useUTC !== undefined && { useUTC: timeAxis.useUTC }),
     textStyle: {
       fontFamily: '"Marianne", arial, sans-serif',
     },
@@ -238,11 +248,11 @@ export const makeOption = ({
     xAxis: {
       type: 'time',
       splitLine: { show: true, lineStyle: { opacity: 0.5 } },
-      // graduation de 5 en 5 années
-      maxInterval: 12 * 365 * 24 * 50 * 60 * 1000,
-      minInterval: 365 * 24 * 50 * 60 * 1000,
+      // graduation de 5 en 5 années par défaut
+      maxInterval: timeAxis?.maxInterval ?? 12 * 365 * 24 * 50 * 60 * 1000,
+      minInterval: timeAxis?.minInterval ?? 365 * 24 * 50 * 60 * 1000,
       axisLabel: {
-        formatter: '{yyyy}',
+        formatter: timeAxis?.formatter ?? '{yyyy}',
         color: colors.primary['9'],
         showMinLabel: !hideMinMaxLabel,
         showMaxLabel: !hideMinMaxLabel,
@@ -279,7 +289,8 @@ export const makeOption = ({
           backgroundColor: '#6a7985',
           formatter: (params) =>
             params.axisDimension === 'x'
-              ? new Date(params.value).getFullYear().toString()
+              ? timeAxis?.formatter?.(Number(params.value)) ??
+                new Date(params.value).getFullYear().toString()
               : NumFormat.format(params.value as number),
         },
       },

--- a/packages/ui/src/design-system/Input/Input.spec.tsx
+++ b/packages/ui/src/design-system/Input/Input.spec.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import { createRef } from 'react';
+import { describe, expect, it } from 'vitest';
+import { Input } from './Input';
+
+describe('Input', () => {
+  it('préserve les sémantiques natives et la ref pour un mois', () => {
+    const ref = createRef<HTMLInputElement>();
+
+    render(
+      <Input
+        ref={ref}
+        type="month"
+        aria-label="Mois"
+        value="2026-02"
+        readOnly
+      />
+    );
+
+    const input = screen.getByLabelText('Mois');
+    expect(input).toHaveAttribute('type', 'month');
+    expect(input).toHaveValue('2026-02');
+    expect(ref.current).toBe(input);
+  });
+});

--- a/packages/ui/src/design-system/Input/Input.stories.tsx
+++ b/packages/ui/src/design-system/Input/Input.stories.tsx
@@ -148,6 +148,15 @@ export const TypeDateAvecValeur: Story = {
   },
 };
 
+/** Mois avec une valeur renseignée. */
+export const TypeMonthAvecValeur: Story = {
+  args: {
+    type: 'month',
+    value: '2024-01',
+    onChange: action('onChange'),
+  },
+};
+
 /** Mot de passe sans aucune props renseignée. */
 export const TypePassword: Story = {
   args: { type: 'password' },

--- a/packages/ui/src/design-system/Input/Input.tsx
+++ b/packages/ui/src/design-system/Input/Input.tsx
@@ -1,24 +1,25 @@
-import {Ref, forwardRef} from 'react';
-import {InputBase, InputBaseProps} from './InputBase';
-import {InputDate, InputDateProps} from './InputDate';
-import {InputSearch, InputSearchProps} from './InputSearch';
-import {InputPassword, InputPasswordProps} from './InputPassword';
-import {InputNumber, InputNumberProps} from './InputNumber';
-import {InputPattern, InputPatternProps} from './InputPattern';
-import {InputOTP, InputOTPProps} from './InputOTP';
-import {InputTel, InputTelProps} from './InputTel';
-import {InputFile, InputFileProps} from './InputFile';
+import { Ref, forwardRef } from 'react';
+import { InputBase, InputBaseProps } from './InputBase';
+import { InputDate, InputDateProps } from './InputDate';
+import { InputSearch, InputSearchProps } from './InputSearch';
+import { InputPassword, InputPasswordProps } from './InputPassword';
+import { InputNumber, InputNumberProps } from './InputNumber';
+import { InputPattern, InputPatternProps } from './InputPattern';
+import { InputOTP, InputOTPProps } from './InputOTP';
+import { InputTel, InputTelProps } from './InputTel';
+import { InputFile, InputFileProps } from './InputFile';
 
 type InputProps =
-  | (Omit<InputBaseProps, 'type'> & {type: 'text'})
-  | (InputNumberProps & {type: 'number'})
-  | (InputDateProps & {type: 'date'})
-  | (InputSearchProps & {type: 'search'})
-  | (InputPasswordProps & {type: 'password'})
-  | (InputPatternProps & {type: 'pattern'})
-  | (InputTelProps & {type: 'tel'})
-  | (InputOTPProps & {type: 'otp'})
-  | (InputFileProps & {type: 'file'});
+  | (Omit<InputBaseProps, 'type'> & { type: 'text' })
+  | (InputNumberProps & { type: 'number' })
+  | (InputDateProps & { type: 'date' })
+  | (Omit<InputBaseProps, 'type'> & { type: 'month' })
+  | (InputSearchProps & { type: 'search' })
+  | (InputPasswordProps & { type: 'password' })
+  | (InputPatternProps & { type: 'pattern' })
+  | (InputTelProps & { type: 'tel' })
+  | (InputOTPProps & { type: 'otp' })
+  | (InputFileProps & { type: 'file' });
 
 /**
  * Affiche un champ de saisie, éventuellement combiné à une zone d'icône (ou de
@@ -27,9 +28,15 @@ type InputProps =
  * - type : restreint à un sous-ensemble des types standards
  */
 export const Input = forwardRef(
-  ({type = 'text', ...props}: InputProps, ref?: Ref<HTMLInputElement>) => {
+  ({ type = 'text', ...props }: InputProps, ref?: Ref<HTMLInputElement>) => {
     if (type === 'date') {
       return <InputDate {...(props as InputDateProps)} ref={ref} />;
+    }
+
+    if (type === 'month') {
+      return (
+        <InputBase {...(props as InputBaseProps)} type="month" ref={ref} />
+      );
     }
 
     if (type === 'search') {

--- a/packages/ui/src/design-system/Input/InputBase.tsx
+++ b/packages/ui/src/design-system/Input/InputBase.tsx
@@ -15,6 +15,7 @@ export type InputType =
   | 'text'
   | 'password'
   | 'date'
+  | 'month'
   | 'search'
   | 'tel'
   | 'file';


### PR DESCRIPTION
Superseded by [PR 5/10](https://github.com/incubateur-ademe/territoires-en-transitions/pull/4972) in the consolidated 10-PR stack. Review and merge using the [updated index](https://github.com/incubateur-ademe/territoires-en-transitions/pull/4959). This PR is closed without merging; its changes are included in the replacement.

---

Prepare indicator value editing and cache updates for periodicity support. Shared invalidation covers related indicator queries; source filtering preserves a stable selection; chart timestamps use UTC; the shared input supports month fields. Grid edits serialize pending saves and preserve newer drafts when an earlier save completes or is cancelled.

Validation: 19 focused tests passed, along with ESLint, backend/API/UI builds and app source/spec typechecks. The app checks exclude unchanged Next configuration because the installed Next version is 16.2.10 while main requires 16.3.4.

The existing annual API and PCAET table remain compatible at this boundary.

Validation completed: 19 focused tests passed; backend API UI and frontend production/test TypeScript checks passed; ESLint passed.

Stack base: `split/05-definition-periodicite`. Review against that branch; after its PR merges, restack this branch onto main and rerun checks before merging.
