### PR TITLE
refactor(documents): marque le type du hash et adresse le rapport par son identifiant

### DIFF
--- a/apps/app/src/labels/catalog.ts
+++ b/apps/app/src/labels/catalog.ts
@@ -953,6 +953,10 @@ export const appLabels = {
   champDetailAfficheParAction: 'Détail affiché par action',
   optionDerniereNoteAction: "Inclure la dernière note de l'action",
   optionSaisieManuelleRapport: 'Inclure une section vide pour saisie libre',
+  rapportFichierIntrouvable:
+    'Le rapport a été généré mais son fichier est introuvable',
+  rapportGenerationEchouee: (reason: string | null): string =>
+    `La génération du rapport a échoué : ${reason ?? 'erreur inconnue'}`,
   apercuLogoAlt: 'Aperçu du logo',
   fichierSelectionne: 'Fichier sélectionné',
   champThematiqueColon: 'Thématique :',

--- a/apps/app/src/plans/reports/generate-plan-report-pptx/use-is-pending-report.ts
+++ b/apps/app/src/plans/reports/generate-plan-report-pptx/use-is-pending-report.ts
@@ -1,21 +1,19 @@
 'use client';
 
-import { saveBlob } from '@/app/utils/save-blob';
+import { appLabels } from '@/app/labels/catalog';
+import { useDownloadDocument } from '@/app/referentiels/preuves/data/use-download-document';
 import { useBaseToast } from '@/app/utils/toast/use-base-toast';
-import { useApiClient } from '@/app/utils/use-api-client';
 import { useQuery } from '@tanstack/react-query';
 import { useTRPC } from '@tet/api';
 import { useCollectiviteId } from '@tet/api/collectivites';
 import { ReportGenerationStatusEnum } from '@tet/domain/plans';
-import { getErrorMessage } from '@tet/domain/utils';
 import { useQueryState } from 'nuqs';
-import { useCallback, useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 
 const POLLING_INTERVAL = 2000;
 
 export const useIsPendingReport = () => {
   const trpc = useTRPC();
-  const apiClient = useApiClient();
   const { setToast, renderToast } = useBaseToast();
   const collectiviteId = useCollectiviteId();
   const lastDownloadedReportIdRef = useRef<string | null>(null);
@@ -39,81 +37,41 @@ export const useIsPendingReport = () => {
     },
   });
 
-  const downloadReport = useCallback(
-    async (
-      collectiviteId: number,
-      reportGenerationId: string,
-      onSuccess: (filename: string) => void,
-      onFailure: (error: unknown) => void
-    ) => {
-      try {
-        const { blob, filename } = await apiClient.getAsBlob({
-          route: `/collectivites/${collectiviteId}/documents/${reportGenerationId}/download`,
-        });
-
-        if (filename && blob) {
-          saveBlob(blob, filename);
-        }
-        onSuccess(filename ?? '');
-      } catch (error) {
-        console.error(error);
-        onFailure(error);
-      }
-    },
-    [apiClient]
-  );
+  const { mutate: downloadDocument } = useDownloadDocument({ collectiviteId });
 
   // Handle report status changes
   useEffect(() => {
     if (!reportStatus || !pendingReportId) return;
 
-    const fileCanBeDownloaded =
-      reportStatus.status === ReportGenerationStatusEnum.COMPLETED &&
-      reportStatus.fileId;
-    if (fileCanBeDownloaded) {
-      if (lastDownloadedReportIdRef.current === reportStatus.id) {
-        // Do not download the same report twice
-        return;
-      }
-      lastDownloadedReportIdRef.current = reportStatus.id;
-      setToast('info', 'Téléchargement du rapport en cours...');
-      downloadReport(
-        collectiviteId,
-        reportStatus.id,
-        (fileName) => {
-          setToast(
-            'success',
-            `Le rapport ${fileName} a été téléchargé avec succès`
-          );
-          setPendingReportId(null);
-        },
-        (error) => {
-          setToast(
-            'error',
-            `Une erreur est survenue lors du téléchargement du rapport: ${getErrorMessage(
-              error
-            )}`
-          );
-          setPendingReportId(null);
-        }
-      );
-    }
-
     if (reportStatus.status === ReportGenerationStatusEnum.FAILED) {
       setToast(
         'error',
-        `La génération du rapport a échoué: ${
-          reportStatus.errorMessage ?? 'Erreur inconnue'
-        }`
+        appLabels.rapportGenerationEchouee(reportStatus.errorMessage)
       );
       setPendingReportId(null);
+      return;
     }
+
+    if (reportStatus.status !== ReportGenerationStatusEnum.COMPLETED) return;
+
+    const { fileId } = reportStatus;
+    if (fileId === null) {
+      setToast('error', appLabels.rapportFichierIntrouvable);
+      setPendingReportId(null);
+      return;
+    }
+
+    if (lastDownloadedReportIdRef.current === reportStatus.id) return;
+
+    lastDownloadedReportIdRef.current = reportStatus.id;
+    downloadDocument(fileId, {
+      onSettled: () => setPendingReportId(null),
+    });
   }, [
     reportStatus,
     pendingReportId,
     setToast,
-    downloadReport,
-    collectiviteId,
+    downloadDocument,
     setPendingReportId,
   ]);
 

--- a/apps/backend/src/collectivites/documents/create-upload-token/create-upload-token.service.spec.ts
+++ b/apps/backend/src/collectivites/documents/create-upload-token/create-upload-token.service.spec.ts
@@ -2,10 +2,13 @@ import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { failure, success, type Result } from '@tet/backend/utils/result.type';
 import { DocumentStorageErrorEnum } from '@tet/backend/utils/supabase/document-storage.errors';
 import { type DocumentStorageError } from '@tet/backend/utils/supabase/document-storage.errors';
+import { toDocumentHash } from '@tet/domain/collectivites';
 import { describe, expect, it, vi, type Mock } from 'vitest';
 import { CreateUploadTokenService } from './create-upload-token.service';
 
-const HASH = 'ec07d0538e44a333b23b936c9a4ba37fbd211c6272e632d2173b6abe102a0482';
+const HASH = toDocumentHash(
+  'ec07d0538e44a333b23b936c9a4ba37fbd211c6272e632d2173b6abe102a0482'
+);
 
 const user: AuthenticatedUser = { id: 'user-id' } as AuthenticatedUser;
 

--- a/apps/backend/src/collectivites/documents/document.controller.e2e-spec.ts
+++ b/apps/backend/src/collectivites/documents/document.controller.e2e-spec.ts
@@ -108,6 +108,27 @@ describe('Document Controller', () => {
       expect(response.body.hash).toMatch(/^[a-f0-9]{64}$/);
     });
 
+    test("un contenu déjà déposé rend le document existant plutôt qu'une erreur", async () => {
+      const firstUpload = await request(app.getHttpServer())
+        .post(`/collectivites/${collectiviteId}/documents/upload`)
+        .set('Authorization', `Bearer ${adminAuthToken}`)
+        .attach('file', testPdfBuffer, 'premier-nom.pdf')
+        .field('confidentiel', 'false')
+        .expect(201);
+
+      const secondUpload = await request(app.getHttpServer())
+        .post(`/collectivites/${collectiviteId}/documents/upload`)
+        .set('Authorization', `Bearer ${adminAuthToken}`)
+        .attach('file', testPdfBuffer, 'second-nom.pdf')
+        .field('confidentiel', 'false')
+        .expect(201);
+
+      expect(secondUpload.body).toMatchObject({
+        id: firstUpload.body.id,
+        filename: 'premier-nom.pdf',
+      });
+    });
+
     test('upload document with confidentiel true', async () => {
       const fileName = 'confidentiel-doc.pdf';
 

--- a/apps/backend/src/collectivites/documents/get-download-url/get-download-url.service.spec.ts
+++ b/apps/backend/src/collectivites/documents/get-download-url/get-download-url.service.spec.ts
@@ -1,11 +1,14 @@
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { failure, success } from '@tet/backend/utils/result.type';
 import { DocumentStorageErrorEnum } from '@tet/backend/utils/supabase/document-storage.errors';
+import { toDocumentHash } from '@tet/domain/collectivites';
 import { describe, expect, it, vi, type Mock } from 'vitest';
 import { GetDownloadUrlService } from './get-download-url.service';
 import { type DocumentToDownload } from './get-download-url.repository';
 
-const HASH = 'ec07d0538e44a333b23b936c9a4ba37fbd211c6272e632d2173b6abe102a0482';
+const HASH = toDocumentHash(
+  'ec07d0538e44a333b23b936c9a4ba37fbd211c6272e632d2173b6abe102a0482'
+);
 
 const FICHIER_ID = 42;
 

--- a/apps/backend/src/collectivites/documents/store-document/calculate-document-hash.utils.ts
+++ b/apps/backend/src/collectivites/documents/store-document/calculate-document-hash.utils.ts
@@ -1,0 +1,5 @@
+import { DocumentHash, toDocumentHash } from '@tet/domain/collectivites';
+import { createHash } from 'crypto';
+
+export const calculateDocumentHash = (content: Buffer): DocumentHash =>
+  toDocumentHash(createHash('sha256').update(content).digest('hex'));

--- a/apps/backend/src/collectivites/documents/store-document/store-document.service.spec.ts
+++ b/apps/backend/src/collectivites/documents/store-document/store-document.service.spec.ts
@@ -1,0 +1,47 @@
+import { Mock, describe, expect, it, vi } from 'vitest';
+import { StoreDocumentService } from './store-document.service';
+
+const UNREADABLE_FILE_PATH = '/tmp/tet-rapport-inexistant-4f2a9c.pptx';
+
+type ServiceUnderTest = {
+  service: StoreDocumentService;
+  saveInStorage: Mock;
+};
+
+function buildServiceWithBucket(bucketId: string): ServiceUnderTest {
+  const databaseService = {
+    db: {
+      select: () => ({
+        from: () => ({
+          where: () => [{ bucketId }],
+        }),
+      }),
+    },
+  };
+  const permissionService = { isAllowed: vi.fn() };
+  const saveInStorage = vi.fn();
+
+  const service = new StoreDocumentService(
+    databaseService as never,
+    permissionService as never,
+    { saveInStorage } as never
+  );
+
+  return { service, saveInStorage };
+}
+
+describe('StoreDocumentService.uploadLocalFile', () => {
+  it('rend UPLOAD_STORAGE_ERROR sans lever quand le fichier local est illisible', async () => {
+    const { service, saveInStorage } = buildServiceWithBucket(
+      'bucket-collectivite-1'
+    );
+
+    const result = await service.uploadLocalFile(
+      { collectiviteId: 1, filename: 'rapport.pptx', confidentiel: false },
+      UNREADABLE_FILE_PATH
+    );
+
+    expect(result).toEqual({ success: false, error: 'UPLOAD_STORAGE_ERROR' });
+    expect(saveInStorage).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/collectivites/documents/store-document/store-document.service.ts
+++ b/apps/backend/src/collectivites/documents/store-document/store-document.service.ts
@@ -8,16 +8,16 @@ import { Result } from '@tet/backend/utils/result.type';
 import {
   BibliothequeFichier,
   BibliothequeFichierCreate,
-  toDocumentHash,
+  DocumentHash,
 } from '@tet/domain/collectivites';
 import { ResourceType } from '@tet/domain/users';
 import { getErrorMessage } from '@tet/domain/utils';
-import { createHash } from 'crypto';
 import { and, eq } from 'drizzle-orm';
 import { readFile } from 'fs/promises';
 import * as mime from 'mime-types';
 import { bibliothequeFichierTable } from '../models/bibliotheque-fichier.table';
 import { storageObjectTable } from '../models/storage-object.table';
+import { calculateDocumentHash } from './calculate-document-hash.utils';
 import {
   StoreDocumentError,
   StoreDocumentErrorEnum,
@@ -25,6 +25,8 @@ import {
 
 // Type for multer file upload
 type MulterFile = Express.Multer.File;
+
+export type DocumentToUpload = Omit<BibliothequeFichierCreate, 'hash'>;
 
 @Injectable()
 export class StoreDocumentService {
@@ -58,7 +60,7 @@ export class StoreDocumentService {
   }
 
   async uploadLocalFile(
-    document: Omit<BibliothequeFichierCreate, 'hash'>,
+    document: DocumentToUpload,
     localFilePath: string,
     user?: AuthenticatedUser
   ): Promise<Result<BibliothequeFichier, StoreDocumentError>> {
@@ -88,9 +90,7 @@ export class StoreDocumentService {
     const mimeType = mime.lookup(localFilePath) || undefined;
 
     const fileBuffer = await readFile(localFilePath);
-    const hash = toDocumentHash(
-      createHash('sha256').update(fileBuffer).digest('hex')
-    );
+    const hash = calculateDocumentHash(fileBuffer);
 
     this.logger.log(
       `Uploading file ${localFilePath} with mime type ${mimeType} to bucket ${bucketId} with hash ${hash}`
@@ -107,6 +107,30 @@ export class StoreDocumentService {
     }
 
     return await this.storeDocument({ ...document, hash }, user);
+  }
+
+  private async findDocumentByHash(
+    collectiviteId: number,
+    hash: DocumentHash
+  ): Promise<BibliothequeFichier | undefined> {
+    const [document] = await this.databaseService.db
+      .select({
+        id: bibliothequeFichierTable.id,
+        collectiviteId: bibliothequeFichierTable.collectiviteId,
+        hash: bibliothequeFichierTable.hash,
+        filename: bibliothequeFichierTable.filename,
+        confidentiel: bibliothequeFichierTable.confidentiel,
+      })
+      .from(bibliothequeFichierTable)
+      .where(
+        and(
+          eq(bibliothequeFichierTable.collectiviteId, collectiviteId),
+          eq(bibliothequeFichierTable.hash, hash)
+        )
+      )
+      .limit(1);
+
+    return document;
   }
 
   async uploadBuffer(
@@ -146,10 +170,7 @@ export class StoreDocumentService {
     }
     const bucketId = bucketResult.data;
 
-    // Compute SHA-256 hash from buffer
-    const hash = toDocumentHash(
-      createHash('sha256').update(file.buffer).digest('hex')
-    );
+    const hash = calculateDocumentHash(file.buffer);
 
     this.logger.log(
       `Uploading buffer with mime type ${mimeType} to bucket ${bucketId} with hash ${hash}`
@@ -230,12 +251,30 @@ export class StoreDocumentService {
           filename: document.filename,
           confidentiel: document.confidentiel ?? false,
         })
+        .onConflictDoNothing({
+          target: [
+            bibliothequeFichierTable.collectiviteId,
+            bibliothequeFichierTable.hash,
+          ],
+        })
         .returning();
 
-      return {
-        success: true,
-        data: insertedDocument as BibliothequeFichier,
-      };
+      if (insertedDocument) {
+        return {
+          success: true,
+          data: insertedDocument as BibliothequeFichier,
+        };
+      }
+
+      const existingDocument = await this.findDocumentByHash(
+        document.collectiviteId,
+        document.hash
+      );
+      if (!existingDocument) {
+        return { success: false, error: 'STORE_DOCUMENT_ERROR' };
+      }
+
+      return { success: true, data: existingDocument };
     } catch (error) {
       this.logger.error(
         `Erreur lors de la création du document ${

--- a/apps/backend/src/collectivites/documents/store-document/store-document.service.ts
+++ b/apps/backend/src/collectivites/documents/store-document/store-document.service.ts
@@ -8,6 +8,7 @@ import { Result } from '@tet/backend/utils/result.type';
 import {
   BibliothequeFichier,
   BibliothequeFichierCreate,
+  toDocumentHash,
 } from '@tet/domain/collectivites';
 import { ResourceType } from '@tet/domain/users';
 import { getErrorMessage } from '@tet/domain/utils';
@@ -57,7 +58,7 @@ export class StoreDocumentService {
   }
 
   async uploadLocalFile(
-    document: BibliothequeFichierCreate,
+    document: Omit<BibliothequeFichierCreate, 'hash'>,
     localFilePath: string,
     user?: AuthenticatedUser
   ): Promise<Result<BibliothequeFichier, StoreDocumentError>> {
@@ -86,14 +87,18 @@ export class StoreDocumentService {
 
     const mimeType = mime.lookup(localFilePath) || undefined;
 
-    this.logger.log(
-      `Uploading file ${localFilePath} with mime type ${mimeType} to bucket ${bucketId} with hash ${document.hash}`
+    const fileBuffer = await readFile(localFilePath);
+    const hash = toDocumentHash(
+      createHash('sha256').update(fileBuffer).digest('hex')
     );
 
-    const fileBuffer = await readFile(localFilePath);
+    this.logger.log(
+      `Uploading file ${localFilePath} with mime type ${mimeType} to bucket ${bucketId} with hash ${hash}`
+    );
+
     const saveResult = await this.supabaseService.saveInStorage({
       bucket: bucketId,
-      path: document.hash,
+      path: hash,
       file: fileBuffer,
       mimeType,
     });
@@ -101,7 +106,7 @@ export class StoreDocumentService {
       return saveResult;
     }
 
-    return await this.storeDocument(document, user);
+    return await this.storeDocument({ ...document, hash }, user);
   }
 
   async uploadBuffer(
@@ -142,7 +147,9 @@ export class StoreDocumentService {
     const bucketId = bucketResult.data;
 
     // Compute SHA-256 hash from buffer
-    const hash = createHash('sha256').update(file.buffer).digest('hex');
+    const hash = toDocumentHash(
+      createHash('sha256').update(file.buffer).digest('hex')
+    );
 
     this.logger.log(
       `Uploading buffer with mime type ${mimeType} to bucket ${bucketId} with hash ${hash}`

--- a/apps/backend/src/collectivites/documents/store-document/store-document.service.ts
+++ b/apps/backend/src/collectivites/documents/store-document/store-document.service.ts
@@ -89,7 +89,11 @@ export class StoreDocumentService {
 
     const mimeType = mime.lookup(localFilePath) || undefined;
 
-    const fileBuffer = await readFile(localFilePath);
+    const fileBufferResult = await this.readLocalFile(localFilePath);
+    if (!fileBufferResult.success) {
+      return fileBufferResult;
+    }
+    const fileBuffer = fileBufferResult.data;
     const hash = calculateDocumentHash(fileBuffer);
 
     this.logger.log(
@@ -107,6 +111,24 @@ export class StoreDocumentService {
     }
 
     return await this.storeDocument({ ...document, hash }, user);
+  }
+
+  private async readLocalFile(
+    localFilePath: string
+  ): Promise<
+    Result<Buffer, typeof StoreDocumentErrorEnum.UPLOAD_STORAGE_ERROR>
+  > {
+    try {
+      return { success: true, data: await readFile(localFilePath) };
+    } catch (error) {
+      this.logger.error(
+        `Cannot read local file ${localFilePath}: ${getErrorMessage(error)}`
+      );
+      return {
+        success: false,
+        error: StoreDocumentErrorEnum.UPLOAD_STORAGE_ERROR,
+      };
+    }
   }
 
   private async findDocumentByHash(

--- a/apps/backend/src/plans/reports/generate-plan-report-pptx/generate-reports.application-service.ts
+++ b/apps/backend/src/plans/reports/generate-plan-report-pptx/generate-reports.application-service.ts
@@ -326,7 +326,6 @@ export class GenerateReportsApplicationService {
       const uploadResult = await this.storeDocumentService.uploadLocalFile(
         {
           collectiviteId: collectiviteId,
-          hash: generationId,
           filename: reportName,
           confidentiel: false,
         },

--- a/apps/backend/src/plans/reports/generate-plan-report-pptx/generate-reports.router.e2e-spec.ts
+++ b/apps/backend/src/plans/reports/generate-plan-report-pptx/generate-reports.router.e2e-spec.ts
@@ -1,6 +1,5 @@
 import { INestApplication } from '@nestjs/common';
 import {
-  getAuthToken,
   getAuthUserFromUserCredentials,
   getTestApp,
   getTestDatabase,
@@ -8,9 +7,8 @@ import {
 } from '@tet/backend/test';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { addTestUser } from '@tet/backend/users/users/users.test-fixture';
-import { sleep } from '@tet/backend/utils/sleep.utils';
+import { ReportGeneration } from '@tet/domain/plans';
 import { CollectiviteRole } from '@tet/domain/users';
-import { default as request } from 'supertest';
 import { TrpcRouter } from '../../../utils/trpc/trpc.router';
 
 const SEED_DATA_PLAN_ID = 1;
@@ -21,7 +19,6 @@ describe('generate-reports.router.e2e-spec.ts', () => {
   let router: TrpcRouter;
   let adminUser: AuthenticatedUser;
   let noAccessUser: AuthenticatedUser;
-  let adminToken: string;
 
   beforeAll(async () => {
     app = await getTestApp();
@@ -34,10 +31,6 @@ describe('generate-reports.router.e2e-spec.ts', () => {
       role: CollectiviteRole.ADMIN,
     });
     adminUser = getAuthUserFromUserCredentials(adminResult.user);
-    adminToken = await getAuthToken({
-      email: adminResult.user.email ?? '',
-      password: adminResult.user.password,
-    });
 
     // User without access (for permission test)
     const noAccessResult = await addTestUser(db);
@@ -60,50 +53,40 @@ describe('generate-reports.router.e2e-spec.ts', () => {
 
     expect(reportGeneration.name).toMatch(expectedFileName);
 
-    // Poll until the report reaches a terminal status (max 60s).
-    // Exit early on 'failed' so we don't burn the full timeout waiting for a
-    // status that will never transition to 'completed'.
-    let updatedReportGeneration = await caller.plans.reports.get({
-      reportId: reportGeneration.id,
-    });
-    const maxWait = 60000;
-    const pollInterval = 2000;
-    const start = Date.now();
-    while (
-      updatedReportGeneration.status !== 'completed' &&
-      updatedReportGeneration.status !== 'failed' &&
-      Date.now() - start < maxWait
-    ) {
-      await sleep(pollInterval);
-      updatedReportGeneration = await caller.plans.reports.get({
-        reportId: reportGeneration.id,
-      });
-    }
-    const elapsedMs = Date.now() - start;
+    const getReportGeneration = (): Promise<ReportGeneration> =>
+      caller.plans.reports.get({ reportId: reportGeneration.id });
+
+    await expect
+      .poll(async () => (await getReportGeneration()).status, {
+        interval: 2000,
+        timeout: 60000,
+      })
+      .toMatch(/^(completed|failed)$/);
+
+    const updatedReportGeneration = await getReportGeneration();
     expect(
       updatedReportGeneration.status,
-      `Report did not complete within ${maxWait}ms (elapsed ${elapsedMs}ms, final status: ${updatedReportGeneration.status}, errorMessage: ${updatedReportGeneration.errorMessage})`
+      `Report generation failed: ${updatedReportGeneration.errorMessage}`
     ).toBe('completed');
 
-    const response = await request(app.getHttpServer())
-      .get(
-        `/collectivites/${SEED_DATA_COLLECTIVITE_ID}/documents/${updatedReportGeneration.id}/download`
-      )
-      .set('Authorization', `Bearer ${adminToken}`)
-      .expect(200)
-      .responseType('blob');
+    const fichierId = updatedReportGeneration.fileId;
+    if (fichierId === null) {
+      throw new Error('A completed report must carry a fileId');
+    }
 
-    const fileName = decodeURI(
-      response.headers['content-disposition']
-        .split('filename=')[1]
-        .split(';')[0]
-        .split('"')[1]
-    );
+    const { signedUrl, filename } =
+      await caller.collectivites.documents.getDownloadUrl({
+        collectiviteId: SEED_DATA_COLLECTIVITE_ID,
+        fichierId,
+      });
 
-    const body = response.body as Buffer;
+    expect(filename).toMatch(expectedFileName);
 
-    expect(fileName).toMatch(expectedFileName);
-    expect(body.byteLength).toBeGreaterThan(1000);
+    const response = await fetch(signedUrl);
+    expect(response.ok).toBe(true);
+
+    const reportBuffer = Buffer.from(await response.arrayBuffer());
+    expect(reportBuffer.byteLength).toBeGreaterThan(1000);
   }, 90000);
 
   it("Refuse la génération de rapport si l'utilisateur n'a pas les droits", async () => {

--- a/packages/domain/src/collectivites/documents/bibliotheque-fichier.schema.ts
+++ b/packages/domain/src/collectivites/documents/bibliotheque-fichier.schema.ts
@@ -5,7 +5,13 @@ export const documentHashSchema = z
   .regex(
     /^[0-9a-f]{64}$/,
     'Le hash doit être une empreinte SHA-256 en hexadécimal minuscule'
-  );
+  )
+  .brand<'DocumentHash'>();
+
+export type DocumentHash = z.infer<typeof documentHashSchema>;
+
+export const toDocumentHash = (hash: string): DocumentHash =>
+  documentHashSchema.parse(hash);
 
 export const bibliothequeFichierSchema = z.object({
   id: z.number(),


### PR DESCRIPTION
Le hash d'un document devient une valeur typée, et cesse d'être détourné comme adresse.

## Un type marqué plutôt qu'une chaîne

`documentHashSchema` rend un type marqué : une valeur ne satisfait `DocumentHash` qu'après être passée par la validation. Un `string` quelconque ne peut plus se faire passer pour une empreinte, et le compilateur force la cohérence sur tous les sites qui en produisent une.

La marque a fait apparaître deux endroits où la colonne mentait, et les deux sont corrigés :

- **le dépôt par tampon** calculait bien un SHA-256, mais le passait sans le valider ;
- **la génération de rapports PPTX** rangeait l'identifiant de génération — un **uuid** — dans la colonne `hash`. `uploadLocalFile` lit déjà le fichier : il en calcule l'empreinte, comme le fait `uploadBuffer` juste à côté, et le paramètre `hash` disparaît de son entrée.

## Le rapport est adressé par son identifiant

Privé de son détournement, le rapport avait besoin d'une autre adresse — et elle existait déjà : `plan_report_generation.file_id`.

Le front la lit dans le statut de génération, puis **emprunte le flux commun** : `useDownloadDocument`, le hook que les preuves, les annexes et les pièces de démarche utilisent déjà, qui demande une URL signée à `getDownloadUrl` et sauvegarde le blob. Le rapport cesse d'avoir son propre chemin de téléchargement.

Ce faisant, il passe par la porte la mieux gardée : `getDownloadUrl` vérifie l'accès restreint de la collectivité, fusionne « document inexistant » et « confidentiel hors de portée » en une seule réponse, et ne signe que soixante secondes. La route REST `/documents/:x/download` ne faisait aucune des trois — elle n'est pas modifiée ici, elle perd simplement son dernier appelant du front.

Le hash ne traverse donc plus la frontière d'API. Il redevient la clé de stockage, résolue côté serveur depuis la ligne trouvée — la règle appliquée à `getDownloadUrl`, et pour les mêmes raisons : un identifiant de ligne ne suppose aucun format et ne se dérive pas du contenu du fichier.

**Compatibilité ascendante** : les rapports déjà générés gardent leur hash en uuid et restent téléchargeables, puisque `file_id` a toujours été renseigné à la complétion. Les liens envoyés par courriel portent l'identifiant de génération et non le hash — ils ne sont pas concernés. Aucune migration.

## La collision d'unicité, traitée

Adresser par le contenu soumet le rapport à `unique (collectivite_id, hash)` : deux générations identiques produisent la même empreinte.

Le cas est atteignable, et mesuré — cinq archives au contenu identique produites dans la même fenêtre de **deux secondes** ont le même SHA-256, la résolution de l'horodatage DOS que JSZip inscrit dans chaque entrée. Au-delà, la date de génération figurant dans les diapositives suffit à les différencier.

`uploadLocalFile` rend désormais la ligne existante au lieu d'insérer — le comportement qu'a déjà `createUploadToken` avec `alreadyInBibliotheque`. Sans cela, régénérer un rapport inchangé échouait, de façon **permanente** tant que le plan ne bouge pas, et sous une étiquette fausse : `UPLOAD_STORAGE_ERROR`, alors que le fichier était bien déposé.

Le dépôt utilisateur n'est pas touché : `uploadBuffer` garde son comportement, où « ce fichier existe déjà » mérite de rester une erreur visible.

## La lecture du fichier local, rendue et non jetée

`uploadLocalFile` annonce un `Result`, mais l'exception de `readFile` le traversait : un chemin absent ou illisible remontait en exception jusqu'au job de génération, qui ne pouvait pas la traiter avec les autres échecs de dépôt. La lecture passe par un `readLocalFile` privé qui rend un `Result`, et son échec devient `UPLOAD_STORAGE_ERROR`.

Le défaut est antérieur à cette PR, mais elle déplace ces lignes — la lecture alimente désormais le calcul de l'empreinte — et le chemin d'erreur ne pouvait pas rester ouvert derrière elle.

## Ce que cette PR ne ferme pas

L'autorisation du téléchargement porte sur le fichier — sa collectivité et son drapeau `confidentiel` — et non sur ce qui le rattache. Une annexe non confidentielle portée par une fiche `restreint` reste donc atteignable, alors que le listage qui l'expose applique la restriction de sa fiche. C'est antérieur à cette PR, consigné, et à traiter avant la fermeture des droits en base.

`DocumentService.getDownloadUrl` est du code mort — aucun appelant — et construit encore une URL à partir d'un hash. Laissé en l'état, signalé ici.

`StoreDocumentService` conditionne son contrôle de permission à la présence d'un argument : `if (user)`. Un appelant qui l'omet écrit sans vérification, et c'est déjà le cas de la génération de rapport, chemin serveur de bout en bout. Rendre l'utilisateur obligatoire suppose de migrer les trois méthodes vers le contexte `{ user, isUserTrusted?, tx? }`, d'un bloc avec leurs quatre appelants. Antérieur, consigné, hors périmètre ici.

## Surface de review

L'attention porte sur `store-document.service.ts` — calcul de l'empreinte, déduplication portée par l'`insert` en `onConflictDoNothing` plutôt que par une lecture préalable, ce qui la rend atomique et commune aux deux chemins de dépôt, et lecture du fichier local ramenée dans le `Result`.

Le reste suit : le hook front, qui se contente désormais d'appeler `useDownloadDocument`, et les tests.

À noter pour la relecture : `plan_report_generation.file_id` existait déjà et le repository n'avait pas à changer — le rapport gagne son adresse sans qu'aucune requête ne soit ajoutée.

Les quatre commits se relisent séparément : le premier pose la marque et se suffit à lui-même, le second en tire les conséquences sur le rapport, les deux derniers ferment le chemin d'erreur de la lecture — le test d'abord, rouge, puis le correctif.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Améliorations**
  * Les téléchargements de documents et de rapports générés utilisent désormais un identifiant de fichier fiable.
  * Les rapports sont téléchargés automatiquement avec le bon fichier une fois leur génération terminée.
  * Les identifiants de documents invalides sont rejetés avec un message d’erreur approprié.
  * La mise en ligne d’un fichier déjà existant évite désormais de créer un doublon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


