### PR TITLE
ci(database): harden Sqitch and maintenance workflows

### DIFF
--- a/.github/actions/compute-affected-scope/action.yml
+++ b/.github/actions/compute-affected-scope/action.yml
@@ -92,7 +92,7 @@ runs:
         fi
 
         run_db_deploy=false
-        if grep -Eq '^(data_layer/|supabase/|sqitch\.conf$|\.github/actions/sqitch/|\.github/actions/sqitch-local/|\.github/workflows/prepare-test-db\.yml$|\.github/workflows/test-db-deploy\.yml$)' <<<"$changed_files"; then
+        if grep -Eq '^(Makefile$|Earthfile$|data_layer/|supabase/|sqitch\.conf$|\.github/actions/sqitch/|\.github/actions/sqitch-local/|\.github/workflows/(backup-database|cd-restore-preprod|prepare-test-db|test-db-deploy)\.yml$)' <<<"$changed_files"; then
           run_db_deploy=true
         fi
 

--- a/.github/actions/sqitch-local/action.yml
+++ b/.github/actions/sqitch-local/action.yml
@@ -1,17 +1,19 @@
 name: sqitch-local
-description: Run sqitch (for local dev)
+description: |
+  Run sqitch for local development.
+  Docker actions preserve the standard libpq PGOPTIONS variable supplied by the calling step.
 
 inputs:
   command:
-    description: "Command to run"
+    description: 'Command to run'
     required: true
   target:
-    description: "Target"
+    description: 'Target'
     required: true
 
 runs:
-  using: "docker"
-  image: "Dockerfile"
+  using: 'docker'
+  image: 'Dockerfile'
   args:
     - ${{ inputs.command }}
     - ${{ inputs.target }}

--- a/.github/actions/sqitch-local/entrypoint.sh
+++ b/.github/actions/sqitch-local/entrypoint.sh
@@ -1,8 +1,18 @@
 #!/bin/bash
 
+set -euo pipefail
+
+if (( $# != 2 )) || [[ -z "$1" || -z "$2" ]]; then
+  echo 'sqitch-local requires a non-empty command and target' >&2
+  exit 2
+fi
+
 # Split the command input into an array by space
 IFS=' ' read -r -a cmd_array <<< "$1"
+if (( ${#cmd_array[@]} == 0 )); then
+  echo 'sqitch-local command cannot be empty' >&2
+  exit 2
+fi
 
 # Execute sqitch with the array
 sqitch "${cmd_array[@]}" --target "$2"
-

--- a/.github/actions/sqitch/action.yml
+++ b/.github/actions/sqitch/action.yml
@@ -1,21 +1,21 @@
 name: sqitch
 description: |
   Run sqitch into a container with a prebuilt image to allow passing the --network option.
-
+  The standard libpq PGOPTIONS environment variable is forwarded unchanged when callers set it.
 
 inputs:
   command:
-    description: "Command to run"
+    description: 'Command to run'
     required: true
   target:
-    description: "Target"
+    description: 'Target'
     required: true
   network:
     description: Docker network
     required: true
 
 runs:
-  using: "composite"
+  using: 'composite'
 
   steps:
     - name: Get image path
@@ -43,12 +43,24 @@ runs:
     # docker-compose évite un déploiement vert en local et rouge ici.
     - name: Execute command within image
       shell: bash
-      run: >
-        docker run
-        --rm
-        --network ${{ inputs.network }}
-        -v ./sqitch.conf:/sqitch.conf
-        -v ./data_layer:/data_layer
-        ${{ steps.get_image_path.outputs.path }}
-        ${{ inputs.command }}
-        --target ${{ inputs.target }}
+      env:
+        SQITCH_COMMAND: ${{ inputs.command }}
+        SQITCH_IMAGE: ${{ steps.get_image_path.outputs.path }}
+        SQITCH_NETWORK: ${{ inputs.network }}
+        SQITCH_TARGET: ${{ inputs.target }}
+      run: |
+        IFS=' ' read -r -a sqitch_command <<< "$SQITCH_COMMAND"
+        if (( ${#sqitch_command[@]} == 0 )); then
+          echo '::error::La commande Sqitch ne peut pas être vide.'
+          exit 2
+        fi
+
+        docker run \
+          --rm \
+          --network "$SQITCH_NETWORK" \
+          --env PGOPTIONS \
+          -v ./sqitch.conf:/sqitch.conf \
+          -v ./data_layer:/data_layer \
+          "$SQITCH_IMAGE" \
+          "${sqitch_command[@]}" \
+          --target "$SQITCH_TARGET"

--- a/.github/workflows/backup-database.yml
+++ b/.github/workflows/backup-database.yml
@@ -15,9 +15,14 @@ jobs:
     environment: prod
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    concurrency:
+      group: database-maintenance-prod
+      cancel-in-progress: false
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install PostgreSQL client
         run: |
@@ -63,11 +68,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     concurrency:
-      group: restore-staging
+      group: database-maintenance-staging
       cancel-in-progress: false
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install PostgreSQL client
         run: |
@@ -76,7 +83,7 @@ jobs:
 
       - name: Install yq
         run: |
-          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.53.2/yq_linux_amd64
           sudo chmod +x /usr/local/bin/yq
 
       - name: Install AWS CLI
@@ -104,11 +111,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     concurrency:
-      group: restore-preprod
+      group: database-maintenance-preprod
       cancel-in-progress: false
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install PostgreSQL client
         run: |
@@ -117,7 +126,7 @@ jobs:
 
       - name: Install yq
         run: |
-          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.53.2/yq_linux_amd64
           sudo chmod +x /usr/local/bin/yq
 
       - name: Install AWS CLI
@@ -143,4 +152,5 @@ jobs:
           BACKUP_BUCKET: ${{ vars.BACKUP_BUCKET }}
           BACKUP_REGION: ${{ vars.BACKUP_REGION }}
           BACKUP_ENDPOINT_URL: ${{ vars.BACKUP_ENDPOINT_URL }}
-        run: bash data_layer/backup/restore.sh "${{ steps.dminus1.outputs.date }}"
+          RESTORE_ARGUMENT: ${{ steps.dminus1.outputs.date }}
+        run: bash data_layer/backup/restore.sh "$RESTORE_ARGUMENT"

--- a/.github/workflows/cd-restore-preprod.yml
+++ b/.github/workflows/cd-restore-preprod.yml
@@ -20,11 +20,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     concurrency:
-      group: restore-preprod
+      group: database-maintenance-preprod
       cancel-in-progress: false
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install PostgreSQL client
         run: |
@@ -33,7 +35,7 @@ jobs:
 
       - name: Install yq
         run: |
-          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.53.2/yq_linux_amd64
           sudo chmod +x /usr/local/bin/yq
 
       - name: Install AWS CLI
@@ -75,4 +77,5 @@ jobs:
           BACKUP_BUCKET: ${{ vars.BACKUP_BUCKET }}
           BACKUP_REGION: ${{ vars.BACKUP_REGION }}
           BACKUP_ENDPOINT_URL: ${{ vars.BACKUP_ENDPOINT_URL }}
-        run: bash data_layer/backup/restore.sh "${{ steps.restore_arg.outputs.restore_arg }}"
+          RESTORE_ARGUMENT: ${{ steps.restore_arg.outputs.restore_arg }}
+        run: bash data_layer/backup/restore.sh "$RESTORE_ARGUMENT"

--- a/.github/workflows/test-db-deploy.yml
+++ b/.github/workflows/test-db-deploy.yml
@@ -7,13 +7,13 @@ permissions:
 on:
   workflow_call:
 
-
 env:
   # le tag sqitch jusqu'où on test les revert/deploy
   tag: v4.0.0
 
 jobs:
   test-db-deploy:
+    name: Test database deployment lifecycle
     runs-on: ubuntu-latest
     environment: ci
 
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@v7.0.1
         with:
           persist-credentials: false
+
       - uses: ./.github/actions/docker-login
         if: ${{ !env.ACT }}
         with:
@@ -33,30 +34,85 @@ jobs:
           network: ${{ vars.SUPABASE_NETWORK }}
           pull: ${{ !env.ACT }}
 
+      - name: Bind database tests to the local Supabase container
+        id: local-supabase
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@supabase_db_tet:5432/postgres
+          SUPABASE_NETWORK: ${{ vars.SUPABASE_NETWORK }}
+        run: |
+          set -euo pipefail
+
+          container_id="$(docker inspect --format '{{.Id}}' supabase_db_tet)"
+          if [[ "$(docker inspect --format '{{.State.Running}}' supabase_db_tet)" != 'true' ]]; then
+            echo "::error::Le conteneur Supabase local n'est pas démarré."
+            exit 2
+          fi
+
+          attached_container_ip=''
+          while IFS='|' read -r attached_container_id attached_container_cidr; do
+            if [[ "$attached_container_id" == "$container_id" ]]; then
+              attached_container_ip="${attached_container_cidr%%/*}"
+              break
+            fi
+          done < <(
+            docker network inspect \
+              --format '{{range $id, $container := .Containers}}{{$id}}|{{$container.IPv4Address}}{{"\n"}}{{end}}' \
+              "$SUPABASE_NETWORK"
+          )
+          if [[ -z "$attached_container_ip" ]]; then
+            echo "::error::Le conteneur Supabase local n'est pas rattaché au réseau $SUPABASE_NETWORK."
+            exit 2
+          fi
+
+          postgres_image="$(docker inspect --format '{{.Config.Image}}' supabase_db_tet)"
+          connection_identity="$(
+            docker run \
+              --rm \
+              --network "$SUPABASE_NETWORK" \
+              --env DATABASE_URL \
+              --entrypoint psql \
+              "$postgres_image" \
+              "$DATABASE_URL" \
+              --no-psqlrc \
+              --tuples-only \
+              --no-align \
+              --set ON_ERROR_STOP=1 \
+              --command "select current_database() || '|' || host(inet_server_addr())"
+          )"
+          if [[ "$connection_identity" != "postgres|$attached_container_ip" ]]; then
+            echo '::error::La cible PostgreSQL ne correspond pas au conteneur Supabase local démarré.'
+            exit 2
+          fi
+
+          echo "database-url=$DATABASE_URL" >> "$GITHUB_OUTPUT"
+          echo "sqitch-target=db:$DATABASE_URL" >> "$GITHUB_OUTPUT"
+
       - name: Sqitch revert to ${{ env.tag }}
         if: ${{ !env.ACT }}
         uses: ./.github/actions/sqitch
         with:
-          command: "revert --to @${{ env.tag }} --y"
-          target: ${{ vars.SQITCH_TARGET }}
+          command: 'revert --to @${{ env.tag }} --y'
+          target: ${{ steps.local-supabase.outputs.sqitch-target }}
           network: ${{ vars.SUPABASE_NETWORK }}
 
       - name: Sqitch deploy/verify
         if: ${{ !env.ACT }}
         uses: ./.github/actions/sqitch
         with:
-          command: "deploy --mode change --verify"
-          target: ${{ vars.SQITCH_TARGET }}
+          command: 'deploy --mode change --verify'
+          target: ${{ steps.local-supabase.outputs.sqitch-target }}
           network: ${{ vars.SUPABASE_NETWORK }}
 
       - name: Sqitch revert to ${{ env.tag }} (local)
         if: ${{ env.ACT }}
         uses: ./.github/actions/sqitch-local
         with:
-          command: "revert --to @${{ env.tag }} --y"
+          command: 'revert --to @${{ env.tag }} --y'
+          target: ${{ steps.local-supabase.outputs.sqitch-target }}
 
       - name: Sqitch deploy/verify (local)
         if: ${{ env.ACT }}
         uses: ./.github/actions/sqitch-local
         with:
-          command: "deploy --mode change --verify"
+          command: 'deploy --mode change --verify'
+          target: ${{ steps.local-supabase.outputs.sqitch-target }}


### PR DESCRIPTION
Database deployment checks can use a configured Sqitch target outside the local Supabase container, and the local Sqitch calls omit their required target. Bind CI and local revert/deploy checks to the running container and verify its network membership and PostgreSQL identity before exporting the target.

- Preserve Sqitch argument boundaries, reject empty commands, and forward `PGOPTIONS` to the Docker invocation.
- Run database deployment validation when the Makefile, Earthfile, or backup/restore workflows change.
- Use shared database-maintenance concurrency groups, pin yq to `v4.53.2`, update checkout, disable persisted credentials, and pass restore arguments through environment variables.

Extracted from #4961 onto current `main`, limited to the seven requested workflow/action files. This PR has no dependency on the periodicity stack. The schema PR retains the URL-validator calls, restore compatibility tests, periodicity lifecycle tests, migration tags, and `--mode all` deployment behavior; this PR retains main’s `--mode change --verify` behavior.

Validation: actionlint passed for all three changed workflows; Prettier, YAML parsing, Bash syntax, and local action references passed. Temporary smoke checks passed 36 argument-handling, exit-status, container-identity, and affected-path cases, plus concurrency and configuration assertions. The full database lifecycle remains to be run in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Améliorations**
  - Les déploiements et restaurations de bases de données vérifient désormais explicitement l’état et la cible du conteneur PostgreSQL avant l’exécution.
  - Les commandes Sqitch transmettent correctement les options PostgreSQL définies par l’environnement appelant.
  - Les entrées invalides ou commandes vides sont détectées avec des messages d’erreur explicites.

- **Fiabilité**
  - Les outils utilisés pour les restaurations sont désormais versionnés afin d’obtenir des exécutions plus reproductibles.
  - Les opérations de maintenance utilisent des groupes de concurrence distincts pour limiter les exécutions simultanées.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->