### PR TITLE
feat(referentiels)!: ferme l'export de comparaison des scores aux anonymes

### DIFF
--- a/apps/backend/src/plans/fiches/bulk-edit/bulk-edit.service.ts
+++ b/apps/backend/src/plans/fiches/bulk-edit/bulk-edit.service.ts
@@ -5,7 +5,7 @@ import { ShareFicheService } from '@tet/backend/plans/fiches/share-fiches/share-
 import { ficheActionLibreTagTable } from '@tet/backend/plans/fiches/shared/models/fiche-action-libre-tag.table';
 import { ficheActionTable } from '@tet/backend/plans/fiches/shared/models/fiche-action.table';
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
-import { AuthUser } from '@tet/backend/users/models/auth.models';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { PermissionOperationEnum, ResourceType } from '@tet/domain/users';
 import { and, inArray, or, sql } from 'drizzle-orm';
@@ -30,7 +30,10 @@ export class BulkEditService {
     private readonly notificationsFicheService: NotifyPiloteService
   ) {}
 
-  async bulkEdit(request: BulkEditRequest, user: AuthUser): Promise<void> {
+  async bulkEdit(
+    request: BulkEditRequest,
+    user: AuthenticatedUser
+  ): Promise<void> {
     const filters =
       request.ficheIds === 'all'
         ? request.filters

--- a/apps/backend/src/plans/fiches/count-by/count-by.service.ts
+++ b/apps/backend/src/plans/fiches/count-by/count-by.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger, NotImplementedException } from '@nestjs/common';
-import { AuthUser } from '@tet/backend/users/models/auth.models';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { countByDateSlots } from '@tet/backend/plans/fiches/count-by/count-by-date-slots.enum';
 import { countByArrayValues } from '@tet/backend/plans/fiches/count-by/utils/count-by-array-value';
 import ListFichesService from '@tet/backend/plans/fiches/list-fiches/list-fiches.service';
@@ -452,7 +452,7 @@ export class CountByService {
     collectiviteId: number,
     countByProperty: CountByPropertyEnumType,
     filters: ListFichesRequestFilters,
-    { user }: { user: AuthUser }
+    { user }: { user: AuthenticatedUser }
   ) {
     this.logger.log(
       `Calcul du count by ${countByProperty} des fiches action pour la collectivité ${collectiviteId}: filtre ${JSON.stringify(

--- a/apps/backend/src/plans/fiches/list-fiches/list-fiches.service.ts
+++ b/apps/backend/src/plans/fiches/list-fiches/list-fiches.service.ts
@@ -40,6 +40,7 @@ import { tempsDeMiseEnOeuvreTable } from '@tet/backend/shared/models/temps-de-mi
 import { sousThematiqueTable } from '@tet/backend/shared/thematiques/sous-thematique.table';
 import { thematiqueTable } from '@tet/backend/shared/thematiques/thematique.table';
 import { AuthUser } from '@tet/backend/users/models/auth.models';
+import { ServiceSecondArg } from '@tet/backend/utils/nest/service-second-arg.utils';
 import { sqlAuthorOrNull } from '@tet/backend/users/models/author.utils';
 import { dcpTable } from '@tet/backend/users/models/dcp.table';
 import { sqlToDateTimeISO } from '@tet/backend/utils/column.utils';
@@ -109,11 +110,6 @@ const sortColumn: Record<ListFichesSortValue, PgColumn> = {
   created_at: ficheActionTable.createdAt,
   dateDebut: ficheActionTable.dateDebut,
   titre: ficheActionTable.titre,
-};
-
-export type FichesReadContext = {
-  user: AuthUser;
-  tx?: Transaction;
 };
 
 type ReadableFichesFilters =
@@ -1956,7 +1952,7 @@ export default class ListFichesService {
       collectiviteId,
       filters,
     }: { collectiviteId: number; filters: ListFichesRequestFilters },
-    { user, tx }: FichesReadContext
+    { user, tx }: ServiceSecondArg
   ): Promise<ReadableFichesFilters> {
     const canReadFichesRestreintes =
       await this.fichePermissionService.hasReadFichePermission(
@@ -1995,7 +1991,7 @@ export default class ListFichesService {
       filters: ListFichesRequestFilters;
       queryOptions?: QueryOptionsSchema;
     },
-    { user, tx }: FichesReadContext
+    { user, tx }: ServiceSecondArg
   ): Promise<{
     count: number;
     nextPage: number | null;

--- a/apps/backend/src/plans/fiches/plan-actions.service.ts
+++ b/apps/backend/src/plans/fiches/plan-actions.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import FicheActionPermissionsService from '@tet/backend/plans/fiches/fiche-action-permissions.service';
 import ListFichesService from '@tet/backend/plans/fiches/list-fiches/list-fiches.service';
 import { ficheActionTable } from '@tet/backend/plans/fiches/shared/models/fiche-action.table';
-import { AuthUser } from '@tet/backend/users/models/auth.models';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { Fiche, FicheWithRelations } from '@tet/domain/plans';
 import { and, count, eq, isNull, sql } from 'drizzle-orm';
 import { uniq } from 'es-toolkit';
@@ -54,7 +54,7 @@ export default class PlanActionsService {
   /**
    * Charge les axes et les fiches d'un plan
    */
-  async getPlan(input: GetPlanRequest, user: AuthUser) {
+  async getPlan(input: GetPlanRequest, user: AuthenticatedUser) {
     const { collectiviteId, planId } = input;
 
     this.logger.log(
@@ -97,7 +97,7 @@ export default class PlanActionsService {
     };
   }
 
-  private async fetchPlan(input: GetPlanRequest, user: AuthUser) {
+  private async fetchPlan(input: GetPlanRequest, user: AuthenticatedUser) {
     const { collectiviteId, planId } = input;
 
     // charge les données

--- a/apps/backend/src/referentiels/export-score/export-score-comparison.controller.e2e-spec.ts
+++ b/apps/backend/src/referentiels/export-score/export-score-comparison.controller.e2e-spec.ts
@@ -1,5 +1,6 @@
 import { INestApplication } from '@nestjs/common';
 import { addTestCollectiviteAndUser } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { addTestUser } from '@tet/backend/users/users/users.test-fixture';
 import { SnapshotsService } from '@tet/backend/referentiels/snapshots/snapshots.service';
 import { SNAPSHOTS } from '@tet/backend/referentiels/snapshots/snapshots.constants';
 import {
@@ -20,7 +21,11 @@ import { CellValue, Workbook } from 'exceljs';
 import { DateTime } from 'luxon';
 import { default as request } from 'supertest';
 import { getTestApp, getTestRouter } from '../../../test/app-utils';
+import { getAuthToken } from '../../../test/auth-utils';
 import { cleanupReferentielActionStatutsAndLabellisations } from '../update-action-statut/referentiel-action-statut.test-fixture';
+
+// sur la collectivité 1, le référentiel CAE est verrouillé par une demande de labellisation
+const SEEDED_COLLECTIVITE_ID = 2;
 
 describe('Referentiels scoring routes', () => {
   let app: INestApplication;
@@ -29,6 +34,8 @@ describe('Referentiels scoring routes', () => {
   let snapshotsService: SnapshotsService;
   let collectivite: Collectivite;
   let editionUser: AuthenticatedUser;
+  let editionUserToken: string;
+  let collectivite2UserToken: string;
 
   beforeAll(async () => {
     app = await getTestApp();
@@ -47,7 +54,18 @@ describe('Referentiels scoring routes', () => {
     collectivite = testCollectiviteAndUserResult.collectivite;
     const editionUserFixture = testCollectiviteAndUserResult.user;
     editionUser = getAuthUserFromUserCredentials(editionUserFixture);
-
+    editionUserToken = await getAuthToken({
+      email: editionUserFixture.email ?? '',
+      password: editionUserFixture.password,
+    });
+    const collectivite2UserFixture = await addTestUser(databaseService, {
+      collectiviteId: SEEDED_COLLECTIVITE_ID,
+      role: CollectiviteRole.EDITION,
+    });
+    collectivite2UserToken = await getAuthToken({
+      email: collectivite2UserFixture.user.email ?? '',
+      password: collectivite2UserFixture.user.password,
+    });
   });
 
   afterAll(async () => {
@@ -111,7 +129,7 @@ describe('Referentiels scoring routes', () => {
       .get(
         `/collectivites/${collectiviteId}/referentiels/${referentielId}/score-snapshots/export-comparison`
       )
-      .set('Authorization', `Bearer ${process.env.SUPABASE_ANON_KEY}`)
+      .set('Authorization', `Bearer ${editionUserToken}`)
       .query({
         exportFormat: 'excel',
         isAudit: 'false',
@@ -134,7 +152,7 @@ describe('Referentiels scoring routes', () => {
       .get(
         `/collectivites/${collectiviteId}/referentiels/${referentielId}/score-snapshots/export-comparison`
       )
-      .set('Authorization', `Bearer ${process.env.SUPABASE_ANON_KEY}`)
+      .set('Authorization', `Bearer ${editionUserToken}`)
       .query({
         exportFormat: 'excel',
         isAudit: 'false',
@@ -154,190 +172,8 @@ describe('Referentiels scoring routes', () => {
     expect(foundWithFlag).toBeUndefined();
   }, 30000);
 
-  test(`Export du snapshot pour un utilisateur anonyme`, async () => {
-    const responseSnapshotExport = await request(app.getHttpServer())
-      .get(
-        `/collectivites/1/referentiels/eci/score-snapshots/export-comparison`
-      )
-      .set('Authorization', `Bearer ${process.env.SUPABASE_ANON_KEY}`)
-      .query({
-        exportFormat: 'excel',
-        isAudit: 'false',
-        snapshotReferences: ['score-courant'],
-      })
-      .expect(200)
-      .responseType('blob');
-
-    const currentDate = DateTime.now().toISODate();
-    const exportFileName = responseSnapshotExport.headers['content-disposition']
-      .split('filename=')[1]
-      .split(';')[0];
-
-    expect(exportFileName).toBe(
-      `"Export_ECI_Amberieu-en-Bugey_${currentDate}.xlsx"`
-    );
-    const body = responseSnapshotExport.body as ArrayBuffer;
-    const wb = new Workbook();
-    await wb.xlsx.load(body);
-    const ws = wb.getWorksheet(1);
-    expect(ws).toBeDefined();
-    // vérifie la ligne d'en-têtes
-    const header2 = ws?.getRow(7);
-    expect(header2?.values).toEqual(
-      expect.arrayContaining([
-        'N°',
-        'Intitulé',
-        'Description',
-        'Phase',
-        'Potentiel max',
-        'Potentiel personnalisé',
-        'Points faits',
-        '% fait',
-        'Points programmés',
-        '% programmé',
-        'Points pas faits',
-        '% pas fait',
-        'Statut',
-        "Champs de précision de l'état d'avancement",
-        'Personnes pilotes',
-        'Services ou Directions pilotes',
-        'Documents liés',
-        'Actions liées',
-      ])
-    );
-
-    // vérifie le total du référentiel
-    const row8 = ws?.getRow(8);
-    expect(row8?.values).toEqual([
-      undefined,
-      'Total',
-      '',
-      undefined,
-      '',
-      500,
-      500,
-      {
-        formula: 'G9+G71+G151+G261+G307',
-      },
-      {
-        formula: 'IFERROR(G8/F8,"")',
-      },
-      {
-        formula: 'I9+I71+I151+I261+I307',
-      },
-      {
-        formula: 'IFERROR(I8/F8,"")',
-      },
-      {
-        formula: 'K9+K71+K151+K261+K307',
-      },
-      {
-        formula: 'IFERROR(K8/F8,"")',
-      },
-      '',
-      '',
-      undefined,
-      '',
-      '',
-      undefined,
-      '',
-    ]);
-
-    // vérifie un axe
-    const row9 = ws?.getRow(9);
-    expect(row9?.values).toEqual([
-      undefined,
-      '1',
-      "Définition d'une stratégie globale de la politique économie circulaire et inscription dans le territoire",
-      undefined,
-      '',
-      90,
-      90,
-      {
-        formula: 'G10+G47+G61',
-      },
-      {
-        formula: 'IFERROR(G9/F9,"")',
-      },
-      {
-        formula: 'I10+I47+I61',
-      },
-      {
-        formula: 'IFERROR(I9/F9,"")',
-      },
-      {
-        formula: 'K10+K47+K61',
-      },
-
-      {
-        formula: 'IFERROR(K9/F9,"")',
-      },
-      '',
-      '',
-    ]);
-
-    // vérifie une mesure
-    const row10 = ws?.getRow(10);
-    expect(row10?.values).toEqual([
-      undefined,
-      '1.1',
-      'Définir une stratégie globale de la politique Economie Circulaire et assurer un portage politique fort',
-      expect.any(String),
-      '',
-      30,
-      30,
-      {
-        formula: 'G11+G17+G23+G27+G42',
-      },
-      {
-        formula: 'IFERROR(G10/F10,"")',
-      },
-      {
-        formula: 'I11+I17+I23+I27+I42',
-      },
-      {
-        formula: 'IFERROR(I10/F10,"")',
-      },
-      {
-        formula: 'K11+K17+K23+K27+K42',
-      },
-      {
-        formula: 'IFERROR(K10/F10,"")',
-      },
-      '',
-      '',
-    ]);
-
-    // vérifie une sous-mesure
-    const row11 = ws?.getRow(11);
-    expect(row11?.values).toEqual([
-      undefined,
-      '1.1.1',
-      "S'engager politiquement et mettre en place des moyens",
-      expect.any(String),
-      'Bases',
-      6,
-      6,
-      { formula: 'F11*H11' },
-      undefined,
-      { formula: 'F11*J11' },
-      undefined,
-      { formula: 'F11*L11' },
-      undefined,
-      'Non renseigné',
-      '',
-    ]);
-
-    // vérifie la taille
-    const expectedExportSize = 55.9;
-    const exportFileSize = parseInt(
-      responseSnapshotExport.headers['content-length']
-    );
-    expect(exportFileSize / 1000).toBeCloseTo(expectedExportSize, 0);
-  }, 30000);
-
   test(`Export du snapshot avec un score indicatif`, async () => {
-    const collectiviteId = 2; // sur la 1 CAE est verrouillé par une demande de labellisation
+    const collectiviteId = SEEDED_COLLECTIVITE_ID;
     const fixture = {
       collectiviteId,
       actionId: 'cae_1.2.3.3.1',
@@ -363,7 +199,7 @@ sinon ((limite(cae_6.a) - val(cae_6.a)) / (limite(cae_6.a) - cible(cae_6.a)))`,
       .get(
         `/collectivites/${collectiviteId}/referentiels/cae/score-snapshots/export-comparison`
       )
-      .set('Authorization', `Bearer ${process.env.SUPABASE_ANON_KEY}`)
+      .set('Authorization', `Bearer ${collectivite2UserToken}`)
       .query({
         exportFormat: 'excel',
         isAudit: 'false',

--- a/apps/backend/src/referentiels/export-score/export-score-comparison.controller.ts
+++ b/apps/backend/src/referentiels/export-score/export-score-comparison.controller.ts
@@ -1,9 +1,8 @@
 import { Controller, Get, Logger, Param, Query, Res } from '@nestjs/common';
 import { ApiExcludeController, ApiTags } from '@nestjs/swagger';
 import { COLLECTIVITE_ID_PARAM_KEY } from '@tet/backend/collectivites/shared/models/collectivite-api.constants';
-import { AllowAnonymousAccess } from '@tet/backend/users/decorators/allow-anonymous-access.decorator';
 import { TokenInfo } from '@tet/backend/users/decorators/token-info.decorators';
-import type { AuthUser } from '@tet/backend/users/models/auth.models';
+import type { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { ApiUsageEnum } from '@tet/backend/utils/api/api-usage-type.enum';
 import { ApiUsage } from '@tet/backend/utils/api/api-usage.decorator';
 import { createControllerErrorHandler } from '@tet/backend/utils/nest/controller-error-handler';
@@ -34,7 +33,6 @@ export class ExportScoreComparisonController {
     private readonly exportScoreComparisonService: ExportScoreComparisonService
   ) {}
 
-  @AllowAnonymousAccess()
   @Get(
     `collectivites/:${COLLECTIVITE_ID_PARAM_KEY}/referentiels/:${REFERENTIEL_ID_PARAM_KEY}/score-snapshots/export-comparison`
   )
@@ -44,7 +42,7 @@ export class ExportScoreComparisonController {
     @Param(REFERENTIEL_ID_PARAM_KEY) referentielId: ReferentielId,
     @Query() query: ExportScoreComparisonApiQueryClass,
     @Res() res: Response,
-    @TokenInfo() user: AuthUser
+    @TokenInfo() user: AuthenticatedUser
   ) {
     this.logger.log(
       `Export de comparaison des scores du referentiel ${referentielId} pour la collectivite ${collectiviteId}`

--- a/apps/backend/src/referentiels/export-score/export-score-comparison.service.ts
+++ b/apps/backend/src/referentiels/export-score/export-score-comparison.service.ts
@@ -12,7 +12,7 @@ import {
   ExportScoreComparisonErrorEnum,
 } from './export-score-comparison.errors';
 import { LoadScoreComparisonService } from './load-score-comparison.service';
-import { AuthUser } from '@tet/backend/users/models/auth.models';
+import { ServiceSecondArg } from '@tet/backend/utils/nest/service-second-arg.utils';
 
 @Injectable()
 export class ExportScoreComparisonService {
@@ -26,7 +26,7 @@ export class ExportScoreComparisonService {
     collectiviteId: number,
     referentielId: ReferentielId,
     query: ExportScoreComparisonRequestQuery,
-    { user }: { user: AuthUser }
+    { user }: ServiceSecondArg
   ): Promise<
     Result<{ fileName: string; content: Buffer }, ExportScoreComparisonError>
   > {

--- a/apps/backend/src/referentiels/export-score/load-score-comparison.service.ts
+++ b/apps/backend/src/referentiels/export-score/load-score-comparison.service.ts
@@ -1,4 +1,4 @@
-import { AuthUser } from '@tet/backend/users/models/auth.models';
+import { ServiceSecondArg } from '@tet/backend/utils/nest/service-second-arg.utils';
 import { Injectable, Logger } from '@nestjs/common';
 import ListFichesService from '@tet/backend/plans/fiches/list-fiches/list-fiches.service';
 import { HandleMesureServicesService } from '@tet/backend/referentiels/handle-mesure-services/handle-mesure-services.service';
@@ -101,7 +101,7 @@ export class LoadScoreComparisonService {
     collectiviteId: number,
     referentielId: ReferentielId,
     query: ExportScoreComparisonRequestQuery,
-    { user }: { user: AuthUser }
+    { user }: ServiceSecondArg
   ): Promise<Result<ScoreComparisonData, ExportScoreComparisonError>> {
     const { exportFormat, isAudit, snapshotReferences } = query;
     const excludeDesactive = query.excludeDesactive === true;
@@ -498,7 +498,7 @@ export class LoadScoreComparisonService {
   private async getFichesActionLiees(
     collectiviteId: number,
     mesureIds: ActionId[],
-    { user }: { user: AuthUser }
+    { user }: ServiceSecondArg
   ): Promise<Record<ActionId, string>> {
     const fichesActionLiees: Record<string, string[]> = {};
 


### PR DESCRIPTION
Empilée sur #5000, qu'elle termine : une fois l'export de scores fermé aux anonymes, la lecture des fiches n'a plus d'appelant sans utilisateur et peut suivre la convention du repo.

## Ce que la PR retire

L'endpoint `score-snapshots/export-comparison` acceptait la clé anonyme Supabase. Il ne l'accepte plus.

Ce qui a motivé le retrait, vérifié plutôt que supposé :

- **Le front ne l'appelle que connecté.** `useExportComparisonScore` n'est utilisé que par `download-score.modal.tsx`, montée depuis `referentiel-menu.button.tsx`, dans l'app authentifiée.
- **Ce n'est pas une API publique.** Le contrôleur porte `@ApiExcludeController()` et `@ApiUsage([ApiUsageEnum.APP])`.

**Ce que je ne peux pas prouver d'ici** : aucun appel anonyme n'apparaît dans le code que je peux lire, mais un consommateur externe — site public, script, intégration tierce — ne serait pas visible. C'est la question à trancher en revue.

## Ce que les tests révèlent

Trois des quatre tests du spec passaient par la clé anonyme.

L'un d'eux, `Export du snapshot pour un utilisateur anonyme`, **affirmait** la capacité : il est supprimé, c'est le sujet de la PR. Les deux autres s'authentifient désormais.

Le plus instructif est celui qui vise la collectivité 2 du seed : il s'appuyait sur l'anonymat pour lire une collectivité dont son utilisateur n'était pas membre. Il crée maintenant le membre dont il a besoin — l'accès anonyme masquait une fixture manquante.

Le quatrième test, qui vérifie qu'une requête **sans aucun en-tête** reçoit 401, passait déjà et passe toujours : `AllowAnonymousAccess` n'ouvrait pas l'endpoint à tout le monde, il l'ouvrait au rôle anonyme de Supabase.

## Ce que la conformité fait apparaître

`FichesReadContext` n'existait que pour tolérer un appelant sans utilisateur. Il disparaît au profit de `ServiceSecondArg`.

Le compilateur a alors montré que trois services intermédiaires **élargissaient** un type que `authedProcedure` avait déjà réduit : `bulkEdit`, `countByProperty` et `getPlan` déclaraient `AuthUser` là où elles ne reçoivent que des `AuthenticatedUser`. Elles conservent maintenant l'information.

## Vérifications

79 tests verts sur les suites de fiches — `listFiches`, `count-by`, `bulk-edit`, `plan-actions` — et typecheck vert.

Sur le spec d'export, deux tests échouent en local : `excludeDesactive` sur une `DATABASE_ERROR` et `score indicatif` sur un 401 visant la collectivité 2 du seed. **Les deux échouaient déjà avant cette PR**, avec la clé anonyme. L'environnement local ne permet pas de les faire passer : `getAuthToken()` sur l'utilisateur du seed échoue ici de façon générale, y compris sur des specs sans rapport. La CI tranchera.
