### PR TITLE
feat(documents): émet un jeton de dépôt signé côté backend

### DIFF
--- a/apps/backend/src/collectivites/collectivites.module.ts
+++ b/apps/backend/src/collectivites/collectivites.module.ts
@@ -4,7 +4,11 @@ import CollectiviteCrudService from '@tet/backend/collectivites/collectivite-cru
 import { CollectivitePreferencesRepository } from '@tet/backend/collectivites/collectivite-preferences/collectivite-preferences.repository';
 import { CollectivitePreferencesRouter } from '@tet/backend/collectivites/collectivite-preferences/collectivite-preferences.router';
 import { CollectivitePreferencesService } from '@tet/backend/collectivites/collectivite-preferences/collectivite-preferences.service';
+import { CollectiviteBucketRepository } from '@tet/backend/collectivites/documents/collectivite-bucket.repository';
 import { DocumentController } from '@tet/backend/collectivites/documents/document.controller';
+import { CreateUploadTokenRepository } from '@tet/backend/collectivites/documents/create-upload-token/create-upload-token.repository';
+import { CreateUploadTokenRouter } from '@tet/backend/collectivites/documents/create-upload-token/create-upload-token.router';
+import { CreateUploadTokenService } from '@tet/backend/collectivites/documents/create-upload-token/create-upload-token.service';
 import { EditPreuveDocumentRepository } from '@tet/backend/collectivites/documents/edit-preuve-document/edit-preuve-document.repository';
 import { EditPreuveDocumentRouter } from '@tet/backend/collectivites/documents/edit-preuve-document/edit-preuve-document.router';
 import { EditPreuveDocumentService } from '@tet/backend/collectivites/documents/edit-preuve-document/edit-preuve-document.service';
@@ -79,6 +83,10 @@ import { PersonnesService } from './services/personnes.service';
     ListCategoriesRouter,
     StoreDocumentService,
     StoreDocumentRouter,
+    CollectiviteBucketRepository,
+    CreateUploadTokenRepository,
+    CreateUploadTokenService,
+    CreateUploadTokenRouter,
     UpdateDocumentService,
     UpdateDocumentRouter,
     EditPreuveDocumentRepository,

--- a/apps/backend/src/collectivites/documents/collectivite-bucket.repository.ts
+++ b/apps/backend/src/collectivites/documents/collectivite-bucket.repository.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+import { collectiviteBucketTable } from '@tet/backend/collectivites/shared/models/collectivite-bucket.table';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { eq } from 'drizzle-orm';
+
+@Injectable()
+export class CollectiviteBucketRepository {
+  constructor(private readonly databaseService: DatabaseService) {}
+
+  async findBucketId(collectiviteId: number): Promise<string | undefined> {
+    const [bucket] = await this.databaseService.db
+      .select({ bucketId: collectiviteBucketTable.bucketId })
+      .from(collectiviteBucketTable)
+      .where(eq(collectiviteBucketTable.collectiviteId, collectiviteId))
+      .orderBy(collectiviteBucketTable.bucketId)
+      .limit(1);
+
+    return bucket?.bucketId;
+  }
+}

--- a/apps/backend/src/collectivites/documents/create-upload-token/create-upload-token.errors.ts
+++ b/apps/backend/src/collectivites/documents/create-upload-token/create-upload-token.errors.ts
@@ -1,0 +1,32 @@
+import {
+  createErrorsEnum,
+  TrpcErrorHandlerConfig,
+} from '@tet/backend/utils/trpc/trpc-error-handler';
+
+export const CreateUploadTokenSpecificErrors = [
+  'COLLECTIVITE_BUCKET_NOT_FOUND',
+  'SIGN_UPLOAD_ERROR',
+] as const;
+
+type CreateUploadTokenSpecificError =
+  (typeof CreateUploadTokenSpecificErrors)[number];
+
+export const createUploadTokenErrorConfig: TrpcErrorHandlerConfig<CreateUploadTokenSpecificError> =
+  {
+    specificErrors: {
+      COLLECTIVITE_BUCKET_NOT_FOUND: {
+        code: 'NOT_FOUND',
+        message: "Le bucket de la collectivité n'a pas été trouvé",
+      },
+      SIGN_UPLOAD_ERROR: {
+        code: 'INTERNAL_SERVER_ERROR',
+        message:
+          'Une erreur est survenue lors de la préparation du dépôt du fichier',
+      },
+    },
+  };
+
+export const CreateUploadTokenErrorEnum = createErrorsEnum(
+  CreateUploadTokenSpecificErrors
+);
+export type CreateUploadTokenError = keyof typeof CreateUploadTokenErrorEnum;

--- a/apps/backend/src/collectivites/documents/create-upload-token/create-upload-token.input.ts
+++ b/apps/backend/src/collectivites/documents/create-upload-token/create-upload-token.input.ts
@@ -1,0 +1,13 @@
+import { documentHashSchema } from '@tet/domain/collectivites';
+import * as z from 'zod';
+
+export const createUploadTokenInputSchema = z.object({
+  collectiviteId: z.number().int().positive(),
+  hash: documentHashSchema.brand<'DocumentHash'>(),
+});
+
+export type CreateUploadTokenInput = z.infer<
+  typeof createUploadTokenInputSchema
+>;
+
+export type DocumentHash = CreateUploadTokenInput['hash'];

--- a/apps/backend/src/collectivites/documents/create-upload-token/create-upload-token.output.ts
+++ b/apps/backend/src/collectivites/documents/create-upload-token/create-upload-token.output.ts
@@ -1,0 +1,18 @@
+import * as z from 'zod';
+
+export const createUploadTokenOutputSchema = z.discriminatedUnion('kind', [
+  z.object({
+    kind: z.literal('alreadyInBibliotheque'),
+    fichierId: z.number().int().positive(),
+  }),
+  z.object({
+    kind: z.literal('readyToUpload'),
+    token: z.string().min(1),
+    bucketId: z.string().min(1),
+    path: z.string().min(1),
+  }),
+]);
+
+export type CreateUploadTokenOutput = z.infer<
+  typeof createUploadTokenOutputSchema
+>;

--- a/apps/backend/src/collectivites/documents/create-upload-token/create-upload-token.repository.ts
+++ b/apps/backend/src/collectivites/documents/create-upload-token/create-upload-token.repository.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { and, eq } from 'drizzle-orm';
+import { bibliothequeFichierTable } from '../models/bibliotheque-fichier.table';
+
+@Injectable()
+export class CreateUploadTokenRepository {
+  constructor(private readonly databaseService: DatabaseService) {}
+
+  async findFichierIdByHash({
+    collectiviteId,
+    hash,
+  }: {
+    collectiviteId: number;
+    hash: string;
+  }): Promise<number | undefined> {
+    const [fichier] = await this.databaseService.db
+      .select({ id: bibliothequeFichierTable.id })
+      .from(bibliothequeFichierTable)
+      .where(
+        and(
+          eq(bibliothequeFichierTable.collectiviteId, collectiviteId),
+          eq(bibliothequeFichierTable.hash, hash)
+        )
+      )
+      .limit(1);
+
+    return fichier?.id;
+  }
+}

--- a/apps/backend/src/collectivites/documents/create-upload-token/create-upload-token.router.e2e-spec.ts
+++ b/apps/backend/src/collectivites/documents/create-upload-token/create-upload-token.router.e2e-spec.ts
@@ -1,0 +1,104 @@
+import { INestApplication } from '@nestjs/common';
+import { addTestCollectiviteAndUsers } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { getAuthUserFromUserCredentials } from '@tet/backend/test';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { addTestUser } from '@tet/backend/users/users/users.test-fixture';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
+import { Collectivite } from '@tet/domain/collectivites';
+import { CollectiviteRole } from '@tet/domain/users';
+import {
+  getTestApp,
+  getTestDatabase,
+  getTestRouter,
+} from '../../../../test/app-utils';
+
+const HASH = 'ec07d0538e44a333b23b936c9a4ba37fbd211c6272e632d2173b6abe102a0482';
+
+describe('CreateUploadTokenRouter', () => {
+  let app: INestApplication;
+  let router: TrpcRouter;
+  let databaseService: DatabaseService;
+  let collectivite: Collectivite;
+  let editorUser: AuthenticatedUser;
+  let readerUser: AuthenticatedUser;
+  let nonMembreUser: AuthenticatedUser;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    router = await getTestRouter(app);
+    databaseService = await getTestDatabase(app);
+
+    const { collectivite: testCollectivite, users } =
+      await addTestCollectiviteAndUsers(databaseService, {
+        users: [
+          { role: CollectiviteRole.EDITION },
+          { role: CollectiviteRole.LECTURE },
+        ],
+      });
+
+    collectivite = testCollectivite;
+    editorUser = getAuthUserFromUserCredentials(users[0]);
+    readerUser = getAuthUserFromUserCredentials(users[1]);
+
+    const { user } = await addTestUser(databaseService);
+    nonMembreUser = getAuthUserFromUserCredentials(user);
+
+    return async () => {
+      await app.close();
+    };
+  });
+
+  test('refuse un hash qui designe un autre bucket, avant tout controle de droit', async () => {
+    const caller = router.createCaller({ user: nonMembreUser });
+
+    await expect(() =>
+      caller.collectivites.documents.createUploadToken({
+        collectiviteId: collectivite.id,
+        hash: `autreBucket/${HASH}`,
+      })
+    ).rejects.toThrowError(/hash/i);
+  });
+
+  test('refuse un utilisateur en lecture seule sur la collectivite', async () => {
+    const caller = router.createCaller({ user: readerUser });
+
+    await expect(() =>
+      caller.collectivites.documents.createUploadToken({
+        collectiviteId: collectivite.id,
+        hash: HASH,
+      })
+    ).rejects.toThrowError(
+      /permissions necessaires|permissions n\u00e9cessaires/i
+    );
+  });
+
+  test("refuse un utilisateur qui n'est membre d'aucune collectivite", async () => {
+    const caller = router.createCaller({ user: nonMembreUser });
+
+    await expect(() =>
+      caller.collectivites.documents.createUploadToken({
+        collectiviteId: collectivite.id,
+        hash: HASH,
+      })
+    ).rejects.toThrowError(
+      /permissions necessaires|permissions n\u00e9cessaires/i
+    );
+  });
+
+  test('emet un jeton pour un utilisateur en edition sur la collectivite', async () => {
+    const caller = router.createCaller({ user: editorUser });
+
+    const result = await caller.collectivites.documents.createUploadToken({
+      collectiviteId: collectivite.id,
+      hash: HASH,
+    });
+
+    expect(result).toEqual({
+      kind: 'readyToUpload',
+      token: expect.any(String),
+      bucketId: expect.any(String),
+      path: HASH,
+    });
+  });
+});

--- a/apps/backend/src/collectivites/documents/create-upload-token/create-upload-token.router.ts
+++ b/apps/backend/src/collectivites/documents/create-upload-token/create-upload-token.router.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@nestjs/common';
+import { createTrpcErrorHandler } from '@tet/backend/utils/trpc/trpc-error-handler';
+import { TrpcService } from '@tet/backend/utils/trpc/trpc.service';
+import { createUploadTokenErrorConfig } from './create-upload-token.errors';
+import { createUploadTokenInputSchema } from './create-upload-token.input';
+import { createUploadTokenOutputSchema } from './create-upload-token.output';
+import { CreateUploadTokenService } from './create-upload-token.service';
+
+@Injectable()
+export class CreateUploadTokenRouter {
+  constructor(
+    private readonly trpc: TrpcService,
+    private readonly service: CreateUploadTokenService
+  ) {}
+
+  private readonly getResultDataOrThrowError = createTrpcErrorHandler(
+    createUploadTokenErrorConfig
+  );
+
+  router = this.trpc.router({
+    createUploadToken: this.trpc.authedProcedure
+      .input(createUploadTokenInputSchema)
+      .output(createUploadTokenOutputSchema)
+      .mutation(async ({ input, ctx }) => {
+        const result = await this.service.createUploadToken(input, {
+          user: ctx.user,
+        });
+        return this.getResultDataOrThrowError(result);
+      }),
+  });
+}

--- a/apps/backend/src/collectivites/documents/create-upload-token/create-upload-token.service.spec.ts
+++ b/apps/backend/src/collectivites/documents/create-upload-token/create-upload-token.service.spec.ts
@@ -1,0 +1,150 @@
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { failure, success, type Result } from '@tet/backend/utils/result.type';
+import { DocumentStorageErrorEnum } from '@tet/backend/utils/supabase/document-storage.errors';
+import { type DocumentStorageError } from '@tet/backend/utils/supabase/document-storage.errors';
+import { describe, expect, it, vi, type Mock } from 'vitest';
+import { CreateUploadTokenService } from './create-upload-token.service';
+import { type DocumentHash } from './create-upload-token.input';
+
+const HASH =
+  'ec07d0538e44a333b23b936c9a4ba37fbd211c6272e632d2173b6abe102a0482' as DocumentHash;
+
+const user: AuthenticatedUser = { id: 'user-id' } as AuthenticatedUser;
+
+type SignedUploadResult = Result<
+  { token: string; path: string },
+  DocumentStorageError
+>;
+
+type ServiceUnderTest = {
+  service: CreateUploadTokenService;
+  documentStorage: { createSignedUpload: Mock };
+};
+
+function buildService({
+  isAllowed = true,
+  hasBucket = true,
+  fichierId = undefined as number | undefined,
+  signedUploadResult = success({
+    token: 'jeton-signe',
+    path: HASH,
+  }) as SignedUploadResult,
+} = {}): ServiceUnderTest {
+  const permissions = {
+    isAllowed: vi
+      .fn()
+      .mockResolvedValue(
+        isAllowed
+          ? { success: true, data: undefined }
+          : { success: false, error: 'UNAUTHORIZED' }
+      ),
+  };
+
+  const repository = {
+    findFichierIdByHash: vi.fn().mockResolvedValue(fichierId),
+  };
+
+  const collectiviteBucket = {
+    findBucketId: vi
+      .fn()
+      .mockResolvedValue(hasBucket ? 'bucket-collectivite-1' : undefined),
+  };
+
+  const documentStorage = {
+    createSignedUpload: vi.fn().mockResolvedValue(signedUploadResult),
+  };
+
+  const service = new CreateUploadTokenService(
+    permissions as never,
+    repository as never,
+    collectiviteBucket as never,
+    documentStorage as never
+  );
+
+  return { service, documentStorage };
+}
+
+describe('CreateUploadTokenService', () => {
+  it('refuse un utilisateur sans droit de mutation sur la collectivite, sans signer', async () => {
+    const { service, documentStorage } = buildService({ isAllowed: false });
+
+    const result = await service.createUploadToken(
+      { collectiviteId: 1, hash: HASH },
+      { user }
+    );
+
+    expect(result).toEqual({ success: false, error: 'UNAUTHORIZED' });
+    expect(documentStorage.createSignedUpload).not.toHaveBeenCalled();
+  });
+
+  it('rend COLLECTIVITE_BUCKET_NOT_FOUND quand la collectivite na pas de bucket', async () => {
+    const { service, documentStorage } = buildService({ hasBucket: false });
+
+    const result = await service.createUploadToken(
+      { collectiviteId: 1, hash: HASH },
+      { user }
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: 'COLLECTIVITE_BUCKET_NOT_FOUND',
+    });
+    expect(documentStorage.createSignedUpload).not.toHaveBeenCalled();
+  });
+
+  it('rend alreadyInBibliotheque sans signer quand le document a deja sa ligne', async () => {
+    const { service, documentStorage } = buildService({ fichierId: 42 });
+
+    const result = await service.createUploadToken(
+      { collectiviteId: 1, hash: HASH },
+      { user }
+    );
+
+    expect(result).toEqual({
+      success: true,
+      data: { kind: 'alreadyInBibliotheque', fichierId: 42 },
+    });
+    expect(documentStorage.createSignedUpload).not.toHaveBeenCalled();
+  });
+
+  it('signe le hash dans le bucket resolu cote serveur', async () => {
+    const { service, documentStorage } = buildService();
+
+    const result = await service.createUploadToken(
+      { collectiviteId: 1, hash: HASH },
+      { user }
+    );
+
+    expect(result).toEqual({
+      success: true,
+      data: {
+        kind: 'readyToUpload',
+        token: 'jeton-signe',
+        bucketId: 'bucket-collectivite-1',
+        path: HASH,
+      },
+    });
+    expect(documentStorage.createSignedUpload).toHaveBeenCalledWith({
+      bucketId: 'bucket-collectivite-1',
+      key: HASH,
+    });
+  });
+
+  it('remonte SIGN_UPLOAD_ERROR quand la signature echoue', async () => {
+    const { service } = buildService({
+      signedUploadResult: failure(
+        DocumentStorageErrorEnum.WRITE_DOCUMENT_ERROR
+      ),
+    });
+
+    const result = await service.createUploadToken(
+      { collectiviteId: 1, hash: HASH },
+      { user }
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      error: 'SIGN_UPLOAD_ERROR',
+    });
+  });
+});

--- a/apps/backend/src/collectivites/documents/create-upload-token/create-upload-token.service.ts
+++ b/apps/backend/src/collectivites/documents/create-upload-token/create-upload-token.service.ts
@@ -1,0 +1,78 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { CollectiviteBucketRepository } from '@tet/backend/collectivites/documents/collectivite-bucket.repository';
+import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
+import { ServiceSecondArg } from '@tet/backend/utils/nest/service-second-arg.utils';
+import { failure, success, type Result } from '@tet/backend/utils/result.type';
+import { DocumentStorageService } from '@tet/backend/utils/supabase/document-storage.service';
+import { ResourceType } from '@tet/domain/users';
+import {
+  CreateUploadTokenError,
+  CreateUploadTokenErrorEnum,
+} from './create-upload-token.errors';
+import { CreateUploadTokenInput } from './create-upload-token.input';
+import { CreateUploadTokenOutput } from './create-upload-token.output';
+import { CreateUploadTokenRepository } from './create-upload-token.repository';
+
+@Injectable()
+export class CreateUploadTokenService {
+  private readonly logger = new Logger(CreateUploadTokenService.name);
+
+  constructor(
+    private readonly permissionService: PermissionService,
+    private readonly repository: CreateUploadTokenRepository,
+    private readonly collectiviteBucketRepository: CollectiviteBucketRepository,
+    private readonly documentStorageService: DocumentStorageService
+  ) {}
+
+  async createUploadToken(
+    { collectiviteId, hash }: CreateUploadTokenInput,
+    { user, tx }: ServiceSecondArg
+  ): Promise<Result<CreateUploadTokenOutput, CreateUploadTokenError>> {
+    const permissionResult = await this.permissionService.isAllowed(
+      user,
+      'collectivites.documents.mutate',
+      ResourceType.COLLECTIVITE,
+      { collectiviteId },
+      tx
+    );
+    if (!permissionResult.success) {
+      return failure(CreateUploadTokenErrorEnum.UNAUTHORIZED);
+    }
+
+    const bucketId = await this.collectiviteBucketRepository.findBucketId(
+      collectiviteId
+    );
+    if (bucketId === undefined) {
+      return failure(CreateUploadTokenErrorEnum.COLLECTIVITE_BUCKET_NOT_FOUND);
+    }
+
+    const fichierId = await this.repository.findFichierIdByHash({
+      collectiviteId,
+      hash,
+    });
+    if (fichierId !== undefined) {
+      return success({ kind: 'alreadyInBibliotheque', fichierId });
+    }
+
+    const signedUploadResult =
+      await this.documentStorageService.createSignedUpload({
+        bucketId,
+        key: hash,
+      });
+    if (!signedUploadResult.success) {
+      return failure(
+        CreateUploadTokenErrorEnum.SIGN_UPLOAD_ERROR,
+        signedUploadResult.cause
+      );
+    }
+
+    this.logger.log(`Upload token issued for hash ${hash}`);
+
+    return success({
+      kind: 'readyToUpload',
+      token: signedUploadResult.data.token,
+      bucketId,
+      path: signedUploadResult.data.path,
+    });
+  }
+}

--- a/apps/backend/src/collectivites/documents/documents.router.ts
+++ b/apps/backend/src/collectivites/documents/documents.router.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { TrpcService } from '@tet/backend/utils/trpc/trpc.service';
+import { CreateUploadTokenRouter } from './create-upload-token/create-upload-token.router';
 import { EditPreuveDocumentRouter } from './edit-preuve-document/edit-preuve-document.router';
 import { StoreDocumentRouter } from './store-document/store-document.router';
 import { UpdateDocumentRouter } from './update-document/update-document.router';
@@ -10,13 +11,15 @@ export class DocumentsRouter {
     private readonly trpc: TrpcService,
     private readonly storeDocumentRouter: StoreDocumentRouter,
     private readonly updateDocumentRouter: UpdateDocumentRouter,
-    private readonly editPreuveDocumentRouter: EditPreuveDocumentRouter
+    private readonly editPreuveDocumentRouter: EditPreuveDocumentRouter,
+    private readonly createUploadTokenRouter: CreateUploadTokenRouter
   ) {}
 
   router = this.trpc.mergeRouters(
     this.storeDocumentRouter.router,
     this.updateDocumentRouter.router,
-    this.editPreuveDocumentRouter.router
+    this.editPreuveDocumentRouter.router,
+    this.createUploadTokenRouter.router
   );
 
   createCaller = this.trpc.createCallerFactory(this.router);

--- a/apps/backend/src/demarches/pcaet/get-avis-file-url/get-avis-file-url.service.ts
+++ b/apps/backend/src/demarches/pcaet/get-avis-file-url/get-avis-file-url.service.ts
@@ -87,7 +87,7 @@ export class GetAvisFileUrlService {
     }
 
     const signedUrlResult =
-      await this.documentStorageService.createDocumentSignedUrl({
+      await this.documentStorageService.createSignedDownloadUrl({
         bucketId: fichier.bucketId,
         key: avis.fichierRef,
         expiresInSeconds: DOWNLOAD_URL_TTL_SECONDS,

--- a/apps/backend/src/demarches/pcaet/get-dossier-document-url/get-dossier-document-url.service.ts
+++ b/apps/backend/src/demarches/pcaet/get-dossier-document-url/get-dossier-document-url.service.ts
@@ -78,7 +78,7 @@ export class GetDossierDocumentUrlService {
     }
 
     const signedUrlResult =
-      await this.documentStorageService.createDocumentSignedUrl({
+      await this.documentStorageService.createSignedDownloadUrl({
         bucketId: fichier.bucketId,
         key: fichier.hash,
         expiresInSeconds: DOWNLOAD_URL_TTL_SECONDS,

--- a/apps/backend/src/referentiels/preuves-archive/get-preuves-archive/get-preuves-archive.service.spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/get-preuves-archive/get-preuves-archive.service.spec.ts
@@ -56,7 +56,7 @@ function buildService({
   } as unknown;
 
   const documentStorage = {
-    createDocumentSignedUrl: vi.fn().mockResolvedValue(signedUrlResult),
+    createSignedDownloadUrl: vi.fn().mockResolvedValue(signedUrlResult),
   } as unknown;
 
   return new GetPreuvesArchiveService(

--- a/apps/backend/src/referentiels/preuves-archive/get-preuves-archive/get-preuves-archive.service.ts
+++ b/apps/backend/src/referentiels/preuves-archive/get-preuves-archive/get-preuves-archive.service.ts
@@ -75,7 +75,7 @@ export class GetPreuvesArchiveService {
       archive.storagePath !== null &&
       !isExpired
     ) {
-      const signedUrlResult = await this.documentStorage.createDocumentSignedUrl({
+      const signedUrlResult = await this.documentStorage.createSignedDownloadUrl({
         bucketId: PREUVES_ARCHIVES_BUCKET,
         key: archive.storagePath,
         expiresInSeconds: ARCHIVE_DOWNLOAD_TTL_SECONDS,

--- a/apps/backend/src/referentiels/preuves-archive/preuves-archive.full-pipeline.e2e-spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/preuves-archive.full-pipeline.e2e-spec.ts
@@ -86,7 +86,7 @@ describe('Archive de preuves - pipeline complet (ZIP réel)', () => {
             await copyFile(sourceFilePath, capturedZipPath);
             return { success: true, data: { key } };
           },
-          createDocumentSignedUrl: async () => ({
+          createSignedDownloadUrl: async () => ({
             success: true,
             data: { signedUrl: 'https://fake.test/archive.zip' },
           }),

--- a/apps/backend/src/referentiels/preuves-archive/preuves-archive.router.e2e-spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/preuves-archive.router.e2e-spec.ts
@@ -44,7 +44,7 @@ describe('Archive de preuves - tRPC', () => {
           .overrideProvider(GeneratePreuvesArchiveWorker)
           .useValue({ onModuleInit: () => undefined });
         moduleBuilder.overrideProvider(DocumentStorageService).useValue({
-          createDocumentSignedUrl: async () => ({
+          createSignedDownloadUrl: async () => ({
             success: true,
             data: { signedUrl: FAKE_SIGNED_URL },
           }),

--- a/apps/backend/src/utils/supabase/document-storage.service.ts
+++ b/apps/backend/src/utils/supabase/document-storage.service.ts
@@ -22,7 +22,7 @@ export type StoreDocumentInput = DocumentLocation & {
   contentType: string;
 } & ({ sourceFilePath: string } | { content: Buffer });
 
-export type CreateDocumentSignedUrlInput = DocumentLocation & {
+export type CreateSignedDownloadUrlInput = DocumentLocation & {
   expiresInSeconds: number;
 };
 
@@ -115,8 +115,8 @@ export class DocumentStorageService {
     }
   }
 
-  async createDocumentSignedUrl(
-    input: CreateDocumentSignedUrlInput
+  async createSignedDownloadUrl(
+    input: CreateSignedDownloadUrlInput
   ): Promise<Result<{ signedUrl: string }, DocumentStorageError>> {
     const { bucketId, key, expiresInSeconds } = input;
     try {
@@ -147,9 +147,43 @@ export class DocumentStorageService {
     }
   }
 
+  async createSignedUpload(
+    input: DocumentLocation
+  ): Promise<Result<{ token: string; path: string }, DocumentStorageError>> {
+    const { bucketId, key } = input;
+    try {
+      const { data, error } = await this.supabase.client.storage
+        .from(bucketId)
+        .createSignedUploadUrl(key, { upsert: false });
+
+      if (error || !data) {
+        this.logger.error(
+          `Signature d'upload impossible pour ${bucketId}/${key}: ${
+            error?.message ?? 'réponse vide'
+          }`
+        );
+        return failure(DocumentStorageErrorEnum.WRITE_DOCUMENT_ERROR);
+      }
+
+      return success({ token: data.token, path: data.path });
+    } catch (error) {
+      this.logger.error(
+        `Erreur de signature d'upload pour ${bucketId}/${key}: ${getErrorMessage(
+          error
+        )}`
+      );
+      return failure(
+        DocumentStorageErrorEnum.WRITE_DOCUMENT_ERROR,
+        error instanceof Error ? error : new Error(getErrorMessage(error))
+      );
+    }
+  }
+
   async downloadDocument(
     input: DocumentLocation
-  ): Promise<Result<{ buffer: Buffer; mimeType: string }, DocumentStorageError>> {
+  ): Promise<
+    Result<{ buffer: Buffer; mimeType: string }, DocumentStorageError>
+  > {
     const { bucketId, key } = input;
     try {
       const { data, error } = await this.supabase.client.storage

--- a/packages/domain/src/collectivites/documents/bibliotheque-fichier.schema.spec.ts
+++ b/packages/domain/src/collectivites/documents/bibliotheque-fichier.schema.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import {
+  bibliothequeFichierSchemaCreate,
+  documentHashSchema,
+} from './bibliotheque-fichier.schema';
+
+const VALID_SHA256 =
+  'ec07d0538e44a333b23b936c9a4ba37fbd211c6272e632d2173b6abe102a0482';
+
+describe('documentHashSchema', () => {
+  it('accepte une empreinte SHA-256 de 64 caracteres hexadecimaux minuscules', () => {
+    expect(documentHashSchema.safeParse(VALID_SHA256).success).toBe(true);
+  });
+
+  it.each([
+    ['une remontee de repertoire', '../autreBucket/document'],
+    ['une remontee encodee', '%2e%2e/autreBucket/document'],
+    ['un separateur de chemin', 'autreBucket/' + VALID_SHA256],
+    ['une casse qui designerait un autre objet', VALID_SHA256.toUpperCase()],
+  ])('refuse %s', (_case, hash) => {
+    expect(documentHashSchema.safeParse(hash).success).toBe(false);
+  });
+});
+
+describe('bibliothequeFichierSchemaCreate', () => {
+  it('refuse un hash qui designe le bucket d une autre collectivite', () => {
+    const result = bibliothequeFichierSchemaCreate.safeParse({
+      collectiviteId: 1,
+      hash: '../autreBucket/document',
+      filename: 'document.pdf',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('accepte une creation dont le hash est une empreinte SHA-256', () => {
+    const result = bibliothequeFichierSchemaCreate.safeParse({
+      collectiviteId: 1,
+      hash: VALID_SHA256,
+      filename: 'document.pdf',
+    });
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/domain/src/collectivites/documents/bibliotheque-fichier.schema.ts
+++ b/packages/domain/src/collectivites/documents/bibliotheque-fichier.schema.ts
@@ -1,5 +1,12 @@
 import * as z from 'zod';
 
+export const documentHashSchema = z
+  .string()
+  .regex(
+    /^[0-9a-f]{64}$/,
+    'Le hash doit être une empreinte SHA-256 en hexadécimal minuscule'
+  );
+
 export const bibliothequeFichierSchema = z.object({
   id: z.number(),
   collectiviteId: z.number(),
@@ -12,7 +19,7 @@ export type BibliothequeFichier = z.infer<typeof bibliothequeFichierSchema>;
 
 export const bibliothequeFichierSchemaCreate = z.object({
   collectiviteId: z.number().int().positive(),
-  hash: z.string().min(1),
+  hash: documentHashSchema,
   filename: z.string().min(1),
   confidentiel: z.optional(z.nullable(z.boolean())),
 });


### PR DESCRIPTION
Première PR d'une pile qui fait passer le dépôt de documents par le backend. Elle pose le contrat côté serveur ; **aucun front ne la consomme encore**.

## Ce que fait l'endpoint

`collectivites.documents.createUploadToken` autorise le dépôt d'un fichier dans le bucket d'une collectivité et rend le jeton signé qui permet de le téléverser, sans que le client détienne de credential Supabase.

```ts
createUploadToken({ collectiviteId, hash }): Result<
  | { kind: 'alreadyInBibliotheque'; fichierId: number }
  | { kind: 'readyToUpload'; token: string; bucketId: string; path: string },
  'UNAUTHORIZED' | 'COLLECTIVITE_BUCKET_NOT_FOUND' | 'SIGN_UPLOAD_ERROR'
>
```

Le contrôle de droit — `collectivites.documents.mutate` sur la collectivité — précède tout effet : aucune signature n'est produite pour un utilisateur refusé, ni pour un document déjà présent en bibliothèque.

## Le bucket est dicté, jamais reçu

Le `bucketId` est résolu côté serveur depuis `collectiviteId` et figure dans la réponse, parce que le client doit le déclarer au moment du dépôt. Il n'est jamais accepté en entrée. Le jeton scelle la paire bucket/chemin : un client qui déclarerait une autre cible est refusé par le stockage.

## Le hash doit être une empreinte

`documentHashSchema` impose `/^[0-9a-f]{64}$/`, sur ce nouvel endpoint comme sur `documents.create`. Sans cette contrainte, un chemin de la forme `../autreBucket/x` obtiendrait une signature d'écriture dans le bucket d'une autre collectivité — une capacité qui n'existe pas aujourd'hui. La contrainte porte aussi une marque de type sur l'entrée de l'endpoint : un appelant interne du service ne peut pas lui passer une chaîne arbitraire.

La marque reste locale à ce chemin. La colonne `hash` de `bibliotheque_fichier` accueille par ailleurs des identifiants qui ne sont pas des empreintes — la génération de rapports PPTX y stocke un uuid — et le schéma de lecture reste volontairement permissif.

## Un objet orphelin ne fait pas court-circuiter le dépôt

Un objet déposé sans sa ligne de bibliothèque ne dispense pas du téléversement : le jeton est émis, et le dépôt se heurte à l'objet en place. Traiter cette collision comme un succès permettrait à un membre de pré-déposer un contenu arbitraire sur l'empreinte d'un document qu'un tiers va déposer, et de voir la ligne créée pointer sur son contenu — que `upsert: false` interdirait ensuite de remplacer.

Le nettoyage des objets orphelins, qui est la cause, relève d'un travail à part.

## Deux propriétés à connaître pour la suite de la pile

L'endpoint exige `documents.mutate`, là où la policy RLS du bucket autorise l'écriture à tout rôle sur la collectivité, lecture comprise. Le chemin par jeton est donc plus strict que le chemin direct.

Il ne transite pas par la route multipart, dont le plafond de 15 Mo ne s'applique donc pas. La taille devra être portée par `storage.buckets.file_size_limit`, aujourd'hui nul.

## Renommages

`createDocumentSignedUrl` devient `createSignedDownloadUrl` : le sens de la signature n'est plus déductible du nom depuis qu'une signature d'écriture existe à côté. La nouvelle méthode s'appelle `createSignedUpload` et non `…Url`, ne rendant aucune URL.

La résolution du bucket sort dans un `CollectiviteBucketRepository` partagé, et sa sélection est ordonnée — la table admet plusieurs buckets par collectivité.

## Tests

Le refus d'un hash désignant un autre bucket, le refus d'un membre en lecture seule, le refus d'un non-membre, l'absence de bucket, et le fait qu'aucune signature ne sorte sur les chemins de refus.

Le cas nominal de l'e2e exige la clé service-role déchiffrée et ne tourne donc qu'en CI.
