### PR TITLE
refactor(indicateurs): la config des trajectoires dérive le secteur du domaine

### DIFF
--- a/apps/backend/src/indicateurs/trajectoire-leviers/trajectoire-leviers.config.spec.ts
+++ b/apps/backend/src/indicateurs/trajectoire-leviers/trajectoire-leviers.config.spec.ts
@@ -21,4 +21,92 @@ describe('TRAJECTOIRE_LEVIERS_CONFIGURATION', () => {
 
     expect(configuredSecteurs).toEqual(LEVIER_SECTEURS);
   });
+
+  it('expose les secteurs et leurs leviers dans un ordre stable', () => {
+    const structure = TRAJECTOIRE_LEVIERS_CONFIGURATION.secteurs.map(
+      (secteur) => ({
+        nom: secteur.nom,
+        identifiants: secteur.identifiants,
+        leviers: secteur.leviers.map((levier) => levier.nom),
+      })
+    );
+
+    expect(structure).toEqual([
+      {
+        nom: 'Résidentiel',
+        identifiants: ['cae_1.c'],
+        leviers: [
+          'Changement chaudières fioul + rénovation (résidentiel)',
+          'Changement chaudières gaz + rénovation (résidentiel)',
+          'Sobriété des bâtiments (résidentiel)',
+        ],
+      },
+      {
+        nom: 'Tertiaire',
+        identifiants: ['cae_1.d'],
+        leviers: [
+          'Changement de chaudière à fioul (tertiaire)',
+          'Changement de chaudière à gaz (tertiaire)',
+          'Sobriété et isolation des bâtiments (tertiaire)',
+        ],
+      },
+      {
+        nom: 'Transports',
+        identifiants: ['cae_1.k'],
+        leviers: [
+          'Réduction des déplacements',
+          'Covoiturage',
+          'Vélo et transport en commun',
+          'Véhicules électriques',
+          'Efficacité et carburants décarbonés des véhicules privés',
+          'Bus et cars décarbonés',
+          'Fret décarboné et multimodalité',
+          'Efficacité et sobriété logistique',
+        ],
+      },
+      {
+        nom: 'Agriculture',
+        identifiants: ['cae_1.g'],
+        leviers: [
+          'Bâtiments & Machines agricoles',
+          'Elevage durable',
+          'Changements de pratiques de fertilisation azotée',
+        ],
+      },
+      {
+        nom: 'UTCATF',
+        identifiants: ['cae_63.a'],
+        leviers: [
+          'Gestion des forêts et produits bois',
+          'Pratiques stockantes',
+          'Gestion des haies',
+          'Gestion des prairies',
+          'Sobriété foncière',
+        ],
+      },
+      {
+        nom: 'Industrie',
+        identifiants: ['cae_1.i', 'cae_1.csc'],
+        leviers: ['Production industrielle'],
+      },
+      {
+        nom: 'Déchets',
+        identifiants: ['cae_1.h'],
+        leviers: [
+          'Captage de méthane dans les ISDND',
+          'Prévention des déchets',
+          'Valorisation matière des déchets',
+        ],
+      },
+      {
+        nom: 'Branche énergie',
+        identifiants: ['cae_1.j'],
+        leviers: [
+          'Electricité renouvelable',
+          'Biogaz',
+          'Réseaux de chaleur décarbonés',
+        ],
+      },
+    ]);
+  });
 });

--- a/apps/backend/src/indicateurs/trajectoire-leviers/trajectoire-leviers.config.ts
+++ b/apps/backend/src/indicateurs/trajectoire-leviers/trajectoire-leviers.config.ts
@@ -1,4 +1,4 @@
-import { Levier } from '@tet/domain/shared';
+import { LEVIER_SECTEURS, Levier } from '@tet/domain/shared';
 import {
   TrajectoireSecteursEnum,
   TrajectoireSecteursType,
@@ -68,8 +68,7 @@ const createUniformPercentage = (percentage: number): PourcentagesRegionaux => {
   return result as PourcentagesRegionaux;
 };
 
-// Configuration des leviers par secteur
-const LEVIERS_RESIDENTIEL: LevierConfiguration[] = [
+const LEVIERS: LevierConfiguration[] = [
   {
     nom: 'Changement chaudières fioul + rénovation (résidentiel)',
     pourcentagesRegionaux: createPourcentagesRegionaux({
@@ -124,9 +123,7 @@ const LEVIERS_RESIDENTIEL: LevierConfiguration[] = [
       PROVENCE_ALPES_COTE_AZUR: 26,
     }),
   },
-];
 
-const LEVIERS_TERTIAIRE: LevierConfiguration[] = [
   {
     nom: 'Changement de chaudière à fioul (tertiaire)',
     pourcentagesRegionaux: createPourcentagesRegionaux({
@@ -181,9 +178,7 @@ const LEVIERS_TERTIAIRE: LevierConfiguration[] = [
       PROVENCE_ALPES_COTE_AZUR: 53,
     }),
   },
-];
 
-const LEVIERS_TRANSPORTS: LevierConfiguration[] = [
   {
     nom: 'Réduction des déplacements',
     pourcentagesRegionaux: createPourcentagesRegionaux({
@@ -328,9 +323,7 @@ const LEVIERS_TRANSPORTS: LevierConfiguration[] = [
       PROVENCE_ALPES_COTE_AZUR: 25,
     }),
   },
-];
 
-const LEVIERS_AGRICULTURE: LevierConfiguration[] = [
   {
     nom: 'Bâtiments & Machines agricoles',
     sousSecteursIdentifiants: ['cae_1.ga'],
@@ -346,9 +339,7 @@ const LEVIERS_AGRICULTURE: LevierConfiguration[] = [
     sousSecteursIdentifiants: ['cae_1.gc'],
     pourcentagesRegionaux: createUniformPercentage(100),
   },
-];
 
-const LEVIERS_UTCATF: LevierConfiguration[] = [
   {
     nom: 'Gestion des forêts et produits bois',
     sousSecteursIdentifiants: ['cae_63.b', 'cae_63.e'],
@@ -402,16 +393,12 @@ const LEVIERS_UTCATF: LevierConfiguration[] = [
     sousSecteursIdentifiants: ['cae_63.db'],
     pourcentagesRegionaux: createUniformPercentage(100),
   },
-];
 
-const LEVIERS_INDUSTRIE: LevierConfiguration[] = [
   {
     nom: 'Production industrielle',
     pourcentagesRegionaux: createUniformPercentage(100),
   },
-];
 
-const LEVIERS_DECHETS: LevierConfiguration[] = [
   {
     nom: 'Captage de méthane dans les ISDND',
     pourcentagesRegionaux: createPourcentagesRegionaux({
@@ -466,9 +453,7 @@ const LEVIERS_DECHETS: LevierConfiguration[] = [
       PROVENCE_ALPES_COTE_AZUR: 40,
     }),
   },
-];
 
-const LEVIERS_ENERGIE: LevierConfiguration[] = [
   {
     nom: 'Electricité renouvelable',
     pourcentagesRegionaux: createPourcentagesRegionaux({
@@ -525,50 +510,30 @@ const LEVIERS_ENERGIE: LevierConfiguration[] = [
   },
 ];
 
+const SECTEURS_INDICATEURS = [
+  { nom: TrajectoireSecteursEnum.RÉSIDENTIEL, identifiants: ['cae_1.c'] },
+  { nom: TrajectoireSecteursEnum.TERTIAIRE, identifiants: ['cae_1.d'] },
+  { nom: TrajectoireSecteursEnum.TRANSPORTS, identifiants: ['cae_1.k'] },
+  { nom: TrajectoireSecteursEnum.AGRICULTURE, identifiants: ['cae_1.g'] },
+  { nom: TrajectoireSecteursEnum.UTCATF, identifiants: ['cae_63.a'] },
+  {
+    nom: TrajectoireSecteursEnum.INDUSTRIE,
+    identifiants: ['cae_1.i', 'cae_1.csc'],
+  },
+  { nom: TrajectoireSecteursEnum.DÉCHETS, identifiants: ['cae_1.h'] },
+  {
+    nom: TrajectoireSecteursEnum['BRANCHE ÉNERGIE'],
+    identifiants: ['cae_1.j'],
+  },
+] as const satisfies readonly Omit<SecteurConfiguration, 'leviers'>[];
+
 export const TRAJECTOIRE_LEVIERS_CONFIGURATION: TrajectoireLeviersRegionConfiguration =
   {
-    secteurs: [
-      {
-        nom: TrajectoireSecteursEnum.RÉSIDENTIEL,
-        identifiants: ['cae_1.c'],
-        leviers: LEVIERS_RESIDENTIEL,
-      },
-      {
-        nom: TrajectoireSecteursEnum.TERTIAIRE,
-        identifiants: ['cae_1.d'],
-        leviers: LEVIERS_TERTIAIRE,
-      },
-      {
-        nom: TrajectoireSecteursEnum.TRANSPORTS,
-        identifiants: ['cae_1.k'],
-        leviers: LEVIERS_TRANSPORTS,
-      },
-      {
-        nom: TrajectoireSecteursEnum.AGRICULTURE,
-        identifiants: ['cae_1.g'],
-        leviers: LEVIERS_AGRICULTURE,
-      },
-      {
-        nom: TrajectoireSecteursEnum.UTCATF,
-        identifiants: ['cae_63.a'],
-        leviers: LEVIERS_UTCATF,
-      },
-      {
-        nom: TrajectoireSecteursEnum.INDUSTRIE,
-        identifiants: ['cae_1.i', 'cae_1.csc'],
-        leviers: LEVIERS_INDUSTRIE,
-      },
-      {
-        nom: TrajectoireSecteursEnum.DÉCHETS,
-        identifiants: ['cae_1.h'],
-        leviers: LEVIERS_DECHETS,
-      },
-      {
-        nom: TrajectoireSecteursEnum['BRANCHE ÉNERGIE'],
-        identifiants: ['cae_1.j'],
-        leviers: LEVIERS_ENERGIE,
-      },
-    ],
+    secteurs: SECTEURS_INDICATEURS.map(({ nom, identifiants }) => ({
+      nom,
+      identifiants: [...identifiants],
+      leviers: LEVIERS.filter((levier) => LEVIER_SECTEURS[levier.nom] === nom),
+    })),
   };
 
 export const TRAJECTOIRE_LEVIERS_INDICATEURS_IDENTIFIANTS: string[] =


### PR DESCRIPTION
Le rattachement d'un levier à son secteur vivait à deux endroits : `LEVIER_SECTEURS` dans `@tet/domain/shared`, et le découpage de `trajectoire-leviers.config.ts` en huit tableaux `LEVIERS_RESIDENTIEL`, `LEVIERS_TERTIAIRE`… Rien ne garantissait leur accord, et déplacer un levier d'un secteur à l'autre dans la config passait inaperçu.

Le domaine devient la seule source de cette relation.

## Ce qui change dans la config

Les huit tableaux fusionnent en un `LEVIERS` unique, qui ne porte plus que ce qui lui est propre — pourcentages régionaux et sous-secteurs. Ce qui appartient au secteur seul, son ordre d'exposition et ses identifiants d'indicateurs, reste explicite :

```ts
const SECTEURS_INDICATEURS = [
  { nom: TrajectoireSecteursEnum.RÉSIDENTIEL, identifiants: ['cae_1.c'] },
  ...
] as const satisfies readonly Omit<SecteurConfiguration, 'leviers'>[];

export const TRAJECTOIRE_LEVIERS_CONFIGURATION = {
  secteurs: SECTEURS_INDICATEURS.map(({ nom, identifiants }) => ({
    nom,
    identifiants: [...identifiants],
    leviers: LEVIERS.filter((levier) => LEVIER_SECTEURS[levier.nom] === nom),
  })),
};
```

L'ordre des secteurs reste énoncé plutôt que déduit de l'ordre d'apparition des leviers : il est observable, `trajectoire-leviers.service.ts` en fait un `map`, et le laisser émerger d'un regroupement en aurait fait un effet de bord.

## Pourquoi la structure est bien inchangée

Le premier commit pose un test de caractérisation qui énonce, dans l'ordre, les huit secteurs, leurs identifiants d'indicateurs et la liste ordonnée de leurs leviers. Il a été écrit et vérifié **sur le code d'avant**, et passe sans modification après le refactor.

Les `LevierConfiguration` sont les mêmes objets, seulement redistribués : les pourcentages régionaux et les `sousSecteursIdentifiants` ne sont pas touchés.

## Vérifications

`trajectoire-leviers.config.spec.ts` et `trajectoire-leviers.service.spec.ts` sont verts. Les deux specs e2e du dossier échouent en local sur le chargement des identifiants Google — vérifié identique avant le refactor, sur le même environnement.
