### PR TITLE
feat(plans): découpe la classification en lots tolérants à l'échec

### DIFF
--- a/apps/backend/src/plans/priorisation/fiche-leviers.errors.ts
+++ b/apps/backend/src/plans/priorisation/fiche-leviers.errors.ts
@@ -1,0 +1,12 @@
+import { createErrorsEnum } from '@tet/backend/utils/trpc/trpc-error-handler';
+
+export const FicheLeviersSpecificErrors = ['SAVE_LEVIERS_ERROR'] as const;
+
+export type FicheLeviersSpecificError =
+  (typeof FicheLeviersSpecificErrors)[number];
+
+export const FicheLeviersErrorEnum = createErrorsEnum(
+  FicheLeviersSpecificErrors
+);
+
+export type FicheLeviersError = keyof typeof FicheLeviersErrorEnum;

--- a/apps/backend/src/plans/priorisation/fiche-leviers.repository.ts
+++ b/apps/backend/src/plans/priorisation/fiche-leviers.repository.ts
@@ -1,0 +1,23 @@
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { Result } from '@tet/backend/utils/result.type';
+import { CategorieAction, Levier, LevierSecteur } from '@tet/domain/shared';
+import { FicheLeviersError } from './fiche-leviers.errors';
+
+export type LevierCategorie = {
+  levier: Levier;
+  secteur: LevierSecteur;
+  categorie: CategorieAction;
+};
+
+export type FicheLeviers = {
+  ficheId: number;
+  leviers: LevierCategorie[];
+};
+
+export abstract class FicheLeviersRepository {
+  abstract saveLeviers(
+    collectiviteId: number,
+    fiches: FicheLeviers[],
+    tx?: Transaction
+  ): Promise<Result<void, FicheLeviersError>>;
+}

--- a/apps/backend/src/plans/priorisation/mocked-fiche-leviers.repository.ts
+++ b/apps/backend/src/plans/priorisation/mocked-fiche-leviers.repository.ts
@@ -1,0 +1,28 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { success, type Result } from '@tet/backend/utils/result.type';
+import { FicheLeviersError } from './fiche-leviers.errors';
+import {
+  FicheLeviers,
+  FicheLeviersRepository,
+} from './fiche-leviers.repository';
+
+@Injectable()
+export class MockedFicheLeviersRepository implements FicheLeviersRepository {
+  private readonly logger = new Logger(MockedFicheLeviersRepository.name);
+
+  async saveLeviers(
+    collectiviteId: number,
+    fiches: FicheLeviers[],
+    _tx?: Transaction
+  ): Promise<Result<void, FicheLeviersError>> {
+    const levierCount = fiches.reduce(
+      (total, fiche) => total + fiche.leviers.length,
+      0
+    );
+    this.logger.log(
+      `Écriture simulée de ${levierCount} couples levier-catégorie sur ${fiches.length} fiches de la collectivité ${collectiviteId}`
+    );
+    return success(undefined);
+  }
+}

--- a/apps/backend/src/plans/priorisation/models/classification-draft.ts
+++ b/apps/backend/src/plans/priorisation/models/classification-draft.ts
@@ -1,0 +1,11 @@
+import { ClassifiedFiche } from '../pipeline/classify-fiches/apply-classification';
+
+export type UnclassifiedFiche = {
+  ficheId: number;
+  reason: string;
+};
+
+export type ClassificationDraft = {
+  fiches: ClassifiedFiche[];
+  unclassified: UnclassifiedFiche[];
+};

--- a/apps/backend/src/plans/priorisation/pipeline/run-classification.spec.ts
+++ b/apps/backend/src/plans/priorisation/pipeline/run-classification.spec.ts
@@ -1,0 +1,142 @@
+import { LlmError } from '@tet/backend/utils/llm/llm.errors';
+import {
+  GenerateStructuredArgs,
+  LlmService,
+} from '@tet/backend/utils/llm/llm.service';
+import { failure, success } from '@tet/backend/utils/result.type';
+import { describe, expect, it } from 'vitest';
+import { ZodType } from 'zod';
+import { FicheClassification } from './classify-fiches/classify-fiches.schema';
+import { FicheToClassify } from './classify-fiches/render-fiches-text';
+import { FICHES_PER_BATCH, runClassification } from './run-classification';
+
+const tokens = {
+  promptTokens: 10,
+  candidatesTokens: 5,
+  thoughtsTokens: 1,
+  totalTokens: 16,
+};
+
+type LlmAnswer = Awaited<ReturnType<LlmService['generateStructured']>>;
+type StubbedLlm = Pick<LlmService, 'generateStructured'>;
+
+const toFiche = (ficheId: number): FicheToClassify => ({
+  ficheId,
+  titre: `Fiche ${ficheId}`,
+  description: 'Aménagement de pistes cyclables',
+});
+
+const toFiches = (count: number): FicheToClassify[] =>
+  Array.from({ length: count }, (unused, index) => toFiche(index + 1));
+
+const toFicheClassification = (index: number): FicheClassification => ({
+  index,
+  justification: 'Le texte décrit un aménagement cyclable.',
+  hasNoRelevantLevier: false,
+  volets: [
+    { levier: 'Vélo et transport en commun', categories: ['amenagement'] },
+  ],
+});
+
+const toClassifiedAnswer = (prompt: string): LlmAnswer => {
+  const actionCount = (prompt.match(/<action index=/g) ?? []).length;
+  return success({
+    data: Array.from({ length: actionCount }, (unused, index) =>
+      toFicheClassification(index)
+    ),
+    tokens,
+  });
+};
+
+const llmFailingOnBatch = (failingBatchIndexes: number[]): StubbedLlm => {
+  let batchIndex = -1;
+  const truncated: LlmError = { kind: 'truncated' };
+  const generateStructured = async (
+    args: GenerateStructuredArgs<ZodType>
+  ): Promise<LlmAnswer> => {
+    batchIndex += 1;
+    if (failingBatchIndexes.includes(batchIndex)) {
+      return failure(truncated);
+    }
+    return toClassifiedAnswer(args.prompt);
+  };
+  return { generateStructured } as unknown as StubbedLlm;
+};
+
+const llmClassifying = (): StubbedLlm => llmFailingOnBatch([]);
+
+describe('runClassification', () => {
+  it("classe toutes les fiches d'un lot unique", async () => {
+    const run = await runClassification(llmClassifying(), {
+      fiches: toFiches(3),
+    });
+    expect(
+      run.kind === 'completed' && run.draft.fiches.map(({ ficheId }) => ficheId)
+    ).toEqual([1, 2, 3]);
+  });
+
+  it('découpe au-delà de 25 fiches sans en perdre', async () => {
+    const run = await runClassification(llmClassifying(), {
+      fiches: toFiches(26),
+    });
+    expect(run.kind === 'completed' && run.draft.fiches).toHaveLength(26);
+  });
+
+  it('cumule les jetons de tous les lots', async () => {
+    const run = await runClassification(llmClassifying(), {
+      fiches: toFiches(FICHES_PER_BATCH * 2),
+    });
+    expect(run.kind === 'completed' && run.tokens.totalTokens).toBe(
+      tokens.totalTokens * 2
+    );
+  });
+
+  it('conserve les lots réussis quand un lot échoue', async () => {
+    const run = await runClassification(llmFailingOnBatch([0]), {
+      fiches: toFiches(FICHES_PER_BATCH * 3),
+    });
+    expect(run.kind === 'completed' && run.draft.fiches).toHaveLength(
+      FICHES_PER_BATCH * 2
+    );
+  });
+
+  it('inscrit les fiches du lot en échec dans unclassified, avec leur raison', async () => {
+    const run = await runClassification(llmFailingOnBatch([0]), {
+      fiches: toFiches(FICHES_PER_BATCH * 3),
+    });
+    expect(
+      run.kind === 'completed' && run.draft.unclassified.slice(0, 2)
+    ).toEqual([
+      { ficheId: 1, reason: 'truncated' },
+      { ficheId: 2, reason: 'truncated' },
+    ]);
+  });
+
+  it('abandonne au-delà de la moitié des lots en échec', async () => {
+    const run = await runClassification(llmFailingOnBatch([0, 1, 2]), {
+      fiches: toFiches(FICHES_PER_BATCH * 4),
+    });
+    expect(run).toEqual({
+      kind: 'too_many_failed_batches',
+      failedBatches: 3,
+      totalBatches: 4,
+    });
+  });
+
+  it('accepte exactement la moitié des lots en échec', async () => {
+    const run = await runClassification(llmFailingOnBatch([0, 1]), {
+      fiches: toFiches(FICHES_PER_BATCH * 4),
+    });
+    expect(run.kind).toBe('completed');
+  });
+
+  it('signale la progression après chaque lot', async () => {
+    const progression: number[] = [];
+    await runClassification(llmClassifying(), {
+      fiches: toFiches(FICHES_PER_BATCH * 3),
+      onBatchProcessed: (processedBatches) =>
+        progression.push(processedBatches),
+    });
+    expect(progression).toEqual([1, 2, 3]);
+  });
+});

--- a/apps/backend/src/plans/priorisation/pipeline/run-classification.ts
+++ b/apps/backend/src/plans/priorisation/pipeline/run-classification.ts
@@ -1,0 +1,110 @@
+import { LlmService } from '@tet/backend/utils/llm/llm.service';
+import { TokenUsage } from '@tet/backend/utils/llm/llm.repository';
+import { sumTokenUsage } from '@tet/backend/utils/llm/token-usage';
+import { mapWithConcurrency } from '@tet/backend/utils/map-with-concurrency';
+import { chunk } from 'es-toolkit';
+import {
+  ClassificationDraft,
+  UnclassifiedFiche,
+} from '../models/classification-draft';
+import { ClassifiedFiche } from './classify-fiches/apply-classification';
+import { classifyFiches } from './classify-fiches/classify-fiches';
+import { FicheToClassify } from './classify-fiches/render-fiches-text';
+
+export const FICHES_PER_BATCH = 25;
+export const BATCHES_IN_PARALLEL = 5;
+
+export const MAX_FAILED_BATCH_RATIO = 0.5;
+
+type BatchOutcome =
+  | {
+      kind: 'classified';
+      fiches: ClassifiedFiche[];
+      tokens: TokenUsage;
+    }
+  | { kind: 'failed'; ficheIds: number[]; reason: string };
+
+export type ClassificationRun =
+  | { kind: 'completed'; draft: ClassificationDraft; tokens: TokenUsage }
+  | {
+      kind: 'too_many_failed_batches';
+      failedBatches: number;
+      totalBatches: number;
+    };
+
+const classifyBatch = async (
+  llm: Pick<LlmService, 'generateStructured'>,
+  fiches: FicheToClassify[],
+  signal?: AbortSignal
+): Promise<BatchOutcome> => {
+  const classifyResult = await classifyFiches(llm, { fiches, signal });
+
+  if (classifyResult.success) {
+    return {
+      kind: 'classified',
+      fiches: classifyResult.data.fiches,
+      tokens: classifyResult.data.tokens,
+    };
+  }
+
+  return {
+    kind: 'failed',
+    ficheIds: fiches.map(({ ficheId }) => ficheId),
+    reason: classifyResult.error.kind,
+  };
+};
+
+const toUnclassified = (outcome: BatchOutcome): UnclassifiedFiche[] => {
+  if (outcome.kind !== 'failed') {
+    return [];
+  }
+  return outcome.ficheIds.map((ficheId) => ({
+    ficheId,
+    reason: outcome.reason,
+  }));
+};
+
+export type RunClassificationInput = {
+  fiches: FicheToClassify[];
+  signal?: AbortSignal;
+  onBatchProcessed?: (processedBatches: number) => void;
+};
+
+export const runClassification = async (
+  llm: Pick<LlmService, 'generateStructured'>,
+  { fiches, signal, onBatchProcessed }: RunClassificationInput
+): Promise<ClassificationRun> => {
+  const batches = chunk(fiches, FICHES_PER_BATCH);
+
+  const outcomes = await mapWithConcurrency(
+    batches,
+    BATCHES_IN_PARALLEL,
+    (batch) => classifyBatch(llm, batch, signal),
+    onBatchProcessed
+  );
+
+  const failedBatches = outcomes.filter(({ kind }) => kind === 'failed').length;
+  const isTooDegraded = failedBatches > batches.length * MAX_FAILED_BATCH_RATIO;
+  if (isTooDegraded) {
+    return {
+      kind: 'too_many_failed_batches',
+      failedBatches,
+      totalBatches: batches.length,
+    };
+  }
+
+  return {
+    kind: 'completed',
+    draft: {
+      fiches: outcomes.flatMap((outcome) =>
+        outcome.kind === 'classified' ? outcome.fiches : []
+      ),
+      unclassified: outcomes.flatMap(toUnclassified),
+    },
+    tokens: sumTokenUsage(
+      outcomes.flatMap((outcome) =>
+        outcome.kind === 'classified' ? [outcome.tokens] : []
+      )
+    ),
+  };
+};


### PR DESCRIPTION
`runClassification` découpe les fiches d'un plan en lots de 25, cinq en parallèle, et rend un draft. Aucune I/O : ni base, ni queue, ni routeur — rien ne l'appelle encore, le job vient dans la PR suivante.

## Un lot en échec ne fait pas perdre les autres

Le type de sortie par lot n'est **pas** un `Result`, donc rien ne peut court-circuiter :

```ts
type BatchOutcome =
  | { kind: 'classified'; fiches: ClassifiedFiche[]; tokens: TokenUsage }
  | { kind: 'failed'; ficheIds: number[]; reason: string };
```

Les erreurs dominantes à cette granularité — `truncated`, `invalid_json` — sont déterministes par contenu de lot, et `isTransientError` ne rejoue que `rate_limited` et les 5xx. Un court-circuit ferait donc qu'une seule fiche pathologique rend un plan de 300 fiches définitivement intraitable.

**Le trou fait partie du résultat.** Les fiches d'un lot en échec sont dans `draft.unclassified` avec leur raison : sans elles, une fiche non traitée est indistinguable d'une fiche « aucun levier applicable ». Au-delà de la moitié des lots en échec, le run est abandonné — le résultat ne couvre plus assez du plan pour être relu.

## Le port des volets

`FicheVoletsRepository` porte la donnée durable — un volet levier × catégorie sur une fiche — avec son propre contrat, indépendant de l'étape IA : un humain assignera aussi des volets à la main. Seule l'implémentation mockée existe tant qu'aucune table ne porte ce couple.

## Tests

9 tests sur `runClassification`. Le seuil d'abandon est vérifié des deux côtés — « au-delà de la moitié » et « exactement la moitié » — et les trois invariants qui portent la politique de partiel ont été vus rouges par mutation : conservation des lots réussis, `unclassified` peuplé, seuil de dégradation.
