### PR TITLE
feat(ui): ajoute la variante carte aux onglets TabsNext et rend le composant accessible

### DIFF
--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/ma-collectivite/layout.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/ma-collectivite/layout.tsx
@@ -18,7 +18,7 @@ export default function Layout({ children }: PropsWithChildren) {
           {appLabels.identiteEtPersonnalisation}
         </PageHeader.Title>
       </PageHeader>
-      <Tabs tabsListClassName="justify-start">
+      <Tabs>
         <TabsList className="justify-start">
           <TabsTab href="presentation" label="Présentation" />
           <TabsTab href="personnalisation" label="Personnalisation" />

--- a/packages/ui/src/design-system/TabsNext/Tabs.next.stories.tsx
+++ b/packages/ui/src/design-system/TabsNext/Tabs.next.stories.tsx
@@ -1,5 +1,7 @@
 import { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { useState } from 'react';
 import { StoryWrapper } from '../../storybook/story.wrapper';
+import { TabSize } from '../Tabs/Tabs';
 import { Tabs } from './Tabs.next';
 
 const meta: Meta<typeof Tabs> = {
@@ -44,7 +46,7 @@ export const All: Story = {
               />
               <Tabs.Tab label="MD 2" href={'/tabs-next/md-2'} />
             </Tabs.List>
-            <Tabs.Panel className="p-4 bg-white">MD</Tabs.Panel>
+            <Tabs.Panel>MD</Tabs.Panel>
           </Tabs>
 
           <Tabs size="sm">
@@ -57,7 +59,7 @@ export const All: Story = {
               />
               <Tabs.Tab label="SM 2" href={'/tabs-next/sm-2'} />
             </Tabs.List>
-            <Tabs.Panel className="p-4 bg-white">SM</Tabs.Panel>
+            <Tabs.Panel>SM</Tabs.Panel>
           </Tabs>
 
           <Tabs size="xs">
@@ -70,7 +72,7 @@ export const All: Story = {
               />
               <Tabs.Tab label="XS 2" href={'/tabs-next/xs-2'} />
             </Tabs.List>
-            <Tabs.Panel className="p-4 bg-white">XS</Tabs.Panel>
+            <Tabs.Panel>XS</Tabs.Panel>
           </Tabs>
         </div>
       </StoryWrapper>
@@ -111,8 +113,31 @@ export const All: Story = {
               }}
             />
           </Tabs.List>
-          <Tabs.Panel className="p-4 bg-white">Contenu (sécurisé)</Tabs.Panel>
+          <Tabs.Panel>Contenu (sécurisé)</Tabs.Panel>
         </Tabs>
+      </StoryWrapper>
+
+      <StoryWrapper
+        title="Variante carte"
+        description="Icône au-dessus du libellé, badge en dessous. La largeur des cartes suit la taille : md / sm / xs."
+      >
+        <div className="flex flex-col gap-8 w-full">
+          {cardSizes.map((size) => (
+            <div key={size} className="flex flex-col gap-2">
+              <p className="mb-0 text-sm font-medium text-grey-8 uppercase">
+                {size}
+              </p>
+              <CardTabsPreview size={size} />
+            </div>
+          ))}
+        </div>
+      </StoryWrapper>
+
+      <StoryWrapper
+        title="Variante carte pilotée par un bouton"
+        description="Sans `href`, l'onglet est un bouton : utile quand le volet actif vient d'un paramètre de requête plutôt que du chemin."
+      >
+        <CardTabsWithState />
       </StoryWrapper>
 
       <StoryWrapper
@@ -143,4 +168,104 @@ export const All: Story = {
       </StoryWrapper>
     </div>
   ),
+};
+
+const cardSizes: TabSize[] = ['md', 'sm', 'xs'];
+
+const CardTabsPreview = ({ size }: { size: TabSize }) => (
+  <Tabs variant="card" size={size}>
+    <Tabs.List>
+      <Tabs.Tab
+        label="Emissions GES"
+        href={'/tabs-next/ges'}
+        icon="fire-line"
+        isActive
+        badge={{
+          title: 'A compléter',
+          variant: 'warning',
+          type: 'solid',
+          uppercase: false,
+        }}
+      />
+      <Tabs.Tab
+        label="Polluants atmosphériques"
+        href={'/tabs-next/polluants'}
+        icon="windy-line"
+        badge={{
+          title: 'A compléter',
+          variant: 'warning',
+          type: 'solid',
+          uppercase: false,
+        }}
+      />
+      <Tabs.Tab
+        label="Séquestration carbone"
+        href={'/tabs-next/sequestration'}
+        icon="seedling-line"
+        badge={{
+          title: 'Optionnel',
+          variant: 'default',
+          type: 'solid',
+          uppercase: false,
+        }}
+      />
+      <Tabs.Tab
+        label="Vulnérabilité du territoire"
+        href={'/tabs-next/vulnerabilite'}
+        icon="map-2-line"
+        badge={{
+          title: 'Complète',
+          variant: 'success',
+          type: 'solid',
+          uppercase: false,
+        }}
+      />
+    </Tabs.List>
+    <Tabs.Panel className="p-4 mt-4 bg-white">
+      Contenu (émissions GES)
+    </Tabs.Panel>
+  </Tabs>
+);
+
+const topics = [
+  { code: 'ges', label: 'Emissions GES', icon: 'fire-line' },
+  { code: 'polluants', label: 'Polluants atmosphériques', icon: 'windy-line' },
+  {
+    code: 'sequestration',
+    label: 'Séquestration carbone',
+    icon: 'seedling-line',
+  },
+  { code: 'enr', label: 'Energies renouvelables', icon: 'sun-line' },
+  {
+    code: 'reseaux',
+    label: 'Réseaux de distribution',
+    icon: 'flashlight-line',
+  },
+  {
+    code: 'vulnerabilite',
+    label: 'Vulnérabilité du territoire',
+    icon: 'map-2-line',
+  },
+];
+
+const CardTabsWithState = () => {
+  const [activeCode, setActiveCode] = useState('ges');
+
+  return (
+    <Tabs variant="card">
+      <Tabs.List>
+        {topics.map((topic) => (
+          <Tabs.Tab
+            key={topic.code}
+            label={topic.label}
+            icon={topic.icon}
+            isActive={activeCode === topic.code}
+            onClick={() => setActiveCode(topic.code)}
+            badge={{ title: 'A compléter', variant: 'warning', type: 'solid' }}
+          />
+        ))}
+      </Tabs.List>
+      <Tabs.Panel className="p-4">Contenu ({activeCode})</Tabs.Panel>
+    </Tabs>
+  );
 };

--- a/packages/ui/src/design-system/TabsNext/Tabs.next.tsx
+++ b/packages/ui/src/design-system/TabsNext/Tabs.next.tsx
@@ -4,27 +4,79 @@ import classNames from 'classnames';
 import { Route } from 'next';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { createContext, ReactNode, useContext } from 'react';
+import {
+  createContext,
+  KeyboardEvent,
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useState,
+} from 'react';
 import { cn } from '../../utils/cn';
 import { Badge, BadgeProps } from '../Badge';
-import { Icon, IconValue } from '../Icon';
+import { Icon, IconSize, IconValue } from '../Icon';
 import { TabSize } from '../Tabs/Tabs';
 import { Tooltip } from '../Tooltip';
 
+/** Apparence des onglets : pastilles (par défaut) ou cartes */
+export type TabVariant = 'pill' | 'card';
+
 type TabsContextProps = {
-  /** Permet d'ajuster les styles de la liste d'onglets */
-  tabsListClassName?: string;
   /** Taille des boutons */
   size?: TabSize;
+  /** Apparence des onglets */
+  variant?: TabVariant;
+  /** Préfixe d'id unique pour ce groupe d'onglets */
+  baseId: string;
+  /** Id de l'onglet actif (pour lier le panneau) */
+  activeTabId: string | null;
+  setActiveTabId: (id: string) => void;
+  /**
+   * Id du premier onglet monté : tant qu'aucun n'est actif, c'est lui qui
+   * reste focusable au clavier (roving tabindex — un tablist doit toujours
+   * avoir exactement un onglet avec tabIndex 0).
+   */
+  firstTabId: string | null;
+  registerTab: (id: string) => void;
 };
 
-type TabsProps = TabsContextProps & {
+type TabsProps = {
   dataTest?: string;
   /** Permet d'ajuster les styles du container */
   className?: string;
+  /** Taille des boutons */
+  size?: TabSize;
+  /** Apparence des onglets */
+  variant?: TabVariant;
   /** Onglets */
   children: ReactNode[];
 };
+
+const TabsContext = createContext<TabsContextProps | null>(null);
+
+function useTabsContext() {
+  const context = useContext(TabsContext);
+  if (context === null) {
+    throw new Error('useTabsContext must be used within a TabsProvider');
+  }
+  return context;
+}
+
+function getPanelId(tabId: string) {
+  return `${tabId}-panel`;
+}
+
+function getTabsInList(tablist: HTMLElement): HTMLElement[] {
+  return Array.from(tablist.querySelectorAll<HTMLElement>('[role="tab"]'));
+}
+
+function focusTab(tabs: HTMLElement[], index: number) {
+  const tab = tabs[index];
+  if (!tab) return;
+  tab.focus();
+}
 
 /**
  *  Affiche un groupe d'onglets.
@@ -33,34 +85,33 @@ export function Tabs({
   dataTest,
   className,
   children,
-  // tabsListClassName,
-  // tabPanelClassName,
-  // defaultActiveTab = 0,
-  // size = 'md',
-  // onChange,
-  ...props
+  size,
+  variant,
 }: TabsProps) {
+  const baseId = useId();
+  const [activeTabId, setActiveTabId] = useState<string | null>(null);
+  const [firstTabId, setFirstTabId] = useState<string | null>(null);
+  const registerTab = useCallback((id: string) => {
+    setFirstTabId((current) => current ?? id);
+  }, []);
+
   return (
-    <TabsProvider {...props}>
+    <TabsContext
+      value={{
+        size,
+        variant,
+        baseId,
+        activeTabId,
+        setActiveTabId,
+        firstTabId,
+        registerTab,
+      }}
+    >
       <div className={classNames(className)} data-test={dataTest}>
         {children}
       </div>
-    </TabsProvider>
+    </TabsContext>
   );
-}
-
-const TabsContext = createContext<TabsContextProps>({});
-
-function TabsProvider({ children, ...props }: { children: ReactNode }) {
-  return <TabsContext value={props}>{children}</TabsContext>;
-}
-
-function useTabsContext() {
-  const context = useContext(TabsContext);
-  if (context === undefined) {
-    throw new Error('useTabsContext must be used within a TabsProvider');
-  }
-  return context;
 }
 
 export const TabsList = ({
@@ -70,13 +121,54 @@ export const TabsList = ({
   className?: string;
   children: ReactNode;
 }) => {
+  const { variant = 'pill' } = useTabsContext();
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLUListElement>) => {
+    const tabs = getTabsInList(event.currentTarget);
+    if (tabs.length === 0) return;
+
+    const currentIndex = tabs.findIndex(
+      (tab) => tab === document.activeElement
+    );
+    if (currentIndex === -1) return;
+
+    let nextIndex: number | null = null;
+
+    switch (event.key) {
+      case 'ArrowRight':
+        nextIndex = (currentIndex + 1) % tabs.length;
+        break;
+      case 'ArrowLeft':
+        nextIndex = (currentIndex - 1 + tabs.length) % tabs.length;
+        break;
+      case 'Home':
+        nextIndex = 0;
+        break;
+      case 'End':
+        nextIndex = tabs.length - 1;
+        break;
+      default:
+        return;
+    }
+
+    event.preventDefault();
+    focusTab(tabs, nextIndex);
+  };
+
   return (
     <ul
       className={cn(
-        'inline-flex flex-wrap gap-y-6 justify-center rounded-lg bg-grey-2 p-2 gap-3 md:gap-6 w-full !list-none m-0',
+        'w-full !list-none m-0',
+        {
+          'inline-flex flex-wrap gap-y-6 justify-center rounded-lg bg-grey-2 p-2 gap-3 md:gap-6':
+            variant === 'pill',
+          'flex flex-wrap items-stretch justify-start gap-4 p-0':
+            variant === 'card',
+        },
         className
       )}
       role="tablist"
+      onKeyDown={handleKeyDown}
     >
       {children}
     </ul>
@@ -85,24 +177,80 @@ export const TabsList = ({
 
 export type TabProps = {
   label: string;
-  href: Route;
+  /** Onglet rendu comme un lien. Sans `href`, l'onglet est un bouton piloté par `onClick` */
+  href?: Route;
+  /** Appelée au clic sur l'onglet */
+  onClick?: () => void;
   isActive?: boolean;
   icon?: IconValue;
   iconClassName?: string;
+  /** Sans effet sur la variante `card`, où l'icône est toujours au-dessus du libellé */
   iconPosition?: 'left' | 'right';
   title?: string;
   tooltip?: string;
   badge?: Omit<BadgeProps, 'size'>;
+  /** Id de l'onglet, déduit du `href` ou généré automatiquement */
+  id?: string;
+  /** Id pour les tests e2e */
+  dataTest?: string;
+};
+
+/** Taille de l'icône de la carte associée à chaque taille d'onglet */
+const cardIconSizeByTabSize: Record<TabSize, IconSize> = {
+  xs: 'sm',
+  sm: 'md',
+  md: 'lg',
 };
 
 export const TabsTab = (props: TabProps) => {
-  const { size } = useTabsContext();
+  const {
+    size = 'md',
+    variant = 'pill',
+    baseId,
+    activeTabId,
+    setActiveTabId,
+    firstTabId,
+    registerTab,
+  } = useTabsContext();
+  const generatedId = useId();
   const pathname = usePathname();
-  const isTabActive = props.isActive || pathname.endsWith(props.href);
+  const isTabActive =
+    props.isActive ||
+    (props.href !== undefined && pathname.endsWith(props.href));
+  const isCard = variant === 'card';
 
-  const link = (
-    <Link
-      className={cn(
+  const tabId =
+    props.id ??
+    (props.href ? `${baseId}-tab-${props.href}` : `${baseId}-${generatedId}`);
+  const panelId = getPanelId(tabId);
+
+  useEffect(() => {
+    if (isTabActive) {
+      setActiveTabId(tabId);
+    }
+  }, [isTabActive, setActiveTabId, tabId]);
+
+  useEffect(() => {
+    registerTab(tabId);
+  }, [registerTab, tabId]);
+
+  const className = isCard
+    ? cn(
+        // styles communs
+        'flex flex-col items-center justify-start text-center gap-2 w-full h-full p-4 bg-white bg-none after:hidden border border-solid rounded-lg transition',
+        {
+          // variante de taille
+          'text-md': size === 'md' || size === undefined,
+          'text-sm': size === 'sm',
+          'text-xs': size === 'xs',
+          // variante pour l'onglet actif
+          'border-2 border-primary-7 text-primary-9 font-bold p-[calc(theme(spacing.4)-1px)]':
+            isTabActive,
+          // variante pour les onglets inactifs
+          'border-grey-3 text-primary-10 hover:border-grey-4': !isTabActive,
+        }
+      )
+    : cn(
         // styles communs
         'flex items-center gap-1.5 px-3 py-1 font-bold w-max bg-none',
         // variante au survol
@@ -118,15 +266,35 @@ export const TabsTab = (props: TabProps) => {
           // variante pour les onglets inactifs
           'text-primary-10': !isTabActive,
         }
+      );
+
+  const content = isCard ? (
+    <>
+      {props.icon && (
+        <Icon
+          icon={props.icon}
+          size={cardIconSizeByTabSize[size]}
+          className={cn(
+            { 'text-primary-9': isTabActive, 'text-primary-10': !isTabActive },
+            props.iconClassName
+          )}
+        />
       )}
-      type="button"
-      role="tab"
-      id={`tab-${props.href}`}
-      aria-selected={isTabActive ? 'true' : 'false'}
-      title={props.title}
-      href={props.href}
-      scroll={false}
-    >
+      <span>{props.label}</span>
+      {props.badge && (
+        <Badge
+          className={cn({
+            'mt-0': size === 'xs',
+            'mt-1': size === 'sm',
+            'mt-2': size === 'md',
+          })}
+          size={size}
+          {...props.badge}
+        />
+      )}
+    </>
+  ) : (
+    <>
       {props.icon && (!props.iconPosition || props.iconPosition === 'left') && (
         <Icon
           icon={props.icon}
@@ -144,12 +312,71 @@ export const TabsTab = (props: TabProps) => {
       ) : (
         props.tooltip && <Icon icon="information-line" size={size} />
       )}
-      {props.badge && <Badge size="sm" {...props.badge} />}
-    </Link>
+      {props.badge && <Badge size={size} {...props.badge} />}
+    </>
   );
+
+  const commonProps = {
+    className,
+    role: 'tab' as const,
+    id: tabId,
+    'aria-selected': isTabActive,
+    // Un seul panneau est rendu (celui de l'onglet actif) : seuls les onglets
+    // actifs référencent un panneau existant via `aria-controls`.
+    'aria-controls': isTabActive ? panelId : undefined,
+    // Roving tabindex : l'onglet actif est focusable ; tant qu'aucun ne l'est
+    // encore, le premier onglet monté prend le relais pour que le tablist
+    // reste toujours atteignable au clavier.
+    tabIndex:
+      isTabActive || (activeTabId === null && firstTabId === tabId) ? 0 : -1,
+    title: props.title,
+    'data-test': props.dataTest,
+  };
+
+  const activateLinkOnSpace = (event: KeyboardEvent<HTMLAnchorElement>) => {
+    // Les liens n'activent pas nativement sur Espace ; l'APG Tabs l'exige.
+    if (event.key !== ' ') return;
+    event.preventDefault();
+    event.currentTarget.click();
+  };
+
+  const control =
+    props.href !== undefined ? (
+      <Link
+        {...commonProps}
+        href={props.href}
+        scroll={false}
+        onClick={props.onClick}
+        onKeyDown={activateLinkOnSpace}
+      >
+        {content}
+      </Link>
+    ) : (
+      <button
+        {...commonProps}
+        type="button"
+        onClick={props.onClick}
+        className={cn(commonProps.className, 'cursor-pointer')}
+      >
+        {content}
+      </button>
+    );
+
   return (
-    <li role="presentation" className="p-0">
-      {props.tooltip ? <Tooltip label={props.tooltip}>{link}</Tooltip> : link}
+    <li
+      role="presentation"
+      className={cn('p-0', {
+        'shrink-0': isCard,
+        'w-48': isCard && size === 'md',
+        'w-40': isCard && size === 'sm',
+        'w-32': isCard && size === 'xs',
+      })}
+    >
+      {props.tooltip ? (
+        <Tooltip label={props.tooltip}>{control}</Tooltip>
+      ) : (
+        control
+      )}
     </li>
   );
 };
@@ -161,8 +388,16 @@ export const TabsPanel = ({
   children: ReactNode;
   className?: string;
 }) => {
+  const { activeTabId } = useTabsContext();
+
   return (
-    <div className={cn('grow flex flex-col rounded-lg', className)}>
+    <div
+      role="tabpanel"
+      id={activeTabId ? getPanelId(activeTabId) : undefined}
+      aria-labelledby={activeTabId ?? undefined}
+      className={cn('grow flex flex-col rounded-lg', className)}
+      tabIndex={0}
+    >
       {children}
     </div>
   );


### PR DESCRIPTION
Nouvelle prop `variant` ("pill" par défaut, "card") passée via le contexte
des onglets : icône au-dessus du libellé, badge en dessous, cartes de
largeurs égales qui passent à la ligne sur petit écran.

Claude-Session: https://claude.ai/code/session_01KDTmVh7yAzknY9FT4pXzUy

feat(ui): enhance TabsNext with stateful card variant and keyboard navigation

- Introduced a new `CardTabsWithState` component for managing active tabs with state.
- Updated Tabs and TabsList components to support keyboard navigation for tab switching.
- Simplified Tabs.Panel by removing unnecessary class names.
- Adjusted the description in the "Variante carte" StoryWrapper for clarity.
- Added unique ID generation for tabs to improve accessibility and testing.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Ajout d’une variante « carte » pour les onglets, avec prise en charge des icônes et badges.
  * Les onglets peuvent être activés par clic, sans lien.
  * Prise en charge de différentes tailles d’onglets.

* **Accessibilité**
  * Amélioration de la navigation au clavier avec les flèches, Début, Fin et Espace.
  * Renforcement des associations entre onglets et panneaux pour les technologies d’assistance.

* **Style**
  * Ajustement de l’apparence des panneaux selon les variantes et tailles d’onglets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->