### PR TITLE
refactor(indicateurs): introduce catalogue read application service

### DIFF
--- a/apps/backend/src/indicateurs/definitions/list-collectivite-definitions/list-collectivite-definitions.repository.spec.ts
+++ b/apps/backend/src/indicateurs/definitions/list-collectivite-definitions/list-collectivite-definitions.repository.spec.ts
@@ -1,0 +1,36 @@
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import type { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { ListCollectiviteDefinitionsRepository } from './list-collectivite-definitions.repository';
+
+describe('ListCollectiviteDefinitionsRepository', () => {
+  it('utilise la transaction fournie en conservant le périmètre de la collectivité', async () => {
+    const where = vi.fn().mockResolvedValue([]);
+    const from = vi.fn(() => ({ where }));
+    const select = vi.fn(() => ({ from }));
+    const baseSelect = vi.fn();
+    const repository = new ListCollectiviteDefinitionsRepository({
+      db: { select: baseSelect },
+    } as unknown as DatabaseService);
+    const tx = { select } as unknown as Transaction;
+
+    await repository.listCollectiviteDefinitions(
+      {
+        collectiviteId: 42,
+        identifiantsReferentiel: ['CAE_1.A'],
+        indicateurIds: [7],
+      },
+      tx
+    );
+
+    expect(select).toHaveBeenCalledOnce();
+    expect(baseSelect).not.toHaveBeenCalled();
+    const condition = where.mock.calls[0]?.[0] as SQL;
+    const query = new PgDialect().sqlToQuery(condition);
+    expect(query.sql).toContain('"collectivite_id" =');
+    expect(query.sql).toContain('"collectivite_id" is null');
+    expect(query.sql).toContain('"groupement_id" is not null');
+    expect(query.params).toEqual(['CAE_1.A', 7, 42]);
+  });
+});

--- a/apps/backend/src/indicateurs/definitions/list-collectivite-definitions/list-collectivite-definitions.repository.ts
+++ b/apps/backend/src/indicateurs/definitions/list-collectivite-definitions/list-collectivite-definitions.repository.ts
@@ -4,6 +4,7 @@ import { groupementTable } from '@tet/backend/collectivites/shared/models/groupe
 import { indicateurDefinitionTable } from '@tet/backend/indicateurs/definitions/indicateur-definition.table';
 import { indicateurGroupeTable } from '@tet/backend/indicateurs/shared/models/indicateur-groupe.table';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
 import {
   IndicateurDefinition,
   IndicateurDefinitionAvecEnfants,
@@ -14,6 +15,7 @@ import {
   eq,
   getTableColumns,
   inArray,
+  isNotNull,
   isNull,
   or,
   sql,
@@ -29,15 +31,18 @@ export class ListCollectiviteDefinitionsRepository {
 
   constructor(private readonly databaseService: DatabaseService) {}
 
-  async listCollectiviteDefinitions({
-    identifiantsReferentiel,
-    indicateurIds,
-    collectiviteId,
-  }: {
-    identifiantsReferentiel?: string[];
-    indicateurIds?: number[];
-    collectiviteId?: number;
-  } = {}): Promise<IndicateurDefinition[]> {
+  async listCollectiviteDefinitions(
+    {
+      identifiantsReferentiel,
+      indicateurIds,
+      collectiviteId,
+    }: {
+      identifiantsReferentiel?: string[];
+      indicateurIds?: number[];
+      collectiviteId?: number;
+    } = {},
+    tx?: Transaction
+  ): Promise<IndicateurDefinition[]> {
     this.logger.log(
       `Récupération des définitions des indicateurs ${identifiantsReferentiel?.join(
         ','
@@ -60,7 +65,12 @@ export class ListCollectiviteDefinitionsRepository {
     const byCollectiviteId = collectiviteId
       ? or(
           eq(indicateurDefinitionTable.collectiviteId, collectiviteId),
-          isNull(indicateurDefinitionTable.collectiviteId)
+          isNull(indicateurDefinitionTable.collectiviteId),
+          // Un indicateur de groupement est une restriction d'applicabilité,
+          // pas une définition personnalisée confidentielle. Le groupement
+          // reste donc prioritaire si des données historiques portent les
+          // deux colonnes de périmètre.
+          isNotNull(indicateurDefinitionTable.groupementId)
         )
       : undefined;
 
@@ -70,7 +80,7 @@ export class ListCollectiviteDefinitionsRepository {
       byCollectiviteId,
     ];
 
-    const definitions = await this.databaseService.db
+    const definitions = await (tx ?? this.databaseService.db)
       .select()
       .from(indicateurDefinitionTable)
       .where(and(...conditions));

--- a/apps/backend/src/indicateurs/definitions/list-platform-definitions/list-platform-definitions.controller.ts
+++ b/apps/backend/src/indicateurs/definitions/list-platform-definitions/list-platform-definitions.controller.ts
@@ -8,10 +8,13 @@ import {
 import { AllowAnonymousAccess } from '@tet/backend/users/decorators/allow-anonymous-access.decorator';
 import { ApiUsageEnum } from '@tet/backend/utils/api/api-usage-type.enum';
 import { ApiUsage } from '@tet/backend/utils/api/api-usage.decorator';
+import { TokenInfo } from '@tet/backend/users/decorators/token-info.decorators';
+import type { AuthUser } from '@tet/backend/users/models/auth.models';
+import { createControllerErrorHandler } from '@tet/backend/utils/nest/controller-error-handler';
 import { createZodDto } from 'nestjs-zod';
 import { listPlatformDefinitionsApiRequestSchema } from './list-platform-definitions.api-request';
 import { listPlatformDefinitionsApiResponseSchema } from './list-platform-definitions.api-response';
-import { ListPlatformDefinitionsRepository } from './list-platform-definitions.repository';
+import { ListPlatformDefinitionsService } from './list-platform-definitions.service';
 
 class ListPlatformDefinitionsApiRequestClass extends createZodDto(
   listPlatformDefinitionsApiRequestSchema
@@ -25,8 +28,9 @@ class ListPlatformDefinitionsApiResponseClass extends createZodDto(
 @ApiBearerAuth()
 @Controller()
 export class ListPlatformDefinitionsController {
+  private readonly getResultDataOrThrowError = createControllerErrorHandler();
   constructor(
-    private readonly listPlatformDefinitionsRepository: ListPlatformDefinitionsRepository
+    private readonly listPlatformDefinitionsService: ListPlatformDefinitionsService
   ) {}
 
   @AllowAnonymousAccess()
@@ -42,27 +46,20 @@ export class ListPlatformDefinitionsController {
     type: ListPlatformDefinitionsApiResponseClass,
   })
   async listDefinitions(
-    @Query() input: ListPlatformDefinitionsApiRequestClass
+    @Query() input: ListPlatformDefinitionsApiRequestClass,
+    @TokenInfo() user: AuthUser | null
   ) {
     const result =
-      await this.listPlatformDefinitionsRepository.listPlatformDefinitionAggregates(
-        input
+      await this.listPlatformDefinitionsService.listPlatformDefinitionAggregates(
+        input,
+        { user }
       );
 
     // Parsing will strip keys that are not in the schema
     // ensuring consistent API response format
-    const parsedResult = listPlatformDefinitionsApiResponseSchema.parse(result);
-
-    // const mapToNonBreakingPublicApiOutput = (
-    //   definition: ListPlatformDefinitionsApiResponse[number]
-    // ) => ({
-    //   ...omit(definition, ['estFavori', 'estConfidentiel', 'fiches', 'parent']),
-
-    //   favoris: definition.estFavori,
-    //   confidentiel: definition.estConfidentiel,
-    //   ficheActions: definition.fiches,
-    //   parents: definition.parent ? [definition.parent] : [],
-    // });
+    const parsedResult = listPlatformDefinitionsApiResponseSchema.parse(
+      this.getResultDataOrThrowError(result)
+    );
 
     return {
       count: parsedResult.length,

--- a/apps/backend/src/indicateurs/definitions/list-platform-definitions/list-platform-definitions.repository.spec.ts
+++ b/apps/backend/src/indicateurs/definitions/list-platform-definitions/list-platform-definitions.repository.spec.ts
@@ -1,0 +1,42 @@
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import type { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import { ListPlatformDefinitionsRepository } from './list-platform-definitions.repository';
+
+const makeRepository = () => {
+  const where = vi.fn().mockResolvedValue([]);
+  const from = vi.fn(() => ({ where }));
+  const select = vi.fn(() => ({ from }));
+  const baseSelect = vi.fn();
+  const repository = new ListPlatformDefinitionsRepository({
+    db: { select: baseSelect },
+  } as unknown as DatabaseService);
+
+  return {
+    repository,
+    tx: { select } as unknown as Transaction,
+    select,
+    where,
+    baseSelect,
+  };
+};
+
+describe('ListPlatformDefinitionsRepository', () => {
+  it('utilise la transaction fournie et borne les définitions à la plateforme', async () => {
+    const { repository, tx, select, where, baseSelect } = makeRepository();
+
+    await repository.listPlatformDefinitions(
+      { identifiantsReferentiel: ['CAE_1.A'], indicateurIds: [7] },
+      tx
+    );
+
+    expect(select).toHaveBeenCalledOnce();
+    expect(baseSelect).not.toHaveBeenCalled();
+    const condition = where.mock.calls[0]?.[0] as SQL;
+    const query = new PgDialect().sqlToQuery(condition);
+    expect(query.sql).toContain('"identifiant_referentiel" is not null');
+    expect(query.sql).toContain('"collectivite_id" is null');
+    expect(query.params).toEqual(['CAE_1.A', 7]);
+  });
+});

--- a/apps/backend/src/indicateurs/definitions/list-platform-definitions/list-platform-definitions.repository.ts
+++ b/apps/backend/src/indicateurs/definitions/list-platform-definitions/list-platform-definitions.repository.ts
@@ -4,16 +4,17 @@ import { indicateurDefinitionTable } from '@tet/backend/indicateurs/definitions/
 import { actionDefinitionTable } from '@tet/backend/referentiels/models/action-definition.table';
 import { thematiqueTable } from '@tet/backend/shared/thematiques/thematique.table';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
 import { Tag } from '@tet/domain/collectivites';
 import type { IndicateurDefinition } from '@tet/domain/indicateurs';
 import {
   and,
   eq,
   getTableColumns,
+  like,
   inArray,
   isNotNull,
   isNull,
-  like,
   or,
   sql,
   SQL,
@@ -29,19 +30,22 @@ export class ListPlatformDefinitionsRepository {
 
   constructor(private readonly databaseService: DatabaseService) {}
 
-  async listPlatformDefinitions({
-    identifiantsReferentiel,
-    indicateurIds,
-  }: {
-    identifiantsReferentiel?: string[];
-    indicateurIds?: number[];
-  } = {}): Promise<IndicateurDefinition[]> {
+  async listPlatformDefinitions(
+    {
+      identifiantsReferentiel,
+      indicateurIds,
+    }: {
+      identifiantsReferentiel?: string[];
+      indicateurIds?: number[];
+    } = {},
+    tx?: Transaction
+  ): Promise<IndicateurDefinition[]> {
     const conditions = this.getQueryConditions({
       identifiantsReferentiel,
       indicateurIds,
     });
 
-    const definitions = await this.databaseService.db
+    const definitions = await (tx ?? this.databaseService.db)
       .select()
       .from(indicateurDefinitionTable)
       .where(and(...conditions));
@@ -51,13 +55,16 @@ export class ListPlatformDefinitionsRepository {
     return definitions;
   }
 
-  async listPlatformDefinitionAggregates({
-    identifiantsReferentiel,
-    indicateurIds,
-  }: {
-    identifiantsReferentiel?: string[];
-    indicateurIds?: number[];
-  } = {}): Promise<IndicateurDefinition[]> {
+  async listPlatformDefinitionAggregates(
+    {
+      identifiantsReferentiel,
+      indicateurIds,
+    }: {
+      identifiantsReferentiel?: string[];
+      indicateurIds?: number[];
+    } = {},
+    tx?: Transaction
+  ): Promise<IndicateurDefinition[]> {
     const conditions = this.getQueryConditions({
       identifiantsReferentiel,
       indicateurIds,
@@ -67,7 +74,7 @@ export class ListPlatformDefinitionsRepository {
     const thematiquesSubQuery = this.getThematiquesSubQuery();
     const mesuresSubQuery = this.getMesuresSubQuery();
 
-    const definitions = await this.databaseService.db
+    const definitions = await (tx ?? this.databaseService.db)
       .select({
         ...getTableColumns(indicateurDefinitionTable),
 
@@ -133,11 +140,10 @@ export class ListPlatformDefinitionsRepository {
     return conditions;
   }
 
-  async listPlatformDefinitionsHavingComputedValue({
-    identifiantsReferentiel,
-  }: { identifiantsReferentiel?: string[] } = {}): Promise<
-    IndicateurDefinition[]
-  > {
+  async listPlatformDefinitionsHavingComputedValue(
+    { identifiantsReferentiel }: { identifiantsReferentiel?: string[] } = {},
+    tx?: Transaction
+  ): Promise<IndicateurDefinition[]> {
     const sourceIndicateurSqlConditions: (SQLWrapper | SQL)[] =
       identifiantsReferentiel?.map((identifiant) =>
         like(indicateurDefinitionTable.valeurCalcule, `%${identifiant}%`)
@@ -150,7 +156,7 @@ export class ListPlatformDefinitionsRepository {
       sqlConditions.push(or(...sourceIndicateurSqlConditions) as SQLWrapper);
     }
 
-    const computedIndicateurDefinitions = await this.databaseService.db
+    const computedIndicateurDefinitions = await (tx ?? this.databaseService.db)
       .select()
       .from(indicateurDefinitionTable)
       .where(and(...sqlConditions));

--- a/apps/backend/src/indicateurs/definitions/list-platform-definitions/list-platform-definitions.service.spec.ts
+++ b/apps/backend/src/indicateurs/definitions/list-platform-definitions/list-platform-definitions.service.spec.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ListPlatformDefinitionsService } from './list-platform-definitions.service';
+
+describe('ListPlatformDefinitionsService', () => {
+  const context = { user: null };
+
+  it('propage la transaction et représente les erreurs de lecture par un Result', async () => {
+    const cause = new Error('database unavailable');
+    const repository = {
+      listPlatformDefinitions: vi.fn().mockRejectedValue(cause),
+    };
+    const service = new ListPlatformDefinitionsService(repository as never);
+    const tx = { name: 'catalog-read' } as never;
+
+    await expect(
+      service.listPlatformDefinitions({}, { user: null, tx })
+    ).resolves.toEqual({
+      success: false,
+      error: 'DATABASE_ERROR',
+      cause,
+    });
+    expect(repository.listPlatformDefinitions).toHaveBeenCalledWith({}, tx);
+  });
+  it('délègue la lecture au repository', async () => {
+    const definitions = [{ id: 1, periodicite: 'annuelle' }];
+    const repository = {
+      listPlatformDefinitionAggregates: vi.fn().mockResolvedValue(definitions),
+    };
+    const service = new ListPlatformDefinitionsService(repository as never);
+    const input = { indicateurIds: [1] };
+
+    await expect(
+      service.listPlatformDefinitionAggregates(input, context)
+    ).resolves.toEqual({ success: true, data: definitions });
+    expect(repository.listPlatformDefinitionAggregates).toHaveBeenCalledWith(
+      input,
+      undefined
+    );
+  });
+
+  it('expose les définitions simples sans exposer le repository hors du domaine', async () => {
+    const definitions = [
+      { id: 1, identifiantReferentiel: 'cae_1.a' },
+      { id: 2, identifiantReferentiel: 'cae_1.b' },
+    ];
+    const repository = {
+      listPlatformDefinitions: vi.fn().mockResolvedValue(definitions),
+    };
+    const service = new ListPlatformDefinitionsService(repository as never);
+
+    await expect(
+      service.listPlatformDefinitionIdsByIdentifiantReferentiels(
+        ['cae_1.a', 'cae_1.b'],
+        context
+      )
+    ).resolves.toEqual({ success: true, data: { 'cae_1.a': 1, 'cae_1.b': 2 } });
+    expect(repository.listPlatformDefinitions).toHaveBeenCalledWith(
+      {
+        identifiantsReferentiel: ['cae_1.a', 'cae_1.b'],
+      },
+      undefined
+    );
+  });
+
+  it('préserve le court-circuit historique pour une liste vide', async () => {
+    const repository = {
+      listPlatformDefinitions: vi.fn(),
+    };
+    const service = new ListPlatformDefinitionsService(repository as never);
+
+    await expect(
+      service.listPlatformDefinitionIdsByIdentifiantReferentiels([], context)
+    ).resolves.toEqual({ success: true, data: {} });
+    expect(repository.listPlatformDefinitions).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/indicateurs/definitions/list-platform-definitions/list-platform-definitions.service.ts
+++ b/apps/backend/src/indicateurs/definitions/list-platform-definitions/list-platform-definitions.service.ts
@@ -1,0 +1,78 @@
+import { Injectable } from '@nestjs/common';
+import type { AuthUser } from '@tet/backend/users/models/auth.models';
+import type { ServiceSecondArg } from '@tet/backend/utils/nest/service-second-arg.utils';
+import { failure, Result, success } from '@tet/backend/utils/result.type';
+import { ListPlatformDefinitionsRepository } from './list-platform-definitions.repository';
+
+type DefinitionReadContext = Omit<ServiceSecondArg, 'user'> & {
+  user: AuthUser | null;
+};
+type ListInput = Parameters<
+  ListPlatformDefinitionsRepository['listPlatformDefinitions']
+>[0];
+type AggregateInput = Parameters<
+  ListPlatformDefinitionsRepository['listPlatformDefinitionAggregates']
+>[0];
+type Definitions = Awaited<
+  ReturnType<ListPlatformDefinitionsRepository['listPlatformDefinitions']>
+>;
+type Aggregates = Awaited<
+  ReturnType<
+    ListPlatformDefinitionsRepository['listPlatformDefinitionAggregates']
+  >
+>;
+
+/** Public catalog reads; caller identity is carried without restricting access. */
+@Injectable()
+export class ListPlatformDefinitionsService {
+  constructor(private readonly repository: ListPlatformDefinitionsRepository) {}
+
+  async listPlatformDefinitions(
+    input: ListInput,
+    { tx }: DefinitionReadContext
+  ): Promise<Result<Definitions, 'DATABASE_ERROR'>> {
+    try {
+      return success(await this.repository.listPlatformDefinitions(input, tx));
+    } catch (error) {
+      return failure(
+        'DATABASE_ERROR',
+        error instanceof Error ? error : new Error(String(error))
+      );
+    }
+  }
+
+  async listPlatformDefinitionAggregates(
+    input: AggregateInput,
+    { tx }: DefinitionReadContext
+  ): Promise<Result<Aggregates, 'DATABASE_ERROR'>> {
+    try {
+      return success(
+        await this.repository.listPlatformDefinitionAggregates(input, tx)
+      );
+    } catch (error) {
+      return failure(
+        'DATABASE_ERROR',
+        error instanceof Error ? error : new Error(String(error))
+      );
+    }
+  }
+
+  async listPlatformDefinitionIdsByIdentifiantReferentiels(
+    identifiantsReferentiel: string[],
+    context: DefinitionReadContext
+  ): Promise<Result<Record<string, number>, 'DATABASE_ERROR'>> {
+    if (!identifiantsReferentiel.length) return success({});
+    const result = await this.listPlatformDefinitions(
+      { identifiantsReferentiel },
+      context
+    );
+    if (!result.success) return result;
+    return success(
+      Object.fromEntries(
+        result.data.flatMap(({ id, identifiantReferentiel }) =>
+          identifiantReferentiel ? [[identifiantReferentiel, id]] : []
+        )
+      )
+    );
+  }
+}

--- a/apps/backend/src/indicateurs/indicateurs.module.ts
+++ b/apps/backend/src/indicateurs/indicateurs.module.ts
@@ -1,3 +1,4 @@
+import { ListPlatformDefinitionsService } from './definitions/list-platform-definitions/list-platform-definitions.service';
 import { IndicateurSourcesRepository } from './sources/indicateur-sources.repository';
 import { HandleDefinitionFichesRepository } from './indicateurs/handle-definition-fiches/handle-definition-fiches.repository';
 import { HandleDefinitionPilotesRepository } from './indicateurs/handle-definition-pilotes/handle-definition-pilotes.repository';
@@ -78,6 +79,7 @@ const DEFINITIONS_PROVIDERS = [
     TransactionModule,
   ],
   providers: [
+    ListPlatformDefinitionsService,
     IndicateurSourcesRepository,
     HandleDefinitionFichesRepository,
     HandleDefinitionPilotesRepository,
@@ -109,6 +111,7 @@ const DEFINITIONS_PROVIDERS = [
     ...DEFINITIONS_PROVIDERS,
   ],
   exports: [
+    ListPlatformDefinitionsService,
     ListCollectiviteDefinitionsRepository,
     ListPlatformDefinitionsRepository,
     ListIndicateursService,


### PR DESCRIPTION
Superseded by [PR 3/10](https://github.com/incubateur-ademe/territoires-en-transitions/pull/4966) in the consolidated 10-PR stack. Review and merge using the [updated index](https://github.com/incubateur-ademe/territoires-en-transitions/pull/4959). This PR is closed without merging; its changes are included in the replacement.

---

Introduce a dedicated platform-definition read service with explicit authorization context and optional transaction propagation. Correct the collectivité definition selection without exposing local definitions through the platform endpoint.

Keep the legacy identifier lookup and computed-definition scope while their old import/calculation callers remain in the stack. Their removal belongs with those callers' migration.

Validation completed: 6 focused tests passed; backend app and spec TypeScript checks passed; ESLint passed.

Stack base: `split/06-frontend-foundations`. Review against that branch; after its PR merges, restack this branch onto main and rerun checks before merging.
