### PR TITLE
refactor(documents): convertit la sélection de fichiers par Array.from

### DIFF
--- a/apps/app/src/referentiels/preuves/AddPreuveModal/filesToUploadList.tsx
+++ b/apps/app/src/referentiels/preuves/AddPreuveModal/filesToUploadList.tsx
@@ -35,7 +35,7 @@ export const filesToUploadList = async (
   // trente fichiers pour un contexte qui n'en accepte qu'un ne doit pas les
   // hacher tous ni les chercher tous dans la bibliothèque.
   const filesToProcess = keepWithinMaxFiles(
-    filesToArray(files),
+    Array.from(files),
     constraints.maxFiles
   );
 
@@ -66,16 +66,6 @@ export const filesToUploadList = async (
     }
     return { kind: 'toUpload', file, hash };
   });
-};
-
-// Transforme un objet FileList (retourné par le sélecteur de fichiers standard)
-// en tableau. On le fait comme ça car TS n'accepte pas Array.from(files) ou [...files]
-const filesToArray = (files: FileList): File[] => {
-  const arr: File[] = [];
-  for (let i = 0; i < files.length; i++) {
-    arr.push(files.item(i) as File);
-  }
-  return arr;
 };
 
 const toFailed = (file: File, error: UploadErrorCode): PreparedFile => ({


### PR DESCRIPTION
Empilée sur #5026, qui réécrit le fichier concerné.

`filesToArray` accumulait les entrées d'un `FileList` dans un tableau local, avec une assertion `as File` sur chaque `files.item(i)` :

```ts
const arr: File[] = [];
for (let i = 0; i < files.length; i++) {
  arr.push(files.item(i) as File);
}
```

Son commentaire justifiait le détour par un refus du compilateur — « TS n'accepte pas `Array.from(files)` ou `[...files]` ».

**Ce n'est plus vrai.** `FileList` déclare `length` et un index numérique, donc satisfait `ArrayLike<File>` : `Array.from(files)` se type `File[]` sans assertion. Vérifié en compilant, pas en le supposant.

La mutation locale et l'assertion partent ensemble, et le helper avec elles — un appel direct suffit.

## Surface de review

Onze lignes retirées, une ajoutée, dans un seul fichier. Le comportement est identique : `Array.from` sur un `ArrayLike` lit les mêmes indices dans le même ordre.

## Vérification

`tsc --noEmit` sur `apps/app` ✅, `nx test app` ✅ (666 tests), `eslint` ✅.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplification de la conversion des fichiers importés en liste.
  * Les fonctionnalités de hachage, de validation et de détection des doublons restent inchangées.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->