### PR TITLE
refactor(audits): dégage l'orchestration du dépôt de rapport

### DIFF
--- a/apps/app/src/referentiels/audits/cloture/data/use-upload-audit-report.ts
+++ b/apps/app/src/referentiels/audits/cloture/data/use-upload-audit-report.ts
@@ -2,12 +2,15 @@ import { hashFile } from '@/app/collectivites/documents/upload/hash-file.utils';
 import { useUploadFile } from '@/app/collectivites/documents/upload/use-upload-file';
 import { appLabels } from '@/app/labels/catalog';
 import { auditReportToPreuve } from '@/app/referentiels/preuves/mappers/audit-report-to-preuve';
+import { useRemovePreuve } from '@/app/referentiels/preuves/Bibliotheque/useEditPreuve';
 import {
   EXPECTED_FORMATS,
   MAX_FILE_SIZE_MB,
 } from '@/app/referentiels/preuves/upload/constants';
-import { validateFile } from '@/app/referentiels/preuves/upload/validate-file';
-import { useRemovePreuve } from '@/app/referentiels/preuves/Bibliotheque/useEditPreuve';
+import {
+  FileValidationError,
+  validateFile,
+} from '@/app/referentiels/preuves/upload/validate-file';
 import { useAddPreuveAudit } from '@/app/referentiels/preuves/useAddPreuves';
 import { useToastContext } from '@/app/utils/toast/toast-context';
 import { useQueryClient } from '@tanstack/react-query';
@@ -30,11 +33,23 @@ export type AuditReportUploadState = {
   uploadingReport: UploadingReport | null;
   isUploading: boolean;
   removingReportIds: ReadonlySet<number>;
-  isRemoving: boolean;
   canProceed: boolean;
   uploadReport: (files: FileList | null) => Promise<void>;
   removeReport: (report: AuditReport) => Promise<void>;
   abortUpload: () => void;
+};
+
+const toValidationMessage = (error: FileValidationError): string => {
+  const formats = EXPECTED_FORMATS.join(', ');
+  const messageByError: Record<FileValidationError, string> = {
+    sizeError: appLabels.fichierTropVolumineux({ maxMo: MAX_FILE_SIZE_MB }),
+    formatError: appLabels.fichierFormatNonSupporte({ formats }),
+    formatAndSizeError: appLabels.fichierFormatEtTailleInvalides({
+      maxMo: MAX_FILE_SIZE_MB,
+      formats,
+    }),
+  };
+  return messageByError[error];
 };
 
 export const useUploadAuditReport = (
@@ -66,22 +81,20 @@ export const useUploadAuditReport = (
 
   const isUploading = uploadingReport !== null;
 
+  const refetchReports = (): Promise<void> =>
+    queryClient.refetchQueries({
+      queryKey: trpc.referentiels.documents.listDocumentsAudit.queryKey({
+        auditId,
+      }),
+    });
+
   const uploadReport = async (files: FileList | null): Promise<void> => {
     const file = files?.[0];
     if (!file) return;
 
     const validationError = validateFile(file);
     if (validationError !== null) {
-      const formats = EXPECTED_FORMATS.join(', ');
-      const messageByError: Record<typeof validationError, string> = {
-        sizeError: appLabels.fichierTropVolumineux({ maxMo: MAX_FILE_SIZE_MB }),
-        formatError: appLabels.fichierFormatNonSupporte({ formats }),
-        formatAndSizeError: appLabels.fichierFormatEtTailleInvalides({
-          maxMo: MAX_FILE_SIZE_MB,
-          formats,
-        }),
-      };
-      setToast('error', messageByError[validationError]);
+      setToast('error', toValidationMessage(validationError));
       return;
     }
 
@@ -107,14 +120,11 @@ export const useUploadAuditReport = (
         commentaire: '',
         fichierId,
       });
-      if (controller.signal.aborted) return;
       // Attend que la liste des rapports soit re-fetchée avant de libérer
       // l'état d'upload pour éviter les flickering de refetch
-      await queryClient.refetchQueries({
-        queryKey: trpc.referentiels.documents.listDocumentsAudit.queryKey({
-          auditId,
-        }),
-      });
+      if (!controller.signal.aborted) {
+        await refetchReports();
+      }
     } catch (error) {
       if (controller.signal.aborted) return;
       console.error(error);
@@ -130,18 +140,10 @@ export const useUploadAuditReport = (
   };
 
   const removeReport = async (report: AuditReport): Promise<void> => {
-    setRemovingReportIds((prev) => {
-      const next = new Set(prev);
-      next.add(report.id);
-      return next;
-    });
+    setRemovingReportIds((prev) => new Set(prev).add(report.id));
     try {
       await removePreuve(auditReportToPreuve(report));
-      await queryClient.refetchQueries({
-        queryKey: trpc.referentiels.documents.listDocumentsAudit.queryKey({
-          auditId,
-        }),
-      });
+      await refetchReports();
     } catch (error) {
       console.error(error);
       setToast('error', appLabels.echecSuppressionRapport);
@@ -160,16 +162,17 @@ export const useUploadAuditReport = (
     setUploadingReport(null);
   };
 
-  const isRemoving = removingReportIds.size > 0;
   return {
     reports,
     isLoadingReports,
     uploadingReport,
     isUploading,
     removingReportIds,
-    isRemoving,
     canProceed:
-      !isLoadingReports && reports.length > 0 && !isUploading && !isRemoving,
+      !isLoadingReports &&
+      reports.length > 0 &&
+      !isUploading &&
+      removingReportIds.size === 0,
     uploadReport,
     removeReport,
     abortUpload,


### PR DESCRIPTION
`use-upload-audit-report.ts` portait quatre choses qui n'ont pas besoin d'être dans un hook. Un seul fichier touché, rien de visible pour l'utilisateur.

| | avant | après |
|---|---|---|
| messages de validation | `Record<FileValidationError, string>` reconstruit à chaque rendu, alors qu'il ne dépend que de `MAX_FILE_SIZE_MB` et `EXPECTED_FORMATS` | `toValidationMessage`, fonction pure au niveau module |
| clé de requête | `listDocumentsAudit.queryKey({ auditId })` réécrite aux deux endroits qui rafraîchissent la liste | une closure `refetchReports`, appelée par les deux |
| `isRemoving` | exposé par le hook | retiré de sa surface publique |
| garde d'annulation | après `refetchQueries` | avant `refetchQueries` |

**`isRemoving` n'avait aucun lecteur.** `report-card.tsx` et `audit-reports.list.tsx` dérivent chacun leur état de `removingReportIds.has(id)`, et `AuditReportUploaderProps` ne déclare pas ce champ. En interne, `canProceed` interroge désormais `removingReportIds.size` au lieu du booléen.

**Le déplacement de la garde est le seul changement de comportement.** Après `refetchQueries`, elle ne protégeait plus rien : aucun état n'est touché ensuite, et le `finally` teste déjà l'annulation. Placée avant, elle évite un aller-retour réseau lorsque l'utilisateur a renoncé pendant `addPreuve`.

## Arbitrages

**Pas d'abstraction commune avec `useFileUploadList`.** Les deux hooks déposent un fichier, mais leurs modèles d'état diffèrent — une liste de statuts discriminés d'un côté, un seul `{ filename, progress } | null` de l'autre — et celui-ci ne fait ni détection de doublon ni éviction par limite. Les fusionner produirait l'abstraction « presque la même chose » que le CLAUDE.md proscrit.

**Les gardes ne servent qu'à ne pas travailler pour rien, jamais à interrompre.** Seul `uploadFile` reçoit le `signal` ; `addPreuve` et `refetchReports` ne sont pas interruptibles.

**L'annulation reste trompeuse une fois le dépôt terminé.** Cliquer « annuler » pendant `addPreuve` masque l'indicateur, mais la preuve est créée côté serveur et réapparaît au rafraîchissement suivant. Comportement antérieur à cette PR, non corrigé ici.