### PR TITLE
TET-7416: Dockerfile natifs pour app/site/panier/backend/tools

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -63,7 +63,12 @@ strapi
 infra
 doc
 .agents
+# `.claude` seul ne matche que le répertoire : un motif sans joker est comparé
+# au nom complet, donc `.claude.local.md` (override perso, cf. CLAUDE.md)
+# resterait dans le contexte et invaliderait le `COPY . .` de l'étape builder à
+# chaque fois qu'il change.
 .claude
+.claude.local.md
 
 # `e2e` est un package du workspace (cf. pnpm-workspace.yaml) : son
 # package.json doit rester dans le contexte, sinon `pnpm install

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,83 @@
+# Le contexte de build est la racine du repo (monorepo pnpm) : chaque
+# apps/*/Dockerfile est buildé avec `docker build -f apps/<app>/Dockerfile .`
+# Ce fichier garde ce contexte petit et évite de faire fuiter des artefacts
+# locaux (node_modules, builds précédents, secrets .env) dans les images.
+
+.git
+.github
+
+# dependencies (réinstallées dans l'image, jamais copiées depuis l'hôte)
+# Motifs en double (racine + **/) : un motif sans "**/" ne matche qu'à la
+# racine du contexte, pas dans apps/*/ ou packages/*/ (vérifié : sans le
+# doublon, apps/app/.next à lui seul faisait gonfler le contexte à 7 Go).
+node_modules
+**/node_modules
+.pnpm-store
+**/.pnpm-store
+
+# builds précédents / caches (régénérés dans l'image)
+dist
+**/dist
+out-tsc
+**/out-tsc
+.next
+**/.next
+.nx
+**/.nx
+tmp
+**/tmp
+storybook-static
+**/storybook-static
+coverage
+**/coverage
+*.tsbuildinfo
+**/*.tsbuildinfo
+.tsc-trace
+**/.tsc-trace
+.swc
+**/.swc
+
+# tests / e2e
+**/test-results/
+**/playwright-report/
+**/playwright/.auth/
+**/blob-report/
+**/playwright/.cache/
+**/__tests__/__output__/
+
+# secrets / config locale — les images reçoivent leur config via build args,
+# jamais via un .env committé
+.env
+.env.*
+.env.keys*
+!.env.example
+keyfile.json
+
+# répertoires jamais nécessaires à un build d'app : les exclure garde le
+# contexte petit ET évite qu'une modification qui n'a rien à voir (migration
+# SQL, spec e2e, note de doc) invalide les couches de build.
+data_layer
+supabase
+api_tests
+strapi
+infra
+doc
+.agents
+.claude
+
+# `e2e` est un package du workspace (cf. pnpm-workspace.yaml) : son
+# package.json doit rester dans le contexte, sinon `pnpm install
+# --frozen-lockfile` échoue sur un manifest manquant. Le reste ne sert à
+# aucune image.
+e2e/**
+!e2e/package.json
+
+# divers
+.DS_Store
+.idea
+.vscode
+docker-data
+.docker/node-base-build.log
+earthly-build
+worktrees
+.context

--- a/apps/app/Dockerfile
+++ b/apps/app/Dockerfile
@@ -1,0 +1,112 @@
+# syntax=docker/dockerfile:1-labs
+#
+# Build with the repo root as context:
+#   docker build -f apps/app/Dockerfile \
+#     --build-arg ANON_KEY=... --build-arg API_URL=... --build-arg APP_URL=... \
+#     --secret id=bryntum_token,env=BRYNTUM_ACCESS_TOKEN \
+#     --secret id=sentry_auth_token,env=SENTRY_AUTH_TOKEN \
+#     -t app .
+#
+# Adapted from the official Next.js Docker example
+# (https://github.com/vercel/next.js/blob/canary/examples/with-docker/Dockerfile)
+# for this pnpm/Nx monorepo: dependencies are declared only in the root
+# package.json (per-app package.json files carry no deps), so `pnpm install`
+# always runs against the full workspace.
+#
+# Découpage fetch / manifests / builder : voir apps/backend/Dockerfile pour le
+# détail (le `pnpm fetch` initial ne dépend que du lockfile, l'install ne
+# dépend que des manifests, les sources n'arrivent qu'après).
+
+# Épinglée par digest — cf. apps/backend/Dockerfile. Pour bumper :
+# `docker buildx imagetools inspect node:24-alpine`.
+ARG NODE_IMAGE=node:24.21.0-alpine@sha256:be80f76cf40ec8e42b9bec49f60a55e0660f30af58d3e5a25530785b30ea67e2
+ARG PNPM_VERSION=9.15.5
+
+FROM ${NODE_IMAGE} AS base
+ARG PNPM_VERSION
+# https://github.com/nodejs/docker-node/tree/main#nodealpine — required for
+# native addons (sharp, @swc/core) to run correctly on musl libc.
+RUN apk add --no-cache libc6-compat
+WORKDIR /workspace
+ENV CI=true
+RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
+
+# The @bryntum scope is a private registry (see .npmrc); the token is only
+# needed for these layers and must never land in an image layer or its history.
+FROM base AS fetch
+COPY pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+RUN --mount=type=secret,id=bryntum_token,env=BRYNTUM_ACCESS_TOKEN \
+    pnpm fetch
+
+FROM fetch AS builder
+COPY --parents package.json apps/*/package.json packages/*/package.json e2e/package.json ./
+RUN --mount=type=secret,id=bryntum_token,env=BRYNTUM_ACCESS_TOKEN \
+    pnpm install -r --offline --frozen-lockfile
+
+COPY . .
+
+ARG ANON_KEY
+ARG API_URL
+ARG APP_URL
+ARG PANIER_URL
+ARG BACKEND_URL
+ARG CRISP_WEBSITE_ID
+ARG SENTRY_DSN
+ARG GIT_SHORT_HASH
+ARG GIT_COMMIT_TIMESTAMP
+ARG APPLICATION_VERSION
+ARG ENV_NAME
+
+# NEXT_PUBLIC_* vars are inlined into the client bundle at build time, so
+# each (env, deployment target) combination needs its own image — same
+# constraint as before, just made explicit here.
+ENV NEXT_TELEMETRY_DISABLED=1 \
+    NEXT_PUBLIC_GIT_SHORT_HASH=$GIT_SHORT_HASH \
+    NEXT_PUBLIC_GIT_COMMIT_TIMESTAMP=$GIT_COMMIT_TIMESTAMP \
+    NEXT_PUBLIC_APPLICATION_VERSION=$APPLICATION_VERSION \
+    NEXT_PUBLIC_ENV_NAME=$ENV_NAME \
+    NEXT_PUBLIC_SUPABASE_ANON_KEY=$ANON_KEY \
+    NEXT_PUBLIC_SUPABASE_URL=$API_URL \
+    NEXT_PUBLIC_APP_URL=$APP_URL \
+    NEXT_PUBLIC_PANIER_URL=$PANIER_URL \
+    NEXT_PUBLIC_BACKEND_URL=$BACKEND_URL \
+    NEXT_PUBLIC_CRISP_WEBSITE_ID=$CRISP_WEBSITE_ID \
+    NEXT_PUBLIC_SENTRY_DSN=$SENTRY_DSN
+
+# SENTRY_AUTH_TOKEN is only used by the Sentry build plugin to upload source
+# maps; kept out of ENV so it never gets baked into the image. The bryntum
+# secret here just silences pnpm's harmless "can't resolve
+# ${BRYNTUM_ACCESS_TOKEN} in .npmrc" warning (next build doesn't re-install).
+RUN --mount=type=secret,id=sentry_auth_token,env=SENTRY_AUTH_TOKEN \
+    --mount=type=secret,id=bryntum_token,env=BRYNTUM_ACCESS_TOKEN \
+    pnpm run build:app
+
+FROM ${NODE_IMAGE} AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production \
+    NEXT_TELEMETRY_DISABLED=1 \
+    PORT=3000 \
+    HOSTNAME=0.0.0.0
+
+RUN addgroup --system --gid 1001 nodejs \
+ && adduser --system --uid 1001 nextjs
+
+COPY --from=builder /workspace/apps/app/public ./apps/app/public
+
+# Pre-create with the right ownership: the standalone copy below won't
+# include an empty .next/cache, and Next needs to write there (ISR cache).
+RUN mkdir -p apps/app/.next && chown nextjs:nodejs apps/app/.next
+
+# next.config.ts sets `output: 'standalone'`; Next detects the pnpm-lock.yaml
+# at the monorepo root and nests the trimmed output under apps/app/, hence
+# the apps/app/server.js path below.
+# https://nextjs.org/docs/app/api-reference/config/next-config-js/output
+COPY --from=builder --chown=nextjs:nodejs /workspace/apps/app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /workspace/apps/app/.next/static ./apps/app/.next/static
+
+USER nextjs
+
+EXPOSE 3000
+
+CMD ["node", "apps/app/server.js"]

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -1,0 +1,139 @@
+# syntax=docker/dockerfile:1-labs
+#
+# Build with the repo root as context:
+#   docker build -f apps/backend/Dockerfile \
+#     --build-arg GIT_SHORT_HASH=... --build-arg GIT_COMMIT_TIMESTAMP=... \
+#     --build-arg APPLICATION_VERSION=... \
+#     --secret id=bryntum_token,env=BRYNTUM_ACCESS_TOKEN \
+#     -t backend .
+#
+# `1-labs` (et non `1`) pour `COPY --parents`, qui permet de copier les
+# manifests du workspace en conservant leur arborescence — voir l'étape
+# `manifests` plus bas.
+#
+# NestJS has no official Docker image guide for pnpm/Nx monorepos, so this
+# follows Docker's general multi-stage best practices (build tools never
+# reach the final image; run as a non-root user) plus two repo specifics:
+#
+# - All dependencies live in the root package.json (per-app package.json
+#   files carry no `dependencies`), so `pnpm install` always targets the
+#   whole workspace, and the backend needs the *compiled* output of the
+#   `@tet/domain`, `@tet/design-tokens` and `@tet/pdf-components` workspace
+#   packages (their package.json "exports" point at dist/, not src/).
+# - `canvas` needs cairo/pango/jpeg/gif/rsvg native libraries to compile,
+#   and `.npmrc` sets `ignore-scripts=true` (supply-chain hardening), so its
+#   postinstall never runs automatically — `pnpm rebuild canvas` after
+#   install is required, same as in .github/actions/node-canvas.
+
+# Image de base épinglée par digest : `node:24-slim` flotterait sur le
+# dernier patch 24.x publié, et deux déploiements à une semaine d'écart
+# pourraient partir sur des versions de Node différentes sans qu'aucun diff
+# ne l'explique. Pour bumper : `docker buildx imagetools inspect node:24-slim`
+# puis reporter tag + digest ici et dans les autres apps/*/Dockerfile.
+ARG NODE_IMAGE=node:24.21.0-slim@sha256:2fe369e969550cde8e867afc3fe370b260140cab4a23d467074295b42163d553
+# Aligné sur le champ `packageManager` de la racine (corepack prepare pnpm@9
+# résoudrait le dernier 9.x du jour, encore un input non épinglé).
+ARG PNPM_VERSION=9.15.5
+
+FROM ${NODE_IMAGE} AS base
+ARG PNPM_VERSION
+WORKDIR /workspace
+ENV CI=true
+RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
+
+# ---- store pnpm ----
+# `pnpm fetch` ne lit que le lockfile : cette couche — la seule qui accède au
+# réseau — n'est invalidée que quand pnpm-lock.yaml change, jamais par une
+# modification de source. C'est ce qui rend `--cache-from type=gha` utile.
+#
+# Un `RUN --mount=type=cache` ne suffirait pas : son contenu est local au
+# builder et n'est PAS exporté par `--cache-to`. Sur des runners éphémères il
+# repart vide à chaque exécution.
+FROM base AS fetch
+COPY pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+RUN --mount=type=secret,id=bryntum_token,env=BRYNTUM_ACCESS_TOKEN \
+    pnpm fetch
+
+# ---- manifests du workspace ----
+# Copiés seuls, avant les sources : les deux `pnpm install` ci-dessous ne
+# dépendent que d'eux, donc leur couche reste en cache tant qu'aucun
+# package.json ne bouge. Copier tout le contexte avant l'install (ce que
+# faisait la version précédente) faisait invalider l'install par n'importe
+# quel fichier du repo — une migration SQL, un spec e2e, un README — donc un
+# install complet du workspace à chaque déploiement.
+FROM fetch AS manifests
+COPY --parents package.json apps/*/package.json packages/*/package.json e2e/package.json ./
+
+# ---- production node_modules (with canvas compiled) ----
+# Built as its own stage so build-essential and the *-dev headers never end
+# up in the final image: only the resulting node_modules/ is copied over.
+FROM manifests AS deps-prod
+# python3 : le script d'install de canvas est `prebuild-install -r napi ||
+# node-gyp rebuild`. Sans python3, la branche de repli node-gyp ne peut pas
+# s'exécuter — le jour où aucun binaire préconstruit n'est disponible (nouvel
+# ABI Node, GitHub releases injoignable), le build échouerait sur un
+# « Could not find any Python installation » au lieu de compiler.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      build-essential pkg-config python3 \
+      libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev \
+    && rm -rf /var/lib/apt/lists/*
+# --offline : tout est déjà dans le store depuis l'étape `fetch`, aucun accès
+# réseau ici.
+RUN --mount=type=secret,id=bryntum_token,env=BRYNTUM_ACCESS_TOKEN \
+    pnpm install -r --offline --frozen-lockfile --prod \
+ && pnpm rebuild canvas
+
+# ---- build (full deps, incl. @nestjs/cli / swc / typescript) ----
+FROM manifests AS builder
+RUN --mount=type=secret,id=bryntum_token,env=BRYNTUM_ACCESS_TOKEN \
+    pnpm install -r --offline --frozen-lockfile
+COPY . .
+# `nx build backend` (aliased by this script) also builds the workspace
+# packages it depends on: domain, design-tokens, pdf-components.
+# The secret mount here just silences pnpm's harmless "can't resolve
+# ${BRYNTUM_ACCESS_TOKEN} in .npmrc" warning (nx doesn't re-install).
+RUN --mount=type=secret,id=bryntum_token,env=BRYNTUM_ACCESS_TOKEN \
+    pnpm run build:backend
+
+# ---- runtime ----
+FROM ${NODE_IMAGE} AS runner
+WORKDIR /app
+
+# Runtime-only shared libs for canvas (no -dev headers, no compiler) +
+# fontconfig/fonts-liberation for PDF generation + the fr_FR locale used by
+# date/number formatting in generated documents.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      libcairo2 libpango-1.0-0 libjpeg62-turbo libgif7 librsvg2-2 \
+      fontconfig fonts-liberation locales dumb-init \
+    && sed -i '/fr_FR.UTF-8/s/^# //' /etc/locale.gen \
+    && locale-gen fr_FR.UTF-8 \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV LANG=fr_FR.UTF-8 \
+    NODE_ENV=production \
+    PORT=3000 \
+    APPLICATION_NAME=backend
+
+ARG GIT_SHORT_HASH
+ARG GIT_COMMIT_TIMESTAMP
+ARG APPLICATION_VERSION
+ENV GIT_COMMIT_SHORT_SHA=$GIT_SHORT_HASH \
+    GIT_COMMIT_TIMESTAMP=$GIT_COMMIT_TIMESTAMP \
+    APPLICATION_VERSION=$APPLICATION_VERSION
+
+COPY --from=deps-prod --chown=node:node /workspace/node_modules ./node_modules
+COPY --from=builder --chown=node:node /workspace/apps/backend/dist ./dist
+COPY --from=builder --chown=node:node /workspace/packages/domain/package.json ./packages/domain/package.json
+COPY --from=builder --chown=node:node /workspace/packages/domain/dist ./packages/domain/dist
+COPY --from=builder --chown=node:node /workspace/packages/design-tokens/package.json ./packages/design-tokens/package.json
+COPY --from=builder --chown=node:node /workspace/packages/design-tokens/dist ./packages/design-tokens/dist
+COPY --from=builder --chown=node:node /workspace/packages/pdf-components/package.json ./packages/pdf-components/package.json
+COPY --from=builder --chown=node:node /workspace/packages/pdf-components/dist ./packages/pdf-components/dist
+COPY --from=builder --chown=node:node /workspace/packages/pdf-components/assets ./packages/pdf-components/assets
+
+USER node
+
+EXPOSE ${PORT}
+
+ENTRYPOINT ["dumb-init", "--"]
+CMD ["node", "dist/main.js"]

--- a/apps/panier/Dockerfile
+++ b/apps/panier/Dockerfile
@@ -1,0 +1,79 @@
+# syntax=docker/dockerfile:1-labs
+#
+# Build with the repo root as context:
+#   docker build -f apps/panier/Dockerfile \
+#     --build-arg ANON_KEY=... --build-arg API_URL=... --build-arg APP_URL=... \
+#     --build-arg AXEPTIO_ID=... --build-arg BACKEND_URL=... \
+#     --secret id=bryntum_token,env=BRYNTUM_ACCESS_TOKEN \
+#     -t panier .
+#
+# See apps/app/Dockerfile for the rationale behind this structure (adapted
+# from the official Next.js Docker example for a pnpm/Nx monorepo where
+# dependencies only live in the root package.json), et
+# apps/backend/Dockerfile pour le découpage fetch / manifests / builder.
+
+ARG NODE_IMAGE=node:24.21.0-alpine@sha256:be80f76cf40ec8e42b9bec49f60a55e0660f30af58d3e5a25530785b30ea67e2
+ARG PNPM_VERSION=9.15.5
+
+FROM ${NODE_IMAGE} AS base
+ARG PNPM_VERSION
+RUN apk add --no-cache libc6-compat
+WORKDIR /workspace
+ENV CI=true
+RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
+
+FROM base AS fetch
+COPY pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+RUN --mount=type=secret,id=bryntum_token,env=BRYNTUM_ACCESS_TOKEN \
+    pnpm fetch
+
+FROM fetch AS builder
+COPY --parents package.json apps/*/package.json packages/*/package.json e2e/package.json ./
+RUN --mount=type=secret,id=bryntum_token,env=BRYNTUM_ACCESS_TOKEN \
+    pnpm install -r --offline --frozen-lockfile
+
+COPY . .
+
+ARG ANON_KEY
+ARG API_URL
+ARG APP_URL
+ARG AXEPTIO_ID
+ARG BACKEND_URL
+ARG CRISP_WEBSITE_ID
+
+ENV NEXT_TELEMETRY_DISABLED=1 \
+    NEXT_PUBLIC_SUPABASE_ANON_KEY=$ANON_KEY \
+    NEXT_PUBLIC_SUPABASE_URL=$API_URL \
+    NEXT_PUBLIC_APP_URL=$APP_URL \
+    NEXT_PUBLIC_AXEPTIO_ID=$AXEPTIO_ID \
+    NEXT_PUBLIC_BACKEND_URL=$BACKEND_URL \
+    NEXT_PUBLIC_CRISP_WEBSITE_ID=$CRISP_WEBSITE_ID
+
+# The secret mount here just silences pnpm's harmless "can't resolve
+# ${BRYNTUM_ACCESS_TOKEN} in .npmrc" warning (next build doesn't re-install).
+RUN --mount=type=secret,id=bryntum_token,env=BRYNTUM_ACCESS_TOKEN \
+    pnpm run build:panier
+
+FROM ${NODE_IMAGE} AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production \
+    NEXT_TELEMETRY_DISABLED=1 \
+    PORT=3000 \
+    HOSTNAME=0.0.0.0
+
+RUN addgroup --system --gid 1001 nodejs \
+ && adduser --system --uid 1001 nextjs
+
+COPY --from=builder /workspace/apps/panier/public ./apps/panier/public
+
+RUN mkdir -p apps/panier/.next && chown nextjs:nodejs apps/panier/.next
+
+COPY --from=builder --chown=nextjs:nodejs /workspace/apps/panier/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /workspace/apps/panier/.next/static ./apps/panier/.next/static
+
+USER nextjs
+
+EXPOSE 3000
+
+CMD ["node", "apps/panier/server.js"]

--- a/apps/site/Dockerfile
+++ b/apps/site/Dockerfile
@@ -1,0 +1,88 @@
+# syntax=docker/dockerfile:1-labs
+#
+# Build with the repo root as context:
+#   docker build -f apps/site/Dockerfile \
+#     --build-arg STRAPI_KEY=... --build-arg STRAPI_URL=... \
+#     --build-arg ANON_KEY=... --build-arg API_URL=... \
+#     --build-arg AXEPTIO_ID=... --build-arg APP_URL=... --build-arg PANIER_URL=... \
+#     --secret id=bryntum_token,env=BRYNTUM_ACCESS_TOKEN \
+#     -t site .
+#
+# See apps/app/Dockerfile for the rationale behind this structure (adapted
+# from the official Next.js Docker example for a pnpm/Nx monorepo where
+# dependencies only live in the root package.json), et
+# apps/backend/Dockerfile pour le découpage fetch / manifests / builder.
+
+ARG NODE_IMAGE=node:24.21.0-alpine@sha256:be80f76cf40ec8e42b9bec49f60a55e0660f30af58d3e5a25530785b30ea67e2
+ARG PNPM_VERSION=9.15.5
+
+FROM ${NODE_IMAGE} AS base
+ARG PNPM_VERSION
+RUN apk add --no-cache libc6-compat
+WORKDIR /workspace
+ENV CI=true
+RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
+
+FROM base AS fetch
+COPY pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+RUN --mount=type=secret,id=bryntum_token,env=BRYNTUM_ACCESS_TOKEN \
+    pnpm fetch
+
+FROM fetch AS builder
+COPY --parents package.json apps/*/package.json packages/*/package.json e2e/package.json ./
+RUN --mount=type=secret,id=bryntum_token,env=BRYNTUM_ACCESS_TOKEN \
+    pnpm install -r --offline --frozen-lockfile
+
+COPY . .
+
+ARG STRAPI_KEY
+ARG STRAPI_URL
+ARG ANON_KEY
+ARG API_URL
+ARG AXEPTIO_ID
+ARG APP_URL
+ARG PANIER_URL
+ARG POSTHOG_HOST
+ARG POSTHOG_KEY
+ARG CRISP_WEBSITE_ID
+
+ENV NEXT_TELEMETRY_DISABLED=1 \
+    NEXT_PUBLIC_STRAPI_KEY=$STRAPI_KEY \
+    NEXT_PUBLIC_STRAPI_URL=$STRAPI_URL \
+    NEXT_PUBLIC_SUPABASE_ANON_KEY=$ANON_KEY \
+    NEXT_PUBLIC_SUPABASE_URL=$API_URL \
+    NEXT_PUBLIC_POSTHOG_HOST=$POSTHOG_HOST \
+    NEXT_PUBLIC_POSTHOG_KEY=$POSTHOG_KEY \
+    NEXT_PUBLIC_AXEPTIO_ID=$AXEPTIO_ID \
+    NEXT_PUBLIC_CRISP_WEBSITE_ID=$CRISP_WEBSITE_ID \
+    NEXT_PUBLIC_APP_URL=$APP_URL \
+    NEXT_PUBLIC_PANIER_URL=$PANIER_URL
+
+# The secret mount here just silences pnpm's harmless "can't resolve
+# ${BRYNTUM_ACCESS_TOKEN} in .npmrc" warning (next build doesn't re-install).
+RUN --mount=type=secret,id=bryntum_token,env=BRYNTUM_ACCESS_TOKEN \
+    pnpm run build:site
+
+FROM ${NODE_IMAGE} AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production \
+    NEXT_TELEMETRY_DISABLED=1 \
+    PORT=3000 \
+    HOSTNAME=0.0.0.0
+
+RUN addgroup --system --gid 1001 nodejs \
+ && adduser --system --uid 1001 nextjs
+
+COPY --from=builder /workspace/apps/site/public ./apps/site/public
+
+RUN mkdir -p apps/site/.next && chown nextjs:nodejs apps/site/.next
+
+COPY --from=builder --chown=nextjs:nodejs /workspace/apps/site/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /workspace/apps/site/.next/static ./apps/site/.next/static
+
+USER nextjs
+
+EXPOSE 3000
+
+CMD ["node", "apps/site/server.js"]

--- a/apps/tools/Dockerfile
+++ b/apps/tools/Dockerfile
@@ -1,0 +1,96 @@
+# syntax=docker/dockerfile:1-labs
+#
+# Build with the repo root as context:
+#   docker build -f apps/tools/Dockerfile \
+#     --build-arg GIT_SHORT_HASH=... --build-arg GIT_COMMIT_TIMESTAMP=... \
+#     --build-arg APPLICATION_VERSION=... \
+#     --secret id=bryntum_token,env=BRYNTUM_ACCESS_TOKEN \
+#     -t tools .
+#
+# See apps/backend/Dockerfile for the general rationale (single root
+# package.json, workspace packages need their compiled dist copied in, et le
+# découpage fetch / manifests / builder qui garde la couche d'install en
+# cache).
+# `tools` re-uses part of the backend's compiled output directly (it imports
+# from `@tet/backend/*`) but never touches `canvas`, `@tet/design-tokens` or
+# `@tet/pdf-components` at runtime, so this image skips the native
+# cairo/pango toolchain and the locale setup that apps/backend/Dockerfile
+# needs.
+#
+# Kept on the same Debian base as apps/backend/Dockerfile (not Alpine): the
+# production node_modules is still installed from the single root
+# package.json, so it still pulls in sharp/canvas/argon2 as optional native
+# deps — resolving those against a different libc family than what's tested
+# in this repo would be an unforced risk for no real size gain here.
+
+ARG NODE_IMAGE=node:24.21.0-slim@sha256:2fe369e969550cde8e867afc3fe370b260140cab4a23d467074295b42163d553
+ARG PNPM_VERSION=9.15.5
+
+FROM ${NODE_IMAGE} AS base
+ARG PNPM_VERSION
+WORKDIR /workspace
+ENV CI=true
+RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
+
+FROM base AS fetch
+COPY pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+RUN --mount=type=secret,id=bryntum_token,env=BRYNTUM_ACCESS_TOKEN \
+    pnpm fetch
+
+FROM fetch AS manifests
+COPY --parents package.json apps/*/package.json packages/*/package.json e2e/package.json ./
+
+FROM manifests AS deps-prod
+RUN --mount=type=secret,id=bryntum_token,env=BRYNTUM_ACCESS_TOKEN \
+    pnpm install -r --offline --frozen-lockfile --prod
+
+FROM manifests AS builder
+RUN --mount=type=secret,id=bryntum_token,env=BRYNTUM_ACCESS_TOKEN \
+    pnpm install -r --offline --frozen-lockfile
+COPY . .
+# `nx build tools` (aliased by this script) also builds the workspace
+# packages it depends on, i.e. domain. `backend` itself is built too since
+# tools imports its compiled output directly.
+# The secret mount here just silences pnpm's harmless "can't resolve
+# ${BRYNTUM_ACCESS_TOKEN} in .npmrc" warning (nx doesn't re-install).
+RUN --mount=type=secret,id=bryntum_token,env=BRYNTUM_ACCESS_TOKEN \
+    pnpm run build:tools
+
+FROM ${NODE_IMAGE} AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production \
+    PORT=3000 \
+    APPLICATION_NAME=automation
+
+ARG GIT_SHORT_HASH
+ARG GIT_COMMIT_TIMESTAMP
+ARG APPLICATION_VERSION
+ENV GIT_COMMIT_SHORT_SHA=$GIT_SHORT_HASH \
+    GIT_COMMIT_TIMESTAMP=$GIT_COMMIT_TIMESTAMP \
+    APPLICATION_VERSION=$APPLICATION_VERSION
+
+COPY --from=deps-prod --chown=node:node /workspace/node_modules ./node_modules
+COPY --from=builder --chown=node:node /workspace/apps/tools/dist ./dist
+COPY --from=builder --chown=node:node /workspace/apps/backend/package.json ./apps/backend/package.json
+COPY --from=builder --chown=node:node /workspace/apps/backend/dist ./apps/backend/dist
+COPY --from=builder --chown=node:node /workspace/packages/domain/package.json ./packages/domain/package.json
+COPY --from=builder --chown=node:node /workspace/packages/domain/dist ./packages/domain/dist
+# node_modules/@tet/{design-tokens,pdf-components} sont des liens symboliques
+# vers packages/*/ créés par l'install workspace. Sans ces deux package.json
+# ils pointent dans le vide : `tools` ne les importe pas aujourd'hui (il ne
+# tire de `@tet/backend` que des types, effacés à la compilation), mais le
+# jour où un import runtime remonte jusqu'à `fiche-action-pdf-export` ou
+# `utils/echarts/`, ça planterait au bootstrap Nest sur un MODULE_NOT_FOUND.
+# `nx build tools` ne construit pas leur dist (elles ne sont pas dans son
+# graphe de dépendances) : on rétablit ici le contenu qu'avait l'image
+# Earthly. La résolution complète (dist inclus) viendra avec le passage à des
+# `dependencies` par app + `pnpm deploy --filter`.
+COPY --from=builder --chown=node:node /workspace/packages/design-tokens/package.json ./packages/design-tokens/package.json
+COPY --from=builder --chown=node:node /workspace/packages/pdf-components/package.json ./packages/pdf-components/package.json
+
+USER node
+
+EXPOSE ${PORT}
+
+CMD ["node", "dist/main.js"]

--- a/apps/tools/Dockerfile
+++ b/apps/tools/Dockerfile
@@ -59,6 +59,13 @@ RUN --mount=type=secret,id=bryntum_token,env=BRYNTUM_ACCESS_TOKEN \
 FROM ${NODE_IMAGE} AS runner
 WORKDIR /app
 
+# Seul apt-get de cette image (contrairement à apps/backend/Dockerfile, pas de
+# libs natives ni de locale ici) : `tools` tourne des workers BullMQ, et sans
+# init en PID 1 les processus enfants éventuels ne sont jamais récoltés. Même
+# ENTRYPOINT que le backend pour que les deux apps Nest s'arrêtent pareil.
+RUN apt-get update && apt-get install -y --no-install-recommends dumb-init \
+    && rm -rf /var/lib/apt/lists/*
+
 ENV NODE_ENV=production \
     PORT=3000 \
     APPLICATION_NAME=automation
@@ -93,4 +100,5 @@ USER node
 
 EXPOSE ${PORT}
 
+ENTRYPOINT ["dumb-init", "--"]
 CMD ["node", "dist/main.js"]


### PR DESCRIPTION
## Résumé

- Remplace la construction Docker basée sur Earthly (`Earthfile` racine + par-app) par des `Dockerfile` multi-stage classiques, en repartant des exemples officiels Next.js/pnpm plutôt qu'en traduisant l'existant.
- Build Next.js standalone inchangé (mêmes chemins `.next/standalone`), mais node_modules de prod isolé dans un stage dédié pour `backend`/`tools` (canvas compilé puis le toolchain de build jeté, ne reste que le binaire compilé dans l'image finale).
- Secrets Bryntum/Sentry passés via BuildKit `--mount=type=secret` (jamais dans un layer ou l'historique de l'image) plutôt qu'en `ARG`.
- `.dockerignore` ajouté et corrigé : les motifs sans `**/` ne matchaient pas dans `apps/*/`, ce qui faisait gonfler le contexte de build à 7 Go (à cause de caches `.next` locaux). Corrigé → ~315 Mo.
- Ajout d'un utilisateur non-root (`node`) et de `dumb-init` comme PID 1 pour `backend`/`tools`, qui tournaient en root dans l'ancien setup.

## Hors périmètre (volontairement)

- Les workflows `cd-*.yml` ne sont **pas** modifiés — earthly reste utilisé en CI pour l'instant. Cette PR n'ajoute que les `Dockerfile`, à brancher dans la CI dans une passe suivante.
- Les targets Earthly de test/seed/dev local ne sont pas concernés.

## Vérifications faites

Les 5 images ont été buildées et démarrées en local avant ce commit (avec le vrai token Bryntum déchiffré via `dotenvx`/`.env.keys`, cf `Makefile`) :

- [x] `tools` : build complet OK (chaîne Nx : design-tokens → domain → pdf-components → backend → tools)
- [x] `backend` : build OK, canvas compilé (binaire prébuilt), `require('canvas')`/`@tet/domain`/`@tet/pdf-components`/`@tet/design-tokens` résolus au runtime ; démarrage Nest OK (échoue proprement sur `ZodError` faute de config applicative, comportement attendu)
- [x] `app` : build OK (68 routes générées), conteneur démarré → `HTTP 200`, `/api/version` reflète bien le build-arg `ENV_NAME`
- [x] `site` : build OK, conteneur démarré (500 attendu : tente un `fetch` vers l'URL Strapi factice fournie)
- [x] `panier` : build OK

## Plan de test pour le reviewer

```bash
export BRYNTUM_ACCESS_TOKEN=<votre token>
docker build -f apps/backend/Dockerfile --secret id=bryntum_token,env=BRYNTUM_ACCESS_TOKEN .
docker build -f apps/app/Dockerfile --secret id=bryntum_token,env=BRYNTUM_ACCESS_TOKEN \
  --secret id=sentry_auth_token,env=SENTRY_AUTH_TOKEN \
  --build-arg ANON_KEY=x --build-arg API_URL=x --build-arg APP_URL=x .
```

https://claude.ai/code/session_01VeEHs3ZV5hMP268Aw6fJyJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Ajout de configurations Docker pour déployer les applications App, Backend, Panier, Site et Tools.
  * Les images sont générées via des builds optimisés en plusieurs étapes et exécutent les services avec des utilisateurs non privilégiés.
  * Prise en charge des variables d’environnement de build et des informations de version.
  * Ajout d’exclusions pour limiter le contexte de construction Docker aux fichiers nécessaires.
  * Les images finales incluent uniquement les éléments requis pour l’exécution des applications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->