### PR TITLE
[Batch/pcaet access] Rattachement automatique par ProConnect / MCA

### DIFF
--- a/apps/app/app/(authed)/authed-providers.tsx
+++ b/apps/app/app/(authed)/authed-providers.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import AccepterCGUModal from '@/app/app/pages/Auth/AccepterCGUModal';
-import { SuperAdminModeProvider } from '@/app/users/authorizations/super-admin-mode/super-admin-mode.provider';
-import { LinkOidcIdentityBanner } from '@/app/users/authentications/oidc/link-oidc-identity/link-oidc-identity.banner';
 import { AutoAttachmentWelcomeModal } from '@/app/users/authentications/oidc/auto-attachment/auto-attachment.welcome.modal';
+import { LinkOidcIdentityBanner } from '@/app/users/authentications/oidc/link-oidc-identity/link-oidc-identity.banner';
 import { LinkOidcIdentityModal } from '@/app/users/authentications/oidc/link-oidc-identity/link-oidc-identity.modal';
+import { SuperAdminModeProvider } from '@/app/users/authorizations/super-admin-mode/super-admin-mode.provider';
 import { NPSTracker } from '@/app/utils/nps/nps-tracker';
 import { CollectiviteProvider } from '@tet/api/collectivites';
 import { UserProviderStoreClient } from '@tet/api/users';
@@ -31,9 +31,6 @@ export function AuthedProviders({
       <CollectiviteProvider user={user}>
         <SuperAdminModeProvider>
           <NPSTracker />
-          {/* L'accueil du rattachement est déclaré avant les CGU, et porte un
-              z-index plus bas : l'ordre de lecture et l'ordre d'empilement
-              disent la même chose — les CGU passent devant. */}
           <AutoAttachmentWelcomeModal />
           <AccepterCGUModal />
           <LinkOidcIdentityModal />

--- a/apps/app/app/(authed)/authed-providers.tsx
+++ b/apps/app/app/(authed)/authed-providers.tsx
@@ -3,6 +3,7 @@
 import AccepterCGUModal from '@/app/app/pages/Auth/AccepterCGUModal';
 import { SuperAdminModeProvider } from '@/app/users/authorizations/super-admin-mode/super-admin-mode.provider';
 import { LinkOidcIdentityBanner } from '@/app/users/authentications/oidc/link-oidc-identity/link-oidc-identity.banner';
+import { AutoAttachmentWelcomeModal } from '@/app/users/authentications/oidc/auto-attachment/auto-attachment.welcome.modal';
 import { LinkOidcIdentityModal } from '@/app/users/authentications/oidc/link-oidc-identity/link-oidc-identity.modal';
 import { NPSTracker } from '@/app/utils/nps/nps-tracker';
 import { CollectiviteProvider } from '@tet/api/collectivites';
@@ -31,6 +32,7 @@ export function AuthedProviders({
         <SuperAdminModeProvider>
           <NPSTracker />
           <AccepterCGUModal />
+          <AutoAttachmentWelcomeModal />
           <LinkOidcIdentityModal />
           <BannerInfo />
           <LinkOidcIdentityBanner />

--- a/apps/app/app/(authed)/authed-providers.tsx
+++ b/apps/app/app/(authed)/authed-providers.tsx
@@ -31,8 +31,11 @@ export function AuthedProviders({
       <CollectiviteProvider user={user}>
         <SuperAdminModeProvider>
           <NPSTracker />
-          <AccepterCGUModal />
+          {/* L'accueil du rattachement est déclaré avant les CGU, et porte un
+              z-index plus bas : l'ordre de lecture et l'ordre d'empilement
+              disent la même chose — les CGU passent devant. */}
           <AutoAttachmentWelcomeModal />
+          <AccepterCGUModal />
           <LinkOidcIdentityModal />
           <BannerInfo />
           <LinkOidcIdentityBanner />

--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/tableau-de-bord/page.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/tableau-de-bord/page.tsx
@@ -1,20 +1,23 @@
 'use client';
 
-import { makeUserTdbUrl } from '@/app/tableaux-de-bord/make-user-tdb-url';
+import { makeCollectiviteRootUrl } from '@/app/app/paths';
 import SpinnerLoader from '@/app/ui/shared/SpinnerLoader';
 import { useCurrentCollectivite } from '@tet/api/collectivites';
 import { useUser } from '@tet/api/users';
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 
+/** Même règle que le redirecteur global : le type décide de la racine. */
 export default function RedirectToTdbPage() {
-  const { collectiviteId } = useCurrentCollectivite();
+  const { collectiviteId, collectiviteType } = useCurrentCollectivite();
   const user = useUser();
   const router = useRouter();
 
   useEffect(() => {
-    router.replace(makeUserTdbUrl({ user, collectiviteId }));
-  }, [collectiviteId, router, user]);
+    router.replace(
+      makeCollectiviteRootUrl({ user, collectiviteId, collectiviteType })
+    );
+  }, [collectiviteId, collectiviteType, router, user]);
 
   return <SpinnerLoader className="m-auto" />;
 }

--- a/apps/app/app/(authed)/collectivite/tableau-de-bord/page.tsx
+++ b/apps/app/app/(authed)/collectivite/tableau-de-bord/page.tsx
@@ -9,9 +9,7 @@ import { useEffect } from 'react';
 
 /**
  * `makeCollectiviteRootUrl` et non `makeUserTdbUrl` : un service de l'État n'a
- * pas de tableau de bord, son espace est celui de l'instruction. L'y envoyer
- * quand même l'accueillait avec une page d'erreur d'accès — le seul écran que
- * voyait un agent rattaché à sa DREAL.
+ * pas de tableau de bord, et l'y envoyer l'accueillait par une erreur d'accès.
  */
 export default function RedirectToTdbPage() {
   const { collectivite } = useCollectiviteContext();

--- a/apps/app/app/(authed)/collectivite/tableau-de-bord/page.tsx
+++ b/apps/app/app/(authed)/collectivite/tableau-de-bord/page.tsx
@@ -1,25 +1,34 @@
 'use client';
 
-import { makeUserTdbUrl } from '@/app/tableaux-de-bord/make-user-tdb-url';
+import { makeCollectiviteRootUrl } from '@/app/app/paths';
 import SpinnerLoader from '@/app/ui/shared/SpinnerLoader';
 import { useCollectiviteContext } from '@tet/api/collectivites';
 import { useUser } from '@tet/api/users';
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 
+/**
+ * `makeCollectiviteRootUrl` et non `makeUserTdbUrl` : un service de l'État n'a
+ * pas de tableau de bord, son espace est celui de l'instruction. L'y envoyer
+ * quand même l'accueillait avec une page d'erreur d'accès — le seul écran que
+ * voyait un agent rattaché à sa DREAL.
+ */
 export default function RedirectToTdbPage() {
   const { collectivite } = useCollectiviteContext();
   const user = useUser();
   const router = useRouter();
 
   const collectiviteId = collectivite?.collectiviteId;
+  const collectiviteType = collectivite?.collectiviteType;
 
   useEffect(() => {
-    if (collectiviteId === undefined) {
+    if (collectiviteId === undefined || collectiviteType === undefined) {
       return;
     }
-    router.replace(makeUserTdbUrl({ user, collectiviteId }));
-  }, [collectiviteId, router, user]);
+    router.replace(
+      makeCollectiviteRootUrl({ user, collectiviteId, collectiviteType })
+    );
+  }, [collectiviteId, collectiviteType, router, user]);
 
   return <SpinnerLoader className="m-auto" />;
 }

--- a/apps/app/app/(public)/auth/verify/route.ts
+++ b/apps/app/app/(public)/auth/verify/route.ts
@@ -26,9 +26,7 @@ import { NextRequest, NextResponse } from 'next/server';
  * `OIDC_LOGIN_COOKIE` posé pour `TrackLoginUserWithOidc`.
  *
  * `rattachement` et `rattachement-type` disent qu'un service vient de s'ouvrir
- * à l'agent — voir `readAutoAttachmentLanding`. Un `next` explicite passe
- * devant : il vient d'une intention de l'agent, là où ceci n'est qu'un défaut
- * mieux choisi que la racine.
+ * à l'agent (cf. `readAutoAttachmentLanding`). Un `next` explicite passe devant.
  */
 export async function GET(request: NextRequest) {
   const { searchParams, origin } = getRequestUrl(request);

--- a/apps/app/app/(public)/auth/verify/route.ts
+++ b/apps/app/app/(public)/auth/verify/route.ts
@@ -5,6 +5,7 @@ import {
   OIDC_LOGIN_COOKIE_TTL_S,
   OIDC_PROVIDER_COOKIE,
 } from '@/app/users/authentications/oidc/login-user-with-oidc/login-user-with-oidc.cookies';
+import { readAutoAttachmentLanding } from '@/app/users/authentications/oidc/auto-attachment/auto-attachment.landing';
 import { sanitizeNextPath } from '@/app/users/authentications/sanitize-next-path';
 import { getRequestUrl } from '@tet/api';
 import { createSupabaseServerClient } from '@tet/api/utils/supabase/server-client';
@@ -23,6 +24,11 @@ import { NextRequest, NextResponse } from 'next/server';
  * Ce pont n'est emprunté que par les parcours OIDC : le traverser vaut
  * connexion par fournisseur d'identité réussie, d'où le marqueur one-shot
  * `OIDC_LOGIN_COOKIE` posé pour `TrackLoginUserWithOidc`.
+ *
+ * `rattachement` et `rattachement-type` disent qu'un service vient de s'ouvrir
+ * à l'agent — voir `readAutoAttachmentLanding`. Un `next` explicite passe
+ * devant : il vient d'une intention de l'agent, là où ceci n'est qu'un défaut
+ * mieux choisi que la racine.
  */
 export async function GET(request: NextRequest) {
   const { searchParams, origin } = getRequestUrl(request);
@@ -48,7 +54,10 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  const destination = new URL(next ?? '/', origin);
+  const destination = new URL(
+    next ?? readAutoAttachmentLanding(searchParams) ?? '/',
+    origin
+  );
   if (liaison) {
     destination.searchParams.set('comptes-associes', '1');
   }

--- a/apps/app/src/labels/demarches.labels.ts
+++ b/apps/app/src/labels/demarches.labels.ts
@@ -15,4 +15,39 @@ export const demarchesLabels = {
   contexteInstructionRetourDossier: 'Revenir à l’instruction',
 
   contexteInstructionRetour: 'Revenir à mes dossiers PCAET',
+
+  /**
+   * L'accueil d'un agent que son fournisseur d'identité vient de rattacher à
+   * son service : personne ne l'a invité, il n'a rien choisi, et rien ne lui
+   * dirait où il est ni ce qu'il peut faire.
+   *
+   * « ProConnect » et jamais « MonCompteAdeme », même quand c'est ce dernier qui
+   * a émis le jeton : côté utilisateur, la marque est ProConnect (décision
+   * produit du 28/07/2026).
+   *
+   * Sans territoire, comme le reste de l'écran d'instruction : la modale sert
+   * les cinq familles, dont les périmètres diffèrent — région, département, ou
+   * aucun pour un service national.
+   */
+  accueilRattachementTitre: 'Bienvenue sur Territoires en Transitions',
+
+  accueilRattachementService: ({ nom }: { nom: string }) =>
+    `Votre compte a été automatiquement rattaché à ${nom} via ProConnect.`,
+
+  accueilRattachementIntro:
+    'Voici la page d’accueil de votre service : les dépôts PCAET qui vous concernent y seront listés dès leur transmission.',
+
+  accueilRattachementConsulter:
+    'Consulter les PCAET transmis pour avis et leurs échéances',
+
+  /** Suit la famille, comme le titre de la liste : seules la DREAL et la région instruisent. */
+  accueilRattachementSuivre: ({ deposeAvis }: { deposeAvis: boolean }) =>
+    deposeAvis
+      ? 'Suivre l’état d’instruction de chaque dossier'
+      : 'Suivre l’avancement de chaque dossier',
+
+  accueilRattachementVueEnsemble:
+    'Avoir une vue d’ensemble de tous les PCAET de vos collectivités',
+
+  accueilRattachementAction: 'Découvrir mon espace',
 };

--- a/apps/app/src/users/authentications/oidc/auto-attachment/auto-attachment.landing.spec.ts
+++ b/apps/app/src/users/authentications/oidc/auto-attachment/auto-attachment.landing.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { readAutoAttachmentLanding } from './auto-attachment.landing';
+
+const params = (query: string) => new URLSearchParams(query);
+
+describe('readAutoAttachmentLanding', () => {
+  it('lands a state service on its instruction space', () => {
+    expect(
+      readAutoAttachmentLanding(
+        params('rattachement=42&rattachement-type=dreal')
+      )
+    ).toBe('/collectivite/42/demandes-avis');
+    expect(
+      readAutoAttachmentLanding(params('rattachement=7&rattachement-type=ddt'))
+    ).toBe('/collectivite/7/demandes-avis');
+  });
+
+  /** Il se rejoint par identité, mais garde son propre tableau de bord. */
+  it('leaves a conseil regional to the usual resolution', () => {
+    expect(
+      readAutoAttachmentLanding(
+        params('rattachement=42&rattachement-type=region')
+      )
+    ).toBeNull();
+  });
+
+  it('gives no destination without both parameters', () => {
+    expect(readAutoAttachmentLanding(params(''))).toBeNull();
+    expect(readAutoAttachmentLanding(params('rattachement=42'))).toBeNull();
+    expect(
+      readAutoAttachmentLanding(params('rattachement-type=dreal'))
+    ).toBeNull();
+  });
+
+  it('refuses anything that is not a positive integer id', () => {
+    expect(
+      readAutoAttachmentLanding(
+        params('rattachement=0&rattachement-type=dreal')
+      )
+    ).toBeNull();
+    expect(
+      readAutoAttachmentLanding(
+        params('rattachement=-3&rattachement-type=dreal')
+      )
+    ).toBeNull();
+    expect(
+      readAutoAttachmentLanding(
+        params('rattachement=4.2&rattachement-type=dreal')
+      )
+    ).toBeNull();
+    expect(
+      readAutoAttachmentLanding(
+        params('rattachement=..%2Fadmin&rattachement-type=dreal')
+      )
+    ).toBeNull();
+  });
+
+  it('refuses an unknown type', () => {
+    expect(
+      readAutoAttachmentLanding(
+        params('rattachement=42&rattachement-type=prefecture_lunaire')
+      )
+    ).toBeNull();
+  });
+});

--- a/apps/app/src/users/authentications/oidc/auto-attachment/auto-attachment.landing.ts
+++ b/apps/app/src/users/authentications/oidc/auto-attachment/auto-attachment.landing.ts
@@ -5,18 +5,13 @@ import {
 } from '@tet/domain/collectivites';
 
 /**
- * La page d'accueil du service qu'un rattachement automatique vient d'ouvrir,
- * lue des paramètres que le callback OIDC a posés sur `/auth/verify`.
+ * La page d'accueil du service qu'un rattachement vient d'ouvrir, lue des
+ * paramètres posés sur `/auth/verify`.
  *
- * Ne vaut que pour les structures dont l'espace **est** celui de l'instruction.
- * Un conseil régional se rejoint aussi par identité, mais garde son tableau de
- * bord : le renvoyer sur `demandes-avis` le priverait de son espace, et c'est la
- * résolution habituelle de `/` qui l'y conduit correctement.
- *
- * Les paramètres viennent d'une URL, donc de l'extérieur : un identifiant qui
- * n'est pas un entier positif ou un type inconnu ne donne aucune destination.
- * Le pire qu'un paramètre forgé obtienne est une page d'instruction dont les
- * gardes de route refuseront l'accès.
+ * Rien pour un conseil régional : il se rejoint par identité mais garde son
+ * tableau de bord, où la résolution habituelle de `/` le conduit. Les
+ * paramètres venant d'une URL, un identifiant ou un type invalide ne donne
+ * aucune destination.
  */
 export function readAutoAttachmentLanding(
   searchParams: URLSearchParams

--- a/apps/app/src/users/authentications/oidc/auto-attachment/auto-attachment.landing.ts
+++ b/apps/app/src/users/authentications/oidc/auto-attachment/auto-attachment.landing.ts
@@ -1,0 +1,40 @@
+import { makeDemandesAvisUrl } from '@/app/app/paths';
+import {
+  collectiviteTypeEnumSchema,
+  isServiceDeconcentre,
+} from '@tet/domain/collectivites';
+
+/**
+ * La page d'accueil du service qu'un rattachement automatique vient d'ouvrir,
+ * lue des paramètres que le callback OIDC a posés sur `/auth/verify`.
+ *
+ * Ne vaut que pour les structures dont l'espace **est** celui de l'instruction.
+ * Un conseil régional se rejoint aussi par identité, mais garde son tableau de
+ * bord : le renvoyer sur `demandes-avis` le priverait de son espace, et c'est la
+ * résolution habituelle de `/` qui l'y conduit correctement.
+ *
+ * Les paramètres viennent d'une URL, donc de l'extérieur : un identifiant qui
+ * n'est pas un entier positif ou un type inconnu ne donne aucune destination.
+ * Le pire qu'un paramètre forgé obtienne est une page d'instruction dont les
+ * gardes de route refuseront l'accès.
+ */
+export function readAutoAttachmentLanding(
+  searchParams: URLSearchParams
+): string | null {
+  const collectiviteId = Number(searchParams.get('rattachement'));
+  const type = collectiviteTypeEnumSchema.safeParse(
+    searchParams.get('rattachement-type')
+  );
+
+  if (
+    !Number.isInteger(collectiviteId) ||
+    collectiviteId <= 0 ||
+    !type.success
+  ) {
+    return null;
+  }
+
+  return isServiceDeconcentre(type.data)
+    ? makeDemandesAvisUrl({ collectiviteId })
+    : null;
+}

--- a/apps/app/src/users/authentications/oidc/auto-attachment/auto-attachment.welcome.modal.tsx
+++ b/apps/app/src/users/authentications/oidc/auto-attachment/auto-attachment.welcome.modal.tsx
@@ -9,19 +9,7 @@ import {
 import { useUser } from '@tet/api/users';
 import { peutDeposerAvisInstructeur } from '@tet/domain/demarches';
 import { Button, Modal, ModalFooter } from '@tet/ui';
-import { useSearchParams } from 'next/navigation';
 import { useState } from 'react';
-
-/**
- * Rouvre l'accueil sur une collectivité donnée, sans repasser par un
- * rattachement : `?rattachement-accueil=<id>`.
- *
- * L'accueil ne se montre qu'une fois, et le revoir demandait sinon de rejouer
- * les seeds et de se reconnecter — de quoi rendre toute retouche coûteuse. Rien
- * n'est exposé au passage : l'accueil ne nomme qu'une collectivité dont l'agent
- * est déjà membre, et ne montre rien du tout des autres.
- */
-const PARAM_RECETTE = 'rattachement-accueil';
 
 /**
  * L'accueil d'un agent rattaché automatiquement à son service.
@@ -41,12 +29,7 @@ export const AutoAttachmentWelcomeModal = () => {
   const { mutate: updatePreferences } = useUpdateUserPreferences();
   const [refermee, setRefermee] = useState(false);
 
-  const searchParams = useSearchParams();
-  const forcee = Number(searchParams.get(PARAM_RECETTE));
-  const collectiviteId =
-    Number.isInteger(forcee) && forcee > 0
-      ? forcee
-      : preferences?.oidc.autoAttachedCollectiviteId ?? null;
+  const collectiviteId = preferences?.oidc.autoAttachedCollectiviteId ?? null;
 
   // Le service tel que l'agent y a accès. Absent si le droit a été retiré
   // entre-temps : mieux vaut ne rien annoncer que d'annoncer un espace fermé.

--- a/apps/app/src/users/authentications/oidc/auto-attachment/auto-attachment.welcome.modal.tsx
+++ b/apps/app/src/users/authentications/oidc/auto-attachment/auto-attachment.welcome.modal.tsx
@@ -65,16 +65,24 @@ export const AutoAttachmentWelcomeModal = () => {
         },
       }}
       dataTest="oidc.rattachement.accueil"
+      // Le titre et le sous-titre passent par le design system plutôt que par le
+      // corps : c'est lui qui donne le grand titre `primary-9`, la ligne grise
+      // en dessous et le séparateur qui les détache du reste.
+      title={appLabels.accueilRattachementTitre}
+      subTitle={appLabels.accueilRattachementService({
+        nom: service.collectiviteNom,
+      })}
+      // Sous la modale des CGU (`zIndex.modal`, 1000), qui est bloquante : leur
+      // acceptation passe d'abord, l'accueil attend derrière. Sous `dropdown`
+      // (999) aussi, pour ne pas passer par-dessus la liste déroulante d'une
+      // autre surface.
+      zIndex={998}
       render={() => (
         <div>
-          <h4 className="mb-2">{appLabels.accueilRattachementTitre}</h4>
-          <p className="mb-3">
-            {appLabels.accueilRattachementService({
-              nom: service.collectiviteNom,
-            })}
-          </p>
           <p className="mb-3">{appLabels.accueilRattachementIntro}</p>
-          <ul className="mb-0">
+          {/* Tailwind neutralise le `list-style` des `ul` : sans `list-disc`,
+              les trois lignes se lisent comme un paragraphe haché. */}
+          <ul className="mb-0 list-disc pl-4">
             <li>{appLabels.accueilRattachementConsulter}</li>
             <li>{appLabels.accueilRattachementSuivre({ deposeAvis })}</li>
             <li>{appLabels.accueilRattachementVueEnsemble}</li>

--- a/apps/app/src/users/authentications/oidc/auto-attachment/auto-attachment.welcome.modal.tsx
+++ b/apps/app/src/users/authentications/oidc/auto-attachment/auto-attachment.welcome.modal.tsx
@@ -12,16 +12,9 @@ import { Button, Modal, ModalFooter } from '@tet/ui';
 import { useState } from 'react';
 
 /**
- * L'accueil d'un agent rattaché automatiquement à son service.
- *
- * Personne ne l'a invité et il n'a rien choisi : l'organisation qu'il a
- * désignée chez son fournisseur d'identité lui a ouvert un espace. La modale est
- * ce qui le lui dit, et explique ce qu'il y trouvera.
- *
- * Une seule fois, et par une préférence serveur plutôt qu'un paramètre d'URL :
- * un écran qui explique tout un parcours doit survivre à un onglet fermé en
- * cours de route. Le backend y inscrit le service au moment du rattachement, et
- * la fermeture la remet à `null` — c'est tout le mécanisme.
+ * L'accueil d'un agent que son fournisseur d'identité vient de rattacher à son
+ * service. Une seule fois : le backend inscrit le service dans une préférence
+ * au rattachement, la fermeture la remet à `null`.
  */
 export const AutoAttachmentWelcomeModal = () => {
   const user = useUser();
@@ -31,31 +24,24 @@ export const AutoAttachmentWelcomeModal = () => {
 
   const collectiviteId = preferences?.oidc.autoAttachedCollectiviteId ?? null;
 
-  // Le service tel que l'agent y a accès. Absent si le droit a été retiré
-  // entre-temps : mieux vaut ne rien annoncer que d'annoncer un espace fermé.
+  // Absent si le droit a été retiré entre-temps : ne rien annoncer plutôt
+  // qu'un espace fermé.
   const service = user.collectivites.find(
     (acces) => acces.collectiviteId === collectiviteId
   );
 
-  // Les CGU passent devant. Leur modale est bloquante, et deux modales
-  // ouvertes ensemble se départagent mal : à z-index égal c'est la dernière
-  // **ouverte** qui passe devant, et l'accueil l'est forcément — il attend une
-  // requête, là où les CGU se décident depuis l'utilisateur déjà chargé.
-  // Attendre leur acceptation règle l'ordre par la logique plutôt que par
-  // l'empilement, et accueillir quelqu'un qui n'a pas encore accepté n'aurait
-  // de toute façon pas de sens.
+  // Les CGU passent devant : leur modale est bloquante, et à z-index égal
+  // c'est la dernière **ouverte** qui gagne — l'accueil, qui attend une requête.
   const cguAcceptees = Boolean(user.cguAccepteesLe);
 
-  // Ouverture **dérivée**, sans effet : la préférence dit à elle seule s'il y a
-  // quelque chose à annoncer, et `refermee` couvre l'instant entre le clic et
-  // la fin de l'écriture, où la préférence vaut encore l'ancien service.
+  // `refermee` couvre l'instant entre le clic et la fin de l'écriture, où la
+  // préférence vaut encore l'ancien service.
   const isOpen = Boolean(service) && cguAcceptees && !refermee;
 
   if (!isOpen || !service) {
     return null;
   }
 
-  /** Oublier le service, c'est tout le « une seule fois ». */
   const refermer = () => {
     setRefermee(true);
     updatePreferences({ 'oidc.autoAttachedCollectiviteId': null });
@@ -74,23 +60,17 @@ export const AutoAttachmentWelcomeModal = () => {
         },
       }}
       dataTest="oidc.rattachement.accueil"
-      // Le titre et le sous-titre passent par le design system plutôt que par le
-      // corps : c'est lui qui donne le grand titre `primary-9`, la ligne grise
-      // en dessous et le séparateur qui les détache du reste.
       title={appLabels.accueilRattachementTitre}
       subTitle={appLabels.accueilRattachementService({
         nom: service.collectiviteNom,
       })}
-      // Sous la modale des CGU (`zIndex.modal`, 1000), qui est bloquante : leur
-      // acceptation passe d'abord, l'accueil attend derrière. Sous `dropdown`
-      // (999) aussi, pour ne pas passer par-dessus la liste déroulante d'une
-      // autre surface.
+      // Sous `modal` (1000) et `dropdown` (999) : rien d'une autre surface ne
+      // doit se retrouver dessous.
       zIndex={998}
       render={() => (
         <div>
           <p className="mb-3">{appLabels.accueilRattachementIntro}</p>
-          {/* Tailwind neutralise le `list-style` des `ul` : sans `list-disc`,
-              les trois lignes se lisent comme un paragraphe haché. */}
+          {/* Tailwind neutralise le `list-style` des `ul`. */}
           <ul className="mb-0 list-disc pl-4">
             <li>{appLabels.accueilRattachementConsulter}</li>
             <li>{appLabels.accueilRattachementSuivre({ deposeAvis })}</li>

--- a/apps/app/src/users/authentications/oidc/auto-attachment/auto-attachment.welcome.modal.tsx
+++ b/apps/app/src/users/authentications/oidc/auto-attachment/auto-attachment.welcome.modal.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { makeCollectiviteRootUrl } from '@/app/app/paths';
+import { appLabels } from '@/app/labels/catalog';
+import {
+  useUpdateUserPreferences,
+  useUserPreferences,
+} from '@/app/users/use-user-preferences';
+import { useUser } from '@tet/api/users';
+import { peutDeposerAvisInstructeur } from '@tet/domain/demarches';
+import { Button, Modal, ModalFooter } from '@tet/ui';
+import { useState } from 'react';
+
+/**
+ * L'accueil d'un agent rattaché automatiquement à son service.
+ *
+ * Personne ne l'a invité et il n'a rien choisi : l'organisation qu'il a
+ * désignée chez son fournisseur d'identité lui a ouvert un espace. La modale est
+ * ce qui le lui dit, et explique ce qu'il y trouvera.
+ *
+ * Une seule fois, et par une préférence serveur plutôt qu'un paramètre d'URL :
+ * un écran qui explique tout un parcours doit survivre à un onglet fermé en
+ * cours de route. Le backend y inscrit le service au moment du rattachement, et
+ * la fermeture la remet à `null` — c'est tout le mécanisme.
+ */
+export const AutoAttachmentWelcomeModal = () => {
+  const user = useUser();
+  const { data: preferences } = useUserPreferences();
+  const { mutate: updatePreferences } = useUpdateUserPreferences();
+  const [refermee, setRefermee] = useState(false);
+
+  const collectiviteId = preferences?.oidc.autoAttachedCollectiviteId ?? null;
+
+  // Le service tel que l'agent y a accès. Absent si le droit a été retiré
+  // entre-temps : mieux vaut ne rien annoncer que d'annoncer un espace fermé.
+  const service = user.collectivites.find(
+    (acces) => acces.collectiviteId === collectiviteId
+  );
+
+  // Ouverture **dérivée**, sans effet : la préférence dit à elle seule s'il y a
+  // quelque chose à annoncer, et `refermee` couvre l'instant entre le clic et
+  // la fin de l'écriture, où la préférence vaut encore l'ancien service.
+  const isOpen = Boolean(service) && !refermee;
+
+  if (!isOpen || !service) {
+    return null;
+  }
+
+  /** Oublier le service, c'est tout le « une seule fois ». */
+  const refermer = () => {
+    setRefermee(true);
+    updatePreferences({ 'oidc.autoAttachedCollectiviteId': null });
+  };
+
+  const deposeAvis = peutDeposerAvisInstructeur(service.collectiviteType);
+
+  return (
+    <Modal
+      openState={{
+        isOpen,
+        setIsOpen: (ouvert) => {
+          if (!ouvert) {
+            refermer();
+          }
+        },
+      }}
+      dataTest="oidc.rattachement.accueil"
+      render={() => (
+        <div>
+          <h4 className="mb-2">{appLabels.accueilRattachementTitre}</h4>
+          <p className="mb-3">
+            {appLabels.accueilRattachementService({
+              nom: service.collectiviteNom,
+            })}
+          </p>
+          <p className="mb-3">{appLabels.accueilRattachementIntro}</p>
+          <ul className="mb-0">
+            <li>{appLabels.accueilRattachementConsulter}</li>
+            <li>{appLabels.accueilRattachementSuivre({ deposeAvis })}</li>
+            <li>{appLabels.accueilRattachementVueEnsemble}</li>
+          </ul>
+        </div>
+      )}
+      renderFooter={() => (
+        <ModalFooter>
+          <Button
+            dataTest="oidc.rattachement.accueil.decouvrir"
+            href={makeCollectiviteRootUrl({
+              user,
+              collectiviteId: service.collectiviteId,
+              collectiviteType: service.collectiviteType,
+            })}
+            onClick={refermer}
+          >
+            {appLabels.accueilRattachementAction}
+          </Button>
+        </ModalFooter>
+      )}
+    />
+  );
+};

--- a/apps/app/src/users/authentications/oidc/auto-attachment/auto-attachment.welcome.modal.tsx
+++ b/apps/app/src/users/authentications/oidc/auto-attachment/auto-attachment.welcome.modal.tsx
@@ -9,7 +9,19 @@ import {
 import { useUser } from '@tet/api/users';
 import { peutDeposerAvisInstructeur } from '@tet/domain/demarches';
 import { Button, Modal, ModalFooter } from '@tet/ui';
+import { useSearchParams } from 'next/navigation';
 import { useState } from 'react';
+
+/**
+ * Rouvre l'accueil sur une collectivité donnée, sans repasser par un
+ * rattachement : `?rattachement-accueil=<id>`.
+ *
+ * L'accueil ne se montre qu'une fois, et le revoir demandait sinon de rejouer
+ * les seeds et de se reconnecter — de quoi rendre toute retouche coûteuse. Rien
+ * n'est exposé au passage : l'accueil ne nomme qu'une collectivité dont l'agent
+ * est déjà membre, et ne montre rien du tout des autres.
+ */
+const PARAM_RECETTE = 'rattachement-accueil';
 
 /**
  * L'accueil d'un agent rattaché automatiquement à son service.
@@ -29,7 +41,12 @@ export const AutoAttachmentWelcomeModal = () => {
   const { mutate: updatePreferences } = useUpdateUserPreferences();
   const [refermee, setRefermee] = useState(false);
 
-  const collectiviteId = preferences?.oidc.autoAttachedCollectiviteId ?? null;
+  const searchParams = useSearchParams();
+  const forcee = Number(searchParams.get(PARAM_RECETTE));
+  const collectiviteId =
+    Number.isInteger(forcee) && forcee > 0
+      ? forcee
+      : preferences?.oidc.autoAttachedCollectiviteId ?? null;
 
   // Le service tel que l'agent y a accès. Absent si le droit a été retiré
   // entre-temps : mieux vaut ne rien annoncer que d'annoncer un espace fermé.
@@ -37,10 +54,19 @@ export const AutoAttachmentWelcomeModal = () => {
     (acces) => acces.collectiviteId === collectiviteId
   );
 
+  // Les CGU passent devant. Leur modale est bloquante, et deux modales
+  // ouvertes ensemble se départagent mal : à z-index égal c'est la dernière
+  // **ouverte** qui passe devant, et l'accueil l'est forcément — il attend une
+  // requête, là où les CGU se décident depuis l'utilisateur déjà chargé.
+  // Attendre leur acceptation règle l'ordre par la logique plutôt que par
+  // l'empilement, et accueillir quelqu'un qui n'a pas encore accepté n'aurait
+  // de toute façon pas de sens.
+  const cguAcceptees = Boolean(user.cguAccepteesLe);
+
   // Ouverture **dérivée**, sans effet : la préférence dit à elle seule s'il y a
   // quelque chose à annoncer, et `refermee` couvre l'instant entre le clic et
   // la fin de l'écriture, où la préférence vaut encore l'ancien service.
-  const isOpen = Boolean(service) && !refermee;
+  const isOpen = Boolean(service) && cguAcceptees && !refermee;
 
   if (!isOpen || !service) {
     return null;

--- a/apps/backend/src/users/authentications/oidc/attach-user-to-organisation/attach-user-to-organisation.errors.ts
+++ b/apps/backend/src/users/authentications/oidc/attach-user-to-organisation/attach-user-to-organisation.errors.ts
@@ -1,0 +1,24 @@
+import {
+  createErrorsEnum,
+  TrpcErrorHandlerConfig,
+} from '@tet/backend/utils/trpc/trpc-error-handler';
+
+const specificErrors = ['ATTACH_ORGANISATION_ERROR'] as const;
+
+type AttachUserToOrganisationSpecificError = (typeof specificErrors)[number];
+
+export const attachUserToOrganisationErrorConfig: TrpcErrorHandlerConfig<AttachUserToOrganisationSpecificError> =
+  {
+    specificErrors: {
+      ATTACH_ORGANISATION_ERROR: {
+        code: 'INTERNAL_SERVER_ERROR',
+        message:
+          'Le rattachement automatique à votre service a échoué. Votre connexion est valide : rapprochez-vous du support pour obtenir vos accès.',
+      },
+    },
+  };
+
+export const AttachUserToOrganisationErrorEnum =
+  createErrorsEnum(specificErrors);
+export type AttachUserToOrganisationError =
+  keyof typeof AttachUserToOrganisationErrorEnum;

--- a/apps/backend/src/users/authentications/oidc/attach-user-to-organisation/attach-user-to-organisation.errors.ts
+++ b/apps/backend/src/users/authentications/oidc/attach-user-to-organisation/attach-user-to-organisation.errors.ts
@@ -2,12 +2,7 @@ import { createErrorsEnum } from '@tet/backend/utils/trpc/trpc-error-handler';
 
 const specificErrors = ['ATTACH_ORGANISATION_ERROR'] as const;
 
-/**
- * Pas de `TrpcErrorHandlerConfig` ici : le rattachement automatique n'est
- * exposé par aucun router. Il se déclenche au callback OIDC, et son échec ne
- * remonte jamais à un appelant — il est journalisé, et la connexion se
- * poursuit.
- */
+/** Pas de config tRPC : aucun router n'expose ce use-case. */
 export const AttachUserToOrganisationErrorEnum =
   createErrorsEnum(specificErrors);
 export type AttachUserToOrganisationError =

--- a/apps/backend/src/users/authentications/oidc/attach-user-to-organisation/attach-user-to-organisation.errors.ts
+++ b/apps/backend/src/users/authentications/oidc/attach-user-to-organisation/attach-user-to-organisation.errors.ts
@@ -1,23 +1,13 @@
-import {
-  createErrorsEnum,
-  TrpcErrorHandlerConfig,
-} from '@tet/backend/utils/trpc/trpc-error-handler';
+import { createErrorsEnum } from '@tet/backend/utils/trpc/trpc-error-handler';
 
 const specificErrors = ['ATTACH_ORGANISATION_ERROR'] as const;
 
-type AttachUserToOrganisationSpecificError = (typeof specificErrors)[number];
-
-export const attachUserToOrganisationErrorConfig: TrpcErrorHandlerConfig<AttachUserToOrganisationSpecificError> =
-  {
-    specificErrors: {
-      ATTACH_ORGANISATION_ERROR: {
-        code: 'INTERNAL_SERVER_ERROR',
-        message:
-          'Le rattachement automatique à votre service a échoué. Votre connexion est valide : rapprochez-vous du support pour obtenir vos accès.',
-      },
-    },
-  };
-
+/**
+ * Pas de `TrpcErrorHandlerConfig` ici : le rattachement automatique n'est
+ * exposé par aucun router. Il se déclenche au callback OIDC, et son échec ne
+ * remonte jamais à un appelant — il est journalisé, et la connexion se
+ * poursuit.
+ */
 export const AttachUserToOrganisationErrorEnum =
   createErrorsEnum(specificErrors);
 export type AttachUserToOrganisationError =

--- a/apps/backend/src/users/authentications/oidc/attach-user-to-organisation/attach-user-to-organisation.service.ts
+++ b/apps/backend/src/users/authentications/oidc/attach-user-to-organisation/attach-user-to-organisation.service.ts
@@ -87,7 +87,7 @@ export class AttachUserToOrganisationService {
     tx?: Transaction
   ): Promise<Result<AutoAttachmentOutcome, AttachUserToOrganisationError>> {
     if (!claims.siret) {
-      return success({ statut: 'aucun', raison: 'sans-siret' });
+      return this.refuser(userId, 'sans-siret');
     }
 
     const collectivite = await this.getCollectiviteBySiretService.getBySiret(
@@ -107,20 +107,17 @@ export class AttachUserToOrganisationService {
     );
 
     if (!collectivite) {
-      return success({ statut: 'aucun', raison: 'organisation-inconnue' });
+      return this.refuser(userId, 'organisation-inconnue');
     }
 
     if (!isAutoAttachableType(collectivite.type)) {
-      return success({ statut: 'aucun', raison: 'type-non-rattachable' });
+      return this.refuser(userId, 'type-non-rattachable');
     }
 
     if (
       !canAutoAttachEmail({ siren: collectivite.siren, email: claims.email })
     ) {
-      this.logger.warn(
-        `Rattachement automatique refusé : l'adresse de l'agent ne porte pas le domaine exigé par la collectivité #${collectivite.collectiviteId} (siren ${collectivite.siren})`
-      );
-      return success({ statut: 'aucun', raison: 'domaine-email-refuse' });
+      return this.refuser(userId, 'domaine-email-refuse');
     }
 
     const resultat = await this.transactionManager.executeSingle<
@@ -142,7 +139,7 @@ export class AttachUserToOrganisationService {
         .limit(1);
 
       if (droitExistant) {
-        return success({ statut: 'aucun', raison: 'droit-deja-connu' });
+        return this.refuser(userId, 'droit-deja-connu');
       }
 
       try {
@@ -186,6 +183,21 @@ export class AttachUserToOrganisationService {
     }
 
     return resultat;
+  }
+
+  /**
+   * Un refus, dit au journal. Toute la recette d'un rattachement qui n'a pas eu
+   * lieu tient là : sans la raison, il ne reste qu'un agent sans accès et rien
+   * pour dire lequel des quatre verrous a joué.
+   */
+  private refuser(
+    userId: string,
+    raison: AutoAttachmentRefus
+  ): Result<AutoAttachmentOutcome, AttachUserToOrganisationError> {
+    this.logger.log(
+      `Rattachement automatique du compte ${userId} : aucun (${raison})`
+    );
+    return success({ statut: 'aucun', raison });
   }
 
   /**

--- a/apps/backend/src/users/authentications/oidc/attach-user-to-organisation/attach-user-to-organisation.service.ts
+++ b/apps/backend/src/users/authentications/oidc/attach-user-to-organisation/attach-user-to-organisation.service.ts
@@ -1,0 +1,177 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { UpdateUserRoleService } from '@tet/backend/users/authorizations/update-user-role/update-user-role.service';
+import { utilisateurCollectiviteAccessTable } from '@tet/backend/users/authorizations/utilisateur-collectivite-access.table';
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { failure, Result, success } from '@tet/backend/utils/result.type';
+import { TransactionManager } from '@tet/backend/utils/transaction/transaction-manager.service';
+import {
+  canAutoAttachEmail,
+  isAutoAttachableType,
+} from '@tet/domain/collectivites';
+import { CollectiviteRole } from '@tet/domain/users';
+import { and, eq } from 'drizzle-orm';
+import { GetCollectiviteBySiretService } from '../get-collectivite-by-siret/get-collectivite-by-siret.service';
+import { OidcClaims, OidcProvider } from '../oidc.models';
+import {
+  AttachUserToOrganisationError,
+  AttachUserToOrganisationErrorEnum,
+} from './attach-user-to-organisation.errors';
+
+/**
+ * Le résultat, dit du point de vue de l'appelant : soit un service à annoncer,
+ * soit rien à faire. `raison` n'existe que pour le journal — aucun appelant ne
+ * s'y branche, et l'utilisateur n'en voit jamais rien.
+ */
+export type AutoAttachmentOutcome =
+  | { statut: 'rattache'; collectiviteId: number; nom: string }
+  | { statut: 'aucun'; raison: AutoAttachmentRefus };
+
+type AutoAttachmentRefus =
+  | 'sans-siret'
+  | 'organisation-inconnue'
+  | 'type-non-rattachable'
+  | 'domaine-email-refuse'
+  | 'droit-deja-connu';
+
+/**
+ * Le rattachement automatique d'un agent à son service, sur la seule foi de son
+ * identité.
+ *
+ * Un agent d'un service de l'État n'avait aucun moyen d'entrer : le parcours
+ * « rejoindre une collectivité » refuse ces structures, et l'import des membres
+ * n'est pas livré. Or l'organisation que l'agent choisit chez son fournisseur
+ * d'identité **fait foi** — elle vaut mieux qu'un formulaire, et personne n'a
+ * besoin de l'inviter.
+ *
+ * Quatre conditions, toutes nécessaires :
+ *
+ * 1. le jeton porte un SIRET ;
+ * 2. ce SIRET désigne une collectivité, et une seule ;
+ * 3. son type se rejoint par identité (`isAutoAttachableType`) — une commune
+ *    reste sur le parcours d'invitation ;
+ * 4. l'adresse de l'agent porte le domaine exigé par cet employeur, là où l'un
+ *    est déclaré (`canAutoAttachEmail`).
+ *
+ * La quatrième est volontairement redondante avec la deuxième. Elle vaut pour le
+ * jour où le fournisseur d'identité se tromperait d'organisation : c'est arrivé
+ * en août 2026, quand MonCompteAdeme renvoyait le SIRET du siège de l'ADEME au
+ * lieu de celui du service choisi. Ce SIRET désigne un service à périmètre
+ * national, destinataire de **toute** transmission PCAET — la même erreur y
+ * ferait entrer n'importe qui, et le domaine de messagerie est ce qui l'arrête.
+ *
+ * Le rattachement est **idempotent** et ne réveille rien : il n'agit que s'il
+ * n'existe aucune ligne de droit pour ce couple, active ou non. Un droit retiré
+ * par un administrateur laisse une ligne inactive derrière lui, et le voir
+ * revenir à la connexion suivante annulerait sa décision.
+ */
+@Injectable()
+export class AttachUserToOrganisationService {
+  private readonly logger = new Logger(AttachUserToOrganisationService.name);
+
+  constructor(
+    private readonly getCollectiviteBySiretService: GetCollectiviteBySiretService,
+    private readonly updateUserRoleService: UpdateUserRoleService,
+    private readonly transactionManager: TransactionManager
+  ) {}
+
+  async attach(
+    userId: string,
+    provider: OidcProvider,
+    claims: OidcClaims,
+    tx?: Transaction
+  ): Promise<Result<AutoAttachmentOutcome, AttachUserToOrganisationError>> {
+    if (!claims.siret) {
+      return success({ statut: 'aucun', raison: 'sans-siret' });
+    }
+
+    const collectivite = await this.getCollectiviteBySiretService.getBySiret(
+      claims.siret,
+      tx
+    );
+
+    // Le SIRET reçu et le service rapproché, tracés à chaque connexion : c'est
+    // le seul endroit d'où l'on verra qu'un fournisseur d'identité s'est remis
+    // à renvoyer la mauvaise organisation.
+    this.logger.log(
+      `Rattachement automatique (${provider}) : siret ${claims.siret} → ${
+        collectivite
+          ? `collectivité #${collectivite.collectiviteId} « ${collectivite.nom} » (${collectivite.type})`
+          : 'aucune collectivité'
+      }`
+    );
+
+    if (!collectivite) {
+      return success({ statut: 'aucun', raison: 'organisation-inconnue' });
+    }
+
+    if (!isAutoAttachableType(collectivite.type)) {
+      return success({ statut: 'aucun', raison: 'type-non-rattachable' });
+    }
+
+    if (
+      !canAutoAttachEmail({ siren: collectivite.siren, email: claims.email })
+    ) {
+      this.logger.warn(
+        `Rattachement automatique refusé : l'adresse de l'agent ne porte pas le domaine exigé par la collectivité #${collectivite.collectiviteId} (siren ${collectivite.siren})`
+      );
+      return success({ statut: 'aucun', raison: 'domaine-email-refuse' });
+    }
+
+    return this.transactionManager.executeSingle<
+      AutoAttachmentOutcome,
+      AttachUserToOrganisationError
+    >(async (transaction) => {
+      const [droitExistant] = await transaction
+        .select({ id: utilisateurCollectiviteAccessTable.id })
+        .from(utilisateurCollectiviteAccessTable)
+        .where(
+          and(
+            eq(utilisateurCollectiviteAccessTable.userId, userId),
+            eq(
+              utilisateurCollectiviteAccessTable.collectiviteId,
+              collectivite.collectiviteId
+            )
+          )
+        )
+        .limit(1);
+
+      if (droitExistant) {
+        return success({ statut: 'aucun', raison: 'droit-deja-connu' });
+      }
+
+      try {
+        await transaction.insert(utilisateurCollectiviteAccessTable).values({
+          userId,
+          collectiviteId: collectivite.collectiviteId,
+          isActive: true,
+          role: CollectiviteRole.EDITION,
+          invitationId: null,
+        });
+
+        // Une identité prouvée vaut au moins une invitation par email, et le
+        // compte non vérifié est traité à part par les gardes de collectivité.
+        // C'est aussi ce que fait le chemin d'invitation, dans sa transaction.
+        await this.updateUserRoleService.setIsVerified(
+          userId,
+          true,
+          transaction
+        );
+      } catch (error) {
+        return failure(
+          AttachUserToOrganisationErrorEnum.ATTACH_ORGANISATION_ERROR,
+          error instanceof Error ? error : undefined
+        );
+      }
+
+      this.logger.log(
+        `Compte ${userId} rattaché à la collectivité #${collectivite.collectiviteId} en ${CollectiviteRole.EDITION}`
+      );
+
+      return success({
+        statut: 'rattache',
+        collectiviteId: collectivite.collectiviteId,
+        nom: collectivite.nom,
+      });
+    }, tx);
+  }
+}

--- a/apps/backend/src/users/authentications/oidc/attach-user-to-organisation/attach-user-to-organisation.service.ts
+++ b/apps/backend/src/users/authentications/oidc/attach-user-to-organisation/attach-user-to-organisation.service.ts
@@ -22,11 +22,7 @@ import {
   AttachUserToOrganisationErrorEnum,
 } from './attach-user-to-organisation.errors';
 
-/**
- * Le résultat, dit du point de vue de l'appelant : soit un service à annoncer,
- * soit rien à faire. `raison` n'existe que pour le journal — aucun appelant ne
- * s'y branche, et l'utilisateur n'en voit jamais rien.
- */
+/** `raison` ne sert qu'au journal : aucun appelant ne s'y branche. */
 export type AutoAttachmentOutcome =
   | ({ statut: 'rattache' } & RattachementAutomatique)
   | { statut: 'aucun'; raison: AutoAttachmentRefus };
@@ -39,35 +35,13 @@ type AutoAttachmentRefus =
   | 'droit-deja-connu';
 
 /**
- * Le rattachement automatique d'un agent à son service, sur la seule foi de son
- * identité.
+ * Le rattachement d'un agent à son service, sur la foi de l'organisation que
+ * son fournisseur d'identité atteste.
  *
- * Un agent d'un service de l'État n'avait aucun moyen d'entrer : le parcours
- * « rejoindre une collectivité » refuse ces structures, et l'import des membres
- * n'est pas livré. Or l'organisation que l'agent choisit chez son fournisseur
- * d'identité **fait foi** — elle vaut mieux qu'un formulaire, et personne n'a
- * besoin de l'inviter.
- *
- * Quatre conditions, toutes nécessaires :
- *
- * 1. le jeton porte un SIRET ;
- * 2. ce SIRET désigne une collectivité, et une seule ;
- * 3. son type se rejoint par identité (`isAutoAttachableType`) — une commune
- *    reste sur le parcours d'invitation ;
- * 4. l'adresse de l'agent porte le domaine exigé par cet employeur, là où l'un
- *    est déclaré (`canAutoAttachEmail`).
- *
- * La quatrième est volontairement redondante avec la deuxième. Elle vaut pour le
- * jour où le fournisseur d'identité se tromperait d'organisation : c'est arrivé
- * en août 2026, quand MonCompteAdeme renvoyait le SIRET du siège de l'ADEME au
- * lieu de celui du service choisi. Ce SIRET désigne un service à périmètre
- * national, destinataire de **toute** transmission PCAET — la même erreur y
- * ferait entrer n'importe qui, et le domaine de messagerie est ce qui l'arrête.
- *
- * Le rattachement est **idempotent** et ne réveille rien : il n'agit que s'il
- * n'existe aucune ligne de droit pour ce couple, active ou non. Un droit retiré
- * par un administrateur laisse une ligne inactive derrière lui, et le voir
- * revenir à la connexion suivante annulerait sa décision.
+ * Le verrou de domaine est volontairement redondant avec le rapprochement par
+ * SIRET : en août 2026 MonCompteAdeme renvoyait le SIRET du siège de l'ADEME au
+ * lieu du service choisi, et ce SIRET désigne un service à périmètre national,
+ * destinataire de toute transmission PCAET.
  */
 @Injectable()
 export class AttachUserToOrganisationService {
@@ -86,6 +60,29 @@ export class AttachUserToOrganisationService {
     claims: OidcClaims,
     tx?: Transaction
   ): Promise<Result<AutoAttachmentOutcome, AttachUserToOrganisationError>> {
+    // Aucune exception ne doit sortir d'ici : un échec du rattachement ne fait
+    // jamais échouer la connexion. `executeSingle` relance d'ailleurs
+    // l'exception quand un `tx` lui est passé.
+    try {
+      return await this.rattacher(userId, provider, claims, tx);
+    } catch (error) {
+      this.logger.error(
+        `Rattachement automatique du compte ${userId} interrompu par une exception`,
+        error
+      );
+      return failure(
+        AttachUserToOrganisationErrorEnum.ATTACH_ORGANISATION_ERROR,
+        error instanceof Error ? error : undefined
+      );
+    }
+  }
+
+  private async rattacher(
+    userId: string,
+    provider: OidcProvider,
+    claims: OidcClaims,
+    tx?: Transaction
+  ): Promise<Result<AutoAttachmentOutcome, AttachUserToOrganisationError>> {
     if (!claims.siret) {
       return this.refuser(userId, 'sans-siret');
     }
@@ -95,9 +92,8 @@ export class AttachUserToOrganisationService {
       tx
     );
 
-    // Le SIRET reçu et le service rapproché, tracés à chaque connexion : c'est
-    // le seul endroit d'où l'on verra qu'un fournisseur d'identité s'est remis
-    // à renvoyer la mauvaise organisation.
+    // Seule trace permettant de voir qu'un fournisseur d'identité s'est remis à
+    // renvoyer la mauvaise organisation.
     this.logger.log(
       `Rattachement automatique (${provider}) : siret ${claims.siret} → ${
         collectivite
@@ -142,29 +138,33 @@ export class AttachUserToOrganisationService {
         return this.refuser(userId, 'droit-deja-connu');
       }
 
-      try {
-        await transaction.insert(utilisateurCollectiviteAccessTable).values({
+      // Le `select` porte la règle — ne jamais réveiller un droit retiré ;
+      // l'`on conflict` porte la course, deux callbacks concurrents le passant
+      // tous deux.
+      const [droitPose] = await transaction
+        .insert(utilisateurCollectiviteAccessTable)
+        .values({
           userId,
           collectiviteId: collectivite.collectiviteId,
           isActive: true,
           role: CollectiviteRole.EDITION,
           invitationId: null,
-        });
+        })
+        .onConflictDoNothing({
+          target: [
+            utilisateurCollectiviteAccessTable.userId,
+            utilisateurCollectiviteAccessTable.collectiviteId,
+          ],
+        })
+        .returning({ id: utilisateurCollectiviteAccessTable.id });
 
-        // Une identité prouvée vaut au moins une invitation par email, et le
-        // compte non vérifié est traité à part par les gardes de collectivité.
-        // C'est aussi ce que fait le chemin d'invitation, dans sa transaction.
-        await this.updateUserRoleService.setIsVerified(
-          userId,
-          true,
-          transaction
-        );
-      } catch (error) {
-        return failure(
-          AttachUserToOrganisationErrorEnum.ATTACH_ORGANISATION_ERROR,
-          error instanceof Error ? error : undefined
-        );
+      if (!droitPose) {
+        return this.refuser(userId, 'droit-deja-connu');
       }
+
+      // Comme le chemin d'invitation : sans ça, les gardes de collectivité
+      // traitent le compte à part.
+      await this.updateUserRoleService.setIsVerified(userId, true, transaction);
 
       this.logger.log(
         `Compte ${userId} rattaché à la collectivité #${collectivite.collectiviteId} en ${CollectiviteRole.EDITION}`
@@ -185,11 +185,7 @@ export class AttachUserToOrganisationService {
     return resultat;
   }
 
-  /**
-   * Un refus, dit au journal. Toute la recette d'un rattachement qui n'a pas eu
-   * lieu tient là : sans la raison, il ne reste qu'un agent sans accès et rien
-   * pour dire lequel des quatre verrous a joué.
-   */
+  /** La raison au journal : sans elle, un rattachement absent est muet. */
   private refuser(
     userId: string,
     raison: AutoAttachmentRefus
@@ -201,11 +197,9 @@ export class AttachUserToOrganisationService {
   }
 
   /**
-   * Marque le service à annoncer, pour que l'app en explique le parcours une
-   * fois. Hors de la transaction, et sans conséquence si elle échoue : le droit
-   * est acquis, et c'est lui qui compte — un écran d'accueil manquant n'est pas
-   * un accès manquant. Le dépôt des préférences n'accepte pas de transaction,
-   * et lui en donner une pour cela seul ne vaut pas le détour.
+   * Hors transaction, et sans conséquence si elle échoue : un écran d'accueil
+   * manquant n'est pas un accès manquant, et le dépôt des préférences n'accepte
+   * pas de `tx`.
    */
   private async annoncerLeService(
     userId: string,

--- a/apps/backend/src/users/authentications/oidc/attach-user-to-organisation/attach-user-to-organisation.service.ts
+++ b/apps/backend/src/users/authentications/oidc/attach-user-to-organisation/attach-user-to-organisation.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { UpdateUserRoleService } from '@tet/backend/users/authorizations/update-user-role/update-user-role.service';
+import { UserPreferencesRepository } from '@tet/backend/users/preferences/user-preferences.repository';
 import { utilisateurCollectiviteAccessTable } from '@tet/backend/users/authorizations/utilisateur-collectivite-access.table';
 import { Transaction } from '@tet/backend/utils/database/transaction.utils';
 import { failure, Result, success } from '@tet/backend/utils/result.type';
@@ -11,7 +12,11 @@ import {
 import { CollectiviteRole } from '@tet/domain/users';
 import { and, eq } from 'drizzle-orm';
 import { GetCollectiviteBySiretService } from '../get-collectivite-by-siret/get-collectivite-by-siret.service';
-import { OidcClaims, OidcProvider } from '../oidc.models';
+import {
+  OidcClaims,
+  OidcProvider,
+  RattachementAutomatique,
+} from '../oidc.models';
 import {
   AttachUserToOrganisationError,
   AttachUserToOrganisationErrorEnum,
@@ -23,7 +28,7 @@ import {
  * s'y branche, et l'utilisateur n'en voit jamais rien.
  */
 export type AutoAttachmentOutcome =
-  | { statut: 'rattache'; collectiviteId: number; nom: string }
+  | ({ statut: 'rattache' } & RattachementAutomatique)
   | { statut: 'aucun'; raison: AutoAttachmentRefus };
 
 type AutoAttachmentRefus =
@@ -71,6 +76,7 @@ export class AttachUserToOrganisationService {
   constructor(
     private readonly getCollectiviteBySiretService: GetCollectiviteBySiretService,
     private readonly updateUserRoleService: UpdateUserRoleService,
+    private readonly userPreferencesRepository: UserPreferencesRepository,
     private readonly transactionManager: TransactionManager
   ) {}
 
@@ -117,7 +123,7 @@ export class AttachUserToOrganisationService {
       return success({ statut: 'aucun', raison: 'domaine-email-refuse' });
     }
 
-    return this.transactionManager.executeSingle<
+    const resultat = await this.transactionManager.executeSingle<
       AutoAttachmentOutcome,
       AttachUserToOrganisationError
     >(async (transaction) => {
@@ -171,7 +177,37 @@ export class AttachUserToOrganisationService {
         statut: 'rattache',
         collectiviteId: collectivite.collectiviteId,
         nom: collectivite.nom,
+        type: collectivite.type,
       });
     }, tx);
+
+    if (resultat.success && resultat.data.statut === 'rattache') {
+      await this.annoncerLeService(userId, resultat.data.collectiviteId);
+    }
+
+    return resultat;
+  }
+
+  /**
+   * Marque le service à annoncer, pour que l'app en explique le parcours une
+   * fois. Hors de la transaction, et sans conséquence si elle échoue : le droit
+   * est acquis, et c'est lui qui compte — un écran d'accueil manquant n'est pas
+   * un accès manquant. Le dépôt des préférences n'accepte pas de transaction,
+   * et lui en donner une pour cela seul ne vaut pas le détour.
+   */
+  private async annoncerLeService(
+    userId: string,
+    collectiviteId: number
+  ): Promise<void> {
+    const preferences =
+      await this.userPreferencesRepository.updateUserPreferencesFlat(userId, {
+        'oidc.autoAttachedCollectiviteId': collectiviteId,
+      });
+
+    if (!preferences.success) {
+      this.logger.warn(
+        `Le service #${collectiviteId} du compte ${userId} ne sera pas annoncé (${preferences.error}) : le rattachement, lui, est acquis`
+      );
+    }
   }
 }

--- a/apps/backend/src/users/authentications/oidc/create-user-oidc-identity/create-user-oidc-identity.service.e2e-spec.ts
+++ b/apps/backend/src/users/authentications/oidc/create-user-oidc-identity/create-user-oidc-identity.service.e2e-spec.ts
@@ -4,9 +4,11 @@ import {
   addTestCollectivite,
   addTestCollectiviteAndUser,
 } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { pickFreeRegionCode } from '@tet/backend/demarches/pcaet/demarches-pcaet.test-fixture';
 import { UpdateUserRoleService } from '@tet/backend/users/authorizations/update-user-role/update-user-role.service';
 import { utilisateurCollectiviteAccessTable } from '@tet/backend/users/authorizations/utilisateur-collectivite-access.table';
 import { utilisateurVerifieTable } from '@tet/backend/users/authorizations/roles/utilisateur-verifie.table';
+import { UserPreferencesRepository } from '@tet/backend/users/preferences/user-preferences.repository';
 import { TransactionModule } from '@tet/backend/utils/transaction/transaction.module';
 import { authUsersTable } from '@tet/backend/users/models/auth-users.table';
 import { dcpTable } from '@tet/backend/users/models/dcp.table';
@@ -72,6 +74,7 @@ async function createTestingContext() {
       AttachUserToOrganisationService,
       GetCollectiviteBySiretService,
       UpdateUserRoleService,
+      UserPreferencesRepository,
     ],
   }).compile();
 
@@ -166,13 +169,34 @@ describe('CreateUserOidcIdentityService — création de compte (cas 3-Non, U5)'
     });
   }
 
-  /** Un service de l'État de test, identifié par son SIRET. */
+  /**
+   * Un service de l'État de test, identifié par son SIRET. Le code de région
+   * est tiré libre : une DREAL est unique par région, et les dix-huit codes
+   * réels sont tous occupés par l'import (cf. `pickFreeRegionCode`).
+   */
   async function addService(siren: string, nic: string) {
     const { collectivite, cleanup } = await addTestCollectivite(
       databaseService,
-      { type: 'dreal', regionCode: 'V1', siren, nic }
+      {
+        type: 'dreal',
+        regionCode: await pickFreeRegionCode(databaseService, 'dreal'),
+        siren,
+        nic,
+      }
     );
     onTestFinished(cleanup);
+    // Le droit que le rattachement va poser retient la collectivité (clé
+    // étrangère sans action en cascade). Le défaire ici, et non depuis le
+    // nettoyage du compte, garde la base propre même si une assertion casse
+    // avant : une DREAL laissée derrière soi rend le test infaisable au second
+    // passage — elle est unique par région.
+    onTestFinished(async () => {
+      await databaseService.db
+        .delete(utilisateurCollectiviteAccessTable)
+        .where(
+          eq(utilisateurCollectiviteAccessTable.collectiviteId, collectivite.id)
+        );
+    });
     return collectivite;
   }
 
@@ -392,6 +416,8 @@ describe('CreateUserOidcIdentityService — création de compte (cas 3-Non, U5)'
       expect(result.data.rattachement).toEqual({
         collectiviteId: service_.id,
         nom: service_.nom,
+        // Le type voyage jusqu'à l'app : c'est lui qui dit où atterrir.
+        type: 'dreal',
       });
 
       const [identite] = await databaseService.db
@@ -414,6 +440,16 @@ describe('CreateUserOidcIdentityService — création de compte (cas 3-Non, U5)'
         .from(utilisateurVerifieTable)
         .where(eq(utilisateurVerifieTable.userId, identite.userId));
       expect(verifie?.verifie).toBe(true);
+
+      // Le service à annoncer : c'est ce que l'app lit pour expliquer le
+      // parcours une fois, et qu'elle remet à `null` en refermant.
+      const [dcp] = await databaseService.db
+        .select()
+        .from(dcpTable)
+        .where(eq(dcpTable.id, identite.userId));
+      expect(dcp.preferences?.oidc.autoAttachedCollectiviteId).toBe(
+        service_.id
+      );
     });
 
     /**

--- a/apps/backend/src/users/authentications/oidc/create-user-oidc-identity/create-user-oidc-identity.service.e2e-spec.ts
+++ b/apps/backend/src/users/authentications/oidc/create-user-oidc-identity/create-user-oidc-identity.service.e2e-spec.ts
@@ -1,6 +1,13 @@
 import { JwtModule } from '@nestjs/jwt';
 import { Test } from '@nestjs/testing';
-import { addTestCollectiviteAndUser } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import {
+  addTestCollectivite,
+  addTestCollectiviteAndUser,
+} from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { UpdateUserRoleService } from '@tet/backend/users/authorizations/update-user-role/update-user-role.service';
+import { utilisateurCollectiviteAccessTable } from '@tet/backend/users/authorizations/utilisateur-collectivite-access.table';
+import { utilisateurVerifieTable } from '@tet/backend/users/authorizations/roles/utilisateur-verifie.table';
+import { TransactionModule } from '@tet/backend/utils/transaction/transaction.module';
 import { authUsersTable } from '@tet/backend/users/models/auth-users.table';
 import { dcpTable } from '@tet/backend/users/models/dcp.table';
 import ConfigurationService from '@tet/backend/utils/config/configuration.service';
@@ -25,6 +32,8 @@ import { CreateSupabaseSessionService } from '../create-supabase-session.service
 import { OidcClaims } from '../oidc.models';
 import { utilisateurIdentiteOidcTable } from '../models/utilisateur-identite-oidc.table';
 import { LinkOidcIdentityToUserService } from '../link-oidc-identity-to-user/link-oidc-identity-to-user.service';
+import { AttachUserToOrganisationService } from '../attach-user-to-organisation/attach-user-to-organisation.service';
+import { GetCollectiviteBySiretService } from '../get-collectivite-by-siret/get-collectivite-by-siret.service';
 import { CreateUserOidcIdentityService } from './create-user-oidc-identity.service';
 
 function buildClaims(overrides: Partial<OidcClaims> & { email: string }) {
@@ -50,6 +59,7 @@ async function createTestingContext() {
     imports: [
       ConfigurationModule,
       DatabaseModule,
+      TransactionModule,
       JwtModule.register({ global: true, secret: 'test-secret' }),
     ],
     providers: [
@@ -57,6 +67,11 @@ async function createTestingContext() {
       LinkOidcIdentityToUserService,
       CreateSupabaseSessionService,
       CreateUserOidcIdentityService,
+      // Le rattachement automatique est monté pour de vrai : c'est à la
+      // création de compte qu'il ouvre le service de l'agent.
+      AttachUserToOrganisationService,
+      GetCollectiviteBySiretService,
+      UpdateUserRoleService,
     ],
   }).compile();
 
@@ -135,11 +150,43 @@ describe('CreateUserOidcIdentityService — création de compte (cas 3-Non, U5)'
       await databaseService.db
         .delete(utilisateurIdentiteOidcTable)
         .where(eq(utilisateurIdentiteOidcTable.userId, userId));
+      // Le droit et la vérification que pose un rattachement automatique
+      // référencent `auth.users` sans action en cascade : ils partent d'abord,
+      // sinon la suppression du compte échoue.
+      await databaseService.db
+        .delete(utilisateurCollectiviteAccessTable)
+        .where(eq(utilisateurCollectiviteAccessTable.userId, userId));
+      await databaseService.db
+        .delete(utilisateurVerifieTable)
+        .where(eq(utilisateurVerifieTable.userId, userId));
       await databaseService.db.delete(dcpTable).where(eq(dcpTable.id, userId));
       await databaseService.db
         .delete(authUsersTable)
         .where(eq(authUsersTable.id, userId));
     });
+  }
+
+  /** Un service de l'État de test, identifié par son SIRET. */
+  async function addService(siren: string, nic: string) {
+    const { collectivite, cleanup } = await addTestCollectivite(
+      databaseService,
+      { type: 'dreal', regionCode: 'V1', siren, nic }
+    );
+    onTestFinished(cleanup);
+    return collectivite;
+  }
+
+  async function lireDroit(userId: string, collectiviteId: number) {
+    const [droit] = await databaseService.db
+      .select()
+      .from(utilisateurCollectiviteAccessTable)
+      .where(
+        and(
+          eq(utilisateurCollectiviteAccessTable.userId, userId),
+          eq(utilisateurCollectiviteAccessTable.collectiviteId, collectiviteId)
+        )
+      );
+    return droit;
   }
 
   test('ticket valide, aucun compte existant → compte créé, dcp existe, identité liée, session pontée', async () => {
@@ -325,5 +372,164 @@ describe('CreateUserOidcIdentityService — création de compte (cas 3-Non, U5)'
       );
     expect(identite).toBeDefined();
     expect(identite.userId).toBe(user.id);
+  });
+
+  describe("rattachement automatique à l'organisation du jeton", () => {
+    test("un service de l'État reconnu → droit en édition, compte vérifié, service annoncé", async () => {
+      mockCreateUser();
+      vi.spyOn(creerSessionService, 'creerSession').mockResolvedValue(
+        success({ hashedToken: 'hashed-token-rattachement' })
+      );
+      const service_ = await addService('999777111', '00042');
+
+      const email = `agent-${crypto.randomUUID()}@developpement-durable.gouv.fr`;
+      const claims = buildClaims({ email, siret: '99977711100042' });
+
+      const result = await service.creerCompte('proconnect', claims);
+
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      expect(result.data.rattachement).toEqual({
+        collectiviteId: service_.id,
+        nom: service_.nom,
+      });
+
+      const [identite] = await databaseService.db
+        .select()
+        .from(utilisateurIdentiteOidcTable)
+        .where(eq(utilisateurIdentiteOidcTable.sub, claims.sub));
+      cleanupUser(identite.userId);
+
+      const droit = await lireDroit(identite.userId, service_.id);
+      expect(droit).toMatchObject({
+        role: 'edition',
+        isActive: true,
+        invitationId: null,
+      });
+
+      // Une identité prouvée vaut au moins une invitation par email : sans la
+      // vérification, les gardes de collectivité traitent le compte à part.
+      const [verifie] = await databaseService.db
+        .select()
+        .from(utilisateurVerifieTable)
+        .where(eq(utilisateurVerifieTable.userId, identite.userId));
+      expect(verifie?.verifie).toBe(true);
+    });
+
+    /**
+     * Le second verrou, pour le jour où le fournisseur d'identité se
+     * tromperait d'organisation : en août 2026, MonCompteAdeme renvoyait le
+     * SIRET du siège de l'ADEME au lieu de celui du service choisi.
+     */
+    test("domaine de messagerie hors de celui exigé par l'employeur → aucun droit", async () => {
+      mockCreateUser();
+      vi.spyOn(creerSessionService, 'creerSession').mockResolvedValue(
+        success({ hashedToken: 'hashed-token-refuse' })
+      );
+      // Le SIREN de l'ADEME exige une adresse @ademe.fr.
+      const service_ = await addService('385290309', '99042');
+
+      const claims = buildClaims({
+        email: `agent-${crypto.randomUUID()}@example.org`,
+        siret: '38529030999042',
+      });
+
+      const result = await service.creerCompte('proconnect', claims);
+
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      expect(result.data.compteCree).toBe(true);
+      expect(result.data.rattachement).toBeUndefined();
+
+      const [identite] = await databaseService.db
+        .select()
+        .from(utilisateurIdentiteOidcTable)
+        .where(eq(utilisateurIdentiteOidcTable.sub, claims.sub));
+      cleanupUser(identite.userId);
+
+      expect(await lireDroit(identite.userId, service_.id)).toBeUndefined();
+    });
+
+    test('le domaine exigé, respecté → rattachement', async () => {
+      mockCreateUser();
+      vi.spyOn(creerSessionService, 'creerSession').mockResolvedValue(
+        success({ hashedToken: 'hashed-token-ademe' })
+      );
+      const service_ = await addService('385290309', '99043');
+
+      const claims = buildClaims({
+        email: `agent-${crypto.randomUUID()}@ademe.fr`,
+        siret: '38529030999043',
+      });
+
+      const result = await service.creerCompte('proconnect', claims);
+
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      expect(result.data.rattachement?.collectiviteId).toBe(service_.id);
+
+      const [identite] = await databaseService.db
+        .select()
+        .from(utilisateurIdentiteOidcTable)
+        .where(eq(utilisateurIdentiteOidcTable.sub, claims.sub));
+      cleanupUser(identite.userId);
+    });
+
+    /** Rien ne dit qu'un agent public est employé de la commune qu'il désigne. */
+    test("une commune reste sur le parcours d'invitation", async () => {
+      mockCreateUser();
+      vi.spyOn(creerSessionService, 'creerSession').mockResolvedValue(
+        success({ hashedToken: 'hashed-token-commune' })
+      );
+      const { collectivite: commune, cleanup } = await addTestCollectivite(
+        databaseService,
+        { type: 'commune', siren: '999777222', nic: '00042' }
+      );
+      onTestFinished(cleanup);
+
+      const claims = buildClaims({
+        email: `agent-${crypto.randomUUID()}@ville.fr`,
+        siret: '99977722200042',
+      });
+
+      const result = await service.creerCompte('proconnect', claims);
+
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      expect(result.data.rattachement).toBeUndefined();
+
+      const [identite] = await databaseService.db
+        .select()
+        .from(utilisateurIdentiteOidcTable)
+        .where(eq(utilisateurIdentiteOidcTable.sub, claims.sub));
+      cleanupUser(identite.userId);
+
+      expect(await lireDroit(identite.userId, commune.id)).toBeUndefined();
+    });
+
+    test('un SIRET que rien ne désigne → aucun droit, le compte est créé', async () => {
+      mockCreateUser();
+      vi.spyOn(creerSessionService, 'creerSession').mockResolvedValue(
+        success({ hashedToken: 'hashed-token-inconnu' })
+      );
+
+      const claims = buildClaims({
+        email: `agent-${crypto.randomUUID()}@ailleurs.fr`,
+        siret: '99966600000042',
+      });
+
+      const result = await service.creerCompte('proconnect', claims);
+
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      expect(result.data.compteCree).toBe(true);
+      expect(result.data.rattachement).toBeUndefined();
+
+      const [identite] = await databaseService.db
+        .select()
+        .from(utilisateurIdentiteOidcTable)
+        .where(eq(utilisateurIdentiteOidcTable.sub, claims.sub));
+      cleanupUser(identite.userId);
+    });
   });
 });

--- a/apps/backend/src/users/authentications/oidc/create-user-oidc-identity/create-user-oidc-identity.service.ts
+++ b/apps/backend/src/users/authentications/oidc/create-user-oidc-identity/create-user-oidc-identity.service.ts
@@ -143,10 +143,8 @@ export class CreateUserOidcIdentityService {
       `Compte créé via OIDC ${provider} (sub: ${claims.sub}, cas 3-Non, U5) : ${userId}`
     );
 
-    // Le compte n'existait pas : `authentifier` n'avait aucun droit à poser, et
-    // c'est ici que le service du jeton s'ouvre. Un échec ne perd pas
-    // l'inscription — le compte est créé, la session se ponte, et l'agent
-    // reprendra ses accès par le support.
+    // `authentifier` n'avait aucun compte à rattacher : c'est ici que le
+    // service du jeton s'ouvre. Un échec ne perd pas l'inscription.
     const rattachement = await this.rattacherOrganisationService.attach(
       userId,
       provider,

--- a/apps/backend/src/users/authentications/oidc/create-user-oidc-identity/create-user-oidc-identity.service.ts
+++ b/apps/backend/src/users/authentications/oidc/create-user-oidc-identity/create-user-oidc-identity.service.ts
@@ -3,20 +3,28 @@ import SupabaseService from '@tet/backend/utils/database/supabase.service';
 import { failure, Result, success } from '@tet/backend/utils/result.type';
 import { LoginUserWithOidcProviderService } from '../login-user-with-oidc-provider/login-user-with-oidc-provider.service';
 import { CreateSupabaseSessionService } from '../create-supabase-session.service';
-import { OidcClaims, OidcProvider } from '../oidc.models';
+import {
+  OidcClaims,
+  OidcProvider,
+  RattachementAutomatique,
+} from '../oidc.models';
 import { LinkOidcIdentityToUserService } from '../link-oidc-identity-to-user/link-oidc-identity-to-user.service';
+import { AttachUserToOrganisationService } from '../attach-user-to-organisation/attach-user-to-organisation.service';
 
 export const creerCompteOidcErrors = [
   'CREATION_COMPTE_ERROR',
   'SESSION_ERROR',
   'EMAIL_NON_VERIFIE',
 ] as const;
-export type CreateUserOidcIdentityError = (typeof creerCompteOidcErrors)[number];
+export type CreateUserOidcIdentityError =
+  (typeof creerCompteOidcErrors)[number];
 
 export type CreateUserOidcIdentityResult = {
   /** `true` si un compte a été créé ; `false` si un compte existait déjà (double-clic, défense en profondeur). */
   compteCree: boolean;
   hashedToken: string;
+  /** Renseigné quand l'organisation du jeton a ouvert un service au compte. */
+  rattachement?: RattachementAutomatique;
 };
 
 /**
@@ -33,13 +41,16 @@ export class CreateUserOidcIdentityService {
     private readonly authentifierOidcService: LoginUserWithOidcProviderService,
     private readonly rattacherIdentiteService: LinkOidcIdentityToUserService,
     private readonly supabaseService: SupabaseService,
-    private readonly creerSessionService: CreateSupabaseSessionService
+    private readonly creerSessionService: CreateSupabaseSessionService,
+    private readonly rattacherOrganisationService: AttachUserToOrganisationService
   ) {}
 
   async creerCompte(
     provider: OidcProvider,
     claims: OidcClaims
-  ): Promise<Result<CreateUserOidcIdentityResult, CreateUserOidcIdentityError>> {
+  ): Promise<
+    Result<CreateUserOidcIdentityResult, CreateUserOidcIdentityError>
+  > {
     // Défense en profondeur contre un double-clic / re-soumission du ticket :
     // on rejoue le même matching que le callback (sub OU email vérifié). S'il
     // trouve désormais un compte (créé entre-temps par une première requête,
@@ -64,7 +75,12 @@ export class CreateUserOidcIdentityService {
       this.logger.log(
         `Création de compte OIDC ${provider} (sub: ${claims.sub}) : compte déjà existant détecté (double-clic ou re-soumission), aucune création — reconnexion normale de ${authentification.userId}`
       );
-      return this.ponterSession(authentification.email, false);
+      // `authentifier` a déjà tenté le rattachement : on le reporte tel quel.
+      return this.ponterSession(
+        authentification.email,
+        false,
+        authentification.rattachement
+      );
     }
 
     if (authentification.statut === 'email-non-verifie') {
@@ -83,7 +99,9 @@ export class CreateUserOidcIdentityService {
   private async creerNouveauCompte(
     provider: OidcProvider,
     claims: OidcClaims
-  ): Promise<Result<CreateUserOidcIdentityResult, CreateUserOidcIdentityError>> {
+  ): Promise<
+    Result<CreateUserOidcIdentityResult, CreateUserOidcIdentityError>
+  > {
     const { data, error } =
       await this.supabaseService.client.auth.admin.createUser({
         email: claims.email,
@@ -125,17 +143,47 @@ export class CreateUserOidcIdentityService {
       `Compte créé via OIDC ${provider} (sub: ${claims.sub}, cas 3-Non, U5) : ${userId}`
     );
 
-    return this.ponterSession(claims.email, true);
+    // Le compte n'existait pas : `authentifier` n'avait aucun droit à poser, et
+    // c'est ici que le service du jeton s'ouvre. Un échec ne perd pas
+    // l'inscription — le compte est créé, la session se ponte, et l'agent
+    // reprendra ses accès par le support.
+    const rattachement = await this.rattacherOrganisationService.attach(
+      userId,
+      provider,
+      claims
+    );
+    if (!rattachement.success) {
+      this.logger.error(
+        `Rattachement automatique du compte ${userId} en échec (${rattachement.error}) : l'inscription se poursuit sans`
+      );
+    }
+
+    const service =
+      rattachement.success && rattachement.data.statut === 'rattache'
+        ? {
+            collectiviteId: rattachement.data.collectiviteId,
+            nom: rattachement.data.nom,
+          }
+        : undefined;
+
+    return this.ponterSession(claims.email, true, service);
   }
 
   private async ponterSession(
     email: string,
-    compteCree: boolean
-  ): Promise<Result<CreateUserOidcIdentityResult, CreateUserOidcIdentityError>> {
+    compteCree: boolean,
+    rattachement?: RattachementAutomatique
+  ): Promise<
+    Result<CreateUserOidcIdentityResult, CreateUserOidcIdentityError>
+  > {
     const session = await this.creerSessionService.creerSession(email);
     if (!session.success) {
       return failure('SESSION_ERROR');
     }
-    return success({ compteCree, hashedToken: session.data.hashedToken });
+    return success({
+      compteCree,
+      hashedToken: session.data.hashedToken,
+      rattachement,
+    });
   }
 }

--- a/apps/backend/src/users/authentications/oidc/create-user-oidc-identity/create-user-oidc-identity.service.ts
+++ b/apps/backend/src/users/authentications/oidc/create-user-oidc-identity/create-user-oidc-identity.service.ts
@@ -158,13 +158,11 @@ export class CreateUserOidcIdentityService {
       );
     }
 
-    const service =
-      rattachement.success && rattachement.data.statut === 'rattache'
-        ? {
-            collectiviteId: rattachement.data.collectiviteId,
-            nom: rattachement.data.nom,
-          }
-        : undefined;
+    let service: RattachementAutomatique | undefined;
+    if (rattachement.success && rattachement.data.statut === 'rattache') {
+      const { statut: _, ...rattache } = rattachement.data;
+      service = rattache;
+    }
 
     return this.ponterSession(claims.email, true, service);
   }

--- a/apps/backend/src/users/authentications/oidc/get-collectivite-by-siret/get-collectivite-by-siret.service.ts
+++ b/apps/backend/src/users/authentications/oidc/get-collectivite-by-siret/get-collectivite-by-siret.service.ts
@@ -1,0 +1,105 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { collectiviteTable } from '@tet/backend/collectivites/shared/models/collectivite.table';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { CollectiviteType } from '@tet/domain/collectivites';
+import { and, eq } from 'drizzle-orm';
+
+/** Un SIRET : le SIREN de l'entreprise (9) et le NIC de l'établissement (5). */
+const SIRET_PATTERN = /^\d{14}$/;
+
+export type CollectiviteRapprochee = {
+  collectiviteId: number;
+  nom: string;
+  type: CollectiviteType;
+  siren: string | null;
+  /** Le SIRET d'où vient le rapprochement. */
+  siret: string;
+};
+
+/**
+ * La collectivité que désigne un SIRET, au plus précis dont on dispose.
+ *
+ * Le SIRET nomme un **établissement**, `collectivite` porte un SIREN et un NIC :
+ * les deux se rapprochent donc à deux niveaux, et l'ordre compte.
+ *
+ * 1. Sur le SIRET entier. C'est le seul niveau qui tranche entre les directions
+ *    régionales de l'ADEME, qui partagent son SIREN et ne se distinguent que par
+ *    leur NIC.
+ * 2. À défaut, sur le SIREN seul, et seulement s'il ne désigne qu'une
+ *    collectivité. Le classeur de l'ADEME donne le NIC du **siège** ; un agent
+ *    dont ProConnect renvoie une autre implantation de la même DREAL doit
+ *    quand même retrouver son service.
+ *
+ * Ce service vit dans le module OIDC et non dans le domaine collectivités : ses
+ * deux appelants y sont, et `CollectivitesCoreModule` importe `UsersModule` —
+ * l'y placer refermerait le cycle.
+ */
+@Injectable()
+export class GetCollectiviteBySiretService {
+  private readonly logger = new Logger(GetCollectiviteBySiretService.name);
+
+  constructor(private readonly databaseService: DatabaseService) {}
+
+  async getBySiret(
+    siret: string,
+    tx?: Transaction
+  ): Promise<CollectiviteRapprochee | null> {
+    const db = tx ?? this.databaseService.db;
+
+    if (!SIRET_PATTERN.test(siret)) {
+      this.logger.log(
+        `Rapprochement par SIRET : « ${siret} » n'est pas un SIRET, aucun rapprochement`
+      );
+      return null;
+    }
+
+    const siren = siret.slice(0, 9);
+    const nic = siret.slice(9);
+
+    const colonnes = {
+      collectiviteId: collectiviteTable.id,
+      nom: collectiviteTable.nom,
+      type: collectiviteTable.type,
+      siren: collectiviteTable.siren,
+    };
+
+    // Deux lignes suffisent à conclure : ce qu'on cherche, c'est l'unicité.
+    const parSiret = await db
+      .select(colonnes)
+      .from(collectiviteTable)
+      .where(
+        and(eq(collectiviteTable.siren, siren), eq(collectiviteTable.nic, nic))
+      )
+      .limit(2);
+
+    if (parSiret.length === 1) {
+      return { ...parSiret[0], siret };
+    }
+
+    if (parSiret.length > 1) {
+      // L'import ne pose qu'une ligne par SIRET, et le `verify` de
+      // `collectivite/perimetre_secondaire` le tient. Y arriver quand même
+      // signifie une saisie à la main : on ne devine pas laquelle.
+      this.logger.warn(
+        `Rapprochement par SIRET ${siret} : plusieurs collectivités portent ce SIRET, aucun rapprochement`
+      );
+      return null;
+    }
+
+    const parSiren = await db
+      .select(colonnes)
+      .from(collectiviteTable)
+      .where(eq(collectiviteTable.siren, siren))
+      .limit(2);
+
+    if (parSiren.length !== 1) {
+      this.logger.log(
+        `Rapprochement par SIRET ${siret} : aucune collectivité sur ce SIRET, et ${parSiren.length} sur le SIREN ${siren} — aucun rapprochement`
+      );
+      return null;
+    }
+
+    return { ...parSiren[0], siret };
+  }
+}

--- a/apps/backend/src/users/authentications/oidc/get-collectivite-by-siret/get-collectivite-by-siret.service.ts
+++ b/apps/backend/src/users/authentications/oidc/get-collectivite-by-siret/get-collectivite-by-siret.service.ts
@@ -18,22 +18,13 @@ export type CollectiviteRapprochee = {
 };
 
 /**
- * La collectivité que désigne un SIRET, au plus précis dont on dispose.
+ * La collectivité que désigne un SIRET, au plus précis disponible : sur le SIRET
+ * entier — seul niveau qui départage les directions régionales de l'ADEME, qui
+ * partagent son SIREN — puis sur le SIREN seul s'il est unique, le classeur ne
+ * donnant que le NIC du siège.
  *
- * Le SIRET nomme un **établissement**, `collectivite` porte un SIREN et un NIC :
- * les deux se rapprochent donc à deux niveaux, et l'ordre compte.
- *
- * 1. Sur le SIRET entier. C'est le seul niveau qui tranche entre les directions
- *    régionales de l'ADEME, qui partagent son SIREN et ne se distinguent que par
- *    leur NIC.
- * 2. À défaut, sur le SIREN seul, et seulement s'il ne désigne qu'une
- *    collectivité. Le classeur de l'ADEME donne le NIC du **siège** ; un agent
- *    dont ProConnect renvoie une autre implantation de la même DREAL doit
- *    quand même retrouver son service.
- *
- * Ce service vit dans le module OIDC et non dans le domaine collectivités : ses
- * deux appelants y sont, et `CollectivitesCoreModule` importe `UsersModule` —
- * l'y placer refermerait le cycle.
+ * Dans le module OIDC et non dans le domaine collectivités : ses deux appelants
+ * y sont, et `CollectivitesCoreModule` importe `UsersModule`.
  */
 @Injectable()
 export class GetCollectiviteBySiretService {
@@ -64,7 +55,6 @@ export class GetCollectiviteBySiretService {
       siren: collectiviteTable.siren,
     };
 
-    // Deux lignes suffisent à conclure : ce qu'on cherche, c'est l'unicité.
     const parSiret = await db
       .select(colonnes)
       .from(collectiviteTable)
@@ -78,9 +68,8 @@ export class GetCollectiviteBySiretService {
     }
 
     if (parSiret.length > 1) {
-      // L'import ne pose qu'une ligne par SIRET, et le `verify` de
-      // `collectivite/perimetre_secondaire` le tient. Y arriver quand même
-      // signifie une saisie à la main : on ne devine pas laquelle.
+      // L'import n'en pose qu'une par SIRET : deux signent une saisie à la
+      // main, et on ne devine pas laquelle.
       this.logger.warn(
         `Rapprochement par SIRET ${siret} : plusieurs collectivités portent ce SIRET, aucun rapprochement`
       );

--- a/apps/backend/src/users/authentications/oidc/get-preselected-collectivite/get-preselected-collectivite.router.e2e-spec.ts
+++ b/apps/backend/src/users/authentications/oidc/get-preselected-collectivite/get-preselected-collectivite.router.e2e-spec.ts
@@ -1,5 +1,8 @@
 import { INestApplication } from '@nestjs/common';
-import { addTestCollectiviteAndUser } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import {
+  addTestCollectivite,
+  addTestCollectiviteAndUser,
+} from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
 import { collectiviteTable } from '@tet/backend/collectivites/shared/models/collectivite.table';
 import {
   getAuthUserFromUserCredentials,
@@ -28,7 +31,20 @@ describe('GetPreselectedCollectiviteRouter — pré-sélection par SIRET ProConn
     };
   });
 
-  async function creerContexte(siren: string | null) {
+  /**
+   * Une seconde collectivité sur le même SIREN, distinguée par son NIC : le cas
+   * des directions régionales de l'ADEME, qui partagent celui de l'ADEME.
+   */
+  async function addCollectiviteAvecSiret(siren: string, nic: string) {
+    const { collectivite, cleanup } = await addTestCollectivite(
+      databaseService,
+      { siren, nic }
+    );
+    onTestFinished(cleanup);
+    return collectivite;
+  }
+
+  async function creerContexte(siren: string | null, nic?: string) {
     const { user, collectivite, cleanup } = await addTestCollectiviteAndUser(
       databaseService
     );
@@ -37,7 +53,7 @@ describe('GetPreselectedCollectiviteRouter — pré-sélection par SIRET ProConn
     // Fixe le SIREN de la collectivité de test à une valeur connue (ou null).
     await databaseService.db
       .update(collectiviteTable)
-      .set({ siren })
+      .set({ siren, nic: nic ?? null })
       .where(eq(collectiviteTable.id, collectivite.id));
 
     return {
@@ -70,6 +86,71 @@ describe('GetPreselectedCollectiviteRouter — pré-sélection par SIRET ProConn
       collectiviteId: collectivite.id,
       siret: `${siren}00019`,
     });
+  });
+
+  /**
+   * Le rapprochement va au plus précis : sur le SIREN seul, ces deux
+   * collectivités seraient deux réponses et il n'y en aurait aucune.
+   */
+  test('siren partagé par deux collectivités → le NIC tranche', async () => {
+    // Un SIREN fictif : celui de l'ADEME, que ce cas décrit, est en base — les
+    // dix-sept DR ADEME le portent, et le rapprochement les trouverait.
+    const siren = '999888777';
+    const { user, collectivite, authUser } = await creerContexte(
+      siren,
+      '00397'
+    );
+    const soeur = await addCollectiviteAvecSiret(siren, '00504');
+    await lierIdentiteAvecSiret(user.id, `${siren}00397`);
+
+    const caller = router.createCaller({ user: authUser });
+    const preselection =
+      await caller.users.authentications.oidc.getPreselectedCollectivite();
+
+    expect(preselection).toMatchObject({ collectiviteId: collectivite.id });
+    expect(preselection?.collectiviteId).not.toBe(soeur.id);
+  });
+
+  /** Le NIC ne correspond à personne, et le SIREN à plus d'une : on renonce. */
+  test('siren partagé et NIC inconnu → pas de pré-sélection', async () => {
+    const siren = '999888666';
+    const { user, authUser } = await creerContexte(siren, '00397');
+    await addCollectiviteAvecSiret(siren, '00504');
+    await lierIdentiteAvecSiret(user.id, `${siren}00611`);
+
+    const caller = router.createCaller({ user: authUser });
+    expect(
+      await caller.users.authentications.oidc.getPreselectedCollectivite()
+    ).toBeNull();
+  });
+
+  /**
+   * Le classeur de l'ADEME donne le NIC du siège : un agent dont ProConnect
+   * renvoie une autre implantation de la même DREAL doit quand même la
+   * retrouver.
+   */
+  test('NIC inconnu mais SIREN unique → pré-sélection par le SIREN', async () => {
+    const siren = '999888555';
+    const { user, collectivite, authUser } = await creerContexte(
+      siren,
+      '00011'
+    );
+    await lierIdentiteAvecSiret(user.id, `${siren}00078`);
+
+    const caller = router.createCaller({ user: authUser });
+    expect(
+      await caller.users.authentications.oidc.getPreselectedCollectivite()
+    ).toMatchObject({ collectiviteId: collectivite.id });
+  });
+
+  test('siret mal formé → pas de pré-sélection', async () => {
+    const { user, authUser } = await creerContexte('210900011');
+    await lierIdentiteAvecSiret(user.id, '210900011');
+
+    const caller = router.createCaller({ user: authUser });
+    expect(
+      await caller.users.authentications.oidc.getPreselectedCollectivite()
+    ).toBeNull();
   });
 
   test('aucune identité avec siret → pas de pré-sélection', async () => {

--- a/apps/backend/src/users/authentications/oidc/get-preselected-collectivite/get-preselected-collectivite.service.ts
+++ b/apps/backend/src/users/authentications/oidc/get-preselected-collectivite/get-preselected-collectivite.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { collectiviteTable } from '@tet/backend/collectivites/shared/models/collectivite.table';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { and, desc, eq, isNotNull } from 'drizzle-orm';
+import { GetCollectiviteBySiretService } from '../get-collectivite-by-siret/get-collectivite-by-siret.service';
 import { utilisateurIdentiteOidcTable } from '../models/utilisateur-identite-oidc.table';
 
 export type PreselectedCollectivite = {
@@ -25,7 +25,10 @@ export type PreselectedCollectivite = {
 export class GetPreselectedCollectiviteService {
   private readonly logger = new Logger(GetPreselectedCollectiviteService.name);
 
-  constructor(private readonly databaseService: DatabaseService) {}
+  constructor(
+    private readonly databaseService: DatabaseService,
+    private readonly getCollectiviteBySiretService: GetCollectiviteBySiretService
+  ) {}
 
   async preselectionner(
     userId: string
@@ -53,40 +56,28 @@ export class GetPreselectedCollectiviteService {
       return null;
     }
 
-    // SIRET (14) = SIREN (9) + NIC (5). La table collectivite stocke le SIREN ;
-    // on rapproche au niveau SIREN (une collectivité = un SIREN).
-    const siren = identite.siret.slice(0, 9);
-
-    const collectivites = await db
-      .select({ id: collectiviteTable.id, nom: collectiviteTable.nom })
-      .from(collectiviteTable)
-      .where(eq(collectiviteTable.siren, siren))
-      .limit(2);
-
-    this.logger.log(
-      `Pré-sélection collectivité (compte ${userId}) : siret=${identite.siret} → siren=${siren} → ${collectivites.length} collectivité(s) trouvée(s)` +
-        (collectivites.length > 0
-          ? ` [${collectivites.map((c) => `#${c.id} ${c.nom}`).join(', ')}]`
-          : '')
+    // Le rapprochement lui-même est partagé avec le rattachement automatique :
+    // les deux chemins doivent désigner la même collectivité pour un même
+    // SIRET, sans quoi l'écran de choix proposerait autre chose que ce que
+    // l'identité vaut.
+    const rapprochee = await this.getCollectiviteBySiretService.getBySiret(
+      identite.siret
     );
 
-    // Correspondance unique requise : 0 → pas de collectivité connue pour ce
-    // SIREN ; >1 → ambiguïté (ne devrait pas arriver, SIREN unique) — dans les
-    // deux cas on ne pré-sélectionne rien (sélecteur vide, comportement actuel).
-    if (collectivites.length !== 1) {
+    if (!rapprochee) {
       this.logger.log(
-        `Pas de pré-sélection pour le SIREN ${siren} (compte ${userId}) : ${collectivites.length} collectivité(s) trouvée(s)`
+        `Pas de pré-sélection pour le compte ${userId} : le SIRET ${identite.siret} ne désigne aucune collectivité`
       );
       return null;
     }
 
     this.logger.log(
-      `Pré-sélection retenue pour le compte ${userId} : collectivité #${collectivites[0].id} (${collectivites[0].nom}), siren ${siren}`
+      `Pré-sélection retenue pour le compte ${userId} : collectivité #${rapprochee.collectiviteId} (${rapprochee.nom}), siret ${identite.siret}`
     );
 
     return {
-      collectiviteId: collectivites[0].id,
-      nom: collectivites[0].nom,
+      collectiviteId: rapprochee.collectiviteId,
+      nom: rapprochee.nom,
       siret: identite.siret,
     };
   }

--- a/apps/backend/src/users/authentications/oidc/login-user-with-oidc-provider/login-user-with-oidc-provider.service.e2e-spec.ts
+++ b/apps/backend/src/users/authentications/oidc/login-user-with-oidc-provider/login-user-with-oidc-provider.service.e2e-spec.ts
@@ -1,5 +1,9 @@
 import { INestApplication } from '@nestjs/common';
-import { addTestCollectiviteAndUser } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import {
+  addTestCollectivite,
+  addTestCollectiviteAndUser,
+} from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { utilisateurCollectiviteAccessTable } from '@tet/backend/users/authorizations/utilisateur-collectivite-access.table';
 import { authUsersTable } from '@tet/backend/users/models/auth-users.table';
 import { dcpTable } from '@tet/backend/users/models/dcp.table';
 import { getTestApp, getTestDatabase } from '@tet/backend/test';
@@ -413,5 +417,152 @@ describe('LoginUserWithOidcProviderService — matching des comptes à la connex
     );
 
     expect(result).toEqual({ statut: 'non-reconnu' });
+  });
+
+  describe("rattachement automatique à l'organisation du jeton", () => {
+    /**
+     * Un service de l'État de test, avec son SIRET, et le nettoyage de ce que
+     * le rattachement y écrira — les droits retiennent la collectivité (clé
+     * étrangère sans action en cascade), et `onTestFinished` les défait dans
+     * l'ordre inverse de leur déclaration.
+     */
+    async function addService(siren: string, nic: string) {
+      const { collectivite, cleanup } = await addTestCollectivite(
+        databaseService,
+        { type: 'dreal', regionCode: 'V2', siren, nic }
+      );
+      onTestFinished(cleanup);
+      onTestFinished(async () => {
+        await databaseService.db
+          .delete(utilisateurCollectiviteAccessTable)
+          .where(
+            eq(
+              utilisateurCollectiviteAccessTable.collectiviteId,
+              collectivite.id
+            )
+          );
+      });
+      return collectivite;
+    }
+
+    async function connecterAvecSiret(
+      userId: string,
+      email: string,
+      siret: string
+    ) {
+      const sub = `sub-rattachement-${crypto.randomUUID()}`;
+      await databaseService.db.insert(utilisateurIdentiteOidcTable).values({
+        provider: 'proconnect',
+        sub,
+        userId,
+        email,
+      });
+      return service.authentifier(
+        'proconnect',
+        buildClaims({ sub, email, siret })
+      );
+    }
+
+    async function lireDroit(userId: string, collectiviteId: number) {
+      const [droit] = await databaseService.db
+        .select()
+        .from(utilisateurCollectiviteAccessTable)
+        .where(
+          and(
+            eq(utilisateurCollectiviteAccessTable.userId, userId),
+            eq(
+              utilisateurCollectiviteAccessTable.collectiviteId,
+              collectiviteId
+            )
+          )
+        );
+      return droit;
+    }
+
+    /**
+     * À chaque connexion, pas seulement à la création du compte : un agent qui
+     * avait déjà un compte TeT avant cette bascule doit lui aussi entrer dans
+     * son service.
+     */
+    test('un compte antérieur entre dans son service à la connexion', async () => {
+      const { user, cleanup } = await addTestCollectiviteAndUser(
+        databaseService
+      );
+      onTestFinished(cleanup);
+      const dreal = await addService('999555111', '00042');
+
+      const resultat = await connecterAvecSiret(
+        user.id,
+        user.email,
+        '99955511100042'
+      );
+
+      expect(resultat).toMatchObject({
+        statut: 'connexion',
+        rattachement: { collectiviteId: dreal.id, nom: dreal.nom },
+      });
+      expect(await lireDroit(user.id, dreal.id)).toMatchObject({
+        role: 'edition',
+        isActive: true,
+      });
+    });
+
+    /**
+     * Un administrateur qui retire un accès laisse une ligne inactive derrière
+     * lui. La voir revenir à la connexion suivante annulerait sa décision.
+     */
+    test('un droit retiré ne revient pas', async () => {
+      const { user, cleanup } = await addTestCollectiviteAndUser(
+        databaseService
+      );
+      onTestFinished(cleanup);
+      const dreal = await addService('999555222', '00042');
+
+      await databaseService.db
+        .insert(utilisateurCollectiviteAccessTable)
+        .values({
+          userId: user.id,
+          collectiviteId: dreal.id,
+          isActive: false,
+          role: CollectiviteRole.EDITION,
+        });
+
+      const resultat = await connecterAvecSiret(
+        user.id,
+        user.email,
+        '99955522200042'
+      );
+
+      expect(resultat).toMatchObject({ statut: 'connexion' });
+      expect(resultat).not.toHaveProperty('rattachement');
+      expect(await lireDroit(user.id, dreal.id)).toMatchObject({
+        isActive: false,
+      });
+    });
+
+    /** Et un droit existant n'est jamais élevé : le rattachement n'ouvre, il ne promeut pas. */
+    test('un droit existant garde son niveau', async () => {
+      const { user, cleanup } = await addTestCollectiviteAndUser(
+        databaseService
+      );
+      onTestFinished(cleanup);
+      const dreal = await addService('999555333', '00042');
+
+      await databaseService.db
+        .insert(utilisateurCollectiviteAccessTable)
+        .values({
+          userId: user.id,
+          collectiviteId: dreal.id,
+          isActive: true,
+          role: CollectiviteRole.LECTURE,
+        });
+
+      await connecterAvecSiret(user.id, user.email, '99955533300042');
+
+      expect(await lireDroit(user.id, dreal.id)).toMatchObject({
+        role: 'lecture',
+        isActive: true,
+      });
+    });
   });
 });

--- a/apps/backend/src/users/authentications/oidc/login-user-with-oidc-provider/login-user-with-oidc-provider.service.e2e-spec.ts
+++ b/apps/backend/src/users/authentications/oidc/login-user-with-oidc-provider/login-user-with-oidc-provider.service.e2e-spec.ts
@@ -3,6 +3,7 @@ import {
   addTestCollectivite,
   addTestCollectiviteAndUser,
 } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { pickFreeRegionCode } from '@tet/backend/demarches/pcaet/demarches-pcaet.test-fixture';
 import { utilisateurCollectiviteAccessTable } from '@tet/backend/users/authorizations/utilisateur-collectivite-access.table';
 import { authUsersTable } from '@tet/backend/users/models/auth-users.table';
 import { dcpTable } from '@tet/backend/users/models/dcp.table';
@@ -424,12 +425,18 @@ describe('LoginUserWithOidcProviderService — matching des comptes à la connex
      * Un service de l'État de test, avec son SIRET, et le nettoyage de ce que
      * le rattachement y écrira — les droits retiennent la collectivité (clé
      * étrangère sans action en cascade), et `onTestFinished` les défait dans
-     * l'ordre inverse de leur déclaration.
+     * l'ordre inverse de leur déclaration. Le code de région est tiré libre :
+     * une DREAL est unique par région (cf. `pickFreeRegionCode`).
      */
     async function addService(siren: string, nic: string) {
       const { collectivite, cleanup } = await addTestCollectivite(
         databaseService,
-        { type: 'dreal', regionCode: 'V2', siren, nic }
+        {
+          type: 'dreal',
+          regionCode: await pickFreeRegionCode(databaseService, 'dreal'),
+          siren,
+          nic,
+        }
       );
       onTestFinished(cleanup);
       onTestFinished(async () => {
@@ -499,7 +506,11 @@ describe('LoginUserWithOidcProviderService — matching des comptes à la connex
 
       expect(resultat).toMatchObject({
         statut: 'connexion',
-        rattachement: { collectiviteId: dreal.id, nom: dreal.nom },
+        rattachement: {
+          collectiviteId: dreal.id,
+          nom: dreal.nom,
+          type: 'dreal',
+        },
       });
       expect(await lireDroit(user.id, dreal.id)).toMatchObject({
         role: 'edition',

--- a/apps/backend/src/users/authentications/oidc/login-user-with-oidc-provider/login-user-with-oidc-provider.service.e2e-spec.ts
+++ b/apps/backend/src/users/authentications/oidc/login-user-with-oidc-provider/login-user-with-oidc-provider.service.e2e-spec.ts
@@ -420,6 +420,35 @@ describe('LoginUserWithOidcProviderService — matching des comptes à la connex
     expect(result).toEqual({ statut: 'non-reconnu' });
   });
 
+  /**
+   * L'agent peut changer d'organisation d'un jour à l'autre. Figer le siret à la
+   * première connexion laissait la pré-sélection désigner un service quitté.
+   */
+  test('cas 1 — le siret stocké suit la dernière connexion', async () => {
+    const { user, cleanup } = await addTestCollectiviteAndUser(databaseService);
+    onTestFinished(cleanup);
+
+    const sub = `sub-siret-${crypto.randomUUID()}`;
+    await databaseService.db.insert(utilisateurIdentiteOidcTable).values({
+      provider: 'proconnect',
+      sub,
+      userId: user.id,
+      email: user.email,
+      siret: '11111111100011',
+    });
+
+    await service.authentifier(
+      'proconnect',
+      buildClaims({ sub, email: user.email, siret: '22222222200022' })
+    );
+
+    const [identite] = await databaseService.db
+      .select({ siret: utilisateurIdentiteOidcTable.siret })
+      .from(utilisateurIdentiteOidcTable)
+      .where(eq(utilisateurIdentiteOidcTable.sub, sub));
+    expect(identite.siret).toBe('22222222200022');
+  });
+
   describe("rattachement automatique à l'organisation du jeton", () => {
     /**
      * Un service de l'État de test, avec son SIRET, et le nettoyage de ce que

--- a/apps/backend/src/users/authentications/oidc/login-user-with-oidc-provider/login-user-with-oidc-provider.service.ts
+++ b/apps/backend/src/users/authentications/oidc/login-user-with-oidc-provider/login-user-with-oidc-provider.service.ts
@@ -59,13 +59,9 @@ export class LoginUserWithOidcProviderService {
   }
 
   /**
-   * Le rattachement automatique à l'organisation du jeton, tenté à **chaque**
-   * connexion : il n'agit que si l'agent n'a encore aucun droit sur ce service,
-   * ce qui sert aussi les comptes antérieurs à cette bascule.
-   *
-   * Son échec ne fait jamais échouer la connexion. Un agent authentifié doit
-   * entrer, quitte à ce que ses accès lui manquent : l'inverse le laisserait
-   * dehors sans recours.
+   * Tenté à **chaque** connexion, ce qui sert aussi les comptes antérieurs.
+   * Son échec ne fait jamais échouer la connexion : un agent authentifié doit
+   * entrer, quitte à ce que ses accès lui manquent.
    */
   private async rattacherOrganisation(
     userId: string,
@@ -140,10 +136,8 @@ export class LoginUserWithOidcProviderService {
       );
     }
 
-    // `siret` et `idpId` suivent la connexion, comme `claims` : un agent peut
-    // choisir une autre organisation d'un jour à l'autre, et c'est la dernière
-    // qui fait foi. Les figer à la première connexion laissait la pré-sélection
-    // désigner un service que l'agent avait quitté.
+    // `siret` et `idpId` suivent la connexion : figés à la première, ils
+    // laissaient la pré-sélection désigner un service quitté.
     await db
       .update(utilisateurIdentiteOidcTable)
       .set({

--- a/apps/backend/src/users/authentications/oidc/login-user-with-oidc-provider/login-user-with-oidc-provider.service.ts
+++ b/apps/backend/src/users/authentications/oidc/login-user-with-oidc-provider/login-user-with-oidc-provider.service.ts
@@ -140,11 +140,17 @@ export class LoginUserWithOidcProviderService {
       );
     }
 
+    // `siret` et `idpId` suivent la connexion, comme `claims` : un agent peut
+    // choisir une autre organisation d'un jour à l'autre, et c'est la dernière
+    // qui fait foi. Les figer à la première connexion laissait la pré-sélection
+    // désigner un service que l'agent avait quitté.
     await db
       .update(utilisateurIdentiteOidcTable)
       .set({
         claims,
         email: claims.email,
+        siret: claims.siret ?? null,
+        idpId: claims.idp_id ?? null,
         lastSignInAt: sql`now()`,
       })
       .where(

--- a/apps/backend/src/users/authentications/oidc/login-user-with-oidc-provider/login-user-with-oidc-provider.service.ts
+++ b/apps/backend/src/users/authentications/oidc/login-user-with-oidc-provider/login-user-with-oidc-provider.service.ts
@@ -9,7 +9,9 @@ import {
   isEmailVerified,
   OidcClaims,
   OidcProvider,
+  RattachementAutomatique,
 } from '../oidc.models';
+import { AttachUserToOrganisationService } from '../attach-user-to-organisation/attach-user-to-organisation.service';
 import {
   IdentiteOidc,
   utilisateurIdentiteOidcTable,
@@ -32,10 +34,69 @@ export class LoginUserWithOidcProviderService {
 
   constructor(
     private readonly databaseService: DatabaseService,
-    private readonly rattacherIdentiteService: LinkOidcIdentityToUserService
+    private readonly rattacherIdentiteService: LinkOidcIdentityToUserService,
+    private readonly rattacherOrganisationService: AttachUserToOrganisationService
   ) {}
 
   async authentifier(
+    provider: OidcProvider,
+    claims: OidcClaims,
+    tx?: Transaction
+  ): Promise<LoginUserWithOidcProviderResult> {
+    const compte = await this.resoudreCompte(provider, claims, tx);
+    if (compte.statut !== 'connexion') {
+      return compte;
+    }
+
+    const rattachement = await this.rattacherOrganisation(
+      compte.userId,
+      provider,
+      claims,
+      tx
+    );
+
+    return rattachement ? { ...compte, rattachement } : compte;
+  }
+
+  /**
+   * Le rattachement automatique à l'organisation du jeton, tenté à **chaque**
+   * connexion : il n'agit que si l'agent n'a encore aucun droit sur ce service,
+   * ce qui sert aussi les comptes antérieurs à cette bascule.
+   *
+   * Son échec ne fait jamais échouer la connexion. Un agent authentifié doit
+   * entrer, quitte à ce que ses accès lui manquent : l'inverse le laisserait
+   * dehors sans recours.
+   */
+  private async rattacherOrganisation(
+    userId: string,
+    provider: OidcProvider,
+    claims: OidcClaims,
+    tx?: Transaction
+  ): Promise<RattachementAutomatique | undefined> {
+    const rattachement = await this.rattacherOrganisationService.attach(
+      userId,
+      provider,
+      claims,
+      tx
+    );
+
+    if (!rattachement.success) {
+      this.logger.error(
+        `Rattachement automatique du compte ${userId} en échec (${rattachement.error}) : la connexion se poursuit sans`
+      );
+      return undefined;
+    }
+
+    return rattachement.data.statut === 'rattache'
+      ? {
+          collectiviteId: rattachement.data.collectiviteId,
+          nom: rattachement.data.nom,
+        }
+      : undefined;
+  }
+
+  /** Le matching lui-même : quel compte cette identité désigne. */
+  private async resoudreCompte(
     provider: OidcProvider,
     claims: OidcClaims,
     tx?: Transaction

--- a/apps/backend/src/users/authentications/oidc/login-user-with-oidc-provider/login-user-with-oidc-provider.service.ts
+++ b/apps/backend/src/users/authentications/oidc/login-user-with-oidc-provider/login-user-with-oidc-provider.service.ts
@@ -87,12 +87,11 @@ export class LoginUserWithOidcProviderService {
       return undefined;
     }
 
-    return rattachement.data.statut === 'rattache'
-      ? {
-          collectiviteId: rattachement.data.collectiviteId,
-          nom: rattachement.data.nom,
-        }
-      : undefined;
+    if (rattachement.data.statut !== 'rattache') {
+      return undefined;
+    }
+    const { statut: _, ...service } = rattachement.data;
+    return service;
   }
 
   /** Le matching lui-même : quel compte cette identité désigne. */

--- a/apps/backend/src/users/authentications/oidc/oidc.controller.spec.ts
+++ b/apps/backend/src/users/authentications/oidc/oidc.controller.spec.ts
@@ -166,6 +166,10 @@ describe("Contrôleur OIDC (déclinaison ProConnect) — jamais d'erreur 500 nue
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    // Par défaut, aucun service à ouvrir : les tests qui en veulent un le disent.
+    rattacherOrganisationMock.attach.mockResolvedValue(
+      success({ statut: 'aucun', raison: 'sans-siret' })
+    );
     creerSessionMock.creerSession.mockResolvedValue(
       success({ hashedToken: 'hashed-token-du-spike' })
     );
@@ -655,6 +659,14 @@ describe("Contrôleur OIDC (déclinaison ProConnect) — jamais d'erreur 500 nue
           supabaseAuthCookie('jwt-session-active'),
         ])
         .expect(303);
+
+      // La liaison vaut preuve d'appartenance : elle ouvre le service comme le
+      // ferait une connexion.
+      expect(rattacherOrganisationMock.attach).toHaveBeenCalledWith(
+        'user-courant',
+        'proconnect',
+        claims
+      );
 
       expect(rattacherIdentiteMock.rattacherAvecGardeFous).toHaveBeenCalledWith(
         'proconnect',

--- a/apps/backend/src/users/authentications/oidc/oidc.controller.spec.ts
+++ b/apps/backend/src/users/authentications/oidc/oidc.controller.spec.ts
@@ -484,7 +484,11 @@ describe("Contrôleur OIDC (déclinaison ProConnect) — jamais d'erreur 500 nue
         statut: 'connexion',
         userId: 'user-1',
         email: 'agent@developpement-durable.gouv.fr',
-        rattachement: { collectiviteId: 4242, nom: 'DREAL Syldavie' },
+        rattachement: {
+          collectiviteId: 4242,
+          nom: 'DREAL Syldavie',
+          type: 'dreal',
+        },
       });
 
       const response = await request(app.getHttpServer())

--- a/apps/backend/src/users/authentications/oidc/oidc.controller.spec.ts
+++ b/apps/backend/src/users/authentications/oidc/oidc.controller.spec.ts
@@ -7,6 +7,7 @@ import { failure, success } from '@tet/backend/utils/result.type';
 import * as oidc from 'openid-client';
 import request from 'supertest';
 import { ConvertJwtToAuthUserService } from '../../convert-jwt-to-auth-user.service';
+import { AttachUserToOrganisationService } from './attach-user-to-organisation/attach-user-to-organisation.service';
 import { LoginUserWithOidcProviderService } from './login-user-with-oidc-provider/login-user-with-oidc-provider.service';
 import { CreateUserOidcIdentityService } from './create-user-oidc-identity/create-user-oidc-identity.service';
 import { CreateSupabaseSessionService } from './create-supabase-session.service';
@@ -71,6 +72,12 @@ const rattacherIdentiteMock = {
   rattacherAvecGardeFous: vi.fn(),
 };
 
+// Le rattachement automatique n'est jamais exercé ici : `authentifier` est
+// systématiquement mocké, et c'est lui qui l'appelle.
+const rattacherOrganisationMock = {
+  attach: vi.fn(),
+};
+
 const creerCompteOidcMock = {
   creerCompte: vi.fn(),
 };
@@ -104,6 +111,10 @@ async function createTestApp(
       {
         provide: LinkOidcIdentityToUserService,
         useValue: rattacherIdentiteMock,
+      },
+      {
+        provide: AttachUserToOrganisationService,
+        useValue: rattacherOrganisationMock,
       },
       {
         provide: ConvertJwtToAuthUserService,
@@ -459,6 +470,51 @@ describe("Contrôleur OIDC (déclinaison ProConnect) — jamais d'erreur 500 nue
 
       const location = new URL(response.headers.location);
       expect(location.searchParams.get('liaison')).toBe('1');
+    });
+
+    /**
+     * L'identifiant seul : c'est l'app qui sait où atterrit un service et
+     * comment l'annoncer, le backend n'a pas à connaître la forme de ses routes.
+     */
+    test("statut connexion avec un rattachement → /auth/verify porte l'identifiant du service", async () => {
+      vi.spyOn(
+        app.get(LoginUserWithOidcProviderService),
+        'authentifier'
+      ).mockResolvedValue({
+        statut: 'connexion',
+        userId: 'user-1',
+        email: 'agent@developpement-durable.gouv.fr',
+        rattachement: { collectiviteId: 4242, nom: 'DREAL Syldavie' },
+      });
+
+      const response = await request(app.getHttpServer())
+        .get('/api/v1/proconnect/callback?code=un-code&state=un-state')
+        .set('Cookie', ['oidc-state=un-state', 'oidc-nonce=un-nonce'])
+        .expect(303);
+
+      const location = new URL(response.headers.location);
+      expect(location.pathname).toBe('/auth/verify');
+      expect(location.searchParams.get('rattachement')).toBe('4242');
+    });
+
+    test('statut connexion sans rattachement → aucun paramètre de rattachement', async () => {
+      vi.spyOn(
+        app.get(LoginUserWithOidcProviderService),
+        'authentifier'
+      ).mockResolvedValue({
+        statut: 'connexion',
+        userId: 'user-1',
+        email: 'agent@collectivite.fr',
+      });
+
+      const response = await request(app.getHttpServer())
+        .get('/api/v1/proconnect/callback?code=un-code&state=un-state')
+        .set('Cookie', ['oidc-state=un-state', 'oidc-nonce=un-nonce'])
+        .expect(303);
+
+      expect(
+        new URL(response.headers.location).searchParams.get('rattachement')
+      ).toBeNull();
     });
 
     test('échec du pont session → redirection erreur typée', async () => {

--- a/apps/backend/src/users/authentications/oidc/oidc.controller.ts
+++ b/apps/backend/src/users/authentications/oidc/oidc.controller.ts
@@ -352,9 +352,11 @@ export class OidcController {
   /**
    * Signale à l'app que cette connexion vient d'ouvrir un service.
    *
-   * L'identifiant seul, jamais l'URL : c'est l'app qui sait où atterrit un
-   * service et comment l'annoncer. Le backend n'a pas à connaître la forme de
-   * ses routes — il en construit déjà une de trop avec `/auth/verify`.
+   * L'identifiant et le type, jamais l'URL : c'est l'app qui sait où atterrit
+   * une collectivité, et le type est ce qui lui permet de trancher — l'espace
+   * d'un service *est* celui de l'instruction, celui d'un conseil régional non.
+   * Le backend n'a pas à connaître la forme de ses routes ; il en construit
+   * déjà une de trop avec `/auth/verify`.
    */
   private setRattachement(
     verifyUrl: URL,
@@ -365,6 +367,7 @@ export class OidcController {
         'rattachement',
         String(rattachement.collectiviteId)
       );
+      verifyUrl.searchParams.set('rattachement-type', rattachement.type);
     }
   }
 

--- a/apps/backend/src/users/authentications/oidc/oidc.controller.ts
+++ b/apps/backend/src/users/authentications/oidc/oidc.controller.ts
@@ -232,11 +232,8 @@ export class OidcController {
           return;
         }
 
-        // La liaison volontaire vaut aussi preuve d'appartenance : l'agent
-        // vient de désigner son organisation chez le fournisseur d'identité,
-        // exactement comme à une connexion. Sans ce rattachement, lier son
-        // compte depuis le profil était le seul chemin OIDC à n'ouvrir aucun
-        // service.
+        // Désigner son organisation depuis le profil vaut preuve
+        // d'appartenance autant qu'une connexion.
         const service = await this.rattacherOrganisationService.attach(
           linkUserId,
           providerConfig.provider,
@@ -248,9 +245,7 @@ export class OidcController {
           );
         }
 
-        // Pas de paramètre d'atterrissage ici : l'agent est déjà dans l'app, et
-        // c'est la modale d'accueil — que le rattachement vient d'armer — qui
-        // lui annonce son service.
+        // Pas d'atterrissage : l'agent est déjà dans l'app, la modale annonce.
         profilUrl.searchParams.set('comptes-associes', '1');
         res.redirect(303, profilUrl.href);
         return;
@@ -371,13 +366,8 @@ export class OidcController {
   }
 
   /**
-   * Signale à l'app que cette connexion vient d'ouvrir un service.
-   *
    * L'identifiant et le type, jamais l'URL : c'est l'app qui sait où atterrit
-   * une collectivité, et le type est ce qui lui permet de trancher — l'espace
-   * d'un service *est* celui de l'instruction, celui d'un conseil régional non.
-   * Le backend n'a pas à connaître la forme de ses routes ; il en construit
-   * déjà une de trop avec `/auth/verify`.
+   * une collectivité, et le type est ce qui lui permet de trancher.
    */
   private setRattachement(
     verifyUrl: URL,

--- a/apps/backend/src/users/authentications/oidc/oidc.controller.ts
+++ b/apps/backend/src/users/authentications/oidc/oidc.controller.ts
@@ -21,6 +21,7 @@ import {
   OIDC_FLOW_COOKIES_TTL_MS,
   OIDC_ID_TOKEN_COOKIE_TTL_MS,
   OidcErrorCode,
+  RattachementAutomatique,
 } from './oidc.models';
 import {
   getRequestCookies,
@@ -275,6 +276,7 @@ export class OidcController {
           if (nextPath) {
             verifyUrl.searchParams.set('next', nextPath);
           }
+          this.setRattachement(verifyUrl, creation.data.rattachement);
           res.redirect(303, verifyUrl.href);
           return;
         }
@@ -338,11 +340,31 @@ export class OidcController {
         // l'URL pour déclencher le toast « comptes associés ».
         verifyUrl.searchParams.set('liaison', '1');
       }
+      this.setRattachement(verifyUrl, authentification.rattachement);
 
       res.redirect(303, verifyUrl.href);
     } catch (error) {
       this.logUnexpectedError('callback', providerConfig.provider, error);
       this.redirectLoginError(res, 'oidc-erreur-interne');
+    }
+  }
+
+  /**
+   * Signale à l'app que cette connexion vient d'ouvrir un service.
+   *
+   * L'identifiant seul, jamais l'URL : c'est l'app qui sait où atterrit un
+   * service et comment l'annoncer. Le backend n'a pas à connaître la forme de
+   * ses routes — il en construit déjà une de trop avec `/auth/verify`.
+   */
+  private setRattachement(
+    verifyUrl: URL,
+    rattachement?: RattachementAutomatique
+  ): void {
+    if (rattachement) {
+      verifyUrl.searchParams.set(
+        'rattachement',
+        String(rattachement.collectiviteId)
+      );
     }
   }
 

--- a/apps/backend/src/users/authentications/oidc/oidc.controller.ts
+++ b/apps/backend/src/users/authentications/oidc/oidc.controller.ts
@@ -13,6 +13,7 @@ import { Throttle } from '@nestjs/throttler';
 import { AllowPublicAccess } from '@tet/backend/users/decorators/allow-public-access.decorator';
 import ConfigurationService from '@tet/backend/utils/config/configuration.service';
 import type { CookieOptions, Request, Response } from 'express';
+import { AttachUserToOrganisationService } from './attach-user-to-organisation/attach-user-to-organisation.service';
 import { LoginUserWithOidcProviderService } from './login-user-with-oidc-provider/login-user-with-oidc-provider.service';
 import { CreateUserOidcIdentityService } from './create-user-oidc-identity/create-user-oidc-identity.service';
 import { CreateSupabaseSessionService } from './create-supabase-session.service';
@@ -58,6 +59,7 @@ export class OidcController {
     private readonly creerSessionService: CreateSupabaseSessionService,
     private readonly ticketOidcService: OidcSessionTicketService,
     private readonly rattacherIdentiteService: LinkOidcIdentityToUserService,
+    private readonly rattacherOrganisationService: AttachUserToOrganisationService,
     private readonly creerCompteOidcService: CreateUserOidcIdentityService,
     private readonly convertJwtToAuthUserService: ConvertJwtToAuthUserService
   ) {}
@@ -230,6 +232,25 @@ export class OidcController {
           return;
         }
 
+        // La liaison volontaire vaut aussi preuve d'appartenance : l'agent
+        // vient de désigner son organisation chez le fournisseur d'identité,
+        // exactement comme à une connexion. Sans ce rattachement, lier son
+        // compte depuis le profil était le seul chemin OIDC à n'ouvrir aucun
+        // service.
+        const service = await this.rattacherOrganisationService.attach(
+          linkUserId,
+          providerConfig.provider,
+          claims
+        );
+        if (!service.success) {
+          this.logger.error(
+            `Rattachement automatique du compte ${linkUserId} en échec (${service.error}) : la liaison, elle, est faite`
+          );
+        }
+
+        // Pas de paramètre d'atterrissage ici : l'agent est déjà dans l'app, et
+        // c'est la modale d'accueil — que le rattachement vient d'armer — qui
+        // lui annonce son service.
         profilUrl.searchParams.set('comptes-associes', '1');
         res.redirect(303, profilUrl.href);
         return;

--- a/apps/backend/src/users/authentications/oidc/oidc.models.ts
+++ b/apps/backend/src/users/authentications/oidc/oidc.models.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { CollectiviteType } from '@tet/domain/collectivites';
 import {
   oidcProviderSchema,
   oidcProviders,
@@ -139,6 +140,12 @@ export type OidcErrorCode = (typeof oidcErrorCodes)[number];
 export type RattachementAutomatique = {
   collectiviteId: number;
   nom: string;
+  /**
+   * Le type voyage avec l'identifiant : c'est lui qui dit si l'espace du
+   * service *est* celui de l'instruction, et l'app en a besoin pour choisir la
+   * page d'atterrissage sans avoir encore chargé les droits de l'agent.
+   */
+  type: CollectiviteType;
 };
 
 export type LoginUserWithOidcProviderResult =

--- a/apps/backend/src/users/authentications/oidc/oidc.models.ts
+++ b/apps/backend/src/users/authentications/oidc/oidc.models.ts
@@ -127,7 +127,20 @@ export type OidcErrorCode = (typeof oidcErrorCodes)[number];
  *   (rattachement automatique refusé, l'utilisateur doit vérifier son email) ;
  * - aucun match ou `dcp.deleted` (traité comme non trouvé) → `non-reconnu`
  *   (la dialog de bienvenue est branchée ensuite).
+ *
+ * Toute `connexion` passe ensuite par le rattachement automatique à
+ * l'organisation du jeton, qui peut renseigner `rattachement`.
  */
+/**
+ * Le service qu'un rattachement automatique vient d'ouvrir à l'agent, quand la
+ * connexion en a déclenché un. Voyage jusqu'au callback, qui le passe à l'app
+ * pour qu'elle atterrisse sur cet espace et l'annonce.
+ */
+export type RattachementAutomatique = {
+  collectiviteId: number;
+  nom: string;
+};
+
 export type LoginUserWithOidcProviderResult =
   | {
       statut: 'connexion';
@@ -135,6 +148,8 @@ export type LoginUserWithOidcProviderResult =
       email: string;
       /** Liaison automatique venant d'avoir lieu (cas 2) — déclenche le toast one-shot. */
       nouvelleLiaison?: boolean;
+      /** Renseigné uniquement quand cette connexion vient d'ouvrir un service. */
+      rattachement?: RattachementAutomatique;
     }
   | { statut: 'compte-desactive' }
   | { statut: 'email-non-verifie' }

--- a/apps/backend/src/users/users.module.ts
+++ b/apps/backend/src/users/users.module.ts
@@ -29,6 +29,8 @@ import { OidcController } from './authentications/oidc/oidc.controller';
 import { LinkOidcIdentityToUserSessionRouter } from './authentications/oidc/link-oidc-identity-to-user-session/link-oidc-identity-to-user-session.router';
 import { LinkOidcIdentityToUserSessionService } from './authentications/oidc/link-oidc-identity-to-user-session/link-oidc-identity-to-user-session.service';
 import { OidcClientService } from './authentications/oidc/oidc-client.service';
+import { AttachUserToOrganisationService } from './authentications/oidc/attach-user-to-organisation/attach-user-to-organisation.service';
+import { GetCollectiviteBySiretService } from './authentications/oidc/get-collectivite-by-siret/get-collectivite-by-siret.service';
 import { GetPreselectedCollectiviteRouter } from './authentications/oidc/get-preselected-collectivite/get-preselected-collectivite.router';
 import { GetPreselectedCollectiviteService } from './authentications/oidc/get-preselected-collectivite/get-preselected-collectivite.service';
 import { LinkOidcIdentityToUserService } from './authentications/oidc/link-oidc-identity-to-user/link-oidc-identity-to-user.service';
@@ -89,6 +91,8 @@ import { TransactionModule } from '@tet/backend/utils/transaction/transaction.mo
     ConfirmOidcIdentityLinkedToUserRouter,
     HandleUserOidcIdentitiesService,
     HandleUserOidcIdentitiesRouter,
+    GetCollectiviteBySiretService,
+    AttachUserToOrganisationService,
     GetPreselectedCollectiviteService,
     GetPreselectedCollectiviteRouter,
     GetOidcStatusService,

--- a/packages/domain/src/collectivites/auto-attachment.rules.spec.ts
+++ b/packages/domain/src/collectivites/auto-attachment.rules.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import {
+  canAutoAttachEmail,
+  isAutoAttachableType,
+} from './auto-attachment.rules';
+import { collectiviteTypeEnum } from './collectivite-type.enum';
+
+const SIREN_ADEME = '385290309';
+
+describe('isAutoAttachableType', () => {
+  it('accepts the state services', () => {
+    expect(isAutoAttachableType(collectiviteTypeEnum.DREAL)).toBe(true);
+    expect(isAutoAttachableType(collectiviteTypeEnum.DDT)).toBe(true);
+    expect(isAutoAttachableType(collectiviteTypeEnum.DR_ADEME)).toBe(true);
+    expect(isAutoAttachableType(collectiviteTypeEnum.SERVICE_NATIONAL)).toBe(
+      true
+    );
+  });
+
+  /** Instructeur sans être un service déconcentré : il se rejoint quand même. */
+  it('accepts a conseil regional', () => {
+    expect(isAutoAttachableType(collectiviteTypeEnum.REGION)).toBe(true);
+  });
+
+  /** Rien ne dit qu'un agent public est employé de la commune qu'il désigne. */
+  it('refuses the collectivites that keep the invitation path', () => {
+    expect(isAutoAttachableType(collectiviteTypeEnum.COMMUNE)).toBe(false);
+    expect(isAutoAttachableType(collectiviteTypeEnum.EPCI)).toBe(false);
+    expect(isAutoAttachableType(collectiviteTypeEnum.DEPARTEMENT)).toBe(false);
+    expect(isAutoAttachableType(collectiviteTypeEnum.TEST)).toBe(false);
+  });
+});
+
+describe('canAutoAttachEmail', () => {
+  it('lets any address in where no domain is required', () => {
+    expect(
+      canAutoAttachEmail({ siren: '130017205', email: 'agent@example.org' })
+    ).toBe(true);
+    expect(
+      canAutoAttachEmail({ siren: null, email: 'agent@example.org' })
+    ).toBe(true);
+  });
+
+  it('requires the declared domain of the ademe', () => {
+    expect(
+      canAutoAttachEmail({ siren: SIREN_ADEME, email: 'agent@ademe.fr' })
+    ).toBe(true);
+    expect(
+      canAutoAttachEmail({ siren: SIREN_ADEME, email: 'Agent@ADEME.FR' })
+    ).toBe(true);
+    expect(
+      canAutoAttachEmail({ siren: SIREN_ADEME, email: 'agent@example.org' })
+    ).toBe(false);
+  });
+
+  /**
+   * Ni sous-domaine, ni domaine dont le nom requis n'est qu'un suffixe : sans
+   * savoir lesquels sont légitimes, la correspondance reste exacte.
+   */
+  it('refuses a subdomain and a lookalike', () => {
+    expect(
+      canAutoAttachEmail({ siren: SIREN_ADEME, email: 'agent@dr.ademe.fr' })
+    ).toBe(false);
+    expect(
+      canAutoAttachEmail({ siren: SIREN_ADEME, email: 'agent@notademe.fr' })
+    ).toBe(false);
+  });
+
+  it('refuses an address without a domain', () => {
+    expect(canAutoAttachEmail({ siren: SIREN_ADEME, email: 'agent' })).toBe(
+      false
+    );
+    expect(canAutoAttachEmail({ siren: SIREN_ADEME, email: 'agent@' })).toBe(
+      false
+    );
+  });
+});

--- a/packages/domain/src/collectivites/auto-attachment.rules.ts
+++ b/packages/domain/src/collectivites/auto-attachment.rules.ts
@@ -21,7 +21,7 @@ import {
  * reste l'invitation, parce que rien ne garantit qu'un agent public en soit
  * l'employé.
  */
-export const autoAttachableTypes: readonly CollectiviteType[] = [
+const autoAttachableTypes: readonly CollectiviteType[] = [
   collectiviteTypeEnum.DREAL,
   collectiviteTypeEnum.DDT,
   collectiviteTypeEnum.DR_ADEME,

--- a/packages/domain/src/collectivites/auto-attachment.rules.ts
+++ b/packages/domain/src/collectivites/auto-attachment.rules.ts
@@ -4,22 +4,12 @@ import {
 } from './collectivite-type.enum';
 
 /**
- * Les collectivités qu'un agent rejoint sur la seule foi de son identité : son
- * fournisseur d'identité a déjà attesté qu'il y travaille, et l'organisation
- * qu'il a choisie à la connexion désigne le service.
+ * Les collectivités qu'un agent rejoint sur la seule foi de son identité.
  *
- * Un prédicat **distinct** de ses deux voisins, même quand les listes
- * coïncident :
- * - `isServiceDeconcentre` (`./service-deconcentre.rules`) dit qui n'a pas
- *   d'espace de collectivité propre, et exclut le conseil régional — qui, lui,
- *   se rejoint bien par ProConnect ;
- * - `isTypeInstructeur` (`@tet/domain/demarches`) dit qui voit les dossiers
- *   transmis, et porte aujourd'hui les mêmes types par coïncidence.
- *
- * S'appuyer sur l'un des deux ouvrirait en silence l'auto-rattachement au
- * prochain type qu'on y ajouterait. Une commune n'est pas ici : son parcours
- * reste l'invitation, parce que rien ne garantit qu'un agent public en soit
- * l'employé.
+ * Distinct de `isServiceDeconcentre` (qui exclut le conseil régional) et de
+ * `isTypeInstructeur` (qui porte les mêmes types par coïncidence) : s'appuyer
+ * sur l'un des deux ouvrirait en silence le rattachement au prochain type
+ * qu'on y ajouterait.
  */
 const autoAttachableTypes: readonly CollectiviteType[] = [
   collectiviteTypeEnum.DREAL,
@@ -33,25 +23,14 @@ export const isAutoAttachableType = (type: CollectiviteType): boolean =>
   autoAttachableTypes.includes(type);
 
 /**
- * Les domaines de messagerie exigés pour entrer automatiquement chez un
- * employeur, déclarés par SIREN.
- *
- * Le SIREN et non le type : la DGEC et l'ADEME nationale sont deux
- * `service_national`, et rien ne dit que leurs agents partagent un domaine. Ce
- * qu'on contraint, c'est l'employeur, et c'est le SIREN qui le nomme.
- *
- * Un second verrou, volontairement redondant avec le SIRET du jeton. Il vaut
- * pour le jour où le fournisseur d'identité se tromperait d'organisation : le
- * SIRET du siège de l'ADEME désigne un service à périmètre national,
- * destinataire de toute transmission PCAET, et une erreur de sa part y ferait
- * entrer n'importe qui. Une adresse ne franchit pas ce verrou par erreur.
+ * Par SIREN et non par type : la DGEC et l'ADEME nationale sont deux
+ * `service_national` sans domaine commun. C'est l'employeur qu'on contraint.
  */
 const domainesRequisParSiren: Record<string, readonly string[]> = {
   // L'ADEME : ses directions régionales et l'ADEME nationale partagent ce SIREN.
   '385290309': ['ademe.fr'],
 };
 
-/** Le domaine d'une adresse, en minuscules, ou `null` si elle n'en a pas. */
 const domaineDeEmail = (email: string): string | null => {
   const separateur = email.lastIndexOf('@');
   if (separateur < 0 || separateur === email.length - 1) {
@@ -64,12 +43,9 @@ const domaineDeEmail = (email: string): string | null => {
 };
 
 /**
- * Cette adresse permet-elle d'entrer automatiquement chez cet employeur ?
- *
- * Vraie par défaut : la plupart des employeurs n'imposent aucun domaine, et
- * c'est alors l'organisation du jeton qui fait foi. Là où un domaine est
- * déclaré, la correspondance est **exacte** — un sous-domaine ne passe pas,
- * faute de savoir lesquels sont légitimes.
+ * Vraie par défaut : sans domaine déclaré, l'organisation du jeton fait foi.
+ * Sinon la correspondance est **exacte** — un sous-domaine ne passe pas, faute
+ * de savoir lesquels sont légitimes.
  */
 export const canAutoAttachEmail = ({
   siren,

--- a/packages/domain/src/collectivites/auto-attachment.rules.ts
+++ b/packages/domain/src/collectivites/auto-attachment.rules.ts
@@ -1,0 +1,87 @@
+import {
+  CollectiviteType,
+  collectiviteTypeEnum,
+} from './collectivite-type.enum';
+
+/**
+ * Les collectivités qu'un agent rejoint sur la seule foi de son identité : son
+ * fournisseur d'identité a déjà attesté qu'il y travaille, et l'organisation
+ * qu'il a choisie à la connexion désigne le service.
+ *
+ * Un prédicat **distinct** de ses deux voisins, même quand les listes
+ * coïncident :
+ * - `isServiceDeconcentre` (`./service-deconcentre.rules`) dit qui n'a pas
+ *   d'espace de collectivité propre, et exclut le conseil régional — qui, lui,
+ *   se rejoint bien par ProConnect ;
+ * - `isTypeInstructeur` (`@tet/domain/demarches`) dit qui voit les dossiers
+ *   transmis, et porte aujourd'hui les mêmes types par coïncidence.
+ *
+ * S'appuyer sur l'un des deux ouvrirait en silence l'auto-rattachement au
+ * prochain type qu'on y ajouterait. Une commune n'est pas ici : son parcours
+ * reste l'invitation, parce que rien ne garantit qu'un agent public en soit
+ * l'employé.
+ */
+export const autoAttachableTypes: readonly CollectiviteType[] = [
+  collectiviteTypeEnum.DREAL,
+  collectiviteTypeEnum.DDT,
+  collectiviteTypeEnum.DR_ADEME,
+  collectiviteTypeEnum.SERVICE_NATIONAL,
+  collectiviteTypeEnum.REGION,
+];
+
+export const isAutoAttachableType = (type: CollectiviteType): boolean =>
+  autoAttachableTypes.includes(type);
+
+/**
+ * Les domaines de messagerie exigés pour entrer automatiquement chez un
+ * employeur, déclarés par SIREN.
+ *
+ * Le SIREN et non le type : la DGEC et l'ADEME nationale sont deux
+ * `service_national`, et rien ne dit que leurs agents partagent un domaine. Ce
+ * qu'on contraint, c'est l'employeur, et c'est le SIREN qui le nomme.
+ *
+ * Un second verrou, volontairement redondant avec le SIRET du jeton. Il vaut
+ * pour le jour où le fournisseur d'identité se tromperait d'organisation : le
+ * SIRET du siège de l'ADEME désigne un service à périmètre national,
+ * destinataire de toute transmission PCAET, et une erreur de sa part y ferait
+ * entrer n'importe qui. Une adresse ne franchit pas ce verrou par erreur.
+ */
+const domainesRequisParSiren: Record<string, readonly string[]> = {
+  // L'ADEME : ses directions régionales et l'ADEME nationale partagent ce SIREN.
+  '385290309': ['ademe.fr'],
+};
+
+/** Le domaine d'une adresse, en minuscules, ou `null` si elle n'en a pas. */
+const domaineDeEmail = (email: string): string | null => {
+  const separateur = email.lastIndexOf('@');
+  if (separateur < 0 || separateur === email.length - 1) {
+    return null;
+  }
+  return email
+    .slice(separateur + 1)
+    .trim()
+    .toLowerCase();
+};
+
+/**
+ * Cette adresse permet-elle d'entrer automatiquement chez cet employeur ?
+ *
+ * Vraie par défaut : la plupart des employeurs n'imposent aucun domaine, et
+ * c'est alors l'organisation du jeton qui fait foi. Là où un domaine est
+ * déclaré, la correspondance est **exacte** — un sous-domaine ne passe pas,
+ * faute de savoir lesquels sont légitimes.
+ */
+export const canAutoAttachEmail = ({
+  siren,
+  email,
+}: {
+  siren: string | null;
+  email: string;
+}): boolean => {
+  const domainesRequis = siren ? domainesRequisParSiren[siren] : undefined;
+  if (!domainesRequis) {
+    return true;
+  }
+  const domaine = domaineDeEmail(email);
+  return domaine !== null && domainesRequis.includes(domaine);
+};

--- a/packages/domain/src/collectivites/index.ts
+++ b/packages/domain/src/collectivites/index.ts
@@ -1,3 +1,4 @@
+export * from './auto-attachment.rules';
 export * from './can-mutate-referentiel.rules';
 export * from './categorie-tag.schema';
 export * from './collectivite-banatic-type.enum';

--- a/packages/domain/src/users/user-preferences.schema.ts
+++ b/packages/domain/src/users/user-preferences.schema.ts
@@ -20,12 +20,9 @@ export const userPreferencesSchema = z.object({
     modalDisplayCount: z.number(),
     // Dernier affichage de la modale — sert à ne pas la remontrer le même jour.
     modalLastSeenAt: z.nullable(z.iso.datetime()),
-    // Le service qu'un rattachement automatique vient d'ouvrir, tant que
-    // l'agent n'a pas vu l'écran d'accueil qui le lui explique. Remis à `null`
-    // à la fermeture : c'est ce qui fait le « une seule fois ».
-    //
-    // En préférence et non dans l'URL de retour : une modale qui explique tout
-    // un parcours doit survivre à un onglet fermé en cours de route.
+    // Le service qu'un rattachement vient d'ouvrir, jusqu'à ce que l'agent
+    // voie l'écran d'accueil. En préférence et non dans l'URL de retour : la
+    // modale doit survivre à un onglet fermé en cours de route.
     autoAttachedCollectiviteId: z.nullable(z.number()),
   }),
 });

--- a/packages/domain/src/users/user-preferences.schema.ts
+++ b/packages/domain/src/users/user-preferences.schema.ts
@@ -20,6 +20,13 @@ export const userPreferencesSchema = z.object({
     modalDisplayCount: z.number(),
     // Dernier affichage de la modale — sert à ne pas la remontrer le même jour.
     modalLastSeenAt: z.nullable(z.iso.datetime()),
+    // Le service qu'un rattachement automatique vient d'ouvrir, tant que
+    // l'agent n'a pas vu l'écran d'accueil qui le lui explique. Remis à `null`
+    // à la fermeture : c'est ce qui fait le « une seule fois ».
+    //
+    // En préférence et non dans l'URL de retour : une modale qui explique tout
+    // un parcours doit survivre à un onglet fermé en cours de route.
+    autoAttachedCollectiviteId: z.nullable(z.number()),
   }),
 });
 
@@ -39,5 +46,6 @@ export const defaultUserPreferences: UserPreferences = {
     isBannerVisible: true,
     modalDisplayCount: 0,
     modalLastSeenAt: null,
+    autoAttachedCollectiviteId: null,
   },
 } as const;

--- a/packages/ui/src/design-system/Modal/Modal.behavior.test.tsx
+++ b/packages/ui/src/design-system/Modal/Modal.behavior.test.tsx
@@ -194,3 +194,22 @@ describe('Modal — scrollableContent', () => {
     );
   });
 });
+
+describe('Modal — zIndex', () => {
+  /**
+   * L'overlay porte le z-index. Le prop est resté déclaré et documenté sans
+   * jamais être appliqué : deux modales ouvertes ensemble n'avaient alors aucun
+   * moyen de se départager, et c'était la dernière ouverte qui passait devant.
+   */
+  const overlay = () => screen.getByRole('dialog').parentElement;
+
+  it('empile la modale au niveau du design system par défaut', () => {
+    render(<Modal title="Titre" openState={openState()} />);
+    expect(overlay()).toHaveStyle({ zIndex: '1000' });
+  });
+
+  it('applique le z-index demandé', () => {
+    render(<Modal title="Titre" zIndex={998} openState={openState()} />);
+    expect(overlay()).toHaveStyle({ zIndex: '998' });
+  });
+});

--- a/packages/ui/src/design-system/Modal/Modal.tsx
+++ b/packages/ui/src/design-system/Modal/Modal.tsx
@@ -143,11 +143,9 @@ export const Modal = ({
                 display: 'grid',
                 placeItems: 'center',
                 background: preset.theme.extend.colors.overlay,
-                // Le prop l'emporte quand il est donné : deux modales ouvertes
-                // en même temps se départagent par lui. À défaut, elles
-                // partagent `zIndex.modal` et c'est la dernière **ouverte** qui
-                // passe devant — l'ordre de déclaration n'y change rien, le
-                // portail n'est créé qu'à l'ouverture.
+                // À défaut, deux modales partagent `zIndex.modal` et c'est la
+                // dernière **ouverte** qui passe devant : le portail n'est créé
+                // qu'à l'ouverture, l'ordre de déclaration n'y change rien.
                 zIndex: zIndex ?? preset.theme.extend.zIndex.modal,
                 backdropFilter: backdropBlur ? 'blur(10px)' : undefined,
               }}

--- a/packages/ui/src/design-system/Modal/Modal.tsx
+++ b/packages/ui/src/design-system/Modal/Modal.tsx
@@ -92,6 +92,7 @@ export const Modal = ({
   noCloseButton,
   renderFooter,
   backdropBlur,
+  zIndex,
   dataTest = 'Modal',
   scrollableContent,
 }: ModalProps) => {
@@ -142,7 +143,12 @@ export const Modal = ({
                 display: 'grid',
                 placeItems: 'center',
                 background: preset.theme.extend.colors.overlay,
-                zIndex: preset.theme.extend.zIndex.modal,
+                // Le prop l'emporte quand il est donné : deux modales ouvertes
+                // en même temps se départagent par lui. À défaut, elles
+                // partagent `zIndex.modal` et c'est la dernière **ouverte** qui
+                // passe devant — l'ordre de déclaration n'y change rien, le
+                // portail n'est créé qu'à l'ouverture.
+                zIndex: zIndex ?? preset.theme.extend.zIndex.modal,
                 backdropFilter: backdropBlur ? 'blur(10px)' : undefined,
               }}
             >


### PR DESCRIPTION
> 🧱 **Empilée sur #4997** (périmètres géographiques secondaires) — à relire et fusionner après elle. Le socle y est nécessaire : sans lui, un SIRET peut désigner deux services et le rapprochement ne peut pas trancher.

Un agent d'un service de l'État n'avait **aucun moyen d'entrer** : le parcours « rejoindre une collectivité » refuse ces structures, et l'import des membres (TETH-11) n'est pas livré. Or l'organisation qu'un agent choisit chez son fournisseur d'identité **fait foi** — elle vaut mieux qu'un formulaire, et personne n'a besoin de l'inviter.

Cette PR en fait une porte d'entrée : l'agent entre dans son service en **Éditeur**, sans invitation ni écran de choix, atterrit sur son espace d'instruction, et une modale lui explique le parcours.

## 🎥 Démo

Contexte de la démo (côté ProConnect):

<img width="1266" height="963" alt="image" src="https://github.com/user-attachments/assets/0e75df4f-c0bb-496b-bdca-d0fea5fea05d" />

https://github.com/user-attachments/assets/3e238318-5011-454a-8d19-cbdbfccab7f8

## Le scénario

```mermaid
sequenceDiagram
    actor A as Agent
    participant P as ProConnect / MonCompteAdeme
    participant B as Backend, callback OIDC
    participant D as Base
    participant F as App

    A->>P: choisit son organisation
    P-->>B: jeton — sub, email, siret
    B->>D: ce sub est-il connu ? cet email ?
    Note over B: Trois chemins y mènent désormais :<br/>inscription, connexion, liaison depuis le profil
    B->>B: rattachement automatique
    B->>D: droit édition + compte vérifié + service à annoncer
    B-->>F: /auth/verify?token_hash=…&rattachement=id&rattachement-type=type
    F->>F: pose la session Supabase
    F-->>A: /collectivite/id/demandes-avis
    F-->>A: modale d'accueil, une seule fois
```

Le backend ne passe que l'**identifiant et le type** ; c'est l'app qui sait où atterrit une collectivité. Le type est ce qui lui permet de trancher : l'espace d'un service *est* celui de l'instruction, celui d'un conseil régional non.

## Les quatre verrous

```mermaid
flowchart TD
    S{"un siret dans le jeton ?"} -->|non| R["aucun rattachement"]
    S -->|oui| C{"un seul service<br/>derrière ce SIRET ?"}
    C -->|non| R
    C -->|oui| T{"un type qui se rejoint<br/>par identité ?"}
    T -->|non| R
    T -->|oui| M{"le domaine de messagerie<br/>exigé par l'employeur ?"}
    M -->|non| R
    M -->|oui| E{"un droit déjà connu<br/>pour ce couple ?"}
    E -->|oui| R
    E -->|non| OK["droit édition + compte vérifié"]
```

Le **quatrième est volontairement redondant** avec le deuxième. Il vaut pour le jour où le fournisseur d'identité se tromperait d'organisation : c'est arrivé en août 2026, quand MonCompteAdeme renvoyait le SIRET du siège de l'ADEME au lieu de celui du service choisi. Ce SIRET désigne un service à périmètre **national**, destinataire de toute transmission PCAET — la même erreur y ferait entrer n'importe qui. Le domaine est ce qui l'arrête : le SIREN `385290309` (l'ADEME, ses directions régionales **et** l'ADEME nationale) exige `@ademe.fr`. Clé par SIREN et non par type, parce que la DGEC et l'ADEME nationale sont deux `service_national` sans domaine commun.

Le **cinquième** dit l'idempotence : le rattachement est tenté à *chaque* connexion et n'agit que s'il n'existe aucune ligne de droit pour le couple, **active ou non**. Un droit retiré par un administrateur laisse une ligne inactive derrière lui, et le voir revenir annulerait sa décision.

Le rattachement ne passe **pas** par `MutateMembresService.join`, qui force `admin`, refuse les services déconcentrés et refuse toute collectivité ayant déjà un membre. La carte demande d'ouvrir le verrou « pour ce chemin précis, et pour lui seul » : un chemin qui ne passe pas par `join` le respecte à la lettre, et son test reste vert et pertinent.

Le rapprochement va au **plus précis** : `(siren, nic)` d'abord — seul niveau qui départage les directions régionales de l'ADEME, qui partagent son SIREN — puis le SIREN seul s'il ne désigne qu'une collectivité, parce que le classeur donne le NIC du *siège* et qu'un agent dont ProConnect renvoie une autre implantation de sa DREAL doit quand même la retrouver. La pré-sélection de l'écran de choix passe par le même code : les deux chemins ne peuvent plus diverger.

## Correctifs embarqués

**La DOD n'était pas tenable au-delà de la première connexion.** Les deux redirecteurs de tableau de bord passaient par `makeUserTdbUrl` au lieu de `makeCollectiviteRootUrl`, si bien qu'un agent membre d'un seul service atterrissait sur `ErreurAccesPage` à chaque connexion — le seul écran que voyait un agent rattaché à sa DREAL. Le menu de navigation, lui, passait déjà par la bonne fonction : le lien menait au bon endroit, la connexion non.

**La liaison depuis le profil ne rattachait pas.** C'était le seul chemin OIDC à n'ouvrir aucun service, alors qu'y désigner son organisation vaut preuve d'appartenance autant qu'une connexion.

**Le SIRET stocké ne suivait pas les connexions suivantes.** Figé à la première, il laissait la pré-sélection désigner un service que l'agent avait quitté.

**Le prop `zIndex` du `Modal` était mort** : déclaré, documenté « est placé sur l'overlay », jamais appliqué — l'overlay codait en dur la valeur du design system, et le prop n'était même pas déstructuré. Deux modales ouvertes ensemble n'avaient alors aucun moyen de se départager, et c'était la dernière **ouverte** qui passait devant, l'ordre de déclaration n'y changeant rien puisque le portail n'existe qu'à l'ouverture. Un test l'épingle.

- **La table des domaines de messagerie** dans `auto-attachment.rules.ts` : correspondance **exacte**, ni sous-domaine ni sosie, faute de savoir lesquels seraient légitimes.
- **`isAutoAttachableType`**, distinct de ses deux voisins même quand les listes coïncident : `isServiceDeconcentre` exclut le conseil régional, qui se rejoint pourtant par identité, et `isTypeInstructeur` porte aujourd'hui les mêmes types **par coïncidence**. S'appuyer sur l'un des deux ouvrirait en silence l'auto-rattachement au prochain type qu'on y ajouterait.
- **Le service à annoncer voyage par une préférence**, pas par l'URL de retour : une modale qui explique tout un parcours doit survivre à un onglet fermé en cours de route. Une clé ajoutée au schéma suffit — le dépôt fusionne les défauts à la lecture et dérive la liste blanche, donc ni migration de données ni changement de router.
