### PR TITLE
refactor(side-panel): remove custom Title component from side panel configuration

### DIFF
--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/action/[actionId]/_components/side-panel/context.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/referentiel/[referentielId]/action/[actionId]/_components/side-panel/context.tsx
@@ -135,9 +135,6 @@ function PanelContentManager({
       type: 'open',
       isPersistentWithNextPath: (path) => path.includes('/action/'),
       title: getPanelTitle(activePanel.panelId, panelAction),
-      Title: ({ title }) => (
-        <h5 className="text-primary-9 font-bold leading-7 text-xl">{title}</h5>
-      ),
       content: (
         <div className="px-6 py-4">
           <SidePanelInnerContent

--- a/apps/app/src/demarches/components/transmettre-pour-avis.modal.tsx
+++ b/apps/app/src/demarches/components/transmettre-pour-avis.modal.tsx
@@ -35,7 +35,6 @@ export const TransmettrePourAvisModal = ({ onConfirm, onClose }: Props) => (
             mois: DEMARCHE_PCAET_DELAI_AVIS_MOIS,
           })}
         </p>
-        <p className="m-0">{appLabels.demarcheTransmettreConfirmationGel}</p>
         <p className="m-0">{appLabels.demarcheTransmettreConfirmationSuite}</p>
       </div>
     )}

--- a/apps/app/src/demarches/components/use-avance-side-panel.tsx
+++ b/apps/app/src/demarches/components/use-avance-side-panel.tsx
@@ -68,11 +68,6 @@ export function useDemarcheAvanceSidePanel(
         props.collectiviteId,
         props.demarcheId
       ),
-      Title: ({ title }) => (
-        <h5 className="text-primary-9 font-bold leading-7 text-xl m-0">
-          {title}
-        </h5>
-      ),
       content: <DemarcheAvanceSidePanelContent {...props} />,
     });
   }, [setPanel]);

--- a/apps/app/src/demarches/pcaet/instruction/dossier/use-etapes-instruction-side-panel.tsx
+++ b/apps/app/src/demarches/pcaet/instruction/dossier/use-etapes-instruction-side-panel.tsx
@@ -40,11 +40,6 @@ export function useEtapesInstructionSidePanel(
       type: 'open',
       title: PANEL_TITLE,
       isPersistentWithNextPath: (path) => path === dossierPath,
-      Title: ({ title }) => (
-        <h5 className="text-primary-9 font-bold leading-7 text-xl m-0">
-          {title}
-        </h5>
-      ),
       content: (
         <EtapesInstructionSidePanelContent {...contentPropsRef.current} />
       ),

--- a/apps/app/src/labels/catalog.ts
+++ b/apps/app/src/labels/catalog.ts
@@ -574,13 +574,12 @@ export const appLabels = {
   demarcheAvanceNouvelleDemarche: 'Nouvelle démarche',
   demarcheAvanceRepasserBrouillon: 'Repasser en brouillon',
   demarcheAvanceValiderDepot: 'Valider le dépôt pour avis',
-  demarcheTransmettreConfirmationTitre: 'Valider le dépôt pour avis ?',
+  demarcheTransmettreConfirmationTitre:
+    'Votre dossier va être transmis pour avis',
   demarcheTransmettreConfirmationProcessus: ({ mois }: { mois: number }) =>
-    `Votre dossier sera transmis aux instances consultatives, qui disposent de ${mois} mois pour rendre leur avis. Le diagnostic est figé au moment de la transmission : c’est cette photo qu’elles consultent.`,
-  demarcheTransmettreConfirmationGel:
-    'Vous ne pourrez plus modifier votre dossier d’élaboration incluant le diagnostic et les pièces déposées — jusqu’à la fin de l’instruction.',
+    `Votre dossier sera transmis aux instances consultatives, qui disposent de ${mois} mois pour rendre leurs avis. Il sera figé pendant toute la durée de l'instruction : vous ne pourrez plus modifier le diagnostic ni les pièces déposées, jusqu'à la fin de celle-ci.`,
   demarcheTransmettreConfirmationSuite:
-    'Vous reprendrez la main à l’étape suivante, pour déposer les pièces attendues après les avis et adopter votre PCAET.',
+    "Vous reprendrez la main à l'étape suivante, pour déposer les pièces attendues après les avis et adopter votre PCAET.",
   /**
    * Libellés des codes d'erreur renvoyés par l'API (`data.errorKey`) : le
    * serveur nomme la cause, l'app l'écrit.

--- a/apps/app/src/referentiels/referentiel.table/referentiel-table.comments.cell.tsx
+++ b/apps/app/src/referentiels/referentiel.table/referentiel-table.comments.cell.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { EmptyCell } from './empty-cell';
+import { appLabels } from '@/app/labels/catalog';
 import { ActionProvider } from '@/app/referentiels/actions/action-context';
 import { ActionCommentsSidePanelContent } from '@/app/referentiels/actions/comments/action-comments-side-panel-content';
 import { ActionListItem } from '@/app/referentiels/actions/use-list-actions';
@@ -15,8 +15,8 @@ import {
 } from '@tet/domain/referentiels';
 import { Button, cn, TableCell } from '@tet/ui';
 import { useCallback, useMemo } from 'react';
+import { EmptyCell } from './empty-cell';
 import { getTableMeta } from './utils';
-import { appLabels } from '@/app/labels/catalog';
 
 type Props = {
   info: CellContext<ActionListItem, unknown>;
@@ -56,8 +56,7 @@ function CommentsCellContent({
 
   const { setPanel, setTitle, panel } = useSidePanel();
 
-  const panelKey = `comments-${action.actionId}`;
-  const isActive = panel.isOpen && panel.title === panelKey;
+  const isActive = panel.isOpen && panel.title === appLabels.commentairesTitre;
 
   const toggleCommentsPanel = useCallback(() => {
     if (isActive) {
@@ -67,12 +66,7 @@ function CommentsCellContent({
 
     setPanel({
       type: 'open',
-      title: panelKey,
-      Title: () => (
-        <h5 className="text-primary-9 font-bold leading-7 text-xl">
-          {appLabels.commentairesTitre}
-        </h5>
-      ),
+      title: appLabels.commentairesTitre,
       content: (
         <div className="px-6 py-4">
           <ReferentielProvider referentielId={referentielId}>
@@ -88,7 +82,7 @@ function CommentsCellContent({
         </div>
       ),
     });
-  }, [isActive, setPanel, panelKey, referentielId, action, setTitle]);
+  }, [isActive, setPanel, referentielId, action, setTitle]);
 
   return (
     <TableCell

--- a/apps/app/src/referentiels/referentiel.table/referentiel-table.documents.cell.tsx
+++ b/apps/app/src/referentiels/referentiel.table/referentiel-table.documents.cell.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { EmptyCell } from './empty-cell';
 import { DownloadDocs } from '@/app/referentiels/actions/action-documents.download-button';
 import ActionPreuvePanel from '@/app/referentiels/actions/action-preuve.panel';
 import { ActionListItem } from '@/app/referentiels/actions/use-list-actions';
@@ -15,6 +14,7 @@ import {
 } from '@tet/domain/referentiels';
 import { Button, cn, TableCell } from '@tet/ui';
 import { useCallback } from 'react';
+import { EmptyCell } from './empty-cell';
 
 type Props = {
   info: CellContext<ActionListItem, unknown>;
@@ -33,8 +33,8 @@ function DocumentsCellContent({
 
   const { setPanel, panel } = useSidePanel();
 
-  const isActive =
-    panel.isOpen && panel.title === `documents-${action.actionId}`;
+  const panelTitle = `${action.identifiant} ${action.nom}`;
+  const isActive = panel.isOpen && panel.title === panelTitle;
 
   const toggleDocumentsPanel = useCallback(() => {
     if (isActive) {
@@ -44,12 +44,12 @@ function DocumentsCellContent({
 
     setPanel({
       type: 'open',
-      title: `documents-${action.actionId}`,
-      Title: () => (
-        <h5 className="text-primary-9 font-bold leading-7 text-xl">
-          {action.identifiant} {action.nom}
-        </h5>
-      ),
+      title: panelTitle,
+      // Title: () => (
+      //   <h5 className="text-primary-9 font-bold leading-7 text-xl">
+      //     {action.identifiant} {action.nom}
+      //   </h5>
+      // ),
       content: (
         <div className="px-6 py-4">
           <ReferentielProvider referentielId={referentielId}>
@@ -66,7 +66,7 @@ function DocumentsCellContent({
         </div>
       ),
     });
-  }, [isActive, setPanel, action, referentielId]);
+  }, [isActive, setPanel, panelTitle, referentielId, action]);
 
   return (
     <TableCell

--- a/apps/app/src/referentiels/referentiel.table/referentiel-table.fiches.cell.tsx
+++ b/apps/app/src/referentiels/referentiel.table/referentiel-table.fiches.cell.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { EmptyCell } from './empty-cell';
 import { FichesActionLiees } from '@/app/referentiels/action.show/FichesActionLiees';
 import { ActionListItem } from '@/app/referentiels/actions/use-list-actions';
 import { useSidePanel } from '@/app/ui/layout/side-panel/side-panel.context';
@@ -8,6 +7,7 @@ import { CellContext } from '@tanstack/react-table';
 import { ActionType, ActionTypeEnum } from '@tet/domain/referentiels';
 import { Button, cn, TableCell } from '@tet/ui';
 import { useCallback } from 'react';
+import { EmptyCell } from './empty-cell';
 import { getTableMeta } from './utils';
 
 type Props = {
@@ -28,8 +28,8 @@ function FichesCellContent({
 
   const { setPanel, panel } = useSidePanel();
 
-  const panelKey = `fiches-${action.actionId}`;
-  const isActive = panel.isOpen && panel.title === panelKey;
+  const panelTitle = `${action.identifiant} ${action.nom}`;
+  const isActive = panel.isOpen && panel.title === panelTitle;
 
   const toggleFichesPanel = useCallback(() => {
     if (isActive) {
@@ -39,19 +39,14 @@ function FichesCellContent({
 
     setPanel({
       type: 'open',
-      title: panelKey,
-      Title: () => (
-        <h5 className="text-primary-9 font-bold leading-7 text-xl">
-          {action.identifiant} {action.nom}
-        </h5>
-      ),
+      title: panelTitle,
       content: (
         <div className="px-6 py-4">
           <FichesActionLiees actionId={action.actionId} />
         </div>
       ),
     });
-  }, [isActive, setPanel, panelKey, action]);
+  }, [isActive, setPanel, panelTitle, action]);
 
   return (
     <TableCell

--- a/apps/app/src/ui/layout/side-panel/side-panel.context.tsx
+++ b/apps/app/src/ui/layout/side-panel/side-panel.context.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React, {
-  ComponentType,
   createContext,
   ReactNode,
   useCallback,
@@ -18,7 +17,6 @@ export type SidePanelTitleProps = {
 type Panel = {
   isPersistentWithNextPath?: (path: string) => boolean;
   title?: string;
-  Title?: ComponentType<SidePanelTitleProps>;
   content?: React.ReactNode;
 };
 

--- a/apps/app/src/ui/layout/side-panel/side-panel.tsx
+++ b/apps/app/src/ui/layout/side-panel/side-panel.tsx
@@ -61,8 +61,6 @@ export const SidePanel = (): JSX.Element => {
   const { panel, setPanel } = useSidePanel();
   useCloseOnRouteChange();
 
-  const Title = panel.Title ?? DefaultSidePanelTitle;
-
   return (
     <aside
       aria-label={panel.title}
@@ -79,7 +77,7 @@ export const SidePanel = (): JSX.Element => {
         <div className="flex items-start gap-2">
           <CloseButton onClick={() => setPanel({ type: 'close' })} />
           <Divider />
-          {panel.title && <Title title={panel.title} />}
+          {panel.title && <DefaultSidePanelTitle title={panel.title} />}
         </div>
       </div>
 


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Améliorations**
  - Les panneaux latéraux utilisent désormais des titres standardisés et plus cohérents.
  - Les panneaux de commentaires, documents et fiches affichent des intitulés plus explicites, liés au contenu consulté.
  - Les titres personnalisés sont remplacés par une présentation uniforme dans les différents parcours.

- **Mise à jour des libellés**
  - La confirmation de transmission pour avis est reformulée pour clarifier le gel du dossier pendant l’instruction.
  - Le message associé au gel du diagnostic est intégré directement au texte principal de confirmation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->