### PR TITLE
fix(pcaet): preserve annual editing and reference-year guards

### DIFF
--- a/apps/app/src/demarches/pcaet/diagnostic/indicateurs-grid/diagnostic-indicateur-table.adapter.spec.ts
+++ b/apps/app/src/demarches/pcaet/diagnostic/indicateurs-grid/diagnostic-indicateur-table.adapter.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { fakeRow } from '../../../../indicateurs/valeurs/grid/__tests__/grid-fixtures';
+import { buildDiagnosticIndicateurTableRows } from './diagnostic-indicateur-table.adapter';
+import type { DiagnosticIndicateurTable } from './indicateur-tab.layout';
+
+const createTable = (): DiagnosticIndicateurTable => {
+  const row = fakeRow({ indicateurId: 1, indicateurLabel: 'Émissions' });
+  return {
+    id: 'emissions',
+    title: 'Émissions',
+    isOptional: false,
+    rows: [
+      {
+        label: row.indicateurLabel,
+        indicateurDefinitionId: 'fake_1',
+        optionalYears: [],
+      },
+    ],
+    indicateurDefinitions: [row.indicateurDefinition],
+    indicateurValeurs: row.indicateurValeurs.map((indicateurValeur) => ({
+      indicateurValeur,
+      indicateurDefinition: row.indicateurDefinition,
+      indicateurSourceMetadonnee: null,
+    })),
+  };
+};
+
+describe('buildDiagnosticIndicateurTableRows', () => {
+  it('keeps canonical annual values', () => {
+    const table = createTable();
+    expect(
+      buildDiagnosticIndicateurTableRows(table)[0].indicateurValeurs
+    ).toEqual(
+      table.indicateurValeurs.map(({ indicateurValeur }) => indicateurValeur)
+    );
+  });
+  it('rejects a monthly definition even without values', () => {
+    const table = createTable();
+    table.indicateurDefinitions[0].periodicite = 'mensuelle';
+    table.indicateurValeurs = [];
+    expect(() => buildDiagnosticIndicateurTableRows(table)).toThrow(
+      'périodicité annuelle'
+    );
+  });
+  it('rejects an annual value stored in the middle of a year', () => {
+    const table = createTable();
+    table.indicateurValeurs[0].indicateurValeur.dateValeur = '2025-06-01';
+    expect(() => buildDiagnosticIndicateurTableRows(table)).toThrow();
+  });
+});

--- a/apps/app/src/demarches/pcaet/diagnostic/indicateurs-grid/diagnostic-indicateur-table.adapter.ts
+++ b/apps/app/src/demarches/pcaet/diagnostic/indicateurs-grid/diagnostic-indicateur-table.adapter.ts
@@ -1,0 +1,60 @@
+import {
+  assertAnnualIndicateurPeriodicite,
+  toAnnualIndicateurYear,
+  type IndicateurDefinition,
+  type IndicateurValeur,
+} from '@tet/domain/indicateurs';
+import type { IndicateurTableRow } from '../../../../indicateurs/valeurs/grid/types';
+import type { DiagnosticIndicateurTable } from './indicateur-tab.layout';
+
+export const buildDiagnosticIndicateurTableRows = (
+  table: DiagnosticIndicateurTable
+): IndicateurTableRow[] => {
+  const definitionByIdentifiant = new Map<string, IndicateurDefinition>();
+  for (const definition of table.indicateurDefinitions) {
+    assertAnnualIndicateurPeriodicite(
+      definition.periodicite,
+      'Diagnostic PCAET'
+    );
+    const identifiant = definition.identifiantReferentiel;
+    if (identifiant === null || identifiant === undefined) {
+      continue;
+    }
+    definitionByIdentifiant.set(identifiant, definition);
+  }
+
+  const valeursByIndicateurId = new Map<number, IndicateurValeur[]>();
+  for (const { indicateurValeur } of table.indicateurValeurs) {
+    const valeurs =
+      valeursByIndicateurId.get(indicateurValeur.indicateurId) ?? [];
+    valeurs.push(indicateurValeur);
+    valeursByIndicateurId.set(indicateurValeur.indicateurId, valeurs);
+  }
+
+  return table.rows.flatMap((row) => {
+    const indicateurDefinition = definitionByIdentifiant.get(
+      row.indicateurDefinitionId
+    );
+    if (indicateurDefinition === undefined) {
+      return [];
+    }
+    for (const valeur of valeursByIndicateurId.get(indicateurDefinition.id) ??
+      []) {
+      toAnnualIndicateurYear(
+        indicateurDefinition.periodicite,
+        valeur.dateValeur,
+        'Diagnostic PCAET'
+      );
+    }
+    return [
+      {
+        indicateurId: indicateurDefinition.id,
+        indicateurDefinition,
+        indicateurValeurs:
+          valeursByIndicateurId.get(indicateurDefinition.id) ?? [],
+        indicateurLabel: row.label,
+        optionalYears: row.optionalYears,
+      },
+    ];
+  });
+};

--- a/apps/app/src/demarches/pcaet/diagnostic/indicateurs-grid/use-diagnostic-indicateur-valeurs-table.ts
+++ b/apps/app/src/demarches/pcaet/diagnostic/indicateurs-grid/use-diagnostic-indicateur-valeurs-table.ts
@@ -4,11 +4,7 @@ import {
   deriveReferenceYearFromIndicateurValeurYears,
   PCAET_DIAGNOSTIC_INDICATEURS_REQUIRED_OBJECTIF_YEARS,
 } from '@tet/domain/demarches';
-import {
-  getYearFromIsoDate,
-  IndicateurDefinition,
-  IndicateurValeur,
-} from '@tet/domain/indicateurs';
+import { toAnnualIndicateurYear } from '@tet/domain/indicateurs';
 import { useCallback, useMemo, useState } from 'react';
 import {
   isUnsetReferenceYear,
@@ -16,46 +12,9 @@ import {
 } from '../../../../indicateurs/valeurs/grid/types';
 import { useSetDiagnosticReferenceYear } from '../data/use-set-diagnostic-reference-year';
 import type { DiagnosticIndicateurTable } from './indicateur-tab.layout';
+import { buildDiagnosticIndicateurTableRows } from './diagnostic-indicateur-table.adapter';
 
 const OBJECTIF_YEARS = PCAET_DIAGNOSTIC_INDICATEURS_REQUIRED_OBJECTIF_YEARS;
-
-const toGridRows = (table: DiagnosticIndicateurTable): IndicateurTableRow[] => {
-  const definitionByIdentifiant = new Map<string, IndicateurDefinition>();
-  for (const definition of table.indicateurDefinitions) {
-    const identifiant = definition.identifiantReferentiel;
-    if (identifiant === null || identifiant === undefined) {
-      continue;
-    }
-    definitionByIdentifiant.set(identifiant, definition);
-  }
-
-  const valeursByIndicateurId = new Map<number, IndicateurValeur[]>();
-  for (const { indicateurValeur } of table.indicateurValeurs) {
-    const valeurs =
-      valeursByIndicateurId.get(indicateurValeur.indicateurId) ?? [];
-    valeurs.push(indicateurValeur);
-    valeursByIndicateurId.set(indicateurValeur.indicateurId, valeurs);
-  }
-
-  return table.rows.flatMap((row) => {
-    const indicateurDefinition = definitionByIdentifiant.get(
-      row.indicateurDefinitionId
-    );
-    if (indicateurDefinition === undefined) {
-      return [];
-    }
-    return [
-      {
-        indicateurId: indicateurDefinition.id,
-        indicateurDefinition,
-        indicateurValeurs:
-          valeursByIndicateurId.get(indicateurDefinition.id) ?? [],
-        indicateurLabel: row.label,
-        optionalYears: row.optionalYears,
-      },
-    ];
-  });
-};
 
 type DiagnosticIndicateurValeursTable = {
   rows: IndicateurTableRow[];
@@ -76,13 +35,20 @@ export const useDiagnosticIndicateurValeursTable = ({
   isReadonly: boolean;
 }): DiagnosticIndicateurValeursTable => {
   const { setReferenceYear } = useSetDiagnosticReferenceYear(demarcheId);
-  const rows = useMemo(() => toGridRows(table), [table]);
+  const rows = useMemo(
+    () => buildDiagnosticIndicateurTableRows(table),
+    [table]
+  );
   const derivedReferenceYear = useMemo(
     () =>
       deriveReferenceYearFromIndicateurValeurYears({
         resultYears: rows.flatMap((row) =>
           row.indicateurValeurs.map((valeur) =>
-            getYearFromIsoDate(valeur.dateValeur)
+            toAnnualIndicateurYear(
+              row.indicateurDefinition.periodicite,
+              valeur.dateValeur,
+              'Diagnostic PCAET'
+            )
           )
         ),
       }),
@@ -107,6 +73,7 @@ export const useDiagnosticIndicateurValeursTable = ({
    */
   const onReferenceYearChange = useCallback(
     (nextYear: number) => {
+      if (isReadonly) return;
       setReferenceYearOverride(nextYear);
 
       if (isUnsetReferenceYear(referenceYear) || referenceYear === nextYear) {
@@ -119,7 +86,7 @@ export const useDiagnosticIndicateurValeursTable = ({
         toYear: nextYear,
       });
     },
-    [referenceYear, rows, setReferenceYear]
+    [isReadonly, referenceYear, rows, setReferenceYear]
   );
 
   return {

--- a/apps/app/src/indicateurs/valeurs/grid/__tests__/render-smoke.spec.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/__tests__/render-smoke.spec.tsx
@@ -93,6 +93,17 @@ describe('IndicateurValeursTable année de référence', () => {
 });
 
 describe('IndicateurValeursTable lecture seule', () => {
+  it('does not expose a reference-year editor when readonly', () => {
+    const onReferenceYearChange = vi.fn();
+    renderGrid({ isReadonly: true, onReferenceYearChange });
+    expect(
+      screen.queryByRole('button', {
+        name: appLabels.indicateurAnneeReferenceChamp,
+      })
+    ).toBeNull();
+    expect(onReferenceYearChange).not.toHaveBeenCalled();
+  });
+
   it('affiche les valeurs sans ouvrir l’éditeur au clic', () => {
     renderGrid({ isReadonly: true });
 
@@ -117,7 +128,11 @@ describe('IndicateurValeursTable lecture seule', () => {
 });
 
 const secteursDuPolluant: IndicateurTableRow[] = [
-  fakeRow({ indicateurId: 1, indicateurLabel: 'Résidentiel', indicateurValeurs: [] }),
+  fakeRow({
+    indicateurId: 1,
+    indicateurLabel: 'Résidentiel',
+    indicateurValeurs: [],
+  }),
   fakeRow({
     indicateurId: 2,
     indicateurLabel: 'Transport routier',

--- a/apps/app/src/indicateurs/valeurs/grid/indicateur-valeur.cell.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/indicateur-valeur.cell.tsx
@@ -3,7 +3,7 @@
 import { appLabels } from '@/app/labels/catalog';
 import { CellContext } from '@tanstack/react-table';
 import {
-  getYearFromIsoDate,
+  toAnnualIndicateurYear,
   IndicateurValeurType,
 } from '@tet/domain/indicateurs';
 import { Input, TableCell, VisibleWhen } from '@tet/ui';
@@ -36,14 +36,22 @@ export const IndicateurValeurCell = memo(
     year,
     isReadonly = false,
   }: IndicateurValeurCellProps): ReactNode => {
-    const { indicateurId, indicateurValeurs, optionalYears } =
-      cell.row.original;
+    const {
+      indicateurId,
+      indicateurDefinition,
+      indicateurValeurs,
+      optionalYears,
+    } = cell.row.original;
     const isRequired =
       optionalYears !== 'all' && !optionalYears?.includes(year);
 
     const indicateurValeur = indicateurValeurs.find(
       (indicateurValeur) =>
-        getYearFromIsoDate(indicateurValeur.dateValeur) === year
+        toAnnualIndicateurYear(
+          indicateurDefinition.periodicite,
+          indicateurValeur.dateValeur,
+          'Diagnostic PCAET'
+        ) === year
     );
 
     const currentValue = indicateurValeur?.[indicateurValeurType] ?? null;

--- a/apps/app/src/indicateurs/valeurs/grid/indicateur-valeurs.table.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/indicateur-valeurs.table.tsx
@@ -88,6 +88,7 @@ export const IndicateurValeursTable = ({
 
   const updateIndicateurValeurs: IndicateurValeursTableMeta['updateIndicateurValeurs'] =
     async ({ indicateurId, year, field, value }) => {
+      if (isReadonly) return false;
       try {
         await mutateIndicateurValeurs({
           valeurs: [{ indicateurId, year, field, value }],
@@ -111,7 +112,7 @@ export const IndicateurValeursTable = ({
     columns,
     getCoreRowModel: getCoreRowModel(),
     meta: {
-      onReferenceYearChange,
+      onReferenceYearChange: isReadonly ? undefined : onReferenceYearChange,
       updateIndicateurValeurs,
     },
   });

--- a/apps/app/src/indicateurs/valeurs/grid/use-list-indicateur-valeurs-table-columns.tsx
+++ b/apps/app/src/indicateurs/valeurs/grid/use-list-indicateur-valeurs-table-columns.tsx
@@ -68,7 +68,7 @@ const listColumns = ({
               (candidate) => !isUnsetReferenceYear(candidate)
             )}
             onReferenceYearChange={
-              isReference ? onReferenceYearChange : undefined
+              isReference && !isReadonly ? onReferenceYearChange : undefined
             }
           />
         );


### PR DESCRIPTION
Superseded by [PR 5/10](https://github.com/incubateur-ademe/territoires-en-transitions/pull/4972) in the consolidated 10-PR stack. Review and merge using the [updated index](https://github.com/incubateur-ademe/territoires-en-transitions/pull/4959). This PR is closed without merging; its changes are included in the replacement.

---

Preserve the current PCAET table and its démarche-specific mutation flow while validating that displayed definitions and dates are annual. A read-only table no longer exposes reference-year editing or permits its write callback to mutate values.

The pure table adapter covers canonical annual values, monthly definitions with no values and noncanonical annual dates. A table regression covers read-only reference-year controls.

Validation: 17 adapter/cell/table tests, ESLint, backend/API/UI builds and app source/spec typechecks passed on the isolated PR6-based preparation branch. App typechecks exclude the unchanged Next configuration because the installed version differs from main's lockfile.

Deploy before monthly creation is enabled, after the required periodicity projection and canonical-date cleanup.
