### PR TITLE
fix(ci): fait dépendre le typecheck des déclarations de ses dépendances

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -63,7 +63,7 @@
     },
     "typecheck": {
       "cache": true,
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "^typecheck"],
       "inputs": ["default", "^production"]
     },
     "build-storybook": {


### PR DESCRIPTION
`app:typecheck` échoue sur les PR qui ne touchent que le front, avec des centaines d'erreurs sans rapport avec le diff. Dernière occurrence en date : 921 erreurs sur #5004, dont le contenu se réduit à un déplacement de fichier.

## Une cause, des centaines de symptômes

La cible `typecheck` déclarait `dependsOn: ["^build"]`. Or `backend:build` compile avec swc, qui n'émet **aucune déclaration** : mesuré sur ce dépôt, il produit 1 663 fichiers `.js` et zéro `.d.ts`.

Rien ne garantissait donc que les déclarations de `@tet/backend` existent au moment où `app:typecheck` s'exécute. Quand elles manquent, `AppRouter` — défini comme `TrpcRouter['appRouter']` — devient introuvable :

```
packages/api/src/utils/trpc/trpc-server-client.ts:14 - error TS2305:
  Module '"@tet/backend/utils/trpc/trpc.router"' has no exported member 'AppRouter'.
```

Tout `RouterInput` et `RouterOutput` retombe alors sur `{}`, d'où des cascades de « Property does not exist on type `{}` », de « not assignable to parameter of type `void` », et des types absurdes comme `actionId: AppRouter`. Une seule ligne explique les 920 autres.

## Pourquoi c'était intermittent

Le défaut ne se manifeste que sur les PR ne touchant **que** `apps/app`. Partout ailleurs, `apps/backend` entre dans le périmètre affecté, `backend:typecheck` s'exécute et émet les déclarations au passage — le front compile, sans que la dépendance manquante se voie.

C'est ce qui rendait l'échec incompréhensible depuis le diff, et non reproductible en local, où les déclarations traînent d'un précédent typecheck.

## Ce que ça change

`typecheck` dépend désormais aussi du `typecheck` de ses dépendances, c'est-à-dire de la tâche qui émet réellement les `.d.ts`. Le coût est un enchaînement plus strict : le typecheck d'un projet attend celui de ses dépendances, là où il ne s'appuyait que sur leur compilation.

## Vérification

`apps/backend/dist` supprimé, puis `nx run app:typecheck` :

- avant, `AppRouter` introuvable et la compilation du front s'effondre ;
- après, les 1 331 déclarations sont reconstruites et le typecheck passe à 0 erreur.

## Surface de review

Une ligne, dans `nx.json`. L'attention porte sur l'effet de bord : allongement du graphe de tâches pour toutes les cibles `typecheck` du dépôt.

## Ce que ça débloque

#5004, rouge depuis quatre exécutions pour cette seule raison — son diff ne contient que des changements de chemin d'import.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Maintenance**
  - La vérification des types prend désormais en compte la compilation et la vérification des types des projets dépendants.
  - Cette mise à jour améliore la fiabilité des contrôles lors de la préparation des versions, sans modifier les fonctionnalités visibles dans l’application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->