### PR TITLE
ci: skip CI jobs for drafted pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ permissions:
 on:
   workflow_dispatch:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore: ['**.md']
   push:
     branches:
@@ -19,6 +20,7 @@ concurrency:
 
 jobs:
   analyze-affected:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     outputs:
       cache-key: ${{ steps.deps-metadata.outputs.cache-key }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Le processus d’intégration continue est désormais déclenché uniquement lors des principales étapes d’une pull request : ouverture, mise à jour, réouverture ou passage en prête à l’examen.
  - Les pull requests encore en brouillon sont exclues de certaines analyses automatisées jusqu’à leur passage en statut prêt à l’examen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->