### PR TITLE
refactor(documents): nomme en camelCase l'identifiant du statut de dépôt

### DIFF
--- a/apps/app/src/referentiels/preuves/AddPreuveModal/AddFile.spec.tsx
+++ b/apps/app/src/referentiels/preuves/AddPreuveModal/AddFile.spec.tsx
@@ -23,7 +23,7 @@ vi.mock('./use-file-upload-list', () => ({
         file: new File([''], 'nouveau nom.pdf', { type: 'application/pdf' }),
         status: {
           code: UploadStatusCode.duplicated,
-          fichier_id: 1,
+          fichierId: 1,
           filename: 'nom-original.pdf',
           hash: 'hash-1',
         },

--- a/apps/app/src/referentiels/preuves/AddPreuveModal/AddFile.stories.tsx
+++ b/apps/app/src/referentiels/preuves/AddPreuveModal/AddFile.stories.tsx
@@ -128,7 +128,7 @@ export const DejaDansLaBibliotheque: Story = {
         file: createMockFile('deliberation.pdf', 87 * 1024),
         status: {
           code: UploadStatusCode.duplicated,
-          fichier_id: 1,
+          fichierId: 1,
           filename: 'deliberation.pdf',
           hash: 'hash-1',
         },
@@ -137,7 +137,7 @@ export const DejaDansLaBibliotheque: Story = {
         file: createMockFile('nouveau nom.xls', 15 * MO),
         status: {
           code: UploadStatusCode.duplicated,
-          fichier_id: 2,
+          fichierId: 2,
           filename: 'budget prévisionnel.xls',
           hash: 'hash-2',
         },
@@ -157,7 +157,7 @@ export const TeleversementAbouti: Story = {
         ),
         status: {
           code: UploadStatusCode.completed,
-          fichier_id: 3,
+          fichierId: 3,
           hash: 'hash-3',
         },
       },

--- a/apps/app/src/referentiels/preuves/AddPreuveModal/AddFile.tsx
+++ b/apps/app/src/referentiels/preuves/AddPreuveModal/AddFile.tsx
@@ -136,7 +136,7 @@ export const AddFile = (props: AddFileProps) => {
   }: ValidFileItem): Promise<SubmittedValidFile> => ({
     file,
     status,
-    addedPreuve: await onAddFileFromLib(status.fichier_id),
+    addedPreuve: await onAddFileFromLib(status.fichierId),
   });
 
   const onSubmit = async (e: FormEvent) => {

--- a/apps/app/src/referentiels/preuves/AddPreuveModal/FileItem.spec.tsx
+++ b/apps/app/src/referentiels/preuves/AddPreuveModal/FileItem.spec.tsx
@@ -17,7 +17,7 @@ describe('FileItem duplicate message', () => {
           file: createMockFile('nouveau nom.pdf', 1024),
           status: {
             code: UploadStatusCode.duplicated,
-            fichier_id: 1,
+            fichierId: 1,
             filename: 'nom-original.pdf',
             hash: 'hash-1',
           },
@@ -40,7 +40,7 @@ describe('FileItem duplicate message', () => {
           file: createMockFile('nom-original.pdf', 1024),
           status: {
             code: UploadStatusCode.duplicated,
-            fichier_id: 1,
+            fichierId: 1,
             filename: 'nom-original.pdf',
             hash: 'hash-1',
           },

--- a/apps/app/src/referentiels/preuves/AddPreuveModal/FileItem.stories.tsx
+++ b/apps/app/src/referentiels/preuves/AddPreuveModal/FileItem.stories.tsx
@@ -51,7 +51,7 @@ export const fileItemMocks: Record<string, FileUploadItem> = {
     file: createMockFile('feuille de route des élus responsables CAE.pdf', 100),
     status: {
       code: UploadStatusCode.completed,
-      fichier_id: 1,
+      fichierId: 1,
       hash: MOCK_HASH,
     },
   },
@@ -95,7 +95,7 @@ export const fileItemMocks: Record<string, FileUploadItem> = {
     file: createMockFile('fichier.xls', 15 * 1024 * 1024),
     status: {
       code: UploadStatusCode.duplicated,
-      fichier_id: 1,
+      fichierId: 1,
       filename: 'fichier.xls',
       hash: MOCK_HASH,
     },
@@ -105,7 +105,7 @@ export const fileItemMocks: Record<string, FileUploadItem> = {
     file: createMockFile('nouveau nom.xls', 15 * 1024 * 1024),
     status: {
       code: UploadStatusCode.duplicated,
-      fichier_id: 1,
+      fichierId: 1,
       filename: 'fichier.xls',
       hash: MOCK_HASH,
     },

--- a/apps/app/src/referentiels/preuves/AddPreuveModal/filesToUploadList.tsx
+++ b/apps/app/src/referentiels/preuves/AddPreuveModal/filesToUploadList.tsx
@@ -82,7 +82,7 @@ const toDuplicated = (file: File, fichier: FichierParHash): PreparedFile => ({
   file,
   status: {
     code: UploadStatusCode.duplicated,
-    fichier_id: fichier.id,
+    fichierId: fichier.id,
     filename: fichier.filename,
     hash: fichier.hash,
   },

--- a/apps/app/src/referentiels/preuves/AddPreuveModal/types.ts
+++ b/apps/app/src/referentiels/preuves/AddPreuveModal/types.ts
@@ -38,14 +38,14 @@ export type UploadStatusFailed = {
 // fichier ajouté à la bibliothèque après le téléversement
 export type UploadStatusCompleted = {
   code: UploadStatusCode.completed;
-  fichier_id: number;
+  fichierId: number;
   hash: DocumentHash;
 };
 
 // fichier déjà téléversé
 export type UploadStatusDuplicated = {
   code: UploadStatusCode.duplicated;
-  fichier_id: number;
+  fichierId: number;
   filename: string;
   hash: string;
 };

--- a/apps/app/src/referentiels/preuves/AddPreuveModal/use-file-upload-list.ts
+++ b/apps/app/src/referentiels/preuves/AddPreuveModal/use-file-upload-list.ts
@@ -127,7 +127,7 @@ export const useFileUploadList = ({
       }
       setStatus(item.id, {
         code: UploadStatusCode.completed,
-        fichier_id: fichierId,
+        fichierId,
         hash,
       });
     } catch (error) {


### PR DESCRIPTION
Empilée sur #5026, qui réécrit les fichiers concernés.

`UploadStatusCompleted` et `UploadStatusDuplicated` portaient `fichier_id` — le seul snake_case d'un type qui n'a jamais décrit une ligne de base. Ces statuts représentent l'état d'un dépôt en cours dans la modale « Ajouter une preuve », pas une réponse PostgREST. Le nom vient de l'époque où le statut recopiait la colonne.

Quatorze occurrences, huit fichiers, aucun changement de comportement.

## La frontière, et pourquoi elle est là

**Ce qui est renommé** : le type de statut et ses consommateurs — `types.ts`, `use-file-upload-list.ts`, `filesToUploadList.tsx`, `AddFile.tsx`, plus les specs et stories qui construisent ces statuts.

**Ce qui ne l'est pas, délibérément** : `useAddPreuves.ts:101` garde `fichier_id` dans l'insert de `preuve_audit`. C'est le nom que la base attend, et le renommer casserait l'écriture. Le critère n'est pas l'esthétique du nom mais ce qu'il désigne — une colonne, ou un champ à nous.

## Ce qui reste snake_case et sort du périmètre

`FileOrLink` (`useAddPreuves.ts:13`) et les quatre paramètres nommés `fichier_id` des implémentations de `AddFileFromLibHandler` portent le même défaut. Ils appartiennent à un autre contrat — celui de l'association d'une preuve, pas celui du dépôt — et `fiche_id` y traîne avec. Les traiter ici mêlerait deux sujets dans une PR qui doit rester mécanique et relisible d'un coup d'œil.

## Vérification

`tsc --noEmit` project et spec sur `apps/app` ✅, `nx test app` ✅ (666 tests), `eslint` ✅. Plus aucune occurrence de `fichier_id` dans `AddPreuveModal/`.