### PR TITLE
fix(documents): rétablit l'export du type AppRouter

### DIFF
--- a/apps/backend/src/collectivites/documents/create-upload-token/create-upload-token.input.ts
+++ b/apps/backend/src/collectivites/documents/create-upload-token/create-upload-token.input.ts
@@ -3,11 +3,9 @@ import * as z from 'zod';
 
 export const createUploadTokenInputSchema = z.object({
   collectiviteId: z.number().int().positive(),
-  hash: documentHashSchema.brand<'DocumentHash'>(),
+  hash: documentHashSchema,
 });
 
 export type CreateUploadTokenInput = z.infer<
   typeof createUploadTokenInputSchema
 >;
-
-export type DocumentHash = CreateUploadTokenInput['hash'];

--- a/apps/backend/src/collectivites/documents/create-upload-token/create-upload-token.service.spec.ts
+++ b/apps/backend/src/collectivites/documents/create-upload-token/create-upload-token.service.spec.ts
@@ -4,10 +4,8 @@ import { DocumentStorageErrorEnum } from '@tet/backend/utils/supabase/document-s
 import { type DocumentStorageError } from '@tet/backend/utils/supabase/document-storage.errors';
 import { describe, expect, it, vi, type Mock } from 'vitest';
 import { CreateUploadTokenService } from './create-upload-token.service';
-import { type DocumentHash } from './create-upload-token.input';
 
-const HASH =
-  'ec07d0538e44a333b23b936c9a4ba37fbd211c6272e632d2173b6abe102a0482' as DocumentHash;
+const HASH = 'ec07d0538e44a333b23b936c9a4ba37fbd211c6272e632d2173b6abe102a0482';
 
 const user: AuthenticatedUser = { id: 'user-id' } as AuthenticatedUser;
 


### PR DESCRIPTION
**Correctif bloquant.** `app:typecheck` échoue sur `main` avec 921 erreurs. Toute PR touchant `apps/app` est bloquée.

## La cause

L'entrée de `collectivites.documents.createUploadToken` marquait son hash d'une marque de type zod :

```ts
hash: documentHashSchema.brand<'DocumentHash'>(),
```

`z.brand()` produit une interface à clé symbole. TypeScript ne sait pas la nommer depuis un autre paquet, donc `TrpcRouter['appRouter']` devient incalculable et **l'export `AppRouter` disparaît** :

```
packages/api/src/utils/trpc/trpc-server-client.ts:14 - error TS2305:
  Module '"@tet/backend/utils/trpc/trpc.router"' has no exported member 'AppRouter'.
```

Le front s'effondre en conséquence : chaque `RouterInput` et `RouterOutput` retombe sur `{}`, d'où des centaines de « Property does not exist on type `{}` » et « not assignable to parameter of type `void` ». Une cause, 921 symptômes.

Mesuré : marque retirée, `apps/app` passe de **921 erreurs à 0**.

## Pourquoi la CI ne l'a pas vu

Le typecheck du backend reste vert — à l'intérieur du paquet où elle est déclarée, la marque est nommable. Et `app:typecheck` ne s'exécute que si `apps/app` fait partie des projets affectés, ce qu'aucune PR n'avait déclenché depuis.

## Ce qui reste

La regex `/^[0-9a-f]{64}$/` sur le hash est conservée : c'est elle qui empêche un chemin de la forme `../autreBucket/x` d'obtenir une signature d'écriture dans le bucket d'une autre collectivité.

La marque n'ajoutait qu'une garantie au niveau des types, contre un appelant interne du service qui contournerait le routeur. Cet appelant n'existe pas, et le prix — un `AppRouter` inutilisable côté front — est sans commune mesure.

## Enseignement

Un type qui traverse une frontière de paquet doit être **nommable** de l'autre côté. Les marques zod, les enums nominaux et les types à clé symbole ne le sont pas, et un type de routeur tRPC traverse par construction.
