### PR TITLE
refactor(pcaet): refactor completion badge and update Tabs to card variant

### DIFF
--- a/apps/app/src/demarches/components/completion.badge.tsx
+++ b/apps/app/src/demarches/components/completion.badge.tsx
@@ -26,6 +26,18 @@ const badgeByStatut: Record<
   },
 };
 
+/**
+ * Props du badge pour un statut donné, pour les rendus qui composent leur
+ * propre badge (les onglets du diagnostic passent par celui du design system).
+ */
+export const getDemarcheCompletionBadgeProps = (
+  statut: DemarcheCompletionStatut,
+  { withIcon = true }: { withIcon?: boolean } = {}
+): Pick<BadgeProps, 'title' | 'variant' | 'icon'> => {
+  const { title, variant, icon } = badgeByStatut[statut];
+  return { title, variant, icon: withIcon ? icon : undefined };
+};
+
 type Props = {
   statut: DemarcheCompletionStatut;
   size?: 'xs' | 'sm';
@@ -48,16 +60,12 @@ export const DemarcheCompletionBadge = ({
   trim,
   className,
 }: Props): JSX.Element => {
-  const { title, variant, icon } = badgeByStatut[statut];
-
   return (
     <Badge
       className={className}
       trim={trim}
-      title={title}
-      variant={variant}
       size={size}
-      icon={withIcon ? icon : undefined}
+      {...getDemarcheCompletionBadgeProps(statut, { withIcon })}
     />
   );
 };

--- a/apps/app/src/demarches/pcaet/diagnostic/diagnostic.tabs.tsx
+++ b/apps/app/src/demarches/pcaet/diagnostic/diagnostic.tabs.tsx
@@ -14,11 +14,11 @@ import {
 } from '@tet/ui/design-system/TabsNext/index';
 import { DemarcheSection } from '../../components/section';
 import type { PcaetDiagnostic as DiagnosticPayload } from './data/use-get-pcaet-diagnostic';
+import { DiagnosticTabContent } from './diagnostic.tab-content';
 import {
   isVulnerabiliteTab,
   listDiagnosticTabs,
 } from './diagnostic.tabs.utils';
-import { DiagnosticTabContent } from './diagnostic.tab-content';
 import { TopicTab } from './topic-tab';
 import { usePcaetDiagnosticTabQueryState } from './use-pcaet-diagnostic-tab-query-state';
 
@@ -78,8 +78,12 @@ export const DiagnosticTabs = ({
       ) : isLoading || !activeTab || diagnostic === null ? (
         <SpinnerLoader className="m-auto" />
       ) : (
-        <Tabs dataTest="demarches.pcaet.diagnostic.topics">
-          <TabsList className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-6 gap-2 bg-transparent p-0 m-0 rounded-none w-full !list-none justify-stretch">
+        <Tabs
+          variant="card"
+          size="sm"
+          dataTest="demarches.pcaet.diagnostic.topics"
+        >
+          <TabsList>
             {tabs.map((tab) => {
               const config = diagnostic.indicateurParentConfigs.find(
                 (topic) => topic.code === tab.code
@@ -96,7 +100,6 @@ export const DiagnosticTabs = ({
                   tab={tab}
                   isActive={activeTab.code === tab.code}
                   statut={statut}
-                  isComplete={statut === 'complete'}
                   onSelect={() => setSelectedTab(tab.code)}
                 />
               );
@@ -104,23 +107,17 @@ export const DiagnosticTabs = ({
           </TabsList>
 
           <TabsPanel className="mt-8">
-            <div
-              role="tabpanel"
-              id={`demarche-topic-panel-${activeTab.code}`}
-              aria-labelledby={`demarche-topic-tab-${activeTab.code}`}
-            >
-              <DiagnosticTabContent
-                key={activeTab.code}
-                config={activeConfig}
-                vulnerabilite={
-                  isVulnerabiliteActive ? diagnostic.vulnerabilite : null
-                }
-                definitions={diagnostic.indicateurDefinitions}
-                valeurs={diagnostic.indicateurValeurs}
-                demarcheId={demarcheId}
-                isReadonly={isReadonly}
-              />
-            </div>
+            <DiagnosticTabContent
+              key={activeTab.code}
+              config={activeConfig}
+              vulnerabilite={
+                isVulnerabiliteActive ? diagnostic.vulnerabilite : null
+              }
+              definitions={diagnostic.indicateurDefinitions}
+              valeurs={diagnostic.indicateurValeurs}
+              demarcheId={demarcheId}
+              isReadonly={isReadonly}
+            />
           </TabsPanel>
         </Tabs>
       )}

--- a/apps/app/src/demarches/pcaet/diagnostic/topic-tab.tsx
+++ b/apps/app/src/demarches/pcaet/diagnostic/topic-tab.tsx
@@ -1,9 +1,8 @@
 'use client';
 
-import { Icon } from '@tet/ui';
-import { cn } from '@tet/ui/utils/cn';
+import { TabsTab } from '@tet/ui/design-system/TabsNext/index';
 import { JSX } from 'react';
-import { DemarcheCompletionBadge } from '../../components/completion.badge';
+import { getDemarcheCompletionBadgeProps } from '../../components/completion.badge';
 import type { DemarcheCompletionStatut } from '../../types';
 import type { DiagnosticTab } from './diagnostic.tabs.utils';
 
@@ -11,47 +10,29 @@ type TopicTabProps = {
   tab: DiagnosticTab;
   isActive: boolean;
   statut: DemarcheCompletionStatut;
-  /** Omis en consultation : l'avancement ne concerne que la collectivité. */
-  isComplete?: boolean;
   onSelect: () => void;
 };
 
+/**
+ * Volet du diagnostic, rendu avec la variante `card` des onglets : le volet
+ * sélectionné vient du paramètre `?topic=`, l'onglet est donc un bouton et non
+ * un lien.
+ */
 export const TopicTab = ({
   tab,
   isActive,
   statut,
   onSelect,
 }: TopicTabProps): JSX.Element => (
-  <li role="presentation" className="p-0">
-    <button
-      type="button"
-      role="tab"
-      id={`demarche-topic-tab-${tab.code}`}
-      aria-selected={isActive}
-      aria-controls={`demarche-topic-panel-${tab.code}`}
-      onClick={onSelect}
-      className={cn(
-        'group flex h-full w-full flex-col items-center gap-2 rounded-lg border p-3 text-center transition-colors cursor-pointer',
-        isActive
-          ? 'border-primary-7 bg-primary-0 border-2'
-          : 'border-grey-3 hover:border-primary-5 hover:bg-primary-0'
-      )}
-      data-test={`demarches.pcaet.diagnostic.topic-${tab.code}`}
-    >
-      <span
-        className={cn(
-          'flex h-8 w-8 items-center justify-center rounded-full',
-          statut === 'complete'
-            ? 'bg-success-2 text-success-9'
-            : 'bg-primary-1 text-primary-9'
-        )}
-      >
-        <Icon icon={tab.icon} size="md" />
-      </span>
-      <span className="text-sm font-semibold text-primary-9">{tab.label}</span>
-      {/* Le rond d'icône du volet est juste au-dessus : la répéter dans le
-          badge déborde dès que la sidebar est dépliée. */}
-      <DemarcheCompletionBadge statut={statut} size="xs" withIcon={false} />
-    </button>
-  </li>
+  <TabsTab
+    id={`demarche-topic-tab-${tab.code}`}
+    dataTest={`demarches.pcaet.diagnostic.topic-${tab.code}`}
+    label={tab.label}
+    icon={tab.icon}
+    isActive={isActive}
+    onClick={onSelect}
+    // L'icône du volet est juste au-dessus : la répéter dans le badge déborde
+    // dès que la sidebar est dépliée.
+    badge={getDemarcheCompletionBadgeProps(statut, { withIcon: false })}
+  />
 );

--- a/apps/app/src/demarches/pcaet/instruction/dossier/etape-diagnostic.section.tsx
+++ b/apps/app/src/demarches/pcaet/instruction/dossier/etape-diagnostic.section.tsx
@@ -60,8 +60,11 @@ export const EtapeDiagnosticSection = ({
         <SpinnerLoader className="m-auto" />
       ) : (
         <>
-          <Tabs dataTest="demarches.pcaet.instruction.diagnostic-topics">
-            <TabsList className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-6 gap-2 bg-transparent p-0 m-0 rounded-none w-full !list-none justify-stretch">
+          <Tabs
+            variant="card"
+            dataTest="demarches.pcaet.instruction.diagnostic-topics"
+          >
+            <TabsList className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-6 gap-2">
               {tabs.map((tab) => {
                 const config = diagnostic.indicateurParentConfigs.find(
                   (topic) => topic.code === tab.code
@@ -85,38 +88,32 @@ export const EtapeDiagnosticSection = ({
             </TabsList>
 
             <TabsPanel className="mt-8">
-              <div
-                role="tabpanel"
-                id={`demarche-topic-panel-${activeTab.code}`}
-                aria-labelledby={`demarche-topic-tab-${activeTab.code}`}
-              >
-                {isVulnerabiliteActive ? (
-                  <div className="flex flex-col gap-4">
-                    <p className="text-sm text-primary-9 m-0">
-                      {appLabels.demarcheVulnerabiliteDescription}
-                    </p>
-                    <div className="max-xl:overflow-x-auto p-4 pt-2 lg:p-8 lg:pt-4 bg-white rounded-xl border border-grey-3">
-                      <VulnerabiliteTable
-                        vulnerabilite={{
-                          thematiques: diagnostic.vulnerabilite.thematiques,
-                          lignes: diagnostic.vulnerabilite.lignes,
-                        }}
-                        demarcheId={demarcheId}
-                        isReadonly
-                      />
-                    </div>
+              {isVulnerabiliteActive ? (
+                <div className="flex flex-col gap-4">
+                  <p className="text-sm text-primary-9 m-0">
+                    {appLabels.demarcheVulnerabiliteDescription}
+                  </p>
+                  <div className="max-xl:overflow-x-auto p-4 pt-2 lg:p-8 lg:pt-4 bg-white rounded-xl border border-grey-3">
+                    <VulnerabiliteTable
+                      vulnerabilite={{
+                        thematiques: diagnostic.vulnerabilite.thematiques,
+                        lignes: diagnostic.vulnerabilite.lignes,
+                      }}
+                      demarcheId={demarcheId}
+                      isReadonly
+                    />
                   </div>
-                ) : activeConfig ? (
-                  <DiagnosticIndicateurTabContent
-                    definitions={diagnostic.indicateurDefinitions}
-                    key={activeConfig.code}
-                    demarcheId={demarcheId}
-                    config={activeConfig}
-                    valeurs={diagnostic.indicateurValeurs}
-                    isReadonly
-                  />
-                ) : null}
-              </div>
+                </div>
+              ) : activeConfig ? (
+                <DiagnosticIndicateurTabContent
+                  definitions={diagnostic.indicateurDefinitions}
+                  key={activeConfig.code}
+                  demarcheId={demarcheId}
+                  config={activeConfig}
+                  valeurs={diagnostic.indicateurValeurs}
+                  isReadonly
+                />
+              ) : null}
             </TabsPanel>
           </Tabs>
         </>


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Améliorations de l’interface**
  * Les onglets du diagnostic adoptent une présentation en cartes, plus cohérente visuellement.
  * La navigation entre les sujets utilise désormais les composants d’onglets standardisés.
  * Les badges de complétion affichent les informations de statut de manière harmonisée, avec ou sans icône selon le contexte.
  * L’affichage des panneaux de diagnostic est simplifié tout en conservant le contenu conditionnel existant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->