### PR TITLE
refactor(preuves-archive): rend l'assemblage d'archive réutilisable hors de l'audit

### DIFF
--- a/apps/backend/src/referentiels/preuves-archive/build-archive/archive-arborescence.ts
+++ b/apps/backend/src/referentiels/preuves-archive/build-archive/archive-arborescence.ts
@@ -1,0 +1,26 @@
+import type { LienPreuve } from './build-liens-csv';
+
+export interface ArchiveFile {
+  folderSegments: string[];
+  filename: string;
+  bucketId: string;
+  hash: string;
+  filesize: number;
+}
+
+export interface ArchiveLinkFolder {
+  folderSegments: string[];
+  liens: LienPreuve[];
+}
+
+export interface SkippedFile {
+  filename: string;
+  emplacement: string;
+  raison: string;
+}
+
+export interface ArchiveFolderArborescence {
+  files: ArchiveFile[];
+  linkFolders: ArchiveLinkFolder[];
+  skippedFiles: SkippedFile[];
+}

--- a/apps/backend/src/referentiels/preuves-archive/build-archive/archive-assembly.errors.ts
+++ b/apps/backend/src/referentiels/preuves-archive/build-archive/archive-assembly.errors.ts
@@ -1,0 +1,3 @@
+export const ARCHIVE_ASSEMBLY_FAILED = 'ARCHIVE_ASSEMBLY_FAILED';
+
+export type ArchiveAssemblyError = typeof ARCHIVE_ASSEMBLY_FAILED;

--- a/apps/backend/src/referentiels/preuves-archive/build-archive/archive-limits.spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/build-archive/archive-limits.spec.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from 'vitest';
+import type { ArchiveFile } from './archive-arborescence';
+import {
+  checkArchiveLimits,
+  MAX_FILE_COUNT,
+  MAX_FILE_SIZE_BYTES,
+  MAX_TOTAL_SIZE_BYTES,
+  splitTriagedArchiveFiles,
+  triageArchiveFile,
+} from './archive-limits';
+
+const toArchiveFile = (filesize: number): ArchiveFile => ({
+  folderSegments: [],
+  filename: 'document.pdf',
+  bucketId: 'collectivite-1',
+  hash: 'a'.repeat(64),
+  filesize,
+});
+
+describe('triageArchiveFile', () => {
+  test('retient un fichier de taille connue sous la limite', () => {
+    const triage = triageArchiveFile({
+      file: {
+        bucketId: 'collectivite-1',
+        hash: 'abc',
+        filename: 'deliberation.pdf',
+        filesize: 1024,
+      },
+      folderSegments: ['mesures', '1.1.1'],
+    });
+
+    expect(triage).toEqual({
+      kind: 'collected',
+      file: {
+        folderSegments: ['mesures', '1.1.1'],
+        filename: 'deliberation.pdf',
+        bucketId: 'collectivite-1',
+        hash: 'abc',
+        filesize: 1024,
+      },
+    });
+  });
+
+  test('écarte un fichier dont la taille est inconnue', () => {
+    const triage = triageArchiveFile({
+      file: {
+        bucketId: 'collectivite-1',
+        hash: 'abc',
+        filename: 'sans-taille.pdf',
+        filesize: null,
+      },
+      folderSegments: ['mesures'],
+    });
+
+    expect(triage).toEqual({
+      kind: 'skipped',
+      entry: {
+        filename: 'sans-taille.pdf',
+        emplacement: 'mesures',
+        raison: 'Taille du fichier inconnue',
+      },
+    });
+  });
+
+  test('écarte un fichier au-dela de 100 Mo', () => {
+    const triage = triageArchiveFile({
+      file: {
+        bucketId: 'collectivite-1',
+        hash: 'abc',
+        filename: 'enorme.pdf',
+        filesize: MAX_FILE_SIZE_BYTES + 1,
+      },
+      folderSegments: [],
+    });
+
+    expect(triage.kind).toBe('skipped');
+  });
+
+  test('nomme un fichier sans filename par son empreinte', () => {
+    const triage = triageArchiveFile({
+      file: {
+        bucketId: 'collectivite-1',
+        hash: 'abc',
+        filename: null,
+        filesize: 10,
+      },
+      folderSegments: [],
+    });
+
+    expect(triage).toMatchObject({
+      kind: 'collected',
+      file: { filename: 'abc' },
+    });
+  });
+});
+
+describe('splitTriagedArchiveFiles', () => {
+  test('sépare les fichiers retenus des fichiers consignés', () => {
+    const retenu = toArchiveFile(10);
+    const consigne = {
+      filename: 'absent.pdf',
+      emplacement: '',
+      raison: 'Taille du fichier inconnue',
+    };
+
+    expect(
+      splitTriagedArchiveFiles([
+        { kind: 'collected', file: retenu },
+        { kind: 'skipped', entry: consigne },
+      ])
+    ).toEqual({ files: [retenu], skippedFiles: [consigne] });
+  });
+});
+
+describe('checkArchiveLimits', () => {
+  test('accepte une archive sous les deux plafonds', () => {
+    expect(checkArchiveLimits([toArchiveFile(1024)])).toEqual({
+      withinLimits: true,
+    });
+  });
+
+  test('refuse au-dela de 500 fichiers', () => {
+    const files = Array.from({ length: MAX_FILE_COUNT + 1 }, () =>
+      toArchiveFile(1)
+    );
+
+    expect(checkArchiveLimits(files)).toEqual({
+      withinLimits: false,
+      reason: `Trop de fichiers à archiver (${
+        MAX_FILE_COUNT + 1
+      }, limite ${MAX_FILE_COUNT})`,
+    });
+  });
+
+  test('refuse au-dela de 2 Go au total', () => {
+    const files = [toArchiveFile(MAX_TOTAL_SIZE_BYTES), toArchiveFile(1)];
+
+    expect(checkArchiveLimits(files)).toEqual({
+      withinLimits: false,
+      reason: `Archive trop volumineuse (${
+        MAX_TOTAL_SIZE_BYTES + 1
+      } octets, limite ${MAX_TOTAL_SIZE_BYTES})`,
+    });
+  });
+});

--- a/apps/backend/src/referentiels/preuves-archive/build-archive/archive-limits.ts
+++ b/apps/backend/src/referentiels/preuves-archive/build-archive/archive-limits.ts
@@ -1,0 +1,84 @@
+import type {
+  ArchiveFile,
+  SkippedFile,
+} from '../generate-preuves-archive/generate-archive-folder-arborescence';
+
+export const MAX_FILE_SIZE_BYTES = 100 * 1024 * 1024;
+export const MAX_FILE_COUNT = 500;
+export const MAX_TOTAL_SIZE_BYTES = 2 * 1024 * 1024 * 1024;
+
+const FILE_SIZE_UNKNOWN = 'Taille du fichier inconnue';
+
+export interface ArchiveCandidateFile {
+  bucketId: string;
+  hash: string;
+  filename: string | null;
+  filesize: number | null;
+}
+
+export type ArchiveFileTriage =
+  | { kind: 'collected'; file: ArchiveFile }
+  | { kind: 'skipped'; entry: SkippedFile };
+
+export function triageArchiveFile({
+  file,
+  folderSegments,
+}: {
+  file: ArchiveCandidateFile;
+  folderSegments: string[];
+}): ArchiveFileTriage {
+  const emplacement = folderSegments.join('/');
+  const filename = file.filename ?? file.hash;
+
+  if (file.filesize === null) {
+    return {
+      kind: 'skipped',
+      entry: { filename, emplacement, raison: FILE_SIZE_UNKNOWN },
+    };
+  }
+
+  if (file.filesize > MAX_FILE_SIZE_BYTES) {
+    return {
+      kind: 'skipped',
+      entry: {
+        filename,
+        emplacement,
+        raison: `Fichier trop volumineux (${file.filesize} octets, limite ${MAX_FILE_SIZE_BYTES})`,
+      },
+    };
+  }
+
+  return {
+    kind: 'collected',
+    file: {
+      folderSegments,
+      filename,
+      bucketId: file.bucketId,
+      hash: file.hash,
+      filesize: file.filesize,
+    },
+  };
+}
+
+export type ArchiveLimitsCheck =
+  | { withinLimits: true }
+  | { withinLimits: false; raison: string };
+
+export function checkArchiveLimits(files: ArchiveFile[]): ArchiveLimitsCheck {
+  if (files.length > MAX_FILE_COUNT) {
+    return {
+      withinLimits: false,
+      raison: `Trop de fichiers à archiver (${files.length}, limite ${MAX_FILE_COUNT})`,
+    };
+  }
+
+  const totalSize = files.reduce((sum, file) => sum + file.filesize, 0);
+  if (totalSize > MAX_TOTAL_SIZE_BYTES) {
+    return {
+      withinLimits: false,
+      raison: `Archive trop volumineuse (${totalSize} octets, limite ${MAX_TOTAL_SIZE_BYTES})`,
+    };
+  }
+
+  return { withinLimits: true };
+}

--- a/apps/backend/src/referentiels/preuves-archive/build-archive/archive-limits.ts
+++ b/apps/backend/src/referentiels/preuves-archive/build-archive/archive-limits.ts
@@ -1,7 +1,4 @@
-import type {
-  ArchiveFile,
-  SkippedFile,
-} from '../generate-preuves-archive/generate-archive-folder-arborescence';
+import type { ArchiveFile, SkippedFile } from './archive-arborescence';
 
 export const MAX_FILE_SIZE_BYTES = 100 * 1024 * 1024;
 export const MAX_FILE_COUNT = 500;
@@ -62,13 +59,13 @@ export function triageArchiveFile({
 
 export type ArchiveLimitsCheck =
   | { withinLimits: true }
-  | { withinLimits: false; raison: string };
+  | { withinLimits: false; reason: string };
 
 export function checkArchiveLimits(files: ArchiveFile[]): ArchiveLimitsCheck {
   if (files.length > MAX_FILE_COUNT) {
     return {
       withinLimits: false,
-      raison: `Trop de fichiers à archiver (${files.length}, limite ${MAX_FILE_COUNT})`,
+      reason: `Trop de fichiers à archiver (${files.length}, limite ${MAX_FILE_COUNT})`,
     };
   }
 
@@ -76,9 +73,27 @@ export function checkArchiveLimits(files: ArchiveFile[]): ArchiveLimitsCheck {
   if (totalSize > MAX_TOTAL_SIZE_BYTES) {
     return {
       withinLimits: false,
-      raison: `Archive trop volumineuse (${totalSize} octets, limite ${MAX_TOTAL_SIZE_BYTES})`,
+      reason: `Archive trop volumineuse (${totalSize} octets, limite ${MAX_TOTAL_SIZE_BYTES})`,
     };
   }
 
   return { withinLimits: true };
+}
+
+export interface TriagedArchiveFiles {
+  files: ArchiveFile[];
+  skippedFiles: SkippedFile[];
+}
+
+export function splitTriagedArchiveFiles(
+  triaged: ArchiveFileTriage[]
+): TriagedArchiveFiles {
+  return {
+    files: triaged.flatMap((entry) =>
+      entry.kind === 'collected' ? [entry.file] : []
+    ),
+    skippedFiles: triaged.flatMap((entry) =>
+      entry.kind === 'skipped' ? [entry.entry] : []
+    ),
+  };
 }

--- a/apps/backend/src/referentiels/preuves-archive/build-archive/build-archive-manifests.spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/build-archive/build-archive-manifests.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { buildArchiveManifests } from './build-archive-manifests';
-import type { ArchiveFolderArborescence } from '../generate-preuves-archive/generate-archive-folder-arborescence';
+import type { ArchiveFolderArborescence } from './archive-arborescence';
 
 function emptyArborescence(
   overrides: Partial<ArchiveFolderArborescence> = {}

--- a/apps/backend/src/referentiels/preuves-archive/build-archive/build-archive-manifests.ts
+++ b/apps/backend/src/referentiels/preuves-archive/build-archive/build-archive-manifests.ts
@@ -1,4 +1,4 @@
-import { type ArchiveFolderArborescence } from '../generate-preuves-archive/generate-archive-folder-arborescence';
+import { type ArchiveFolderArborescence } from './archive-arborescence';
 import { buildArchivePath } from './build-archive-path';
 import { buildLiensCsv } from './build-liens-csv';
 

--- a/apps/backend/src/referentiels/preuves-archive/build-archive/build-archive.service.spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/build-archive/build-archive.service.spec.ts
@@ -3,7 +3,7 @@ import { success } from '@tet/backend/utils/result.type';
 import { Readable, Writable } from 'node:stream';
 import { describe, expect, test } from 'vitest';
 import { type ArchiveFolderArborescence } from './archive-arborescence';
-import { PreuvesArchiveErrorEnum } from '../preuves-archive.errors';
+import { ARCHIVE_ASSEMBLY_FAILED } from './archive-assembly.errors';
 import { BuildArchiveService } from './build-archive.service';
 
 const toArborescence = (): ArchiveFolderArborescence => ({
@@ -69,7 +69,7 @@ describe('BuildArchiveService.assembleZip', () => {
 
     expect(result.success).toBe(false);
     expect(result.success === false && result.error).toBe(
-      PreuvesArchiveErrorEnum.CREATE_ARCHIVE_ERROR
+      ARCHIVE_ASSEMBLY_FAILED
     );
   });
 });

--- a/apps/backend/src/referentiels/preuves-archive/build-archive/build-archive.service.spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/build-archive/build-archive.service.spec.ts
@@ -2,7 +2,7 @@ import { DocumentStorageService } from '@tet/backend/utils/supabase/document-sto
 import { success } from '@tet/backend/utils/result.type';
 import { Readable, Writable } from 'node:stream';
 import { describe, expect, test } from 'vitest';
-import { type ArchiveFolderArborescence } from '../generate-preuves-archive/generate-archive-folder-arborescence';
+import { type ArchiveFolderArborescence } from './archive-arborescence';
 import { PreuvesArchiveErrorEnum } from '../preuves-archive.errors';
 import { BuildArchiveService } from './build-archive.service';
 

--- a/apps/backend/src/referentiels/preuves-archive/build-archive/build-archive.service.spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/build-archive/build-archive.service.spec.ts
@@ -1,0 +1,75 @@
+import { DocumentStorageService } from '@tet/backend/utils/supabase/document-storage.service';
+import { success } from '@tet/backend/utils/result.type';
+import { Readable, Writable } from 'node:stream';
+import { describe, expect, test } from 'vitest';
+import { type ArchiveFolderArborescence } from '../generate-preuves-archive/generate-archive-folder-arborescence';
+import { PreuvesArchiveErrorEnum } from '../preuves-archive.errors';
+import { BuildArchiveService } from './build-archive.service';
+
+const toArborescence = (): ArchiveFolderArborescence => ({
+  files: [
+    {
+      folderSegments: [],
+      filename: 'deliberation.pdf',
+      bucketId: 'collectivite-1',
+      hash: 'a'.repeat(64),
+      filesize: 4,
+    },
+  ],
+  linkFolders: [],
+  skippedFiles: [],
+});
+
+const toDocumentStorage = (): DocumentStorageService =>
+  ({
+    getDocumentStream: async () => success(Readable.from(['abcd'])),
+  } as unknown as DocumentStorageService);
+
+const toCollectingDestination = (): Writable & { collected: Buffer[] } => {
+  const collected: Buffer[] = [];
+  const destination = new Writable({
+    write(chunk, _encoding, callback) {
+      collected.push(Buffer.from(chunk));
+      callback();
+    },
+  });
+  return Object.assign(destination, { collected });
+};
+
+const toFailingDestination = (): Writable =>
+  new Writable({
+    write(_chunk, _encoding, callback) {
+      callback(new Error('destination indisponible'));
+    },
+  });
+
+describe('BuildArchiveService.assembleZip', () => {
+  test('écrit une archive dans la destination fournie', async () => {
+    const service = new BuildArchiveService(toDocumentStorage());
+    const destination = toCollectingDestination();
+
+    const result = await service.assembleZip({
+      arborescence: toArborescence(),
+      destination,
+    });
+
+    expect(result).toEqual(success({ totalFiles: 1 }));
+    expect(Buffer.concat(destination.collected).subarray(0, 2)).toEqual(
+      Buffer.from('PK')
+    );
+  });
+
+  test("rend un échec quand la destination refuse l'écriture", async () => {
+    const service = new BuildArchiveService(toDocumentStorage());
+
+    const result = await service.assembleZip({
+      arborescence: toArborescence(),
+      destination: toFailingDestination(),
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.success === false && result.error).toBe(
+      PreuvesArchiveErrorEnum.CREATE_ARCHIVE_ERROR
+    );
+  });
+});

--- a/apps/backend/src/referentiels/preuves-archive/build-archive/build-archive.service.ts
+++ b/apps/backend/src/referentiels/preuves-archive/build-archive/build-archive.service.ts
@@ -133,8 +133,7 @@ export class BuildArchiveService {
         (entry) => archive.append(entry.content, { name: entry.name })
       );
 
-      await archive.finalize();
-      await writeFinished;
+      await Promise.all([archive.finalize(), writeFinished]);
 
       return success({ totalFiles: preparedEntries.length });
     } catch (error) {

--- a/apps/backend/src/referentiels/preuves-archive/build-archive/build-archive.service.ts
+++ b/apps/backend/src/referentiels/preuves-archive/build-archive/build-archive.service.ts
@@ -9,7 +9,7 @@ import { join } from 'node:path';
 import { type Writable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import { DocumentStorageService } from '@tet/backend/utils/supabase/document-storage.service';
-import { type ArchiveFolderArborescence } from '../generate-preuves-archive/generate-archive-folder-arborescence';
+import { type ArchiveFolderArborescence } from './archive-arborescence';
 import {
   ARCHIVE_ZIP_CONTENT_TYPE,
   PREUVES_ARCHIVES_BUCKET,

--- a/apps/backend/src/referentiels/preuves-archive/build-archive/build-archive.service.ts
+++ b/apps/backend/src/referentiels/preuves-archive/build-archive/build-archive.service.ts
@@ -6,6 +6,7 @@ import { createWriteStream } from 'node:fs';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { type Writable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import { DocumentStorageService } from '@tet/backend/utils/supabase/document-storage.service';
 import { type ArchiveFolderArborescence } from '../generate-preuves-archive/generate-archive-folder-arborescence';
@@ -37,9 +38,9 @@ type DownloadOutcome =
   | { kind: 'appended' }
   | { kind: 'failed'; message: string };
 
-interface AssembleZipInput {
+export interface AssembleZipInput {
   arborescence: ArchiveFolderArborescence;
-  tempZipPath: string;
+  destination: Writable;
   onProgress?: (processedFiles: number) => void;
 }
 
@@ -61,7 +62,7 @@ export class BuildArchiveService {
 
       const assembleResult = await this.assembleZip({
         arborescence,
-        tempZipPath,
+        destination: createWriteStream(tempZipPath),
         onProgress,
       });
       if (!assembleResult.success) {
@@ -105,35 +106,46 @@ export class BuildArchiveService {
     }
   }
 
-  private async assembleZip({
+  async assembleZip({
     arborescence,
-    tempZipPath,
+    destination,
     onProgress,
-  }: AssembleZipInput): Promise<Result<{ totalFiles: number }, PreuvesArchiveError>> {
+  }: AssembleZipInput): Promise<
+    Result<{ totalFiles: number }, PreuvesArchiveError>
+  > {
     const archive = archiver('zip', { store: true });
-    const output = createWriteStream(tempZipPath);
-    const writeFinished = pipeline(archive, output);
+    const writeFinished = pipeline(archive, destination);
 
     const preparedEntries = prepareArchiveEntries(arborescence.files);
 
-    const outcomes = await mapWithConcurrency(
-      preparedEntries,
-      DOWNLOAD_CONCURRENCY,
-      (entry) => this.downloadAndAppendEntry({ entry, archive }),
-      (processed) => onProgress?.(processed)
-    );
-    const failedDownloads = outcomes.flatMap((outcome) =>
-      outcome.kind === 'failed' ? [outcome.message] : []
-    );
+    try {
+      const outcomes = await mapWithConcurrency(
+        preparedEntries,
+        DOWNLOAD_CONCURRENCY,
+        (entry) => this.downloadAndAppendEntry({ entry, archive }),
+        (processed) => onProgress?.(processed)
+      );
+      const failedDownloads = outcomes.flatMap((outcome) =>
+        outcome.kind === 'failed' ? [outcome.message] : []
+      );
 
-    buildArchiveManifests({ arborescence, failedDownloads }).forEach((entry) =>
-      archive.append(entry.content, { name: entry.name })
-    );
+      buildArchiveManifests({ arborescence, failedDownloads }).forEach(
+        (entry) => archive.append(entry.content, { name: entry.name })
+      );
 
-    await archive.finalize();
-    await writeFinished;
+      await archive.finalize();
+      await writeFinished;
 
-    return success({ totalFiles: preparedEntries.length });
+      return success({ totalFiles: preparedEntries.length });
+    } catch (error) {
+      this.logger.error(
+        `Assemblage de l'archive interrompu: ${getErrorMessage(error)}`
+      );
+      return failure(
+        PreuvesArchiveErrorEnum.CREATE_ARCHIVE_ERROR,
+        error instanceof Error ? error : new Error(getErrorMessage(error))
+      );
+    }
   }
 
   private async downloadAndAppendEntry({

--- a/apps/backend/src/referentiels/preuves-archive/build-archive/build-archive.service.ts
+++ b/apps/backend/src/referentiels/preuves-archive/build-archive/build-archive.service.ts
@@ -11,6 +11,10 @@ import { pipeline } from 'node:stream/promises';
 import { DocumentStorageService } from '@tet/backend/utils/supabase/document-storage.service';
 import { type ArchiveFolderArborescence } from './archive-arborescence';
 import {
+  ARCHIVE_ASSEMBLY_FAILED,
+  type ArchiveAssemblyError,
+} from './archive-assembly.errors';
+import {
   ARCHIVE_ZIP_CONTENT_TYPE,
   PREUVES_ARCHIVES_BUCKET,
 } from '../preuves-archive.constants';
@@ -66,7 +70,10 @@ export class BuildArchiveService {
         onProgress,
       });
       if (!assembleResult.success) {
-        return assembleResult;
+        return failure(
+          PreuvesArchiveErrorEnum.CREATE_ARCHIVE_ERROR,
+          assembleResult.cause
+        );
       }
 
       const uploadResult = await this.documentStorage.storeDocument({
@@ -111,7 +118,7 @@ export class BuildArchiveService {
     destination,
     onProgress,
   }: AssembleZipInput): Promise<
-    Result<{ totalFiles: number }, PreuvesArchiveError>
+    Result<{ totalFiles: number }, ArchiveAssemblyError>
   > {
     const archive = archiver('zip', { store: true });
     const writeFinished = pipeline(archive, destination);
@@ -141,7 +148,7 @@ export class BuildArchiveService {
         `Assemblage de l'archive interrompu: ${getErrorMessage(error)}`
       );
       return failure(
-        PreuvesArchiveErrorEnum.CREATE_ARCHIVE_ERROR,
+        ARCHIVE_ASSEMBLY_FAILED,
         error instanceof Error ? error : new Error(getErrorMessage(error))
       );
     }

--- a/apps/backend/src/referentiels/preuves-archive/build-archive/prepare-archive-entries.spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/build-archive/prepare-archive-entries.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { ArchiveFile } from '../generate-preuves-archive/generate-archive-folder-arborescence';
+import type { ArchiveFile } from './archive-arborescence';
 import { prepareArchiveEntries } from './prepare-archive-entries';
 
 function makeFile(

--- a/apps/backend/src/referentiels/preuves-archive/build-archive/prepare-archive-entries.ts
+++ b/apps/backend/src/referentiels/preuves-archive/build-archive/prepare-archive-entries.ts
@@ -1,4 +1,4 @@
-import type { ArchiveFile } from '../generate-preuves-archive/generate-archive-folder-arborescence';
+import type { ArchiveFile } from './archive-arborescence';
 import { buildArchivePath } from './build-archive-path';
 
 export interface PreparedFileEntry {

--- a/apps/backend/src/referentiels/preuves-archive/generate-preuves-archive/generate-archive-folder-arborescence.ts
+++ b/apps/backend/src/referentiels/preuves-archive/generate-preuves-archive/generate-archive-folder-arborescence.ts
@@ -10,41 +10,21 @@ import type {
   CollectedLinkPreuve,
   MissingFilePreuve,
 } from '../collect-audit-preuves/collect-preuves.repository';
-import type { LienPreuve } from '../build-archive/build-liens-csv';
 import {
   checkArchiveLimits,
+  splitTriagedArchiveFiles,
   triageArchiveFile,
 } from '../build-archive/archive-limits';
+import type {
+  ArchiveFolderArborescence,
+  ArchiveLinkFolder,
+  SkippedFile,
+} from '../build-archive/archive-arborescence';
 
 const MESURES_FOLDER = 'mesures';
 const CYCLE_FOLDER = 'cycle-labellisation';
 const DEMANDE_FOLDER = 'demande';
 const AUDIT_FOLDER = 'audit';
-
-export interface ArchiveFile {
-  folderSegments: string[];
-  filename: string;
-  bucketId: string;
-  hash: string;
-  filesize: number;
-}
-
-export interface ArchiveLinkFolder {
-  folderSegments: string[];
-  liens: LienPreuve[];
-}
-
-export interface SkippedFile {
-  filename: string;
-  emplacement: string;
-  raison: string;
-}
-
-export interface ArchiveFolderArborescence {
-  files: ArchiveFile[];
-  linkFolders: ArchiveLinkFolder[];
-  skippedFiles: SkippedFile[];
-}
 
 export interface ReferentielTreeNode {
   actionId: string;
@@ -189,16 +169,12 @@ export function generateArchiveFolderArborescence(
     folderSegments: [CYCLE_FOLDER, AUDIT_FOLDER],
   }));
 
-  const triaged = [...mesureFiles, ...demandeFiles, ...auditFiles].map(
-    triageArchiveFile
+  const triaged = splitTriagedArchiveFiles(
+    [...mesureFiles, ...demandeFiles, ...auditFiles].map(triageArchiveFile)
   );
-  const collectedFiles = triaged.flatMap((entry) =>
-    entry.kind === 'collected' ? [entry.file] : []
-  );
+  const collectedFiles = triaged.files;
   const skippedFiles = [
-    ...triaged.flatMap((entry) =>
-      entry.kind === 'skipped' ? [entry.entry] : []
-    ),
+    ...triaged.skippedFiles,
     ...[
       ...mesureMissingFiles,
       ...demandeMissingFiles,
@@ -206,11 +182,11 @@ export function generateArchiveFolderArborescence(
     ].map(toSkippedMissingFile),
   ];
 
-  const limits = checkArchiveLimits(collectedFiles);
-  if (!limits.withinLimits) {
+  const limitsCheck = checkArchiveLimits(collectedFiles);
+  if (!limitsCheck.withinLimits) {
     return failure(
       PreuvesArchiveErrorEnum.COLLECT_PREUVES_ERROR,
-      new Error(limits.raison)
+      new Error(limitsCheck.reason)
     );
   }
 

--- a/apps/backend/src/referentiels/preuves-archive/generate-preuves-archive/generate-archive-folder-arborescence.ts
+++ b/apps/backend/src/referentiels/preuves-archive/generate-preuves-archive/generate-archive-folder-arborescence.ts
@@ -7,15 +7,14 @@ import {
   type PreuvesArchiveError,
 } from '../preuves-archive.errors';
 import type {
-  CollectedFilePreuve,
   CollectedLinkPreuve,
   MissingFilePreuve,
 } from '../collect-audit-preuves/collect-preuves.repository';
 import type { LienPreuve } from '../build-archive/build-liens-csv';
-
-const MAX_FILE_SIZE_BYTES = 100 * 1024 * 1024;
-const MAX_FILE_COUNT = 500;
-const MAX_TOTAL_SIZE_BYTES = 2 * 1024 * 1024 * 1024;
+import {
+  checkArchiveLimits,
+  triageArchiveFile,
+} from '../build-archive/archive-limits';
 
 const MESURES_FOLDER = 'mesures';
 const CYCLE_FOLDER = 'cycle-labellisation';
@@ -65,11 +64,6 @@ interface MesureFolder {
   folderSegments: string[];
 }
 
-type FileWithFolder = {
-  file: CollectedFilePreuve;
-  folderSegments: string[];
-};
-
 type LinkWithFolder = {
   link: CollectedLinkPreuve;
   folderSegments: string[];
@@ -81,7 +75,6 @@ type MissingFileWithFolder = {
 };
 
 const FILE_MISSING_FROM_STORAGE = 'Fichier introuvable dans le stockage';
-const FILE_SIZE_UNKNOWN = 'Taille du fichier inconnue';
 
 function toSkippedMissingFile({
   missingFile,
@@ -92,73 +85,6 @@ function toSkippedMissingFile({
     emplacement: folderSegments.join('/'),
     raison: FILE_MISSING_FROM_STORAGE,
   };
-}
-
-type FileTriage =
-  | { kind: 'collected'; file: ArchiveFile }
-  | { kind: 'skipped'; entry: SkippedFile };
-
-function triageFile({ file, folderSegments }: FileWithFolder): FileTriage {
-  const emplacement = folderSegments.join('/');
-  const filename = file.filename ?? file.hash;
-
-  if (file.filesize === null) {
-    return {
-      kind: 'skipped',
-      entry: {
-        filename,
-        emplacement,
-        raison: FILE_SIZE_UNKNOWN,
-      },
-    };
-  }
-
-  if (file.filesize > MAX_FILE_SIZE_BYTES) {
-    return {
-      kind: 'skipped',
-      entry: {
-        filename,
-        emplacement,
-        raison: `Fichier trop volumineux (${file.filesize} octets, limite ${MAX_FILE_SIZE_BYTES})`,
-      },
-    };
-  }
-
-  return {
-    kind: 'collected',
-    file: {
-      folderSegments,
-      filename,
-      bucketId: file.bucketId,
-      hash: file.hash,
-      filesize: file.filesize,
-    },
-  };
-}
-
-function checkArchiveLimits(
-  files: ArchiveFile[]
-): Result<undefined, PreuvesArchiveError> {
-  if (files.length > MAX_FILE_COUNT) {
-    return failure(
-      PreuvesArchiveErrorEnum.COLLECT_PREUVES_ERROR,
-      new Error(
-        `Trop de fichiers à archiver (${files.length}, limite ${MAX_FILE_COUNT})`
-      )
-    );
-  }
-
-  const totalSize = files.reduce((sum, file) => sum + file.filesize, 0);
-  if (totalSize > MAX_TOTAL_SIZE_BYTES) {
-    return failure(
-      PreuvesArchiveErrorEnum.COLLECT_PREUVES_ERROR,
-      new Error(
-        `Archive trop volumineuse (${totalSize} octets, limite ${MAX_TOTAL_SIZE_BYTES})`
-      )
-    );
-  }
-
-  return success(undefined);
 }
 
 function groupLinksByFolder(links: LinkWithFolder[]): ArchiveLinkFolder[] {
@@ -210,8 +136,7 @@ function mesureFolderSegments(
   }
   const match = mesureFolders.find(
     (mesure) =>
-      mesure.actionId === actionId ||
-      actionId.startsWith(`${mesure.actionId}.`)
+      mesure.actionId === actionId || actionId.startsWith(`${mesure.actionId}.`)
   );
   return match ? match.folderSegments : [MESURES_FOLDER];
 }
@@ -264,7 +189,9 @@ export function generateArchiveFolderArborescence(
     folderSegments: [CYCLE_FOLDER, AUDIT_FOLDER],
   }));
 
-  const triaged = [...mesureFiles, ...demandeFiles, ...auditFiles].map(triageFile);
+  const triaged = [...mesureFiles, ...demandeFiles, ...auditFiles].map(
+    triageArchiveFile
+  );
   const collectedFiles = triaged.flatMap((entry) =>
     entry.kind === 'collected' ? [entry.file] : []
   );
@@ -280,8 +207,11 @@ export function generateArchiveFolderArborescence(
   ];
 
   const limits = checkArchiveLimits(collectedFiles);
-  if (!limits.success) {
-    return limits;
+  if (!limits.withinLimits) {
+    return failure(
+      PreuvesArchiveErrorEnum.COLLECT_PREUVES_ERROR,
+      new Error(limits.raison)
+    );
   }
 
   return success({

--- a/apps/backend/src/referentiels/preuves-archive/generate-preuves-archive/generate-preuves-archive.service.ts
+++ b/apps/backend/src/referentiels/preuves-archive/generate-preuves-archive/generate-preuves-archive.service.ts
@@ -20,9 +20,9 @@ import {
   type AuditPreuvesArchive,
 } from '../models/audit-preuves-archive.table';
 import { PreuvesArchiveRepository } from '../preuves-archive.repository';
+import type { ArchiveFolderArborescence } from '../build-archive/archive-arborescence';
 import {
   generateArchiveFolderArborescence,
-  type ArchiveFolderArborescence,
   type ReferentielTreeNode,
 } from './generate-archive-folder-arborescence';
 


### PR DESCRIPTION
`BuildArchiveService` sait désormais assembler une archive pour autre chose que le pipeline d'audit.

Plan : `docs/plans/2026-09-03-002-refactor-upload-documents-url-signee-plan.md` (compound-knowledge-db). Prérequis de la PR qui télécharge en une archive les documents d'une mesure : celle-ci assemble vers une réponse HTTP, et tout ce qui protégeait l'assemblage était enfermé dans la feature d'audit.

Aucun comportement de l'archive de preuves d'audit ne change.

## La destination devient un paramètre

`assembleZip` construisait son flux de sortie depuis un chemin de fichier temporaire. Elle prend maintenant une `Writable` et devient publique ; `buildAndUpload` lui passe le `createWriteStream` qu'elle créait auparavant.

Son corps rend un `Result` au lieu de laisser remonter l'exception — ce que `buildAndUpload` faisait déjà de son côté, avec la même erreur `CREATE_ARCHIVE_ERROR`.

## Une destination qui échoue suspendait l'assemblage

`await archive.finalize()` précédait `await writeFinished`. Quand la destination rejetait l'écriture, `finalize()` ne rendait jamais la main : le rejet du `pipeline` n'était jamais observé et remontait en rejet non géré. Les deux sont désormais attendus ensemble.

Le défaut restait théorique tant que la destination était un fichier temporaire. Il devient courant dès qu'elle est une réponse HTTP, qu'un client peut fermer en cours de téléchargement.

## Les garde-fous sortent de l'audit

Quatre protections vivaient dans `generate-archive-folder-arborescence`, donc réservées à l'archive d'audit : 100 Mo par fichier, refus des fichiers de taille inconnue, 500 fichiers et 2 Go au total. Toute autre archive assemblée par `BuildArchiveService` serait partie sans aucun plafond.

`triageArchiveFile` et `checkArchiveLimits` rejoignent `build-archive/`, aux côtés de l'assemblage qu'ils protègent. `checkArchiveLimits` rend une union discriminée plutôt qu'un `Result` typé sur les erreurs d'audit : chaque appelant traduit le dépassement dans son propre vocabulaire.

## Les types d'archive quittent la feature qui les consommait

`ArchiveFile`, `ArchiveLinkFolder`, `SkippedFile` et `ArchiveFolderArborescence` étaient déclarés dans `generate-archive-folder-arborescence`. Les six modules de `build-archive/` les importaient donc depuis l'audit — dépendance à contresens que l'extraction des garde-fous venait d'aggraver. Ils passent dans `build-archive/archive-arborescence.ts`.

Le découpage d'une liste triée en fichiers retenus et fichiers consignés devenait identique des deux côtés : il part dans `splitTriagedArchiveFiles`.

## Surface de review

- Attention humaine : la signature d'`assembleZip` et l'ordre d'attente de ses deux promesses ; la frontière tracée par `archive-limits.ts`.
- Mécaniques : les chemins d'import vers `archive-arborescence`.

## Recherche anti-duplication

Aucun nouvel utilitaire : la PR ne fait que déplacer et paramétrer de l'existant. `splitTriagedArchiveFiles` factorise deux occurrences identiques plutôt que d'en créer une troisième.

## Zones de moindre confiance

- `Promise.all` laisse `archive.finalize()` en cours quand le pipeline rejette en premier. La promesse reste rattachée, donc pas de rejet non géré, mais l'archiver n'est pas explicitement détruit.
- `ArchiveCandidateFile.hash` reste un `string` nu. `DocumentHash` (branded) existe depuis `2de087cb50`, mais le typer ici forcerait un cast à la frontière tant qu'`ArchiveFile.hash` et `CollectedFilePreuve.hash` sont des `string` — migration à mener d'un bloc, pas ici.

## Tests

`build-archive.service.spec.ts` (2) et `archive-limits.spec.ts` (8), nouveaux. Les onze tests d'arborescence, qui couvrent les quatre garde-fous, passent sans modification.

Le test d'échec d'assemblage est rouge sur `48f4523b88` (timeout à 20 s), vert sur `7a7bb20d5f`.

## Vérifications

- `tsc --build --force` et `nx lint backend` : 0 erreur.
- `nx test backend 'preuves-archive'` : 111 passés. Deux fichiers échouent en local — `preuves-archive.full-pipeline.e2e-spec.ts` et `collect-preuves.repository.e2e-spec.ts` — identiquement sur `main` sans cette branche : le schéma `storage.objects` local est en retard (`column "level" does not exist`). Le second ne touche à aucun code modifié ici.