### PR TITLE
fix(plans): plafonne les fiches listées par le droit de lecture confidentielle

### DIFF
--- a/apps/backend/src/plans/fiches/bulk-edit/bulk-edit.service.ts
+++ b/apps/backend/src/plans/fiches/bulk-edit/bulk-edit.service.ts
@@ -35,10 +35,13 @@ export class BulkEditService {
       request.ficheIds === 'all'
         ? request.filters
         : { ficheIds: request.ficheIds };
-    const currentFiches = await this.listFichesService.getFichesActionResumes({
-      collectiviteId: request.collectiviteId,
-      filters,
-    });
+    const currentFiches = await this.listFichesService.getFichesActionResumes(
+      {
+        collectiviteId: request.collectiviteId,
+        filters,
+      },
+      { user }
+    );
     const actualFicheIds = currentFiches.data.map((fiche) => fiche.id);
 
     const { ficheIds, ...params } = request;
@@ -68,10 +71,13 @@ export class BulkEditService {
           `Edition not allowed for collectivite ${c.collectiviteId}, checking fiche sharing`
         );
         const { data: fiches } =
-          await this.listFichesService.getFichesActionResumes({
-            collectiviteId: c.collectiviteId,
-            filters: { ficheIds: c.ficheIds },
-          });
+          await this.listFichesService.getFichesActionResumes(
+            {
+              collectiviteId: c.collectiviteId,
+              filters: { ficheIds: c.ficheIds },
+            },
+            { user }
+          );
         // TODO: Optimize by avoid checking each fiche independently
         const ficheSharingsChecks = fiches.map((fiche) =>
           this.fichePermissionsService.isAllowedByFicheSharings(
@@ -267,7 +273,8 @@ export class BulkEditService {
         {
           collectiviteId: request.collectiviteId,
           filters,
-        }
+        },
+        { user }
       );
 
       // prépare les paires de fiches (avant/après)

--- a/apps/backend/src/plans/fiches/count-by/count-by.router.ts
+++ b/apps/backend/src/plans/fiches/count-by/count-by.router.ts
@@ -13,12 +13,13 @@ export class CountByRouter {
   router = this.trpc.router({
     countBy: this.trpc.authedProcedure
       .input(countByRequestSchema)
-      .query(({ input }) => {
+      .query(({ input, ctx }) => {
         const { collectiviteId, countByProperty, filter } = input;
         return this.service.countByProperty(
           collectiviteId,
           countByProperty,
-          filter
+          filter,
+          { user: ctx.user }
         );
       }),
   });

--- a/apps/backend/src/plans/fiches/count-by/count-by.service.ts
+++ b/apps/backend/src/plans/fiches/count-by/count-by.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger, NotImplementedException } from '@nestjs/common';
+import { AuthUser } from '@tet/backend/users/models/auth.models';
 import { countByDateSlots } from '@tet/backend/plans/fiches/count-by/count-by-date-slots.enum';
 import { countByArrayValues } from '@tet/backend/plans/fiches/count-by/utils/count-by-array-value';
 import ListFichesService from '@tet/backend/plans/fiches/list-fiches/list-fiches.service';
@@ -450,7 +451,8 @@ export class CountByService {
   async countByProperty(
     collectiviteId: number,
     countByProperty: CountByPropertyEnumType,
-    filters: ListFichesRequestFilters
+    filters: ListFichesRequestFilters,
+    { user }: { user: AuthUser }
   ) {
     this.logger.log(
       `Calcul du count by ${countByProperty} des fiches action pour la collectivité ${collectiviteId}: filtre ${JSON.stringify(
@@ -459,10 +461,10 @@ export class CountByService {
     );
     try {
       const { data: fiches } =
-        await this.ficheActionListService.getFichesActionResumes({
-          collectiviteId,
-          filters,
-        });
+        await this.ficheActionListService.getFichesActionResumes(
+          { collectiviteId, filters },
+          { user }
+        );
       return this.countByPropertyWithFiches(fiches, countByProperty, filters);
     } catch (error) {
       this.logger.error(error);

--- a/apps/backend/src/plans/fiches/list-fiches/list-fiches-confidentialite.router.e2e-spec.ts
+++ b/apps/backend/src/plans/fiches/list-fiches/list-fiches-confidentialite.router.e2e-spec.ts
@@ -1,0 +1,93 @@
+import { INestApplication } from '@nestjs/common';
+import { addTestCollectivite } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { ficheActionTable } from '@tet/backend/plans/fiches/shared/models/fiche-action.table';
+import {
+  getAuthUserFromUserCredentials,
+  getTestApp,
+  getTestDatabase,
+  getTestRouter,
+} from '@tet/backend/test';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { addTestUser } from '@tet/backend/users/users/users.test-fixture';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
+import { CollectiviteRole } from '@tet/domain/users';
+import { eq } from 'drizzle-orm';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+describe('listFiches et la confidentialité', () => {
+  let router: TrpcRouter;
+  let db: DatabaseService;
+  let collectiviteId: number;
+  let ficheRestreinteId: number;
+  let ficheOuverteId: number;
+  let membreEnLecture: AuthenticatedUser;
+  let visiteurVerifie: AuthenticatedUser;
+
+  beforeAll(async () => {
+    const app: INestApplication = await getTestApp();
+    router = await getTestRouter(app);
+    db = await getTestDatabase(app);
+
+    const { collectivite } = await addTestCollectivite(db);
+    collectiviteId = collectivite.id;
+
+    const { user: membre } = await addTestUser(db, {
+      collectiviteId,
+      role: CollectiviteRole.LECTURE,
+    });
+    membreEnLecture = getAuthUserFromUserCredentials(membre);
+
+    const { user: visiteur } = await addTestUser(db, {
+      collectiviteId: null,
+      role: CollectiviteRole.LECTURE,
+    });
+    visiteurVerifie = getAuthUserFromUserCredentials(visiteur);
+
+    const fiches = await db.db
+      .insert(ficheActionTable)
+      .values([
+        { titre: 'Fiche restreinte', restreint: true, collectiviteId },
+        { titre: 'Fiche ouverte', restreint: false, collectiviteId },
+      ])
+      .returning();
+    ficheRestreinteId = fiches[0].id;
+    ficheOuverteId = fiches[1].id;
+
+    return async () => {
+      await db.db
+        .delete(ficheActionTable)
+        .where(eq(ficheActionTable.collectiviteId, collectiviteId));
+      await app.close();
+    };
+  });
+
+  const listerPour = async (user: AuthenticatedUser): Promise<number[]> => {
+    const { data } = await router
+      .createCaller({ user })
+      .plans.fiches.listFiches({ collectiviteId });
+    return data.map((fiche) => fiche.id);
+  };
+
+  it('cache une fiche restreinte à un visiteur vérifié non membre', async () => {
+    expect(await listerPour(visiteurVerifie)).not.toContain(ficheRestreinteId);
+  });
+
+  it('laisse une fiche non restreinte visible au visiteur vérifié', async () => {
+    expect(await listerPour(visiteurVerifie)).toContain(ficheOuverteId);
+  });
+
+  it('montre la fiche restreinte à un membre en lecture', async () => {
+    expect(await listerPour(membreEnLecture)).toContain(ficheRestreinteId);
+  });
+
+  it('ignore une demande explicite de fiches restreintes venant du visiteur vérifié', async () => {
+    const { data } = await router
+      .createCaller({ user: visiteurVerifie })
+      .plans.fiches.listFiches({
+        collectiviteId,
+        filters: { restreint: true },
+      });
+    expect(data.map((fiche) => fiche.id)).toEqual([]);
+  });
+});

--- a/apps/backend/src/plans/fiches/list-fiches/list-fiches.router.ts
+++ b/apps/backend/src/plans/fiches/list-fiches/list-fiches.router.ts
@@ -26,15 +26,16 @@ export class ListFichesRouter {
 
     listFiches: this.trpc.authedProcedure
       .input(listFichesInputSchema)
-      .query(async ({ input }) => {
+      .query(async ({ input, ctx }) => {
         const { collectiviteId, filters, queryOptions } = input;
 
         return this.service.getFichesActionResumes(
           {
             collectiviteId,
             filters: filters ?? {},
+            queryOptions,
           },
-          queryOptions
+          { user: ctx.user }
         );
       }),
   });

--- a/apps/backend/src/plans/fiches/list-fiches/list-fiches.service.ts
+++ b/apps/backend/src/plans/fiches/list-fiches/list-fiches.service.ts
@@ -111,6 +111,15 @@ const sortColumn: Record<ListFichesSortValue, PgColumn> = {
   titre: ficheActionTable.titre,
 };
 
+export type FichesReadContext = {
+  user: AuthUser;
+  tx?: Transaction;
+};
+
+type ReadableFichesFilters =
+  | { kind: 'filters'; filters: ListFichesRequestFilters }
+  | { kind: 'no_readable_fiche' };
+
 @Injectable()
 export default class ListFichesService {
   private readonly logger = new Logger(ListFichesService.name);
@@ -1942,6 +1951,32 @@ export default class ListFichesService {
     return result[0]?.count ?? 0;
   }
 
+  private async getReadableFichesFilters(
+    {
+      collectiviteId,
+      filters,
+    }: { collectiviteId: number; filters: ListFichesRequestFilters },
+    { user, tx }: FichesReadContext
+  ): Promise<ReadableFichesFilters> {
+    const canReadFichesRestreintes =
+      await this.fichePermissionService.hasReadFichePermission(
+        { collectiviteId, restreint: true },
+        user,
+        true,
+        tx
+      );
+
+    if (!canReadFichesRestreintes && filters.restreint === true) {
+      return { kind: 'no_readable_fiche' };
+    }
+
+    const readableFilters = canReadFichesRestreintes
+      ? filters
+      : { ...filters, restreint: false };
+
+    return { kind: 'filters', filters: readableFilters };
+  }
+
   /**
    * Get fiches actions resumes from the collectivity matching the given filters.
    * Also returns additional data about fetched fiches actions.
@@ -1954,11 +1989,13 @@ export default class ListFichesService {
     {
       collectiviteId,
       filters,
+      queryOptions,
     }: {
       collectiviteId: number;
       filters: ListFichesRequestFilters;
+      queryOptions?: QueryOptionsSchema;
     },
-    queryOptions?: QueryOptionsSchema
+    { user, tx }: FichesReadContext
   ): Promise<{
     count: number;
     nextPage: number | null;
@@ -1971,10 +2008,19 @@ export default class ListFichesService {
         filterSummary ? `(${filterSummary})` : ''
       }`
     );
+    const readable = await this.getReadableFichesFilters(
+      { collectiviteId, filters },
+      { user, tx }
+    );
+    if (readable.kind === 'no_readable_fiche') {
+      return { count: 0, nextPage: null, nbOfPages: 0, data: [] };
+    }
+
     const { data, count } = await this.listFichesQuery(
       collectiviteId,
-      filters,
-      queryOptions
+      readable.filters,
+      queryOptions,
+      tx
     );
 
     if (queryOptions?.limit === 'all' || queryOptions === undefined) {
@@ -1997,5 +2043,4 @@ export default class ListFichesService {
       data,
     };
   }
-
 }

--- a/apps/backend/src/plans/fiches/plan-actions.service.ts
+++ b/apps/backend/src/plans/fiches/plan-actions.service.ts
@@ -67,16 +67,8 @@ export default class PlanActionsService {
       user
     );
 
-    // pour vérifier si il faut charger ou non les fiches en accès restreint
-    const hasReadPrivateFichePermission =
-      await this.fichePermissionsService.hasReadFichePermission(
-        { collectiviteId, restreint: true },
-        user,
-        true
-      );
-
     // charge le plan et extrait les données dérivées nécessaires à l'export
-    const plan = await this.fetchPlan(input, hasReadPrivateFichePermission);
+    const plan = await this.fetchPlan(input, user);
     const { root } = plan;
     const rows = this.getRows(plan, root);
     const maxDepth = Math.max(...rows.map((r) => r.depth));
@@ -105,22 +97,19 @@ export default class PlanActionsService {
     };
   }
 
-  private async fetchPlan(
-    input: GetPlanRequest,
-    hasReadPrivateFichePermission: boolean
-  ) {
+  private async fetchPlan(input: GetPlanRequest, user: AuthUser) {
     const { collectiviteId, planId } = input;
 
     // charge les données
     const axesEtFicheIds = await this.getAxesEtFicheIds(input);
     const { data: fiches } =
-      await this.listFichesService.getFichesActionResumes({
-        collectiviteId,
-        filters: {
-          planActionIds: [planId],
-          restreint: hasReadPrivateFichePermission ? undefined : false,
+      await this.listFichesService.getFichesActionResumes(
+        {
+          collectiviteId,
+          filters: { planActionIds: [planId] },
         },
-      });
+        { user }
+      );
 
     // extrait et tri les fiches associées à un axe
     const getFiches = ({ ficheIds }: AxeEtFicheIds) =>

--- a/apps/backend/src/referentiels/export-score/export-score-comparison.controller.ts
+++ b/apps/backend/src/referentiels/export-score/export-score-comparison.controller.ts
@@ -1,14 +1,9 @@
-import {
-  Controller,
-  Get,
-  Logger,
-  Param,
-  Query,
-  Res,
-} from '@nestjs/common';
+import { Controller, Get, Logger, Param, Query, Res } from '@nestjs/common';
 import { ApiExcludeController, ApiTags } from '@nestjs/swagger';
 import { COLLECTIVITE_ID_PARAM_KEY } from '@tet/backend/collectivites/shared/models/collectivite-api.constants';
 import { AllowAnonymousAccess } from '@tet/backend/users/decorators/allow-anonymous-access.decorator';
+import { TokenInfo } from '@tet/backend/users/decorators/token-info.decorators';
+import type { AuthUser } from '@tet/backend/users/models/auth.models';
 import { ApiUsageEnum } from '@tet/backend/utils/api/api-usage-type.enum';
 import { ApiUsage } from '@tet/backend/utils/api/api-usage.decorator';
 import { createControllerErrorHandler } from '@tet/backend/utils/nest/controller-error-handler';
@@ -48,7 +43,8 @@ export class ExportScoreComparisonController {
     @Param(COLLECTIVITE_ID_PARAM_KEY) collectiviteId: number,
     @Param(REFERENTIEL_ID_PARAM_KEY) referentielId: ReferentielId,
     @Query() query: ExportScoreComparisonApiQueryClass,
-    @Res() res: Response
+    @Res() res: Response,
+    @TokenInfo() user: AuthUser
   ) {
     this.logger.log(
       `Export de comparaison des scores du referentiel ${referentielId} pour la collectivite ${collectiviteId}`
@@ -58,7 +54,8 @@ export class ExportScoreComparisonController {
       await this.exportScoreComparisonService.exportComparisonScore(
         collectiviteId,
         referentielId,
-        query
+        query,
+        { user }
       )
     );
 

--- a/apps/backend/src/referentiels/export-score/export-score-comparison.service.ts
+++ b/apps/backend/src/referentiels/export-score/export-score-comparison.service.ts
@@ -12,6 +12,7 @@ import {
   ExportScoreComparisonErrorEnum,
 } from './export-score-comparison.errors';
 import { LoadScoreComparisonService } from './load-score-comparison.service';
+import { AuthUser } from '@tet/backend/users/models/auth.models';
 
 @Injectable()
 export class ExportScoreComparisonService {
@@ -24,7 +25,8 @@ export class ExportScoreComparisonService {
   async exportComparisonScore(
     collectiviteId: number,
     referentielId: ReferentielId,
-    query: ExportScoreComparisonRequestQuery
+    query: ExportScoreComparisonRequestQuery,
+    { user }: { user: AuthUser }
   ): Promise<
     Result<{ fileName: string; content: Buffer }, ExportScoreComparisonError>
   > {
@@ -38,7 +40,8 @@ export class ExportScoreComparisonService {
       await this.loadScoreComparisonService.loadScoreComparison(
         collectiviteId,
         referentielId,
-        query
+        query,
+        { user }
       );
     if (!scoreComparisonResult.success) {
       return scoreComparisonResult;

--- a/apps/backend/src/referentiels/export-score/load-score-comparison.service.ts
+++ b/apps/backend/src/referentiels/export-score/load-score-comparison.service.ts
@@ -1,3 +1,4 @@
+import { AuthUser } from '@tet/backend/users/models/auth.models';
 import { Injectable, Logger } from '@nestjs/common';
 import ListFichesService from '@tet/backend/plans/fiches/list-fiches/list-fiches.service';
 import { HandleMesureServicesService } from '@tet/backend/referentiels/handle-mesure-services/handle-mesure-services.service';
@@ -99,7 +100,8 @@ export class LoadScoreComparisonService {
   async loadScoreComparison(
     collectiviteId: number,
     referentielId: ReferentielId,
-    query: ExportScoreComparisonRequestQuery
+    query: ExportScoreComparisonRequestQuery,
+    { user }: { user: AuthUser }
   ): Promise<Result<ScoreComparisonData, ExportScoreComparisonError>> {
     const { exportFormat, isAudit, snapshotReferences } = query;
     const excludeDesactive = query.excludeDesactive === true;
@@ -173,7 +175,8 @@ export class LoadScoreComparisonService {
     );
     const fichesActionLiees = await this.getFichesActionLiees(
       collectiviteId,
-      mesureIds
+      mesureIds,
+      { user }
     );
 
     const { snapshot1Label, snapshot2Label } = this.getScoreHeaderLabels(
@@ -257,11 +260,7 @@ export class LoadScoreComparisonService {
       const snapshot1Result =
         snapshot1Ref === SNAPSHOTS.SCORE_COURANT_REF
           ? await this.getCurrentSnapshot(collectiviteId, referentielId)
-          : await this.getSnapshot(
-              collectiviteId,
-              referentielId,
-              snapshot1Ref
-            );
+          : await this.getSnapshot(collectiviteId, referentielId, snapshot1Ref);
       if (!snapshot1Result.success) {
         return snapshot1Result;
       }
@@ -468,8 +467,9 @@ export class LoadScoreComparisonService {
   private async getActionDescriptions(
     referentielId: ReferentielId
   ): Promise<Record<ActionId, string>> {
-    const referentiel =
-      await this.getReferentielService.getReferentielTree(referentielId);
+    const referentiel = await this.getReferentielService.getReferentielTree(
+      referentielId
+    );
 
     const descriptions: Record<string, string> = {};
 
@@ -497,18 +497,22 @@ export class LoadScoreComparisonService {
 
   private async getFichesActionLiees(
     collectiviteId: number,
-    mesureIds: ActionId[]
+    mesureIds: ActionId[],
+    { user }: { user: AuthUser }
   ): Promise<Record<ActionId, string>> {
     const fichesActionLiees: Record<string, string[]> = {};
 
     try {
       const { data: fiches } =
-        await this.listFichesService.getFichesActionResumes({
-          collectiviteId,
-          filters: {
-            mesureIds,
+        await this.listFichesService.getFichesActionResumes(
+          {
+            collectiviteId,
+            filters: {
+              mesureIds,
+            },
           },
-        });
+          { user }
+        );
 
       if (fiches && fiches.length > 0) {
         for (const fiche of fiches) {


### PR DESCRIPTION
`listFiches` rend aujourd'hui les fiches restreintes d'une collectivité à tout compte vérifié, qu'il en soit membre ou non.

`plans.fiches.read` est une permission de plateforme, accordée à tout visiteur vérifié ; `plans.fiches.read_confidentiel` demande d'être membre en lecture. `getFichesActionResumes` n'appliquait ni l'une ni l'autre : `restreint` n'y était qu'un filtre d'affichage fourni par l'appelant, et trois appelants sur sept n'en posaient aucun.

## Le service décide, les appelants ne devinent plus

`getFichesActionResumes` reçoit un contexte de lecture et dérive lui-même la confidentialité :

```ts
getFichesActionResumes(
  { collectiviteId, filters, queryOptions },
  { user, tx }: FichesReadContext
)
```

`queryOptions` rejoint le premier objet plutôt que de rester un troisième paramètre positionnel : le contexte devant venir en dernier, la plupart des appelants auraient dû écrire un `undefined` au milieu de leurs arguments, illisible au site d'appel.

```ts
const readable = await this.getReadableFichesFilters({ collectiviteId, filters }, { user, tx });
if (readable.kind === 'no_readable_fiche') {
  return { count: 0, nextPage: null, nbOfPages: 0, data: [] };
}
```

**Le filtre et la permission se croisent, ils ne se remplacent pas.** Demander les fiches restreintes sans y avoir droit ne renvoie pas les fiches ouvertes à la place — ce serait répondre à une autre question que celle posée — mais ne renvoie rien. D'où l'union discriminée plutôt qu'un rabattement silencieux du filtre sur `false`.

## Les appelants

- **`list-fiches.router`** transmet `ctx.user`, qu'il recevait sans l'utiliser.
- **`count-by`** reçoit l'utilisateur de son routeur, qui l'avait également sans le transmettre.
- **`plan-actions`** dérivait déjà la permission pour construire son filtre. Il rend cette responsabilité au service et perd son paramètre `hasReadPrivateFichePermission`.
- **`bulk-edit`** avait l'utilisateur en portée à ses trois appels.
- **`load-score-comparison`** reçoit l'utilisateur de son contrôleur, via `@TokenInfo()`. Son endpoint porte `AllowAnonymousAccess`, mais la garde attache un `AuthUser` dans tous les cas, anonyme compris — `scores.controller.ts` combine déjà les deux décorateurs. Un membre qui exporte voit donc ses fiches restreintes, un anonyme n'en voit aucune.

## Pourquoi `AuthUser` et pas `ServiceSecondArg`

La convention du repo veut `{ user, tx }` et 78 services la suivent, mais son `user` est un `AuthenticatedUser`. Ce chemin de lecture sert aussi des appelants anonymes, pour qui la permission de lecture confidentielle est simplement fausse. `AuthUser` couvre les deux sans que le service ait à les distinguer ; annoncer `ServiceSecondArg` aurait demandé de fabriquer un utilisateur authentifié là où il n'y en a pas.

## Tests

Le premier commit pose l'e2e et **le montre rouge sur `main`** : deux cas sur quatre échouent, le visiteur vérifié non membre recevant la fiche restreinte, y compris en la demandant explicitement.

Les 57 e2e existants de `listFiches` passent sans modification, ainsi que `count-by`, `bulk-edit` et `plan-actions` — 79 tests au total.

Les trois e2e de `export-score-comparison` échouent en local sur des 401 ; vérifié identique avant le changement, sur le même environnement.

## Ce que cette PR ne fait pas

Elle ne traite que la liste. `getFicheById` garde son `user?` optionnel, et `notify-pilote.service.ts:618` l'appelle sans utilisateur — la garde y est donc inerte. Rendre ce paramètre obligatoire demande de décider ce que fait un flux de notification sans utilisateur, ce qui est une décision, pas un refactor.
