### PR TITLE
[pcaet] Refactor backend test fixtures

### DIFF
--- a/apps/backend/src/demarches/pcaet/add-vulnerabilite-thematique/add-vulnerabilite-thematique.router.e2e-spec.ts
+++ b/apps/backend/src/demarches/pcaet/add-vulnerabilite-thematique/add-vulnerabilite-thematique.router.e2e-spec.ts
@@ -1,31 +1,17 @@
 import { INestApplication } from '@nestjs/common';
-import { addTestCollectiviteAndUser } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
 import {
-  getAuthUserFromUserCredentials,
   getTestApp,
   getTestDatabase,
 } from '@tet/backend/test';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
-import { CollectiviteRole } from '@tet/domain/users';
+import { createDemarche } from '../demarches-pcaet.test-fixture';
 import { vulnerabiliteOf } from '../shared/demarches-pcaet-vulnerabilite.test-fixture';
 
 describe('Thematiques de vulnérabilité ajoutés par la collectivité', () => {
   let app: INestApplication;
   let router: TrpcRouter;
   let db: DatabaseService;
-
-  const freshDemarche = async () => {
-    const fixture = await addTestCollectiviteAndUser(db, {
-      user: { role: CollectiviteRole.EDITION },
-    });
-    const user = getAuthUserFromUserCredentials(fixture.user);
-    const caller = router.createCaller({ user });
-    const demarche = await caller.demarches.pcaet.create({
-      collectiviteId: fixture.collectivite.id,
-    });
-    return { collectiviteId: fixture.collectivite.id, caller, demarche };
-  };
 
   beforeAll(async () => {
     app = await getTestApp();
@@ -38,7 +24,7 @@ describe('Thematiques de vulnérabilité ajoutés par la collectivité', () => {
   });
 
   test('Une thématique ajoutée se range après le socle et n’est pas requise', async () => {
-    const { caller, collectiviteId, demarche } = await freshDemarche();
+    const { caller, collectiviteId, demarche } = await createDemarche(db, router);
 
     const diagnostic =
       await caller.demarches.pcaet.diagnostic.addVulnerabiliteThematique({
@@ -61,7 +47,7 @@ describe('Thematiques de vulnérabilité ajoutés par la collectivité', () => {
   });
 
   test('Un doublon est refusé, y compris face au socle', async () => {
-    const { caller, collectiviteId, demarche } = await freshDemarche();
+    const { caller, collectiviteId, demarche } = await createDemarche(db, router);
 
     await expect(
       caller.demarches.pcaet.diagnostic.addVulnerabiliteThematique({
@@ -86,7 +72,7 @@ describe('Thematiques de vulnérabilité ajoutés par la collectivité', () => {
   });
 
   test('Renommer et supprimer ne valent que pour les thématiques ajoutées', async () => {
-    const { caller, collectiviteId, demarche } = await freshDemarche();
+    const { caller, collectiviteId, demarche } = await createDemarche(db, router);
     const apresAjout =
       await caller.demarches.pcaet.diagnostic.addVulnerabiliteThematique({
         collectiviteId,
@@ -135,7 +121,7 @@ describe('Thematiques de vulnérabilité ajoutés par la collectivité', () => {
   });
 
   test('Supprimer une thématique emporte sa saisie dans toutes les démarches', async () => {
-    const { caller, collectiviteId, demarche } = await freshDemarche();
+    const { caller, collectiviteId, demarche } = await createDemarche(db, router);
     const apresAjout =
       await caller.demarches.pcaet.diagnostic.addVulnerabiliteThematique({
         collectiviteId,
@@ -166,7 +152,7 @@ describe('Thematiques de vulnérabilité ajoutés par la collectivité', () => {
   });
 
   test('Une thématique ajoutée ne bloque jamais la transmission', async () => {
-    const { caller, collectiviteId, demarche } = await freshDemarche();
+    const { caller, collectiviteId, demarche } = await createDemarche(db, router);
     const diagnostic =
       await caller.demarches.pcaet.diagnostic.addVulnerabiliteThematique({
         collectiviteId,

--- a/apps/backend/src/demarches/pcaet/demarches-pcaet.test-fixture.ts
+++ b/apps/backend/src/demarches/pcaet/demarches-pcaet.test-fixture.ts
@@ -11,12 +11,11 @@ import { indicateurSourceMetadonneeTable } from '@tet/backend/indicateurs/shared
 import { indicateurSourceTable } from '@tet/backend/indicateurs/shared/models/indicateur-source.table';
 import { indicateurValeurTable } from '@tet/backend/indicateurs/valeurs/indicateur-valeur.table';
 import { axeTable } from '@tet/backend/plans/fiches/shared/models/axe.table';
-import { getAuthUserFromUserCredentials } from '@tet/backend/test';
-import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import type { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { buildConflictUpdateColumns } from '@tet/backend/utils/database/conflict.utils';
 import { DatabaseServiceInterface } from '@tet/backend/utils/database/database-service.interface';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
-import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
+import type { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
 import { Collectivite, CollectiviteType } from '@tet/domain/collectivites';
 import {
   DemarchePcaet,
@@ -28,6 +27,7 @@ import {
 import { CollectiviteRole } from '@tet/domain/users';
 import { randomUUID } from 'crypto';
 import { and, eq, inArray } from 'drizzle-orm';
+import { getAuthUserFromUserCredentials } from '../../../test/get-auth-user-from-credentials';
 import { CloreInstructionService } from './clore-instruction/clore-instruction.service';
 import { demarchePcaetSourceMetadonneeTable } from './shared/models/demarche-pcaet-source-metadonnee.table';
 

--- a/apps/backend/src/demarches/pcaet/demarches-pcaet.test-fixture.ts
+++ b/apps/backend/src/demarches/pcaet/demarches-pcaet.test-fixture.ts
@@ -1,4 +1,5 @@
 import { INestApplication } from '@nestjs/common';
+import { addTestCollectiviteAndUser } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
 import { bibliothequeFichierTable } from '@tet/backend/collectivites/documents/models/bibliotheque-fichier.table';
 import { collectiviteTable } from '@tet/backend/collectivites/shared/models/collectivite.table';
 import { demarcheDocumentSubstitutionTable } from '@tet/backend/demarches/shared/models/demarche-document-substitution.table';
@@ -10,16 +11,21 @@ import { indicateurSourceMetadonneeTable } from '@tet/backend/indicateurs/shared
 import { indicateurSourceTable } from '@tet/backend/indicateurs/shared/models/indicateur-source.table';
 import { indicateurValeurTable } from '@tet/backend/indicateurs/valeurs/indicateur-valeur.table';
 import { axeTable } from '@tet/backend/plans/fiches/shared/models/axe.table';
+import { getAuthUserFromUserCredentials } from '@tet/backend/test';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { buildConflictUpdateColumns } from '@tet/backend/utils/database/conflict.utils';
 import { DatabaseServiceInterface } from '@tet/backend/utils/database/database-service.interface';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
-import { CollectiviteType } from '@tet/domain/collectivites';
+import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
+import { Collectivite, CollectiviteType } from '@tet/domain/collectivites';
 import {
+  DemarchePcaet,
   listPcaetDiagnosticIndicateurRequiredLeaves,
   PCAET_DIAGNOSTIC_INDICATEURS,
   PCAET_DIAGNOSTIC_INDICATEURS_REQUIRED_OBJECTIF_YEARS,
   type PcaetDiagnosticIndicateurParentConfig,
 } from '@tet/domain/demarches';
+import { CollectiviteRole } from '@tet/domain/users';
 import { randomUUID } from 'crypto';
 import { and, eq, inArray } from 'drizzle-orm';
 import { CloreInstructionService } from './clore-instruction/clore-instruction.service';
@@ -80,6 +86,46 @@ export async function pickFreeRegionCode(
     `Aucun code de région libre pour le type ${type} après 100 tirages ` +
       `(${pris.size} codes pris) — la base de test doit être nettoyée.`
   );
+}
+
+/**
+ * Collectivité neuve + utilisateur + démarche PCAET créée via le router.
+ * Une seule démarche active par collectivité : chaque cas part d'ici.
+ */
+export async function createDemarche(
+  db: DatabaseService,
+  router: TrpcRouter,
+  {
+    role = CollectiviteRole.EDITION,
+    collectivite: collectiviteArgs,
+  }: {
+    role?: CollectiviteRole;
+    collectivite?: Partial<Collectivite>;
+  } = {}
+): Promise<{
+  collectivite: Collectivite;
+  collectiviteId: number;
+  user: AuthenticatedUser;
+  caller: ReturnType<TrpcRouter['createCaller']>;
+  demarche: DemarchePcaet;
+}> {
+  const fixture = await addTestCollectiviteAndUser(db, {
+    user: { role },
+    collectivite: collectiviteArgs,
+  });
+  const user = getAuthUserFromUserCredentials(fixture.user);
+  const caller = router.createCaller({ user });
+  const demarche = await caller.demarches.pcaet.create({
+    collectiviteId: fixture.collectivite.id,
+  });
+
+  return {
+    collectivite: fixture.collectivite,
+    collectiviteId: fixture.collectivite.id,
+    user,
+    caller,
+    demarche,
+  };
 }
 
 /**
@@ -242,7 +288,9 @@ export async function completeTestDiagnosticPcaet(
   );
   if (missing.length > 0) {
     throw new Error(
-      `Indicateurs absents du référentiel pour saturer le diagnostic : ${missing.join(', ')}`
+      `Indicateurs absents du référentiel pour saturer le diagnostic : ${missing.join(
+        ', '
+      )}`
     );
   }
 

--- a/apps/backend/src/demarches/pcaet/diagnostic/set-diagnostic-reference-year/set-diagnostic-reference-year.router.e2e-spec.ts
+++ b/apps/backend/src/demarches/pcaet/diagnostic/set-diagnostic-reference-year/set-diagnostic-reference-year.router.e2e-spec.ts
@@ -1,37 +1,23 @@
 import { INestApplication } from '@nestjs/common';
-import { addTestCollectiviteAndUser } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
 import { indicateurDefinitionTable } from '@tet/backend/indicateurs/definitions/indicateur-definition.table';
 import {
-  getAuthUserFromUserCredentials,
   getTestApp,
   getTestDatabase,
 } from '@tet/backend/test';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
 import { getYearFromIsoDate } from '@tet/domain/indicateurs';
-import { CollectiviteRole } from '@tet/domain/users';
 import { eq } from 'drizzle-orm';
 import {
   completeTestDiagnosticPcaet,
   completeTestDossierPcaet,
+  createDemarche,
 } from '../../demarches-pcaet.test-fixture';
 
 describe("Bascule de l'année de référence du diagnostic PCAET", () => {
   let app: INestApplication;
   let router: TrpcRouter;
   let db: DatabaseService;
-
-  const freshDemarche = async () => {
-    const fixture = await addTestCollectiviteAndUser(db, {
-      user: { role: CollectiviteRole.EDITION },
-    });
-    const user = getAuthUserFromUserCredentials(fixture.user);
-    const caller = router.createCaller({ user });
-    const demarche = await caller.demarches.pcaet.create({
-      collectiviteId: fixture.collectivite.id,
-    });
-    return { collectiviteId: fixture.collectivite.id, caller, demarche };
-  };
 
   const getIndicateurId = async (referentielId: string): Promise<number> => {
     const [definition] = await db.db
@@ -80,7 +66,7 @@ describe("Bascule de l'année de référence du diagnostic PCAET", () => {
   });
 
   test('Les valeurs suivent la nouvelle année de référence', async () => {
-    const { caller, collectiviteId, demarche } = await freshDemarche();
+    const { caller, collectiviteId, demarche } = await createDemarche(db, router);
     const indicateurId = await getIndicateurId('cae_1.c');
 
     await caller.demarches.pcaet.diagnostic.indicateurs.updateValeurs({
@@ -115,7 +101,7 @@ describe("Bascule de l'année de référence du diagnostic PCAET", () => {
   });
 
   test("Une saisie déjà présente sur l'année visée est écrasée, sans doublon", async () => {
-    const { caller, collectiviteId, demarche } = await freshDemarche();
+    const { caller, collectiviteId, demarche } = await createDemarche(db, router);
     const indicateurId = await getIndicateurId('cae_1.c');
 
     await caller.demarches.pcaet.diagnostic.indicateurs.updateValeurs({
@@ -145,7 +131,7 @@ describe("Bascule de l'année de référence du diagnostic PCAET", () => {
   });
 
   test('Seuls les indicateurs du tableau basculent', async () => {
-    const { caller, collectiviteId, demarche } = await freshDemarche();
+    const { caller, collectiviteId, demarche } = await createDemarche(db, router);
     const basculeId = await getIndicateurId('cae_1.c');
     const intactId = await getIndicateurId('cae_1.d');
 
@@ -183,7 +169,7 @@ describe("Bascule de l'année de référence du diagnostic PCAET", () => {
   });
 
   test("Un horizon d'objectif n'est pas une année de référence acceptable", async () => {
-    const { caller, collectiviteId, demarche } = await freshDemarche();
+    const { caller, collectiviteId, demarche } = await createDemarche(db, router);
     const indicateurId = await getIndicateurId('cae_1.c');
 
     await expect(
@@ -198,7 +184,7 @@ describe("Bascule de l'année de référence du diagnostic PCAET", () => {
   });
 
   test("Refus quand le diagnostic n'est plus modifiable", async () => {
-    const { caller, collectiviteId, demarche } = await freshDemarche();
+    const { caller, collectiviteId, demarche } = await createDemarche(db, router);
     await completeTestDossierPcaet(db, {
       collectiviteId,
       demarcheId: demarche.id,
@@ -220,8 +206,8 @@ describe("Bascule de l'année de référence du diagnostic PCAET", () => {
   });
 
   test("IDOR : la mutation n'est pas applicable via une autre collectivité", async () => {
-    const { collectiviteId, demarche } = await freshDemarche();
-    const autre = await freshDemarche();
+    const { collectiviteId, demarche } = await createDemarche(db, router);
+    const autre = await createDemarche(db, router);
 
     await completeTestDiagnosticPcaet(db, {
       collectiviteId,

--- a/apps/backend/src/demarches/pcaet/diagnostic/update-diagnostic-indicateurs-valeurs/update-diagnostic-indicateurs-valeurs.router.e2e-spec.ts
+++ b/apps/backend/src/demarches/pcaet/diagnostic/update-diagnostic-indicateurs-valeurs/update-diagnostic-indicateurs-valeurs.router.e2e-spec.ts
@@ -1,10 +1,8 @@
 import { INestApplication } from '@nestjs/common';
-import { addTestCollectiviteAndUser } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
 import { demarcheTable } from '@tet/backend/demarches/shared/models/demarche.table';
 import { indicateurDefinitionTable } from '@tet/backend/indicateurs/definitions/indicateur-definition.table';
 import { indicateurValeurTable } from '@tet/backend/indicateurs/valeurs/indicateur-valeur.table';
 import {
-  getAuthUserFromUserCredentials,
   getTestApp,
   getTestDatabase,
 } from '@tet/backend/test';
@@ -12,11 +10,11 @@ import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
 import { DemarchePcaetStatusEnum } from '@tet/domain/demarches';
 import { getYearFromIsoDate } from '@tet/domain/indicateurs';
-import { CollectiviteRole } from '@tet/domain/users';
 import { and, eq } from 'drizzle-orm';
 import {
   completeTestDiagnosticPcaet,
   completeTestDossierPcaet,
+  createDemarche,
 } from '../../demarches-pcaet.test-fixture';
 import { demarchePcaetSourceMetadonneeTable } from '../../shared/models/demarche-pcaet-source-metadonnee.table';
 
@@ -24,18 +22,6 @@ describe('Mise à jour des valeurs du diagnostic PCAET', () => {
   let app: INestApplication;
   let router: TrpcRouter;
   let db: DatabaseService;
-
-  const freshDemarche = async () => {
-    const fixture = await addTestCollectiviteAndUser(db, {
-      user: { role: CollectiviteRole.EDITION },
-    });
-    const user = getAuthUserFromUserCredentials(fixture.user);
-    const caller = router.createCaller({ user });
-    const demarche = await caller.demarches.pcaet.create({
-      collectiviteId: fixture.collectivite.id,
-    });
-    return { collectiviteId: fixture.collectivite.id, caller, demarche };
-  };
 
   const getIndicateurId = async (referentielId: string): Promise<number> => {
     const rows = await db.db
@@ -62,7 +48,7 @@ describe('Mise à jour des valeurs du diagnostic PCAET', () => {
   });
 
   test('Écrire une valeur met à jour le diagnostic servi', async () => {
-    const { caller, collectiviteId, demarche } = await freshDemarche();
+    const { caller, collectiviteId, demarche } = await createDemarche(db, router);
 
     await completeTestDiagnosticPcaet(db, {
       collectiviteId,
@@ -112,7 +98,7 @@ describe('Mise à jour des valeurs du diagnostic PCAET', () => {
   });
 
   test('La valeur écrite est liée à demarche_pcaet_source_metadonnee', async () => {
-    const { caller, collectiviteId, demarche } = await freshDemarche();
+    const { caller, collectiviteId, demarche } = await createDemarche(db, router);
     const indicateurId = await getIndicateurId('cae_1.c');
 
     await caller.demarches.pcaet.diagnostic.indicateurs.updateValeurs({
@@ -165,7 +151,7 @@ describe('Mise à jour des valeurs du diagnostic PCAET', () => {
 
   test('Deux PCAET d’une même Ct ont des métadonnées et valeurs isolées', async () => {
     const { caller, collectiviteId, demarche: premiere } =
-      await freshDemarche();
+      await createDemarche(db, router);
     const indicateurId = await getIndicateurId('cae_1.c');
 
     await caller.demarches.pcaet.diagnostic.indicateurs.updateValeurs({
@@ -256,7 +242,7 @@ describe('Mise à jour des valeurs du diagnostic PCAET', () => {
   });
 
   test("Refus quand le diagnostic n'est plus modifiable", async () => {
-    const { caller, collectiviteId, demarche } = await freshDemarche();
+    const { caller, collectiviteId, demarche } = await createDemarche(db, router);
     await completeTestDossierPcaet(db, {
       collectiviteId,
       demarcheId: demarche.id,
@@ -283,8 +269,8 @@ describe('Mise à jour des valeurs du diagnostic PCAET', () => {
   });
 
   test("IDOR : la mutation n'est pas applicable via une autre collectivité", async () => {
-    const { collectiviteId, demarche } = await freshDemarche();
-    const autre = await freshDemarche();
+    const { collectiviteId, demarche } = await createDemarche(db, router);
+    const autre = await createDemarche(db, router);
 
     await completeTestDiagnosticPcaet(db, {
       collectiviteId,

--- a/apps/backend/src/demarches/pcaet/documents/documents.router.e2e-spec.ts
+++ b/apps/backend/src/demarches/pcaet/documents/documents.router.e2e-spec.ts
@@ -29,6 +29,7 @@ import {
   cloreTestInstructionPcaet,
   completeTestDiagnosticPcaet,
   completeTestDossierPcaet,
+  createDemarche,
 } from '../demarches-pcaet.test-fixture';
 
 describe('Documents d’une démarche PCAET', () => {
@@ -37,7 +38,7 @@ describe('Documents d’une démarche PCAET', () => {
   let db: DatabaseService;
 
   // Une seule démarche active par collectivité : chaque cas part d'une
-  // collectivité neuve.
+  // collectivité neuve. Sans démarrage de démarche quand on n'en a pas besoin.
   const freshEditor = async (
     role: CollectiviteRole = CollectiviteRole.EDITION
   ) => {
@@ -48,33 +49,6 @@ describe('Documents d’une démarche PCAET', () => {
       user,
       caller: router.createCaller({ user }),
     };
-  };
-
-  const freshDemarche = async (role?: CollectiviteRole) => {
-    const editor = await freshEditor(role);
-    const demarche = await editor.caller.demarches.pcaet.create({
-      collectiviteId: editor.collectivite.id,
-    });
-    return { ...editor, demarche };
-  };
-
-  /**
-   * Une collectivité dont l'identité déclenche les pièces conditionnelles. Sans
-   * population ni nature INSEE — le cas des autres tests — aucune ne s'applique.
-   */
-  const freshDemarcheAssujettie = async (
-    collectivite: { population?: number; natureInsee?: 'CA' | 'SMF' } = {}
-  ) => {
-    const fixture = await addTestCollectiviteAndUser(db, {
-      user: { role: CollectiviteRole.EDITION },
-      collectivite,
-    });
-    const user = getAuthUserFromUserCredentials(fixture.user);
-    const caller = router.createCaller({ user });
-    const demarche = await caller.demarches.pcaet.create({
-      collectiviteId: fixture.collectivite.id,
-    });
-    return { collectivite: fixture.collectivite, user, caller, demarche };
   };
 
   const listDocumentIds = async (
@@ -100,7 +74,7 @@ describe('Documents d’une démarche PCAET', () => {
   });
 
   test('Le modèle de démarche est servi par la base, dossier vide', async () => {
-    const { caller, collectivite, demarche } = await freshDemarche();
+    const { caller, collectivite, demarche } = await createDemarche(db, router);
 
     const snapshot = await caller.demarches.pcaet.documents.list({
       collectiviteId: collectivite.id,
@@ -211,7 +185,7 @@ describe('Documents d’une démarche PCAET', () => {
   });
 
   test('Le PCAET global couvre les sections qu’il regroupe d’office', async () => {
-    const { caller, collectivite, demarche } = await freshDemarche();
+    const { caller, collectivite, demarche } = await createDemarche(db, router);
     const fichier = await addTestBibliothequeFichier(db, {
       collectiviteId: collectivite.id,
     });
@@ -279,7 +253,7 @@ describe('Documents d’une démarche PCAET', () => {
   });
 
   test('Retirer le document global découvre les sections', async () => {
-    const { caller, collectivite, demarche } = await freshDemarche();
+    const { caller, collectivite, demarche } = await createDemarche(db, router);
     const fichier = await addTestBibliothequeFichier(db, {
       collectiviteId: collectivite.id,
     });
@@ -315,7 +289,7 @@ describe('Documents d’une démarche PCAET', () => {
   });
 
   test('Un second dépôt sur la même pièce remplace le fichier', async () => {
-    const { caller, collectivite, demarche } = await freshDemarche();
+    const { caller, collectivite, demarche } = await createDemarche(db, router);
     const premier = await addTestBibliothequeFichier(db, {
       collectiviteId: collectivite.id,
       filename: 'diagnostic-v1.pdf',
@@ -347,7 +321,7 @@ describe('Documents d’une démarche PCAET', () => {
   });
 
   test('Seuls les PDF sont acceptés', async () => {
-    const { caller, collectivite, demarche } = await freshDemarche();
+    const { caller, collectivite, demarche } = await createDemarche(db, router);
     const fichier = await addTestBibliothequeFichier(db, {
       collectiviteId: collectivite.id,
       filename: 'diagnostic.docx',
@@ -366,7 +340,7 @@ describe('Documents d’une démarche PCAET', () => {
   });
 
   test('Un fichier d’une autre collectivité est introuvable', async () => {
-    const { caller, collectivite, demarche } = await freshDemarche();
+    const { caller, collectivite, demarche } = await createDemarche(db, router);
     const autre = await freshEditor();
     const fichierEtranger = await addTestBibliothequeFichier(db, {
       collectiviteId: autre.collectivite.id,
@@ -385,7 +359,7 @@ describe('Documents d’une démarche PCAET', () => {
   });
 
   test('Une pièce hors modèle de démarche est refusée', async () => {
-    const { caller, collectivite, demarche } = await freshDemarche();
+    const { caller, collectivite, demarche } = await createDemarche(db, router);
     const fichier = await addTestBibliothequeFichier(db, {
       collectiviteId: collectivite.id,
     });
@@ -401,7 +375,7 @@ describe('Documents d’une démarche PCAET', () => {
   });
 
   test('La déclaration d’inclusion n’accepte que les pièces éligibles', async () => {
-    const { caller, collectivite, demarche } = await freshDemarche();
+    const { caller, collectivite, demarche } = await createDemarche(db, router);
 
     // Seul le modèle décide : l'EES n'est rangée dans aucune autre pièce.
     await expect(
@@ -500,7 +474,7 @@ describe('Documents d’une démarche PCAET', () => {
   });
 
   test('L’étude d’impact et la délibération d’arrêt se déclarent comprises dans le PCAET global', async () => {
-    const { caller, collectivite, demarche } = await freshDemarche();
+    const { caller, collectivite, demarche } = await createDemarche(db, router);
     const fichier = await addTestBibliothequeFichier(db, {
       collectiviteId: collectivite.id,
     });
@@ -555,7 +529,7 @@ describe('Documents d’une démarche PCAET', () => {
   });
 
   test('La couverture refuse de s’appliquer sur une pièce déjà pourvue d’un dépôt', async () => {
-    const { caller, collectivite, demarche } = await freshDemarche();
+    const { caller, collectivite, demarche } = await createDemarche(db, router);
     const fichier = await addTestBibliothequeFichier(db, {
       collectiviteId: collectivite.id,
     });
@@ -605,7 +579,7 @@ describe('Documents d’une démarche PCAET', () => {
   });
 
   test('Un dossier transmis pour avis n’accepte plus de dépôt ni de retrait', async () => {
-    const { caller, collectivite, demarche } = await freshDemarche();
+    const { caller, collectivite, demarche } = await createDemarche(db, router);
     const fichier = await addTestBibliothequeFichier(db, {
       collectiviteId: collectivite.id,
     });
@@ -690,7 +664,7 @@ describe('Documents d’une démarche PCAET', () => {
   });
 
   test('La délibération d’adoption (pièce aval) se dépose une fois le PCAET adopté', async () => {
-    const { caller, collectivite, demarche } = await freshDemarche();
+    const { caller, collectivite, demarche } = await createDemarche(db, router);
     const deliberation = await addTestBibliothequeFichier(db, {
       collectiviteId: collectivite.id,
       filename: 'deliberation-adoption.pdf',
@@ -752,7 +726,7 @@ describe('Documents d’une démarche PCAET', () => {
   });
 
   test('Une démarche n’est pas accessible via une autre collectivité (IDOR)', async () => {
-    const { collectivite, demarche } = await freshDemarche();
+    const { collectivite, demarche } = await createDemarche(db, router);
     const autre = await freshEditor();
 
     await expect(
@@ -772,7 +746,7 @@ describe('Documents d’une démarche PCAET', () => {
   });
 
   test('Une pièce additionnelle s’ouvre sans nom, puis se nomme et reçoit son fichier', async () => {
-    const { caller, collectivite, demarche } = await freshDemarche();
+    const { caller, collectivite, demarche } = await createDemarche(db, router);
     const dossier = {
       collectiviteId: collectivite.id,
       demarcheId: demarche.id,
@@ -853,7 +827,7 @@ describe('Documents d’une démarche PCAET', () => {
   });
 
   test('Plusieurs pièces additionnelles coexistent, dans leur ordre d’ajout', async () => {
-    const { caller, collectivite, demarche } = await freshDemarche();
+    const { caller, collectivite, demarche } = await createDemarche(db, router);
     const dossier = {
       collectiviteId: collectivite.id,
       demarcheId: demarche.id,
@@ -891,7 +865,7 @@ describe('Documents d’une démarche PCAET', () => {
   });
 
   test('Une pièce additionnelle n’accepte que les formats du dossier', async () => {
-    const { caller, collectivite, demarche } = await freshDemarche();
+    const { caller, collectivite, demarche } = await createDemarche(db, router);
     const dossier = {
       collectiviteId: collectivite.id,
       demarcheId: demarche.id,
@@ -936,8 +910,8 @@ describe('Documents d’une démarche PCAET', () => {
   });
 
   test('Une pièce additionnelle d’une autre démarche est introuvable (IDOR)', async () => {
-    const { caller, collectivite, demarche } = await freshDemarche();
-    const autre = await freshDemarche();
+    const { caller, collectivite, demarche } = await createDemarche(db, router);
+    const autre = await createDemarche(db, router);
     const additionalDAutrui =
       await autre.caller.demarches.pcaet.documents.createAdditional({
         collectiviteId: autre.collectivite.id,
@@ -975,7 +949,7 @@ describe('Documents d’une démarche PCAET', () => {
   });
 
   test('Une pièce additionnelle sans fichier ne retient pas la transmission', async () => {
-    const { caller, collectivite, demarche } = await freshDemarche();
+    const { caller, collectivite, demarche } = await createDemarche(db, router);
     const dossier = {
       collectiviteId: collectivite.id,
       demarcheId: demarche.id,
@@ -995,7 +969,7 @@ describe('Documents d’une démarche PCAET', () => {
   });
 
   test('La transmission gèle les pièces additionnelles amont, l’adoption ouvre l’aval', async () => {
-    const { caller, collectivite, demarche } = await freshDemarche();
+    const { caller, collectivite, demarche } = await createDemarche(db, router);
     const dossier = {
       collectiviteId: collectivite.id,
       demarcheId: demarche.id,
@@ -1056,7 +1030,7 @@ describe('Documents d’une démarche PCAET', () => {
   });
 
   test('Un type de démarche qui n’ouvre pas le dépôt de pièces additionnelles le refuse', async () => {
-    const { caller, collectivite, demarche } = await freshDemarche();
+    const { caller, collectivite, demarche } = await createDemarche(db, router);
 
     // La configuration est une donnée partagée par le type : on relit l'état
     // d'origine pour le rendre tel quel, et ne pas fermer le dépôt de pièces
@@ -1093,7 +1067,7 @@ describe('Documents d’une démarche PCAET', () => {
   });
 
   test('Un rôle lecture ne peut ni lire ni déposer les documents du dossier', async () => {
-    const { collectivite, demarche } = await freshDemarche();
+    const { collectivite, demarche } = await createDemarche(db, router);
     const lecteur = await addTestUser(db, {
       collectiviteId: collectivite.id,
       role: CollectiviteRole.LECTURE,
@@ -1189,7 +1163,7 @@ describe('Documents d’une démarche PCAET', () => {
     };
 
     it('une première élaboration ne se voit pas demander le bilan', async () => {
-      const { caller, collectivite, demarche } = await freshDemarche();
+      const { caller, collectivite, demarche } = await createDemarche(db, router);
 
       const ids = await listDocumentIds(caller, collectivite.id, demarche.id);
 
@@ -1230,7 +1204,7 @@ describe('Documents d’une démarche PCAET', () => {
     it('un dépôt antérieur resté en instruction ne fait pas un renouvellement', async () => {
       // Dans cet ordre : une démarche en instruction est « en cours », elle
       // interdirait la création d'une seconde par l'API.
-      const { caller, collectivite, demarche } = await freshDemarche();
+      const { caller, collectivite, demarche } = await createDemarche(db, router);
       await addDemarcheAnterieure(collectivite.id, 'instruit');
 
       const ids = await listDocumentIds(caller, collectivite.id, demarche.id);
@@ -1282,9 +1256,11 @@ describe('Documents d’une démarche PCAET', () => {
     // Sans population ni nature INSEE, la collectivité des autres tests n'est
     // assujettie à rien : les deux plans annexes lui sont invisibles.
     it('un EPCI à fiscalité propre de plus de 100 000 habitants voit les deux plans', async () => {
-      const { caller, collectivite, demarche } = await freshDemarcheAssujettie({
-        population: 684371,
-        natureInsee: 'CA',
+      const { caller, collectivite, demarche } = await createDemarche(db, router, {
+        collectivite: {
+          population: 684371,
+          natureInsee: 'CA',
+        },
       });
 
       const snapshot = await caller.demarches.pcaet.documents.list({
@@ -1323,9 +1299,11 @@ describe('Documents d’une démarche PCAET', () => {
     });
 
     it('les deux conditions sont indépendantes : à 60 000 habitants, seul le plan chaleur et froid est attendu', async () => {
-      const { caller, collectivite, demarche } = await freshDemarcheAssujettie({
-        population: 60000,
-        natureInsee: 'CA',
+      const { caller, collectivite, demarche } = await createDemarche(db, router, {
+        collectivite: {
+          population: 60000,
+          natureInsee: 'CA',
+        },
       });
 
       const ids = await listDocumentIds(caller, collectivite.id, demarche.id);
@@ -1335,9 +1313,11 @@ describe('Documents d’une démarche PCAET', () => {
     });
 
     it('le seuil est strict : à exactement 100 000 habitants la qualité de l’air n’est pas attendue', async () => {
-      const { caller, collectivite, demarche } = await freshDemarcheAssujettie({
-        population: 100000,
-        natureInsee: 'CA',
+      const { caller, collectivite, demarche } = await createDemarche(db, router, {
+        collectivite: {
+          population: 100000,
+          natureInsee: 'CA',
+        },
       });
 
       const ids = await listDocumentIds(caller, collectivite.id, demarche.id);
@@ -1348,9 +1328,11 @@ describe('Documents d’une démarche PCAET', () => {
     });
 
     it('un syndicat n’est pas assujetti à la qualité de l’air, quelle que soit sa taille', async () => {
-      const { caller, collectivite, demarche } = await freshDemarcheAssujettie({
-        population: 200000,
-        natureInsee: 'SMF',
+      const { caller, collectivite, demarche } = await createDemarche(db, router, {
+        collectivite: {
+          population: 200000,
+          natureInsee: 'SMF',
+        },
       });
 
       const ids = await listDocumentIds(caller, collectivite.id, demarche.id);
@@ -1360,7 +1342,7 @@ describe('Documents d’une démarche PCAET', () => {
     });
 
     it('une pièce qui ne concerne pas la collectivité ne peut ni être déposée ni être déclarée incluse', async () => {
-      const { caller, collectivite, demarche } = await freshDemarche();
+      const { caller, collectivite, demarche } = await createDemarche(db, router);
       const fichier = await addTestBibliothequeFichier(db, {
         collectiviteId: collectivite.id,
       });
@@ -1385,9 +1367,11 @@ describe('Documents d’une démarche PCAET', () => {
     });
 
     it('déclarer le plan compris dans le programme d’actions suffit à couvrir la pièce', async () => {
-      const { caller, collectivite, demarche } = await freshDemarcheAssujettie({
-        population: 60000,
-        natureInsee: 'CA',
+      const { caller, collectivite, demarche } = await createDemarche(db, router, {
+        collectivite: {
+          population: 60000,
+          natureInsee: 'CA',
+        },
       });
       const fichier = await addTestBibliothequeFichier(db, {
         collectiviteId: collectivite.id,
@@ -1420,9 +1404,11 @@ describe('Documents d’une démarche PCAET', () => {
     });
 
     it('une pièce conditionnelle non couverte retient la complétude du dossier', async () => {
-      const { caller, collectivite, demarche } = await freshDemarcheAssujettie({
-        population: 60000,
-        natureInsee: 'CA',
+      const { caller, collectivite, demarche } = await createDemarche(db, router, {
+        collectivite: {
+          population: 60000,
+          natureInsee: 'CA',
+        },
       });
       // Dépose le document global, qui couvre d'office les sections requises
       // inconditionnelles — mais pas les deux plans annexes.

--- a/apps/backend/src/demarches/pcaet/get-diagnostic/get-diagnostic.router.e2e-spec.ts
+++ b/apps/backend/src/demarches/pcaet/get-diagnostic/get-diagnostic.router.e2e-spec.ts
@@ -17,6 +17,7 @@ import { CollectiviteRole } from '@tet/domain/users';
 import { and, eq } from 'drizzle-orm';
 import {
   completeTestDossierPcaet,
+  createDemarche,
   ensureTestPcaetMetadonneeId,
 } from '../demarches-pcaet.test-fixture';
 
@@ -51,21 +52,8 @@ describe('Récupérer le diagnostic PCAET', () => {
   let otherCollectivite: Collectivite;
   let otherEditorUser: AuthenticatedUser;
 
-  /** Le diagnostic dépend des valeurs de la collectivité : une par test. */
-  const freshDemarche = async () => {
-    const fixture = await addTestCollectiviteAndUser(db, {
-      user: { role: CollectiviteRole.EDITION },
-    });
-    const user = getAuthUserFromUserCredentials(fixture.user);
-    const caller = router.createCaller({ user });
-    const demarche = await caller.demarches.pcaet.create({
-      collectiviteId: fixture.collectivite.id,
-    });
-    return { collectivite: fixture.collectivite, caller, demarche };
-  };
-
   const getDiagnostic = (
-    caller: Awaited<ReturnType<typeof freshDemarche>>['caller'],
+    caller: ReturnType<TrpcRouter['createCaller']>,
     {
       collectivite,
       demarche,
@@ -107,7 +95,7 @@ describe('Récupérer le diagnostic PCAET', () => {
   });
 
   test('Renvoie les topics du diagnostic dans l’ordre d’affichage', async () => {
-    const { caller, collectivite, demarche } = await freshDemarche();
+    const { caller, collectivite, demarche } = await createDemarche(db, router);
 
     const diagnostic = await getDiagnostic(caller, { collectivite, demarche });
 
@@ -122,7 +110,7 @@ describe('Récupérer le diagnostic PCAET', () => {
   });
 
   test('Les émissions de GES s’arrêtent aux secteurs du décret', async () => {
-    const { caller, collectivite, demarche } = await freshDemarche();
+    const { caller, collectivite, demarche } = await createDemarche(db, router);
 
     const diagnostic = await getDiagnostic(caller, { collectivite, demarche });
     const emissions = diagnostic.indicateurParentConfigs.find(
@@ -149,7 +137,7 @@ describe('Récupérer le diagnostic PCAET', () => {
   });
 
   test('La consommation énergétique finale est un topic à part entière', async () => {
-    const { caller, collectivite, demarche } = await freshDemarche();
+    const { caller, collectivite, demarche } = await createDemarche(db, router);
 
     const conso = (
       await getDiagnostic(caller, { collectivite, demarche })
@@ -164,7 +152,7 @@ describe('Récupérer le diagnostic PCAET', () => {
   });
 
   test('La séquestration est optionnelle', async () => {
-    const { caller, collectivite, demarche } = await freshDemarche();
+    const { caller, collectivite, demarche } = await createDemarche(db, router);
 
     const sequestration = (
       await getDiagnostic(caller, { collectivite, demarche })
@@ -177,7 +165,7 @@ describe('Récupérer le diagnostic PCAET', () => {
   });
 
   test('Les polluants déclinent chaque total par secteur', async () => {
-    const { caller, collectivite, demarche } = await freshDemarche();
+    const { caller, collectivite, demarche } = await createDemarche(db, router);
 
     const polluants = (
       await getDiagnostic(caller, { collectivite, demarche })
@@ -199,7 +187,7 @@ describe('Récupérer le diagnostic PCAET', () => {
   });
 
   test('Sans saisie PCAET, aucune valeur n’est remontée', async () => {
-    const { caller, collectivite, demarche } = await freshDemarche();
+    const { caller, collectivite, demarche } = await createDemarche(db, router);
 
     const diagnostic = await getDiagnostic(caller, { collectivite, demarche });
 
@@ -208,7 +196,7 @@ describe('Récupérer le diagnostic PCAET', () => {
   });
 
   test('La saisie PCAET remplit les valeurs servies', async () => {
-    const { caller, collectivite, demarche } = await freshDemarche();
+    const { caller, collectivite, demarche } = await createDemarche(db, router);
     const indicateurId = await getIndicateurId('cae_1.c');
     const metadonneeId = await ensureTestPcaetMetadonneeId(db, {
       collectiviteId: collectivite.id,
@@ -243,7 +231,7 @@ describe('Récupérer le diagnostic PCAET', () => {
   });
 
   test('Le topic vulnérabilité n’a pas de grille', async () => {
-    const { caller, collectivite, demarche } = await freshDemarche();
+    const { caller, collectivite, demarche } = await createDemarche(db, router);
 
     const { vulnerabilite } = await getDiagnostic(caller, {
       collectivite,
@@ -261,7 +249,7 @@ describe('Récupérer le diagnostic PCAET', () => {
   });
 
   test('Après transmission, le diagnostic reste live', async () => {
-    const { caller, collectivite, demarche } = await freshDemarche();
+    const { caller, collectivite, demarche } = await createDemarche(db, router);
     await completeTestDossierPcaet(db, {
       collectiviteId: collectivite.id,
       demarcheId: demarche.id,
@@ -299,8 +287,8 @@ describe('Récupérer le diagnostic PCAET', () => {
   });
 
   test('Les valeurs remontées sont celles de la collectivité de la démarche', async () => {
-    const first = await freshDemarche();
-    const second = await freshDemarche();
+    const first = await createDemarche(db, router);
+    const second = await createDemarche(db, router);
     const indicateurId = await getIndicateurId('cae_1.c');
     const metadonneeId = await ensureTestPcaetMetadonneeId(db, {
       collectiviteId: first.collectivite.id,
@@ -324,7 +312,7 @@ describe('Récupérer le diagnostic PCAET', () => {
   });
 
   test("IDOR : le diagnostic n'est pas lisible via une autre collectivité", async () => {
-    const { demarche } = await freshDemarche();
+    const { demarche } = await createDemarche(db, router);
 
     const otherCaller = router.createCaller({ user: otherEditorUser });
     await expect(

--- a/apps/backend/src/demarches/pcaet/remove-vulnerabilite-thematique/remove-vulnerabilite-thematique.router.e2e-spec.ts
+++ b/apps/backend/src/demarches/pcaet/remove-vulnerabilite-thematique/remove-vulnerabilite-thematique.router.e2e-spec.ts
@@ -1,8 +1,5 @@
 import { INestApplication } from '@nestjs/common';
-import {
-  addTestCollectiviteAndUser,
-  addTestCollectiviteAndUsers,
-} from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { addTestCollectiviteAndUsers } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
 import {
   getAuthUserFromUserCredentials,
   getTestApp,
@@ -13,6 +10,7 @@ import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
 import { CollectiviteRole } from '@tet/domain/users';
 import {
   completeTestDossierPcaet,
+  createDemarche,
   publierTestDemarchePcaet,
 } from '../demarches-pcaet.test-fixture';
 import {
@@ -25,21 +23,8 @@ describe('Retrait d’une thématique de vulnérabilité', () => {
   let router: TrpcRouter;
   let db: DatabaseService;
 
-  const freshDemarche = async () => {
-    const fixture = await addTestCollectiviteAndUser(db, {
-      user: { role: CollectiviteRole.EDITION },
-    });
-    const caller = router.createCaller({
-      user: getAuthUserFromUserCredentials(fixture.user),
-    });
-    const demarche = await caller.demarches.pcaet.create({
-      collectiviteId: fixture.collectivite.id,
-    });
-    return { collectiviteId: fixture.collectivite.id, caller, demarche };
-  };
-
   const ajouterThematique = async (
-    caller: Awaited<ReturnType<typeof freshDemarche>>['caller'],
+    caller: ReturnType<TrpcRouter['createCaller']>,
     {
       collectiviteId,
       demarcheId,
@@ -73,7 +58,7 @@ describe('Retrait d’une thématique de vulnérabilité', () => {
   });
 
   test('Retirer une thématique que cette démarche seule utilise la supprime du catalogue', async () => {
-    const { caller, collectiviteId, demarche } = await freshDemarche();
+    const { caller, collectiviteId, demarche } = await createDemarche(db, router);
     const ajout = await ajouterThematique(caller, {
       collectiviteId,
       demarcheId: demarche.id,
@@ -98,7 +83,7 @@ describe('Retrait d’une thématique de vulnérabilité', () => {
   });
 
   test('Retirer une thématique utilisée par une autre démarche ne touche que celle-ci', async () => {
-    const { caller, collectiviteId, demarche } = await freshDemarche();
+    const { caller, collectiviteId, demarche } = await createDemarche(db, router);
     const ajout = await ajouterThematique(caller, {
       collectiviteId,
       demarcheId: demarche.id,
@@ -158,7 +143,7 @@ describe('Retrait d’une thématique de vulnérabilité', () => {
   });
 
   test('Une thématique du socle ne se retire pas', async () => {
-    const { caller, collectiviteId, demarche } = await freshDemarche();
+    const { caller, collectiviteId, demarche } = await createDemarche(db, router);
     const diagnostic = await caller.demarches.pcaet.diagnostic.get({
       collectiviteId,
       demarcheId: demarche.id,
@@ -174,8 +159,8 @@ describe('Retrait d’une thématique de vulnérabilité', () => {
   });
 
   test('Une thématique inconnue ou d’une autre collectivité est refusée', async () => {
-    const premiere = await freshDemarche();
-    const seconde = await freshDemarche();
+    const premiere = await createDemarche(db, router);
+    const seconde = await createDemarche(db, router);
     const ajout = await ajouterThematique(seconde.caller, {
       collectiviteId: seconde.collectiviteId,
       demarcheId: seconde.demarche.id,
@@ -192,8 +177,8 @@ describe('Retrait d’une thématique de vulnérabilité', () => {
   });
 
   test('La démarche d’une autre collectivité reste introuvable', async () => {
-    const premiere = await freshDemarche();
-    const seconde = await freshDemarche();
+    const premiere = await createDemarche(db, router);
+    const seconde = await createDemarche(db, router);
     const ajout = await ajouterThematique(premiere.caller, {
       collectiviteId: premiere.collectiviteId,
       demarcheId: premiere.demarche.id,
@@ -237,7 +222,7 @@ describe('Retrait d’une thématique de vulnérabilité', () => {
   });
 
   test('Le retrait est fermé une fois le dossier transmis', async () => {
-    const { caller, collectiviteId, demarche } = await freshDemarche();
+    const { caller, collectiviteId, demarche } = await createDemarche(db, router);
     const ajout = await ajouterThematique(caller, {
       collectiviteId,
       demarcheId: demarche.id,

--- a/apps/backend/src/demarches/pcaet/set-vulnerabilite-ligne/set-vulnerabilite-ligne.router.e2e-spec.ts
+++ b/apps/backend/src/demarches/pcaet/set-vulnerabilite-ligne/set-vulnerabilite-ligne.router.e2e-spec.ts
@@ -1,8 +1,5 @@
 import { INestApplication } from '@nestjs/common';
-import {
-  addTestCollectiviteAndUser,
-  addTestCollectiviteAndUsers,
-} from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { addTestCollectiviteAndUsers } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
 import {
   getAuthUserFromUserCredentials,
   getTestApp,
@@ -18,6 +15,7 @@ import {
   completeTestDiagnosticPcaet,
   completeTestDossierPcaet,
   coverTestDocumentsPcaet,
+  createDemarche,
 } from '../demarches-pcaet.test-fixture';
 import {
   ligneOf,
@@ -29,16 +27,6 @@ describe('Vulnérabilité du territoire', () => {
   let app: INestApplication;
   let router: TrpcRouter;
   let db: DatabaseService;
-
-  const freshDemarche = async (role = CollectiviteRole.EDITION) => {
-    const fixture = await addTestCollectiviteAndUser(db, { user: { role } });
-    const user = getAuthUserFromUserCredentials(fixture.user);
-    const caller = router.createCaller({ user });
-    const demarche = await caller.demarches.pcaet.create({
-      collectiviteId: fixture.collectivite.id,
-    });
-    return { collectiviteId: fixture.collectivite.id, caller, demarche };
-  };
 
   const thematiqueId = (diagnostic: PcaetDiagnostic, code: string): number =>
     thematiqueIdOf(diagnostic, code);
@@ -54,7 +42,7 @@ describe('Vulnérabilité du territoire', () => {
   });
 
   test('Le socle est servi avec une ligne vierge par thématique', async () => {
-    const { caller, collectiviteId, demarche } = await freshDemarche();
+    const { caller, collectiviteId, demarche } = await createDemarche(db, router);
 
     const diagnostic = await caller.demarches.pcaet.diagnostic.get({
       collectiviteId,
@@ -76,7 +64,7 @@ describe('Vulnérabilité du territoire', () => {
   });
 
   test('Une saisie de niveau ne touche que l’horizon visé', async () => {
-    const { caller, collectiviteId, demarche } = await freshDemarche();
+    const { caller, collectiviteId, demarche } = await createDemarche(db, router);
     const initial = await caller.demarches.pcaet.diagnostic.get({
       collectiviteId,
       demarcheId: demarche.id,
@@ -112,7 +100,7 @@ describe('Vulnérabilité du territoire', () => {
   });
 
   test('Un objectif vidé redevient une absence de saisie', async () => {
-    const { caller, collectiviteId, demarche } = await freshDemarche();
+    const { caller, collectiviteId, demarche } = await createDemarche(db, router);
     const initial = await caller.demarches.pcaet.diagnostic.get({
       collectiviteId,
       demarcheId: demarche.id,
@@ -140,8 +128,8 @@ describe('Vulnérabilité du territoire', () => {
   });
 
   test('Une thématique d’une autre collectivité n’est pas adressable', async () => {
-    const premiere = await freshDemarche();
-    const seconde = await freshDemarche();
+    const premiere = await createDemarche(db, router);
+    const seconde = await createDemarche(db, router);
 
     const diagnostic = await seconde.caller.demarches.pcaet.diagnostic.get({
       collectiviteId: seconde.collectiviteId,
@@ -171,8 +159,8 @@ describe('Vulnérabilité du territoire', () => {
   });
 
   test('La démarche d’une autre collectivité reste introuvable', async () => {
-    const premiere = await freshDemarche();
-    const seconde = await freshDemarche();
+    const premiere = await createDemarche(db, router);
+    const seconde = await createDemarche(db, router);
     const diagnostic = await premiere.caller.demarches.pcaet.diagnostic.get({
       collectiviteId: premiere.collectiviteId,
       demarcheId: premiere.demarche.id,
@@ -216,7 +204,7 @@ describe('Vulnérabilité du territoire', () => {
   });
 
   test('Le diagnostic n’est plus modifiable une fois le dossier transmis', async () => {
-    const { caller, collectiviteId, demarche } = await freshDemarche();
+    const { caller, collectiviteId, demarche } = await createDemarche(db, router);
     const diagnostic = await caller.demarches.pcaet.diagnostic.get({
       collectiviteId,
       demarcheId: demarche.id,
@@ -241,7 +229,7 @@ describe('Vulnérabilité du territoire', () => {
   });
 
   test('La vulnérabilité ne conditionne pas la complétude du diagnostic', async () => {
-    const { caller, collectiviteId, demarche } = await freshDemarche();
+    const { caller, collectiviteId, demarche } = await createDemarche(db, router);
     await attachTestPlanToDemarchePcaet(db, {
       collectiviteId,
       demarcheId: demarche.id,

--- a/apps/backend/src/demarches/pcaet/update-vulnerabilite-thematique/update-vulnerabilite-thematique.router.e2e-spec.ts
+++ b/apps/backend/src/demarches/pcaet/update-vulnerabilite-thematique/update-vulnerabilite-thematique.router.e2e-spec.ts
@@ -1,8 +1,5 @@
 import { INestApplication } from '@nestjs/common';
-import {
-  addTestCollectiviteAndUser,
-  addTestCollectiviteAndUsers,
-} from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { addTestCollectiviteAndUsers } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
 import {
   getAuthUserFromUserCredentials,
   getTestApp,
@@ -12,7 +9,10 @@ import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
 import { VULNERABILITE_THEMATIQUE_LABEL_MAX } from '@tet/domain/demarches';
 import { CollectiviteRole } from '@tet/domain/users';
-import { completeTestDossierPcaet } from '../demarches-pcaet.test-fixture';
+import {
+  completeTestDossierPcaet,
+  createDemarche,
+} from '../demarches-pcaet.test-fixture';
 import {
   thematiqueIdOf,
   vulnerabiliteOf,
@@ -23,21 +23,8 @@ describe('Renommage d’une thématique de vulnérabilité', () => {
   let router: TrpcRouter;
   let db: DatabaseService;
 
-  const freshDemarche = async () => {
-    const fixture = await addTestCollectiviteAndUser(db, {
-      user: { role: CollectiviteRole.EDITION },
-    });
-    const caller = router.createCaller({
-      user: getAuthUserFromUserCredentials(fixture.user),
-    });
-    const demarche = await caller.demarches.pcaet.create({
-      collectiviteId: fixture.collectivite.id,
-    });
-    return { collectiviteId: fixture.collectivite.id, caller, demarche };
-  };
-
   const ajouterThematique = async (
-    caller: Awaited<ReturnType<typeof freshDemarche>>['caller'],
+    caller: ReturnType<TrpcRouter['createCaller']>,
     {
       collectiviteId,
       demarcheId,
@@ -70,7 +57,7 @@ describe('Renommage d’une thématique de vulnérabilité', () => {
   });
 
   test('Une thématique ajoutée se renomme', async () => {
-    const { caller, collectiviteId, demarche } = await freshDemarche();
+    const { caller, collectiviteId, demarche } = await createDemarche(db, router);
     const ajout = await ajouterThematique(caller, {
       collectiviteId,
       demarcheId: demarche.id,
@@ -91,7 +78,7 @@ describe('Renommage d’une thématique de vulnérabilité', () => {
   });
 
   test('Se renommer soi-même, à la casse près, reste permis', async () => {
-    const { caller, collectiviteId, demarche } = await freshDemarche();
+    const { caller, collectiviteId, demarche } = await createDemarche(db, router);
     const ajout = await ajouterThematique(caller, {
       collectiviteId,
       demarcheId: demarche.id,
@@ -112,7 +99,7 @@ describe('Renommage d’une thématique de vulnérabilité', () => {
   });
 
   test('Heurter une autre thématique, socle compris, est refusé', async () => {
-    const { caller, collectiviteId, demarche } = await freshDemarche();
+    const { caller, collectiviteId, demarche } = await createDemarche(db, router);
     const premier = await ajouterThematique(caller, {
       collectiviteId,
       demarcheId: demarche.id,
@@ -144,7 +131,7 @@ describe('Renommage d’une thématique de vulnérabilité', () => {
   });
 
   test('Une thématique du socle ne se renomme pas', async () => {
-    const { caller, collectiviteId, demarche } = await freshDemarche();
+    const { caller, collectiviteId, demarche } = await createDemarche(db, router);
     const diagnostic = await caller.demarches.pcaet.diagnostic.get({
       collectiviteId,
       demarcheId: demarche.id,
@@ -161,7 +148,7 @@ describe('Renommage d’une thématique de vulnérabilité', () => {
   });
 
   test('Un libellé trop long est refusé', async () => {
-    const { caller, collectiviteId, demarche } = await freshDemarche();
+    const { caller, collectiviteId, demarche } = await createDemarche(db, router);
     const ajout = await ajouterThematique(caller, {
       collectiviteId,
       demarcheId: demarche.id,
@@ -179,8 +166,8 @@ describe('Renommage d’une thématique de vulnérabilité', () => {
   });
 
   test('Une thématique d’une autre collectivité est refusée', async () => {
-    const premiere = await freshDemarche();
-    const seconde = await freshDemarche();
+    const premiere = await createDemarche(db, router);
+    const seconde = await createDemarche(db, router);
     const ajout = await ajouterThematique(seconde.caller, {
       collectiviteId: seconde.collectiviteId,
       demarcheId: seconde.demarche.id,
@@ -198,8 +185,8 @@ describe('Renommage d’une thématique de vulnérabilité', () => {
   });
 
   test('La démarche d’une autre collectivité reste introuvable', async () => {
-    const premiere = await freshDemarche();
-    const seconde = await freshDemarche();
+    const premiere = await createDemarche(db, router);
+    const seconde = await createDemarche(db, router);
     const ajout = await ajouterThematique(premiere.caller, {
       collectiviteId: premiere.collectiviteId,
       demarcheId: premiere.demarche.id,
@@ -245,7 +232,7 @@ describe('Renommage d’une thématique de vulnérabilité', () => {
   });
 
   test('Le renommage est fermé une fois le dossier transmis', async () => {
-    const { caller, collectiviteId, demarche } = await freshDemarche();
+    const { caller, collectiviteId, demarche } = await createDemarche(db, router);
     const ajout = await ajouterThematique(caller, {
       collectiviteId,
       demarcheId: demarche.id,

--- a/apps/backend/src/indicateurs/valeurs/valeurs-moyenne.service.ts
+++ b/apps/backend/src/indicateurs/valeurs/valeurs-moyenne.service.ts
@@ -15,6 +15,7 @@ import {
 } from 'drizzle-orm';
 import { DatabaseService } from '../../utils/database/database.service';
 
+import { PCAET_COLLECTIVITE_SOURCE_ID } from '@tet/backend/demarches/pcaet/shared/demarche-pcaet-source-metadonnee.repository';
 import { indicateurSourceMetadonneeTable } from '@tet/backend/indicateurs/shared/models/indicateur-source-metadonnee.table';
 import { indicateurSourceTable } from '@tet/backend/indicateurs/shared/models/indicateur-source.table';
 import { AuthUser } from '@tet/backend/users/models/auth.models';
@@ -118,7 +119,7 @@ export default class ValeursMoyenneService {
             // Sources hors moyenne nationale : SNBC (trajectoire) et PCAET
             // collectivité (valeurs de démarche, pas une source ouverte partagée).
             ne(ism.sourceId, 'snbc'),
-            ne(ism.sourceId, 'pcaet-collectivite'),
+            ne(ism.sourceId, PCAET_COLLECTIVITE_SOURCE_ID),
             eq(iv.indicateurId, indicateurId)
           )
         )


### PR DESCRIPTION
## Summary
- Centralize PCAET e2e setup with a shared `createDemarche` fixture (collectivité + user + démarche via the router), and replace duplicated local `freshDemarche` / `freshDemarcheAssujettie` helpers across 8 Nest specs.
- Keep the fixture Playwright-safe: import `getAuthUserFromUserCredentials` from the relative test helper (not `@tet/backend/test`), and type-only Nest router types — Playwright loads this module via `pickFreeRegionCode`.
- Use `PCAET_COLLECTIVITE_SOURCE_ID` in `valeurs-moyenne` instead of a hardcoded `'pcaet-collectivite'` string when excluding démarche values from national averages.

## Test plan
- [x] Spot-check that PCAET Nest e2e specs import `createDemarche` and no longer define local `freshDemarche`
- [x] CI Playwright e2e green after the fixture import-boundary fix
- [x] CI `test-backend-api` green
- [ ] Confirm moyennes nationales still exclude SNBC and PCAET collectivité sources

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>