### PR TITLE
fix(plans): les verify assertent ce que leur change établit

### DIFF
--- a/data_layer/sqitch/verify/plan_action/classification_leviers_job.sql
+++ b/data_layer/sqitch/verify/plan_action/classification_leviers_job.sql
@@ -35,8 +35,10 @@ BEGIN
         FROM information_schema.columns
         WHERE table_schema = 'public'
           AND table_name = 'classification_leviers_job'
+          AND column_name IN ('id', 'collectivite_id', 'plan_id', 'created_by', 'status',
+                              'processed_batches', 'total_batches', 'created_at', 'modified_at')
           AND is_nullable = 'NO'
-    ), 'Toutes les colonnes sauf draft, token_usage et error doivent être NOT NULL';
+    ), 'Les 9 colonnes posees par ce change hors draft, token_usage et error doivent être NOT NULL';
 
     SELECT cc.check_clause INTO status_check
     FROM information_schema.check_constraints cc

--- a/data_layer/sqitch/verify/plan_action/fiche_action_levier.sql
+++ b/data_layer/sqitch/verify/plan_action/fiche_action_levier.sql
@@ -62,20 +62,6 @@ BEGIN
     ), 'levier_id, categorie et created_by doivent etre NOT NULL : c''est ce qui transforme un levier non mappe en echec bruyant plutot qu''en ligne muette';
 
     ASSERT (
-        SELECT COUNT(*) = 29
-        FROM pg_enum e
-                 JOIN pg_type t ON t.oid = e.enumtypid
-        WHERE t.typname = 'levier_id'
-    ), 'Le type levier_id doit declarer les 29 leviers ; sa liste fait foi dans levierIdEnumValues (@tet/domain/shared)';
-
-    ASSERT (
-        SELECT COUNT(*) = 6
-        FROM pg_enum e
-                 JOIN pg_type t ON t.oid = e.enumtypid
-        WHERE t.typname = 'levier_categorie'
-    ), 'Le type levier_categorie doit declarer les 6 categories ; sa liste fait foi dans categorieActionEnumValues (@tet/domain/shared)';
-
-    ASSERT (
         SELECT COUNT(*) = 2
         FROM pg_attribute
         WHERE attrelid = 'public.fiche_action_levier'::regclass


### PR DESCRIPTION
Trois assertions de verify comptaient un **état global** plutôt que ce que leur change établit. Deux sont supprimées, une passe en liste blanche.

## Les deux assertions d'enum sont supprimées

`verify/plan_action/fiche_action_levier.sql` comptait les 29 valeurs de `levier_id` et les 6 de `levier_categorie`. Ces deux assertions n'apportent aucun signal :

- **le `deploy` est la liste.** `create type levier_id as enum (…)` déclare les 29 valeurs. Le verify les recomptait. Il n'existe pas de cas où le deploy réussit et où le type a d'autres valeurs.
- **une garde plus forte existe déjà.** `models/fiche-action-levier.e2e-spec.ts` lit les labels réels en base et les compare à `levierIdEnumValues` et `categorieActionEnumValues`, **ordre compris**. Le verify ne vérifiait qu'un décompte, non ordonné.

Les lister explicitement dans le verify aurait créé un **troisième** exemplaire des 29 chaînes à maintenir : TypeScript, `deploy`, `verify`.

**Ce qui reste dans ce fichier** : l'assertion qui vérifie que `levier_id` et `categorie` portent leurs types enum plutôt que du texte libre. Elle n'est couverte nulle part ailleurs.

## La troisième passe en liste blanche

`verify/plan_action/classification_leviers_job.sql:33-39` faisait `COUNT(*) = 9` sur les colonnes `NOT NULL` sans lister lesquelles. Toute colonne ajoutée plus tard rend le compte faux. Elle nomme désormais les neuf, sur le modèle de l'assertion voisine (`:24-31`) qui liste déjà `draft`, `token_usage` et `error`.

Ce cas diffère des deux précédents : aucun test ne couvre la nullabilité de ces colonnes, et la forme sans liste blanche est réellement fragile.

## Vérification

Sur la base locale :

- les deux verify passent ;
- l'assertion conservée **sait rougir** : en passant `levier_id` en `text`, elle échoue ;
- `sqitch revert` puis `deploy --verify` repassent au vert.

## Ce qui n'est pas touché

Aucun `deploy/`, aucun `revert/`, aucun `.ts`. Un verify décrit l'état produit par **son propre** change, et ces deux changes sont déjà déployés — les réécrire casserait `test-db-deploy` sur toutes les branches, comme en `b8275c7526`.

Les 6 autres assertions de `fiche_action_levier` et les 13 autres de `classification_leviers_job` sont inchangées.