### PR TITLE
fix(ci): borne les artefacts du build backend et matérialise les déclarations

### DIFF
--- a/.github/workflows/validate-affected-projects.yml
+++ b/.github/workflows/validate-affected-projects.yml
@@ -90,21 +90,21 @@ jobs:
       - name: Build affected projects
         run: pnpm nx affected -t build --base="${{ inputs.nx-base }}" --head="${{ inputs.nx-head }}" --exclude=app,backend,e2e --parallel=50%
 
-      - name: Materialise backend declarations before concurrent Nx commands
-        run: pnpm nx typecheck backend
+      # Keep these Nx commands sequential: with the daemon disabled in CI, cache
+      # hits restore shared dependency outputs even when they are already present.
+      # A concurrent restore can overwrite declarations while typecheck reads them.
+      - name: Typecheck affected projects
+        env:
+          SIRENE_API_KEY: ${{ secrets.SIRENE_API_KEY }}
+          SIRENE_API_URL: ${{ vars.SIRENE_API_URL }}
+        run: |
+          pnpm nx affected -t typecheck --base="${{ inputs.nx-base }}" --head="${{ inputs.nx-head }}" --parallel=50%
 
-      - parallel:
-          - name: Typecheck affected projects
-            env:
-              SIRENE_API_KEY: ${{ secrets.SIRENE_API_KEY }}
-              SIRENE_API_URL: ${{ vars.SIRENE_API_URL }}
-            run: |
-              pnpm nx affected -t typecheck --base="${{ inputs.nx-base }}" --head="${{ inputs.nx-head }}" --parallel=50%
-          - name: Test affected projects
-            env:
-              SIRENE_API_KEY: ${{ secrets.SIRENE_API_KEY }}
-              SIRENE_API_URL: ${{ vars.SIRENE_API_URL }}
-            run: |
-              pnpm nx affected -t test --base="${{ inputs.nx-base }}" --head="${{ inputs.nx-head }}" --exclude=backend,api,e2e --parallel=50%
+      - name: Test affected projects
+        env:
+          SIRENE_API_KEY: ${{ secrets.SIRENE_API_KEY }}
+          SIRENE_API_URL: ${{ vars.SIRENE_API_URL }}
+        run: |
+          pnpm nx affected -t test --base="${{ inputs.nx-base }}" --head="${{ inputs.nx-head }}" --exclude=backend,api,e2e --parallel=50%
 
       - wait-all:

--- a/.github/workflows/validate-affected-projects.yml
+++ b/.github/workflows/validate-affected-projects.yml
@@ -90,6 +90,9 @@ jobs:
       - name: Build affected projects
         run: pnpm nx affected -t build --base="${{ inputs.nx-base }}" --head="${{ inputs.nx-head }}" --exclude=app,backend,e2e --parallel=50%
 
+      - name: Materialise backend declarations before concurrent Nx commands
+        run: pnpm nx typecheck backend
+
       - parallel:
           - name: Typecheck affected projects
             env:

--- a/apps/backend/project.json
+++ b/apps/backend/project.json
@@ -27,6 +27,14 @@
     "build": {
       "command": "nest build",
       "dependsOn": ["^build"],
+      "outputs": [
+        "{projectRoot}/dist/**/*.js",
+        "{projectRoot}/dist/**/*.js.map",
+        "{projectRoot}/dist/**/*.csv",
+        "{projectRoot}/dist/**/*.xlsx",
+        "{projectRoot}/dist/**/*.pptx",
+        "{projectRoot}/dist/**/*.ttf"
+      ],
       "options": {
         "cwd": "apps/backend"
       }


### PR DESCRIPTION
Toute PR dont le diff est purement front échoue au typecheck, pour une raison étrangère à son contenu. **#5027 et #5028 ont été mergées avec la CI rouge**, #5031 l'est encore.

## Le symptôme

`validate-affected-projects` → `app:typecheck` : `Found 923 errors in 339 files`, toutes en cascade de deux lignes.

```
packages/api/src/utils/trpc/trpc-server-client.ts:14:15 - error TS2305:
  Module '"@tet/backend/utils/trpc/trpc.router"' has no exported member 'AppRouter'.
```

`AppRouter` disparu, tous les `RouterInput`/`RouterOutput` s'effondrent en `{}`. L'erreur est `TS2305` et non `TS2307` : le `.d.ts` est là, il est incomplet — et `AppRouter` en est la **dernière** ligne, sur 17 183.

## Ce qui discrimine

| diff de la PR | `backend:typecheck` | résultat |
|---|---|---|
| touche le backend | cache **miss**, `tsc` rejoue et réécrit les déclarations | ✅ |
| purement front | cache **hit** | ❌ |

C'est aussi pourquoi #5019 n'a pas suffi : il a corrigé l'ordonnancement, mais un cache hit satisfait la dépendance sans rien produire.

## Deux causes cumulées

**`backend:build` était `cache: true` sans aucun `outputs`**, alors que `nest build` écrit dans `apps/backend/dist` — le répertoire que `backend:typecheck` déclare comme sortie. Nx arbitrait entre deux cibles sur un répertoire dont il ne connaissait qu'une moitié. Les `outputs` sont désormais bornés à ce que `nest build` émet, `nest-cli.json` faisant foi pour les assets.

**Le workflow lance deux commandes Nx concurrentes** qui tirent toutes deux `apps/backend/dist`. Les déclarations y sont matérialisées avant, séquentiellement — le motif déjà appliqué trois lignes plus haut au téléchargement du client Nx Cloud, pour le même ticket nrwl/nx#35209.

## Vérification locale

`dist` effacé, les deux caches joués à la suite :

| étape | `trpc.router.js` | `trpc.router.d.ts` |
|---|---|---|
| `nx build backend` (cache hit) | 7 942 | **absent** |
| puis `nx typecheck backend` (cache hit) | 7 942 | 952 654 |

La restauration du cache de `build` est bornée aux `.js` et ne peut plus écraser les déclarations.

## Arbitrage

**L'entrelacement des deux process concurrents n'est pas reproductible en local.** Je n'ai pas observé la troncature elle-même — seulement établi qu'une cible écrit dans `dist` sans que Nx le sache, et que `AppRouter` est le symbole qu'une troncature perd en premier. La confirmation sera #5031 repassant au vert. Si elle reste rouge, la piste suivante est de sérialiser les deux lanes.

Pas de test de régression : une course entre deux process de CI ne se capture pas dans une spec.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Améliorations**
  - Les vérifications de typage et les tests sont désormais exécutés successivement, pour des contrôles plus fiables.
  - Le processus de build suit désormais plus précisément les fichiers générés, notamment les formats JavaScript, CSV, Excel, PowerPoint et de polices.

- **Tests**
  - Les commandes et paramètres utilisés pour le typage et les tests restent inchangés.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->