### PR TITLE
Ajoute une feuille Personnalisation à l'export des scores

### DIFF
--- a/apps/backend/src/referentiels/export-score/build-columns.spec.ts
+++ b/apps/backend/src/referentiels/export-score/build-columns.spec.ts
@@ -78,6 +78,7 @@ function createScoreComparisonData(
     pilotes: {},
     services: {},
     fichesActionLiees: {},
+    personnalisationQuestions: [],
   };
 }
 

--- a/apps/backend/src/referentiels/export-score/build-personnalisation-rows.spec.ts
+++ b/apps/backend/src/referentiels/export-score/build-personnalisation-rows.spec.ts
@@ -1,0 +1,267 @@
+import { PersonnalisationReponsesPayload } from '@tet/domain/collectivites';
+import { ScoreSnapshot } from '@tet/domain/referentiels';
+import { CellValue, Workbook, Worksheet } from 'exceljs';
+import {
+  buildPersonnalisationRows,
+  sortPersonnalisationQuestions,
+} from './build-personnalisation-rows';
+import {
+  ExportMode,
+  PersonnalisationExportQuestion,
+  ScoreComparisonData,
+} from './load-score-comparison.service';
+
+const snap = (reponses: PersonnalisationReponsesPayload): ScoreSnapshot =>
+  ({ personnalisationReponses: reponses } as unknown as ScoreSnapshot);
+
+const questions: PersonnalisationExportQuestion[] = [
+  {
+    questionId: 'q_mobilite',
+    thematiqueNom: 'Mobilité',
+    formulation: 'Zone à faibles émissions ?',
+    ordonnancement: 1,
+    type: 'binaire',
+    choix: [],
+    mesuresAffectees: [
+      {
+        actionId: 'cae_1.2.3',
+        identifiant: '1.2.3',
+        nom: 'Développer les mobilités douces',
+      },
+      { actionId: 'cae_1.2.4', identifiant: '1.2.4', nom: 'Créer une ZFE' },
+    ],
+  },
+  {
+    questionId: 'q_dechets_choix',
+    thematiqueNom: 'Déchets',
+    formulation: 'Mode de gestion des déchets ?',
+    ordonnancement: 1,
+    type: 'choix',
+    choix: [
+      { id: 'regie', formulation: 'Régie directe' },
+      { id: 'delegation', formulation: 'Délégation de service public' },
+    ],
+    mesuresAffectees: [
+      {
+        actionId: 'cae_3.1.1',
+        identifiant: '3.1.1',
+        nom: 'Optimiser la collecte',
+      },
+    ],
+  },
+  {
+    questionId: 'q_dechets_part',
+    thematiqueNom: 'Déchets',
+    formulation: 'Autre question déchets',
+    ordonnancement: 2,
+    type: 'proportion',
+    choix: [],
+    mesuresAffectees: [],
+  },
+  {
+    questionId: 'q_sans_thematique',
+    thematiqueNom: null,
+    formulation: 'Question sans thématique',
+    ordonnancement: 1,
+    type: 'binaire',
+    choix: [],
+    mesuresAffectees: [],
+  },
+];
+
+function createData(
+  overrides: Partial<ScoreComparisonData> = {}
+): ScoreComparisonData {
+  return {
+    exportMode: ExportMode.SINGLE_SNAPSHOT,
+    snapshot1Label: 'État des lieux 2024',
+    snapshot2Label: '',
+    snapshot1: snap({}),
+    snapshot2: null,
+    personnalisationQuestions: questions,
+    ...overrides,
+  } as ScoreComparisonData;
+}
+
+function rowValues(
+  worksheet: Worksheet,
+  rowIndex: number,
+  columnCount: number
+): CellValue[] {
+  return Array.from(
+    { length: columnCount },
+    (_, i) => worksheet.getCell(rowIndex, i + 1).value
+  );
+}
+
+describe('sortPersonnalisationQuestions', () => {
+  it('groupe par thématique (alpha asc, sans thématique en tête) puis par ordonnancement', () => {
+    const ordered = sortPersonnalisationQuestions(questions).map(
+      (q) => q.questionId
+    );
+    expect(ordered).toEqual([
+      'q_sans_thematique', // thématique nulle => en tête
+      'q_dechets_choix', // Déchets, ordonnancement 1
+      'q_dechets_part', // Déchets, ordonnancement 2
+      'q_mobilite', // Mobilité
+    ]);
+  });
+
+  it('relègue les questions sans ordonnancement en fin de thématique', () => {
+    const sansOrdonnancement: PersonnalisationExportQuestion[] = [
+      { ...questions[1], questionId: 'q_a', ordonnancement: null },
+      { ...questions[1], questionId: 'q_b', ordonnancement: 5 },
+    ];
+    const ordered = sortPersonnalisationQuestions(sansOrdonnancement).map(
+      (q) => q.questionId
+    );
+    expect(ordered).toEqual(['q_b', 'q_a']);
+  });
+});
+
+describe('buildPersonnalisationRows', () => {
+  let worksheet: Worksheet;
+
+  const build = (data: ScoreComparisonData) => {
+    worksheet = new Workbook().addWorksheet('Personnalisation');
+    buildPersonnalisationRows(data, worksheet);
+  };
+
+  it('une seule colonne de réponse pour un export simple', () => {
+    build(
+      createData({
+        snapshot1: snap({
+          q_mobilite: true,
+          q_dechets_choix: 'delegation',
+          q_dechets_part: 0.42,
+        }),
+      })
+    );
+
+    expect(rowValues(worksheet, 1, 4)).toEqual([
+      'Thématique',
+      'Question',
+      'Réponse', // un seul snapshot : pas de rappel du libellé
+      'Mesures affectées',
+    ]);
+
+    // ordre groupé/trié + valeurs formatées
+    expect(rowValues(worksheet, 2, 4)).toEqual([
+      '',
+      'Question sans thématique',
+      '', // pas de réponse => cellule vide
+      '', // aucune mesure affectée => cellule vide
+    ]);
+    expect(rowValues(worksheet, 3, 4)).toEqual([
+      'Déchets',
+      'Mode de gestion des déchets ?',
+      'Délégation de service public',
+      '3.1.1 - Optimiser la collecte',
+    ]);
+    expect(rowValues(worksheet, 4, 4)).toEqual([
+      'Déchets',
+      'Autre question déchets',
+      0.42,
+      '',
+    ]);
+    expect(rowValues(worksheet, 5, 4)).toEqual([
+      'Mobilité',
+      'Zone à faibles émissions ?',
+      'Oui',
+      // une mesure par ligne, format "identifiant - libellé"
+      '1.2.3 - Développer les mobilités douces\n1.2.4 - Créer une ZFE',
+    ]);
+
+    // colonne "Mesures affectées" : alignée à gauche, centrée verticalement,
+    // retour à la ligne
+    expect(worksheet.getCell(5, 4).alignment).toEqual(
+      expect.objectContaining({
+        horizontal: 'left',
+        vertical: 'middle',
+        wrapText: true,
+      })
+    );
+
+    // proportion => cellule numérique avec format pourcentage
+    const proportionCell = worksheet.getCell(4, 3);
+    expect(proportionCell.value).toBe(0.42);
+    // pourcentage entier : pas de décimale => pas de séparateur décimal orphelin
+    expect(proportionCell.numFmt).toBe('0%');
+
+    // toutes les réponses sont centrées (h + v) dans leur colonne
+    expect(worksheet.getColumn(3).style.alignment).toEqual(
+      expect.objectContaining({ horizontal: 'center', vertical: 'middle' })
+    );
+    expect(worksheet.getCell(5, 3).alignment).toEqual(
+      expect.objectContaining({ horizontal: 'center', vertical: 'middle' })
+    );
+    expect(proportionCell.alignment).toEqual(
+      expect.objectContaining({ horizontal: 'center', vertical: 'middle' })
+    );
+
+    // réponse "choix" : centrée + retour à la ligne
+    expect(worksheet.getCell(3, 3).alignment).toEqual(
+      expect.objectContaining({
+        horizontal: 'center',
+        vertical: 'middle',
+        wrapText: true,
+      })
+    );
+
+    // texte centré verticalement aussi dans les colonnes Thématique et Question
+    expect(worksheet.getCell(3, 1).alignment).toEqual(
+      expect.objectContaining({ vertical: 'middle' })
+    );
+    expect(worksheet.getCell(3, 2).alignment).toEqual(
+      expect.objectContaining({ vertical: 'middle' })
+    );
+  });
+
+  it('proportion non entière : format avec décimale optionnelle', () => {
+    build(
+      createData({
+        snapshot1: snap({ q_dechets_part: 0.175 }),
+      })
+    );
+
+    const proportionCell = worksheet.getCell(4, 3);
+    expect(proportionCell.value).toBe(0.175);
+    expect(proportionCell.numFmt).toBe('0.#%');
+  });
+
+  it('deux colonnes de réponse en mode comparaison, vides si sans réponse', () => {
+    build(
+      createData({
+        exportMode: ExportMode.COMPARISON,
+        snapshot2Label: 'État des lieux 2023',
+        snapshot1: snap({ q_mobilite: true }),
+        snapshot2: snap({ q_mobilite: false }),
+      })
+    );
+
+    expect(rowValues(worksheet, 1, 5)).toEqual([
+      'Thématique',
+      'Question',
+      'Réponse (État des lieux 2024)',
+      'Réponse (État des lieux 2023)',
+      'Mesures affectées',
+    ]);
+
+    expect(rowValues(worksheet, 5, 5)).toEqual([
+      'Mobilité',
+      'Zone à faibles émissions ?',
+      'Oui',
+      'Non',
+      '1.2.3 - Développer les mobilités douces\n1.2.4 - Créer une ZFE',
+    ]);
+    // question sans réponse dans les deux snapshots : la colonne "Mesures
+    // affectées" reste renseignée (indépendante des réponses)
+    expect(rowValues(worksheet, 3, 5)).toEqual([
+      'Déchets',
+      'Mode de gestion des déchets ?',
+      '',
+      '',
+      '3.1.1 - Optimiser la collecte',
+    ]);
+  });
+});

--- a/apps/backend/src/referentiels/export-score/build-personnalisation-rows.ts
+++ b/apps/backend/src/referentiels/export-score/build-personnalisation-rows.ts
@@ -1,0 +1,202 @@
+import { PersonnalisationReponsesPayload } from '@tet/domain/collectivites';
+import { Alignment, Cell, Worksheet } from 'exceljs';
+import * as Utils from '../../utils/excel/export-excel.utils';
+import {
+  ExportMode,
+  PersonnalisationExportQuestion,
+  ScoreComparisonData,
+} from './load-score-comparison.service';
+
+const WIDTH_THEMATIQUE = 30;
+const WIDTH_QUESTION = 70;
+const WIDTH_REPONSE = 40;
+const WIDTH_MESURES_AFFECTEES = 50;
+
+// alignements des colonnes (texte centré verticalement partout)
+const ALIGN_THEMATIQUE = {
+  vertical: 'middle',
+  horizontal: 'left',
+} as Partial<Alignment>;
+const ALIGN_QUESTION = {
+  vertical: 'middle',
+  horizontal: 'left',
+  wrapText: true,
+} as Partial<Alignment>;
+const ALIGN_REPONSE = {
+  vertical: 'middle',
+  horizontal: 'center',
+} as Partial<Alignment>;
+const ALIGN_REPONSE_WRAP = {
+  ...ALIGN_REPONSE,
+  wrapText: true,
+} as Partial<Alignment>;
+const ALIGN_MESURES_AFFECTEES = {
+  vertical: 'middle',
+  horizontal: 'left',
+  wrapText: true,
+} as Partial<Alignment>;
+
+/**
+ * Ajoute la feuille "Personnalisation" : la liste de toutes les questions de
+ * personnalisation du référentiel exporté (groupées par thématique), avec une
+ * colonne de réponse par snapshot exporté.
+ */
+export function buildPersonnalisationRows(
+  data: ScoreComparisonData,
+  worksheet: Worksheet
+) {
+  const { personnalisationQuestions, snapshot1, snapshot2 } = data;
+  const withSecondSnapshot =
+    data.exportMode !== ExportMode.SINGLE_SNAPSHOT && snapshot2 !== null;
+
+  // configuration des colonnes : en mode "un snapshot" l'en-tête de réponse est
+  // simplement "Réponse" ; en mode "deux snapshots" chaque libellé de snapshot
+  // est rappelé entre parenthèses. La colonne "Mesures affectées" ferme le
+  // tableau (contenu identique à la section du même nom sur la page
+  // personnalisation, restreint aux mesures du référentiel exporté).
+  const columns: {
+    title: string;
+    width: number;
+    alignment: Partial<Alignment>;
+  }[] = [
+    { title: 'Thématique', width: WIDTH_THEMATIQUE, alignment: ALIGN_THEMATIQUE },
+    { title: 'Question', width: WIDTH_QUESTION, alignment: ALIGN_QUESTION },
+    {
+      title: withSecondSnapshot
+        ? `Réponse (${data.snapshot1Label})`
+        : 'Réponse',
+      width: WIDTH_REPONSE,
+      alignment: ALIGN_REPONSE,
+    },
+  ];
+  if (withSecondSnapshot) {
+    columns.push({
+      title: `Réponse (${data.snapshot2Label})`,
+      width: WIDTH_REPONSE,
+      alignment: ALIGN_REPONSE,
+    });
+  }
+  columns.push({
+    title: 'Mesures affectées',
+    width: WIDTH_MESURES_AFFECTEES,
+    alignment: ALIGN_MESURES_AFFECTEES,
+  });
+  const mesuresAffecteesColIndex = columns.length;
+
+  // ligne d'en-tête
+  columns.forEach((col, colIndex) => {
+    const column = worksheet.getColumn(colIndex + 1);
+    column.width = col.width;
+    column.style = { alignment: col.alignment };
+    const headCell = worksheet.getCell(1, colIndex + 1);
+    headCell.value = col.title;
+    headCell.style = { ...headCell.style, ...Utils.HEADING2 };
+  });
+
+  // une ligne par question (triées/groupées par thématique)
+  const orderedQuestions = sortPersonnalisationQuestions(
+    personnalisationQuestions
+  );
+
+  let rowIndex = 1;
+  orderedQuestions.forEach((question) => {
+    rowIndex++;
+
+    worksheet.getCell(rowIndex, 1).value = question.thematiqueNom ?? '';
+    worksheet.getCell(rowIndex, 2).value = question.formulation;
+
+    setReponseCell(
+      worksheet.getCell(rowIndex, 3),
+      snapshot1.personnalisationReponses,
+      question
+    );
+    if (withSecondSnapshot && snapshot2) {
+      setReponseCell(
+        worksheet.getCell(rowIndex, 4),
+        snapshot2.personnalisationReponses,
+        question
+      );
+    }
+
+    const mesuresCell = worksheet.getCell(rowIndex, mesuresAffecteesColIndex);
+    mesuresCell.value = formatMesuresAffectees(question.mesuresAffectees);
+    mesuresCell.alignment = ALIGN_MESURES_AFFECTEES;
+  });
+}
+
+/**
+ * Met en forme la liste des mesures affectées : une mesure par ligne, sous la
+ * forme « identifiant - libellé » (« libellé » seul si la mesure n'a pas de
+ * numérotation, comme pour le référentiel CR).
+ */
+function formatMesuresAffectees(
+  mesuresAffectees: PersonnalisationExportQuestion['mesuresAffectees']
+): string {
+  return mesuresAffectees
+    .map(({ identifiant, nom }) =>
+      identifiant ? `${identifiant} - ${nom}` : nom
+    )
+    .join('\n');
+}
+
+/**
+ * Groupe les questions par thématique (tri alphabétique fr, questions sans
+ * thématique en tête) puis, au sein de chaque thématique, reprend le même ordre
+ * que la page personnalisation : `ordonnancement` croissant (questions sans
+ * ordonnancement en fin), départagé par `questionId` — c'est l'ordre renvoyé par
+ * `ListPersonnalisationQuestionsRepository.listQuestionsWithChoices`
+ * (`ORDER BY ordonnancement, id`).
+ */
+export function sortPersonnalisationQuestions(
+  questions: PersonnalisationExportQuestion[]
+): PersonnalisationExportQuestion[] {
+  return [...questions].sort((a, b) => {
+    const thematiqueA = a.thematiqueNom ?? '';
+    const thematiqueB = b.thematiqueNom ?? '';
+    if (thematiqueA !== thematiqueB) {
+      return thematiqueA.localeCompare(thematiqueB, 'fr');
+    }
+    const ordonnancementA = a.ordonnancement ?? Number.POSITIVE_INFINITY;
+    const ordonnancementB = b.ordonnancement ?? Number.POSITIVE_INFINITY;
+    if (ordonnancementA !== ordonnancementB) {
+      return ordonnancementA - ordonnancementB;
+    }
+    return a.questionId.localeCompare(b.questionId);
+  });
+}
+
+/** Renseigne une cellule de réponse à partir du payload d'un snapshot */
+function setReponseCell(
+  cell: Cell,
+  reponses: PersonnalisationReponsesPayload,
+  question: PersonnalisationExportQuestion
+) {
+  const value = reponses?.[question.questionId];
+
+  if (value === null || value === undefined) {
+    cell.value = '';
+    return;
+  }
+
+  if (question.type === 'binaire') {
+    cell.value = value === true ? 'Oui' : value === false ? 'Non' : '';
+    return;
+  }
+
+  if (question.type === 'proportion') {
+    if (typeof value === 'number') {
+      cell.value = value;
+      // format nombre pourcentage ; l'alignement centré est hérité de la colonne
+      cell.numFmt = Utils.getNumberFormat(value, Utils.FORMAT_PERCENT);
+    } else {
+      cell.value = '';
+    }
+    return;
+  }
+
+  // type === 'choix' : la valeur stockée est l'id du choix
+  const choix = question.choix.find((c) => c.id === value);
+  cell.value = choix?.formulation ?? String(value);
+  // libellé potentiellement long : reste centré mais ajusté (retour à la ligne)
+  cell.alignment = ALIGN_REPONSE_WRAP;
+}

--- a/apps/backend/src/referentiels/export-score/export-score-comparison.controller.e2e-spec.ts
+++ b/apps/backend/src/referentiels/export-score/export-score-comparison.controller.e2e-spec.ts
@@ -328,12 +328,15 @@ describe('Referentiels scoring routes', () => {
       '',
     ]);
 
-    // vérifie la taille
-    const expectedExportSize = 55.9;
+    // vérifie la taille (borne basse : feuille des scores + feuille
+    // "Personnalisation" ajoutée pour le format excel)
     const exportFileSize = parseInt(
       responseSnapshotExport.headers['content-length']
     );
-    expect(exportFileSize / 1000).toBeCloseTo(expectedExportSize, 0);
+    expect(exportFileSize).toBeGreaterThan(55_000);
+
+    // la feuille "Personnalisation" est présente
+    expect(wb.getWorksheet('Personnalisation')).toBeDefined();
   }, 30000);
 
   test(`Export du snapshot avec un score indicatif`, async () => {
@@ -378,11 +381,11 @@ sinon ((limite(cae_6.a) - val(cae_6.a)) / (limite(cae_6.a) - cible(cae_6.a)))`,
       .split(';')[0];
 
     expect(exportFileName).toBe(`"Export_CAE_Arbent_${currentDate}.xlsx"`);
-    const expectedExportSize = 221.12;
+    // borne basse : feuille des scores + feuille "Personnalisation"
     const exportFileSize = parseInt(
       responseSnapshotExport.headers['content-length']
     );
-    expect(exportFileSize / 1000).toBeCloseTo(expectedExportSize, 0);
+    expect(exportFileSize).toBeGreaterThan(221_000);
 
     const body = responseSnapshotExport.body as ArrayBuffer;
     const wb = new Workbook();
@@ -566,5 +569,119 @@ Pourcentage indicatif Fait en 2020 de 100% calculé si 300 kg/hab en 2020 (sourc
       'Non renseigné',
       '',
     ]);
+  }, 30000);
+
+  test(`Export xlsx : feuille "Personnalisation" listant toutes les questions du référentiel`, async () => {
+    const referentielId: ReferentielId = 'eci';
+    const collectiviteId = collectivite.id;
+    const caller = router.createCaller({ user: editionUser });
+
+    // une réponse binaire connue
+    await caller.collectivites.personnalisations.setReponse({
+      collectiviteId,
+      questionId: 'dechets_1',
+      reponse: false,
+    });
+
+    const snapshotResult = await snapshotsService.computeAndUpsert({
+      collectiviteId,
+      referentielId,
+      jalon: SnapshotJalonEnum.COURANT,
+    });
+    expect(snapshotResult.success).toBe(true);
+
+    const response = await request(app.getHttpServer())
+      .get(
+        `/collectivites/${collectiviteId}/referentiels/${referentielId}/score-snapshots/export-comparison`
+      )
+      .set('Authorization', `Bearer ${process.env.SUPABASE_ANON_KEY}`)
+      .query({
+        exportFormat: 'excel',
+        isAudit: 'false',
+        snapshotReferences: [SNAPSHOTS.SCORE_COURANT_REF],
+      })
+      .expect(200)
+      .responseType('blob');
+
+    const wb = new Workbook();
+    await wb.xlsx.load(response.body as ArrayBuffer);
+
+    const ws = wb.getWorksheet('Personnalisation');
+    expect(ws).toBeDefined();
+
+    // en-tête : Thématique | Question | Réponse (un seul snapshot => pas de
+    // libellé) | Mesures affectées
+    const header = ws?.getRow(1).values as CellValue[];
+    expect(header?.[1]).toBe('Thématique');
+    expect(header?.[2]).toBe('Question');
+    expect(header?.[3]).toBe('Réponse');
+    expect(header?.[4]).toBe('Mesures affectées');
+    expect(header?.[5]).toBeUndefined();
+
+    const dataRows = ws?.getRows(2, 5000) ?? [];
+    expect(dataRows.length).toBeGreaterThan(1);
+
+    // la question répondue apparaît avec sa réponse "Non"
+    const answered = dataRows.find(
+      (r) => (r.values as CellValue[])?.[3] === 'Non'
+    );
+    expect(answered).toBeDefined();
+
+    // au moins une question du référentiel sans réponse : cellule réponse vide
+    const unanswered = dataRows.find((r) => {
+      const values = r.values as CellValue[];
+      return (
+        typeof values?.[2] === 'string' &&
+        (values?.[3] === '' || values?.[3] === undefined)
+      );
+    });
+    expect(unanswered).toBeDefined();
+
+    // colonne "Mesures affectées" : quand elle est renseignée, une mesure par
+    // ligne au format "identifiant - libellé"
+    const mesuresCells = dataRows
+      .map((r) => (r.values as CellValue[])?.[4])
+      .filter((v): v is string => typeof v === 'string' && v.length > 0);
+    for (const cell of mesuresCells) {
+      for (const line of cell.split('\n')) {
+        expect(line).toMatch(/ - .+/);
+      }
+    }
+
+    // groupement par thématique : la colonne "Thématique" est triée et contiguë
+    const thematiques = dataRows
+      .map((r) => (r.values as CellValue[])?.[1])
+      .filter((t): t is string => typeof t === 'string' && t.length > 0);
+    const contiguousDistinct = thematiques.filter(
+      (t, i) => i === 0 || t !== thematiques[i - 1]
+    );
+    expect(contiguousDistinct).toEqual([...new Set(thematiques)]);
+    expect(contiguousDistinct).toEqual(
+      [...contiguousDistinct].sort((a, b) =>
+        a.localeCompare(b, 'fr', { sensitivity: 'base' })
+      )
+    );
+  }, 30000);
+
+  test(`Export csv : pas de feuille "Personnalisation"`, async () => {
+    const referentielId: ReferentielId = 'eci';
+    const collectiviteId = collectivite.id;
+
+    const response = await request(app.getHttpServer())
+      .get(
+        `/collectivites/${collectiviteId}/referentiels/${referentielId}/score-snapshots/export-comparison`
+      )
+      .set('Authorization', `Bearer ${process.env.SUPABASE_ANON_KEY}`)
+      .query({
+        exportFormat: 'csv',
+        isAudit: 'false',
+        snapshotReferences: [SNAPSHOTS.SCORE_COURANT_REF],
+      })
+      .expect(200)
+      .responseType('blob');
+
+    // un CSV est mono-feuille : seule la feuille des scores est sérialisée
+    const csv = (response.body as Buffer).toString('utf-8');
+    expect(csv).not.toContain('Thématique');
   }, 30000);
 });

--- a/apps/backend/src/referentiels/export-score/export-score-comparison.service.ts
+++ b/apps/backend/src/referentiels/export-score/export-score-comparison.service.ts
@@ -6,6 +6,7 @@ import {
   ReferentielId,
 } from '@tet/domain/referentiels';
 import { Workbook } from 'exceljs';
+import { buildPersonnalisationRows } from './build-personnalisation-rows';
 import { buildRows } from './build-rows';
 import {
   ExportScoreComparisonError,
@@ -56,6 +57,10 @@ export class ExportScoreComparisonService {
 
       if (exportFormat === 'csv') {
         sanitizeWorksheetForCsvExport(worksheet);
+      } else {
+        // la feuille "Personnalisation" n'est ajoutée que pour le format excel
+        const personnalisationSheet = workbook.addWorksheet('Personnalisation');
+        buildPersonnalisationRows(scoreComparisonData, personnalisationSheet);
       }
 
       const buffer =

--- a/apps/backend/src/referentiels/export-score/load-score-comparison.service.ts
+++ b/apps/backend/src/referentiels/export-score/load-score-comparison.service.ts
@@ -1,26 +1,30 @@
-import { AuthUser } from '@tet/backend/users/models/auth.models';
 import { Injectable, Logger } from '@nestjs/common';
+import ListPersonnalisationQuestionsService from '@tet/backend/collectivites/personnalisations/list-personnalisation-questions/list-personnalisation-questions.service';
 import ListFichesService from '@tet/backend/plans/fiches/list-fiches/list-fiches.service';
 import { HandleMesureServicesService } from '@tet/backend/referentiels/handle-mesure-services/handle-mesure-services.service';
 import { auditeurTable } from '@tet/backend/referentiels/labellisations/auditeur.table';
+import { AuthUser } from '@tet/backend/users/models/auth.models';
 import { dcpTable } from '@tet/backend/users/models/dcp.table';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { failure, success, type Result } from '@tet/backend/utils/result.type';
 import { unaccent } from '@tet/backend/utils/unaccent.utils';
 import {
   PersonneTagOrUser,
+  QuestionType,
   TagWithCollectiviteId,
 } from '@tet/domain/collectivites';
 import {
   ActionId,
   flatMapActionsEnfants,
   ReferentielId,
+  rollUpActionIdToActionLevel,
   ScoreSnapshot,
   SnapshotJalonEnum,
   TreeOfActionsIncludingScore,
   type ActionType,
   type ExportScoreComparisonRequestQuery,
 } from '@tet/domain/referentiels';
+import { htmlToText } from '@tet/domain/utils';
 import { format } from 'date-fns';
 import { and, desc, eq } from 'drizzle-orm';
 import * as Utils from '../../utils/excel/export-excel.utils';
@@ -51,6 +55,34 @@ export type ScoreRow = {
   score2: TreeOfActionsIncludingScore | null;
 };
 
+/** Mesure du référentiel exporté affectée par une question de personnalisation */
+export type MesureAffectee = {
+  actionId: ActionId;
+  /** numérotation de la mesure (ex. « 1.2.3 »), vide pour le référentiel CR */
+  identifiant: string;
+  /** libellé de la mesure */
+  nom: string;
+};
+
+export type PersonnalisationExportQuestion = {
+  questionId: string;
+  thematiqueNom: string | null;
+  /** libellé de la question en texte brut */
+  formulation: string;
+  /** ordre d'affichage de la question au sein de sa thématique */
+  ordonnancement: number | null;
+  type: QuestionType;
+  choix: { id: string; formulation: string }[];
+  /**
+   * Mesures du référentiel exporté affectées par la question : chaque lien
+   * question→action est remonté au niveau « mesure » puis dédoublonné, comme
+   * dans la section « Afficher les mesures affectées et règles associées » de la
+   * page Personnalisation. Le résultat est restreint aux mesures du référentiel
+   * exporté (un lien pointant vers un autre référentiel est ignoré).
+   */
+  mesuresAffectees: MesureAffectee[];
+};
+
 export type ScoreComparisonData = {
   collectiviteName: string;
   referentielId: ReferentielId;
@@ -67,6 +99,7 @@ export type ScoreComparisonData = {
   pilotes: Record<ActionId, PersonneTagOrUser[]>;
   services: Record<ActionId, TagWithCollectiviteId[]>;
   fichesActionLiees: Record<ActionId, string>;
+  personnalisationQuestions: PersonnalisationExportQuestion[];
 };
 
 export enum ExportMode {
@@ -94,7 +127,8 @@ export class LoadScoreComparisonService {
     private readonly handlePilotesService: HandleMesurePilotesService,
     private readonly handleServicesService: HandleMesureServicesService,
     private readonly getReferentielService: GetReferentielService,
-    private readonly listFichesService: ListFichesService
+    private readonly listFichesService: ListFichesService,
+    private readonly listPersonnalisationQuestionsService: ListPersonnalisationQuestionsService
   ) {}
 
   async loadScoreComparison(
@@ -163,7 +197,11 @@ export class LoadScoreComparisonService {
           referentielId
         )
       : null;
-    const descriptions = await this.getActionDescriptions(referentielId);
+    // un seul chargement de l'arbre du référentiel exporté, consommé à la fois
+    // pour les descriptions d'action et pour les mesures affectées des questions
+    // de personnalisation
+    const { hierarchie, actionsById, descriptions } =
+      await this.getReferentielActionsIndex(referentielId);
     const mesureIds = scoreRows.map((r) => r.actionId);
     const pilotes = await this.handlePilotesService.listPilotes(
       collectiviteId,
@@ -177,6 +215,10 @@ export class LoadScoreComparisonService {
       collectiviteId,
       mesureIds,
       { user }
+    );
+    const personnalisationQuestions = await this.getPersonnalisationQuestions(
+      referentielId,
+      { hierarchie, actionsById }
     );
 
     const { snapshot1Label, snapshot2Label } = this.getScoreHeaderLabels(
@@ -209,7 +251,154 @@ export class LoadScoreComparisonService {
       pilotes,
       services,
       fichesActionLiees,
+      personnalisationQuestions,
     });
+  }
+
+  /**
+   * Charge toutes les questions de personnalisation rattachées au référentiel
+   * exporté (indépendamment de leur activation pour la collectivité) et les
+   * prépare pour la feuille "Personnalisation".
+   */
+  private async getPersonnalisationQuestions(
+    referentielId: ReferentielId,
+    actionsIndex: {
+      hierarchie: ActionType[];
+      actionsById: Map<ActionId, { identifiant: string; nom: string }>;
+    }
+  ): Promise<PersonnalisationExportQuestion[]> {
+    try {
+      const questions =
+        await this.listPersonnalisationQuestionsService.listQuestionsWithChoices(
+          [referentielId]
+        );
+      return questions.map((question) => ({
+        questionId: question.id,
+        thematiqueNom: question.thematiqueNom ?? null,
+        formulation: htmlToText(question.formulation || '').trim(),
+        ordonnancement: question.ordonnancement ?? null,
+        type: question.type,
+        choix: (question.choix ?? []).map((choix) => ({
+          id: choix.id,
+          formulation: choix.formulation,
+        })),
+        mesuresAffectees: this.resolveMesuresAffectees(
+          question.actionIds,
+          actionsIndex
+        ),
+      }));
+    } catch (error) {
+      this.logger.warn(
+        `Erreur lors de la récupération des questions de personnalisation pour le référentiel ${referentielId}:`,
+        error
+      );
+      return [];
+    }
+  }
+
+  /**
+   * Charge l'arbre du référentiel exporté une seule fois et en dérive :
+   * - `hierarchie` : les niveaux ordonnés du référentiel (axe, sous-axe,
+   *   mesure…), nécessaires pour remonter un lien question→action au niveau
+   *   « mesure » ;
+   * - `actionsById` : index par `actionId` (numérotation + libellé), pour
+   *   résoudre les mesures affectées par les questions de personnalisation ;
+   * - `descriptions` : description HTML nettoyée, par `actionId`.
+   */
+  private async getReferentielActionsIndex(
+    referentielId: ReferentielId
+  ): Promise<{
+    hierarchie: ActionType[];
+    actionsById: Map<ActionId, { identifiant: string; nom: string }>;
+    descriptions: Record<ActionId, string>;
+  }> {
+    const referentiel = await this.getReferentielService.getReferentielTree(
+      referentielId
+    );
+
+    type ActionNode = {
+      actionId?: ActionId;
+      identifiant?: string | null;
+      nom?: string | null;
+      description?: string | null;
+      actionsEnfant?: ActionNode[];
+    };
+
+    const actionsById = new Map<
+      ActionId,
+      { identifiant: string; nom: string }
+    >();
+    const descriptions: Record<ActionId, string> = {};
+    const walk = (node: ActionNode) => {
+      if (node.actionId) {
+        actionsById.set(node.actionId, {
+          identifiant: node.identifiant ?? '',
+          nom: (node.nom ?? '').trim(),
+        });
+        if (node.description) {
+          descriptions[node.actionId] = Utils.cleanHtmlDescription(
+            node.description
+          );
+        }
+      }
+      node.actionsEnfant?.forEach(walk);
+    };
+    walk(referentiel.itemsTree as ActionNode);
+
+    return {
+      hierarchie: referentiel.orderedItemTypes,
+      actionsById,
+      descriptions,
+    };
+  }
+
+  /**
+   * Reproduit la logique de la section « Afficher les mesures affectées et
+   * règles associées » de la page personnalisation : remonte chaque lien
+   * question→action au niveau « mesure » (via `rollUpActionIdToActionLevel`),
+   * dédoublonne, puis résout numérotation et libellé depuis l'index du
+   * référentiel exporté.
+   *
+   * - le tri est fait ici (et non en SQL) car `array_agg` trie de façon
+   *   lexicographique et placerait « 4.10 » avant « 4.2 » ;
+   * - le `flatMap` ne conserve que les mesures présentes dans l'index : c'est ce
+   *   qui restreint le résultat au seul référentiel exporté (un lien vers une
+   *   autre version / un autre référentiel est ignoré).
+   */
+  private resolveMesuresAffectees(
+    actionIds: string[] | null | undefined,
+    {
+      hierarchie,
+      actionsById,
+    }: {
+      hierarchie: ActionType[];
+      actionsById: Map<ActionId, { identifiant: string; nom: string }>;
+    }
+  ): MesureAffectee[] {
+    if (!actionIds?.length) {
+      return [];
+    }
+
+    const mesureIds = [
+      ...new Set(
+        actionIds.map((actionId) => {
+          try {
+            return rollUpActionIdToActionLevel(actionId, hierarchie);
+          } catch {
+            return actionId;
+          }
+        })
+      ),
+    ];
+
+    return mesureIds
+      .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
+      .flatMap((actionId) => {
+        const action = actionsById.get(actionId);
+        return action
+          ? [{ actionId, identifiant: action.identifiant, nom: action.nom }]
+          : [];
+      });
   }
 
   private getExportMode(
@@ -462,37 +651,6 @@ export class LoadScoreComparisonService {
         sensitivity: 'base',
       });
     });
-  }
-
-  private async getActionDescriptions(
-    referentielId: ReferentielId
-  ): Promise<Record<ActionId, string>> {
-    const referentiel = await this.getReferentielService.getReferentielTree(
-      referentielId
-    );
-
-    const descriptions: Record<string, string> = {};
-
-    type ActionWithAllFields = typeof referentiel.itemsTree & {
-      description?: string;
-      nom?: string;
-      identifiant?: string;
-      actionsEnfant?: ActionWithAllFields[];
-    };
-
-    const extractDescriptions = (action: ActionWithAllFields) => {
-      if (action.actionId && action.description) {
-        descriptions[action.actionId] = Utils.cleanHtmlDescription(
-          action.description
-        );
-      }
-      if (action.actionsEnfant) {
-        action.actionsEnfant.forEach(extractDescriptions);
-      }
-    };
-
-    extractDescriptions(referentiel.itemsTree as ActionWithAllFields);
-    return descriptions;
   }
 
   private async getFichesActionLiees(

--- a/apps/backend/src/utils/excel/export-excel.utils.ts
+++ b/apps/backend/src/utils/excel/export-excel.utils.ts
@@ -69,6 +69,14 @@ export const getNumberFormat = (value: CellValue, numFmt?: string) => {
   }
 
   if (numFmt === FORMAT_PERCENT) {
+    // Excel / LibreOffice affichent toujours le séparateur décimal littéral du
+    // format, même sans décimale : `0.#%` produit "17,%" pour un pourcentage
+    // entier. On ne garde la décimale optionnelle que si la valeur en affiche
+    // effectivement une (au 1er chiffre près, ce que `0.#%` montrerait).
+    if (typeof value === 'number') {
+      const percent = Math.round(value * 1000) / 10;
+      return Number.isInteger(percent) ? '0%' : '0.#%';
+    }
     return '0.#%';
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Nouvelles fonctionnalités**
  - Les exports de scores au format Excel incluent désormais une feuille « Personnalisation ».
  - Cette feuille présente les questions, leurs thématiques, les réponses et les mesures associées.
  - Les réponses sont formatées selon leur type : Oui/Non, pourcentage ou libellé des choix.
  - Les questions sont triées par thématique, puis par ordre et intitulé.
  - Les exports CSV restent inchangés et n’incluent pas cette feuille.

- **Améliorations**
  - Les pourcentages affichent un format plus lisible, avec une décimale uniquement lorsque nécessaire.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->