### PR TITLE
[Batch/pcaet access] Périmètres géographiques secondaires d'une collectivité

### DIFF
--- a/apps/backend/src/collectivites/shared/models/collectivite-perimetre-secondaire.table.ts
+++ b/apps/backend/src/collectivites/shared/models/collectivite-perimetre-secondaire.table.ts
@@ -1,0 +1,29 @@
+import { collectiviteTable } from '@tet/backend/collectivites/shared/models/collectivite.table';
+import { createdAt } from '@tet/backend/utils/column.utils';
+import { PerimetreSecondaireSource } from '@tet/domain/collectivites';
+import { integer, pgTable, serial, text, varchar } from 'drizzle-orm/pg-core';
+
+/**
+ * Les périmètres géographiques d'une collectivité au-delà du principal.
+ *
+ * `collectivite` porte **un** code de région et **un** code de département. Or
+ * une DR ADEME peut piloter deux régions, et un EPCI chevaucher plusieurs
+ * départements — Redon Agglomération s'étale sur 44, 56 et 35. Le principal
+ * reste sur `collectivite`, les autres viennent ici.
+ *
+ * Une ligne porte un code de région **ou** un code de département, jamais les
+ * deux : la base l'impose (`collectivite_perimetre_secondaire_un_seul_code`).
+ */
+export const collectivitePerimetreSecondaireTable = pgTable(
+  'collectivite_perimetre_secondaire',
+  {
+    id: serial('id').primaryKey(),
+    collectiviteId: integer('collectivite_id')
+      .notNull()
+      .references(() => collectiviteTable.id, { onDelete: 'cascade' }),
+    regionCode: varchar('region_code', { length: 2 }),
+    departementCode: varchar('departement_code', { length: 3 }),
+    source: text('source').notNull().$type<PerimetreSecondaireSource>(),
+    createdAt,
+  }
+);

--- a/apps/backend/src/demarches/pcaet/list-demandes-avis/list-demandes-avis.repository.ts
+++ b/apps/backend/src/demarches/pcaet/list-demandes-avis/list-demandes-avis.repository.ts
@@ -13,6 +13,10 @@ import {
 import type { CollectiviteType } from '@tet/domain/collectivites';
 import { CollectiviteRole } from '@tet/domain/users';
 import { and, eq, inArray, sql, type SQL } from 'drizzle-orm';
+import {
+  couvreLesCodesSql,
+  perimetreCodesSql,
+} from '../shared/perimetre-instructeur.columns';
 import { pcaetAvisTable } from '../shared/models/pcaet-avis.table';
 import { pcaetDemandeAvisTable } from '../shared/models/pcaet-demande-avis.table';
 import type { DemarchePcaetStatus } from '@tet/domain/demarches';
@@ -67,8 +71,8 @@ export class ListDemandesAvisRepository {
       const instructrices = await db
         .select({
           type: collectiviteTable.type,
-          regionCode: collectiviteTable.regionCode,
-          departementCode: collectiviteTable.departementCode,
+          regionCodes: perimetreCodesSql(collectiviteTable, 'region'),
+          departementCodes: perimetreCodesSql(collectiviteTable, 'departement'),
         })
         .from(collectiviteTable)
         .where(eq(collectiviteTable.id, instructeurCollectiviteId))
@@ -85,23 +89,28 @@ export class ListDemandesAvisRepository {
       }
 
       // Aucun filtre au national : le service voit toutes les déposantes.
-      // Ailleurs, un code manquant côté service ne couvre personne.
+      // Ailleurs, un service sans territoire ne couvre personne.
       let filtrePerimetre: SQL | undefined;
       if (perimetre !== PerimetreInstructeurEnum.NATIONAL) {
-        const codeInstructrice =
+        const maille =
           perimetre === PerimetreInstructeurEnum.REGION
-            ? instructrice.regionCode
-            : instructrice.departementCode;
+            ? 'region'
+            : 'departement';
+        const codesInstructrice =
+          maille === 'region'
+            ? instructrice.regionCodes
+            : instructrice.departementCodes;
 
-        if (!codeInstructrice) {
+        if (codesInstructrice.length === 0) {
           return success({ instructeurType: instructrice.type, rows: [] });
         }
 
-        filtrePerimetre = eq(
-          perimetre === PerimetreInstructeurEnum.REGION
-            ? collectiviteTable.regionCode
-            : collectiviteTable.departementCode,
-          codeInstructrice
+        // `collectiviteTable` est ici la déposante : ses territoires — le
+        // principal comme les secondaires — sont confrontés à ceux du service.
+        filtrePerimetre = couvreLesCodesSql(
+          collectiviteTable,
+          maille,
+          codesInstructrice
         );
       }
 

--- a/apps/backend/src/demarches/pcaet/shared/pcaet-instructeurs.repository.ts
+++ b/apps/backend/src/demarches/pcaet/shared/pcaet-instructeurs.repository.ts
@@ -2,11 +2,16 @@ import { Injectable, Logger } from '@nestjs/common';
 import { collectiviteTable } from '@tet/backend/collectivites/shared/models/collectivite.table';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { CollectiviteType } from '@tet/domain/collectivites';
 import {
   PerimetreInstructeurEnum,
   typesInstructeurDuPerimetre,
 } from '@tet/domain/demarches';
-import { and, eq, inArray, ne, or } from 'drizzle-orm';
+import { and, eq, inArray, ne, or, SQL } from 'drizzle-orm';
+import {
+  couvreLesCodesSql,
+  perimetreCodesSql,
+} from './perimetre-instructeur.columns';
 import { pcaetDemandeAvisTable } from './models/pcaet-demande-avis.table';
 
 /** Le type d'instructeur, ventilé par le périmètre qu'il couvre. */
@@ -44,10 +49,14 @@ export class PcaetInstructeursRepository {
   ): Promise<InstructeurSaisi[]> {
     const db = tx ?? this.databaseService.db;
 
+    // Les territoires de la déposante : son code principal et ses secondaires.
+    // Un EPCI peut chevaucher plusieurs départements — Redon Agglomération
+    // s'étale sur 44, 56 et 35 — et doit alors être saisi par les instructeurs
+    // de chacun, pas seulement par ceux de son siège.
     const deposantes = await db
       .select({
-        regionCode: collectiviteTable.regionCode,
-        departementCode: collectiviteTable.departementCode,
+        regionCodes: perimetreCodesSql(collectiviteTable, 'region'),
+        departementCodes: perimetreCodesSql(collectiviteTable, 'departement'),
       })
       .from(collectiviteTable)
       .where(eq(collectiviteTable.id, collectiviteId))
@@ -58,21 +67,30 @@ export class PcaetInstructeursRepository {
       return [];
     }
 
-    // Un code absent ne couvre rien : sans lui, le périmètre correspondant est
-    // simplement écarté plutôt que comparé à NULL.
+    /**
+     * Les services d'une maille qui couvrent l'un des territoires de la
+     * déposante — par leur code propre ou par un périmètre secondaire.
+     */
+    const couvreLaDeposante = (
+      types: readonly CollectiviteType[],
+      maille: 'region' | 'departement',
+      codesDeposante: string[]
+    ): SQL | undefined =>
+      // Une déposante sans territoire à cette maille ne se compare à rien.
+      types.length === 0 || codesDeposante.length === 0
+        ? undefined
+        : and(
+            inArray(collectiviteTable.type, types),
+            couvreLesCodesSql(collectiviteTable, maille, codesDeposante)
+          );
+
     const perimetres = [
-      deposante.regionCode && typesParRegion.length > 0
-        ? and(
-            inArray(collectiviteTable.type, typesParRegion),
-            eq(collectiviteTable.regionCode, deposante.regionCode)
-          )
-        : undefined,
-      deposante.departementCode && typesParDepartement.length > 0
-        ? and(
-            inArray(collectiviteTable.type, typesParDepartement),
-            eq(collectiviteTable.departementCode, deposante.departementCode)
-          )
-        : undefined,
+      couvreLaDeposante(typesParRegion, 'region', deposante.regionCodes),
+      couvreLaDeposante(
+        typesParDepartement,
+        'departement',
+        deposante.departementCodes
+      ),
       // Le national couvre la déposante quels que soient ses codes.
       typesNationaux.length > 0
         ? inArray(collectiviteTable.type, typesNationaux)

--- a/apps/backend/src/demarches/pcaet/shared/perimetre-instructeur.columns.ts
+++ b/apps/backend/src/demarches/pcaet/shared/perimetre-instructeur.columns.ts
@@ -1,5 +1,7 @@
+import { collectivitePerimetreSecondaireTable } from '@tet/backend/collectivites/shared/models/collectivite-perimetre-secondaire.table';
 import { collectiviteTable } from '@tet/backend/collectivites/shared/models/collectivite.table';
-import type { alias } from 'drizzle-orm/pg-core';
+import { getTableName, inArray, SQL, sql } from 'drizzle-orm';
+import type { alias, PgColumn } from 'drizzle-orm/pg-core';
 
 /**
  * Un alias de `collectivite`. Le type ne se réduit pas à celui de la table :
@@ -8,6 +10,115 @@ import type { alias } from 'drizzle-orm/pg-core';
 type CollectiviteAlias = ReturnType<
   typeof alias<typeof collectiviteTable, string>
 >;
+
+/**
+ * La table elle-même ou l'un de ses alias : `perimetreCodesSql` se lit aussi
+ * bien dans une requête à une seule collectivité que dans une jointure
+ * déposante/instructrice.
+ */
+type CollectiviteSource = typeof collectiviteTable | CollectiviteAlias;
+
+type MaillePerimetre = 'region' | 'departement';
+
+/**
+ * `table.colonne`, écrit en entier.
+ *
+ * Drizzle rend une colonne **sans** son préfixe de table dans un template
+ * `sql`. Inoffensif sur une requête à une table, piégeux dès qu'une autre entre
+ * en scène : `where "collectivite_id" = "id"` se lit alors entièrement dans
+ * `collectivite_perimetre_secondaire`, qui a justement les deux colonnes — la
+ * jointure devient une comparaison d'une table avec elle-même, toujours fausse,
+ * et les périmètres secondaires disparaissent sans une ligne d'erreur.
+ */
+const qualifie = (colonne: PgColumn): SQL =>
+  sql`${sql.identifier(getTableName(colonne.table))}.${sql.identifier(
+    colonne.name
+  )}`;
+
+/**
+ * Tous les codes géographiques d'une collectivité à une maille donnée : le
+ * principal, porté par `collectivite`, et les secondaires, portés par
+ * `collectivite_perimetre_secondaire`.
+ *
+ * Une DR ADEME peut piloter deux régions, un EPCI chevaucher plusieurs
+ * départements : comparer les seuls codes de `collectivite` laisserait de côté
+ * une partie du territoire réellement couvert.
+ *
+ * Le `where code is not null` rend une liste vide plutôt qu'une liste d'un
+ * `null` : `instructeurCouvreCollectivite` lit une liste vide comme « aucun
+ * territoire », qui ne croise jamais rien.
+ */
+export const perimetreCodesSql = (
+  collectivite: CollectiviteSource,
+  maille: MaillePerimetre
+): SQL<string[]> => {
+  const principal = qualifie(
+    maille === 'region' ? collectivite.regionCode : collectivite.departementCode
+  );
+  const secondaire = qualifie(
+    maille === 'region'
+      ? collectivitePerimetreSecondaireTable.regionCode
+      : collectivitePerimetreSecondaireTable.departementCode
+  );
+
+  return sql<string[]>`coalesce((
+    select array_agg(codes.code)
+    from (
+      select ${principal} as code
+      union all
+      select ${secondaire}
+      from ${collectivitePerimetreSecondaireTable}
+      where ${qualifie(
+        collectivitePerimetreSecondaireTable.collectiviteId
+      )} = ${qualifie(collectivite.id)}
+    ) as codes
+    where codes.code is not null
+  ), '{}')`;
+};
+
+/**
+ * « Cette collectivité couvre-t-elle l'un de ces territoires ? », en SQL.
+ *
+ * Le pendant filtrant de `perimetreCodesSql` : là où celui-ci ramène les codes
+ * pour que le domaine tranche, celui-ci tranche dans la requête, quand il faut
+ * écarter des lignes plutôt que les qualifier.
+ *
+ * Les deux orientations s'écrivent avec : dire quels services couvrent une
+ * déposante (`cible` = le service, `codes` = ceux de la déposante), et dire
+ * quelles déposantes un service couvre (l'inverse). Le `exists` est ce qui
+ * empêche d'oublier un périmètre secondaire — sans lui, la DR ADEME Océan
+ * Indien, qui n'a qu'une ligne pour La Réunion et Mayotte, ne verrait jamais la
+ * seconde.
+ *
+ * Une liste de codes vide n'a pas de sens ici : l'appelant doit avoir renoncé
+ * avant, un territoire absent ne se compare à rien.
+ */
+export const couvreLesCodesSql = (
+  cible: CollectiviteSource,
+  maille: MaillePerimetre,
+  codes: readonly string[]
+): SQL => {
+  const principal = qualifie(
+    maille === 'region' ? cible.regionCode : cible.departementCode
+  );
+  const secondaire = qualifie(
+    maille === 'region'
+      ? collectivitePerimetreSecondaireTable.regionCode
+      : collectivitePerimetreSecondaireTable.departementCode
+  );
+
+  return sql`(
+    ${inArray(principal, codes as string[])}
+    or exists (
+      select 1
+      from ${collectivitePerimetreSecondaireTable}
+      where ${qualifie(
+        collectivitePerimetreSecondaireTable.collectiviteId
+      )} = ${qualifie(cible.id)}
+        and ${inArray(secondaire, codes as string[])}
+    )
+  )`;
+};
 
 /**
  * Projection SQL de `PerimetreInstructeurEntree`, la forme que
@@ -24,8 +135,8 @@ export const perimetreInstructeurColumns = (
   instructrice: CollectiviteAlias
 ) => ({
   instructeurType: instructrice.type,
-  instructeurRegionCode: instructrice.regionCode,
-  instructeurDepartementCode: instructrice.departementCode,
-  collectiviteRegionCode: deposante.regionCode,
-  collectiviteDepartementCode: deposante.departementCode,
+  instructeurRegionCodes: perimetreCodesSql(instructrice, 'region'),
+  instructeurDepartementCodes: perimetreCodesSql(instructrice, 'departement'),
+  collectiviteRegionCodes: perimetreCodesSql(deposante, 'region'),
+  collectiviteDepartementCodes: perimetreCodesSql(deposante, 'departement'),
 });

--- a/apps/backend/src/demarches/pcaet/transmettre-pour-avis/transmettre-pour-avis.router.e2e-spec.ts
+++ b/apps/backend/src/demarches/pcaet/transmettre-pour-avis/transmettre-pour-avis.router.e2e-spec.ts
@@ -20,6 +20,7 @@ import { onTestFinished, vi } from 'vitest';
 import { demarcheStatusHistoryTable } from '@tet/backend/demarches/shared/models/demarche-status-history.table';
 import { demarcheTable } from '@tet/backend/demarches/shared/models/demarche.table';
 import { CloreInstructionService } from '../clore-instruction/clore-instruction.service';
+import { collectivitePerimetreSecondaireTable } from '@tet/backend/collectivites/shared/models/collectivite-perimetre-secondaire.table';
 import { pcaetDemandeAvisTable } from '../shared/models/pcaet-demande-avis.table';
 import { PcaetAvisRepository } from '../shared/pcaet-avis.repository';
 import { PcaetInstructeursRepository } from '../shared/pcaet-instructeurs.repository';
@@ -429,6 +430,21 @@ describe('Cycle de vie de la démarche PCAET (transitions)', () => {
       return creee;
     };
 
+    /**
+     * Un territoire couvert en plus du principal. Rien à nettoyer : la ligne
+     * cascade avec la collectivité.
+     */
+    const addPerimetreSecondaire = async (
+      collectiviteId: number,
+      perimetre: { regionCode: string } | { departementCode: string }
+    ) => {
+      await db.db.insert(collectivitePerimetreSecondaireTable).values({
+        collectiviteId,
+        source: 'import_service_etat',
+        ...perimetre,
+      });
+    };
+
     const listDestinataires = async (demarcheId: number) =>
       db.db
         .select({
@@ -511,6 +527,110 @@ describe('Cycle de vie de la démarche PCAET (transitions)', () => {
       expect(destinataires.every((d) => d.source === 'transmission')).toBe(
         true
       );
+    });
+
+    /**
+     * Le cas de la DR ADEME Océan Indien : une seule ligne pour deux régions,
+     * la seconde portée par un périmètre secondaire. Sans elle, le service ne
+     * serait jamais saisi pour la moitié de son territoire.
+     */
+    test('saisit un service dont un périmètre secondaire couvre la déposante', async () => {
+      const regionDeposante = 'S1';
+      const { caller, collectivite } = await freshEditor({
+        regionCode: regionDeposante,
+        departementCode: 'S1',
+      });
+
+      // Sa région principale est ailleurs : seul le périmètre secondaire la relie.
+      const drAdemeDeuxRegions = await addInstructeur({
+        type: 'dr_ademe',
+        regionCode: 'S2',
+      });
+      await addPerimetreSecondaire(drAdemeDeuxRegions.id, {
+        regionCode: regionDeposante,
+      });
+      const drAdemeAilleurs = await addInstructeur({
+        type: 'dr_ademe',
+        regionCode: 'S3',
+      });
+
+      const created = await caller.demarches.pcaet.create({
+        collectiviteId: collectivite.id,
+      });
+      await completeTestDossierPcaet(db, {
+        collectiviteId: collectivite.id,
+        demarcheId: created.id,
+      });
+      await caller.demarches.pcaet.transmettrePourAvis({
+        collectiviteId: collectivite.id,
+        demarcheId: created.id,
+      });
+
+      const saisis = (await listDestinataires(created.id)).map(
+        (d) => d.instructeurCollectiviteId
+      );
+      expect(saisis).toContain(drAdemeDeuxRegions.id);
+      expect(saisis).not.toContain(drAdemeAilleurs.id);
+    });
+
+    /**
+     * Et réciproquement, le cas de Redon Agglomération : un EPCI qui chevauche
+     * plusieurs départements relève des instructeurs de chacun, pas seulement de
+     * ceux de son siège.
+     */
+    test('saisit les instructeurs des territoires secondaires de la déposante', async () => {
+      const { caller, collectivite } = await freshEditor({
+        regionCode: 'S4',
+        departementCode: 'S4',
+      });
+      await addPerimetreSecondaire(collectivite.id, {
+        departementCode: 'S5',
+      });
+      await addPerimetreSecondaire(collectivite.id, { regionCode: 'S5' });
+
+      const ddtDuSiege = await addInstructeur({
+        type: 'ddt',
+        regionCode: 'S4',
+        departementCode: 'S4',
+      });
+      const ddtDebordee = await addInstructeur({
+        type: 'ddt',
+        regionCode: 'S5',
+        departementCode: 'S5',
+      });
+      const drealDebordee = await addInstructeur({
+        type: 'dreal',
+        regionCode: 'S5',
+      });
+      const ddtAilleurs = await addInstructeur({
+        type: 'ddt',
+        regionCode: 'S6',
+        departementCode: 'S6',
+      });
+
+      const created = await caller.demarches.pcaet.create({
+        collectiviteId: collectivite.id,
+      });
+      await completeTestDossierPcaet(db, {
+        collectiviteId: collectivite.id,
+        demarcheId: created.id,
+      });
+      await caller.demarches.pcaet.transmettrePourAvis({
+        collectiviteId: collectivite.id,
+        demarcheId: created.id,
+      });
+
+      const saisis = (await listDestinataires(created.id)).map(
+        (d) => d.instructeurCollectiviteId
+      );
+      expect(saisis).toEqual(
+        expect.arrayContaining([
+          ddtDuSiege.id,
+          ddtDebordee.id,
+          drealDebordee.id,
+        ])
+      );
+      expect(saisis).not.toContain(ddtAilleurs.id);
     });
 
     /**

--- a/data_layer/scripts/generate_service_etat.py
+++ b/data_layer/scripts/generate_service_etat.py
@@ -1,14 +1,22 @@
 #!/usr/bin/env python3
 """Régénère l'import des services de l'État depuis `seed/sources/service-etat/`.
 
-Écrit **un seul** fichier, `seed/imports/09-service_etat.sql` : `seed.sh` le
-charge sur une base neuve, et le change sqitch
-`collectivite/service_etat_import` l'inclut par `\\ir` pour les bases déjà
-peuplées (staging, production), où le seed ne repasse jamais.
+Écrit deux fichiers, un seul exemplaire des données chacun :
 
-Un seul exemplaire des données, donc : générer les deux fichiers les avait fait
-diverger en une journée. Le script de deploy sqitch, lui, ne bouge jamais — son
-empreinte reste stable quand la liste est régénérée.
+- `seed/imports/09-service_etat.sql` — les services eux-mêmes, inclus par `\\ir`
+  dans le change sqitch `collectivite/service_etat_import` ;
+- `seed/imports/10-service_etat_perimetre_secondaire.sql` — les régions qu'un
+  service couvre au-delà de sa principale, incluses par le change
+  `collectivite/perimetre_secondaire`.
+
+Deux fichiers parce que deux changes : le premier est déjà déployé et ne sera pas
+rejoué, or les périmètres secondaires ont besoin d'une table qui n'existait pas
+quand il a été écrit. Les mettre dans le même fichier ferait échouer les
+migrations d'une base neuve, où le change antérieur les jouerait trop tôt.
+
+`seed.sh` charge les deux dans l'ordre lexicographique, donc dans le bon. Le
+script de deploy sqitch, lui, ne bouge jamais — son empreinte reste stable quand
+la liste est régénérée.
 
 Le corps est idempotent : il s'apparie sur la famille et le code géographique,
 qui sont les clés que la base impose déjà (index uniques partiels), et ne réécrit
@@ -37,6 +45,9 @@ import urllib.request
 DATA_LAYER = pathlib.Path(__file__).resolve().parents[1]
 SOURCES = DATA_LAYER / 'seed' / 'sources' / 'service-etat'
 DESTINATION = DATA_LAYER / 'seed' / 'imports' / '09-service_etat.sql'
+DESTINATION_PERIMETRE = (
+    DATA_LAYER / 'seed' / 'imports' / '10-service_etat_perimetre_secondaire.sql'
+)
 
 # Le NIC du siège vient du répertoire SIRENE, exposé sans clé par la DINUM.
 API = 'https://recherche-entreprises.api.gouv.fr/search'
@@ -302,11 +313,17 @@ do update set siren       = excluded.siren,
               nic         = excluded.nic,
               region_code = excluded.region_code;
 
--- Les DR ADEME, appariées sur la région. Les dix-huit partagent le SIREN 385290309
--- de l'ADEME : seul le NIC les distingue, et c'est ce qui rendra possible le
--- rattachement automatique par ProConnect. La direction Océan Indien couvre deux
--- régions (La Réunion et Mayotte) : deux lignes, même nom et même SIRET, ce que
--- l'index autorise puisqu'il ne porte que sur la région.
+-- Les DR ADEME, appariées sur la région. Elles partagent toutes le SIREN
+-- 385290309 de l'ADEME : seul le NIC les distingue, et c'est ce qui rend
+-- possible le rattachement automatique d'un agent à son service.
+--
+-- Une ligne par SIRET, donc une par direction — et non une par région. La
+-- direction Océan Indien pilote La Réunion et Mayotte : elle a ici sa région
+-- principale, et l'autre lui vient en périmètre secondaire
+-- (`10-service_etat_perimetre_secondaire.sql`). L'index unique ne porte que sur
+-- la région et tolérerait deux lignes, mais ce serait deux fois le même service :
+-- deux destinataires pour une transmission, et un SIRET qui ne désigne plus rien
+-- en particulier.
 insert into collectivite (nom, type, region_code, siren, nic)
 select v.nom, v.type, v.region_code, v.siren, v.nic
 from (values
@@ -384,6 +401,58 @@ HEADER = """-- Services de l'État instructeurs du dépôt PCAET : DREAL, DDT, D
 FOOTER = ''
 
 
+PERIMETRE_HEADER = """-- Périmètres géographiques secondaires des services de l'État.
+--
+-- Une direction régionale peut en piloter plusieurs — l'ADEME Océan Indien
+-- couvre La Réunion et Mayotte. `collectivite` ne porte qu'un code de région et
+-- un code de département, le périmètre principal ; les autres viennent ici.
+--
+-- Source : data_layer/seed/sources/service-etat/*.csv. Fichier généré —
+-- régénérer avec `make seeds_rebuild_from_source`
+-- (script : data_layer/scripts/generate_service_etat.py).
+--
+-- Deux lecteurs, comme son voisin `09-service_etat.sql` : `seed.sh` le charge sur
+-- une base neuve, et le change sqitch `collectivite/perimetre_secondaire`
+-- l'inclut par `\\ir` pour les bases déjà peuplées. D'où l'absence de
+-- `begin`/`commit` : c'est le change qui ouvre la transaction.
+--
+-- Il est séparé de `09-service_etat.sql` parce que la table qu'il peuple est
+-- arrivée après lui : le change qui inclut le premier fichier est déjà déployé,
+-- ne sera pas rejoué, et sur une base neuve il jouerait ces lignes avant que la
+-- table existe.
+
+"""
+
+PERIMETRE_VIDE = """-- Aucun service ne couvre aujourd'hui de périmètre au-delà du sien : les CSV
+-- source ne listent aucune direction sur deux régions. Le fichier reste, pour
+-- que le change sqitch qui l'inclut n'ait pas à s'interroger.
+"""
+
+
+def corps_perimetre(lignes: list[tuple[str, ...]]) -> str:
+    """Les régions couvertes en plus de la principale.
+
+    Pas de `where exists (select 1 from collectivite)` : la jointure sur
+    `collectivite` fait cette garde d'elle-même — sur une base vide, au moment des
+    migrations, elle ne ramène rien. L'appariement se fait sur le SIRET, seule clé
+    qui distingue deux directions partageant le SIREN de l'ADEME.
+    """
+    if not lignes:
+        return PERIMETRE_VIDE
+    return f"""insert into collectivite_perimetre_secondaire (collectivite_id, region_code, source)
+select principale.id, v.region_code, 'import_service_etat'
+from (values
+{valeurs(lignes)}
+) as v (type, siren, nic, region_code)
+join collectivite as principale
+  on principale.type = v.type
+ and principale.siren = v.siren
+ and principale.nic = v.nic
+on conflict (collectivite_id, region_code) where region_code is not null
+do nothing;
+"""
+
+
 # ————————————————————————————————— main —————————————————————————————————
 
 
@@ -459,15 +528,33 @@ def main() -> None:
     ]
 
     # — DR ADEME : SIRET complet au classeur, le NIC n'est jamais cherché ailleurs
+    #
+    # Le classeur liste une direction une fois par région couverte. C'est pourtant
+    # un seul service, avec un seul SIRET : la première région rencontrée devient
+    # son périmètre principal, les suivantes des périmètres secondaires.
     fichier = 'dr-ademe.csv'
     lignes = read_csv(fichier, ('region_code', 'siret', 'nom'))
     check_unique(fichier, 'code région', [(l['region_code'], l['_ligne']) for l in lignes])
     services['dr_ademe'] = []
+    services['perimetre_secondaire'] = []
+    principales: dict[tuple[str, str], str] = {}
     for ligne in lignes:
         siren, nic = decoupe_siret(fichier, ligne)
-        services['dr_ademe'].append(
-            (check_libelle(fichier, ligne), 'dr_ademe', check_region(fichier, ligne), siren, nic)
-        )
+        nom = check_libelle(fichier, ligne)
+        region = check_region(fichier, ligne)
+        deja_vu = principales.get((siren, nic))
+        if deja_vu is None:
+            principales[(siren, nic)] = nom
+            services['dr_ademe'].append((nom, 'dr_ademe', region, siren, nic))
+            continue
+        # Un SIRET est un établissement : deux dénominations sous le même signent
+        # une erreur de source, pas un service à deux périmètres.
+        if deja_vu != nom:
+            fail(
+                f'{fichier}:{ligne["_ligne"]} — le SIRET {siren}{nic} porte deux '
+                f'dénominations, {deja_vu!r} et {nom!r}'
+            )
+        services['perimetre_secondaire'].append(('dr_ademe', siren, nic, region))
 
     # — Services nationaux : appariés sur le nom, donc unique par construction
     fichier = 'service-national.csv'
@@ -505,14 +592,20 @@ def main() -> None:
     # Rien n'est écrit avant que tout soit lu, validé et complété : une source
     # abîmée laisse les deux SQL en place.
     DESTINATION.write_text(HEADER + corps(services) + FOOTER, encoding='utf-8')
+    DESTINATION_PERIMETRE.write_text(
+        PERIMETRE_HEADER + corps_perimetre(services['perimetre_secondaire']),
+        encoding='utf-8',
+    )
 
     print(
         f'✓ {len(services["dreal"])} DREAL, {len(services["ddt"])} DDT, '
         f'{len(services["dr_ademe"])} DR ADEME, '
         f'{len(services["service_national"])} services nationaux, '
-        f'{len(services["conseil_regional"])} conseils régionaux'
+        f'{len(services["conseil_regional"])} conseils régionaux, '
+        f'{len(services["perimetre_secondaire"])} périmètre(s) secondaire(s)'
     )
     print(f'  → {DESTINATION.relative_to(DATA_LAYER.parent)}')
+    print(f'  → {DESTINATION_PERIMETRE.relative_to(DATA_LAYER.parent)}')
 
 
 if __name__ == '__main__':

--- a/data_layer/seed/imports/09-service_etat.sql
+++ b/data_layer/seed/imports/09-service_etat.sql
@@ -175,11 +175,17 @@ do update set siren       = excluded.siren,
               nic         = excluded.nic,
               region_code = excluded.region_code;
 
--- Les DR ADEME, appariées sur la région. Les dix-huit partagent le SIREN 385290309
--- de l'ADEME : seul le NIC les distingue, et c'est ce qui rendra possible le
--- rattachement automatique par ProConnect. La direction Océan Indien couvre deux
--- régions (La Réunion et Mayotte) : deux lignes, même nom et même SIRET, ce que
--- l'index autorise puisqu'il ne porte que sur la région.
+-- Les DR ADEME, appariées sur la région. Elles partagent toutes le SIREN
+-- 385290309 de l'ADEME : seul le NIC les distingue, et c'est ce qui rend
+-- possible le rattachement automatique d'un agent à son service.
+--
+-- Une ligne par SIRET, donc une par direction — et non une par région. La
+-- direction Océan Indien pilote La Réunion et Mayotte : elle a ici sa région
+-- principale, et l'autre lui vient en périmètre secondaire
+-- (`10-service_etat_perimetre_secondaire.sql`). L'index unique ne porte que sur
+-- la région et tolérerait deux lignes, mais ce serait deux fois le même service :
+-- deux destinataires pour une transmission, et un SIRET qui ne désigne plus rien
+-- en particulier.
 insert into collectivite (nom, type, region_code, siren, nic)
 select v.nom, v.type, v.region_code, v.siren, v.nic
 from (values
@@ -187,7 +193,6 @@ from (values
         ('Direction Régionale (DR) Ademe Martinique', 'dr_ademe', '02', '385290309', '00595'),
         ('Direction Régionale (DR) Ademe Guyane', 'dr_ademe', '03', '385290309', '00538'),
         ('Direction Régionale (DR) Ademe Océan Indien', 'dr_ademe', '04', '385290309', '00397'),
-        ('Direction Régionale (DR) Ademe Océan Indien', 'dr_ademe', '06', '385290309', '00397'),
         ('Direction Régionale (DR) Ademe Île-de-France', 'dr_ademe', '11', '385290309', '00199'),
         ('Direction Régionale (DR) Ademe Centre-Val de Loire', 'dr_ademe', '24', '385290309', '00579'),
         ('Direction Régionale (DR) Ademe Bourgogne-Franche-Comté', 'dr_ademe', '27', '385290309', '00520'),

--- a/data_layer/seed/imports/10-service_etat_perimetre_secondaire.sql
+++ b/data_layer/seed/imports/10-service_etat_perimetre_secondaire.sql
@@ -1,0 +1,31 @@
+-- Périmètres géographiques secondaires des services de l'État.
+--
+-- Une direction régionale peut en piloter plusieurs — l'ADEME Océan Indien
+-- couvre La Réunion et Mayotte. `collectivite` ne porte qu'un code de région et
+-- un code de département, le périmètre principal ; les autres viennent ici.
+--
+-- Source : data_layer/seed/sources/service-etat/*.csv. Fichier généré —
+-- régénérer avec `make seeds_rebuild_from_source`
+-- (script : data_layer/scripts/generate_service_etat.py).
+--
+-- Deux lecteurs, comme son voisin `09-service_etat.sql` : `seed.sh` le charge sur
+-- une base neuve, et le change sqitch `collectivite/perimetre_secondaire`
+-- l'inclut par `\ir` pour les bases déjà peuplées. D'où l'absence de
+-- `begin`/`commit` : c'est le change qui ouvre la transaction.
+--
+-- Il est séparé de `09-service_etat.sql` parce que la table qu'il peuple est
+-- arrivée après lui : le change qui inclut le premier fichier est déjà déployé,
+-- ne sera pas rejoué, et sur une base neuve il jouerait ces lignes avant que la
+-- table existe.
+
+insert into collectivite_perimetre_secondaire (collectivite_id, region_code, source)
+select principale.id, v.region_code, 'import_service_etat'
+from (values
+        ('dr_ademe', '385290309', '00397', '06')
+) as v (type, siren, nic, region_code)
+join collectivite as principale
+  on principale.type = v.type
+ and principale.siren = v.siren
+ and principale.nic = v.nic
+on conflict (collectivite_id, region_code) where region_code is not null
+do nothing;

--- a/data_layer/seed/sources/service-etat/README.md
+++ b/data_layer/seed/sources/service-etat/README.md
@@ -17,7 +17,7 @@ Corriger le CSV concerné, puis :
 
 ```bash
 make seeds_rebuild_from_source   # regénère le SQL, ne touche pas la base
-git diff data_layer/seed/imports/09-service_etat.sql
+git diff data_layer/seed/imports
 ```
 
 Le générateur refuse toute anomalie plutôt que de réécrire un SQL douteux : code
@@ -25,8 +25,13 @@ géographique inconnu, SIREN mal formé, doublon sur une clé, SIREN inactif au
 répertoire SIRENE. Mieux vaut un seed daté qu'un seed corrompu.
 
 Le SQL généré est **idempotent** et sert deux fois : `seed.sh` le charge sur une base
-neuve, et le change sqitch `collectivite/service_etat_import` porte le même corps
-pour les bases déjà peuplées (staging, production).
+neuve, et un change sqitch porte le même corps pour les bases déjà peuplées
+(staging, production). Deux fichiers, donc deux changes :
+`09-service_etat.sql` par `collectivite/service_etat_import`, et
+`10-service_etat_perimetre_secondaire.sql` par `collectivite/perimetre_secondaire`.
+Ils sont séparés parce que le premier change était déjà déployé quand la table des
+périmètres est arrivée : réunis, ils feraient échouer les migrations d'une base
+neuve, où le change antérieur les jouerait avant que la table existe.
 
 ## Les fichiers
 
@@ -34,13 +39,30 @@ pour les bases déjà peuplées (staging, production).
 |---|---|---|---|
 | `ddt.csv` | 92 | `collectivite` type `ddt` | `departement_code` |
 | `dreal.csv` | 18 | type `dreal` | `region_code` |
-| `dr-ademe.csv` | 18 | type `dr_ademe` | `region_code` |
+| `dr-ademe.csv` | 18 | **17** lignes type `dr_ademe` + 1 périmètre secondaire | `region_code` |
 | `service-national.csv` | 2 | type `service_national` | `nom` |
 | `conseil-regional.csv` | 18 | **update** des `type='region'` existants | `region_code` |
 | `dreal-contacts.csv` | 22 | — | réservé à la slice 4 (TETH-11) |
 
 `dreal-contacts.csv` n'est lu par personne aujourd'hui : les correspondants DREAL
 relèvent de l'import des membres et de son mail d'invitation, pas de cette slice.
+
+### Une direction sur deux régions
+
+`dr-ademe.csv` liste dix-huit lignes pour dix-sept directions : l'Océan Indien y
+figure deux fois, une fois par région couverte (La Réunion et Mayotte), avec le
+même nom et le même SIRET.
+
+L'import n'en fait qu'**une** ligne `collectivite`. La première région rencontrée
+devient son périmètre principal, la seconde une ligne de
+`collectivite_perimetre_secondaire`. L'index unique ne portant que sur la région,
+la base tolérerait deux lignes — mais ce serait deux fois le même service : deux
+destinataires pour une transmission, et un SIRET qui ne désigne plus un service en
+particulier, donc un rattachement automatique par ProConnect incapable de trancher.
+
+Le générateur refuse deux dénominations sous un même SIRET : un SIRET est un
+établissement, et deux noms signeraient une erreur de source plutôt qu'un service à
+deux périmètres.
 
 ### La colonne `nom_anterieur` de `service-national.csv`
 
@@ -65,14 +87,18 @@ SIRET, et c'est lui qui distingue deux services partageant un SIREN — sans quo
 rattachement automatique par ProConnect ne peut pas trancher.
 
 - `dr-ademe.csv` et `service-national.csv` portent un **SIRET** : le NIC en est
-  extrait directement. Les 18 DR ADEME partagent le SIREN 385290309 de l'ADEME, seul
+  extrait directement. Les DR ADEME partagent le SIREN 385290309 de l'ADEME, seul
   le NIC les sépare — le NIC ne doit donc **jamais** être cherché ailleurs pour elles
-  (le siège du SIREN 385290309 est Angers, il vaudrait pour les 18).
+  (le siège du SIREN 385290309 est Angers, il vaudrait pour toutes).
 - `ddt.csv`, `dreal.csv` et `conseil-regional.csv` ne portent qu'un **SIREN** : le
   générateur récupère le NIC du siège auprès de `recherche-entreprises.api.gouv.fr`.
 
 Quand un service compte plusieurs implantations, le classeur les liste en
 « Implantation 1..3 » ; c'est la première, le siège de la direction, qui est retenue.
+
+Une fois l'import joué, un SIRET désigne un service et un seul — c'est l'invariant
+que vérifie le `verify` de `collectivite/perimetre_secondaire`, et ce sur quoi
+s'appuie le rattachement automatique.
 
 ## Lignes du classeur écartées (11)
 

--- a/data_layer/sqitch/deploy/collectivite/perimetre_secondaire.sql
+++ b/data_layer/sqitch/deploy/collectivite/perimetre_secondaire.sql
@@ -1,0 +1,193 @@
+-- Deploy tet:collectivite/perimetre_secondaire to pg
+-- requires: collectivite/service_etat_import
+
+-- Les périmètres géographiques secondaires d'une collectivité.
+--
+-- `collectivite` porte **un** code de région et **un** code de département : le
+-- périmètre principal. Or plusieurs collectivités en couvrent plusieurs. Une DR
+-- ADEME peut piloter deux régions (Océan Indien = La Réunion et Mayotte), et un
+-- EPCI peut chevaucher plusieurs départements et régions (Redon Agglomération
+-- s'étale sur 44, 56 et 35, donc sur Pays de la Loire et Bretagne).
+--
+-- Jusqu'ici le second périmètre d'une DR ADEME était rendu par une **seconde
+-- ligne** `collectivite`, ce que l'index unique partiel autorise puisqu'il ne
+-- porte que sur la région. Le même service existait donc deux fois : deux
+-- destinataires pour une transmission, et un SIRET qui ne désignait plus un
+-- service mais deux — de quoi rendre impossible le rattachement automatique d'un
+-- agent à son service depuis l'organisation que ProConnect renvoie.
+--
+-- Le périmètre principal reste sur `collectivite` ; les autres viennent ici.
+
+BEGIN;
+
+CREATE TABLE public.collectivite_perimetre_secondaire (
+    id               serial      PRIMARY KEY,
+    collectivite_id  integer     NOT NULL REFERENCES collectivite (id) ON DELETE CASCADE,
+    region_code      varchar(2)  NULL,
+    departement_code varchar(3)  NULL,
+    source           text        NOT NULL,
+    created_at       timestamptz NOT NULL DEFAULT now(),
+
+    -- Une ligne porte un périmètre, pas deux : un code de région **ou** un code
+    -- de département. Une collectivité qui déborde sur les deux plans a une
+    -- ligne par code.
+    CONSTRAINT collectivite_perimetre_secondaire_un_seul_code
+        CHECK (num_nonnulls(region_code, departement_code) = 1),
+
+    -- Qui a écrit la ligne. Ce n'est pas une trace décorative : le calcul des
+    -- périmètres des EPCI se rejoue périodiquement depuis la composition
+    -- communale Banatic, et il doit pouvoir remplacer **ses** lignes sans
+    -- emporter celles de l'import des services de l'État.
+    CONSTRAINT collectivite_perimetre_secondaire_source_connue
+        CHECK (source IN ('import_service_etat', 'banatic'))
+);
+
+-- Pas de clé étrangère vers `imports.region` ni `imports.departement` :
+-- `collectivite.region_code` n'en a pas non plus, et pour une bonne raison — les
+-- fixtures de test prennent des codes en lettres (`AB`, `M1`), hors répertoire,
+-- justement pour ne pas se disputer les dix-huit codes réels que l'import des
+-- services occupe désormais tous.
+
+CREATE UNIQUE INDEX collectivite_perimetre_secondaire_region_unique
+    ON public.collectivite_perimetre_secondaire (collectivite_id, region_code)
+    WHERE region_code IS NOT NULL;
+
+CREATE UNIQUE INDEX collectivite_perimetre_secondaire_departement_unique
+    ON public.collectivite_perimetre_secondaire (collectivite_id, departement_code)
+    WHERE departement_code IS NOT NULL;
+
+CREATE INDEX collectivite_perimetre_secondaire_collectivite_id_idx
+    ON public.collectivite_perimetre_secondaire (collectivite_id);
+
+COMMENT ON TABLE public.collectivite_perimetre_secondaire IS 'Périmètres géographiques d''une collectivité au-delà du principal porté par collectivite.region_code / departement_code : une DR ADEME couvrant deux régions, un EPCI chevauchant plusieurs départements.';
+COMMENT ON COLUMN public.collectivite_perimetre_secondaire.region_code IS 'Région couverte en plus de collectivite.region_code. Exclusif de departement_code.';
+COMMENT ON COLUMN public.collectivite_perimetre_secondaire.departement_code IS 'Département couvert en plus de collectivite.departement_code. Exclusif de region_code.';
+COMMENT ON COLUMN public.collectivite_perimetre_secondaire.source IS 'Producteur de la ligne : import_service_etat (classeur ADEME) ou banatic (composition communale des EPCI, rejouée périodiquement). Chaque producteur ne remplace que ses propres lignes.';
+
+-- RLS sans policy : la table se lit par la connexion directe du backend.
+ALTER TABLE public.collectivite_perimetre_secondaire ENABLE ROW LEVEL SECURITY;
+
+-- `public` est exposé à PostgREST (supabase/config.toml) et Supabase y applique
+-- un GRANT par défaut vers anon/authenticated. Le REVOKE garde une seule porte.
+REVOKE ALL ON public.collectivite_perimetre_secondaire FROM anon, authenticated;
+REVOKE ALL ON SEQUENCE public.collectivite_perimetre_secondaire_id_seq FROM anon, authenticated;
+
+-- Repli des services dédoublés par leur périmètre.
+--
+-- Sur une base neuve il n'y a rien à replier : l'import ne pose plus qu'une
+-- ligne par SIRET, et le corps inclus plus bas y ajoute les régions secondaires.
+-- Mais sur une base où `collectivite/service_etat_import` est **déjà** déployé,
+-- la seconde ligne existe et ce change ne rejouera pas l'import : c'est ici
+-- qu'elle doit disparaître.
+--
+-- Supprimer une collectivité n'est pas anodin — vingt et une tables la suivent
+-- en cascade, dont les démarches, les saisines et les avis. La garde ne les
+-- énumère pas à la main : elle interroge `pg_constraint` et refuse de replier
+-- une ligne à laquelle **quoi que ce soit** se rattache. Une liste écrite en dur
+-- vieillirait mal ; cette garde-là se met à jour toute seule.
+--
+-- Une seule exception, `collectivite_bucket` : le trigger
+-- `after_collectivite_write` pose un bucket de stockage à toute collectivité dès
+-- son insertion. Ce n'est pas une donnée *sur* le service, c'est une
+-- conséquence de son existence — un doublon en a forcément un, et le garder
+-- serait garder un lien vers un service disparu. Le lien s'en va donc avec la
+-- ligne, mais seulement si le bucket est vide : un seul fichier dedans et c'est
+-- une donnée, qui reprend la voie du refus.
+DO $$
+DECLARE
+    doublon   record;
+    reference record;
+    presence  boolean;
+    bucket    text;
+    objets    integer;
+BEGIN
+    FOR doublon IN
+        SELECT garde.id AS garde_id, replie.id AS replie_id, replie.region_code
+        FROM collectivite AS garde
+        JOIN collectivite AS replie
+          ON replie.type = garde.type
+         AND replie.siren = garde.siren
+         AND replie.nic = garde.nic
+         AND replie.id > garde.id
+        WHERE garde.type = 'dr_ademe'
+          AND garde.siren IS NOT NULL
+          AND garde.nic IS NOT NULL
+          -- La ligne gardée est la première du SIRET, jamais une intermédiaire.
+          AND NOT EXISTS (
+              SELECT 1 FROM collectivite AS anterieure
+              WHERE anterieure.type = garde.type
+                AND anterieure.siren = garde.siren
+                AND anterieure.nic = garde.nic
+                AND anterieure.id < garde.id
+          )
+    LOOP
+        FOR reference IN
+            SELECT conrelid::regclass AS relation,
+                   quote_ident(attname) AS colonne
+            FROM pg_constraint
+            JOIN pg_attribute
+              ON pg_attribute.attrelid = pg_constraint.conrelid
+             AND pg_attribute.attnum = pg_constraint.conkey[1]
+            WHERE contype = 'f'
+              AND confrelid = 'collectivite'::regclass
+              AND conrelid NOT IN (
+                  'collectivite_perimetre_secondaire'::regclass,
+                  'collectivite_bucket'::regclass
+              )
+              AND array_length(conkey, 1) = 1
+        LOOP
+            EXECUTE format(
+                'SELECT EXISTS (SELECT 1 FROM %s WHERE %s = $1)',
+                reference.relation, reference.colonne
+            ) INTO presence USING doublon.replie_id;
+
+            IF presence THEN
+                RAISE EXCEPTION
+                    'collectivite #% (doublon de #%) est référencée par %.% : repli impossible, à arbitrer à la main',
+                    doublon.replie_id, doublon.garde_id, reference.relation, reference.colonne;
+            END IF;
+        END LOOP;
+
+        SELECT bucket_id INTO bucket
+        FROM collectivite_bucket
+        WHERE collectivite_id = doublon.replie_id;
+
+        IF bucket IS NOT NULL THEN
+            SELECT count(*) INTO objets
+            FROM storage.objects
+            WHERE bucket_id = bucket;
+
+            IF objets > 0 THEN
+                RAISE EXCEPTION
+                    'le bucket % de la collectivite #% contient % objet(s) : repli impossible, a arbitrer a la main',
+                    bucket, doublon.replie_id, objets;
+            END IF;
+
+            -- Le lien s'en va ; la ligne de `storage.buckets`, non. Supabase
+            -- protège ses tables (`storage.protect_delete`) et veut qu'on passe
+            -- par son API. Un bucket vide et sans propriétaire est un déchet
+            -- inoffensif, et c'est déjà ce que laisse derrière lui le nettoyage
+            -- des fixtures de test.
+            DELETE FROM collectivite_bucket WHERE collectivite_id = doublon.replie_id;
+        END IF;
+
+        INSERT INTO collectivite_perimetre_secondaire (collectivite_id, region_code, source)
+        VALUES (doublon.garde_id, doublon.region_code, 'import_service_etat')
+        ON CONFLICT (collectivite_id, region_code) WHERE region_code IS NOT NULL
+        DO NOTHING;
+
+        DELETE FROM collectivite WHERE id = doublon.replie_id;
+
+        RAISE NOTICE 'collectivite #% repliée sur #% : région % devient un périmètre secondaire',
+            doublon.replie_id, doublon.garde_id, doublon.region_code;
+    END LOOP;
+END $$;
+
+-- Les périmètres secondaires de l'import des services de l'État. Fichier généré,
+-- séparé de `09-service_etat.sql` parce que celui-là est inclus par un change
+-- antérieur : sur une base neuve il serait joué avant que cette table existe.
+--
+-- `\ir` résout relativement à ce fichier, pas au répertoire de travail.
+\ir ../../../seed/imports/10-service_etat_perimetre_secondaire.sql
+
+COMMIT;

--- a/data_layer/sqitch/revert/collectivite/perimetre_secondaire.sql
+++ b/data_layer/sqitch/revert/collectivite/perimetre_secondaire.sql
@@ -1,0 +1,13 @@
+-- Revert tet:collectivite/perimetre_secondaire from pg
+
+-- La table s'en va, mais le repli ne se défait pas : la seconde ligne
+-- `collectivite` de la DR ADEME Océan Indien a été supprimée, et la ressusciter
+-- lui rendrait un `id` neuf sans rien rattacher. Un revert rend donc une base
+-- où le service ne couvre plus que sa région principale — état correct, moins
+-- complet. Le rejeu du change le rétablit.
+
+BEGIN;
+
+DROP TABLE IF EXISTS public.collectivite_perimetre_secondaire;
+
+COMMIT;

--- a/data_layer/sqitch/sqitch.plan
+++ b/data_layer/sqitch/sqitch.plan
@@ -1057,5 +1057,5 @@ collectivite/service_etat_import [collectivite/type_add_dr_ademe_service_nationa
 demarche/pcaet_diagnostic_indicateur_source_metadonnee [demarche/pcaet_diagnostic indicateur/fusion] 2026-08-19T00:00:00Z System Administrator <root@localhost> # Lien PCAET ↔ source métadonnée pour les valeurs saisies
 
 demarche/pcaet_diagnostic_drop_referentiel_tables [demarche/pcaet_diagnostic_indicateur_source_metadonnee demarche/pcaet_diagnostic_ordre_reglementaire demarche/pcaet_vulnerabilite_thematique_socle_recadre] 2026-08-27T10:00:00Z Farnoux <farnoux@users.noreply.github.com> # Supprime le référentiel SQL du diagnostic PCAET (topics/state/snapshot) désormais porté par le package domain
-
 referentiel/banatic_2025_perimetre [referentiel/banatic_2025] 2026-08-31T10:58:47Z Marc Rutkowski <marc@attractive-media.fr> # Ajoute collectivite_banatic_2025_perimetre (nb_communes_membres par EPCI) et collectivite_banatic_2025_transfert.nb_communes_transferees pour l'inference de delegation totale
+collectivite/perimetre_secondaire [collectivite/service_etat_import] 2026-09-07T13:20:00Z Leny Bernard <leny.bernard.ext@beta.gouv.fr> # Les perimetres geographiques secondaires d'une collectivite : une DR ADEME sur deux regions, un EPCI sur plusieurs departements ; replie les services que leur second perimetre dedoublait

--- a/data_layer/sqitch/verify/collectivite/perimetre_secondaire.sql
+++ b/data_layer/sqitch/verify/collectivite/perimetre_secondaire.sql
@@ -1,0 +1,80 @@
+-- Verify tet:collectivite/perimetre_secondaire on pg
+
+BEGIN;
+
+-- La table et ses garde-fous existent, quel que soit l'état des données.
+SELECT id, collectivite_id, region_code, departement_code, source, created_at
+FROM public.collectivite_perimetre_secondaire
+WHERE false;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'collectivite_perimetre_secondaire_un_seul_code'
+    ) THEN
+        RAISE EXCEPTION 'la contrainte « un seul code » manque';
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'collectivite_perimetre_secondaire_source_connue'
+    ) THEN
+        RAISE EXCEPTION 'la contrainte sur `source` manque';
+    END IF;
+
+    IF has_table_privilege('anon', 'public.collectivite_perimetre_secondaire', 'SELECT')
+    THEN
+        RAISE EXCEPTION 'anon peut lire collectivite_perimetre_secondaire';
+    END IF;
+
+    IF has_table_privilege('authenticated', 'public.collectivite_perimetre_secondaire', 'SELECT')
+    THEN
+        RAISE EXCEPTION 'authenticated peut lire collectivite_perimetre_secondaire';
+    END IF;
+END $$;
+
+-- L'invariant des données est conditionnel, comme le change qui les pose : sur
+-- une base neuve — la CI, qui déploie avant de charger le seed — `collectivite`
+-- est vide et il n'y a rien à vérifier. Sur une base déjà peuplée, en revanche,
+-- le repli doit avoir eu lieu.
+DO $$
+DECLARE
+    dedoubles integer;
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM collectivite) THEN
+        RETURN;
+    END IF;
+
+    -- Un SIRET désigne un service et un seul : c'est ce qui rend le
+    -- rattachement automatique par ProConnect capable de trancher.
+    SELECT count(*) INTO dedoubles
+    FROM (
+        SELECT siren, nic
+        FROM collectivite
+        WHERE type = 'dr_ademe' AND siren IS NOT NULL AND nic IS NOT NULL
+        GROUP BY siren, nic
+        HAVING count(*) > 1
+    ) AS doublons;
+
+    IF dedoubles > 0 THEN
+        RAISE EXCEPTION '% SIRET de DR ADEME portés par plusieurs lignes', dedoubles;
+    END IF;
+
+    -- Le témoin : la DR ADEME Océan Indien couvre deux régions, l'une en
+    -- principal et l'autre ici.
+    IF NOT EXISTS (
+        SELECT 1
+        FROM collectivite AS c
+        JOIN collectivite_perimetre_secondaire AS p ON p.collectivite_id = c.id
+        WHERE c.type = 'dr_ademe'
+          AND c.siren = '385290309'
+          AND c.nic = '00397'
+          AND p.region_code IS NOT NULL
+          AND p.source = 'import_service_etat'
+    ) THEN
+        RAISE EXCEPTION 'la DR ADEME Océan Indien n''a pas de région secondaire';
+    END IF;
+END $$;
+
+ROLLBACK;

--- a/data_layer/sqitch/verify/collectivite/service_etat_import.sql
+++ b/data_layer/sqitch/verify/collectivite/service_etat_import.sql
@@ -11,7 +11,9 @@ BEGIN;
 --
 -- Des **minimums** par famille plutôt que des totaux exacts : un service ajouté
 -- plus tard ne doit pas faire échouer un `verify` qui n'aurait rien à dire de
--- neuf. Le SIREN sert de marqueur de l'import — les services créés par les tests
+-- neuf. Dix-sept DR ADEME et non dix-huit : l'Océan Indien couvre deux régions
+-- sous un seul SIRET, donc sur une seule ligne (cf.
+-- `collectivite/perimetre_secondaire`). Le SIREN sert de marqueur de l'import — les services créés par les tests
 -- n'en portent pas.
 --
 -- Deux témoins nommément vérifiés, un par mode d'appariement : une DDT (index
@@ -28,7 +30,7 @@ BEGIN
     END IF;
 
     FOR attendu IN
-        SELECT * FROM (VALUES ('ddt', 92), ('dreal', 18), ('dr_ademe', 18), ('service_national', 2))
+        SELECT * FROM (VALUES ('ddt', 92), ('dreal', 18), ('dr_ademe', 17), ('service_national', 2))
             AS v(famille, minimum)
     LOOP
         SELECT count(*) INTO obtenu

--- a/data_layer/tests/collectivite/perimetre_secondaire.sql
+++ b/data_layer/tests/collectivite/perimetre_secondaire.sql
@@ -1,0 +1,71 @@
+begin;
+select plan(6);
+
+-- Ce que la table des périmètres secondaires garantit : une ligne porte un seul
+-- code géographique, sa source est déclarée, et une collectivité ne couvre pas
+-- deux fois le même territoire.
+--
+-- Le sujet est un EPCI et non un service de l'État : la table ne leur est pas
+-- réservée — un EPCI qui chevauche plusieurs départements en relève tout autant —
+-- et surtout `epci` ne porte aucun index unique sur le code de région, ce qui
+-- évite de disputer aux dix-huit régions réelles un code de test.
+
+insert into collectivite (nom, type, region_code, departement_code)
+values ('EPCI témoin des périmètres', 'epci', 'Z9', 'Z99');
+
+create temporary view sujet as
+select id from collectivite where type = 'epci' and region_code = 'Z9';
+
+select lives_ok(
+    $$ insert into collectivite_perimetre_secondaire (collectivite_id, region_code, source)
+       select id, 'Z8', 'banatic' from sujet $$,
+    'une région secondaire s''ajoute'
+);
+
+select throws_ok(
+    $$ insert into collectivite_perimetre_secondaire (collectivite_id, region_code, departement_code, source)
+       select id, 'Z7', 'Z98', 'banatic' from sujet $$,
+    '23514',
+    null,
+    'une ligne ne porte pas à la fois une région et un département'
+);
+
+select throws_ok(
+    $$ insert into collectivite_perimetre_secondaire (collectivite_id, source)
+       select id, 'banatic' from sujet $$,
+    '23514',
+    null,
+    'une ligne sans aucun code géographique est refusée'
+);
+
+select throws_ok(
+    $$ insert into collectivite_perimetre_secondaire (collectivite_id, region_code, source)
+       select id, 'Z6', 'a_la_main' from sujet $$,
+    '23514',
+    null,
+    'une source inconnue est refusée : chaque producteur ne remplace que ses lignes'
+);
+
+select throws_ok(
+    $$ insert into collectivite_perimetre_secondaire (collectivite_id, region_code, source)
+       select id, 'Z8', 'import_service_etat' from sujet $$,
+    '23505',
+    null,
+    'la même région ne se déclare pas deux fois, même sous une autre source'
+);
+
+-- La collectivité emporte ses périmètres. Son bucket de stockage, posé par le
+-- trigger `after_collectivite_write`, retient la suppression (clé étrangère sans
+-- action) et part d'abord — c'est aussi ce que fait le nettoyage des fixtures.
+delete from collectivite_bucket where collectivite_id in (select id from sujet);
+delete from collectivite where id in (select id from sujet);
+
+select is(
+    (select count(*) from collectivite_perimetre_secondaire p
+     where not exists (select 1 from collectivite c where c.id = p.collectivite_id))::int,
+    0,
+    'la suppression d''une collectivité emporte ses périmètres secondaires'
+);
+
+select * from finish();
+rollback;

--- a/data_layer/tests/collectivite/service_etat_import.sql
+++ b/data_layer/tests/collectivite/service_etat_import.sql
@@ -28,8 +28,8 @@ select is(
 
 select is(
     (select count(*) from collectivite where type = 'dr_ademe' and siren is not null)::int,
-    18,
-    'une DR ADEME par région'
+    17,
+    'une DR ADEME par SIRET : dix-sept directions pour dix-huit régions, l''Océan Indien en couvrant deux'
 );
 
 select is(
@@ -40,7 +40,7 @@ select is(
 
 -- Le NIC est ce qui distingue deux services partageant un SIREN — sans lui, le
 -- rattachement automatique par ProConnect ne peut pas trancher entre les
--- dix-huit DR ADEME.
+-- dix-sept DR ADEME.
 select is(
     (select count(*) from collectivite
      where type in ('dreal', 'ddt', 'dr_ademe', 'service_national', 'region')
@@ -55,14 +55,19 @@ select is(
     'les dix-huit conseils régionaux ont gagné leur SIREN'
 );
 
--- La DR ADEME Océan Indien couvre La Réunion et Mayotte : deux lignes, même
--- SIRET. L'index ne portant que sur la région, la base l'accepte — et rien
--- n'impose l'unicité de `siren` sur `collectivite`.
+-- La DR ADEME Océan Indien couvre La Réunion et Mayotte, et n'a pourtant qu'une
+-- ligne. L'index ne portant que sur la région, la base tolérerait le doublon —
+-- mais ce serait deux fois le même service : deux destinataires pour une
+-- transmission, et un SIRET qui ne désigne plus un service en particulier, donc
+-- un rattachement automatique incapable de trancher. La seconde région est un
+-- périmètre secondaire ; la première est celle que l'import rencontre d'abord.
 select is(
-    (select count(distinct region_code) from collectivite
-     where type = 'dr_ademe' and siren = '385290309' and nic = '00397')::int,
-    2,
-    'une même DR ADEME peut couvrir deux régions avec un seul SIRET'
+    (select c.region_code || ' + ' || p.region_code
+     from collectivite as c
+     join collectivite_perimetre_secondaire as p on p.collectivite_id = c.id
+     where c.type = 'dr_ademe' and c.siren = '385290309' and c.nic = '00397'),
+    '04 + 06',
+    'la DR ADEME Océan Indien couvre deux régions avec une seule ligne'
 );
 
 -- L'appariement se fait sur la famille et le code géographique, jamais sur le

--- a/packages/domain/src/collectivites/index.ts
+++ b/packages/domain/src/collectivites/index.ts
@@ -32,6 +32,7 @@ export * from './libre-tag.schema';
 export * from './membres/invitation.schema';
 export * from './membres/membre.schema';
 export * from './partenaire-tag.schema';
+export * from './perimetre-secondaire.enum';
 export * from './personnalisation-reponses-payload.schema';
 export * from './personnalisations/competence-banatic.schema';
 export * from './personnalisations/personnalisation-regle.schema';

--- a/packages/domain/src/collectivites/perimetre-secondaire.enum.ts
+++ b/packages/domain/src/collectivites/perimetre-secondaire.enum.ts
@@ -1,0 +1,15 @@
+/**
+ * Qui a écrit un périmètre secondaire.
+ *
+ * Ce n'est pas une trace décorative : le calcul des périmètres des EPCI se
+ * rejoue périodiquement depuis la composition communale Banatic, et il doit
+ * pouvoir remplacer **ses** lignes sans emporter celles de l'import des services
+ * de l'État, qui viennent d'un classeur et ne se recalculent pas.
+ */
+export const perimetreSecondaireSourceEnum = {
+  IMPORT_SERVICE_ETAT: 'import_service_etat',
+  BANATIC: 'banatic',
+} as const;
+
+export type PerimetreSecondaireSource =
+  (typeof perimetreSecondaireSourceEnum)[keyof typeof perimetreSecondaireSourceEnum];

--- a/packages/domain/src/demarches/pcaet/pcaet-depot-permissions.rules.spec.ts
+++ b/packages/domain/src/demarches/pcaet/pcaet-depot-permissions.rules.spec.ts
@@ -7,10 +7,10 @@ import {
 
 const perimetre = {
   instructeurType: collectiviteTypeEnum.DREAL,
-  instructeurRegionCode: '27',
-  instructeurDepartementCode: null,
-  collectiviteRegionCode: '27',
-  collectiviteDepartementCode: '25',
+  instructeurRegionCodes: ['27'],
+  instructeurDepartementCodes: [],
+  collectiviteRegionCodes: ['27'],
+  collectiviteDepartementCodes: ['25'],
 };
 
 describe('instructeurCouvreCollectivite', () => {
@@ -22,32 +22,32 @@ describe('instructeurCouvreCollectivite', () => {
     expect(
       instructeurCouvreCollectivite({
         ...perimetre,
-        collectiviteRegionCode: '84',
+        collectiviteRegionCodes: ['84'],
       })
     ).toBe(false);
   });
 
-  it('two missing region codes never match', () => {
+  it('two empty territories never match', () => {
     expect(
       instructeurCouvreCollectivite({
         ...perimetre,
-        instructeurRegionCode: null,
-        collectiviteRegionCode: null,
+        instructeurRegionCodes: [],
+        collectiviteRegionCodes: [],
       })
     ).toBe(false);
   });
 
-  it('a missing code on either side never matches', () => {
+  it('an empty territory on either side never matches', () => {
     expect(
       instructeurCouvreCollectivite({
         ...perimetre,
-        collectiviteRegionCode: null,
+        collectiviteRegionCodes: [],
       })
     ).toBe(false);
     expect(
       instructeurCouvreCollectivite({
         ...perimetre,
-        instructeurRegionCode: null,
+        instructeurRegionCodes: [],
       })
     ).toBe(false);
   });
@@ -82,16 +82,16 @@ describe('instructeurCouvreCollectivite', () => {
       instructeurCouvreCollectivite({
         ...perimetre,
         instructeurType: collectiviteTypeEnum.DDT,
-        instructeurDepartementCode: '01',
-        collectiviteDepartementCode: '01',
+        instructeurDepartementCodes: ['01'],
+        collectiviteDepartementCodes: ['01'],
       })
     ).toBe(true);
     expect(
       instructeurCouvreCollectivite({
         ...perimetre,
         instructeurType: collectiviteTypeEnum.DDT,
-        instructeurDepartementCode: '01',
-        collectiviteDepartementCode: '69',
+        instructeurDepartementCodes: ['01'],
+        collectiviteDepartementCodes: ['69'],
       })
     ).toBe(false);
   });
@@ -108,9 +108,49 @@ describe('instructeurCouvreCollectivite', () => {
       instructeurCouvreCollectivite({
         ...perimetre,
         instructeurType: collectiviteTypeEnum.DR_ADEME,
-        collectiviteRegionCode: '84',
+        collectiviteRegionCodes: ['84'],
       })
     ).toBe(false);
+  });
+
+  /**
+   * La DR ADEME Océan Indien : une seule ligne, deux régions. La seconde lui
+   * vient d'un périmètre secondaire, et couvre autant que la première.
+   */
+  it('an instructeur covers a collectivite of its secondary region', () => {
+    expect(
+      instructeurCouvreCollectivite({
+        ...perimetre,
+        instructeurType: collectiviteTypeEnum.DR_ADEME,
+        instructeurRegionCodes: ['04', '06'],
+        collectiviteRegionCodes: ['06'],
+      })
+    ).toBe(true);
+  });
+
+  /**
+   * Et réciproquement : un EPCI qui chevauche deux régions — Redon
+   * Agglomération, Pays de la Loire et Bretagne — est couvert par la DREAL de
+   * chacune, pas seulement par celle de son siège.
+   */
+  it('an instructeur covers a collectivite spanning into its region', () => {
+    expect(
+      instructeurCouvreCollectivite({
+        ...perimetre,
+        collectiviteRegionCodes: ['53', '27'],
+      })
+    ).toBe(true);
+  });
+
+  it('a ddt covers a collectivite spanning into its department', () => {
+    expect(
+      instructeurCouvreCollectivite({
+        ...perimetre,
+        instructeurType: collectiviteTypeEnum.DDT,
+        instructeurDepartementCodes: ['35'],
+        collectiviteDepartementCodes: ['44', '56', '35'],
+      })
+    ).toBe(true);
   });
 
   /**
@@ -123,18 +163,18 @@ describe('instructeurCouvreCollectivite', () => {
       instructeurCouvreCollectivite({
         ...perimetre,
         instructeurType: collectiviteTypeEnum.SERVICE_NATIONAL,
-        instructeurRegionCode: null,
-        instructeurDepartementCode: null,
+        instructeurRegionCodes: [],
+        instructeurDepartementCodes: [],
       })
     ).toBe(true);
     expect(
       instructeurCouvreCollectivite({
         ...perimetre,
         instructeurType: collectiviteTypeEnum.SERVICE_NATIONAL,
-        instructeurRegionCode: null,
-        instructeurDepartementCode: null,
-        collectiviteRegionCode: null,
-        collectiviteDepartementCode: null,
+        instructeurRegionCodes: [],
+        instructeurDepartementCodes: [],
+        collectiviteRegionCodes: [],
+        collectiviteDepartementCodes: [],
       })
     ).toBe(true);
   });

--- a/packages/domain/src/demarches/pcaet/pcaet-depot-permissions.rules.ts
+++ b/packages/domain/src/demarches/pcaet/pcaet-depot-permissions.rules.ts
@@ -7,20 +7,38 @@ import {
   PerimetreInstructeurEnum,
 } from './pcaet-instructeur.rules';
 
+/**
+ * Les territoires de part et d'autre, en **listes** et non en codes uniques :
+ * une collectivité peut couvrir plusieurs régions ou départements. Une DR ADEME
+ * en pilote deux (l'Océan Indien couvre La Réunion et Mayotte), un EPCI
+ * chevauche plusieurs départements (Redon Agglomération s'étale sur 44, 56 et
+ * 35, donc sur deux régions).
+ *
+ * Chaque liste réunit le périmètre principal, porté par `collectivite`, et les
+ * secondaires, portés par `collectivite_perimetre_secondaire`. Les codes
+ * manquants n'y figurent pas : une liste vide dit « aucun territoire », ce qui ne
+ * croise jamais rien.
+ */
 export type PerimetreInstructeurEntree = {
   instructeurType: CollectiviteType;
-  instructeurRegionCode: string | null;
-  instructeurDepartementCode: string | null;
-  collectiviteRegionCode: string | null;
-  collectiviteDepartementCode: string | null;
+  instructeurRegionCodes: readonly string[];
+  instructeurDepartementCodes: readonly string[];
+  collectiviteRegionCodes: readonly string[];
+  collectiviteDepartementCodes: readonly string[];
 };
+
+/** Deux territoires se rencontrent-ils ? Deux listes vides, jamais. */
+const seCroisent = (
+  instructeur: readonly string[],
+  collectivite: readonly string[]
+): boolean => instructeur.some((code) => collectivite.includes(code));
 
 export const instructeurCouvreCollectivite = ({
   instructeurType,
-  instructeurRegionCode,
-  instructeurDepartementCode,
-  collectiviteRegionCode,
-  collectiviteDepartementCode,
+  instructeurRegionCodes,
+  instructeurDepartementCodes,
+  collectiviteRegionCodes,
+  collectiviteDepartementCodes,
 }: PerimetreInstructeurEntree): boolean => {
   if (!isTypeInstructeur(instructeurType)) {
     return false;
@@ -32,15 +50,12 @@ export const instructeurCouvreCollectivite = ({
     return true;
   }
   if (perimetre === PerimetreInstructeurEnum.REGION) {
-    return (
-      Boolean(instructeurRegionCode) &&
-      instructeurRegionCode === collectiviteRegionCode
-    );
+    return seCroisent(instructeurRegionCodes, collectiviteRegionCodes);
   }
   if (perimetre === PerimetreInstructeurEnum.DEPARTEMENT) {
-    return (
-      Boolean(instructeurDepartementCode) &&
-      instructeurDepartementCode === collectiviteDepartementCode
+    return seCroisent(
+      instructeurDepartementCodes,
+      collectiviteDepartementCodes
     );
   }
   return false;


### PR DESCRIPTION
`collectivite` porte **un** code de région et **un** code de département. Or plusieurs collectivités en couvrent plusieurs, et le modèle n'avait qu'une façon de le dire : **une ligne de plus**.

La DR ADEME Océan Indien en était l'exemple — deux lignes pour La Réunion et Mayotte, même nom, même SIRET, ce que l'index unique tolère puisqu'il ne porte que sur la région.

```mermaid
flowchart LR
    subgraph avant["Avant — deux lignes, un SIRET"]
        A1["DR ADEME Océan Indien<br/>région 04"]
        A2["DR ADEME Océan Indien<br/>région 06"]
    end
    subgraph apres["Après — une ligne, deux périmètres"]
        B1["DR ADEME Océan Indien<br/>région 04"]
        B2["périmètre secondaire<br/>région 06"]
        B1 --- B2
    end
```

C'était deux fois le même service : **deux destinataires pour une transmission**, et un SIRET qui ne désignait plus un service en particulier.

Cette PR est le socle de deux cartes :

- **TETH-14** (rattachement automatique par ProConnect, PR empilée au-dessus) a besoin qu'un SIRET désigne un service et un seul, sinon le rapprochement ne peut pas trancher ;
- **TETH-12** (départements et régions secondaires des EPCI) alimentera la même table depuis la composition communale Banatic — Redon Agglomération s'étale sur 44, 56 et 35, donc sur deux régions.

## La table

<img width="1543" height="139" alt="image" src="https://github.com/user-attachments/assets/2de58b42-2282-470c-ae4c-396b281c2e55" />

`public.collectivite_perimetre_secondaire` : un code de région **ou** un code de département, jamais les deux (`num_nonnulls(...) = 1`). Le périmètre principal reste sur `collectivite`, les autres viennent ici.

La colonne `source` n'est pas décorative : le rejeu périodique du calcul Banatic doit pouvoir remplacer **ses** lignes sans emporter celles de l'import des services, qui viennent d'un classeur et ne se recalculent pas.

Pas de clé étrangère vers `imports.region` ni `imports.departement` — `collectivite.region_code` n'en a pas non plus, et pour une bonne raison : les fixtures de test prennent des codes en lettres, hors répertoire, justement pour ne pas se disputer les dix-huit codes réels que l'import des services occupe désormais tous.

## Un code unique devient une liste

`instructeurCouvreCollectivite` comparait deux codes ; elle compare maintenant deux **listes**, et répond à l'intersection non vide. Une liste vide dit « aucun territoire », qui ne croise jamais rien — ce qui remplace exactement les gardes `Boolean(code)` d'avant.

Les quatre lieux qui comparaient des codes géographiques passent par deux helpers, selon qu'ils **qualifient** ou **filtrent** :

| Lieu | Ce qu'il décide |
|---|---|
| `perimetre-instructeur.columns.ts` | la projection que le domaine juge (3 appelants) |
| `pcaet-instructeurs.repository.ts` | qui est saisi à la transmission |
| `list-demandes-avis.repository.ts` | quels dossiers un service voit |

Deux effets, l'un attendu et l'autre gratuit : un service est saisi pour son périmètre secondaire, **et** une déposante qui déborde est saisie par les instructeurs de chaque territoire qu'elle touche, plus seulement par ceux de son siège.

## L'import

Le générateur regroupe les DR ADEME **par SIRET** : la première région rencontrée devient le périmètre principal, les suivantes des périmètres secondaires. **17 DR ADEME** au lieu de 18. Il refuse deux dénominations sous un même SIRET — un SIRET est un établissement, et deux noms signeraient une erreur de source plutôt qu'un service à deux périmètres.

Le corps généré est réparti sur **deux fichiers**, donc deux changes sqitch, et ce n'est pas un choix esthétique : `collectivite/service_etat_import` est déjà déployé et ne sera pas rejoué, or les périmètres ont besoin d'une table qui n'existait pas quand il a été écrit. Réunis, ils feraient échouer les migrations d'une base neuve, où le change antérieur les jouerait avant que la table existe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Nouvelles fonctionnalités**
  - Prise en charge des collectivités et services couvrant plusieurs régions ou départements.
  - Les instructeurs et services compétents sont désormais identifiés selon l’ensemble des périmètres géographiques concernés.
  - Ajout de la gestion des périmètres secondaires, avec leurs sources d’import.

- **Améliorations des données**
  - Les directions ADEME couvrant plusieurs régions sont regroupées correctement tout en conservant leurs territoires associés.
  - Les transmissions pour avis tiennent désormais compte des chevauchements géographiques.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->