### PR TITLE
feat(documents): rend une URL de téléchargement signée côté backend

### DIFF
--- a/apps/backend/src/collectivites/collectivites.module.ts
+++ b/apps/backend/src/collectivites/collectivites.module.ts
@@ -6,6 +6,9 @@ import { CollectivitePreferencesRouter } from '@tet/backend/collectivites/collec
 import { CollectivitePreferencesService } from '@tet/backend/collectivites/collectivite-preferences/collectivite-preferences.service';
 import { CollectiviteBucketRepository } from '@tet/backend/collectivites/documents/collectivite-bucket.repository';
 import { DocumentController } from '@tet/backend/collectivites/documents/document.controller';
+import { GetDownloadUrlRepository } from '@tet/backend/collectivites/documents/get-download-url/get-download-url.repository';
+import { GetDownloadUrlRouter } from '@tet/backend/collectivites/documents/get-download-url/get-download-url.router';
+import { GetDownloadUrlService } from '@tet/backend/collectivites/documents/get-download-url/get-download-url.service';
 import { CreateUploadTokenRepository } from '@tet/backend/collectivites/documents/create-upload-token/create-upload-token.repository';
 import { CreateUploadTokenRouter } from '@tet/backend/collectivites/documents/create-upload-token/create-upload-token.router';
 import { CreateUploadTokenService } from '@tet/backend/collectivites/documents/create-upload-token/create-upload-token.service';
@@ -87,6 +90,9 @@ import { PersonnesService } from './services/personnes.service';
     CreateUploadTokenRepository,
     CreateUploadTokenService,
     CreateUploadTokenRouter,
+    GetDownloadUrlRepository,
+    GetDownloadUrlService,
+    GetDownloadUrlRouter,
     UpdateDocumentService,
     UpdateDocumentRouter,
     EditPreuveDocumentRepository,

--- a/apps/backend/src/collectivites/documents/documents.router.ts
+++ b/apps/backend/src/collectivites/documents/documents.router.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { TrpcService } from '@tet/backend/utils/trpc/trpc.service';
 import { CreateUploadTokenRouter } from './create-upload-token/create-upload-token.router';
 import { EditPreuveDocumentRouter } from './edit-preuve-document/edit-preuve-document.router';
+import { GetDownloadUrlRouter } from './get-download-url/get-download-url.router';
 import { StoreDocumentRouter } from './store-document/store-document.router';
 import { UpdateDocumentRouter } from './update-document/update-document.router';
 
@@ -12,14 +13,16 @@ export class DocumentsRouter {
     private readonly storeDocumentRouter: StoreDocumentRouter,
     private readonly updateDocumentRouter: UpdateDocumentRouter,
     private readonly editPreuveDocumentRouter: EditPreuveDocumentRouter,
-    private readonly createUploadTokenRouter: CreateUploadTokenRouter
+    private readonly createUploadTokenRouter: CreateUploadTokenRouter,
+    private readonly getDownloadUrlRouter: GetDownloadUrlRouter
   ) {}
 
   router = this.trpc.mergeRouters(
     this.storeDocumentRouter.router,
     this.updateDocumentRouter.router,
     this.editPreuveDocumentRouter.router,
-    this.createUploadTokenRouter.router
+    this.createUploadTokenRouter.router,
+    this.getDownloadUrlRouter.router
   );
 
   createCaller = this.trpc.createCallerFactory(this.router);

--- a/apps/backend/src/collectivites/documents/get-download-url/get-download-url.errors.ts
+++ b/apps/backend/src/collectivites/documents/get-download-url/get-download-url.errors.ts
@@ -1,0 +1,37 @@
+import {
+  createErrorsEnum,
+  TrpcErrorHandlerConfig,
+} from '@tet/backend/utils/trpc/trpc-error-handler';
+
+export const GetDownloadUrlSpecificErrors = [
+  'DOCUMENT_NOT_FOUND',
+  'COLLECTIVITE_BUCKET_NOT_FOUND',
+  'SIGN_DOWNLOAD_ERROR',
+] as const;
+
+type GetDownloadUrlSpecificError =
+  (typeof GetDownloadUrlSpecificErrors)[number];
+
+export const getDownloadUrlErrorConfig: TrpcErrorHandlerConfig<GetDownloadUrlSpecificError> =
+  {
+    specificErrors: {
+      DOCUMENT_NOT_FOUND: {
+        code: 'NOT_FOUND',
+        message: "Le document demandé n'existe pas",
+      },
+      COLLECTIVITE_BUCKET_NOT_FOUND: {
+        code: 'NOT_FOUND',
+        message: "Le bucket de la collectivité n'a pas été trouvé",
+      },
+      SIGN_DOWNLOAD_ERROR: {
+        code: 'INTERNAL_SERVER_ERROR',
+        message:
+          'Une erreur est survenue lors de la préparation du téléchargement',
+      },
+    },
+  };
+
+export const GetDownloadUrlErrorEnum = createErrorsEnum(
+  GetDownloadUrlSpecificErrors
+);
+export type GetDownloadUrlError = keyof typeof GetDownloadUrlErrorEnum;

--- a/apps/backend/src/collectivites/documents/get-download-url/get-download-url.input.ts
+++ b/apps/backend/src/collectivites/documents/get-download-url/get-download-url.input.ts
@@ -1,0 +1,9 @@
+import { documentHashSchema } from '@tet/domain/collectivites';
+import * as z from 'zod';
+
+export const getDownloadUrlInputSchema = z.object({
+  collectiviteId: z.number().int().positive(),
+  hash: documentHashSchema,
+});
+
+export type GetDownloadUrlInput = z.infer<typeof getDownloadUrlInputSchema>;

--- a/apps/backend/src/collectivites/documents/get-download-url/get-download-url.output.ts
+++ b/apps/backend/src/collectivites/documents/get-download-url/get-download-url.output.ts
@@ -1,0 +1,8 @@
+import * as z from 'zod';
+
+export const getDownloadUrlOutputSchema = z.object({
+  signedUrl: z.string().min(1),
+  filename: z.string().min(1),
+});
+
+export type GetDownloadUrlOutput = z.infer<typeof getDownloadUrlOutputSchema>;

--- a/apps/backend/src/collectivites/documents/get-download-url/get-download-url.repository.ts
+++ b/apps/backend/src/collectivites/documents/get-download-url/get-download-url.repository.ts
@@ -1,0 +1,53 @@
+import { Injectable } from '@nestjs/common';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { and, eq } from 'drizzle-orm';
+import { collectiviteTable } from '@tet/backend/collectivites/shared/models/collectivite.table';
+import { bibliothequeFichierTable } from '../models/bibliotheque-fichier.table';
+
+export type DocumentToDownload = Pick<
+  typeof bibliothequeFichierTable.$inferSelect,
+  'hash' | 'filename' | 'confidentiel'
+>;
+
+@Injectable()
+export class GetDownloadUrlRepository {
+  constructor(private readonly databaseService: DatabaseService) {}
+
+  async isCollectiviteAccesRestreint(collectiviteId: number): Promise<boolean> {
+    const [collectivite] = await this.databaseService.db
+      .select({ accesRestreint: collectiviteTable.accesRestreint })
+      .from(collectiviteTable)
+      .where(eq(collectiviteTable.id, collectiviteId))
+      .limit(1);
+
+    if (collectivite === undefined) {
+      return true;
+    }
+    return collectivite.accesRestreint ?? false;
+  }
+
+  async findDocument({
+    collectiviteId,
+    hash,
+  }: {
+    collectiviteId: number;
+    hash: string;
+  }): Promise<DocumentToDownload | undefined> {
+    const [document] = await this.databaseService.db
+      .select({
+        hash: bibliothequeFichierTable.hash,
+        filename: bibliothequeFichierTable.filename,
+        confidentiel: bibliothequeFichierTable.confidentiel,
+      })
+      .from(bibliothequeFichierTable)
+      .where(
+        and(
+          eq(bibliothequeFichierTable.collectiviteId, collectiviteId),
+          eq(bibliothequeFichierTable.hash, hash)
+        )
+      )
+      .limit(1);
+
+    return document;
+  }
+}

--- a/apps/backend/src/collectivites/documents/get-download-url/get-download-url.router.e2e-spec.ts
+++ b/apps/backend/src/collectivites/documents/get-download-url/get-download-url.router.e2e-spec.ts
@@ -1,0 +1,77 @@
+import { INestApplication } from '@nestjs/common';
+import { addTestCollectiviteAndUsers } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { getAuthUserFromUserCredentials } from '@tet/backend/test';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { addTestUser } from '@tet/backend/users/users/users.test-fixture';
+import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
+import { Collectivite } from '@tet/domain/collectivites';
+import { CollectiviteRole } from '@tet/domain/users';
+import {
+  getTestApp,
+  getTestDatabase,
+  getTestRouter,
+} from '../../../../test/app-utils';
+
+const HASH = 'ec07d0538e44a333b23b936c9a4ba37fbd211c6272e632d2173b6abe102a0482';
+
+describe('GetDownloadUrlRouter', () => {
+  let app: INestApplication;
+  let router: TrpcRouter;
+  let collectivite: Collectivite;
+  let lecteurUser: AuthenticatedUser;
+  let nonMembreUser: AuthenticatedUser;
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    router = await getTestRouter(app);
+    const databaseService = await getTestDatabase(app);
+
+    const { collectivite: testCollectivite, users } =
+      await addTestCollectiviteAndUsers(databaseService, {
+        users: [{ role: CollectiviteRole.LECTURE }],
+      });
+
+    collectivite = testCollectivite;
+    lecteurUser = getAuthUserFromUserCredentials(users[0]);
+
+    const { user } = await addTestUser(databaseService);
+    nonMembreUser = getAuthUserFromUserCredentials(user);
+
+    return async () => {
+      await app.close();
+    };
+  });
+
+  test('refuse un hash qui designe un autre bucket, avant tout controle de droit', async () => {
+    const caller = router.createCaller({ user: nonMembreUser });
+
+    await expect(() =>
+      caller.collectivites.documents.getDownloadUrl({
+        collectiviteId: collectivite.id,
+        hash: `autreBucket/${HASH}`,
+      })
+    ).rejects.toThrowError(/hash/i);
+  });
+
+  test("un compte verifie non membre franchit la garde d'une collectivite publique", async () => {
+    const caller = router.createCaller({ user: nonMembreUser });
+
+    await expect(() =>
+      caller.collectivites.documents.getDownloadUrl({
+        collectiviteId: collectivite.id,
+        hash: HASH,
+      })
+    ).rejects.toThrowError(/n'existe pas/i);
+  });
+
+  test('rend DOCUMENT_NOT_FOUND a un lecteur de la collectivite quand le hash ne designe rien', async () => {
+    const caller = router.createCaller({ user: lecteurUser });
+
+    await expect(() =>
+      caller.collectivites.documents.getDownloadUrl({
+        collectiviteId: collectivite.id,
+        hash: HASH,
+      })
+    ).rejects.toThrowError(/n'existe pas/i);
+  });
+});

--- a/apps/backend/src/collectivites/documents/get-download-url/get-download-url.router.ts
+++ b/apps/backend/src/collectivites/documents/get-download-url/get-download-url.router.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@nestjs/common';
+import { createTrpcErrorHandler } from '@tet/backend/utils/trpc/trpc-error-handler';
+import { TrpcService } from '@tet/backend/utils/trpc/trpc.service';
+import { getDownloadUrlErrorConfig } from './get-download-url.errors';
+import { getDownloadUrlInputSchema } from './get-download-url.input';
+import { getDownloadUrlOutputSchema } from './get-download-url.output';
+import { GetDownloadUrlService } from './get-download-url.service';
+
+@Injectable()
+export class GetDownloadUrlRouter {
+  constructor(
+    private readonly trpc: TrpcService,
+    private readonly service: GetDownloadUrlService
+  ) {}
+
+  private readonly getResultDataOrThrowError = createTrpcErrorHandler(
+    getDownloadUrlErrorConfig
+  );
+
+  router = this.trpc.router({
+    getDownloadUrl: this.trpc.authedProcedure
+      .input(getDownloadUrlInputSchema)
+      .output(getDownloadUrlOutputSchema)
+      .mutation(async ({ input, ctx }) => {
+        const result = await this.service.getDownloadUrl(input, {
+          user: ctx.user,
+        });
+        return this.getResultDataOrThrowError(result);
+      }),
+  });
+}

--- a/apps/backend/src/collectivites/documents/get-download-url/get-download-url.service.spec.ts
+++ b/apps/backend/src/collectivites/documents/get-download-url/get-download-url.service.spec.ts
@@ -1,0 +1,239 @@
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { failure, success } from '@tet/backend/utils/result.type';
+import { DocumentStorageErrorEnum } from '@tet/backend/utils/supabase/document-storage.errors';
+import { describe, expect, it, vi, type Mock } from 'vitest';
+import { GetDownloadUrlService } from './get-download-url.service';
+import { type DocumentToDownload } from './get-download-url.repository';
+
+const HASH = 'ec07d0538e44a333b23b936c9a4ba37fbd211c6272e632d2173b6abe102a0482';
+
+const user: AuthenticatedUser = { id: 'user-id' } as AuthenticatedUser;
+
+const allowed = { success: true, data: undefined };
+const denied = { success: false, error: 'UNAUTHORIZED' };
+
+type ServiceUnderTest = {
+  service: GetDownloadUrlService;
+  repository: { findDocument: Mock };
+  documentStorage: { createSignedDownloadUrl: Mock };
+};
+
+function buildService({
+  isCollectivitePrivate = false,
+  canRead = true,
+  canReadConfidentiel = false,
+  document = {
+    hash: HASH,
+    filename: 'rapport.pdf',
+    confidentiel: false,
+  },
+  documentExists = true,
+  hasBucket = true,
+  signatureFails = false,
+}: {
+  isCollectivitePrivate?: boolean;
+  canRead?: boolean;
+  canReadConfidentiel?: boolean;
+  document?: DocumentToDownload;
+  documentExists?: boolean;
+  hasBucket?: boolean;
+  signatureFails?: boolean;
+} = {}): ServiceUnderTest {
+  const permissionService = {
+    isAllowed: vi
+      .fn()
+      .mockImplementation((_user, operation) =>
+        Promise.resolve(
+          operation === 'collectivites.documents.read_confidentiel'
+            ? canReadConfidentiel
+              ? allowed
+              : denied
+            : canRead
+            ? allowed
+            : denied
+        )
+      ),
+  };
+
+  const repository = {
+    isCollectiviteAccesRestreint: vi
+      .fn()
+      .mockResolvedValue(isCollectivitePrivate),
+    findDocument: vi
+      .fn()
+      .mockResolvedValue(documentExists ? document : undefined),
+  };
+
+  const collectiviteBucket = {
+    findBucketId: vi
+      .fn()
+      .mockResolvedValue(hasBucket ? 'bucket-collectivite-1' : undefined),
+  };
+
+  const documentStorage = {
+    createSignedDownloadUrl: vi
+      .fn()
+      .mockResolvedValue(
+        signatureFails
+          ? failure(DocumentStorageErrorEnum.READ_DOCUMENT_ERROR)
+          : success({ signedUrl: 'https://signe.example/doc' })
+      ),
+  };
+
+  const service = new GetDownloadUrlService(
+    permissionService as never,
+    repository as never,
+    collectiviteBucket as never,
+    documentStorage as never
+  );
+
+  return { service, repository, documentStorage };
+}
+
+describe('GetDownloadUrlService', () => {
+  it("refuse un document non confidentiel d'une collectivite en acces restreint a un compte sans droit confidentiel", async () => {
+    const { service, documentStorage } = buildService({
+      isCollectivitePrivate: true,
+      canRead: true,
+      canReadConfidentiel: false,
+      document: { hash: HASH, filename: 'rapport.pdf', confidentiel: false },
+    });
+
+    const result = await service.getDownloadUrl(
+      { collectiviteId: 1, hash: HASH },
+      { user }
+    );
+
+    expect(result).toEqual({ success: false, error: 'UNAUTHORIZED' });
+    expect(documentStorage.createSignedDownloadUrl).not.toHaveBeenCalled();
+  });
+
+  it("signe un document non confidentiel d'une collectivite en acces restreint pour un compte qui a le droit confidentiel", async () => {
+    const { service } = buildService({
+      isCollectivitePrivate: true,
+      canReadConfidentiel: true,
+    });
+
+    const result = await service.getDownloadUrl(
+      { collectiviteId: 1, hash: HASH },
+      { user }
+    );
+
+    expect(result).toEqual({
+      success: true,
+      data: { signedUrl: 'https://signe.example/doc', filename: 'rapport.pdf' },
+    });
+  });
+
+  it("refuse un document confidentiel sans reveler qu'il existe", async () => {
+    const { service, documentStorage } = buildService({
+      document: { hash: HASH, filename: 'rapport.pdf', confidentiel: true },
+    });
+
+    const result = await service.getDownloadUrl(
+      { collectiviteId: 1, hash: HASH },
+      { user }
+    );
+
+    expect(result).toEqual({ success: false, error: 'DOCUMENT_NOT_FOUND' });
+    expect(documentStorage.createSignedDownloadUrl).not.toHaveBeenCalled();
+  });
+
+  it('signe un document confidentiel pour un compte qui a le droit confidentiel', async () => {
+    const { service } = buildService({
+      canReadConfidentiel: true,
+      document: { hash: HASH, filename: 'rapport.pdf', confidentiel: true },
+    });
+
+    const result = await service.getDownloadUrl(
+      { collectiviteId: 1, hash: HASH },
+      { user }
+    );
+
+    expect(result.success).toBe(true);
+  });
+
+  it('signe un document non confidentiel dune collectivite publique', async () => {
+    const { service } = buildService();
+
+    const result = await service.getDownloadUrl(
+      { collectiviteId: 1, hash: HASH },
+      { user }
+    );
+
+    expect(result).toEqual({
+      success: true,
+      data: { signedUrl: 'https://signe.example/doc', filename: 'rapport.pdf' },
+    });
+  });
+
+  it('refuse un compte sans aucun droit de lecture sans consulter le document', async () => {
+    const { service, repository, documentStorage } = buildService({
+      canRead: false,
+    });
+
+    const result = await service.getDownloadUrl(
+      { collectiviteId: 1, hash: HASH },
+      { user }
+    );
+
+    expect(result).toEqual({ success: false, error: 'UNAUTHORIZED' });
+    expect(repository.findDocument).not.toHaveBeenCalled();
+    expect(documentStorage.createSignedDownloadUrl).not.toHaveBeenCalled();
+  });
+
+  it('rend DOCUMENT_NOT_FOUND quand le hash ne designe aucun document de la collectivite', async () => {
+    const { service } = buildService({ documentExists: false });
+
+    const result = await service.getDownloadUrl(
+      { collectiviteId: 1, hash: HASH },
+      { user }
+    );
+
+    expect(result).toEqual({ success: false, error: 'DOCUMENT_NOT_FOUND' });
+  });
+
+  it("rend COLLECTIVITE_BUCKET_NOT_FOUND quand la collectivite n'a pas de bucket", async () => {
+    const { service, documentStorage } = buildService({ hasBucket: false });
+
+    const result = await service.getDownloadUrl(
+      { collectiviteId: 1, hash: HASH },
+      { user }
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: 'COLLECTIVITE_BUCKET_NOT_FOUND',
+    });
+    expect(documentStorage.createSignedDownloadUrl).not.toHaveBeenCalled();
+  });
+
+  it('remonte SIGN_DOWNLOAD_ERROR quand la signature echoue', async () => {
+    const { service } = buildService({ signatureFails: true });
+
+    const result = await service.getDownloadUrl(
+      { collectiviteId: 1, hash: HASH },
+      { user }
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      error: 'SIGN_DOWNLOAD_ERROR',
+    });
+  });
+
+  it('traite une collectivite inconnue comme un acces restreint', async () => {
+    const { service, documentStorage } = buildService({
+      isCollectivitePrivate: true,
+      canReadConfidentiel: false,
+    });
+
+    const result = await service.getDownloadUrl(
+      { collectiviteId: 404, hash: HASH },
+      { user }
+    );
+
+    expect(result).toEqual({ success: false, error: 'UNAUTHORIZED' });
+    expect(documentStorage.createSignedDownloadUrl).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/collectivites/documents/get-download-url/get-download-url.service.ts
+++ b/apps/backend/src/collectivites/documents/get-download-url/get-download-url.service.ts
@@ -1,0 +1,103 @@
+import { Injectable } from '@nestjs/common';
+import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
+import { ServiceSecondArg } from '@tet/backend/utils/nest/service-second-arg.utils';
+import { failure, success, type Result } from '@tet/backend/utils/result.type';
+import { DocumentStorageService } from '@tet/backend/utils/supabase/document-storage.service';
+import { ResourceType } from '@tet/domain/users';
+import { CollectiviteBucketRepository } from '../collectivite-bucket.repository';
+import {
+  GetDownloadUrlError,
+  GetDownloadUrlErrorEnum,
+} from './get-download-url.errors';
+import { GetDownloadUrlInput } from './get-download-url.input';
+import { GetDownloadUrlOutput } from './get-download-url.output';
+import { GetDownloadUrlRepository } from './get-download-url.repository';
+
+const DOWNLOAD_URL_TTL_SECONDS = 60;
+
+@Injectable()
+export class GetDownloadUrlService {
+  constructor(
+    private readonly permissionService: PermissionService,
+    private readonly repository: GetDownloadUrlRepository,
+    private readonly collectiviteBucketRepository: CollectiviteBucketRepository,
+    private readonly documentStorageService: DocumentStorageService
+  ) {}
+
+  async getDownloadUrl(
+    { collectiviteId, hash }: GetDownloadUrlInput,
+    { user, tx }: ServiceSecondArg
+  ): Promise<Result<GetDownloadUrlOutput, GetDownloadUrlError>> {
+    const [readResult, readConfidentielResult] = await Promise.all([
+      this.permissionService.isAllowed(
+        user,
+        'collectivites.documents.read',
+        ResourceType.COLLECTIVITE,
+        { collectiviteId },
+        tx
+      ),
+      this.permissionService.isAllowed(
+        user,
+        'collectivites.documents.read_confidentiel',
+        ResourceType.COLLECTIVITE,
+        { collectiviteId },
+        tx
+      ),
+    ]);
+
+    const canReadConfidentiel = readConfidentielResult.success;
+    if (!readResult.success && !canReadConfidentiel) {
+      return failure(GetDownloadUrlErrorEnum.UNAUTHORIZED);
+    }
+
+    const isAccesRestreint = await this.repository.isCollectiviteAccesRestreint(
+      collectiviteId
+    );
+
+    const canReachCollectivite = isAccesRestreint
+      ? canReadConfidentiel
+      : readResult.success;
+    if (!canReachCollectivite) {
+      return failure(GetDownloadUrlErrorEnum.UNAUTHORIZED);
+    }
+
+    const document = await this.repository.findDocument({
+      collectiviteId,
+      hash,
+    });
+    if (document === undefined) {
+      return failure(GetDownloadUrlErrorEnum.DOCUMENT_NOT_FOUND);
+    }
+
+    const isDocumentOutOfReach =
+      document.confidentiel === true && !canReadConfidentiel;
+    if (isDocumentOutOfReach) {
+      return failure(GetDownloadUrlErrorEnum.DOCUMENT_NOT_FOUND);
+    }
+
+    const bucketId = await this.collectiviteBucketRepository.findBucketId(
+      collectiviteId
+    );
+    if (bucketId === undefined) {
+      return failure(GetDownloadUrlErrorEnum.COLLECTIVITE_BUCKET_NOT_FOUND);
+    }
+
+    const signedUrlResult =
+      await this.documentStorageService.createSignedDownloadUrl({
+        bucketId,
+        key: document.hash,
+        expiresInSeconds: DOWNLOAD_URL_TTL_SECONDS,
+      });
+    if (!signedUrlResult.success) {
+      return failure(
+        GetDownloadUrlErrorEnum.SIGN_DOWNLOAD_ERROR,
+        signedUrlResult.cause
+      );
+    }
+
+    return success({
+      signedUrl: signedUrlResult.data.signedUrl,
+      filename: document.filename,
+    });
+  }
+}


### PR DESCRIPTION
Troisième PR de la pile qui fait passer le stockage de documents par le backend, et la première de la chaîne **lecture**. Elle pose le contrat côté serveur ; **aucun front ne la consomme encore**.

## Ce que fait l'endpoint

`collectivites.documents.getDownloadUrl` autorise la lecture d'un document et rend une URL signée valable une minute. Le client ne résout plus le bucket et n'interroge plus le stockage.

```ts
getDownloadUrl({ collectiviteId, hash }): Result<
  { signedUrl: string; filename: string },
  'UNAUTHORIZED' | 'DOCUMENT_NOT_FOUND' | 'COLLECTIVITE_BUCKET_NOT_FOUND' | 'SIGN_DOWNLOAD_ERROR'
>
```

## Le contrôle est à deux étages

`collectivites.documents.read` appartient aux permissions du visiteur vérifié, attribuées à un rôle **plateforme** — donc valables sur toutes les collectivités. Un endpoint qui n'élèverait le droit que sur le caractère confidentiel du document rendrait donc des URL signées à tout compte vérifié sur les documents ordinaires des collectivités **en accès restreint**.

L'accès restreint élève l'exigence au même titre que la confidentialité du document :

```
collectivité en accès restreint ? → exiger documents.read_confidentiel
document confidentiel           ? → exiger documents.read_confidentiel
sinon                             → documents.read
```

## Un refus ne révèle pas l'existence du document

Le document introuvable et le document interdit rendent la même erreur. Sans cela, quiconque détient un fichier pourrait confirmer qu'une collectivité le possède en calculant son empreinte et en lisant le code d'erreur.

## Ordre des opérations

Le droit sur la collectivité est vérifié **avant** toute lecture du document. L'accès restreint est lu par le repository, qui rend l'absence au lieu de lever sur une collectivité inconnue : le type `Result` porte alors tous les dénouements, y compris pour un `collectiviteId` que le client contrôle.

Le document est cherché sur `(collectiviteId, hash)`, jamais sur le hash seul — c'est la clé unique de la table. Et la clé effectivement signée est celle de la **ligne**, pas celle de l'entrée : un hash non conforme ne peut pas atteindre le stockage.

## `.mutation()` et non `.query()`

Une URL signée est datée. Une entrée de cache la resservirait périmée sur un re-render ou un retry.

## Ce que cette PR ne ferme pas

Deux chemins concurrents restent ouverts, tous deux antérieurs et traités plus loin dans la pile :

- la route REST `GET collectivites/:id/documents/:hash/download` n'élève le droit que sur la confidentialité du document, sans tenir compte de l'accès restreint ;
- la policy de lecture sur `storage.objects` autorise tout compte authentifié.

Tant qu'ils tiennent, ce contrôle applicatif est une porte blindée à côté d'une fenêtre ouverte. Il prend son sens avec la fermeture des droits, en fin de pile.

## Deux durcissements à connaître

Les rôles plateforme `ADEME` et `SUPPORT` détiennent `documents.read` mais pas `read_confidentiel` : ils perdent donc, sur cet endpoint, l'accès aux documents **ordinaires** des collectivités en accès restreint. La règle SQL équivalente accorde explicitement le support. Une PR dédiée rétablit l'ADEME plus loin dans la pile.

## Tests

La matrice d'accès complète — collectivité publique ou restreinte, document ordinaire ou confidentiel, droit confidentiel ou non — plus l'absence de signature sur les chemins de refus, l'ordre des opérations, et les deux branches d'erreur.

Le refus d'un hash désignant un autre bucket est vérifié de bout en bout, ainsi que le fait qu'un compte vérifié non membre franchit bien la garde d'une collectivité **publique** — c'est le comportement produit qui rend l'élévation nécessaire sur les collectivités restreintes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Nouvelles fonctionnalités**
  - Ajout de la génération d’URL signées pour télécharger les documents d’une collectivité.
  - Contrôle des droits d’accès, y compris pour les documents confidentiels.
  - Retour du nom du fichier avec l’URL de téléchargement.
  - Gestion des erreurs lorsque le document, le stockage ou les autorisations sont indisponibles.

- **Tests**
  - Ajout de tests couvrant les autorisations, les documents inexistants et les échecs de génération de liens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->