### PR TITLE
ci: improve e2e sharding

### DIFF
--- a/.github/workflows/test-end-to-end.yml
+++ b/.github/workflows/test-end-to-end.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        shard: [1, 2, 3, 4, 5]
 
     steps:
       - uses: actions/checkout@v7.0.1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Étend l’exécution des tests de bout en bout à 5 partitions parallèles au lieu de 4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->