### PR TITLE
feat(indicateurs): make value writes and calculation transactional

### DIFF
--- a/apps/backend/src/demarches/pcaet/diagnostic/update-diagnostic-indicateurs-valeurs/update-diagnostic-indicateurs-valeurs.service.ts
+++ b/apps/backend/src/demarches/pcaet/diagnostic/update-diagnostic-indicateurs-valeurs/update-diagnostic-indicateurs-valeurs.service.ts
@@ -86,7 +86,10 @@ export class UpdateDiagnosticIndicateursValeursService {
       valeurs,
     });
 
-    await this.crudValeursService.upsertIndicateurValeurs(upsertRecords, user);
+    await this.crudValeursService.upsertIndicateurValeurs(upsertRecords, {
+      user,
+      tx,
+    });
 
     const payload = await this.diagnosticService.loadPayload(
       { demarcheId, collectiviteId },

--- a/apps/backend/src/indicateurs/charts/indicateur-chart.service.ts
+++ b/apps/backend/src/indicateurs/charts/indicateur-chart.service.ts
@@ -510,10 +510,13 @@ export class IndicateurChartService {
     }
 
     const indicateursEnfantValeurs = (
-      await this.indicateurValeursService.listIndicateurValeurs({
-        collectiviteId,
-        indicateurIds: segmentatedIndicateursEnfantIds,
-      })
+      await this.indicateurValeursService.listIndicateurValeurs(
+        {
+          collectiviteId,
+          indicateurIds: segmentatedIndicateursEnfantIds,
+        },
+        { isUserTrusted: true }
+      )
     ).indicateurs;
 
     const sourceAndValeurType =
@@ -592,11 +595,14 @@ export class IndicateurChartService {
     ] = await Promise.all([
       // Always fetch indicateur valeurs
       this.indicateurValeursService
-        .listIndicateurValeurs({
-          collectiviteId,
-          indicateurIds: [definition.id],
-          sources: sources?.map((s) => s.sourceId),
-        })
+        .listIndicateurValeurs(
+          {
+            collectiviteId,
+            indicateurIds: [definition.id],
+            sources: sources?.map((s) => s.sourceId),
+          },
+          { isUserTrusted: true }
+        )
         .then((result) => result.indicateurs[0]),
       // Conditionally fetch reference valeurs
       includeReferenceValeurs

--- a/apps/backend/src/indicateurs/import-indicateurs/import-indicateur-definition.service.ts
+++ b/apps/backend/src/indicateurs/import-indicateurs/import-indicateur-definition.service.ts
@@ -155,8 +155,10 @@ export default class ImportIndicateurDefinitionService extends BaseSpreadsheetIm
         await this.crudValeursService.recomputeAllCalculatedIndicateurValeurs(
           undefined,
           null,
-          updatedIndicateurDefinitionFormulas,
-          true
+          {
+            definitions: updatedIndicateurDefinitionFormulas,
+            skipPermissionCheck: true,
+          }
         );
       recomputeResults.forEach((result) => {
         result.identifiants.forEach((identifiant) => {

--- a/apps/backend/src/indicateurs/indicateurs.module.ts
+++ b/apps/backend/src/indicateurs/indicateurs.module.ts
@@ -1,3 +1,7 @@
+import { TransactionModule } from '@tet/backend/utils/transaction/transaction.module';
+import { WriteIndicateurValeursService } from './valeurs/write-indicateur-valeurs.service';
+import { ValidateIndicateurValeursWriteService } from './valeurs/validate-indicateur-valeurs-write.service';
+import { ReconcileIndicateurValeursService } from './valeurs/reconcile-indicateur-valeurs.service';
 import { IndicateurDefinitionLockRepository } from './definitions/indicateur-definition-lock.repository';
 import { IndicateurValeurLockRepository } from './valeurs/indicateur-valeur-lock.repository';
 import { ComputeValeursRepository } from './valeurs/compute-valeurs.repository';
@@ -23,7 +27,6 @@ import { PersonnalisationsModule } from '../collectivites/personnalisations/pers
 import { ReferentielsCoreModule } from '../referentiels/referentiels-core.module';
 import { UsersModule } from '../users/users.module';
 import { SheetModule } from '../utils/google-sheets/sheet.module';
-import { TransactionModule } from '../utils/transaction/transaction.module';
 import { IndicateurChartService } from './charts/indicateur-chart.service';
 import { ListCollectiviteDefinitionsRepository } from './definitions/list-collectivite-definitions/list-collectivite-definitions.repository';
 import { ListPlatformDefinitionsController } from './definitions/list-platform-definitions/list-platform-definitions.controller';
@@ -77,14 +80,17 @@ const DEFINITIONS_PROVIDERS = [
 
 @Module({
   imports: [
+    TransactionModule,
     UsersModule,
     CollectivitesModule,
     SheetModule,
     PersonnalisationsModule,
     ReferentielsCoreModule,
-    TransactionModule,
   ],
   providers: [
+    WriteIndicateurValeursService,
+    ValidateIndicateurValeursWriteService,
+    ReconcileIndicateurValeursService,
     IndicateurDefinitionLockRepository,
     IndicateurValeurLockRepository,
     ComputeValeursRepository,

--- a/apps/backend/src/indicateurs/indicateurs/list-indicateurs/list-indicateurs.router.e2e-spec.ts
+++ b/apps/backend/src/indicateurs/indicateurs/list-indicateurs/list-indicateurs.router.e2e-spec.ts
@@ -172,7 +172,7 @@ describe('ListIndicateursRouter', () => {
           valeurs: [
             {
               resultat: 10,
-              dateValeur: new Date().toISOString().slice(0, 10),
+              dateValeur: '2026-01-01',
             },
           ],
         },
@@ -1083,7 +1083,7 @@ describe('ListIndicateursRouter', () => {
       await database.db.insert(indicateurValeurTable).values({
         indicateurId,
         collectiviteId: 1,
-        dateValeur: new Date().toISOString().slice(0, 10),
+        dateValeur: '2026-01-01',
         metadonneeId: 1,
       });
 
@@ -1548,7 +1548,7 @@ describe('ListIndicateursRouter', () => {
           valeurs: [
             {
               resultat: 1,
-              dateValeur: new Date().toISOString().slice(0, 10),
+              dateValeur: '2026-01-01',
             },
           ],
         },
@@ -1599,7 +1599,7 @@ describe('ListIndicateursRouter', () => {
       expect(descData.map((i) => i.id)).toEqual([zId, aId]);
     });
 
-    test("pas de doublons entre les pages en triant par un champ non unique (estRempli)", async () => {
+    test('pas de doublons entre les pages en triant par un champ non unique (estRempli)', async () => {
       const caller = router.createCaller({ user: testUser });
 
       // Crée plusieurs indicateurs qui ont tous la même valeur `estRempli`

--- a/apps/backend/src/indicateurs/trajectoire-leviers/trajectoire-leviers.service.ts
+++ b/apps/backend/src/indicateurs/trajectoire-leviers/trajectoire-leviers.service.ts
@@ -305,7 +305,7 @@ export class TrajectoireLeviersService {
           dateDebut: `${this.TARGET_YEAR}-01-01`,
           dateFin: `${this.TARGET_YEAR}-12-31`,
         },
-        user
+        { user }
       );
 
     const indicateurValeursObjectifs2019 =
@@ -317,7 +317,7 @@ export class TrajectoireLeviersService {
           dateDebut: `${this.REFERENCE_YEAR}-01-01`,
           dateFin: `${this.REFERENCE_YEAR}-12-31`,
         },
-        user
+        { user }
       );
 
     // On peut extraire la source de données utilisée pour calculer la trajectoire
@@ -342,7 +342,7 @@ export class TrajectoireLeviersService {
           dateDebut: `${this.REFERENCE_YEAR}-01-01`,
           dateFin: `${this.REFERENCE_YEAR}-12-31`,
         },
-        user
+        { user }
       );
 
     // On affecte les données aux secteurs à partir de la configuration

--- a/apps/backend/src/indicateurs/trajectoires/trajectoires-spreadsheet.service.ts
+++ b/apps/backend/src/indicateurs/trajectoires/trajectoires-spreadsheet.service.ts
@@ -282,7 +282,7 @@ export default class TrajectoiresSpreadsheetService {
     const upsertedTrajectoireIndicateurValeurs =
       await this.valeursService.upsertIndicateurValeurs(
         indicateurValeursTrajectoireResultat,
-        undefined // we don't want to check permission, we have already checked it and it's not the same
+        { isUserTrusted: true } // This workflow has already checked its trajectory permissions.
       );
 
     const [

--- a/apps/backend/src/indicateurs/valeurs/compute-valeurs.service.spec.ts
+++ b/apps/backend/src/indicateurs/valeurs/compute-valeurs.service.spec.ts
@@ -1,0 +1,1191 @@
+import {
+  IndicateurDefinition,
+  IndicateurPeriodicite,
+  IndicateurPeriods,
+  IndicateurValeur,
+} from '@tet/domain/indicateurs';
+import { describe, expect, it, vi } from 'vitest';
+import ComputeValeursService from './compute-valeurs.service';
+import IndicateurExpressionService from './indicateur-expression.service';
+import { LoadIndicateurCalculGraphService } from './load-indicateur-calcul-graph.service';
+const createService = (
+  repository: never,
+  definitions: never,
+  sources: never,
+  expressions: IndicateurExpressionService,
+  locks: never,
+  valeurLocks: never
+) =>
+  new ComputeValeursService(
+    repository,
+    new LoadIndicateurCalculGraphService(definitions, locks, expressions),
+    sources,
+    expressions,
+    valeurLocks
+  );
+
+const createComputeValeursRepository = (
+  overrides: Record<string, unknown> = {}
+) => ({
+  listSourceCalculs: vi.fn().mockResolvedValue([]),
+  listSourceValeurs: vi.fn().mockResolvedValue([]),
+  listStoredCalculatedValeurs: vi.fn().mockResolvedValue([]),
+  listPeriodKeys: vi.fn().mockResolvedValue([]),
+  listRelevantValeurs: vi.fn().mockResolvedValue([]),
+  ...overrides,
+});
+
+const definition = (
+  id: number,
+  identifiantReferentiel: string,
+  valeurCalcule: string | null = null,
+  periodicite: IndicateurPeriodicite = 'mensuelle'
+) =>
+  ({
+    id,
+    identifiantReferentiel,
+    valeurCalcule,
+    periodicite,
+    collectiviteId: null,
+    precision: 2,
+  } as IndicateurDefinition);
+
+const valeur = (indicateurId: number, resultat: number | null) =>
+  ({
+    id: indicateurId,
+    indicateurId,
+    collectiviteId: 1,
+    dateValeur: '2026-02-01',
+    resultat,
+    objectif: null,
+    metadonneeId: null,
+  } as IndicateurValeur);
+
+describe('ComputeValeursService', () => {
+  it.each([10, 0, null])(
+    'conserve le calcul après suppression d’une source optionnelle (résultat restant : %s)',
+    async (resultat) => {
+      const sourceA = definition(1, 'source_a');
+      const sourceB = definition(2, 'source_b');
+      const target = definition(
+        3,
+        'target',
+        'opt_val(source_a) + val(source_b)'
+      );
+      const storedCalculatedValeur = {
+        ...valeur(target.id, 15),
+        id: 30,
+        calculAuto: true,
+        periodicite: 'mensuelle' as const,
+        sourceId: null,
+      };
+      const repository = createComputeValeursRepository({
+        // The SQL left join returns null for a surviving collectivité source;
+        // the deleted input row has no sourceId property at all.
+        listSourceValeurs: vi.fn().mockResolvedValue([
+          {
+            ...valeur(sourceB.id, resultat),
+            objectif: 20,
+            indicateurIdentifiant: 'source_b',
+            sourceId: null,
+            metadonneeDateVersion: null,
+            deleted: false,
+            period: IndicateurPeriods.parse('mensuelle', '2026-02'),
+          },
+        ]),
+        listStoredCalculatedValeurs: vi
+          .fn()
+          .mockResolvedValue([storedCalculatedValeur]),
+      });
+      const service = createService(
+        repository as never,
+        {
+          listPlatformDefinitions: vi
+            .fn()
+            .mockResolvedValueOnce([sourceA])
+            .mockResolvedValueOnce([sourceB]),
+          listPlatformDefinitionsHavingComputedValue: vi
+            .fn()
+            .mockResolvedValue([target]),
+        } as never,
+        {
+          getAllIndicateurSourceMetadonnees: vi.fn().mockResolvedValue([]),
+        } as never,
+        new IndicateurExpressionService(),
+        {
+          lockForValueWrite: vi.fn(),
+          lockDefinitions: vi
+            .fn()
+            .mockResolvedValue([sourceA, sourceB, target]),
+        } as never,
+        {} as never
+      );
+      vi.spyOn(service, 'getSourcesCalcul').mockResolvedValue([]);
+
+      const result = await service.reconcileDeletedIndicateurValeurs(
+        [valeur(sourceA.id, 5)],
+        {} as never
+      );
+
+      expect(result.valeurIdsToDelete).toEqual([]);
+      expect(result.valeursToUpsert).toEqual([
+        expect.objectContaining({
+          indicateurId: target.id,
+          resultat,
+          objectif: 20,
+          metadonneeId: null,
+          calculAuto: true,
+          calculAutoIdentifiantsManquants: ['source_a'],
+        }),
+      ]);
+    }
+  );
+
+  it('remet le calcul à null lorsqu une source obligatoire devient nulle', async () => {
+    const sourceA = definition(1, 'source_a');
+    const sourceB = definition(2, 'source_b');
+    const target = definition(3, 'target', 'val(source_a) + val(source_b)');
+    const listPlatformDefinitionsRepository = {
+      listPlatformDefinitions: vi.fn().mockResolvedValue([sourceA, sourceB]),
+      listPlatformDefinitionsHavingComputedValue: vi
+        .fn()
+        .mockResolvedValue([target]),
+    };
+    const definitionLockRepository = {
+      lockForValueWrite: vi.fn().mockResolvedValue(undefined),
+      lockDefinitions: vi.fn().mockResolvedValue([sourceA, sourceB, target]),
+    };
+    const sourceService = {
+      getAllIndicateurSourceMetadonnees: vi.fn().mockResolvedValue([]),
+    };
+    const service = createService(
+      createComputeValeursRepository() as never,
+      listPlatformDefinitionsRepository as never,
+      sourceService as never,
+      new IndicateurExpressionService(),
+      definitionLockRepository as never,
+      {} as never
+    );
+    vi.spyOn(service, 'getSourcesCalcul').mockResolvedValue([]);
+    const tx = {} as never;
+
+    const result = await service.updateCalculatedIndicateurValeurs(
+      [valeur(1, null), valeur(2, 5)],
+      tx
+    );
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        indicateurId: 3,
+        collectiviteId: 1,
+        dateValeur: '2026-02-01',
+        resultat: null,
+        calculAuto: true,
+      }),
+    ]);
+    expect(
+      listPlatformDefinitionsRepository.listPlatformDefinitionsHavingComputedValue
+    ).toHaveBeenCalledWith(
+      { identifiantsReferentiel: ['source_a', 'source_b'] },
+      tx
+    );
+    expect(definitionLockRepository.lockDefinitions).toHaveBeenCalledWith(
+      [sourceA.id, sourceB.id, target.id],
+      tx
+    );
+    expect(
+      definitionLockRepository.lockForValueWrite.mock.invocationCallOrder[0]
+    ).toBeLessThan(
+      listPlatformDefinitionsRepository
+        .listPlatformDefinitionsHavingComputedValue.mock.invocationCallOrder[0]
+    );
+    expect(
+      sourceService.getAllIndicateurSourceMetadonnees
+    ).toHaveBeenCalledWith(tx);
+  });
+
+  it('ne produit aucune ligne quand une source obligatoire est absente', async () => {
+    const sourceA = definition(1, 'source_a');
+    const sourceB = definition(2, 'source_b');
+    const target = definition(3, 'target', 'val(source_a) + val(source_b)');
+    const listPlatformDefinitionsRepository = {
+      listPlatformDefinitions: vi
+        .fn()
+        .mockResolvedValueOnce([sourceA])
+        .mockResolvedValueOnce([sourceB]),
+      listPlatformDefinitionsHavingComputedValue: vi
+        .fn()
+        .mockResolvedValue([target]),
+    };
+    const definitionLockRepository = {
+      lockForValueWrite: vi.fn().mockResolvedValue(undefined),
+      lockDefinitions: vi.fn().mockResolvedValue([sourceA, sourceB, target]),
+    };
+    const sourceService = {
+      getAllIndicateurSourceMetadonnees: vi.fn().mockResolvedValue([]),
+    };
+    const tx = {
+      select: vi.fn(() => ({
+        from: () => ({
+          leftJoin: () => ({
+            leftJoin: () => ({ where: vi.fn().mockResolvedValue([]) }),
+          }),
+        }),
+      })),
+    };
+    const service = createService(
+      createComputeValeursRepository() as never,
+      listPlatformDefinitionsRepository as never,
+      sourceService as never,
+      new IndicateurExpressionService(),
+      definitionLockRepository as never,
+      {} as never
+    );
+    vi.spyOn(service, 'getSourcesCalcul').mockResolvedValue([]);
+
+    await expect(
+      service.updateCalculatedIndicateurValeurs(
+        [valeur(sourceA.id, 5)],
+        tx as never
+      )
+    ).resolves.toEqual([]);
+  });
+
+  it('traite une suppression comme une absence et réconcilie la ligne automatique', async () => {
+    const source = definition(1, 'source_a');
+    const target = definition(3, 'target', 'val(source_a)');
+    const listPlatformDefinitionsRepository = {
+      listPlatformDefinitions: vi.fn().mockResolvedValue([source]),
+      listPlatformDefinitionsHavingComputedValue: vi
+        .fn()
+        .mockResolvedValue([target]),
+    };
+    const definitionLockRepository = {
+      lockForValueWrite: vi.fn().mockResolvedValue(undefined),
+      lockDefinitions: vi.fn().mockResolvedValue([source, target]),
+    };
+    const sourceService = {
+      getAllIndicateurSourceMetadonnees: vi.fn().mockResolvedValue([]),
+    };
+    const storedCalculatedValeur = {
+      ...valeur(target.id, 5),
+      id: 30,
+      calculAuto: true,
+      periodicite: 'mensuelle' as const,
+      sourceId: null,
+    };
+    const repository = createComputeValeursRepository({
+      // No surviving source row exists after the deletion.
+      listSourceValeurs: vi.fn().mockResolvedValue([]),
+      // The former automatic output is now stale.
+      listStoredCalculatedValeurs: vi
+        .fn()
+        .mockResolvedValue([storedCalculatedValeur]),
+    });
+    const tx = {};
+    const service = createService(
+      repository as never,
+      listPlatformDefinitionsRepository as never,
+      sourceService as never,
+      new IndicateurExpressionService(),
+      definitionLockRepository as never,
+      {} as never
+    );
+    vi.spyOn(service, 'getSourcesCalcul').mockResolvedValue([]);
+
+    await expect(
+      service.reconcileDeletedIndicateurValeurs(
+        // Its former payload must not be interpreted as a present value.
+        [valeur(source.id, 5)],
+        tx as never
+      )
+    ).resolves.toEqual({
+      valeursToUpsert: [],
+      valeurIdsToDelete: [storedCalculatedValeur.id],
+    });
+  });
+
+  it('utilise aussi la version de métadonnées la plus récente en calcul incrémental', async () => {
+    const source = definition(1, 'source_a');
+    const target = definition(3, 'target', 'val(source_a)');
+    const listPlatformDefinitionsRepository = {
+      listPlatformDefinitions: vi.fn().mockResolvedValue([source]),
+      listPlatformDefinitionsHavingComputedValue: vi
+        .fn()
+        .mockResolvedValue([target]),
+    };
+    const definitionLockRepository = {
+      lockForValueWrite: vi.fn().mockResolvedValue(undefined),
+      lockDefinitions: vi.fn().mockResolvedValue([source, target]),
+    };
+    const sourceService = {
+      getAllIndicateurSourceMetadonnees: vi.fn().mockResolvedValue([
+        {
+          id: 10,
+          sourceId: 'insee',
+          dateVersion: '2025-01-01 00:00:00',
+        },
+        {
+          id: 20,
+          sourceId: 'insee',
+          dateVersion: '2026-01-01 00:00:00',
+        },
+      ]),
+    };
+    const service = createService(
+      createComputeValeursRepository() as never,
+      listPlatformDefinitionsRepository as never,
+      sourceService as never,
+      new IndicateurExpressionService(),
+      definitionLockRepository as never,
+      {} as never
+    );
+    vi.spyOn(service, 'getSourcesCalcul').mockResolvedValue([]);
+
+    await expect(
+      service.updateCalculatedIndicateurValeurs(
+        [
+          { ...valeur(source.id, 1), id: 101, metadonneeId: 10 },
+          { ...valeur(source.id, 2), id: 102, metadonneeId: 20 },
+        ],
+        {} as never
+      )
+    ).resolves.toEqual([
+      expect.objectContaining({
+        indicateurId: target.id,
+        metadonneeId: 20,
+        resultat: 2,
+      }),
+    ]);
+  });
+
+  it.each([
+    { latestResultat: 20, expectedResultat: 50 },
+    { latestResultat: null, expectedResultat: null },
+  ])(
+    'relit la version récente quand seule une ancienne observation est modifiée ($latestResultat)',
+    async ({ latestResultat, expectedResultat }) => {
+      const sourceA = definition(1, 'source_a');
+      const sourceB = definition(2, 'source_b');
+      const target = definition(3, 'target', 'val(source_a) + val(source_b)');
+      const updatedOldValeur = {
+        ...valeur(sourceA.id, 1),
+        id: 101,
+        metadonneeId: 10,
+      };
+      const storedSources = [
+        {
+          ...valeur(sourceA.id, latestResultat),
+          id: 102,
+          indicateurIdentifiant: 'source_a',
+        },
+        {
+          ...valeur(sourceB.id, 30),
+          id: 103,
+          indicateurIdentifiant: 'source_b',
+        },
+      ].map((stored) => ({
+        ...stored,
+        metadonneeId: 20,
+        sourceId: 'rare',
+        metadonneeDateVersion: '2026-01-01',
+        deleted: false,
+        period: IndicateurPeriods.parse('mensuelle', '2026-02'),
+      }));
+      const repository = createComputeValeursRepository({
+        // Match the repository filter: returning a newer A requires explicitly
+        // querying A, even though the updated batch already contains that id.
+        listSourceValeurs: vi.fn(
+          async (queries: { identifiants: string[] }[]) =>
+            storedSources.filter((stored) =>
+              queries.some((query) =>
+                query.identifiants.includes(stored.indicateurIdentifiant)
+              )
+            )
+        ),
+      });
+      const service = createService(
+        repository as never,
+        {
+          listPlatformDefinitions: vi
+            .fn()
+            .mockResolvedValueOnce([sourceA])
+            .mockResolvedValueOnce([sourceB]),
+          listPlatformDefinitionsHavingComputedValue: vi
+            .fn()
+            .mockResolvedValue([target]),
+        } as never,
+        {
+          getAllIndicateurSourceMetadonnees: vi.fn().mockResolvedValue([
+            { id: 10, sourceId: 'rare', dateVersion: '2025-01-01' },
+            { id: 20, sourceId: 'rare', dateVersion: '2026-01-01' },
+          ]),
+        } as never,
+        new IndicateurExpressionService(),
+        {
+          lockForValueWrite: vi.fn(),
+          lockDefinitions: vi
+            .fn()
+            .mockResolvedValue([sourceA, sourceB, target]),
+        } as never,
+        {} as never
+      );
+      const tx = {} as never;
+
+      const result = await service.updateCalculatedIndicateurValeurs(
+        [updatedOldValeur],
+        tx
+      );
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          indicateurId: target.id,
+          resultat: expectedResultat,
+          metadonneeId: 20,
+          calculAuto: true,
+        }),
+      ]);
+      expect(repository.listSourceValeurs).toHaveBeenCalledWith(
+        [expect.objectContaining({ identifiants: ['source_a', 'source_b'] })],
+        tx
+      );
+    }
+  );
+
+  it('refuse une agrégation implicite entre deux périodicités', async () => {
+    const annualSource = definition(1, 'source_a', null, 'annuelle');
+    const monthlyTarget = definition(3, 'target', 'val(source_a)', 'mensuelle');
+    const listPlatformDefinitionsRepository = {
+      listPlatformDefinitions: vi.fn().mockResolvedValue([annualSource]),
+      listPlatformDefinitionsHavingComputedValue: vi
+        .fn()
+        .mockResolvedValue([monthlyTarget]),
+    };
+    const definitionLockRepository = {
+      lockForValueWrite: vi.fn().mockResolvedValue(undefined),
+      lockDefinitions: vi.fn().mockResolvedValue([annualSource, monthlyTarget]),
+    };
+    const sourceService = {
+      getAllIndicateurSourceMetadonnees: vi.fn().mockResolvedValue([]),
+    };
+    const service = createService(
+      createComputeValeursRepository() as never,
+      listPlatformDefinitionsRepository as never,
+      sourceService as never,
+      new IndicateurExpressionService(),
+      definitionLockRepository as never,
+      {} as never
+    );
+    vi.spyOn(service, 'getSourcesCalcul').mockResolvedValue([]);
+
+    await expect(
+      service.updateCalculatedIndicateurValeurs(
+        [
+          {
+            ...valeur(1, 5),
+            dateValeur: '2026-01-01',
+          },
+        ],
+        {} as never
+      )
+    ).rejects.toThrow(/agrégation explicite.*source_a \(annuelle\)/);
+  });
+
+  it('revalide la périodicité verrouillée avant d interpréter une valeur de janvier', async () => {
+    const monthlySource = definition(1, 'source_a', null, 'mensuelle');
+    const discoveredMonthlyTarget = definition(
+      3,
+      'target',
+      'val(source_a)',
+      'mensuelle'
+    );
+    const lockedAnnualTarget = definition(
+      3,
+      'target',
+      'val(source_a)',
+      'annuelle'
+    );
+    const listPlatformDefinitionsRepository = {
+      listPlatformDefinitions: vi.fn().mockResolvedValue([monthlySource]),
+      listPlatformDefinitionsHavingComputedValue: vi
+        .fn()
+        .mockResolvedValue([discoveredMonthlyTarget]),
+    };
+    const definitionLockRepository = {
+      lockForValueWrite: vi.fn().mockResolvedValue(undefined),
+      lockDefinitions: vi
+        .fn()
+        .mockResolvedValue([monthlySource, lockedAnnualTarget]),
+    };
+    const sourceService = {
+      getAllIndicateurSourceMetadonnees: vi.fn().mockResolvedValue([]),
+    };
+    const service = createService(
+      createComputeValeursRepository() as never,
+      listPlatformDefinitionsRepository as never,
+      sourceService as never,
+      new IndicateurExpressionService(),
+      definitionLockRepository as never,
+      {} as never
+    );
+    vi.spyOn(service, 'getSourcesCalcul').mockResolvedValue([]);
+    const tx = {} as never;
+
+    await expect(
+      service.updateCalculatedIndicateurValeurs(
+        [
+          {
+            ...valeur(1, 5),
+            dateValeur: '2026-01-01',
+          },
+        ],
+        tx
+      )
+    ).rejects.toThrow(/agrégation explicite.*source_a \(mensuelle\)/);
+    expect(definitionLockRepository.lockDefinitions).toHaveBeenCalledWith(
+      [monthlySource.id, discoveredMonthlyTarget.id],
+      tx
+    );
+  });
+
+  it('revalide aussi les dépendances de formule sous verrou', async () => {
+    const sourceA = definition(1, 'source_a', null, 'mensuelle');
+    const discoveredSourceB = definition(2, 'source_b', null, 'mensuelle');
+    const lockedSourceB = definition(2, 'source_b', null, 'annuelle');
+    const target = definition(
+      3,
+      'target',
+      'val(source_a) + val(source_b)',
+      'mensuelle'
+    );
+    const listPlatformDefinitionsRepository = {
+      listPlatformDefinitionsHavingComputedValue: vi
+        .fn()
+        .mockResolvedValue([target]),
+      listPlatformDefinitions: vi
+        .fn()
+        .mockResolvedValueOnce([sourceA])
+        .mockResolvedValueOnce([discoveredSourceB]),
+    };
+    const definitionLockRepository = {
+      lockForValueWrite: vi.fn().mockResolvedValue(undefined),
+      lockDefinitions: vi
+        .fn()
+        .mockResolvedValue([sourceA, lockedSourceB, target]),
+    };
+    const sourceService = {
+      getAllIndicateurSourceMetadonnees: vi.fn().mockResolvedValue([]),
+    };
+    const service = createService(
+      createComputeValeursRepository() as never,
+      listPlatformDefinitionsRepository as never,
+      sourceService as never,
+      new IndicateurExpressionService(),
+      definitionLockRepository as never,
+      {} as never
+    );
+    vi.spyOn(service, 'getSourcesCalcul').mockResolvedValue([]);
+    const tx = {} as never;
+
+    await expect(
+      service.updateCalculatedIndicateurValeurs([valeur(sourceA.id, 5)], tx)
+    ).rejects.toThrow(/agrégation explicite.*source_b \(annuelle\)/);
+    expect(definitionLockRepository.lockDefinitions).toHaveBeenCalledWith(
+      [sourceA.id, target.id, discoveredSourceB.id],
+      tx
+    );
+  });
+
+  it('recalcule depuis les définitions et les valeurs relues sous les mêmes verrous', async () => {
+    const events: string[] = [];
+    const source = definition(1, 'source_a');
+    const target = definition(3, 'target', 'val(source_a)');
+    const listPlatformDefinitionsRepository = {
+      listPlatformDefinitions: vi.fn(
+        async ({ indicateurIds }: { indicateurIds?: number[] }) => {
+          if (indicateurIds) {
+            events.push('discover-targets');
+            return [target];
+          }
+          events.push('discover-sources');
+          return [source];
+        }
+      ),
+    };
+    const definitionLockRepository = {
+      lockForValueWrite: vi.fn(async () => {
+        events.push('lock-graph');
+      }),
+      lockDefinitions: vi.fn(async () => {
+        events.push('lock-definitions');
+        return [source, target];
+      }),
+    };
+    const valeurLockRepository = {
+      lock: vi.fn(async () => {
+        events.push('lock-periods');
+      }),
+    };
+    const storedSourceValeur = {
+      ...valeur(source.id, 5),
+      indicateurIdentifiant: source.identifiantReferentiel,
+      periodicite: source.periodicite,
+      sourceId: null,
+    };
+    const staleCalculatedValeur = {
+      ...valeur(target.id, 4),
+      id: 99,
+      dateValeur: '2025-01-01',
+      calculAuto: true,
+      indicateurIdentifiant: target.identifiantReferentiel,
+      periodicite: target.periodicite,
+      sourceId: null,
+    };
+    const tx = {};
+    const repository = createComputeValeursRepository({
+      listPeriodKeys: vi.fn(async () => {
+        events.push('discover-periods');
+        return [
+          {
+            collectiviteId: storedSourceValeur.collectiviteId,
+            dateValeur: storedSourceValeur.dateValeur,
+          },
+          {
+            collectiviteId: staleCalculatedValeur.collectiviteId,
+            dateValeur: staleCalculatedValeur.dateValeur,
+          },
+        ];
+      }),
+      listRelevantValeurs: vi.fn(async () => {
+        events.push('reread-values');
+        return [storedSourceValeur, staleCalculatedValeur];
+      }),
+    });
+    const service = createService(
+      repository as never,
+      listPlatformDefinitionsRepository as never,
+      {} as never,
+      new IndicateurExpressionService(),
+      definitionLockRepository as never,
+      valeurLockRepository as never
+    );
+    vi.spyOn(service, 'getSourcesCalcul').mockImplementation(async () => {
+      events.push('read-source-priorities');
+      return [];
+    });
+
+    await expect(
+      service.recomputeCollectiviteCalculatedIndicateurValeurs(
+        storedSourceValeur.collectiviteId,
+        [target.id],
+        tx as never
+      )
+    ).resolves.toEqual({
+      valeursToUpsert: [
+        expect.objectContaining({
+          indicateurId: target.id,
+          collectiviteId: storedSourceValeur.collectiviteId,
+          dateValeur: storedSourceValeur.dateValeur,
+          resultat: 5,
+        }),
+      ],
+      valeurIdsToDelete: [staleCalculatedValeur.id],
+      indicateurIdentifiants: ['target'],
+    });
+
+    expect(events).toEqual([
+      'lock-graph',
+      'discover-targets',
+      'discover-sources',
+      'lock-definitions',
+      'discover-periods',
+      'lock-periods',
+      'reread-values',
+      'read-source-priorities',
+    ]);
+    expect(definitionLockRepository.lockDefinitions).toHaveBeenCalledWith(
+      [target.id, source.id],
+      tx
+    );
+    expect(valeurLockRepository.lock).toHaveBeenCalledWith(
+      [
+        {
+          collectiviteId: storedSourceValeur.collectiviteId,
+          dateValeur: storedSourceValeur.dateValeur,
+        },
+        {
+          collectiviteId: staleCalculatedValeur.collectiviteId,
+          dateValeur: staleCalculatedValeur.dateValeur,
+        },
+      ],
+      tx
+    );
+  });
+
+  it('conserve la version de métadonnées la plus récente et supprime les anciens calculs', async () => {
+    const source = definition(1, 'source_a');
+    const target = definition(3, 'target', 'val(source_a)');
+    const oldMetadonnee = {
+      id: 10,
+      sourceId: 'insee',
+      dateVersion: '2025-01-01 00:00:00',
+    };
+    const latestMetadonnee = {
+      id: 20,
+      sourceId: 'insee',
+      dateVersion: '2026-01-01 00:00:00',
+    };
+    const sourceValeur = (
+      id: number,
+      resultat: number,
+      metadonnee: typeof oldMetadonnee
+    ) => ({
+      ...valeur(source.id, resultat),
+      id,
+      metadonneeId: metadonnee.id,
+      indicateurIdentifiant: source.identifiantReferentiel,
+      periodicite: source.periodicite,
+      sourceId: metadonnee.sourceId,
+      metadonneeDateVersion: metadonnee.dateVersion,
+    });
+    const calculatedValeur = (
+      id: number,
+      metadonnee: typeof oldMetadonnee
+    ) => ({
+      ...valeur(target.id, -1),
+      id,
+      metadonneeId: metadonnee.id,
+      calculAuto: true,
+      indicateurIdentifiant: target.identifiantReferentiel,
+      periodicite: target.periodicite,
+      sourceId: metadonnee.sourceId,
+      metadonneeDateVersion: metadonnee.dateVersion,
+    });
+    const oldSourceValeur = sourceValeur(101, 1, oldMetadonnee);
+    const latestSourceValeur = sourceValeur(102, 2, latestMetadonnee);
+    const oldCalculatedValeur = calculatedValeur(201, oldMetadonnee);
+    const latestCalculatedValeur = calculatedValeur(202, latestMetadonnee);
+    const listPlatformDefinitionsRepository = {
+      listPlatformDefinitions: vi
+        .fn()
+        .mockResolvedValueOnce([target])
+        .mockResolvedValueOnce([source]),
+    };
+    const definitionLockRepository = {
+      lockForValueWrite: vi.fn().mockResolvedValue(undefined),
+      lockDefinitions: vi.fn().mockResolvedValue([source, target]),
+    };
+    const valeurLockRepository = {
+      lock: vi.fn().mockResolvedValue(undefined),
+    };
+    const tx = {};
+    const repository = createComputeValeursRepository({
+      listPeriodKeys: vi.fn().mockResolvedValue([
+        {
+          collectiviteId: 1,
+          dateValeur: oldSourceValeur.dateValeur,
+        },
+      ]),
+      // Old first is intentional: row order must not decide which metadata
+      // identity survives reconciliation.
+      listRelevantValeurs: vi
+        .fn()
+        .mockResolvedValue([
+          oldSourceValeur,
+          latestSourceValeur,
+          oldCalculatedValeur,
+          latestCalculatedValeur,
+        ]),
+    });
+    const service = createService(
+      repository as never,
+      listPlatformDefinitionsRepository as never,
+      {} as never,
+      new IndicateurExpressionService(),
+      definitionLockRepository as never,
+      valeurLockRepository as never
+    );
+    vi.spyOn(service, 'getSourcesCalcul').mockResolvedValue([]);
+
+    await expect(
+      service.recomputeCollectiviteCalculatedIndicateurValeurs(
+        1,
+        [target.id],
+        tx as never
+      )
+    ).resolves.toEqual({
+      valeursToUpsert: [
+        expect.objectContaining({
+          indicateurId: target.id,
+          metadonneeId: latestMetadonnee.id,
+          resultat: 2,
+        }),
+      ],
+      valeurIdsToDelete: [oldCalculatedValeur.id],
+      indicateurIdentifiants: ['target'],
+    });
+  });
+
+  it('supprime un ancien calcul quand une source obligatoire est absente de la réconciliation', async () => {
+    const sourceA = definition(1, 'source_a');
+    const sourceB = definition(2, 'source_b');
+    const target = definition(3, 'target', 'val(source_a) + val(source_b)');
+    const storedSourceValeur = {
+      ...valeur(sourceA.id, 5),
+      id: 101,
+      indicateurIdentifiant: sourceA.identifiantReferentiel,
+      periodicite: sourceA.periodicite,
+      sourceId: null,
+      metadonneeDateVersion: null,
+    };
+    const staleCalculatedValeur = {
+      ...valeur(target.id, null),
+      id: 201,
+      calculAuto: true,
+      indicateurIdentifiant: target.identifiantReferentiel,
+      periodicite: target.periodicite,
+      sourceId: null,
+      metadonneeDateVersion: null,
+    };
+    const listPlatformDefinitionsRepository = {
+      listPlatformDefinitions: vi
+        .fn()
+        .mockResolvedValueOnce([target])
+        .mockResolvedValueOnce([sourceA, sourceB]),
+    };
+    const definitionLockRepository = {
+      lockForValueWrite: vi.fn().mockResolvedValue(undefined),
+      lockDefinitions: vi.fn().mockResolvedValue([sourceA, sourceB, target]),
+    };
+    const valeurLockRepository = {
+      lock: vi.fn().mockResolvedValue(undefined),
+    };
+    const tx = {};
+    const repository = createComputeValeursRepository({
+      listPeriodKeys: vi.fn().mockResolvedValue([
+        {
+          collectiviteId: 1,
+          dateValeur: storedSourceValeur.dateValeur,
+        },
+      ]),
+      listRelevantValeurs: vi
+        .fn()
+        .mockResolvedValue([storedSourceValeur, staleCalculatedValeur]),
+    });
+    const service = createService(
+      repository as never,
+      listPlatformDefinitionsRepository as never,
+      {} as never,
+      new IndicateurExpressionService(),
+      definitionLockRepository as never,
+      valeurLockRepository as never
+    );
+    vi.spyOn(service, 'getSourcesCalcul').mockResolvedValue([]);
+
+    await expect(
+      service.recomputeCollectiviteCalculatedIndicateurValeurs(
+        1,
+        [target.id],
+        tx as never
+      )
+    ).resolves.toEqual({
+      valeursToUpsert: [],
+      valeurIdsToDelete: [staleCalculatedValeur.id],
+      indicateurIdentifiants: ['target'],
+    });
+  });
+
+  it('ignore une période apparue après la découverte de ses clés de verrou', async () => {
+    const source = definition(1, 'source_a');
+    const target = definition(3, 'target', 'val(source_a)');
+    const discoveredSourceValeur = {
+      ...valeur(source.id, 5),
+      id: 101,
+      indicateurIdentifiant: source.identifiantReferentiel,
+      periodicite: source.periodicite,
+      sourceId: null,
+      metadonneeDateVersion: null,
+    };
+    const concurrentSourceValeur = {
+      ...discoveredSourceValeur,
+      id: 102,
+      dateValeur: '2026-03-01',
+      resultat: 8,
+    };
+    const concurrentCalculatedValeur = {
+      ...valeur(target.id, 8),
+      id: 202,
+      dateValeur: concurrentSourceValeur.dateValeur,
+      calculAuto: true,
+      indicateurIdentifiant: target.identifiantReferentiel,
+      periodicite: target.periodicite,
+      sourceId: null,
+      metadonneeDateVersion: null,
+    };
+    const listPlatformDefinitionsRepository = {
+      listPlatformDefinitions: vi
+        .fn()
+        .mockResolvedValueOnce([target])
+        .mockResolvedValueOnce([source]),
+    };
+    const definitionLockRepository = {
+      lockForValueWrite: vi.fn().mockResolvedValue(undefined),
+      lockDefinitions: vi.fn().mockResolvedValue([source, target]),
+    };
+    const valeurLockRepository = {
+      lock: vi.fn().mockResolvedValue(undefined),
+    };
+    const tx = {};
+    const repository = createComputeValeursRepository({
+      listPeriodKeys: vi.fn().mockResolvedValue([
+        {
+          collectiviteId: 1,
+          dateValeur: discoveredSourceValeur.dateValeur,
+        },
+      ]),
+      // Simulates a row committed between discovery and reread. The service
+      // defensively rejects it even if a repository/mock failed to honor the
+      // requested date predicate.
+      listRelevantValeurs: vi
+        .fn()
+        .mockResolvedValue([
+          discoveredSourceValeur,
+          concurrentSourceValeur,
+          concurrentCalculatedValeur,
+        ]),
+    });
+    const service = createService(
+      repository as never,
+      listPlatformDefinitionsRepository as never,
+      {} as never,
+      new IndicateurExpressionService(),
+      definitionLockRepository as never,
+      valeurLockRepository as never
+    );
+    vi.spyOn(service, 'getSourcesCalcul').mockResolvedValue([]);
+
+    await expect(
+      service.recomputeCollectiviteCalculatedIndicateurValeurs(
+        1,
+        [target.id],
+        tx as never
+      )
+    ).resolves.toEqual({
+      valeursToUpsert: [
+        expect.objectContaining({
+          dateValeur: discoveredSourceValeur.dateValeur,
+          resultat: 5,
+        }),
+      ],
+      valeurIdsToDelete: [],
+      indicateurIdentifiants: ['target'],
+    });
+    expect(valeurLockRepository.lock).toHaveBeenCalledWith(
+      [
+        {
+          collectiviteId: 1,
+          dateValeur: discoveredSourceValeur.dateValeur,
+        },
+      ],
+      tx
+    );
+  });
+
+  it('supprime les anciens résultats auto quand une formule disparaît', async () => {
+    const targetWithoutFormula = definition(3, 'target', null);
+    const autoValeur = {
+      ...valeur(targetWithoutFormula.id, 5),
+      id: 98,
+      calculAuto: true,
+      indicateurIdentifiant: targetWithoutFormula.identifiantReferentiel,
+      periodicite: targetWithoutFormula.periodicite,
+      sourceId: null,
+    };
+    const manualValeur = {
+      ...autoValeur,
+      id: 99,
+      calculAuto: false,
+    };
+    const listPlatformDefinitionsRepository = {
+      listPlatformDefinitions: vi
+        .fn()
+        .mockResolvedValue([targetWithoutFormula]),
+    };
+    const definitionLockRepository = {
+      lockForValueWrite: vi.fn().mockResolvedValue(undefined),
+      lockDefinitions: vi.fn().mockResolvedValue([targetWithoutFormula]),
+    };
+    const valeurLockRepository = {
+      lock: vi.fn().mockResolvedValue(undefined),
+    };
+    const tx = {};
+    const repository = createComputeValeursRepository({
+      listPeriodKeys: vi.fn().mockResolvedValue([
+        {
+          collectiviteId: autoValeur.collectiviteId,
+          dateValeur: autoValeur.dateValeur,
+        },
+      ]),
+      listRelevantValeurs: vi
+        .fn()
+        .mockResolvedValue([autoValeur, manualValeur]),
+    });
+    const service = createService(
+      repository as never,
+      listPlatformDefinitionsRepository as never,
+      {} as never,
+      new IndicateurExpressionService(),
+      definitionLockRepository as never,
+      valeurLockRepository as never
+    );
+    vi.spyOn(service, 'getSourcesCalcul').mockResolvedValue([]);
+
+    await expect(
+      service.recomputeCollectiviteCalculatedIndicateurValeurs(
+        autoValeur.collectiviteId,
+        [targetWithoutFormula.id],
+        tx as never
+      )
+    ).resolves.toEqual({
+      valeursToUpsert: [],
+      valeurIdsToDelete: [autoValeur.id],
+      indicateurIdentifiants: ['target'],
+    });
+  });
+});
+
+describe('PCAET calculation isolation', () => {
+  const source = definition(1, 'source_a');
+  const extra = definition(2, 'source_b');
+  const target = definition(3, 'target', 'val(source_a) + val(source_b)');
+  const observation = (
+    indicateurId: number,
+    resultat: number,
+    metadonneeId: number,
+    sourceId: string
+  ) => ({
+    ...valeur(indicateurId, resultat),
+    metadonneeId,
+    indicateurIdentifiant: indicateurId === 1 ? 'source_a' : 'source_b',
+    sourceId,
+    metadonneeDateVersion: `2026-01-${metadonneeId
+      .toString()
+      .padStart(2, '0')}`,
+    deleted: false,
+    period: IndicateurPeriods.parse('mensuelle', '2026-02'),
+    periodicite: 'mensuelle' as const,
+  });
+  const pcaet = (resultat: number, metadonneeId: number) =>
+    observation(1, resultat, metadonneeId, 'pcaet-collectivite');
+  const shared = observation(2, 2, 20, 'insee');
+  const setup = (rows: ReturnType<typeof observation>[]) => {
+    const repository = createComputeValeursRepository({
+      listSourceValeurs: vi.fn().mockResolvedValue(rows),
+      listRelevantValeurs: vi.fn().mockResolvedValue(rows),
+      listPeriodKeys: vi
+        .fn()
+        .mockResolvedValue([{ collectiviteId: 1, dateValeur: '2026-02-01' }]),
+    });
+    const definitions = {
+      listPlatformDefinitions: vi
+        .fn()
+        .mockResolvedValue([source, extra, target]),
+      listPlatformDefinitionsHavingComputedValue: vi
+        .fn()
+        .mockResolvedValue([target]),
+    };
+    const service = createService(
+      repository as never,
+      definitions as never,
+      {
+        getAllIndicateurSourceMetadonnees: vi.fn().mockResolvedValue(
+          [10, 11, 20].map((id) => ({
+            id,
+            sourceId: id === 20 ? 'insee' : 'pcaet-collectivite',
+            dateVersion: `2026-01-${id}`,
+          }))
+        ),
+      } as never,
+      new IndicateurExpressionService(),
+      {
+        lockForValueWrite: vi.fn(),
+        lockDefinitions: vi.fn().mockResolvedValue([source, extra, target]),
+      } as never,
+      { lock: vi.fn() } as never
+    );
+    vi.spyOn(service, 'getSourcesCalcul').mockResolvedValue([
+      { sourceId: 'pcaet-collectivite', sourceCalculIds: ['insee'] },
+    ]);
+    return { service, repository };
+  };
+
+  it('recalcule les deux démarches sans mélanger leurs valeurs', async () => {
+    const { service } = setup([shared, pcaet(10, 10), pcaet(100, 11)]);
+    const result =
+      await service.recomputeCollectiviteCalculatedIndicateurValeurs(
+        1,
+        [3],
+        {} as never
+      );
+    expect(result.valeursToUpsert).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ resultat: 12, metadonneeId: 10 }),
+        expect.objectContaining({ resultat: 102, metadonneeId: 11 }),
+      ])
+    );
+    expect(result.valeursToUpsert).toHaveLength(2);
+  });
+
+  it('une modification de démarche charge seulement sa métadonnée', async () => {
+    const { service, repository } = setup([pcaet(10, 10), shared]);
+    const result = await service.updateCalculatedIndicateurValeurs(
+      [pcaet(10, 10)],
+      {} as never
+    );
+    expect(repository.listSourceValeurs).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({
+          sourceId: 'pcaet-collectivite',
+          metadonneeId: 10,
+        }),
+      ],
+      expect.anything()
+    );
+    expect(result).toEqual([
+      expect.objectContaining({ resultat: 12, metadonneeId: 10 }),
+    ]);
+  });
+
+  it('une source partagée recalcule chaque métadonnée PCAET', async () => {
+    const { service } = setup([shared, pcaet(10, 10), pcaet(100, 11)]);
+    const result = await service.updateCalculatedIndicateurValeurs(
+      [shared],
+      {} as never
+    );
+    expect(result).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ resultat: 12, metadonneeId: 10 }),
+        expect.objectContaining({ resultat: 102, metadonneeId: 11 }),
+      ])
+    );
+    expect(result).toHaveLength(2);
+  });
+
+  it('supprimer une source ne supprime pas le calcul d’une autre démarche', async () => {
+    const { service, repository } = setup([shared]);
+    repository.listStoredCalculatedValeurs.mockResolvedValue(
+      [10, 11].map((metadonneeId) => ({
+        ...pcaet(12, metadonneeId),
+        indicateurId: 3,
+        id: metadonneeId + 100,
+        calculAuto: true,
+      }))
+    );
+    const result = await service.reconcileDeletedIndicateurValeurs(
+      [pcaet(10, 10)],
+      {} as never
+    );
+    expect(result.valeurIdsToDelete).toEqual([110]);
+    expect(result.valeursToUpsert).toEqual([]);
+  });
+});

--- a/apps/backend/src/indicateurs/valeurs/compute-valeurs.service.ts
+++ b/apps/backend/src/indicateurs/valeurs/compute-valeurs.service.ts
@@ -1,833 +1,323 @@
-import { Injectable, Logger } from '@nestjs/common';
-import { indicateurDefinitionTable } from '@tet/backend/indicateurs/definitions/indicateur-definition.table';
-import { indicateurSourceMetadonneeTable } from '@tet/backend/indicateurs/shared/models/indicateur-source-metadonnee.table';
-import { indicateurSourceSourceCalculTable } from '@tet/backend/indicateurs/shared/models/indicateur-source-source-calcul.table';
-import { indicateurSourceTable } from '@tet/backend/indicateurs/shared/models/indicateur-source.table';
+import { Injectable } from '@nestjs/common';
 import IndicateurSourcesService from '@tet/backend/indicateurs/sources/indicateur-sources.service';
-import IndicateurExpressionService from '@tet/backend/indicateurs/valeurs/indicateur-expression.service';
-import { indicateurValeurTable } from '@tet/backend/indicateurs/valeurs/indicateur-valeur.table';
-import { DEFAULT_ROUNDING_PRECISION } from '@tet/backend/indicateurs/valeurs/valeurs.constants';
-import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
 import {
   COLLECTIVITE_SOURCE_ID,
   IndicateurDefinition,
   IndicateurValeur,
   IndicateurValeurCreate,
-  IndicateurValeurWithIdentifiant,
 } from '@tet/domain/indicateurs';
+import type {
+  CalculSourceGroups,
+  CalculSourceValeur,
+  IndicateurFormula,
+  RecomputedIndicateurValeurs,
+  SourceCalculPolicy,
+} from './calcul-indicateur.types';
+import { ComputeValeursRepository } from './compute-valeurs.repository';
 import {
-  and,
-  eq,
-  getTableColumns,
-  inArray,
-  isNull,
-  or,
-  sql,
-  SQLWrapper,
-} from 'drizzle-orm';
-import { isNil, round } from 'es-toolkit';
-import { ListPlatformDefinitionsRepository } from '../definitions/list-platform-definitions/list-platform-definitions.repository';
+  evaluateCalculIndicateur,
+  getCalculatedValeurIdentity,
+} from './evaluate-calcul-indicateur.rules';
+import {
+  fillCalculSourceGroups,
+  getCalculSourceGroupKey,
+  normalizeCalculSourceId,
+} from './group-calcul-indicateur-sources.rules';
+import IndicateurExpressionService from './indicateur-expression.service';
+import {
+  dehydrateIndicateurPeriod,
+  hydrateIndicateurPeriod,
+} from './indicateur-period.adapter';
+import { IndicateurValeurLockRepository } from './indicateur-valeur-lock.repository';
+import { LoadIndicateurCalculGraphService } from './load-indicateur-calcul-graph.service';
 
-type IndicateurValeurInsert = IndicateurValeurCreate;
+type ReconciledValeurs = Pick<
+  RecomputedIndicateurValeurs,
+  'valeursToUpsert' | 'valeurIdsToDelete'
+>;
 
 @Injectable()
 export default class ComputeValeursService {
-  private readonly logger = new Logger(ComputeValeursService.name);
-
-  /**
-   * By default, we can use the INSEE source to calculate the values for other sources
-   */
   static DEFAULT_SOURCE_CALCUL_IDS = ['insee'];
 
   constructor(
-    private readonly databaseService: DatabaseService,
-    private readonly listPlatformDefinitionsRepository: ListPlatformDefinitionsRepository,
+    private readonly repository: ComputeValeursRepository,
+    private readonly graphService: LoadIndicateurCalculGraphService,
     private readonly indicateurSourceService: IndicateurSourcesService,
-    private readonly indicateurExpressionService: IndicateurExpressionService
+    private readonly expressions: IndicateurExpressionService,
+    private readonly valeurLockRepository: IndicateurValeurLockRepository
   ) {}
 
-  async getSourcesCalcul() {
-    const sourceSourceCalculIds = await this.databaseService.db
-      .select({
-        sourceId: indicateurSourceTable.id,
-        sourceCalculIds: sql<
-          string[]
-        >`array_agg(${indicateurSourceSourceCalculTable.sourceCalculId})`.as(
-          'source_calcul_ids'
-        ),
-      })
-      .from(indicateurSourceTable)
-      .leftJoin(
-        indicateurSourceSourceCalculTable,
-        eq(indicateurSourceTable.id, indicateurSourceSourceCalculTable.sourceId)
-      )
-      .groupBy(indicateurSourceTable.id);
-    sourceSourceCalculIds.forEach((source) => {
-      if (!source.sourceCalculIds) {
-        source.sourceCalculIds = [];
-      } else {
-        source.sourceCalculIds = source.sourceCalculIds.filter(
-          (id) => id !== null
-        );
-      }
-      ComputeValeursService.DEFAULT_SOURCE_CALCUL_IDS.forEach(
-        (defaultSourceCalculId) => {
-          if (
-            source.sourceId !== defaultSourceCalculId &&
-            !source.sourceCalculIds.includes(defaultSourceCalculId)
-          ) {
-            source.sourceCalculIds.push(defaultSourceCalculId);
-            this.logger.log(
-              `Allow to use ${defaultSourceCalculId} to compute ${source.sourceId} indicateur values`
-            );
-          }
-        }
-      );
-    });
-    sourceSourceCalculIds.push({
-      sourceId: COLLECTIVITE_SOURCE_ID,
-      sourceCalculIds: ComputeValeursService.DEFAULT_SOURCE_CALCUL_IDS,
-    });
-
-    return sourceSourceCalculIds;
+  async getSourcesCalcul(tx?: Transaction): Promise<SourceCalculPolicy[]> {
+    const stored = await this.repository.listSourceCalculs(tx);
+    return [
+      ...stored.map(({ sourceId, sourceCalculIds }) => ({
+        sourceId,
+        sourceCalculIds: [
+          ...new Set([
+            ...(sourceCalculIds?.filter(Boolean) ?? []),
+            ...ComputeValeursService.DEFAULT_SOURCE_CALCUL_IDS.filter(
+              (id) => id !== sourceId
+            ),
+          ]),
+        ],
+      })),
+      {
+        sourceId: COLLECTIVITE_SOURCE_ID,
+        sourceCalculIds: ComputeValeursService.DEFAULT_SOURCE_CALCUL_IDS,
+      },
+    ];
   }
 
   async getAllSourceIdentifiants(
-    forComputedIndicateurDefinitions?: IndicateurDefinition[]
+    definitions?: IndicateurDefinition[]
   ): Promise<string[]> {
-    if (!forComputedIndicateurDefinitions) {
-      forComputedIndicateurDefinitions =
-        await this.listPlatformDefinitionsRepository.listPlatformDefinitionsHavingComputedValue();
+    if (!definitions) {
+      const result = await this.graphService.loadAllComputedDefinitions();
+      if (!result.success) throw result.cause ?? result.error;
+      definitions = result.data;
     }
-
-    this.logger.log(
-      `Recompute all calculated indicateur valeurs for ${
-        forComputedIndicateurDefinitions.length
-      } computed indicateur definitions: ${forComputedIndicateurDefinitions
-        .map((d) => d.identifiantReferentiel)
-        .join(',')}`
-    );
-
-    const allSourceIdentifiants: string[] = [];
-    forComputedIndicateurDefinitions.forEach((computedIndicateurDefinition) => {
-      const sourceIdentifiants =
-        this.indicateurExpressionService.extractNeededSourceIndicateursFromFormula(
-          computedIndicateurDefinition.valeurCalcule ?? ''
-        );
-      sourceIdentifiants.forEach((source) => {
-        if (!allSourceIdentifiants.includes(source.identifiant)) {
-          allSourceIdentifiants.push(source.identifiant);
-        }
-      });
-    });
-    this.logger.log(
-      `Found ${
-        allSourceIdentifiants.length
-      } source indicateur identifiants: ${allSourceIdentifiants.join(',')}`
-    );
-    return allSourceIdentifiants;
-  }
-
-  private getSourceIndicateurKeyForCalculatedIndicateurValeur(
-    indicateurValeur: IndicateurValeurWithIdentifiant,
-    forceSourceId?: string
-  ): string | null {
-    return `${indicateurValeur.collectiviteId}_${indicateurValeur.dateValeur}_${
-      forceSourceId || indicateurValeur.sourceId || COLLECTIVITE_SOURCE_ID
-    }`;
-  }
-
-  /**
-   * TODO: unit test
-   * @param targetIndicateurDefinition
-   * @param sourceIndicateurValeurs
-   * @param allowedExtraSourcesForCalculatedValues
-   * @param relatedSourceIndicateurValeursByDate
-   * @param allowToAddEntry
-   * @returns
-   */
-  private fillRelatedSourceIndicateurValeursByDate(
-    targetIndicateurDefinition: IndicateurDefinition,
-    sourceIndicateurValeurs: IndicateurValeurWithIdentifiant[],
-    allowedExtraSourcesForCalculatedValues: {
-      sourceId: string;
-      sourceCalculIds: string[];
-    }[],
-    relatedSourceIndicateurValeursByDate: {
-      [collectiviteIdDateSourceIdKey: string]: {
-        collectiviteId: number;
-        valeurs: IndicateurValeurWithIdentifiant[];
-        sourceId?: string | null;
-        metadonneeId: number | null;
-        missingIdentifiants: string[];
-        date: string;
-      };
-    },
-    allowToAddEntry: boolean
-  ) {
-    // Find related source indicateur valeurs grouped by date/sourceId
-    if (targetIndicateurDefinition.valeurCalcule) {
-      const neededSourceIndicateurs =
-        this.indicateurExpressionService.extractNeededSourceIndicateursFromFormula(
-          targetIndicateurDefinition.valeurCalcule
-        );
-
-      const neededSourceIndicateurValeurs = sourceIndicateurValeurs.filter(
-        (v) =>
-          v.indicateurIdentifiant &&
-          neededSourceIndicateurs.find(
-            (ind) => ind.identifiant === v.indicateurIdentifiant
-          )
-      );
-
-      neededSourceIndicateurValeurs.forEach((v) => {
-        const collectiviteIdDateSourceIdKey =
-          this.getSourceIndicateurKeyForCalculatedIndicateurValeur(v);
-        if (collectiviteIdDateSourceIdKey) {
-          if (
-            !relatedSourceIndicateurValeursByDate[
-              collectiviteIdDateSourceIdKey
-            ] &&
-            allowToAddEntry
-          ) {
-            relatedSourceIndicateurValeursByDate[
-              collectiviteIdDateSourceIdKey
-            ] = {
-              collectiviteId: v.collectiviteId,
-              valeurs: [],
-              sourceId: v.sourceId,
-              metadonneeId: v.metadonneeId,
-              date: v.dateValeur,
-              missingIdentifiants: [],
-            };
-          }
-
-          if (
-            relatedSourceIndicateurValeursByDate[collectiviteIdDateSourceIdKey]
-          ) {
-            const dateRelatedSourceIndicateurValeurs =
-              relatedSourceIndicateurValeursByDate[
-                collectiviteIdDateSourceIdKey
-              ];
-            // If we didn't know the metadonneeId yet, we set it to the current one
-            if (
-              dateRelatedSourceIndicateurValeurs.metadonneeId &&
-              dateRelatedSourceIndicateurValeurs.metadonneeId < 0
-            ) {
-              dateRelatedSourceIndicateurValeurs.metadonneeId = v.metadonneeId;
-            }
-            dateRelatedSourceIndicateurValeurs.valeurs.push(v);
-          }
-        }
-
-        for (const source of allowedExtraSourcesForCalculatedValues) {
-          if (
-            source.sourceCalculIds.includes(
-              v.sourceId || COLLECTIVITE_SOURCE_ID
-            )
-          ) {
-            this.logger.log(
-              `Value of indicateur ${v.indicateurIdentifiant} for source ${v.sourceId} can be used to calculate source ${source.sourceId}`
-            );
-
-            const collectiviteIdDateSourceIdKey =
-              this.getSourceIndicateurKeyForCalculatedIndicateurValeur(
-                v,
-                source.sourceId
-              );
-            if (collectiviteIdDateSourceIdKey) {
-              if (
-                !relatedSourceIndicateurValeursByDate[
-                  collectiviteIdDateSourceIdKey
-                ] &&
-                allowToAddEntry
-              ) {
-                relatedSourceIndicateurValeursByDate[
-                  collectiviteIdDateSourceIdKey
-                ] = {
-                  collectiviteId: v.collectiviteId,
-                  valeurs: [],
-                  sourceId: source.sourceId,
-                  metadonneeId: -1, // Set the metadonneeId to -1 to indicate that we don't know it yet
-                  date: v.dateValeur,
-                  missingIdentifiants: [],
-                };
-              }
-
-              if (
-                relatedSourceIndicateurValeursByDate[
-                  collectiviteIdDateSourceIdKey
-                ]
-              ) {
-                relatedSourceIndicateurValeursByDate[
-                  collectiviteIdDateSourceIdKey
-                ].valeurs.push(v);
-              }
-            }
-          }
-        }
-      });
-
-      this.logger.log(
-        `Found related source indicateur valeurs associated to ${
-          Object.keys(relatedSourceIndicateurValeursByDate).length
-        } collectiviteId/date/sourceId keys to compute ${
-          targetIndicateurDefinition.identifiantReferentiel
-        } (${targetIndicateurDefinition.id})`
-      );
-
-      // For each date get missing indicateur valeurs
-      for (const collectiviteIdDateSourceIdKey in relatedSourceIndicateurValeursByDate) {
-        const relatedSourceIndicateurInfo =
-          relatedSourceIndicateurValeursByDate[collectiviteIdDateSourceIdKey];
-
-        // Check that we have all needed values
-        const missingIndicateurIdentifiants = neededSourceIndicateurs
-          .filter(
-            (neededIndicateur) =>
-              !relatedSourceIndicateurInfo.valeurs.find(
-                (v) => v.indicateurIdentifiant === neededIndicateur.identifiant
-              )
-          )
-          .map((ind) => ind.identifiant);
-
-        this.logger.log(
-          `${
-            missingIndicateurIdentifiants.length
-          } missing values (identifiants: ${missingIndicateurIdentifiants.join(
-            ','
-          )}) to compute ${
-            targetIndicateurDefinition.identifiantReferentiel
-          } (${targetIndicateurDefinition.id}) for collectivite ${
-            relatedSourceIndicateurInfo.collectiviteId
-          } at date ${relatedSourceIndicateurInfo.date} with sourceId ${
-            relatedSourceIndicateurInfo.sourceId
-          }`
-        );
-
-        relatedSourceIndicateurInfo.missingIdentifiants =
-          missingIndicateurIdentifiants;
-      }
-    }
-
-    return relatedSourceIndicateurValeursByDate;
-  }
-
-  private computeCalculatedIndicateurValeur(
-    targetIndicateurDefinition: IndicateurDefinition,
-    relatedSourceIndicateurValeursByDate: {
-      [collectiviteIdDateSourceIdKey: string]: {
-        collectiviteId: number;
-        valeurs: IndicateurValeurWithIdentifiant[];
-        sourceId?: string | null;
-        metadonneeId: number | null;
-        missingIdentifiants: string[];
-        date: string;
-      };
-    }
-  ): IndicateurValeurInsert[] {
-    const computedIndicateurValeurs: IndicateurValeurInsert[] = [];
-
-    if (targetIndicateurDefinition.valeurCalcule) {
-      this.logger.log(
-        `Compute calculated value for ${targetIndicateurDefinition.identifiantReferentiel} (${targetIndicateurDefinition.id})`
-      );
-      const neededSourceIndicateurs =
-        this.indicateurExpressionService.extractNeededSourceIndicateursFromFormula(
-          targetIndicateurDefinition.valeurCalcule
-        );
-      const neededSourceIndicateurIdentifiants = neededSourceIndicateurs.map(
-        (ind) => ind.identifiant
-      );
-
-      // For each date check that we can compute the value
-      for (const collectiviteIdDateSourceIdKey in relatedSourceIndicateurValeursByDate) {
-        const relatedSourceIndicateurInfo =
-          relatedSourceIndicateurValeursByDate[collectiviteIdDateSourceIdKey];
-
-        // Check that we were able to define the metadonneeId, otherwise we can't save it
-        // WARNING: can happen in once case: we have filled insee data for all sources  but we don't have have other source data
-        if (
-          !relatedSourceIndicateurInfo.metadonneeId ||
-          relatedSourceIndicateurInfo.metadonneeId > 0
-        ) {
-          // Check that we have all needed values
-          const missingMandatoryIndicateurIdentifiants = neededSourceIndicateurs
-            .filter(
-              (neededIndicateur) =>
-                !neededIndicateur.optional &&
-                !relatedSourceIndicateurInfo.valeurs.find(
-                  (v) =>
-                    v.indicateurIdentifiant === neededIndicateur.identifiant
-                )
-            )
-            .map((ind) => ind.identifiant);
-          const missingOptionalIndicateurIdentifiants = neededSourceIndicateurs
-            .filter(
-              (neededIndicateur) =>
-                neededIndicateur.optional &&
-                !relatedSourceIndicateurInfo.valeurs.find(
-                  (v) =>
-                    v.indicateurIdentifiant === neededIndicateur.identifiant
-                )
-            )
-            .map((ind) => ind.identifiant);
-          if (missingMandatoryIndicateurIdentifiants.length) {
-            this.logger.warn(
-              `Missing mandatory values (identifiants: ${missingMandatoryIndicateurIdentifiants.join(
-                ','
-              )}) to compute ${
-                targetIndicateurDefinition.identifiantReferentiel
-              } (${targetIndicateurDefinition.id}) for collectivite ${
-                relatedSourceIndicateurInfo.collectiviteId
-              } at date ${relatedSourceIndicateurInfo.date} with sourceId ${
-                relatedSourceIndicateurInfo.sourceId
-              }`
-            );
-          } else {
-            this.logger.log(
-              `All mandatory values are present to compute ${targetIndicateurDefinition.identifiantReferentiel} (${targetIndicateurDefinition.id}) for collectivite ${relatedSourceIndicateurInfo.collectiviteId} at date ${relatedSourceIndicateurInfo.date} with sourceId ${relatedSourceIndicateurInfo.sourceId}`
-            );
-            const resultatSourceValues: {
-              [indicateurIdentifiant: string]: number | null;
-            } = {};
-            const objectifSourceValues: {
-              [indicateurIdentifiant: string]: number | null;
-            } = {};
-            // TODO: use in priority value with the same sourceId
-            relatedSourceIndicateurInfo.valeurs.forEach((v) => {
-              if (
-                v.sourceId === relatedSourceIndicateurInfo.sourceId &&
-                v.indicateurIdentifiant &&
-                neededSourceIndicateurIdentifiants.includes(
-                  v.indicateurIdentifiant
-                )
-              ) {
-                this.logger.log(
-                  `Use source ${v.sourceId} for ${v.indicateurIdentifiant} indicateur values`
-                );
-                resultatSourceValues[v.indicateurIdentifiant] = v.resultat;
-                objectifSourceValues[v.indicateurIdentifiant] = v.objectif;
-              }
-            });
-
-            // No value for the source, we don't want to use only value from other sources. Other sources are used only to be combined
-            if (
-              !Object.keys(resultatSourceValues).length &&
-              !Object.keys(objectifSourceValues).length
-            ) {
-              continue;
-            }
-
-            relatedSourceIndicateurInfo.valeurs.forEach((v) => {
-              if (
-                v.indicateurIdentifiant &&
-                isNil(resultatSourceValues[v.indicateurIdentifiant]) &&
-                !isNil(v.resultat) &&
-                neededSourceIndicateurIdentifiants.includes(
-                  v.indicateurIdentifiant
-                )
-              ) {
-                this.logger.log(
-                  `Use source ${v.sourceId} for ${v.indicateurIdentifiant} resultat indicateur values`
-                );
-                resultatSourceValues[v.indicateurIdentifiant] = v.resultat;
-              }
-
-              if (
-                v.indicateurIdentifiant &&
-                isNil(objectifSourceValues[v.indicateurIdentifiant]) &&
-                !isNil(v.objectif) &&
-                neededSourceIndicateurIdentifiants.includes(
-                  v.indicateurIdentifiant
-                )
-              ) {
-                this.logger.log(
-                  `Use source ${v.sourceId} for ${v.indicateurIdentifiant} objectif indicateur values`
-                );
-                objectifSourceValues[v.indicateurIdentifiant] = v.objectif;
-              }
-            });
-
-            const atLeastOneResult = Object.values(resultatSourceValues).some(
-              (v) => !isNil(v)
-            );
-            const computedResultat = atLeastOneResult
-              ? this.indicateurExpressionService.parseAndEvaluateExpression(
-                  targetIndicateurDefinition.valeurCalcule.toLowerCase(),
-                  resultatSourceValues
-                )
-              : null;
-
-            // Check if at least one non null objectif value is present
-            // otherwise if only optional values are used in the formuat may result in zero instead of null
-            const atLeastOneObjectif = Object.values(objectifSourceValues).some(
-              (v) => !isNil(v)
-            );
-            const computedObjectif = atLeastOneObjectif
-              ? this.indicateurExpressionService.parseAndEvaluateExpression(
-                  targetIndicateurDefinition.valeurCalcule.toLowerCase(),
-                  objectifSourceValues
-                )
-              : null;
-
-            const indicateurPrecision = !isNil(
-              targetIndicateurDefinition.precision
-            )
-              ? targetIndicateurDefinition.precision
-              : DEFAULT_ROUNDING_PRECISION;
-            const indicateurValeur: IndicateurValeurInsert = {
-              collectiviteId: relatedSourceIndicateurInfo.collectiviteId,
-              indicateurId: targetIndicateurDefinition.id,
-              dateValeur: relatedSourceIndicateurInfo.date,
-              resultat:
-                computedResultat !== null
-                  ? round(computedResultat, indicateurPrecision)
-                  : null,
-              objectif:
-                computedObjectif !== null
-                  ? round(computedObjectif, indicateurPrecision)
-                  : null,
-              metadonneeId: relatedSourceIndicateurInfo.metadonneeId,
-              calculAuto: true,
-              calculAutoIdentifiantsManquants:
-                missingOptionalIndicateurIdentifiants,
-            };
-            computedIndicateurValeurs.push(indicateurValeur);
-          }
-        }
-      }
-    }
-
-    return computedIndicateurValeurs;
-  }
-
-  private async fetchMissingIndicateurValeurs(
-    missingIndicateurValeurs: {
-      collectiviteId: number;
-      identifiants: string[];
-      sourceId?: string | null;
-      date: string;
-    }[],
-    allowedExtraSourcesForCalculatedValues: {
-      sourceId: string;
-      sourceCalculIds: string[];
-    }[]
-  ): Promise<IndicateurValeurWithIdentifiant[]> {
-    if (!missingIndicateurValeurs.length) {
-      return [];
-    }
-
-    const condition: (SQLWrapper | undefined)[] = [];
-    missingIndicateurValeurs.forEach((missing) => {
-      let extraSourceCalculIds = allowedExtraSourcesForCalculatedValues.find(
-        (source) =>
-          source.sourceId === (missing.sourceId || COLLECTIVITE_SOURCE_ID)
-      )?.sourceCalculIds;
-      if (!extraSourceCalculIds) {
-        // Allow to use Insee data for collectivite data
-        extraSourceCalculIds = ComputeValeursService.DEFAULT_SOURCE_CALCUL_IDS;
-      }
-      this.logger.log(
-        `Search missing values for source ${
-          missing.sourceId || COLLECTIVITE_SOURCE_ID
-        } including allowed extra sources: ${extraSourceCalculIds.join(',')}`
-      );
-
-      const missingConditions: (SQLWrapper | undefined)[] = [];
-      missingConditions.push(
-        eq(indicateurValeurTable.collectiviteId, missing.collectiviteId)
-      );
-      missingConditions.push(
-        eq(indicateurValeurTable.dateValeur, missing.date)
-      );
-      missingConditions.push(
-        inArray(
-          indicateurDefinitionTable.identifiantReferentiel,
-          missing.identifiants
+    return [
+      ...new Set(
+        definitions.flatMap((definition) =>
+          this.graphService
+            .getFormula(definition)
+            .references.map(({ identifiant }) => identifiant)
         )
-      );
-      if (missing.sourceId) {
-        missingConditions.push(
-          or(
-            eq(indicateurSourceMetadonneeTable.sourceId, missing.sourceId),
-            inArray(
-              indicateurSourceMetadonneeTable.sourceId,
-              extraSourceCalculIds
-            )
-          )
-        );
-      } else {
-        missingConditions.push(
-          or(
-            isNull(indicateurSourceMetadonneeTable.sourceId),
-            inArray(
-              indicateurSourceMetadonneeTable.sourceId,
-              extraSourceCalculIds
-            )
-          )
-        );
-      }
-      condition.push(and(...missingConditions));
-    });
-
-    const result = await this.databaseService.db
-      .select({
-        ...getTableColumns(indicateurValeurTable),
-        indicateurIdentifiant: indicateurDefinitionTable.identifiantReferentiel,
-        sourceId: indicateurSourceMetadonneeTable.sourceId,
-      })
-      .from(indicateurValeurTable)
-      .leftJoin(
-        indicateurDefinitionTable,
-        eq(indicateurValeurTable.indicateurId, indicateurDefinitionTable.id)
-      )
-      .leftJoin(
-        indicateurSourceMetadonneeTable,
-        eq(
-          indicateurValeurTable.metadonneeId,
-          indicateurSourceMetadonneeTable.id
-        )
-      )
-      .where(or(...condition));
-
-    return result;
-  }
-
-  private mapIndicateurIdToIdentifiantReferentiel(
-    indicateurDefinitions: Pick<
-      IndicateurDefinition,
-      'id' | 'identifiantReferentiel'
-    >[]
-  ): Record<number, string> {
-    return indicateurDefinitions.reduce((acc, def) => {
-      if (!def.identifiantReferentiel) {
-        return acc;
-      } else {
-        return { ...acc, [def.id]: def.identifiantReferentiel };
-      }
-    }, {});
+      ),
+    ];
   }
 
   async updateCalculatedIndicateurValeurs(
-    updatedSourceIndicateurValeurs: IndicateurValeur[],
-    sourceIndicateurDefinitions: Omit<
-      IndicateurDefinition,
-      'modifiedBy' | 'modifiedAt'
-    >[] = []
-  ): Promise<IndicateurValeurInsert[]> {
-    const indicateurIds = [
-      ...new Set(updatedSourceIndicateurValeurs.map((v) => v.indicateurId)),
-    ];
+    valeurs: IndicateurValeur[],
+    tx: Transaction
+  ): Promise<IndicateurValeurCreate[]> {
+    return (await this.computeDependants(valeurs, new Set(), tx))
+      .valeursToUpsert;
+  }
 
-    if (!sourceIndicateurDefinitions.length) {
-      sourceIndicateurDefinitions =
-        await this.listPlatformDefinitionsRepository.listPlatformDefinitions({
-          indicateurIds,
-        });
-    } else {
-      const missingIds = indicateurIds.filter(
-        (id) => !sourceIndicateurDefinitions.find((d) => d.id === id)
+  /** Deleted rows identify affected groups; only surviving rows supply values. */
+  async reconcileDeletedIndicateurValeurs(
+    valeurs: IndicateurValeur[],
+    tx: Transaction
+  ): Promise<ReconciledValeurs> {
+    if (!valeurs.length) return { valeursToUpsert: [], valeurIdsToDelete: [] };
+    const { valeursToUpsert, groupsByIndicateur } =
+      await this.computeDependants(
+        valeurs,
+        new Set(valeurs.map(({ id }) => id)),
+        tx
       );
-      if (missingIds.length) {
-        const missingIndicateurDefinitions =
-          await this.listPlatformDefinitionsRepository.listPlatformDefinitions({
-            indicateurIds: missingIds,
-          });
-        sourceIndicateurDefinitions.push(...missingIndicateurDefinitions);
-      }
-    }
-    const indicateurIdToIdentifiant =
-      this.mapIndicateurIdToIdentifiantReferentiel(sourceIndicateurDefinitions);
-
-    const sourceMetadonnees =
-      await this.indicateurSourceService.getAllIndicateurSourceMetadonnees();
-
-    const allowedExtraSourcesForCalculatedValeurs =
-      await this.getSourcesCalcul();
-
-    const updatedSourceIndicateurValeursAvecIdentifiant =
-      updatedSourceIndicateurValeurs as IndicateurValeurWithIdentifiant[];
-    updatedSourceIndicateurValeursAvecIdentifiant.forEach((v) => {
-      v.indicateurIdentifiant = indicateurIdToIdentifiant[v.indicateurId];
-      const sourceMetadonnee = v.metadonneeId
-        ? sourceMetadonnees.find((sm) => sm.id === v.metadonneeId)
-        : undefined;
-      if (sourceMetadonnee) {
-        v.sourceId = sourceMetadonnee.sourceId;
-      }
+    const groups = [...groupsByIndicateur.values()].flatMap(Object.values);
+    if (!groups.length) return { valeursToUpsert, valeurIdsToDelete: [] };
+    const stored = await this.repository.listStoredCalculatedValeurs(
+      {
+        indicateurIds: [...groupsByIndicateur.keys()],
+        collectiviteIds: [
+          ...new Set(groups.map(({ collectiviteId }) => collectiviteId)),
+        ],
+        dateValeurs: [
+          ...new Set(
+            groups.map(({ period }) => dehydrateIndicateurPeriod(period))
+          ),
+        ],
+      },
+      tx
+    );
+    const expected = new Set(valeursToUpsert.map(getCalculatedValeurIdentity));
+    const valeurIdsToDelete = stored.flatMap((valeur) => {
+      if (!valeur.periodicite) return [];
+      const period = hydrateIndicateurPeriod({
+        periodicite: valeur.periodicite,
+        dateValeur: valeur.dateValeur,
+      });
+      const key = getCalculSourceGroupKey(
+        valeur.collectiviteId,
+        period,
+        valeur.sourceId,
+        valeur.metadonneeId
+      );
+      return groupsByIndicateur.get(valeur.indicateurId)?.[key] &&
+        !expected.has(getCalculatedValeurIdentity(valeur))
+        ? [valeur.id]
+        : [];
     });
+    return { valeursToUpsert, valeurIdsToDelete };
+  }
 
-    const computedIndicateurDefinitions =
-      await this.listPlatformDefinitionsRepository.listPlatformDefinitionsHavingComputedValue(
+  private async computeDependants(
+    valeurs: IndicateurValeur[],
+    deletedIds: ReadonlySet<number>,
+    tx: Transaction
+  ) {
+    const graphResult = await this.graphService.loadDependants(
+      [...new Set(valeurs.map(({ indicateurId }) => indicateurId))],
+      { tx }
+    );
+    if (!graphResult.success) throw graphResult.cause ?? graphResult.error;
+    const { formulas, sourceDefinitions } = graphResult.data;
+    const groupsByIndicateur = new Map<number, CalculSourceGroups>();
+    if (!formulas.length) return { valeursToUpsert: [], groupsByIndicateur };
+    const metadonnees =
+      await this.indicateurSourceService.getAllIndicateurSourceMetadonnees(tx);
+    const policies = await this.getSourcesCalcul(tx);
+    const definitionsById = new Map(
+      sourceDefinitions.map((definition) => [definition.id, definition])
+    );
+    const sources = valeurs.flatMap<CalculSourceValeur>((valeur) => {
+      const definition = definitionsById.get(valeur.indicateurId);
+      if (!definition?.identifiantReferentiel) return [];
+      const metadonnee = metadonnees.find(
+        ({ id }) => id === valeur.metadonneeId
+      );
+      return [
         {
-          identifiantsReferentiel: Object.values(indicateurIdToIdentifiant),
-        }
-      );
-
-    if (computedIndicateurDefinitions.length) {
-      // Fill the map (used at the end)
-      computedIndicateurDefinitions.forEach((def) => {
-        if (def.identifiantReferentiel) {
-          indicateurIdToIdentifiant[def.id] = def.identifiantReferentiel;
-        }
-      });
-
-      // Retrieve missing indicateur valeur needed to compute calculated indicateur valeurs
-      const allMissingIndicateurValeurs: {
-        collectiviteId: number;
-        identifiants: string[];
-        sourceId?: string | null;
-        date: string;
-      }[] = [];
-      const indicateurRelatedSourceIndicateurValeursByDate: {
-        [indicateurDefinitionId: string]: {
-          [collectiviteIdDateSourceIdKey: string]: {
-            collectiviteId: number;
-            valeurs: IndicateurValeurWithIdentifiant[];
-            sourceId?: string | null;
-            metadonneeId: number | null;
-            missingIdentifiants: string[];
-            date: string;
-          };
-        };
-      } = {};
-      computedIndicateurDefinitions.forEach((computedIndicateurDefinition) => {
-        const relatedSourceIndicateurValeursByDate =
-          this.fillRelatedSourceIndicateurValeursByDate(
-            computedIndicateurDefinition,
-            updatedSourceIndicateurValeursAvecIdentifiant,
-            allowedExtraSourcesForCalculatedValeurs,
-            {},
-            true
-          );
-        indicateurRelatedSourceIndicateurValeursByDate[
-          `${computedIndicateurDefinition.id}`
-        ] = relatedSourceIndicateurValeursByDate;
-
-        for (const collectiviteIdDateSourceIdKey in relatedSourceIndicateurValeursByDate) {
-          const relatedSourceIndicateurInfo =
-            relatedSourceIndicateurValeursByDate[collectiviteIdDateSourceIdKey];
-          if (relatedSourceIndicateurInfo.missingIdentifiants.length) {
-            allMissingIndicateurValeurs.push({
-              collectiviteId: relatedSourceIndicateurInfo.collectiviteId,
-              identifiants: relatedSourceIndicateurInfo.missingIdentifiants,
-              sourceId: relatedSourceIndicateurInfo.sourceId,
-              date: relatedSourceIndicateurInfo.date,
-            });
-          }
-        }
-      });
-      this.logger.log(
-        `Need to retrieve missing indicateur valeurs (${allMissingIndicateurValeurs.length} sets) to compute calculated indicateur valeurs`
-      );
-      const retrievedMissingIndicateurValeurs =
-        allMissingIndicateurValeurs.length
-          ? await this.fetchMissingIndicateurValeurs(
-              allMissingIndicateurValeurs,
-              allowedExtraSourcesForCalculatedValeurs
-            )
-          : [];
-      this.logger.log(
-        `Retrieved ${retrievedMissingIndicateurValeurs.length} missing indicateur valeurs`
-      );
-
-      // Now that we have retrieved all needed values, we can compute the calculated indicateur valeurs
-      const computedIndicateurValeurs: IndicateurValeurInsert[] = [];
-      computedIndicateurDefinitions.forEach((computedIndicateurDefinition) => {
-        // Fill missing retrieved values. We don't want to add new entry in the map but only fill existing ones
-        const relatedSourceIndicateurValeursByDate =
-          indicateurRelatedSourceIndicateurValeursByDate[
-            `${computedIndicateurDefinition.id}`
-          ];
-        this.fillRelatedSourceIndicateurValeursByDate(
-          computedIndicateurDefinition,
-          retrievedMissingIndicateurValeurs,
-          allowedExtraSourcesForCalculatedValeurs,
-          relatedSourceIndicateurValeursByDate,
-          false
-        );
-
-        const calculateValeur = this.computeCalculatedIndicateurValeur(
-          computedIndicateurDefinition,
-          relatedSourceIndicateurValeursByDate
-        );
-
-        computedIndicateurValeurs.push(...calculateValeur);
-      });
-      return computedIndicateurValeurs;
-    }
-
-    return [];
+          ...valeur,
+          indicateurIdentifiant: definition.identifiantReferentiel,
+          sourceId: normalizeCalculSourceId(metadonnee?.sourceId),
+          metadonneeDateVersion: metadonnee?.dateVersion ?? null,
+          deleted: deletedIds.has(valeur.id),
+          period: hydrateIndicateurPeriod({
+            periodicite: definition.periodicite,
+            dateValeur: valeur.dateValeur,
+          }),
+        },
+      ];
+    });
+    const formulasWithGroups = formulas.map((formula) => {
+      const groups = fillCalculSourceGroups(formula, sources, policies);
+      groupsByIndicateur.set(formula.definition.id, groups);
+      return { formula, groups };
+    });
+    // Updating an older metadata version must still calculate from the newest
+    // stored observation. Re-read every referenced identifier under the same
+    // period locks, including identifiers already present in the incoming batch.
+    const sourceQueries = formulasWithGroups.flatMap(({ formula, groups }) =>
+      Object.values(groups).map((group) => ({
+        collectiviteId: group.collectiviteId,
+        period: group.period,
+        sourceId: group.sourceId,
+        metadonneeId: group.metadonneeId,
+        identifiants: formula.references.map(({ identifiant }) => identifiant),
+        extraSourceCalculIds:
+          policies.find(
+            (policy) =>
+              normalizeCalculSourceId(policy.sourceId) === group.sourceId
+          )?.sourceCalculIds ?? ComputeValeursService.DEFAULT_SOURCE_CALCUL_IDS,
+      }))
+    );
+    const storedSources = sourceQueries.length
+      ? await this.repository.listSourceValeurs(sourceQueries, tx)
+      : [];
+    const valeursToUpsert = formulasWithGroups.flatMap(
+      ({ formula, groups }) => {
+        fillCalculSourceGroups(formula, storedSources, policies, groups, false);
+        return this.evaluate(formula, groups);
+      }
+    );
+    return { valeursToUpsert, groupsByIndicateur };
   }
 
   async recomputeCollectiviteCalculatedIndicateurValeurs(
     collectiviteId: number,
-    computedIndicateurDefinitions: IndicateurDefinition[],
-    sourceIdentifiants: string[],
-    allowedExtraSourcesForCalculatedValues: {
-      sourceId: string;
-      sourceCalculIds: string[];
-    }[]
-  ) {
-    this.logger.log(
-      `Recompute calculated indicateur valeurs for collectivite ${collectiviteId}`
+    indicateurIds: number[],
+    tx: Transaction
+  ): Promise<RecomputedIndicateurValeurs> {
+    const graphResult = await this.graphService.loadForRecompute(
+      indicateurIds,
+      { tx }
     );
-
-    const sourceValeurs: IndicateurValeurWithIdentifiant[] =
-      await this.databaseService.db
-        .select({
-          ...getTableColumns(indicateurValeurTable),
-          indicateurIdentifiant:
-            indicateurDefinitionTable.identifiantReferentiel,
-          sourceId: indicateurSourceMetadonneeTable.sourceId,
-        })
-        .from(indicateurValeurTable)
-        .leftJoin(
-          indicateurDefinitionTable,
-          eq(indicateurValeurTable.indicateurId, indicateurDefinitionTable.id)
-        )
-        .leftJoin(
-          indicateurSourceMetadonneeTable,
-          eq(
-            indicateurValeurTable.metadonneeId,
-            indicateurSourceMetadonneeTable.id
-          )
-        )
-        .where(
-          and(
-            eq(indicateurValeurTable.collectiviteId, collectiviteId),
-            inArray(
-              indicateurDefinitionTable.identifiantReferentiel,
-              sourceIdentifiants
-            )
-          )
-        );
-    this.logger.log(
-      `Found ${sourceValeurs.length} source indicateur valeurs for collectivite ${collectiviteId}`
+    if (!graphResult.success) throw graphResult.cause ?? graphResult.error;
+    const { formulas, targetDefinitions, sourceDefinitions } = graphResult.data;
+    if (!indicateurIds.length)
+      return {
+        valeursToUpsert: [],
+        valeurIdsToDelete: [],
+        indicateurIdentifiants: [],
+      };
+    const neededIdentifiants = new Set(
+      formulas.flatMap(({ references }) =>
+        references.map(({ identifiant }) => identifiant)
+      )
     );
-
-    // We don't want top call updateCalculatedIndicateurValeurs because it's looking for missing values: we already have all collectivite values
-
-    const computedIndicateurValeurs: IndicateurValeurInsert[] = [];
-    computedIndicateurDefinitions.forEach((computedIndicateurDefinition) => {
-      // Fill the map by date
-      const relatedSourceIndicateurValeursByDate =
-        this.fillRelatedSourceIndicateurValeursByDate(
-          computedIndicateurDefinition,
-          sourceValeurs,
-          allowedExtraSourcesForCalculatedValues,
-          {},
-          true
-        );
-      computedIndicateurValeurs.push(
-        ...this.computeCalculatedIndicateurValeur(
-          computedIndicateurDefinition,
-          relatedSourceIndicateurValeursByDate
+    const sourceIds = new Set(
+      sourceDefinitions
+        .filter(
+          ({ identifiantReferentiel }) =>
+            identifiantReferentiel &&
+            neededIdentifiants.has(identifiantReferentiel)
         )
-      );
-    });
+        .map(({ id }) => id)
+    );
+    const relevantIds = [...new Set([...indicateurIds, ...sourceIds])];
+    const discoveredPeriods = await this.repository.listPeriodKeys(
+      { collectiviteId, indicateurIds: relevantIds },
+      tx
+    );
+    // Discover keys, acquire all period locks, then re-read the values used by
+    // calculation. Writers arriving after discovery perform their own refresh.
+    await this.valeurLockRepository.lock(discoveredPeriods, tx);
+    const lockedDates = new Set(
+      discoveredPeriods.map(({ dateValeur }) => dateValeur)
+    );
+    const stored = (
+      await this.repository.listRelevantValeurs(
+        {
+          collectiviteId,
+          indicateurIds: relevantIds,
+          dateValeurs: [...lockedDates],
+        },
+        tx
+      )
+    ).filter(({ dateValeur }) => lockedDates.has(dateValeur));
+    const sources = stored
+      .filter(({ indicateurId }) => sourceIds.has(indicateurId))
+      .map<CalculSourceValeur>((valeur) => {
+        if (!valeur.indicateurIdentifiant || !valeur.periodicite)
+          throw new Error(
+            `Impossible d'hydrater la période de la valeur d'indicateur ${valeur.indicateurId}`
+          );
+        return {
+          ...valeur,
+          indicateurIdentifiant: valeur.indicateurIdentifiant,
+          sourceId: normalizeCalculSourceId(valeur.sourceId),
+          deleted: false,
+          period: hydrateIndicateurPeriod({
+            periodicite: valeur.periodicite,
+            dateValeur: valeur.dateValeur,
+          }),
+        };
+      });
+    const policies = await this.getSourcesCalcul(tx);
+    const valeursToUpsert = formulas.flatMap((formula) =>
+      this.evaluate(formula, fillCalculSourceGroups(formula, sources, policies))
+    );
+    const expected = new Set(valeursToUpsert.map(getCalculatedValeurIdentity));
+    const targetIds = new Set(indicateurIds);
+    return {
+      valeursToUpsert,
+      valeurIdsToDelete: stored
+        .filter(
+          (valeur) =>
+            targetIds.has(valeur.indicateurId) &&
+            valeur.calculAuto === true &&
+            !expected.has(getCalculatedValeurIdentity(valeur))
+        )
+        .map(({ id }) => id),
+      indicateurIdentifiants: targetDefinitions.flatMap(
+        ({ identifiantReferentiel }) =>
+          identifiantReferentiel ? [identifiantReferentiel] : []
+      ),
+    };
+  }
 
-    return computedIndicateurValeurs;
+  private evaluate(
+    formula: IndicateurFormula,
+    groups: CalculSourceGroups
+  ): IndicateurValeurCreate[] {
+    return evaluateCalculIndicateur(formula, groups, (expression, values) =>
+      this.expressions.parseAndEvaluateExpression(expression, values)
+    );
   }
 }

--- a/apps/backend/src/indicateurs/valeurs/crud-valeurs-authorization.controller.e2e-spec.ts
+++ b/apps/backend/src/indicateurs/valeurs/crud-valeurs-authorization.controller.e2e-spec.ts
@@ -1,0 +1,291 @@
+import { INestApplication } from '@nestjs/common';
+import {
+  addTestCollectivite,
+  addTestCollectiviteAndUser,
+} from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { createGroupement } from '@tet/backend/collectivites/shared/models/groupement.test-fixture';
+import { indicateurDefinitionTable } from '@tet/backend/indicateurs/definitions/indicateur-definition.table';
+import { indicateurValeurTable } from '@tet/backend/indicateurs/valeurs/indicateur-valeur.table';
+import {
+  getTestApp,
+  getTestDatabase,
+  signTestAuthToken,
+} from '@tet/backend/test';
+import { AuthRole } from '@tet/backend/users/models/auth.models';
+import ConfigurationService from '@tet/backend/utils/config/configuration.service';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { CollectiviteRole } from '@tet/domain/users';
+import { eq, inArray } from 'drizzle-orm';
+import request from 'supertest';
+
+describe("Autorisation REST des valeurs d'indicateur", () => {
+  let app: INestApplication;
+  let databaseService: DatabaseService;
+  let collectiviteId: number;
+  let authenticatedToken: string;
+  let serviceRoleToken: string;
+  let cleanupCollectiviteAndUser: () => Promise<void>;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    databaseService = await getTestDatabase(app);
+    const fixture = await addTestCollectiviteAndUser(databaseService, {
+      user: { role: CollectiviteRole.ADMIN },
+    });
+    collectiviteId = fixture.collectivite.id;
+    cleanupCollectiviteAndUser = fixture.cleanup;
+
+    const jwtSecret = app.get(ConfigurationService).get('SUPABASE_JWT_SECRET');
+    authenticatedToken = signTestAuthToken(
+      { role: AuthRole.AUTHENTICATED, sub: fixture.user.id },
+      jwtSecret
+    );
+    serviceRoleToken = signTestAuthToken(
+      { role: AuthRole.SERVICE_ROLE },
+      jwtSecret
+    );
+  });
+
+  afterAll(async () => {
+    await cleanupCollectiviteAndUser?.();
+    await app?.close();
+  });
+
+  it("ne divulgue pas la définition personnalisée d'une autre collectivité", async () => {
+    const { collectivite: otherCollectivite, cleanup } =
+      await addTestCollectivite(databaseService);
+    const [foreignDefinition] = await databaseService.db
+      .insert(indicateurDefinitionTable)
+      .values({
+        collectiviteId: otherCollectivite.id,
+        titre: 'Indicateur privé à masquer',
+        unite: 't',
+        periodicite: 'annuelle',
+      })
+      .returning();
+
+    onTestFinished(async () => {
+      await databaseService.db
+        .delete(indicateurDefinitionTable)
+        .where(eq(indicateurDefinitionTable.id, foreignDefinition.id));
+      await cleanup();
+    });
+
+    const response = await request(app.getHttpServer())
+      .get(
+        `/indicateurs/valeurs?collectiviteId=${collectiviteId}&indicateurIds=${foreignDefinition.id}`
+      )
+      .set('Authorization', `Bearer ${authenticatedToken}`)
+      .expect(200);
+
+    expect(response.body).toEqual({ count: 0, indicateurs: [] });
+  });
+
+  it("refuse d'écrire une valeur pour la définition personnalisée d'une autre collectivité", async () => {
+    const { collectivite: otherCollectivite, cleanup } =
+      await addTestCollectivite(databaseService);
+    const [foreignDefinition] = await databaseService.db
+      .insert(indicateurDefinitionTable)
+      .values({
+        collectiviteId: otherCollectivite.id,
+        titre: 'Indicateur privé à une autre collectivité',
+        unite: 't',
+        periodicite: 'annuelle',
+      })
+      .returning();
+
+    onTestFinished(async () => {
+      await databaseService.db
+        .delete(indicateurValeurTable)
+        .where(eq(indicateurValeurTable.indicateurId, foreignDefinition.id));
+      await databaseService.db
+        .delete(indicateurDefinitionTable)
+        .where(eq(indicateurDefinitionTable.id, foreignDefinition.id));
+      await cleanup();
+    });
+
+    const response = await request(app.getHttpServer())
+      .post('/indicateurs/valeurs')
+      .set('Authorization', `Bearer ${authenticatedToken}`)
+      .send({
+        valeurs: [
+          {
+            collectiviteId,
+            indicateurId: foreignDefinition.id,
+            dateValeur: '2026-01-01',
+            resultat: 42,
+          },
+        ],
+      })
+      .expect(400);
+
+    expect(response.body.message).toContain(
+      `Indicateur ${foreignDefinition.id} non disponible pour la collectivité ${collectiviteId}`
+    );
+    await expect(
+      databaseService.db
+        .select()
+        .from(indicateurValeurTable)
+        .where(eq(indicateurValeurTable.indicateurId, foreignDefinition.id))
+    ).resolves.toEqual([]);
+  });
+
+  it("refuse atomiquement un lot contenant un indicateur de groupement dont la collectivité n'est pas membre", async () => {
+    const groupement = await createGroupement({
+      database: databaseService,
+      groupementData: { nom: 'Groupement non membre' },
+    });
+    const definitions = await databaseService.db
+      .insert(indicateurDefinitionTable)
+      .values([
+        {
+          titre: 'Indicateur global autorisé',
+          unite: 't',
+          periodicite: 'annuelle',
+        },
+        {
+          groupementId: groupement.id,
+          titre: 'Indicateur de groupement interdit',
+          unite: 't',
+          periodicite: 'annuelle',
+        },
+      ])
+      .returning();
+    const definitionIds = definitions.map(({ id }) => id);
+
+    onTestFinished(async () => {
+      await databaseService.db
+        .delete(indicateurValeurTable)
+        .where(inArray(indicateurValeurTable.indicateurId, definitionIds));
+      await databaseService.db
+        .delete(indicateurDefinitionTable)
+        .where(inArray(indicateurDefinitionTable.id, definitionIds));
+      await groupement.cleanup();
+    });
+
+    const response = await request(app.getHttpServer())
+      .post('/indicateurs/valeurs')
+      .set('Authorization', `Bearer ${authenticatedToken}`)
+      .send({
+        valeurs: definitions.map(({ id }, index) => ({
+          collectiviteId,
+          indicateurId: id,
+          dateValeur: '2026-01-01',
+          resultat: index + 1,
+        })),
+      })
+      .expect(400);
+
+    expect(response.body.message).toContain(
+      `Indicateur ${definitions[1].id} non disponible pour la collectivité ${collectiviteId}`
+    );
+    await expect(
+      databaseService.db
+        .select()
+        .from(indicateurValeurTable)
+        .where(inArray(indicateurValeurTable.indicateurId, definitionIds))
+    ).resolves.toEqual([]);
+  });
+
+  it("autorise l'écriture d'un indicateur de groupement pour une collectivité membre", async () => {
+    const groupement = await createGroupement({
+      database: databaseService,
+      groupementData: {
+        nom: 'Groupement membre',
+        collectiviteIds: [collectiviteId],
+      },
+    });
+    const [definition] = await databaseService.db
+      .insert(indicateurDefinitionTable)
+      .values({
+        groupementId: groupement.id,
+        titre: 'Indicateur de groupement autorisé',
+        unite: 't',
+        periodicite: 'annuelle',
+      })
+      .returning();
+
+    onTestFinished(async () => {
+      await databaseService.db
+        .delete(indicateurValeurTable)
+        .where(eq(indicateurValeurTable.indicateurId, definition.id));
+      await databaseService.db
+        .delete(indicateurDefinitionTable)
+        .where(eq(indicateurDefinitionTable.id, definition.id));
+      await groupement.cleanup();
+    });
+
+    const response = await request(app.getHttpServer())
+      .post('/indicateurs/valeurs')
+      .set('Authorization', `Bearer ${authenticatedToken}`)
+      .send({
+        valeurs: [
+          {
+            collectiviteId,
+            indicateurId: definition.id,
+            dateValeur: '2026-01-01',
+            resultat: 42,
+          },
+        ],
+      })
+      .expect(201);
+
+    expect(response.body.valeurs).toEqual([
+      expect.objectContaining({
+        collectiviteId,
+        indicateurId: definition.id,
+        resultat: 42,
+      }),
+    ]);
+  });
+
+  it("préserve l'écriture service-role pour une collectivité non membre", async () => {
+    const groupement = await createGroupement({
+      database: databaseService,
+      groupementData: { nom: 'Groupement réservé au traitement interne' },
+    });
+    const [definition] = await databaseService.db
+      .insert(indicateurDefinitionTable)
+      .values({
+        groupementId: groupement.id,
+        titre: 'Indicateur de traitement interne',
+        unite: 'MWh',
+        periodicite: 'annuelle',
+        sansValeurUtilisateur: true,
+      })
+      .returning();
+
+    onTestFinished(async () => {
+      await databaseService.db
+        .delete(indicateurValeurTable)
+        .where(eq(indicateurValeurTable.indicateurId, definition.id));
+      await databaseService.db
+        .delete(indicateurDefinitionTable)
+        .where(eq(indicateurDefinitionTable.id, definition.id));
+      await groupement.cleanup();
+    });
+
+    const response = await request(app.getHttpServer())
+      .post('/indicateurs/valeurs')
+      .set('Authorization', `Bearer ${serviceRoleToken}`)
+      .send({
+        valeurs: [
+          {
+            collectiviteId,
+            indicateurId: definition.id,
+            dateValeur: '2026-01-01',
+            resultat: 42,
+          },
+        ],
+      })
+      .expect(201);
+
+    expect(response.body.valeurs).toEqual([
+      expect.objectContaining({
+        collectiviteId,
+        indicateurId: definition.id,
+        resultat: 42,
+      }),
+    ]);
+  });
+});

--- a/apps/backend/src/indicateurs/valeurs/crud-valeurs.controller.e2e-spec.ts
+++ b/apps/backend/src/indicateurs/valeurs/crud-valeurs.controller.e2e-spec.ts
@@ -1,5 +1,6 @@
 import { INestApplication } from '@nestjs/common';
 import { collectiviteTable } from '@tet/backend/collectivites/shared/models/collectivite.table';
+import { indicateurDefinitionTable } from '@tet/backend/indicateurs/definitions/indicateur-definition.table';
 import { indicateurValeurTable } from '@tet/backend/indicateurs/valeurs/indicateur-valeur.table';
 import { UpsertIndicateursValeursResponse } from '@tet/backend/indicateurs/valeurs/upsert-indicateurs-valeurs.response';
 import {
@@ -8,12 +9,15 @@ import {
   getIndicateurIdByIdentifiant,
   getTestApp,
   getTestDatabase,
+  signTestAuthToken,
 } from '@tet/backend/test';
+import { AuthRole } from '@tet/backend/users/models/auth.models';
 import {
   addTestUser,
   setUserCollectiviteRole,
 } from '@tet/backend/users/users/users.test-fixture';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import ConfigurationService from '@tet/backend/utils/config/configuration.service';
 import { CollectiviteRole } from '@tet/domain/users';
 import { and, eq, isNull } from 'drizzle-orm';
 import { default as request } from 'supertest';
@@ -26,11 +30,16 @@ describe('Indicateurs', () => {
   let authToken: string;
   let testUserId: string;
   let databaseService: DatabaseService;
+  let serviceRoleToken: string;
   let paysDuLaonCollectiviteId: number;
 
   beforeAll(async () => {
     app = await getTestApp();
     databaseService = await getTestDatabase(app);
+    serviceRoleToken = signTestAuthToken(
+      { role: AuthRole.SERVICE_ROLE },
+      app.get(ConfigurationService).get('SUPABASE_JWT_SECRET')
+    );
 
     // Create isolated test user with access to needed collectivites
     const testUserResult = await addTestUser(databaseService);
@@ -64,7 +73,6 @@ describe('Indicateurs', () => {
       .update(collectiviteTable)
       .set({ accesRestreint: false })
       .where(eq(collectiviteTable.id, collectiviteId));
-
   });
 
   afterAll(async () => {
@@ -161,6 +169,52 @@ describe('Indicateurs', () => {
       statusCode: 403,
     });
     expect(response.body.message).toMatch(/Droits insuffisants/);
+  });
+
+  it(`Une intégration service-role peut alimenter une source open-data d'un indicateur sans valeur utilisateur`, async () => {
+    const [protectedDefinition] = await databaseService.db
+      .insert(indicateurDefinitionTable)
+      .values({
+        titre: 'Indicateur open-data protégé',
+        unite: 'MWh',
+        periodicite: 'annuelle',
+        sansValeurUtilisateur: true,
+      })
+      .returning();
+    onTestFinished(async () => {
+      await databaseService.db
+        .delete(indicateurValeurTable)
+        .where(eq(indicateurValeurTable.indicateurId, protectedDefinition.id));
+      await databaseService.db
+        .delete(indicateurDefinitionTable)
+        .where(eq(indicateurDefinitionTable.id, protectedDefinition.id));
+    });
+
+    const response = await request(app.getHttpServer())
+      .post('/indicateurs/valeurs')
+      .set('Authorization', `Bearer ${serviceRoleToken}`)
+      .send({
+        valeurs: [
+          {
+            collectiviteId,
+            indicateurId: protectedDefinition.id,
+            dateValeur: '2026-01-01',
+            metadonneeId: 1,
+            resultat: 42,
+          },
+        ],
+      })
+      .expect(201);
+
+    expect(response.body.valeurs).toEqual([
+      expect.objectContaining({
+        collectiviteId,
+        indicateurId: protectedDefinition.id,
+        dateValeur: '2026-01-01',
+        metadonneeId: 1,
+        resultat: 42,
+      }),
+    ]);
   });
 
   it(`Ecriture avec accès et calcul d'un autre indicateur pour la collectivité > ok si pas de valeur déja saisie manuellement, sinon pas de valeur calculée`, async () => {

--- a/apps/backend/src/indicateurs/valeurs/crud-valeurs.controller.ts
+++ b/apps/backend/src/indicateurs/valeurs/crud-valeurs.controller.ts
@@ -11,7 +11,10 @@ import { ApiUsageEnum } from '@tet/backend/utils/api/api-usage-type.enum';
 import { ApiUsage } from '@tet/backend/utils/api/api-usage.decorator';
 import { createZodDto } from 'nestjs-zod';
 import { TokenInfo } from '../../users/decorators/token-info.decorators';
-import type { AuthenticatedUser } from '../../users/models/auth.models';
+import type {
+  AuthenticatedOrServiceRoleUser,
+  AuthenticatedUser,
+} from '../../users/models/auth.models';
 import CrudValeursService from './crud-valeurs.service';
 import { getIndicateursValeursApiRequestSchema } from './get-indicateur-valeurs.api-request';
 import { getIndicateursValeursResponseSchema } from './get-indicateur-valeurs.response';
@@ -51,7 +54,7 @@ export class IndicateursValeursController {
     @Query() request: GetIndicateursValeursApiRequestClass,
     @TokenInfo() tokenInfo: AuthenticatedUser
   ): Promise<GetIndicateursValeursResponseClass> {
-    return this.service.listIndicateurValeurs(request, tokenInfo);
+    return this.service.listIndicateurValeurs(request, { user: tokenInfo });
   }
 
   @ApiUsage([ApiUsageEnum.EXTERNAL_API])
@@ -67,11 +70,11 @@ export class IndicateursValeursController {
   })
   async upsertIndicateurValeurs(
     @Body() request: UpsertIndicateursValeursRequest,
-    @TokenInfo() tokenInfo: AuthenticatedUser
+    @TokenInfo() tokenInfo: AuthenticatedOrServiceRoleUser
   ): Promise<UpsertIndicateursValeursResponse> {
     const upsertedValeurs = await this.service.upsertIndicateurValeurs(
       request.valeurs,
-      tokenInfo
+      { user: tokenInfo }
     );
     return { valeurs: upsertedValeurs };
   }

--- a/apps/backend/src/indicateurs/valeurs/crud-valeurs.repository.ts
+++ b/apps/backend/src/indicateurs/valeurs/crud-valeurs.repository.ts
@@ -201,6 +201,17 @@ export class CrudValeursRepository {
       .where(inArray(indicateurSourceTable.id, sourceIds));
   }
 
+  async listMetadataSources(metadataIds: number[], tx: Transaction) {
+    if (metadataIds.length === 0) return [];
+    return tx
+      .select({
+        id: indicateurSourceMetadonneeTable.id,
+        sourceId: indicateurSourceMetadonneeTable.sourceId,
+      })
+      .from(indicateurSourceMetadonneeTable)
+      .where(inArray(indicateurSourceMetadonneeTable.id, metadataIds));
+  }
+
   /**
    * Verrouille les appartenances utilisées pour autoriser le lot d'écriture.
    * Une suppression concurrente attend ainsi la fin de la transaction qui a

--- a/apps/backend/src/indicateurs/valeurs/crud-valeurs.router.ts
+++ b/apps/backend/src/indicateurs/valeurs/crud-valeurs.router.ts
@@ -26,7 +26,7 @@ export class IndicateurValeursRouter {
     list: this.trpc.authedOrServiceRoleProcedure
       .input(listIndicateurValeursInputSchema)
       .query(({ ctx, input }) => {
-        return this.service.listIndicateurValeurs(input, ctx.user);
+        return this.service.listIndicateurValeurs(input, { user: ctx.user });
       }),
     upsert: this.trpc.authedProcedure
       .input(upsertValeurIndicateurSchema)

--- a/apps/backend/src/indicateurs/valeurs/crud-valeurs.service.spec.ts
+++ b/apps/backend/src/indicateurs/valeurs/crud-valeurs.service.spec.ts
@@ -2,6 +2,11 @@ import { Test } from '@nestjs/testing';
 import ComputeValeursService from '@tet/backend/indicateurs/valeurs/compute-valeurs.service';
 import { GetUserRolesAndPermissionsService } from '@tet/backend/users/authorizations/get-user-roles-and-permissions/get-user-roles-and-permissions.service';
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
+import { TransactionManager } from '@tet/backend/utils/transaction/transaction-manager.service';
+import {
+  AuthRole,
+  ServiceRoleUser,
+} from '@tet/backend/users/models/auth.models';
 import {
   IndicateurAvecValeurs,
   IndicateurAvecValeursParSource,
@@ -12,17 +17,89 @@ import {
   IndicateurValeurAvecMetadonnesDefinition,
 } from '@tet/domain/indicateurs';
 import { cloneDeep } from 'es-toolkit';
+import { vi } from 'vitest';
 import CollectivitesService from '../../collectivites/services/collectivites.service';
-import { DatabaseService } from '../../utils/database/database.service';
+import { IndicateurDefinitionLockRepository } from '../definitions/indicateur-definition-lock.repository';
 import { ListCollectiviteDefinitionsRepository } from '../definitions/list-collectivite-definitions/list-collectivite-definitions.repository';
 import { ListPlatformDefinitionsRepository } from '../definitions/list-platform-definitions/list-platform-definitions.repository';
 import { UpdateDefinitionService } from '../definitions/mutate-definition/update-definition.service';
 import { ListIndicateursService } from '../indicateurs/list-indicateurs/list-indicateurs.service';
 import IndicateurSourcesService from '../sources/indicateur-sources.service';
+import { CrudValeursRepository } from './crud-valeurs.repository';
 import CrudValeursService from './crud-valeurs.service';
-import { ListIndicateurValeursService } from './list-indicateur-valeurs.service';
+import { IndicateurValeurLockRepository } from './indicateur-valeur-lock.repository';
 import IndicateurExpressionService from './indicateur-expression.service';
 import { indicateur1, indicateur2, indicateur3 } from './tests/fixture';
+import { ListIndicateurValeursService } from './list-indicateur-valeurs.service';
+import { ValidateIndicateurValeursWriteService } from './validate-indicateur-valeurs-write.service';
+import { WriteIndicateurValeursService } from './write-indicateur-valeurs.service';
+import { ReconcileIndicateurValeursService } from './reconcile-indicateur-valeurs.service';
+
+// Compose the real workflows around repository mocks so these tests continue to
+// exercise authorization, persistence and propagation together after extraction.
+const createCrudValeursService = (
+  repository: CrudValeursRepository,
+  permissions: PermissionService,
+  userPermissions: GetUserRolesAndPermissionsService,
+  collectivites: CollectivitesService,
+  definitions: ListCollectiviteDefinitionsRepository,
+  platformDefinitions: ListPlatformDefinitionsRepository,
+  indicateurs: ListIndicateursService,
+  updateDefinition: UpdateDefinitionService,
+  compute: ComputeValeursService,
+  locks: IndicateurValeurLockRepository,
+  definitionLocks: IndicateurDefinitionLockRepository,
+  transactions: TransactionManager
+) => {
+  const validation = new ValidateIndicateurValeursWriteService(
+    repository,
+    permissions,
+    definitions,
+    definitionLocks
+  );
+  const writer = new WriteIndicateurValeursService(
+    repository,
+    validation,
+    definitionLocks,
+    locks
+  );
+  const reader = new ListIndicateurValeursService(
+    repository,
+    permissions,
+    collectivites,
+    definitions
+  );
+  const reconciliation = new ReconcileIndicateurValeursService(
+    repository,
+    compute,
+    validation,
+    writer,
+    platformDefinitions,
+    transactions
+  );
+  return new CrudValeursService(
+    repository,
+    permissions,
+    userPermissions,
+    indicateurs,
+    updateDefinition,
+    locks,
+    definitionLocks,
+    transactions,
+    reader,
+    writer,
+    reconciliation
+  );
+};
+
+const createTransactionManager = <TTransaction>(tx: TTransaction) => ({
+  executeSingle: vi.fn(
+    (
+      operation: (transaction: TTransaction) => unknown,
+      existingTx?: TTransaction
+    ) => operation(existingTx ?? tx)
+  ),
+});
 
 describe('Indicateurs → crud-valeurs.service', () => {
   let indicateurService: CrudValeursService;
@@ -33,7 +110,7 @@ describe('Indicateurs → crud-valeurs.service', () => {
     })
       .useMocker((token) => {
         if (
-          token === DatabaseService ||
+          token === CrudValeursRepository ||
           token === PermissionService ||
           token === CollectivitesService ||
           token === ListCollectiviteDefinitionsRepository ||
@@ -43,8 +120,13 @@ describe('Indicateurs → crud-valeurs.service', () => {
           token === UpdateDefinitionService ||
           token === IndicateurSourcesService ||
           token === ComputeValeursService ||
+          token === IndicateurValeurLockRepository ||
+          token === IndicateurDefinitionLockRepository ||
+          token === TransactionManager ||
+          token === GetUserRolesAndPermissionsService ||
           token === ListIndicateurValeursService ||
-          token === GetUserRolesAndPermissionsService
+          token === WriteIndicateurValeursService ||
+          token === ReconcileIndicateurValeursService
         ) {
           return {};
         }
@@ -52,6 +134,47 @@ describe('Indicateurs → crud-valeurs.service', () => {
       .compile();
 
     indicateurService = moduleRef.get(CrudValeursService);
+  });
+
+  describe('listIndicateurValeurs', () => {
+    it('limite les définitions retournées à la collectivité demandée', async () => {
+      const repository = {
+        listIndicateurValeurs: vi.fn().mockResolvedValue([]),
+        listSources: vi.fn().mockResolvedValue([]),
+      };
+      const definitionsRepository = {
+        listCollectiviteDefinitions: vi.fn().mockResolvedValue([]),
+      };
+      const service = createCrudValeursService(
+        repository as never,
+        {} as never,
+        {} as never,
+        {} as never,
+        definitionsRepository as never,
+        {} as never,
+        {} as never,
+        {} as never,
+        {} as never,
+        {} as never,
+        {} as never,
+        {} as never
+      );
+
+      await expect(
+        service.listIndicateurValeurs(
+          { collectiviteId: 3, indicateurIds: [10] },
+          { isUserTrusted: true }
+        )
+      ).resolves.toEqual({ count: 0, indicateurs: [] });
+
+      expect(
+        definitionsRepository.listCollectiviteDefinitions
+      ).toHaveBeenCalledWith({
+        collectiviteId: 3,
+        indicateurIds: [10],
+        identifiantsReferentiel: undefined,
+      });
+    });
   });
 
   describe('groupeIndicateursValeursParIndicateur', () => {
@@ -133,8 +256,8 @@ describe('Indicateurs → crud-valeurs.service', () => {
             titreLong:
               'Emissions de gaz à effet de serre du secteur résidentiel',
             description: '',
-            periodicite: 'annuelle',
             unite: 'teq CO2',
+            periodicite: 'annuelle',
             borneMin: null,
             borneMax: null,
           },
@@ -160,8 +283,8 @@ describe('Indicateurs → crud-valeurs.service', () => {
             titre: 'Emissions de gaz à effet de serre - tertiaire',
             titreLong: 'Emissions de gaz à effet de serre du secteur tertiaire',
             description: '',
-            periodicite: 'annuelle',
             unite: 'teq CO2',
+            periodicite: 'annuelle',
             borneMin: null,
             borneMax: null,
           },
@@ -326,8 +449,8 @@ describe('Indicateurs → crud-valeurs.service', () => {
               titreLong:
                 'Emissions de gaz à effet de serre du secteur résidentiel',
               description: '',
-              periodicite: 'annuelle',
               unite: 'teq CO2',
+              periodicite: 'annuelle',
               borneMin: null,
               borneMax: null,
             } as IndicateurDefinition,
@@ -396,8 +519,8 @@ describe('Indicateurs → crud-valeurs.service', () => {
               titreLong:
                 'Emissions de gaz à effet de serre du secteur tertiaire',
               description: '',
-              periodicite: 'annuelle',
               unite: 'teq CO2',
+              periodicite: 'annuelle',
               borneMin: null,
               borneMax: null,
             } as IndicateurDefinition,
@@ -471,8 +594,8 @@ describe('Indicateurs → crud-valeurs.service', () => {
             titreLong:
               'Emissions de gaz à effet de serre du secteur résidentiel',
             description: '',
-            periodicite: 'annuelle',
             unite: 'teq CO2',
+            periodicite: 'annuelle',
             borneMin: null,
             borneMax: null,
             participationScore: false,
@@ -528,8 +651,8 @@ describe('Indicateurs → crud-valeurs.service', () => {
             titreLong:
               'Emissions de gaz à effet de serre du secteur résidentiel',
             description: '',
-            periodicite: 'annuelle',
             unite: 'teq CO2',
+            periodicite: 'annuelle',
             borneMin: null,
             borneMax: null,
             participationScore: false,
@@ -602,8 +725,8 @@ describe('Indicateurs → crud-valeurs.service', () => {
             titreLong:
               'Emissions de gaz à effet de serre du secteur résidentiel',
             description: '',
-            periodicite: 'annuelle',
             unite: 'teq CO2',
+            periodicite: 'annuelle',
             borneMin: null,
             borneMax: null,
             participationScore: false,
@@ -658,8 +781,8 @@ describe('Indicateurs → crud-valeurs.service', () => {
             titre: 'Emissions de gaz à effet de serre - tertiaire',
             titreLong: 'Emissions de gaz à effet de serre du secteur tertiaire',
             description: '',
-            periodicite: 'annuelle',
             unite: 'teq CO2',
+            periodicite: 'annuelle',
             borneMin: null,
             borneMax: null,
             participationScore: false,
@@ -732,8 +855,8 @@ describe('Indicateurs → crud-valeurs.service', () => {
             titreLong:
               'Emissions de gaz à effet de serre du secteur résidentiel',
             description: '',
-            periodicite: 'annuelle',
             unite: 'teq CO2',
+            periodicite: 'annuelle',
             borneMin: null,
             borneMax: null,
             participationScore: false,
@@ -789,8 +912,8 @@ describe('Indicateurs → crud-valeurs.service', () => {
             titreLong:
               'Emissions de gaz à effet de serre du secteur résidentiel',
             description: '',
-            periodicite: 'annuelle',
             unite: 'teq CO2',
+            periodicite: 'annuelle',
             borneMin: null,
             borneMax: null,
             participationScore: false,
@@ -854,8 +977,8 @@ describe('Indicateurs → crud-valeurs.service', () => {
             titreLong:
               'Emissions de gaz à effet de serre du secteur résidentiel',
             description: '',
-            periodicite: 'annuelle',
             unite: 'teq CO2',
+            periodicite: 'annuelle',
             borneMin: null,
             borneMax: null,
             participationScore: false,
@@ -911,8 +1034,8 @@ describe('Indicateurs → crud-valeurs.service', () => {
             titreLong:
               'Emissions de gaz à effet de serre du secteur résidentiel',
             description: '',
-            periodicite: 'annuelle',
             unite: 'teq CO2',
+            periodicite: 'annuelle',
             borneMin: null,
             borneMax: null,
             participationScore: false,
@@ -985,8 +1108,8 @@ describe('Indicateurs → crud-valeurs.service', () => {
             titreLong:
               'Emissions de gaz à effet de serre du secteur résidentiel',
             description: '',
-            periodicite: 'annuelle',
             unite: 'teq CO2',
+            periodicite: 'annuelle',
             borneMin: null,
             borneMax: null,
             participationScore: false,
@@ -1042,8 +1165,8 @@ describe('Indicateurs → crud-valeurs.service', () => {
             titreLong:
               'Emissions de gaz à effet de serre du secteur résidentiel',
             description: '',
-            periodicite: 'annuelle',
             unite: 'teq CO2',
+            periodicite: 'annuelle',
             borneMin: null,
             borneMax: null,
             participationScore: false,
@@ -1114,8 +1237,8 @@ describe('Indicateurs → crud-valeurs.service', () => {
           titre: 'Emissions de gaz à effet de serre - résidentiel',
           titreLong: 'Emissions de gaz à effet de serre du secteur résidentiel',
           description: '',
-          periodicite: 'annuelle',
           unite: 'teq CO2',
+          periodicite: 'annuelle',
           borneMin: null,
           borneMax: null,
           participationScore: false,
@@ -1170,8 +1293,8 @@ describe('Indicateurs → crud-valeurs.service', () => {
           titre: 'Emissions de gaz à effet de serre - résidentiel',
           titreLong: 'Emissions de gaz à effet de serre du secteur résidentiel',
           description: '',
-          periodicite: 'annuelle',
           unite: 'teq CO2',
+          periodicite: 'annuelle',
           borneMin: null,
           borneMax: null,
           participationScore: false,
@@ -1223,6 +1346,30 @@ describe('Indicateurs → crud-valeurs.service', () => {
       expect(indicateurValeursDedoublonnees2).toEqual(
         indicateurValeursDedoublonneesAttendues
       );
+
+      const sameVersionOlderMetadata = cloneDeep(indicateurValeur1);
+      const sameVersionNewerMetadata = cloneDeep(indicateurValeur2);
+      const olderMetadata = sameVersionOlderMetadata.indicateurSourceMetadonnee;
+      const newerMetadata = sameVersionNewerMetadata.indicateurSourceMetadonnee;
+      if (!olderMetadata || !newerMetadata) {
+        throw new Error('Les métadonnées de test doivent être définies');
+      }
+      newerMetadata.dateVersion = olderMetadata.dateVersion;
+
+      // Une date de version identique ne doit pas rendre le résultat dépendant
+      // de l'ordre SQL : le plus grand identifiant de métadonnée gagne.
+      expect(
+        indicateurService.dedoublonnageIndicateurValeursParSource([
+          sameVersionOlderMetadata,
+          sameVersionNewerMetadata,
+        ])
+      ).toEqual([sameVersionNewerMetadata]);
+      expect(
+        indicateurService.dedoublonnageIndicateurValeursParSource([
+          sameVersionNewerMetadata,
+          sameVersionOlderMetadata,
+        ])
+      ).toEqual([sameVersionNewerMetadata]);
     });
 
     it("Doublon parfait, on en conserve qu'un", async () => {
@@ -1253,8 +1400,8 @@ describe('Indicateurs → crud-valeurs.service', () => {
           titre: 'Emissions de gaz à effet de serre - résidentiel',
           titreLong: 'Emissions de gaz à effet de serre du secteur résidentiel',
           description: '',
-          periodicite: 'annuelle',
           unite: 'teq CO2',
+          periodicite: 'annuelle',
           borneMin: null,
           borneMax: null,
           participationScore: false,
@@ -1295,6 +1442,720 @@ describe('Indicateurs → crud-valeurs.service', () => {
       expect(indicateurValeursDedoublonnees).toEqual(
         indicateurValeursDedoublonneesAttendues
       );
+    });
+  });
+
+  describe('upsertValeur', () => {
+    it('refuse une périodicité modifiée avant le verrou de transaction', async () => {
+      const tx = { insert: vi.fn(), update: vi.fn(), select: vi.fn() };
+      const repository = {};
+      const transactionManager = createTransactionManager(tx);
+      const listIndicateursService = {
+        getIndicateur: vi.fn().mockResolvedValue({
+          id: 10,
+          periodicite: 'annuelle',
+          precision: 2,
+          sansValeurUtilisateur: false,
+        }),
+      };
+      const definitionLockRepository = {
+        lockDefinitions: vi.fn().mockResolvedValue([
+          {
+            id: 10,
+            collectiviteId: null,
+            identifiantReferentiel: null,
+            periodicite: 'mensuelle',
+            precision: 2,
+            sansValeurUtilisateur: false,
+          },
+        ]),
+      };
+      const service = createCrudValeursService(
+        repository as never,
+        {} as never,
+        {} as never,
+        {} as never,
+        {} as never,
+        {} as never,
+        listIndicateursService as never,
+        {} as never,
+        {} as never,
+        {} as never,
+        definitionLockRepository as never,
+        transactionManager as never
+      );
+      vi.spyOn(service, 'canMutateValeur').mockResolvedValue(true);
+
+      await expect(
+        service.upsertValeur(
+          {
+            collectiviteId: 3,
+            indicateurId: 10,
+            // Janvier est canonique pour les deux périodicités : seule la
+            // comparaison de la définition verrouillée révèle la course.
+            dateValeur: '2026-01-01',
+            resultat: 42,
+          },
+          {
+            id: '00000000-0000-0000-0000-000000000001',
+            role: AuthRole.AUTHENTICATED,
+          } as never
+        )
+      ).rejects.toThrow(
+        "La périodicité de l'indicateur 10 a changé de annuelle à mensuelle pendant l'écriture"
+      );
+
+      expect(definitionLockRepository.lockDefinitions).toHaveBeenCalledWith(
+        [10],
+        tx
+      );
+      expect(tx.select).not.toHaveBeenCalled();
+      expect(tx.insert).not.toHaveBeenCalled();
+      expect(tx.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('upsertIndicateurValeurs', () => {
+    it("autorise le service-role à écrire une valeur open-data d'un indicateur protégé", async () => {
+      const saved = {
+        id: 1,
+        collectiviteId: 3,
+        indicateurId: 10,
+        dateValeur: '2026-01-01',
+        metadonneeId: 1,
+        resultat: 42,
+        objectif: null,
+        resultatCommentaire: null,
+        objectifCommentaire: null,
+        estimation: null,
+        calculAuto: false,
+        calculAutoIdentifiantsManquants: null,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        modifiedAt: '2026-01-01T00:00:00.000Z',
+        createdBy: null,
+        modifiedBy: null,
+      } satisfies IndicateurValeur;
+      const tx = {
+        marker: 'transaction',
+      };
+      const transactionManager = createTransactionManager(tx);
+      const repository = {
+        upsertValeursWithMetadata: vi.fn().mockResolvedValue([saved]),
+        listMetadataSources: vi
+          .fn()
+          .mockResolvedValue([{ id: 1, sourceId: 'rare' }]),
+        lockGroupementMemberships: vi.fn(),
+      };
+      const permissionService = {
+        assertAllowed: vi.fn().mockResolvedValue(undefined),
+      };
+      const definitionsRepository = {
+        listCollectiviteDefinitions: vi.fn().mockResolvedValue([
+          {
+            id: 10,
+            collectiviteId: null,
+            groupementId: 99,
+            identifiantReferentiel: null,
+            periodicite: 'annuelle',
+            precision: 2,
+            sansValeurUtilisateur: true,
+          },
+        ]),
+      };
+      const computeValeursService = {
+        updateCalculatedIndicateurValeurs: vi.fn().mockResolvedValue([]),
+      };
+      const lockRepository = { lock: vi.fn().mockResolvedValue(undefined) };
+      const definitionLockRepository = {
+        lockDefinitions: vi.fn().mockResolvedValue([
+          {
+            id: 10,
+            collectiviteId: null,
+            groupementId: 99,
+            identifiantReferentiel: null,
+            periodicite: 'annuelle',
+            precision: 2,
+            sansValeurUtilisateur: true,
+          },
+        ]),
+      };
+      const service = createCrudValeursService(
+        repository as never,
+        permissionService as never,
+        {} as never,
+        {} as never,
+        definitionsRepository as never,
+        {} as never,
+        {} as never,
+        {} as never,
+        computeValeursService as never,
+        lockRepository as never,
+        definitionLockRepository as never,
+        transactionManager as never
+      );
+      const serviceRoleUser = {
+        id: null,
+        role: AuthRole.SERVICE_ROLE,
+        isAnonymous: true,
+        jwtPayload: { role: AuthRole.SERVICE_ROLE },
+      } satisfies ServiceRoleUser;
+
+      await expect(
+        service.upsertIndicateurValeurs(
+          [
+            {
+              collectiviteId: 3,
+              indicateurId: 10,
+              dateValeur: '2026-01-01',
+              metadonneeId: 1,
+              resultat: 42,
+            },
+          ],
+          { user: serviceRoleUser }
+        )
+      ).resolves.toEqual([
+        { ...saved, sourceId: 'rare', indicateurIdentifiant: null },
+      ]);
+
+      expect(permissionService.assertAllowed).toHaveBeenCalledOnce();
+      expect(definitionLockRepository.lockDefinitions).toHaveBeenCalledWith(
+        [10],
+        tx
+      );
+      expect(repository.upsertValeursWithMetadata).toHaveBeenCalledWith(
+        [expect.objectContaining({ indicateurId: 10, metadonneeId: 1 })],
+        tx
+      );
+      expect(repository.lockGroupementMemberships).not.toHaveBeenCalled();
+    });
+
+    it('donne la priorité au périmètre groupement pour une définition historique portant aussi une collectivité', async () => {
+      const tx = { marker: 'transaction' };
+      const definition = {
+        id: 10,
+        collectiviteId: 4,
+        groupementId: 99,
+        identifiantReferentiel: null,
+        periodicite: 'annuelle',
+        precision: 2,
+        sansValeurUtilisateur: false,
+      };
+      const repository = {
+        lockGroupementMemberships: vi
+          .fn()
+          .mockResolvedValue([{ groupementId: 99, collectiviteId: 3 }]),
+        upsertValeursWithoutMetadata: vi.fn().mockResolvedValue([]),
+      };
+      const permissionService = {
+        assertAllowed: vi.fn().mockResolvedValue(undefined),
+      };
+      const definitionsRepository = {
+        listCollectiviteDefinitions: vi.fn().mockResolvedValue([definition]),
+      };
+      const lockRepository = { lock: vi.fn().mockResolvedValue(undefined) };
+      const definitionLockRepository = {
+        lockDefinitions: vi.fn().mockResolvedValue([definition]),
+      };
+      const service = createCrudValeursService(
+        repository as never,
+        permissionService as never,
+        {} as never,
+        {} as never,
+        definitionsRepository as never,
+        {} as never,
+        {} as never,
+        {} as never,
+        {} as never,
+        lockRepository as never,
+        definitionLockRepository as never,
+        createTransactionManager(tx) as never
+      );
+
+      await expect(
+        service.upsertIndicateurValeurs(
+          [
+            {
+              collectiviteId: 3,
+              indicateurId: 10,
+              dateValeur: '2026-01-01',
+              resultat: 42,
+            },
+          ],
+          {
+            user: {
+              id: '00000000-0000-0000-0000-000000000001',
+              role: AuthRole.AUTHENTICATED,
+            } as never,
+          }
+        )
+      ).resolves.toEqual([]);
+
+      expect(repository.lockGroupementMemberships).toHaveBeenCalledWith(
+        [{ groupementId: 99, collectiviteId: 3 }],
+        tx
+      );
+      expect(repository.upsertValeursWithoutMetadata).toHaveBeenCalledOnce();
+    });
+
+    it("préserve la capacité interne explicite d'écrire un indicateur de groupement pour une non-membre", async () => {
+      const tx = { marker: 'transaction' };
+      const definition = {
+        id: 10,
+        collectiviteId: null,
+        groupementId: 99,
+        identifiantReferentiel: null,
+        periodicite: 'annuelle',
+        precision: 2,
+        sansValeurUtilisateur: false,
+      };
+      const repository = {
+        lockGroupementMemberships: vi.fn(),
+        upsertValeursWithoutMetadata: vi.fn().mockResolvedValue([]),
+      };
+      const definitionsRepository = {
+        listCollectiviteDefinitions: vi.fn().mockResolvedValue([definition]),
+      };
+      const lockRepository = { lock: vi.fn().mockResolvedValue(undefined) };
+      const definitionLockRepository = {
+        lockDefinitions: vi.fn().mockResolvedValue([definition]),
+      };
+      const service = createCrudValeursService(
+        repository as never,
+        {} as never,
+        {} as never,
+        {} as never,
+        definitionsRepository as never,
+        {} as never,
+        {} as never,
+        {} as never,
+        {} as never,
+        lockRepository as never,
+        definitionLockRepository as never,
+        createTransactionManager(tx) as never
+      );
+
+      await expect(
+        service.upsertIndicateurValeurs(
+          [
+            {
+              collectiviteId: 3,
+              indicateurId: 10,
+              dateValeur: '2026-01-01',
+              resultat: 42,
+            },
+          ],
+          { isUserTrusted: true }
+        )
+      ).resolves.toEqual([]);
+
+      expect(repository.lockGroupementMemberships).not.toHaveBeenCalled();
+      expect(repository.upsertValeursWithoutMetadata).toHaveBeenCalledOnce();
+    });
+
+    it('refuse une périodicité modifiée avant le verrou de transaction', async () => {
+      const tx = { insert: vi.fn() };
+      const repository = {};
+      const transactionManager = createTransactionManager(tx);
+      const definitionLockRepository = {
+        // Simule une définition passée d'annuelle à mensuelle juste avant le
+        // début de la transaction d'écriture.
+        lockDefinitions: vi.fn().mockResolvedValue([
+          {
+            id: 10,
+            collectiviteId: null,
+            identifiantReferentiel: null,
+            periodicite: 'mensuelle',
+            precision: 2,
+            sansValeurUtilisateur: false,
+          },
+        ]),
+      };
+      const definitionsRepository = {
+        listCollectiviteDefinitions: vi.fn().mockResolvedValue([
+          {
+            id: 10,
+            identifiantReferentiel: null,
+            periodicite: 'annuelle',
+            precision: 2,
+            sansValeurUtilisateur: false,
+          },
+        ]),
+      };
+      const service = createCrudValeursService(
+        repository as never,
+        {} as never,
+        {} as never,
+        {} as never,
+        definitionsRepository as never,
+        {} as never,
+        {} as never,
+        {} as never,
+        {} as never,
+        {} as never,
+        definitionLockRepository as never,
+        transactionManager as never
+      );
+
+      await expect(
+        service.upsertIndicateurValeurs(
+          [
+            {
+              collectiviteId: 3,
+              indicateurId: 10,
+              // Janvier est une date SQL canonique pour les deux périodicités :
+              // seule la comparaison des définitions détecte la course.
+              dateValeur: '2026-01-01',
+              resultat: 42,
+            },
+          ],
+          { isUserTrusted: true }
+        )
+      ).rejects.toThrow(
+        "La périodicité de l'indicateur 10 a changé de annuelle à mensuelle pendant l'écriture"
+      );
+
+      expect(definitionLockRepository.lockDefinitions).toHaveBeenCalledWith(
+        [10],
+        tx
+      );
+      expect(tx.insert).not.toHaveBeenCalled();
+    });
+
+    it("refuse d'écrire une valeur pour la définition personnalisée d'une autre collectivité", async () => {
+      const tx = { insert: vi.fn() };
+      const transactionManager = createTransactionManager(tx);
+      const foreignDefinition = {
+        id: 10,
+        collectiviteId: 4,
+        identifiantReferentiel: null,
+        periodicite: 'annuelle',
+        precision: 2,
+        sansValeurUtilisateur: false,
+      };
+      const definitionsRepository = {
+        listCollectiviteDefinitions: vi
+          .fn()
+          .mockResolvedValue([foreignDefinition]),
+      };
+      const definitionLockRepository = {
+        lockDefinitions: vi.fn().mockResolvedValue([foreignDefinition]),
+      };
+      const service = createCrudValeursService(
+        {} as never,
+        {} as never,
+        {} as never,
+        {} as never,
+        definitionsRepository as never,
+        {} as never,
+        {} as never,
+        {} as never,
+        {} as never,
+        {} as never,
+        definitionLockRepository as never,
+        transactionManager as never
+      );
+
+      await expect(
+        service.upsertIndicateurValeurs(
+          [
+            {
+              collectiviteId: 3,
+              indicateurId: 10,
+              dateValeur: '2026-01-01',
+              resultat: 42,
+            },
+          ],
+          { isUserTrusted: true }
+        )
+      ).rejects.toThrow('Indicateur 10 non disponible pour la collectivité 3');
+
+      expect(tx.insert).not.toHaveBeenCalled();
+    });
+
+    it("refuse atomiquement un lot contenant un indicateur de groupement dont la collectivité n'est pas membre", async () => {
+      const tx = { insert: vi.fn() };
+      const transactionManager = createTransactionManager(tx);
+      const definitions = [
+        {
+          id: 10,
+          collectiviteId: null,
+          groupementId: null,
+          identifiantReferentiel: null,
+          periodicite: 'annuelle',
+          precision: 2,
+          sansValeurUtilisateur: false,
+        },
+        {
+          id: 11,
+          collectiviteId: null,
+          groupementId: 99,
+          identifiantReferentiel: null,
+          periodicite: 'annuelle',
+          precision: 2,
+          sansValeurUtilisateur: false,
+        },
+      ];
+      const repository = {
+        lockGroupementMemberships: vi.fn().mockResolvedValue([]),
+        upsertValeursWithoutMetadata: vi.fn(),
+        upsertValeursWithMetadata: vi.fn(),
+      };
+      const permissionService = {
+        assertAllowed: vi.fn().mockResolvedValue(undefined),
+      };
+      const definitionsRepository = {
+        listCollectiviteDefinitions: vi.fn().mockResolvedValue(definitions),
+      };
+      const definitionLockRepository = {
+        lockDefinitions: vi.fn().mockResolvedValue(definitions),
+      };
+      const lockRepository = { lock: vi.fn() };
+      const service = createCrudValeursService(
+        repository as never,
+        permissionService as never,
+        {} as never,
+        {} as never,
+        definitionsRepository as never,
+        {} as never,
+        {} as never,
+        {} as never,
+        {} as never,
+        lockRepository as never,
+        definitionLockRepository as never,
+        transactionManager as never
+      );
+
+      await expect(
+        service.upsertIndicateurValeurs(
+          [
+            {
+              collectiviteId: 3,
+              indicateurId: 10,
+              dateValeur: '2026-01-01',
+              resultat: 1,
+            },
+            {
+              collectiviteId: 3,
+              indicateurId: 11,
+              dateValeur: '2026-01-01',
+              resultat: 2,
+            },
+          ],
+          {
+            user: {
+              id: '00000000-0000-0000-0000-000000000001',
+              role: AuthRole.AUTHENTICATED,
+            } as never,
+          }
+        )
+      ).rejects.toThrow('Indicateur 11 non disponible pour la collectivité 3');
+
+      expect(repository.lockGroupementMemberships).toHaveBeenCalledWith(
+        [{ groupementId: 99, collectiviteId: 3 }],
+        tx
+      );
+      expect(lockRepository.lock).not.toHaveBeenCalled();
+      expect(repository.upsertValeursWithoutMetadata).not.toHaveBeenCalled();
+      expect(repository.upsertValeursWithMetadata).not.toHaveBeenCalled();
+      expect(tx.insert).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('recomputeAllCalculatedIndicateurValeurs', () => {
+    it('réconcilie et propage une suppression sur la même transaction', async () => {
+      const staleValeur = {
+        id: 99,
+        indicateurId: 3,
+        collectiviteId: 1,
+        dateValeur: '2025-01-01',
+        resultat: 4,
+        objectif: null,
+        calculAuto: true,
+        metadonneeId: null,
+      };
+      const downstreamStaleValeur = {
+        ...staleValeur,
+        id: 100,
+        indicateurId: 4,
+      };
+      const deletedRows = [[staleValeur], [downstreamStaleValeur]];
+      const tx = { marker: 'transaction' };
+      const transactionManager = createTransactionManager(tx);
+      const repository = {
+        deleteAutomaticValeurs: vi.fn(async () => deletedRows.shift() ?? []),
+        upsertValeursWithoutMetadata: vi.fn(),
+      };
+      const target = {
+        id: 3,
+        identifiantReferentiel: 'target',
+        valeurCalcule: 'val(source_a)',
+        periodicite: 'mensuelle',
+      } as IndicateurDefinition;
+      const computedValeur = {
+        indicateurId: target.id,
+        collectiviteId: 1,
+        dateValeur: '2026-02-01',
+        resultat: 5,
+        objectif: null,
+        calculAuto: true,
+      };
+      const computeValeursService = {
+        getAllSourceIdentifiants: vi.fn().mockResolvedValue(['source_a']),
+        updateCalculatedIndicateurValeurs: vi.fn().mockResolvedValue([]),
+        recomputeCollectiviteCalculatedIndicateurValeurs: vi
+          .fn()
+          .mockResolvedValue({
+            valeursToUpsert: [computedValeur],
+            valeurIdsToDelete: [99],
+            indicateurIdentifiants: ['target'],
+          }),
+        reconcileDeletedIndicateurValeurs: vi
+          .fn()
+          .mockResolvedValueOnce({
+            valeursToUpsert: [],
+            valeurIdsToDelete: [100],
+          })
+          .mockResolvedValueOnce({
+            valeursToUpsert: [],
+            valeurIdsToDelete: [],
+          }),
+      };
+      const service = createCrudValeursService(
+        repository as never,
+        {} as never,
+        {} as never,
+        {} as never,
+        {
+          listCollectiviteDefinitions: vi.fn().mockResolvedValue([target]),
+        } as never,
+        {} as never,
+        {} as never,
+        {} as never,
+        computeValeursService as never,
+        { lock: vi.fn() } as never,
+        { lockDefinitions: vi.fn().mockResolvedValue([target]) } as never,
+        transactionManager as never
+      );
+      const upsertedValeur = {
+        ...computedValeur,
+        indicateurIdentifiant: target.identifiantReferentiel,
+      };
+      repository.upsertValeursWithoutMetadata.mockResolvedValueOnce([
+        upsertedValeur,
+      ]);
+
+      await expect(
+        service.recomputeAllCalculatedIndicateurValeurs(1, null, {
+          definitions: [target],
+          skipPermissionCheck: true,
+        })
+      ).resolves.toEqual([
+        {
+          collectiviteId: 1,
+          valeursCount: 3,
+          identifiants: ['target'],
+        },
+      ]);
+
+      expect(
+        computeValeursService.recomputeCollectiviteCalculatedIndicateurValeurs
+      ).toHaveBeenCalledWith(1, [target.id], tx);
+      expect(
+        computeValeursService.reconcileDeletedIndicateurValeurs
+      ).toHaveBeenNthCalledWith(1, [staleValeur], tx);
+      expect(
+        computeValeursService.reconcileDeletedIndicateurValeurs
+      ).toHaveBeenNthCalledWith(2, [downstreamStaleValeur], tx);
+      expect(repository.upsertValeursWithoutMetadata).toHaveBeenCalledWith(
+        [computedValeur],
+        tx
+      );
+      expect(repository.deleteAutomaticValeurs).toHaveBeenCalledTimes(2);
+      expect(
+        transactionManager.executeSingle.mock.calls.filter(
+          ([, existingTx]) => !existingTx
+        )
+      ).toHaveLength(1);
+    });
+  });
+
+  describe('deleteIndicateurValeurs', () => {
+    it('verrouille, supprime et recalcule dans la même transaction', async () => {
+      const events: string[] = [];
+      const candidate = {
+        id: 7,
+        indicateurId: 10,
+        collectiviteId: 1,
+        dateValeur: '2026-02-01',
+        resultat: 5,
+        objectif: 6,
+        metadonneeId: 2,
+      };
+      const tx = { marker: 'transaction' };
+      const transactionManager = createTransactionManager(tx);
+      const repository = {
+        listValeursToDelete: vi.fn(async () => {
+          events.push('discover-values');
+          return [candidate];
+        }),
+        deleteByIds: vi.fn(async () => {
+          events.push('delete-values');
+          return [candidate];
+        }),
+      };
+      const computeValeursService = {
+        reconcileDeletedIndicateurValeurs: vi.fn(async () => {
+          events.push('recalculate');
+          return {
+            valeursToUpsert: [],
+            valeurIdsToDelete: [],
+          };
+        }),
+      };
+      const lockRepository = {
+        lock: vi.fn(async () => {
+          events.push('lock-periods');
+        }),
+      };
+      const definitionLockRepository = {
+        lockForValueWrite: vi.fn(async () => {
+          events.push('lock-graph');
+        }),
+      };
+      const service = createCrudValeursService(
+        repository as never,
+        {} as never,
+        {} as never,
+        {} as never,
+        {} as never,
+        {} as never,
+        {} as never,
+        {} as never,
+        computeValeursService as never,
+        lockRepository as never,
+        definitionLockRepository as never,
+        transactionManager as never
+      );
+
+      await expect(
+        service.deleteIndicateurValeurs({
+          collectiviteId: candidate.collectiviteId,
+          metadonneeId: candidate.metadonneeId,
+        })
+      ).resolves.toEqual({
+        indicateurValeurIdsSupprimes: [{ id: candidate.id }],
+      });
+
+      expect(events).toEqual([
+        'lock-graph',
+        'discover-values',
+        'lock-periods',
+        'delete-values',
+        'recalculate',
+      ]);
+      expect(
+        computeValeursService.reconcileDeletedIndicateurValeurs
+      ).toHaveBeenCalledWith([candidate], tx);
     });
   });
 });

--- a/apps/backend/src/indicateurs/valeurs/crud-valeurs.service.ts
+++ b/apps/backend/src/indicateurs/valeurs/crud-valeurs.service.ts
@@ -1,98 +1,72 @@
-import {
-  BadRequestException,
-  ForbiddenException,
-  Injectable,
-  Logger,
-} from '@nestjs/common';
-import CollectivitesService from '@tet/backend/collectivites/services/collectivites.service';
+import { ForbiddenException, Injectable, Logger } from '@nestjs/common';
 import { UpdateDefinitionService } from '@tet/backend/indicateurs/definitions/mutate-definition/update-definition.service';
-import ComputeValeursService from '@tet/backend/indicateurs/valeurs/compute-valeurs.service';
-import { DEFAULT_ROUNDING_PRECISION } from '@tet/backend/indicateurs/valeurs/valeurs.constants';
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
 import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { success } from '@tet/backend/utils/result.type';
+import { TransactionManager } from '@tet/backend/utils/transaction/transaction-manager.service';
 import {
   IndicateurDefinition,
-  IndicateurValeur,
-  IndicateurValeurAvecMetadonnesDefinition,
   IndicateurValeurCreate,
-  IndicateurValeurWithIdentifiant,
 } from '@tet/domain/indicateurs';
-import {
-  hasPermission,
-  PermissionOperationEnum,
-  ResourceType,
-} from '@tet/domain/users';
-import { getErrorMessage } from '@tet/domain/utils';
-import {
-  and,
-  eq,
-  inArray,
-  isNotNull,
-  isNull,
-  or,
-  sql,
-  SQL,
-  SQLWrapper,
-} from 'drizzle-orm';
-import { chunk, isNil, isNotNil, keyBy, partition, round } from 'es-toolkit';
+import { hasPermission, ResourceType } from '@tet/domain/users';
 import { GetUserRolesAndPermissionsService } from '../../users/authorizations/get-user-roles-and-permissions/get-user-roles-and-permissions.service';
 import {
+  AuthenticatedOrServiceRoleUser,
   AuthenticatedUser,
-  AuthRole,
   AuthUser,
 } from '../../users/models/auth.models';
-import { DatabaseService } from '../../utils/database/database.service';
-import { indicateurDefinitionTable } from '../definitions/indicateur-definition.table';
-import { ListCollectiviteDefinitionsRepository } from '../definitions/list-collectivite-definitions/list-collectivite-definitions.repository';
-import { ListPlatformDefinitionsRepository } from '../definitions/list-platform-definitions/list-platform-definitions.repository';
+import { IndicateurDefinitionLockRepository } from '../definitions/indicateur-definition-lock.repository';
 import { IndicateurListItem } from '../indicateurs/list-indicateurs/list-indicateurs.output';
 import { ListIndicateursService } from '../indicateurs/list-indicateurs/list-indicateurs.service';
+import { CrudValeursRepository } from './crud-valeurs.repository';
 import { DeleteIndicateursValeursRequestType } from './delete-indicateur-valeurs.request';
 import { DeleteValeurIndicateur } from './delete-valeur-indicateur.request';
-import { GetIndicateursValeursResponse } from './get-indicateur-valeurs.response';
-import { indicateurValeurTable } from './indicateur-valeur.table';
+import { IndicateurValeurLockRepository } from './indicateur-valeur-lock.repository';
+import { IndicateurValeursContext } from './indicateur-valeurs-context';
+import { getIndicateurValeursDataOrThrow } from './indicateur-valeurs.errors';
 import {
   deduplicateIndicateurValeursBySource,
   groupIndicateurValeurs,
   groupIndicateurValeursBySource,
 } from './indicateur-valeurs-read.adapter';
-import { getIndicateurValeursDataOrThrow } from './indicateur-valeurs.errors';
 import { ListIndicateurValeursInput } from './list-indicateur-valeurs.input';
 import { ListIndicateurValeursService } from './list-indicateur-valeurs.service';
+import { ReconcileIndicateurValeursService } from './reconcile-indicateur-valeurs.service';
 import { UpsertValeurIndicateur } from './upsert-valeur-indicateur.request';
+import { assertUserIndicateurValeursAllowed } from './user-indicateur-valeur.rules';
+import { DEFAULT_ROUNDING_PRECISION } from './valeurs.constants';
+import { WriteIndicateurValeursService } from './write-indicateur-valeurs.service';
 
-type IndicateurValeurInsert = IndicateurValeurCreate;
-
+/** Compatibility facade: preserves the historical API while delegating cohesive workflows. */
 @Injectable()
 export default class CrudValeursService {
   private readonly logger = new Logger(CrudValeursService.name);
-
-  public readonly UNKOWN_SOURCE_ID = 'unknown';
-
-  private readonly PARALLEL_COLLECTIVITE_COMPUTE_VALEURS = 1;
-
-  /**
-   * Number of decimal in order to round the value
-   */
   static DEFAULT_ROUNDING_PRECISION = DEFAULT_ROUNDING_PRECISION;
-
   constructor(
-    private readonly databaseService: DatabaseService,
+    private readonly repository: CrudValeursRepository,
     private readonly permissionService: PermissionService,
     private readonly getUserPermissionsService: GetUserRolesAndPermissionsService,
-    private readonly collectiviteService: CollectivitesService,
-    private readonly listCollectiviteDefinitionsRepository: ListCollectiviteDefinitionsRepository,
-    private readonly listPlatformDefinitionsRepository: ListPlatformDefinitionsRepository,
     private readonly listIndicateursService: ListIndicateursService,
     private readonly updateIndicateurService: UpdateDefinitionService,
-    private readonly computeValeursService: ComputeValeursService,
-    private readonly reader: ListIndicateurValeursService
+    private readonly lockRepository: IndicateurValeurLockRepository,
+    private readonly definitionLockRepository: IndicateurDefinitionLockRepository,
+    private readonly transactionManager: TransactionManager,
+    private readonly reader: ListIndicateurValeursService,
+    private readonly writer: WriteIndicateurValeursService,
+    private readonly reconciliation: ReconcileIndicateurValeursService
   ) {}
+
+  dedoublonnageIndicateurValeursParSource =
+    deduplicateIndicateurValeursBySource;
+  groupeIndicateursValeursParIndicateur = groupIndicateurValeurs;
+  groupeIndicateursValeursParIndicateurEtSource =
+    groupIndicateurValeursBySource;
+
   async getIndicateursValeurs(
     options: ListIndicateurValeursInput,
     ignoreDedoublonnage?: boolean,
     tx?: Transaction
-  ): Promise<IndicateurValeurAvecMetadonnesDefinition[]> {
+  ) {
     return getIndicateurValeursDataOrThrow(
       await this.reader.get(
         { ...options, ignoreDedoublonnage },
@@ -101,53 +75,89 @@ export default class CrudValeursService {
     );
   }
 
-  async deleteIndicateurValeurs(options: DeleteIndicateursValeursRequestType) {
-    this.logger.log(
-      `Suppression des valeurs des indicateurs selon ces options : ${JSON.stringify(
-        options
-      )}`
-    );
-
-    const conditions: (SQLWrapper | SQL)[] = [
-      eq(indicateurValeurTable.collectiviteId, options.collectiviteId),
-    ];
-    if (options.indicateurId) {
-      conditions.push(
-        eq(indicateurValeurTable.indicateurId, options.indicateurId)
-      );
-    }
-    if (options.metadonneeId) {
-      conditions.push(
-        eq(indicateurValeurTable.metadonneeId, options.metadonneeId)
-      );
-    }
-
-    const deleteQuery = this.databaseService.db
-      .delete(indicateurValeurTable)
-      .where(and(...conditions));
-
-    const deletedIds = await deleteQuery.returning({
-      id: indicateurValeurTable.id,
-    });
-    this.logger.log(
-      `${deletedIds.length} valeurs d'indicateurs ont été supprimées`
-    );
-    return { indicateurValeurIdsSupprimes: deletedIds };
-  }
   async listIndicateurValeurs(
     options: ListIndicateurValeursInput,
-    user?: AuthUser
-  ): Promise<GetIndicateursValeursResponse> {
+    context: IndicateurValeursContext
+  ) {
     return getIndicateurValeursDataOrThrow(
-      await this.reader.list(options, user ? { user } : { isUserTrusted: true })
+      await this.reader.list(options, context)
     );
   }
 
+  async upsertIndicateurValeurs(
+    valeurs: IndicateurValeurCreate[],
+    context: IndicateurValeursContext<AuthenticatedOrServiceRoleUser>
+  ) {
+    return getIndicateurValeursDataOrThrow(
+      await this.reconciliation.upsert(valeurs, context)
+    );
+  }
+
+  async reconcileCollectiviteCalculatedIndicateurValeurs(
+    collectiviteId: number,
+    definitions: IndicateurDefinition[],
+    tx: Transaction
+  ) {
+    return getIndicateurValeursDataOrThrow(
+      await this.reconciliation.reconcileCollectivite(
+        { collectiviteId, definitions },
+        { isUserTrusted: true, tx }
+      )
+    );
+  }
+
+  async recomputeAllCalculatedIndicateurValeurs(
+    onlyForCollectiviteId: number | undefined,
+    user: AuthUser | null,
+    options: {
+      definitions?: IndicateurDefinition[];
+      skipPermissionCheck?: boolean;
+    } = {}
+  ) {
+    if (!options.skipPermissionCheck)
+      this.permissionService.hasServiceRole(user);
+    return getIndicateurValeursDataOrThrow(
+      await this.reconciliation.recomputeAll(
+        {
+          collectiviteId: onlyForCollectiviteId,
+          definitions: options.definitions,
+        },
+        { isUserTrusted: true }
+      )
+    );
+  }
+  private async executeTransaction<T>(
+    operation: (tx: Transaction) => Promise<T>
+  ): Promise<T> {
+    const result = await this.transactionManager.executeSingle<T, unknown>(
+      async (tx) => success(await operation(tx))
+    );
+    if (!result.success) {
+      throw result.cause ?? result.error;
+    }
+    return result.data;
+  }
   async canMutateValeur(
     user: AuthenticatedUser,
     collectiviteId: number,
     indicateur: IndicateurListItem
   ): Promise<boolean> {
+    await this.canMutateValeurs(user, collectiviteId, [indicateur]);
+    return true;
+  }
+  async canMutateValeurs(
+    user: AuthenticatedUser,
+    collectiviteId: number,
+    indicateurs: IndicateurListItem[]
+  ): Promise<void> {
+    // `authedProcedure` also accepts API-key JWTs whose permissions claim can
+    // deliberately be narrower than the owner's collectivity role.
+    this.permissionService.assertApiKeyPermission(
+      user,
+      'indicateurs.valeurs.mutate'
+    );
+    assertUserIndicateurValeursAllowed(indicateurs);
+
     const userPermissionsResult =
       await this.getUserPermissionsService.getUserRolesAndPermissions({
         userId: user.id,
@@ -155,7 +165,7 @@ export default class CrudValeursService {
 
     if (!userPermissionsResult.success) {
       throw new ForbiddenException(
-        `Droits insuffisants, l'utilisateur ${user.id} n'a pas les droits pour muter la valeur de l'indicateur ${indicateur.id} de la collectivité ${collectiviteId}`
+        `Droits insuffisants, l'utilisateur ${user.id} n'a pas les droits pour muter les valeurs d'indicateur de la collectivité ${collectiviteId}`
       );
     }
 
@@ -166,7 +176,7 @@ export default class CrudValeursService {
         collectiviteId,
       })
     ) {
-      return true;
+      return;
     }
 
     if (
@@ -175,9 +185,11 @@ export default class CrudValeursService {
         'indicateurs.valeurs.mutate_piloted_by_me',
         { collectiviteId }
       ) &&
-      indicateur.pilotes?.some((p) => p.userId === user.id)
+      indicateurs.every((indicateur) =>
+        indicateur.pilotes?.some((p) => p.userId === user.id)
+      )
     ) {
-      return true;
+      return;
     }
 
     this.permissionService.throwForbiddenException(
@@ -186,138 +198,32 @@ export default class CrudValeursService {
       ResourceType.COLLECTIVITE,
       { collectiviteId }
     );
-
-    return false;
   }
 
-  /**
-   * Variante de `upsertIndicateurValeurs` qui permet de ne pas être obligé de
-   * redonner l'objet complet sans pour autant écraser la valeur existante. Et
-   * donc de mettre à jour la colonne resultat indépendamment de la valeur
-   * objectif (et pareil pour les commentaires).
-   */
   async upsertValeur(data: UpsertValeurIndicateur, user: AuthenticatedUser) {
     const { collectiviteId, indicateurId } = data;
-
-    const indicateur = await this.listIndicateursService.getIndicateur({
+    const definition = await this.listIndicateursService.getIndicateur({
       collectiviteId,
       indicateurId,
     });
-
-    await this.canMutateValeur(user, collectiviteId, indicateur);
-
-    this.logger.log(`Upsert valeur with data ${JSON.stringify(data)}`);
-
-    if (user.role === AuthRole.AUTHENTICATED && user.id) {
-      if (!isNil(data.resultat)) {
-        data.resultat = round(data.resultat, indicateur.precision);
-      }
-      if (!isNil(data.objectif)) {
-        data.objectif = round(data.objectif, indicateur.precision);
-      }
-
-      const now = new Date().toISOString();
-      let upsertedIndicateurValeur: IndicateurValeur | undefined = undefined;
-      if (!isNil(data.id)) {
-        this.logger.log(
-          `Mise à jour de la valeur id ${data.id} pour la collectivité ${data.collectiviteId}`
-        );
-        const updated = await this.databaseService.db
-          .update(indicateurValeurTable)
-          .set({
-            resultat: data.resultat,
-            resultatCommentaire: data.resultatCommentaire,
-            objectif: data.objectif,
-            objectifCommentaire: data.objectifCommentaire,
-            modifiedBy: user.id,
-            modifiedAt: now,
-          })
-          .where(
-            and(
-              eq(indicateurValeurTable.collectiviteId, collectiviteId),
-              eq(indicateurValeurTable.indicateurId, indicateurId),
-              eq(indicateurValeurTable.id, data.id),
-              isNull(indicateurValeurTable.metadonneeId)
-            )
-          )
-          .returning();
-        upsertedIndicateurValeur = updated[0];
-      } else if (!isNil(data.dateValeur)) {
-        this.logger.log(
-          `Insertion de la valeur de l'indicateur ${data.indicateurId} pour la collectivité ${data.collectiviteId}`
-        );
-
-        try {
-          const inserted = await this.databaseService.db
-            .insert(indicateurValeurTable)
-            .values({
-              collectiviteId,
-              indicateurId: data.indicateurId,
-              dateValeur: data.dateValeur,
-              resultat: data.resultat,
-              resultatCommentaire: data.resultatCommentaire,
-              objectif: data.objectif,
-              objectifCommentaire: data.objectifCommentaire,
-              createdBy: user.id,
-              createdAt: now,
-              modifiedBy: user.id,
-              modifiedAt: now,
-              metadonneeId: null,
-            })
-            .onConflictDoUpdate({
-              target: [
-                indicateurValeurTable.indicateurId,
-                indicateurValeurTable.collectiviteId,
-                indicateurValeurTable.dateValeur,
-              ],
-              targetWhere: isNull(indicateurValeurTable.metadonneeId),
-              set: {
-                resultat: data.resultat,
-                resultatCommentaire: data.resultatCommentaire,
-                objectif: data.objectif,
-                objectifCommentaire: data.objectifCommentaire,
-                modifiedBy: user.id,
-                modifiedAt: now,
-              },
-            })
-            .returning();
-
-          upsertedIndicateurValeur = inserted[0];
-        } catch (error) {
-          this.logger.error(
-            `Error d'insert de la valeur pour la collectivité ${collectiviteId} et l'indicateur ${
-              data.indicateurId
-            } et la date ${data.dateValeur} : ${getErrorMessage(error)}`
-          );
-          throw error;
-        }
-      }
-
-      if (upsertedIndicateurValeur) {
-        const calculatedIndicateurValeurToUpsert =
-          await this.computeValeursService.updateCalculatedIndicateurValeurs(
-            [upsertedIndicateurValeur],
-            [indicateur]
-          );
-        this.logger.log(
-          `${calculatedIndicateurValeurToUpsert.length} valeurs d'indicateurs calculées`
-        );
-        // WARNING : can recursively call updateCalculatedIndicateurValeurs if the computed indicateur valeur allows to calcule oher ones
-        await this.upsertIndicateurValeurs(
-          calculatedIndicateurValeurToUpsert,
-          undefined
-        );
-      }
-
-      // update indicateur definition modifiedBy field
-      await this.updateIndicateurService.updateDefinitionModifiedFields({
-        indicateurId: indicateur.id,
-        collectiviteId,
-        user,
-      });
-
-      return upsertedIndicateurValeur;
-    }
+    await this.canMutateValeur(user, collectiviteId, definition);
+    return this.executeTransaction(async (tx) => {
+      const saved = getIndicateurValeursDataOrThrow(
+        await this.writer.saveSingle({ data, definition }, { user, tx })
+      );
+      if (!saved) return undefined;
+      getIndicateurValeursDataOrThrow(
+        await this.reconciliation.propagateUpdated([saved], {
+          isUserTrusted: true,
+          tx,
+        })
+      );
+      await this.updateIndicateurService.updateDefinitionModifiedFields(
+        { indicateurId, collectiviteId, user },
+        tx
+      );
+      return saved;
+    });
   }
 
   async deleteValeurIndicateur(
@@ -333,480 +239,71 @@ export default class CrudValeursService {
 
     await this.canMutateValeur(user, collectiviteId, indicateur);
 
-    if (user.role === AuthRole.AUTHENTICATED && user.id) {
-      await this.databaseService.db
-        .delete(indicateurValeurTable)
-        .where(
-          and(
-            eq(indicateurValeurTable.collectiviteId, collectiviteId),
-            eq(indicateurValeurTable.indicateurId, indicateurId),
-            eq(indicateurValeurTable.id, id)
-          )
-        );
-    }
+    await this.executeTransaction(async (tx) => {
+      await this.definitionLockRepository.lockForValueWrite(tx);
 
-    // update indicateur definition modifiedBy field
-    await this.updateIndicateurService.updateDefinitionModifiedFields({
-      indicateurId,
-      collectiviteId,
-      user,
+      const existing = await this.repository.findUserValeur(
+        { collectiviteId, indicateurId, id },
+        tx
+      );
+      if (!existing) return;
+
+      await this.lockRepository.lock([existing], tx);
+      const deleted = await this.repository.deleteUserValeur(
+        { collectiviteId, indicateurId, id },
+        tx
+      );
+      if (!deleted) return;
+
+      getIndicateurValeursDataOrThrow(
+        await this.reconciliation.propagateDeleted([deleted], {
+          isUserTrusted: true,
+          tx,
+        })
+      );
+
+      await this.updateIndicateurService.updateDefinitionModifiedFields(
+        { indicateurId, collectiviteId, user },
+        tx
+      );
     });
   }
-
-  async upsertIndicateurValeurs(
-    indicateurValeurs: IndicateurValeurInsert[],
-    user: AuthenticatedUser | undefined
-  ): Promise<IndicateurValeurWithIdentifiant[]> {
-    const collectiviteIds = [
-      ...new Set(indicateurValeurs.map((v) => v.collectiviteId)),
-    ];
-    if (user) {
-      for (const collectiviteId of collectiviteIds) {
-        await this.permissionService.assertAllowed(
-          user,
-          PermissionOperationEnum['INDICATEURS.VALEURS.MUTATE'],
-          ResourceType.COLLECTIVITE,
-          { collectiviteId }
-        );
-      }
-
-      if (user.role === AuthRole.AUTHENTICATED && user.id) {
-        indicateurValeurs.forEach((v) => {
-          v.createdBy = user.id;
-          v.modifiedBy = user.id;
-        });
-      }
-    }
-
+  async deleteIndicateurValeurs(options: DeleteIndicateursValeursRequestType) {
     this.logger.log(
-      `Upsert des ${indicateurValeurs.length} valeurs des indicateurs pour l'utilisateur ${user?.id} (role ${user?.role})`
-    );
-
-    // Retrieve indicateur definition to be able to round values
-    const indicateurIds = [
-      ...new Set(indicateurValeurs.map((v) => v.indicateurId)),
-    ];
-    const indicateurDefinitions =
-      await this.listCollectiviteDefinitionsRepository.listCollectiviteDefinitions(
-        { indicateurIds }
-      );
-    const indicateurDefinitionsById = keyBy(
-      indicateurDefinitions,
-      (item) => item.id
-    );
-    // Round values for each record
-    indicateurValeurs.forEach((v) => {
-      const definition = indicateurDefinitionsById[v.indicateurId];
-      if (definition) {
-        v.resultat = isNotNil(v.resultat)
-          ? round(v.resultat, definition.precision)
-          : null;
-        v.objectif = isNotNil(v.objectif)
-          ? round(v.objectif, definition.precision)
-          : null;
-      } else {
-        throw new BadRequestException(
-          `Indicateur definition not found for id ${v.indicateurId}`
-        );
-      }
-    });
-
-    // On doit distinguer les valeurs avec et sans métadonnées car la clause d'unicité est différente (onConflictDoUpdate)
-    const [indicateurValeursAvecMetadonnees, indicateurValeursSansMetadonnees] =
-      partition(indicateurValeurs, (v) => Boolean(v.metadonneeId));
-    const indicateurValeursResultat: IndicateurValeurWithIdentifiant[] = [];
-    if (indicateurValeursAvecMetadonnees.length) {
-      this.logger.log(
-        `Upsert des ${
-          indicateurValeursAvecMetadonnees.length
-        } valeurs avec métadonnées des indicateurs ${[
-          ...new Set(
-            indicateurValeursAvecMetadonnees.map((v) => v.indicateurId)
-          ),
-        ].join(',')} pour les collectivités ${[
-          ...new Set(
-            indicateurValeursAvecMetadonnees.map((v) => v.collectiviteId)
-          ),
-        ].join(',')}`
-      );
-      try {
-        const indicateurValeursAvecMetadonneesResultat =
-          await this.databaseService.db
-            .insert(indicateurValeurTable)
-            .values(indicateurValeursAvecMetadonnees)
-            .onConflictDoUpdate({
-              target: [
-                indicateurValeurTable.indicateurId,
-                indicateurValeurTable.collectiviteId,
-                indicateurValeurTable.dateValeur,
-                indicateurValeurTable.metadonneeId,
-              ],
-              targetWhere: isNotNull(indicateurValeurTable.metadonneeId),
-              set: {
-                resultat: sql.raw(
-                  `excluded.${indicateurValeurTable.resultat.name}`
-                ),
-                resultatCommentaire: sql.raw(
-                  `excluded.${indicateurValeurTable.resultatCommentaire.name}`
-                ),
-                objectif: sql.raw(
-                  `excluded.${indicateurValeurTable.objectif.name}`
-                ),
-                objectifCommentaire: sql.raw(
-                  `excluded.${indicateurValeurTable.objectifCommentaire.name}`
-                ),
-                calculAuto: sql.raw(
-                  `excluded.${indicateurValeurTable.calculAuto.name}`
-                ),
-                calculAutoIdentifiantsManquants: sql.raw(
-                  `excluded.${indicateurValeurTable.calculAutoIdentifiantsManquants.name}`
-                ),
-                modifiedBy: sql.raw(
-                  `excluded.${indicateurValeurTable.modifiedBy.name}`
-                ),
-              },
-            })
-            .returning();
-        indicateurValeursResultat.push(
-          ...indicateurValeursAvecMetadonneesResultat
-        );
-      } catch (e) {
-        this.logger.error(
-          `Erreur lors de l'upsert des valeurs avec métadonnées pour les collectivités ${collectiviteIds} : ${getErrorMessage(
-            e
-          )}`
-        );
-        this.logger.log(
-          `Données en erreur : ${JSON.stringify(
-            indicateurValeursAvecMetadonnees
-          )}`
-        );
-        throw e;
-      }
-    }
-
-    if (indicateurValeursSansMetadonnees.length) {
-      let indicateurValeursSansMetadonneesToInsert: IndicateurValeurInsert[] =
-        indicateurValeursSansMetadonnees;
-
-      // Vérifie si les données à insérer sont autocalculées, si c'est le cas, on ne doit pas écraser les données des collectivités saisies manuellement
-      const indicateurValeursAutocalculees =
-        indicateurValeursSansMetadonneesToInsert.filter((v) => v.calculAuto);
-      if (indicateurValeursAutocalculees.length) {
-        const indicateurValeursAutocalculeesConditions: (
-          | SQLWrapper
-          | undefined
-        )[] = [];
-        indicateurValeursAutocalculees.forEach((v) => {
-          indicateurValeursAutocalculeesConditions.push(
-            and(
-              eq(indicateurValeurTable.indicateurId, v.indicateurId),
-              eq(indicateurValeurTable.collectiviteId, v.collectiviteId),
-              eq(indicateurValeurTable.dateValeur, v.dateValeur),
-              isNull(indicateurValeurTable.metadonneeId),
-              or(
-                isNull(indicateurValeurTable.calculAuto),
-                eq(indicateurValeurTable.calculAuto, false)
-              )
-            )
-          );
-        });
-
-        const valeursSaisiesManuellementExistantes =
-          await this.databaseService.db
-            .select()
-            .from(indicateurValeurTable)
-            .where(or(...indicateurValeursAutocalculeesConditions));
-
-        this.logger.log(
-          `${valeursSaisiesManuellementExistantes.length} valeurs saisies manuellement existantes pour les indicateurs`
-        );
-
-        if (valeursSaisiesManuellementExistantes.length) {
-          indicateurValeursSansMetadonneesToInsert =
-            indicateurValeursSansMetadonneesToInsert.filter((v) => {
-              const valeurSaisiesManuellementExistante =
-                valeursSaisiesManuellementExistantes.find(
-                  (v2) =>
-                    v2.indicateurId === v.indicateurId &&
-                    v2.collectiviteId === v.collectiviteId &&
-                    v2.dateValeur === v.dateValeur
-                );
-              return !valeurSaisiesManuellementExistante;
-            });
-          this.logger.log(
-            `${indicateurValeursSansMetadonneesToInsert.length} valeurs à insérer après filtrage des données saisies manuellement`
-          );
-        }
-      }
-      if (indicateurValeursSansMetadonneesToInsert.length) {
-        try {
-          this.logger.log(
-            `Upsert des ${
-              indicateurValeursSansMetadonneesToInsert.length
-            } valeurs sans métadonnées des indicateurs ${[
-              ...new Set(
-                indicateurValeursSansMetadonneesToInsert.map(
-                  (v) => v.indicateurId
-                )
-              ),
-            ].join(',')} pour les collectivités ${[
-              ...new Set(
-                indicateurValeursSansMetadonneesToInsert.map(
-                  (v) => v.collectiviteId
-                )
-              ),
-            ].join(',')}`
-          );
-
-          const indicateurValeursSansMetadonneesResultat =
-            await this.databaseService.db
-              .insert(indicateurValeurTable)
-              .values(indicateurValeursSansMetadonneesToInsert)
-              .onConflictDoUpdate({
-                target: [
-                  indicateurValeurTable.indicateurId,
-                  indicateurValeurTable.collectiviteId,
-                  indicateurValeurTable.dateValeur,
-                ],
-                targetWhere: isNull(indicateurValeurTable.metadonneeId),
-                set: {
-                  resultat: sql.raw(
-                    `excluded.${indicateurValeurTable.resultat.name}`
-                  ),
-                  resultatCommentaire: sql.raw(
-                    `excluded.${indicateurValeurTable.resultatCommentaire.name}`
-                  ),
-                  objectif: sql.raw(
-                    `excluded.${indicateurValeurTable.objectif.name}`
-                  ),
-                  objectifCommentaire: sql.raw(
-                    `excluded.${indicateurValeurTable.objectifCommentaire.name}`
-                  ),
-                  calculAuto: sql.raw(
-                    `excluded.${indicateurValeurTable.calculAuto.name}`
-                  ),
-                  calculAutoIdentifiantsManquants: sql.raw(
-                    `excluded.${indicateurValeurTable.calculAutoIdentifiantsManquants.name}`
-                  ),
-                  modifiedBy: sql.raw(
-                    `excluded.${indicateurValeurTable.modifiedBy.name}`
-                  ),
-                },
-              })
-              .returning();
-          indicateurValeursResultat.push(
-            ...indicateurValeursSansMetadonneesResultat
-          );
-        } catch (e) {
-          this.logger.error(
-            `Erreur lors de l'upsert des valeurs sans métadonnées pour les collectivités ${collectiviteIds} : ${getErrorMessage(
-              e
-            )}`
-          );
-          this.logger.log(
-            `Données en erreur : ${JSON.stringify(
-              indicateurValeursSansMetadonneesToInsert
-            )}`
-          );
-          throw e;
-        }
-      }
-    }
-    indicateurValeursResultat.forEach((v) => {
-      if (
-        !v.indicateurIdentifiant &&
-        indicateurDefinitionsById[`${v.indicateurId}`]
-      ) {
-        v.indicateurIdentifiant =
-          indicateurDefinitionsById[`${v.indicateurId}`].identifiantReferentiel;
-      }
-    });
-
-    if (indicateurValeursResultat.length) {
-      const calculatedIndicateursResultatToUpsert =
-        await this.computeValeursService.updateCalculatedIndicateurValeurs(
-          indicateurValeursResultat
-        );
-      this.logger.log(
-        `${calculatedIndicateursResultatToUpsert.length} valeurs d'indicateurs calculées`
-      );
-
-      const calculatedIndicateurValeur: IndicateurValeurWithIdentifiant[] =
-        calculatedIndicateursResultatToUpsert.length
-          ? await this.upsertIndicateurValeurs(
-              calculatedIndicateursResultatToUpsert,
-              undefined
-            )
-          : [];
-
-      indicateurValeursResultat.push(...calculatedIndicateurValeur);
-    }
-
-    return indicateurValeursResultat;
-  }
-
-  async recomputeAllCalculatedIndicateurValeurs(
-    onlyForCollectiviteId: number | undefined,
-    user: AuthUser | null,
-    forComputedIndicateurDefinitions?: IndicateurDefinition[],
-    doNotCheckRights?: boolean
-  ) {
-    // Check if the user has the permission to recompute all calculated indicateur valeurs
-    if (!doNotCheckRights) {
-      this.permissionService.hasServiceRole(user);
-    }
-
-    if (!forComputedIndicateurDefinitions) {
-      forComputedIndicateurDefinitions =
-        await this.listPlatformDefinitionsRepository.listPlatformDefinitionsHavingComputedValue();
-    }
-    this.logger.log(
-      `Recompute all calculated indicateur valeurs for collectivite ${
-        onlyForCollectiviteId || 'all'
-      } and identifiants ${forComputedIndicateurDefinitions
-        .map((d) => d.identifiantReferentiel)
-        .join(',')}`
-    );
-
-    const allSourceIdentifiants =
-      await this.computeValeursService.getAllSourceIdentifiants(
-        forComputedIndicateurDefinitions
-      );
-
-    const allowedExtraSourcesForCalculatedValeurs =
-      await this.computeValeursService.getSourcesCalcul();
-
-    // Identify all collectivites which have some values for these source identifiants
-
-    const collectiviteIds = onlyForCollectiviteId
-      ? [onlyForCollectiviteId]
-      : (
-          await this.databaseService.db
-            .selectDistinct({ id: indicateurValeurTable.collectiviteId })
-            .from(indicateurValeurTable)
-            .leftJoin(
-              indicateurDefinitionTable,
-              eq(
-                indicateurValeurTable.indicateurId,
-                indicateurDefinitionTable.id
-              )
-            )
-            .where(
-              inArray(
-                indicateurDefinitionTable.identifiantReferentiel,
-                allSourceIdentifiants
-              )
-            )
-        ).map((c) => c.id);
-
-    const allComputedIndicateurValeurs: {
-      collectiviteId: number;
-      valeursCount: number;
-      identifiants: string[];
-    }[] = [];
-    const collectiviteIdsChunks = chunk(
-      collectiviteIds,
-      this.PARALLEL_COLLECTIVITE_COMPUTE_VALEURS
-    );
-    this.logger.log(
-      `Found ${collectiviteIds.length} collectivites with values for these source indicateur identifiants (${collectiviteIdsChunks.length} chunks of ${this.PARALLEL_COLLECTIVITE_COMPUTE_VALEURS} collectivites)`
-    );
-
-    const recomputeResult: Promise<{
-      collectiviteId: number;
-      valeursCount: number;
-      identifiants: string[];
-    }>[] = [];
-    let totalComputedIndicateurValeursCount = 0;
-    let iChunk = 0;
-    for (const collectiviteIdsChunk of collectiviteIdsChunks) {
-      collectiviteIdsChunk.forEach((collectiviteId) => {
-        recomputeResult.push(
-          this.recomputeCollectiviteCalculatedIndicateurValeurs(
-            collectiviteId,
-            forComputedIndicateurDefinitions,
-            allSourceIdentifiants,
-            allowedExtraSourcesForCalculatedValeurs
-          )
-        );
-      });
-      const computedIndicateurValeurs = await Promise.all(recomputeResult);
-      allComputedIndicateurValeurs.push(...computedIndicateurValeurs);
-      computedIndicateurValeurs.forEach((result) => {
-        totalComputedIndicateurValeursCount += result.valeursCount;
-      });
-      iChunk++;
-      this.logger.log(
-        `Computed ${totalComputedIndicateurValeursCount} indicateur valeurs for ${iChunk}/${collectiviteIdsChunks.length} collectivite chunks`
-      );
-      recomputeResult.length = 0;
-    }
-
-    this.logger.log(
-      `${totalComputedIndicateurValeursCount} recomputed indicateur valeurs`
-    );
-
-    return allComputedIndicateurValeurs;
-  }
-
-  private async recomputeCollectiviteCalculatedIndicateurValeurs(
-    collectiviteId: number,
-    computedIndicateurDefinitions: IndicateurDefinition[] | undefined,
-    sourceIdentifiants: string[],
-    allowedExtraSourcesForCalculatedValues: {
-      sourceId: string;
-      sourceCalculIds: string[];
-    }[]
-  ) {
-    this.logger.log(
-      `Recompute calculated indicateur valeurs for collectivite ${collectiviteId}`
-    );
-
-    if (!computedIndicateurDefinitions) {
-      computedIndicateurDefinitions =
-        await this.listPlatformDefinitionsRepository.listPlatformDefinitionsHavingComputedValue();
-    }
-
-    const computedIndicateurValeurs =
-      await this.computeValeursService.recomputeCollectiviteCalculatedIndicateurValeurs(
-        collectiviteId,
-        computedIndicateurDefinitions,
-        sourceIdentifiants,
-        allowedExtraSourcesForCalculatedValues
-      );
-
-    // WARNING : can recursively call updateCalculatedIndicateurValeurs if the computed indicateur valeur allows to calcule oher ones
-    const insertedIndicateurValeurs: IndicateurValeurWithIdentifiant[] =
-      computedIndicateurValeurs.length
-        ? await this.upsertIndicateurValeurs(
-            computedIndicateurValeurs,
-            undefined
-          )
-        : [];
-    const insertedIndicateurValeurIdentifiants = [
-      ...new Set(
-        insertedIndicateurValeurs
-          .map((v) => v.indicateurIdentifiant)
-          .filter((v) => v)
-      ).values(),
-    ] as string[];
-    this.logger.log(
-      `Inserted ${
-        insertedIndicateurValeurs.length
-      } computed indicateur valeurs for collectivite ${collectiviteId} and identifiants ${insertedIndicateurValeurIdentifiants.join(
-        ','
+      `Suppression des valeurs des indicateurs selon ces options : ${JSON.stringify(
+        options
       )}`
     );
-    return {
-      valeursCount: insertedIndicateurValeurs.length,
-      identifiants: insertedIndicateurValeurIdentifiants,
-      collectiviteId,
-    };
+
+    const deletedIds = await this.executeTransaction(async (tx) => {
+      // Le trigger statement-level arrive trop tard pour imposer l'ordre
+      // graphe -> table : PostgreSQL a déjà pris le verrou de table du DELETE.
+      await this.definitionLockRepository.lockForValueWrite(tx);
+
+      const candidates = await this.repository.listValeursToDelete(options, tx);
+      if (candidates.length === 0) return [];
+
+      // Une suppression en masse participe au même protocole par période que
+      // les upserts. Supprimer les ids découverts donne une sémantique de
+      // snapshot claire : une insertion concurrente postérieure est conservée.
+      await this.lockRepository.lock(candidates, tx);
+      const deleted = await this.repository.deleteByIds(
+        candidates.map(({ id }) => id),
+        tx
+      );
+
+      getIndicateurValeursDataOrThrow(
+        await this.reconciliation.propagateDeleted(deleted, {
+          isUserTrusted: true,
+          tx,
+        })
+      );
+
+      return deleted.map(({ id }) => ({ id }));
+    });
+    this.logger.log(
+      `${deletedIds.length} valeurs d'indicateurs ont été supprimées`
+    );
+    return { indicateurValeurIdsSupprimes: deletedIds };
   }
-  dedoublonnageIndicateurValeursParSource =
-    deduplicateIndicateurValeursBySource;
-  groupeIndicateursValeursParIndicateur = groupIndicateurValeurs;
-  groupeIndicateursValeursParIndicateurEtSource =
-    groupIndicateurValeursBySource;
 }

--- a/apps/backend/src/indicateurs/valeurs/reconcile-indicateur-valeurs.service.ts
+++ b/apps/backend/src/indicateurs/valeurs/reconcile-indicateur-valeurs.service.ts
@@ -1,0 +1,255 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { Result, success } from '@tet/backend/utils/result.type';
+import { TransactionManager } from '@tet/backend/utils/transaction/transaction-manager.service';
+import {
+  IndicateurDefinition,
+  IndicateurValeur,
+  IndicateurValeurCreate,
+  IndicateurValeurWithIdentifiant,
+} from '@tet/domain/indicateurs';
+import { ListPlatformDefinitionsRepository } from '../definitions/list-platform-definitions/list-platform-definitions.repository';
+import ComputeValeursService from './compute-valeurs.service';
+import { CrudValeursRepository } from './crud-valeurs.repository';
+import {
+  IndicateurValeursContext,
+  IndicateurValeursWriteContext,
+} from './indicateur-valeurs-context';
+import {
+  captureIndicateurValeursResult,
+  getIndicateurValeursDataOrThrow,
+  IndicateurValeursError,
+} from './indicateur-valeurs.errors';
+import { ValidateIndicateurValeursWriteService } from './validate-indicateur-valeurs-write.service';
+import { WriteIndicateurValeursService } from './write-indicateur-valeurs.service';
+
+export type RecomputedCollectiviteIndicateurValeurs = {
+  collectiviteId: number;
+  valeursCount: number;
+  identifiants: string[];
+};
+
+/** Applies source changes and derived values together, including deletion propagation. */
+@Injectable()
+export class ReconcileIndicateurValeursService {
+  private readonly logger = new Logger(ReconcileIndicateurValeursService.name);
+  constructor(
+    private readonly repository: CrudValeursRepository,
+    private readonly computeValeursService: ComputeValeursService,
+    private readonly validationService: ValidateIndicateurValeursWriteService,
+    private readonly writer: WriteIndicateurValeursService,
+    private readonly definitionsRepository: ListPlatformDefinitionsRepository,
+    private readonly transactionManager: TransactionManager
+  ) {}
+
+  async upsert(
+    valeurs: IndicateurValeurCreate[],
+    context: IndicateurValeursContext
+  ): Promise<
+    Result<IndicateurValeurWithIdentifiant[], IndicateurValeursError>
+  > {
+    if (valeurs.length === 0) return success([]);
+    const prepared = await this.validationService.prepare(valeurs, context);
+    if (!prepared.success) return prepared;
+    return captureIndicateurValeursResult(async () => {
+      const result = await this.transactionManager.executeSingle(async (tx) => {
+        const written = await this.writer.saveBatch(prepared.data, {
+          ...context,
+          tx,
+        });
+        if (!written.success) return written;
+        const calculated = written.data.length
+          ? await this.computeValeursService.updateCalculatedIndicateurValeurs(
+              written.data,
+              tx
+            )
+          : [];
+        const dependent = await this.upsert(calculated, {
+          isUserTrusted: true,
+          tx,
+        });
+        if (!dependent.success) return dependent;
+        return success([...written.data, ...dependent.data]);
+      }, context.tx);
+      return getIndicateurValeursDataOrThrow(result);
+    });
+  }
+
+  propagateUpdated(
+    valeurs: IndicateurValeur[],
+    context: IndicateurValeursWriteContext
+  ) {
+    return captureIndicateurValeursResult(async () => {
+      const calculated =
+        await this.computeValeursService.updateCalculatedIndicateurValeurs(
+          valeurs,
+          context.tx
+        );
+      return getIndicateurValeursDataOrThrow(
+        await this.upsert(calculated, { isUserTrusted: true, tx: context.tx })
+      );
+    });
+  }
+
+  propagateDeleted(
+    valeurs: IndicateurValeur[],
+    context: IndicateurValeursWriteContext
+  ) {
+    return captureIndicateurValeursResult(() =>
+      this.propagateDeletedInTransaction(valeurs, context.tx)
+    );
+  }
+  private async propagateDeletedInTransaction(
+    initialDeletedValeurs: IndicateurValeur[],
+    tx: Transaction
+  ): Promise<{
+    deletedValeurs: IndicateurValeur[];
+    upsertedValeurs: IndicateurValeurWithIdentifiant[];
+  }> {
+    let deletedValeursToPropagate = initialDeletedValeurs;
+    const allDeletedValeurs: IndicateurValeur[] = [];
+    const allUpsertedValeurs: IndicateurValeurWithIdentifiant[] = [];
+
+    while (deletedValeursToPropagate.length > 0) {
+      const reconciliation =
+        await this.computeValeursService.reconcileDeletedIndicateurValeurs(
+          deletedValeursToPropagate,
+          tx
+        );
+      const deletedDependentValeurs = reconciliation.valeurIdsToDelete.length
+        ? await this.repository.deleteAutomaticValeurs(
+            reconciliation.valeurIdsToDelete,
+            {},
+            tx
+          )
+        : [];
+      const upsertedDependentValeurs = reconciliation.valeursToUpsert.length
+        ? getIndicateurValeursDataOrThrow(
+            await this.upsert(reconciliation.valeursToUpsert, {
+              isUserTrusted: true,
+              tx,
+            })
+          )
+        : [];
+
+      allDeletedValeurs.push(...deletedDependentValeurs);
+      allUpsertedValeurs.push(...upsertedDependentValeurs);
+      deletedValeursToPropagate = deletedDependentValeurs;
+    }
+
+    return {
+      deletedValeurs: allDeletedValeurs,
+      upsertedValeurs: allUpsertedValeurs,
+    };
+  }
+
+  reconcileCollectivite(
+    input: { collectiviteId: number; definitions: IndicateurDefinition[] },
+    context: IndicateurValeursWriteContext
+  ) {
+    return captureIndicateurValeursResult(() =>
+      this.reconcileInTransaction(
+        input.collectiviteId,
+        input.definitions,
+        context.tx
+      )
+    );
+  }
+  private async reconcileInTransaction(
+    collectiviteId: number,
+    definitions: IndicateurDefinition[],
+    tx: Transaction
+  ): Promise<RecomputedCollectiviteIndicateurValeurs> {
+    const recomputed =
+      await this.computeValeursService.recomputeCollectiviteCalculatedIndicateurValeurs(
+        collectiviteId,
+        definitions.map(({ id }) => id),
+        tx
+      );
+
+    const deletedValeurs = recomputed.valeurIdsToDelete.length
+      ? await this.repository.deleteAutomaticValeurs(
+          recomputed.valeurIdsToDelete,
+          { collectiviteId },
+          tx
+        )
+      : [];
+
+    // Peut recalculer récursivement les indicateurs qui dépendent des
+    // résultats produits. Le même tx conserve le snapshot et les verrous
+    // jusqu'au dernier upsert de la chaîne.
+    const insertedValeurs = recomputed.valeursToUpsert.length
+      ? getIndicateurValeursDataOrThrow(
+          await this.upsert(recomputed.valeursToUpsert, {
+            isUserTrusted: true,
+            tx,
+          })
+        )
+      : [];
+
+    // Une ligne automatique retirée devient une suppression explicite
+    // pour les formules en aval. `null` reste ainsi réservé aux
+    // observations réellement présentes.
+    const propagated = deletedValeurs.length
+      ? await this.propagateDeletedInTransaction(deletedValeurs, tx)
+      : { deletedValeurs: [], upsertedValeurs: [] };
+    const allDeletedValeurs = [...deletedValeurs, ...propagated.deletedValeurs];
+    const allInsertedValeurs = [
+      ...insertedValeurs,
+      ...propagated.upsertedValeurs,
+    ];
+    const insertedIndicateurValeurIdentifiants = [
+      ...new Set(
+        [
+          ...recomputed.indicateurIdentifiants,
+          ...allInsertedValeurs.map((v) => v.indicateurIdentifiant),
+        ].filter((v): v is string => Boolean(v))
+      ).values(),
+    ] as string[];
+    this.logger.log(
+      `Inserted ${
+        allInsertedValeurs.length
+      } computed indicateur valeurs for collectivite ${collectiviteId} and identifiants ${insertedIndicateurValeurIdentifiants.join(
+        ','
+      )}`
+    );
+    return {
+      valeursCount: allInsertedValeurs.length + allDeletedValeurs.length,
+      identifiants: insertedIndicateurValeurIdentifiants,
+      collectiviteId,
+    };
+  }
+
+  recomputeAll(
+    input: { collectiviteId?: number; definitions?: IndicateurDefinition[] },
+    context: IndicateurValeursContext
+  ) {
+    return captureIndicateurValeursResult(async () => {
+      const definitions =
+        input.definitions ??
+        (await this.definitionsRepository.listPlatformDefinitionsHavingComputedValue(
+          {}
+        ));
+      const sourceIdentifiants =
+        await this.computeValeursService.getAllSourceIdentifiants(definitions);
+      const collectiviteIds = input.collectiviteId
+        ? [input.collectiviteId]
+        : await this.repository.listRecomputeCandidateCollectiviteIds({
+            sourceIdentifiants,
+            computedIndicateurIds: definitions.map(({ id }) => id),
+          });
+      const results: RecomputedCollectiviteIndicateurValeurs[] = [];
+      // Keep one bounded transaction per collectivité, as in the existing recompute contract.
+      for (const collectiviteId of collectiviteIds) {
+        const result = await this.transactionManager.executeSingle(async (tx) =>
+          this.reconcileCollectivite(
+            { collectiviteId, definitions },
+            { ...context, tx }
+          )
+        );
+        results.push(getIndicateurValeursDataOrThrow(result));
+      }
+      return results;
+    });
+  }
+}

--- a/apps/backend/src/indicateurs/valeurs/user-indicateur-valeur.rules.spec.ts
+++ b/apps/backend/src/indicateurs/valeurs/user-indicateur-valeur.rules.spec.ts
@@ -1,0 +1,23 @@
+import { UserIndicateurValeurNotAllowedException } from './user-indicateur-valeur.errors';
+import { assertUserIndicateurValeursAllowed } from './user-indicateur-valeur.rules';
+
+describe('assertUserIndicateurValeursAllowed', () => {
+  test('accepte les indicateurs ouverts à la saisie utilisateur', () => {
+    expect(() =>
+      assertUserIndicateurValeursAllowed([
+        { id: 1, sansValeurUtilisateur: false },
+        { id: 2, sansValeurUtilisateur: false },
+      ])
+    ).not.toThrow();
+  });
+
+  test('refuse tous les indicateurs protégés dans une seule erreur', () => {
+    expect(() =>
+      assertUserIndicateurValeursAllowed([
+        { id: 1, sansValeurUtilisateur: true },
+        { id: 2, sansValeurUtilisateur: false },
+        { id: 3, sansValeurUtilisateur: true },
+      ])
+    ).toThrow(new UserIndicateurValeurNotAllowedException([1, 3]).message);
+  });
+});

--- a/apps/backend/src/indicateurs/valeurs/user-indicateur-valeur.rules.ts
+++ b/apps/backend/src/indicateurs/valeurs/user-indicateur-valeur.rules.ts
@@ -1,0 +1,14 @@
+import type { IndicateurDefinition } from '@tet/domain/indicateurs';
+import { UserIndicateurValeurNotAllowedException } from './user-indicateur-valeur.errors';
+
+/** Politique unique protégeant les indicateurs alimentés exclusivement par calcul/source. */
+export const assertUserIndicateurValeursAllowed = (
+  indicateurs: Pick<IndicateurDefinition, 'id' | 'sansValeurUtilisateur'>[]
+): void => {
+  const protectedIndicateurIds = indicateurs
+    .filter(({ sansValeurUtilisateur }) => sansValeurUtilisateur)
+    .map(({ id }) => id);
+  if (protectedIndicateurIds.length > 0) {
+    throw new UserIndicateurValeurNotAllowedException(protectedIndicateurIds);
+  }
+};

--- a/apps/backend/src/indicateurs/valeurs/validate-indicateur-valeurs-write.service.ts
+++ b/apps/backend/src/indicateurs/valeurs/validate-indicateur-valeurs-write.service.ts
@@ -1,0 +1,201 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
+import type { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import {
+  IndicateurDefinition,
+  IndicateurValeurCreate,
+} from '@tet/domain/indicateurs';
+import { PermissionOperationEnum, ResourceType } from '@tet/domain/users';
+import { isNil, isNotNil, keyBy } from 'es-toolkit';
+import { AuthRole } from '../../users/models/auth.models';
+import { IndicateurDefinitionLockRepository } from '../definitions/indicateur-definition-lock.repository';
+import { ListCollectiviteDefinitionsRepository } from '../definitions/list-collectivite-definitions/list-collectivite-definitions.repository';
+import { CrudValeursRepository } from './crud-valeurs.repository';
+import {
+  IndicateurValeursContext,
+  IndicateurValeursWriteContext,
+} from './indicateur-valeurs-context';
+import { captureIndicateurValeursResult } from './indicateur-valeurs.errors';
+import { assertUserIndicateurValeursAllowed } from './user-indicateur-valeur.rules';
+
+export type PreparedIndicateurValeurs = {
+  valeurs: IndicateurValeurCreate[];
+  definitions: Partial<Record<number, IndicateurDefinition>>;
+};
+
+@Injectable()
+export class ValidateIndicateurValeursWriteService {
+  constructor(
+    private readonly repository: CrudValeursRepository,
+    private readonly permissionService: PermissionService,
+    private readonly definitionsRepository: ListCollectiviteDefinitionsRepository,
+    private readonly definitionLockRepository: IndicateurDefinitionLockRepository
+  ) {}
+
+  prepare(
+    valeurs: IndicateurValeurCreate[],
+    context: IndicateurValeursContext
+  ) {
+    return captureIndicateurValeursResult(
+      async (): Promise<PreparedIndicateurValeurs> => {
+        const { user, isUserTrusted = false, tx } = context;
+        if (!isUserTrusted && user) {
+          for (const collectiviteId of new Set(
+            valeurs.map((v) => v.collectiviteId)
+          )) {
+            await this.permissionService.assertAllowed(
+              user,
+              PermissionOperationEnum['INDICATEURS.VALEURS.MUTATE'],
+              ResourceType.COLLECTIVITE,
+              { collectiviteId }
+            );
+          }
+        } else if (!isUserTrusted) {
+          throw new ForbiddenException(
+            'Un contexte utilisateur ou une capacité interne explicite est requis pour écrire des valeurs'
+          );
+        }
+        const indicateurIds = [...new Set(valeurs.map((v) => v.indicateurId))];
+        // Capture the client's interpretation before entering the transaction.
+        const definitions = keyBy(
+          await this.definitionsRepository.listCollectiviteDefinitions(
+            { indicateurIds },
+            tx
+          ),
+          (d) => d.id
+        );
+        for (const id of indicateurIds) {
+          if (!definitions[id])
+            throw new BadRequestException(
+              `Indicateur definition not found for id ${id}`
+            );
+        }
+        return {
+          definitions,
+          valeurs: valeurs.map((valeur) =>
+            !isUserTrusted && user?.role === AuthRole.AUTHENTICATED && user.id
+              ? { ...valeur, createdBy: user.id, modifiedBy: user.id }
+              : valeur
+          ),
+        };
+      }
+    );
+  }
+
+  validate(
+    input: PreparedIndicateurValeurs,
+    context: IndicateurValeursWriteContext
+  ) {
+    return captureIndicateurValeursResult(async () => {
+      const { tx, user, isUserTrusted = false } = context;
+      const indicateurIds = [
+        ...new Set(input.valeurs.map((v) => v.indicateurId)),
+      ];
+      const definitions = await this.definitionLockRepository.lockDefinitions(
+        indicateurIds,
+        tx
+      );
+      const definitionsById = keyBy(definitions, (d) => d.id);
+      const enforceUserRules =
+        !isUserTrusted && user?.role === AuthRole.AUTHENTICATED;
+      if (enforceUserRules) assertUserIndicateurValeursAllowed(definitions);
+      await this.assertIndicateurValeursAvailableForWrite(
+        input.valeurs,
+        definitionsById,
+        enforceUserRules,
+        tx
+      );
+      for (const id of indicateurIds) {
+        const definition = definitionsById[id];
+        const requested = input.definitions[id];
+        if (!definition || !requested)
+          throw new BadRequestException(
+            `Indicateur definition not found for id ${id}`
+          );
+        if (definition.periodicite !== requested.periodicite) {
+          throw new BadRequestException(
+            `La périodicité de l'indicateur ${id} a changé de ${requested.periodicite} à ${definition.periodicite} pendant l'écriture`
+          );
+        }
+      }
+      return definitionsById;
+    });
+  }
+  private async assertIndicateurValeursAvailableForWrite(
+    valeurs: IndicateurValeurCreate[],
+    definitionsById: Partial<Record<number, IndicateurDefinition>>,
+    enforceGroupementMembership: boolean,
+    tx: Transaction
+  ): Promise<void> {
+    const groupementScopes: Array<{
+      indicateurId: number;
+      groupementId: number;
+      collectiviteId: number;
+    }> = [];
+
+    for (const valeur of valeurs) {
+      const definition = definitionsById[valeur.indicateurId];
+      if (!definition) {
+        throw new BadRequestException(
+          `Indicateur definition not found for id ${valeur.indicateurId}`
+        );
+      }
+      if (
+        isNil(definition.groupementId) &&
+        isNotNil(definition.collectiviteId) &&
+        definition.collectiviteId !== valeur.collectiviteId
+      ) {
+        throw new BadRequestException(
+          `Indicateur ${valeur.indicateurId} non disponible pour la collectivité ${valeur.collectiviteId}`
+        );
+      }
+      if (enforceGroupementMembership && isNotNil(definition.groupementId)) {
+        groupementScopes.push({
+          indicateurId: valeur.indicateurId,
+          groupementId: definition.groupementId,
+          collectiviteId: valeur.collectiviteId,
+        });
+      }
+    }
+
+    if (groupementScopes.length === 0) return;
+
+    const memberships = await this.repository.lockGroupementMemberships(
+      groupementScopes.map(({ groupementId, collectiviteId }) => ({
+        groupementId,
+        collectiviteId,
+      })),
+      tx
+    );
+    const memberCollectiviteIdsByGroupementId = new Map<number, Set<number>>();
+    for (const membership of memberships) {
+      if (isNil(membership.groupementId) || isNil(membership.collectiviteId)) {
+        continue;
+      }
+      const collectiviteIds =
+        memberCollectiviteIdsByGroupementId.get(membership.groupementId) ??
+        new Set<number>();
+      collectiviteIds.add(membership.collectiviteId);
+      memberCollectiviteIdsByGroupementId.set(
+        membership.groupementId,
+        collectiviteIds
+      );
+    }
+
+    for (const scope of groupementScopes) {
+      if (
+        !memberCollectiviteIdsByGroupementId
+          .get(scope.groupementId)
+          ?.has(scope.collectiviteId)
+      ) {
+        throw new BadRequestException(
+          `Indicateur ${scope.indicateurId} non disponible pour la collectivité ${scope.collectiviteId}`
+        );
+      }
+    }
+  }
+}

--- a/apps/backend/src/indicateurs/valeurs/write-indicateur-valeurs.service.spec.ts
+++ b/apps/backend/src/indicateurs/valeurs/write-indicateur-valeurs.service.spec.ts
@@ -1,0 +1,84 @@
+import { IndicateurDefinition } from '@tet/domain/indicateurs';
+import { success } from '../../utils/result.type';
+import { WriteIndicateurValeursService } from './write-indicateur-valeurs.service';
+
+describe('WriteIndicateurValeursService', () => {
+  const definition = {
+    id: 10,
+    periodicite: 'annuelle',
+    precision: 2,
+    identifiantReferentiel: 'cae_1.a',
+  } as IndicateurDefinition;
+  const valeur = {
+    collectiviteId: 3,
+    indicateurId: definition.id,
+    dateValeur: '2026-01-01',
+    resultat: 42,
+  };
+
+  it('retourne la source de chaque métadonnée sans dépendre du recalcul', async () => {
+    const valeurs = [
+      { ...valeur, metadonneeId: 2 },
+      { ...valeur, metadonneeId: 1 },
+      { ...valeur, collectiviteId: 4, metadonneeId: 2 },
+      { ...valeur, metadonneeId: null },
+    ];
+    const repository = {
+      upsertValeursWithMetadata: vi.fn().mockResolvedValue(valeurs.slice(0, 3)),
+      upsertValeursWithoutMetadata: vi.fn().mockResolvedValue(valeurs.slice(3)),
+      listMetadataSources: vi.fn().mockResolvedValue([
+        { id: 1, sourceId: 'rare' },
+        { id: 2, sourceId: 'insee' },
+      ]),
+    };
+    const tx = { marker: 'transaction' };
+    const service = new WriteIndicateurValeursService(
+      repository as never,
+      {
+        validate: vi.fn().mockResolvedValue(success({ 10: definition })),
+      } as never,
+      {} as never,
+      { lock: vi.fn() } as never
+    );
+
+    const result = await service.saveBatch(
+      { valeurs, definitions: { 10: definition } },
+      { isUserTrusted: true, tx: tx as never }
+    );
+
+    expect(result).toEqual(
+      success([
+        { ...valeurs[0], indicateurIdentifiant: 'cae_1.a', sourceId: 'insee' },
+        { ...valeurs[1], indicateurIdentifiant: 'cae_1.a', sourceId: 'rare' },
+        { ...valeurs[2], indicateurIdentifiant: 'cae_1.a', sourceId: 'insee' },
+        { ...valeurs[3], indicateurIdentifiant: 'cae_1.a' },
+      ])
+    );
+    expect(repository.listMetadataSources).toHaveBeenCalledWith([2, 1], tx);
+  });
+
+  it('ne charge aucune métadonnée pour les valeurs saisies par la collectivité', async () => {
+    const repository = {
+      upsertValeursWithoutMetadata: vi.fn().mockResolvedValue([valeur]),
+      listMetadataSources: vi.fn(),
+    };
+    const service = new WriteIndicateurValeursService(
+      repository as never,
+      {
+        validate: vi.fn().mockResolvedValue(success({ 10: definition })),
+      } as never,
+      {} as never,
+      { lock: vi.fn() } as never
+    );
+
+    const result = await service.saveBatch(
+      { valeurs: [valeur], definitions: { 10: definition } },
+      { isUserTrusted: true, tx: {} as never }
+    );
+
+    expect(result).toEqual(
+      success([{ ...valeur, indicateurIdentifiant: 'cae_1.a' }])
+    );
+    expect(repository.listMetadataSources).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/indicateurs/valeurs/write-indicateur-valeurs.service.ts
+++ b/apps/backend/src/indicateurs/valeurs/write-indicateur-valeurs.service.ts
@@ -1,0 +1,197 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import {
+  IndicateurDefinition,
+  IndicateurValeur,
+  IndicateurValeurWithIdentifiant,
+} from '@tet/domain/indicateurs';
+import { isNil, partition, round } from 'es-toolkit';
+import { AuthenticatedUser } from '../../users/models/auth.models';
+import { IndicateurDefinitionLockRepository } from '../definitions/indicateur-definition-lock.repository';
+import { CrudValeursRepository } from './crud-valeurs.repository';
+import { IndicateurValeurLockRepository } from './indicateur-valeur-lock.repository';
+import { IndicateurValeursWriteContext } from './indicateur-valeurs-context';
+import { captureIndicateurValeursResult } from './indicateur-valeurs.errors';
+import {
+  hydrateIndicateurPeriod,
+  dehydrateIndicateurPeriod,
+} from './indicateur-period.adapter';
+import { UpsertValeurIndicateur } from './upsert-valeur-indicateur.request';
+import { assertUserIndicateurValeursAllowed } from './user-indicateur-valeur.rules';
+import {
+  PreparedIndicateurValeurs,
+  ValidateIndicateurValeursWriteService,
+} from './validate-indicateur-valeurs-write.service';
+
+/** Persists values under the caller's transaction; recalculation stays in the reconciliation service. */
+@Injectable()
+export class WriteIndicateurValeursService {
+  constructor(
+    private readonly repository: CrudValeursRepository,
+    private readonly validationService: ValidateIndicateurValeursWriteService,
+    private readonly definitionLockRepository: IndicateurDefinitionLockRepository,
+    private readonly lockRepository: IndicateurValeurLockRepository
+  ) {}
+
+  async saveBatch(
+    input: PreparedIndicateurValeurs,
+    context: IndicateurValeursWriteContext
+  ) {
+    const validation = await this.validationService.validate(input, context);
+    if (!validation.success) return validation;
+    return captureIndicateurValeursResult(
+      async (): Promise<IndicateurValeurWithIdentifiant[]> => {
+        const valeurs = input.valeurs.map((valeur) => {
+          const definition = validation.data[valeur.indicateurId];
+          return {
+            ...valeur,
+            dateValeur: this.getCanonicalDateValeur(
+              valeur.dateValeur,
+              definition
+            ),
+            resultat: !isNil(valeur.resultat)
+              ? round(valeur.resultat, definition.precision)
+              : null,
+            objectif: !isNil(valeur.objectif)
+              ? round(valeur.objectif, definition.precision)
+              : null,
+          };
+        });
+        await this.lockRepository.lock(valeurs, context.tx);
+        const [withMetadata, withoutMetadata] = partition(valeurs, (valeur) =>
+          Boolean(valeur.metadonneeId)
+        );
+        const saved: IndicateurValeurWithIdentifiant[] = [
+          ...(withMetadata.length
+            ? await this.repository.upsertValeursWithMetadata(
+                withMetadata,
+                context.tx
+              )
+            : []),
+          ...(withoutMetadata.length
+            ? await this.repository.upsertValeursWithoutMetadata(
+                withoutMetadata,
+                context.tx
+              )
+            : []),
+        ];
+        const metadataIds = [
+          ...new Set(
+            saved.flatMap(({ metadonneeId }) =>
+              metadonneeId == null ? [] : [metadonneeId]
+            )
+          ),
+        ];
+        const metadataSources = metadataIds.length
+          ? await this.repository.listMetadataSources(metadataIds, context.tx)
+          : [];
+        const sourceIdByMetadataId = new Map(
+          metadataSources.map(({ id, sourceId }) => [id, sourceId])
+        );
+        return saved.map((valeur) => ({
+          ...valeur,
+          ...(valeur.metadonneeId == null
+            ? {}
+            : { sourceId: sourceIdByMetadataId.get(valeur.metadonneeId) }),
+          indicateurIdentifiant:
+            valeur.indicateurIdentifiant ||
+            validation.data[valeur.indicateurId]?.identifiantReferentiel,
+        }));
+      }
+    );
+  }
+
+  saveSingle(
+    {
+      data,
+      definition,
+    }: {
+      data: UpsertValeurIndicateur;
+      definition: Pick<IndicateurDefinition, 'periodicite'>;
+    },
+    { user, tx }: IndicateurValeursWriteContext & { user: AuthenticatedUser }
+  ) {
+    return captureIndicateurValeursResult(
+      async (): Promise<IndicateurValeur | undefined> => {
+        const { collectiviteId, indicateurId } = data;
+        const [lockedDefinition] =
+          await this.definitionLockRepository.lockDefinitions(
+            [indicateurId],
+            tx
+          );
+        if (!lockedDefinition)
+          throw new BadRequestException(
+            `Indicateur definition not found for id ${indicateurId}`
+          );
+        if (lockedDefinition.periodicite !== definition.periodicite) {
+          throw new BadRequestException(
+            `La périodicité de l'indicateur ${indicateurId} a changé de ${definition.periodicite} à ${lockedDefinition.periodicite} pendant l'écriture`
+          );
+        }
+        assertUserIndicateurValeursAllowed([lockedDefinition]);
+        const dateValeur =
+          data.dateValeur === undefined
+            ? undefined
+            : this.getCanonicalDateValeur(data.dateValeur, lockedDefinition);
+        const now = new Date().toISOString();
+        const fields = {
+          resultat: !isNil(data.resultat)
+            ? round(data.resultat, lockedDefinition.precision)
+            : data.resultat,
+          objectif: !isNil(data.objectif)
+            ? round(data.objectif, lockedDefinition.precision)
+            : data.objectif,
+          resultatCommentaire: data.resultatCommentaire,
+          objectifCommentaire: data.objectifCommentaire,
+          calculAuto: false,
+          calculAutoIdentifiantsManquants: null,
+          modifiedBy: user.id,
+          modifiedAt: now,
+        };
+        if (!isNil(data.id)) {
+          const key = { collectiviteId, indicateurId, id: data.id };
+          const existing = await this.repository.findUserValeur(key, tx);
+          if (!existing) return undefined;
+          await this.lockRepository.lock([existing], tx);
+          return (
+            (await this.repository.updateUserValeur(key, fields, tx)) ??
+            undefined
+          );
+        }
+        if (dateValeur === undefined)
+          throw new BadRequestException('Une valeur ou une date est requise');
+        await this.lockRepository.lock([{ collectiviteId, dateValeur }], tx);
+        return (
+          (await this.repository.upsertUserValeur(
+            {
+              ...fields,
+              collectiviteId,
+              indicateurId,
+              dateValeur,
+              createdBy: user.id,
+              createdAt: now,
+              metadonneeId: null,
+            },
+            tx
+          )) ?? undefined
+        );
+      }
+    );
+  }
+  private getCanonicalDateValeur(
+    dateValeur: string,
+    definition: Pick<IndicateurDefinition, 'id' | 'periodicite'>
+  ): string {
+    try {
+      return dehydrateIndicateurPeriod(
+        hydrateIndicateurPeriod({
+          periodicite: definition.periodicite,
+          dateValeur,
+        })
+      );
+    } catch {
+      throw new BadRequestException(
+        `Date de valeur ${dateValeur} non canonique pour l'indicateur ${definition.id} (${definition.periodicite})`
+      );
+    }
+  }
+}

--- a/apps/backend/src/referentiels/score-indicatif/score-indicatif.router.e2e-spec.ts
+++ b/apps/backend/src/referentiels/score-indicatif/score-indicatif.router.e2e-spec.ts
@@ -115,7 +115,7 @@ describe('ScoreIndicatifRouter', () => {
                 programme: [
                   {
                     annee: 2025,
-                    dateValeur: '2025-05-29',
+                    dateValeur: '2025-01-01',
                     utilisee: true,
                     valeur: 44,
                   },
@@ -130,7 +130,7 @@ describe('ScoreIndicatifRouter', () => {
                 fait: [
                   {
                     annee: 2025,
-                    dateValeur: '2025-05-29',
+                    dateValeur: '2025-01-01',
                     utilisee: true,
                     valeur: 63,
                   },
@@ -165,7 +165,7 @@ describe('ScoreIndicatifRouter', () => {
       'cae_1.2.3.3.4': [
         {
           actionId: 'cae_1.2.3.3.4',
-          dateValeur: '2025-05-29',
+          dateValeur: '2025-01-01',
           indicateurId: expect.any(Number),
           indicateurValeurId: expect.any(Number),
           sourceLibelle: null,
@@ -175,7 +175,7 @@ describe('ScoreIndicatifRouter', () => {
         },
         {
           actionId: 'cae_1.2.3.3.4',
-          dateValeur: '2025-05-29',
+          dateValeur: '2025-01-01',
           indicateurId: expect.any(Number),
           indicateurValeurId: expect.any(Number),
           sourceLibelle: 'CITEPA',
@@ -459,7 +459,7 @@ describe('ScoreIndicatifRouter', () => {
           score: 0,
           valeursUtilisees: [
             {
-              dateValeur: '2025-05-29',
+              dateValeur: '2025-01-01',
               indicateurId,
               sourceLibelle: 'CITEPA',
               sourceMetadonnee: {
@@ -481,7 +481,7 @@ describe('ScoreIndicatifRouter', () => {
           score: 0,
           valeursUtilisees: [
             {
-              dateValeur: '2025-05-29',
+              dateValeur: '2025-01-01',
               indicateurId,
               sourceLibelle: null,
               sourceMetadonnee: null,

--- a/apps/backend/src/referentiels/score-indicatif/score-indicatif.service.ts
+++ b/apps/backend/src/referentiels/score-indicatif/score-indicatif.service.ts
@@ -95,7 +95,7 @@ export class ScoreIndicatifService {
           collectiviteId: input.collectiviteId,
           indicateurIds,
         },
-        user
+        { user }
       );
 
     const valeursUtiliseesParActionId =

--- a/apps/backend/test/auth-utils.ts
+++ b/apps/backend/test/auth-utils.ts
@@ -1,3 +1,4 @@
+import { JwtService } from '@nestjs/jwt';
 import {
   createClient,
   SignInWithPasswordCredentials,
@@ -5,6 +6,7 @@ import {
 } from '@supabase/supabase-js';
 import { ConvertJwtToAuthUserService } from '@tet/backend/users/convert-jwt-to-auth-user.service';
 import {
+  AuthJwtPayload,
   AuthenticatedUser,
   AuthRole,
   AuthUser,
@@ -16,6 +18,17 @@ import { YOLO_DODO } from './test-users.samples';
 export { getAuthUserFromUserCredentials } from './get-auth-user-from-credentials';
 
 let supabase: SupabaseClient;
+
+/** Signs a token against the backend verifier, independently of Supabase CLI key formats. */
+export function signTestAuthToken(
+  jwtPayload: AuthJwtPayload,
+  jwtSecret = process.env.SUPABASE_JWT_SECRET
+): string {
+  if (!jwtSecret) {
+    throw new Error('SUPABASE_JWT_SECRET is required to sign a test token');
+  }
+  return new JwtService().sign(jwtPayload, { secret: jwtSecret });
+}
 
 export const getSupabaseClient = (): SupabaseClient => {
   if (!supabase) {

--- a/apps/backend/test/indicateurs-utils.ts
+++ b/apps/backend/test/indicateurs-utils.ts
@@ -41,7 +41,7 @@ export const fixturePourScoreIndicatif = {
   collectiviteId: 1,
   actionId: 'cae_1.2.3.3.4',
   identifiantReferentiel: 'cae_7',
-  dateValeur: '2025-05-29',
+  dateValeur: '2025-01-01',
   exprScore: `si val(cae_7) < limite(cae_7) alors 0
   sinon si val(cae_7) > cible(cae_7) alors 1
   sinon ((val(cae_7) - limite(cae_7)) * 0.05) / (limite(cae_7) - cible(cae_7))`,


### PR DESCRIPTION
Superseded by [PR 4/10](https://github.com/incubateur-ademe/territoires-en-transitions/pull/4969) in the consolidated 10-PR stack. Review and merge using the [updated index](https://github.com/incubateur-ademe/territoires-en-transitions/pull/4959). This PR is closed without merging; its changes are included in the replacement.

---

Move indicator writes and dependent recalculation into the same transaction. The CRUD facade, calculation service and existing callers switch together, so a failed recalculation rolls back the write and PCAET values remain scoped to their démarche metadata.

Deploy only after the expand migrations are installed and periodicity audit conflicts have been resolved. Verify canonical dates before enabling these strict reads/calculations, including for annual-only traffic.

 Monthly definition creation remains gated until the later writer and consumer migrations complete.

Validation completed: 53 focused tests passed; backend app and spec TypeScript checks passed; live HTTP and DB end-to-end suites deferred to CI.

Stack base: `split/09-calcul-foundations`. Merge after its PR, restack onto main, and rerun required checks.

Upsert responses retain their sourceId through explicit metadata hydration in the write transaction. Two regression tests cover mixed sources and metadata-free values; 46 focused tests pass. Score response assertions use canonical annual dates while retaining noncanonical input coverage.
