### PR TITLE
fix(llm): cesse de retenter un appel annulé

### DIFF
--- a/apps/backend/src/utils/llm/llm.service.ts
+++ b/apps/backend/src/utils/llm/llm.service.ts
@@ -3,11 +3,7 @@ import { failure, Result, success } from '@tet/backend/utils/result.type';
 import { Options, default as retry } from 'async-retry';
 import { z, ZodType } from 'zod';
 import { LlmError } from './llm.errors';
-import {
-  LlmRawCompletion,
-  LlmRepository,
-  TokenUsage,
-} from './llm.repository';
+import { LlmRawCompletion, LlmRepository, TokenUsage } from './llm.repository';
 import { parseStructuredResponse } from './parse-json-response';
 
 const DEFAULT_TEMPERATURE = 0.2;
@@ -43,16 +39,18 @@ export class LlmService {
   async generateStructured<Schema extends ZodType>(
     args: GenerateStructuredArgs<Schema>
   ): Promise<Result<StructuredCompletion<Schema>, LlmError>> {
-    const completionResult = await this.callWithRetry(() =>
-      this.llmRepository.complete({
-        prompt: args.prompt,
-        jsonSchema: z.toJSONSchema(args.schema),
-        systemInstruction: args.systemInstruction,
-        temperature: args.temperature ?? DEFAULT_TEMPERATURE,
-        maxOutputTokens: args.maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS,
-        thinkingBudget: args.thinkingBudget ?? DEFAULT_THINKING_BUDGET,
-        signal: args.signal,
-      })
+    const completionResult = await this.callWithRetry(
+      () =>
+        this.llmRepository.complete({
+          prompt: args.prompt,
+          jsonSchema: z.toJSONSchema(args.schema),
+          systemInstruction: args.systemInstruction,
+          temperature: args.temperature ?? DEFAULT_TEMPERATURE,
+          maxOutputTokens: args.maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS,
+          thinkingBudget: args.thinkingBudget ?? DEFAULT_THINKING_BUDGET,
+          signal: args.signal,
+        }),
+      args.signal
     );
     if (!completionResult.success) {
       return completionResult;
@@ -72,20 +70,27 @@ export class LlmService {
   }
 
   private async callWithRetry(
-    call: () => Promise<Result<LlmRawCompletion, LlmError>>
+    call: () => Promise<Result<LlmRawCompletion, LlmError>>,
+    signal?: AbortSignal
   ): Promise<Result<LlmRawCompletion, LlmError>> {
     let lastRetryableResult: Result<LlmRawCompletion, LlmError> | null = null;
     try {
       return await retry(async () => {
         const result = await call();
-        if (!result.success && isTransientError(result.error)) {
+        if (
+          !result.success &&
+          isTransientError(result.error) &&
+          !signal?.aborted
+        ) {
           lastRetryableResult = result;
           throw new Error(result.error.kind);
         }
         return result;
       }, RETRY_OPTIONS);
     } catch {
-      return lastRetryableResult ?? failure({ kind: 'api_error', httpStatus: null });
+      return (
+        lastRetryableResult ?? failure({ kind: 'api_error', httpStatus: null })
+      );
     }
   }
 }


### PR DESCRIPTION
Un appel interrompu par son `AbortSignal` remonte en `api_error` avec un `httpStatus` nul, qu'`isTransientError` juge transitoire. Il est donc rejoué jusqu'à cinq fois **après** l'annulation.

Avec `CALL_TIMEOUT_MS` à neuf minutes, un appelant qui abandonne paie jusqu'à cinquante minutes d'appels qu'il n'attend plus — et rien ne le lui signale, puisque le `Result` final est celui de la dernière tentative.

`callWithRetry` reçoit le signal et cesse de retenter dès qu'il est déclenché. Un appel non annulé garde exactement le comportement actuel.

Sans ce correctif, aucune deadline posée par un appelant ne borne quoi que ce soit.