### PR TITLE
refactor(plans): sort le secteur du contrat de classification

### DIFF
--- a/apps/backend/src/plans/priorisation/get-classification-status/get-classification-status.output.ts
+++ b/apps/backend/src/plans/priorisation/get-classification-status/get-classification-status.output.ts
@@ -1,23 +1,25 @@
-import { trajectoireSecteursEnumValues } from '@tet/domain/indicateurs';
 import {
   categorieActionEnumValues,
   levierEnumValues,
 } from '@tet/domain/shared';
 import { z } from 'zod';
+import {
+  ClassifiedFiche,
+  ClassifiedVolet,
+} from '../pipeline/classify-fiches/apply-classification';
 import { ClassificationLeviersJobStatusEnum } from '../models/classification-leviers-job';
 
 const classifiedVoletSchema = z.object({
   levier: z.enum(levierEnumValues),
-  secteur: z.enum(trajectoireSecteursEnumValues).exclude(['CSC']),
   categorie: z.enum(categorieActionEnumValues),
-});
+}) satisfies z.ZodType<ClassifiedVolet>;
 
 const classifiedFicheSchema = z.object({
   ficheId: z.number().int().positive(),
   justification: z.string(),
   isDescriptionTruncated: z.boolean(),
   volets: z.array(classifiedVoletSchema),
-});
+}) satisfies z.ZodType<ClassifiedFiche>;
 
 const unclassifiedFicheSchema = z.object({
   ficheId: z.number().int().positive(),

--- a/apps/backend/src/plans/priorisation/pipeline/classify-fiches/apply-classification.spec.ts
+++ b/apps/backend/src/plans/priorisation/pipeline/classify-fiches/apply-classification.spec.ts
@@ -44,17 +44,6 @@ describe('applyClassification', () => {
     );
   });
 
-  it('dérive le secteur du levier annoncé', () => {
-    const result = applyClassification(toClassificationPerFiche(), rendered);
-    expect(result.success && result.data[0].volets).toEqual([
-      {
-        levier: 'Covoiturage',
-        secteur: 'Transports',
-        categorie: 'amenagement',
-      },
-    ]);
-  });
-
   it('développe un levier portant plusieurs catégories en autant de volets', () => {
     const result = applyClassification(
       [
@@ -92,16 +81,8 @@ describe('applyClassification', () => {
       rendered
     );
     expect(result.success && result.data[0].volets).toEqual([
-      {
-        levier: 'Covoiturage',
-        secteur: 'Transports',
-        categorie: 'amenagement',
-      },
-      {
-        levier: 'Covoiturage',
-        secteur: 'Transports',
-        categorie: 'financement',
-      },
+      { levier: 'Covoiturage', categorie: 'amenagement' },
+      { levier: 'Covoiturage', categorie: 'financement' },
     ]);
   });
 

--- a/apps/backend/src/plans/priorisation/pipeline/classify-fiches/apply-classification.ts
+++ b/apps/backend/src/plans/priorisation/pipeline/classify-fiches/apply-classification.ts
@@ -1,17 +1,11 @@
 import { failure, Result, success } from '@tet/backend/utils/result.type';
-import {
-  CategorieAction,
-  Levier,
-  LEVIER_SECTEURS,
-  LevierSecteur,
-} from '@tet/domain/shared';
+import { CategorieAction, Levier } from '@tet/domain/shared';
 import { uniqBy } from 'es-toolkit';
 import { FicheClassification } from './classify-fiches.schema';
 import { RenderedFiche } from './render-fiches-text';
 
 export type ClassifiedVolet = {
   levier: Levier;
-  secteur: LevierSecteur;
   categorie: CategorieAction;
 };
 
@@ -35,7 +29,6 @@ const toVolets = (classification: FicheClassification): ClassifiedVolet[] =>
     classification.volets.flatMap((volet) =>
       volet.categories.map((categorie) => ({
         levier: volet.levier,
-        secteur: LEVIER_SECTEURS[volet.levier],
         categorie,
       }))
     ),

--- a/apps/backend/src/plans/priorisation/pipeline/classify-fiches/classify-fiches.spec.ts
+++ b/apps/backend/src/plans/priorisation/pipeline/classify-fiches/classify-fiches.spec.ts
@@ -75,13 +75,7 @@ describe('classifyFiches', () => {
             ficheId: 42,
             justification: 'Le texte décrit une infrastructure de covoiturage.',
             isDescriptionTruncated: false,
-            volets: [
-              {
-                levier: 'Covoiturage',
-                secteur: 'Transports',
-                categorie: 'amenagement',
-              },
-            ],
+            volets: [{ levier: 'Covoiturage', categorie: 'amenagement' }],
           },
         ],
       },

--- a/packages/domain/src/shared/levier.enum.ts
+++ b/packages/domain/src/shared/levier.enum.ts
@@ -109,7 +109,7 @@ export const LEVIER_NOM_BY_ID = {
 export const LEVIER_ID_BY_NOM: Record<Levier, LevierId> =
   invert(LEVIER_NOM_BY_ID);
 
-export type LevierSecteur = Exclude<TrajectoireSecteursType, 'CSC'>;
+type LevierSecteur = Exclude<TrajectoireSecteursType, 'CSC'>;
 
 export const LEVIER_SECTEURS = {
   'Changement chaudières fioul + rénovation (résidentiel)': 'Résidentiel',


### PR DESCRIPTION
Le volet de classification portait un `secteur`, dérivé du levier par `LEVIER_SECTEURS` et servi au client par le contrat tRPC. Il sort.

## Pourquoi

**Personne ne le lit.** Zéro occurrence de `classificationLeviers` dans `apps/app/` et `e2e/` — constaté, pas supposé.

**Et c'est le seul champ du résultat qu'un enjeu non-GES ne pourrait pas remplir.** `LEVIER_SECTEURS` est un `Exclude<TrajectoireSecteursType, 'CSC'>` : il n'a de sens que sur le référentiel SNBC. Le traîner en optionnel dans la suite du travail multi-enjeux coûterait plus cher que le retirer maintenant.

## Le piège, et la garde qui l'aurait évité

`ClassifiedVolet` (pipeline) et `classifiedVoletSchema` (contrat tRPC) sont **deux déclarations indépendantes de la même forme**. Le compilateur n'a rien réclamé quand la première a perdu le champ — il a fallu retirer le second à la main.

Les deux schémas du contrat portent désormais un `satisfies z.ZodType<…>`. Vérifié en retirant `categorie` du schéma :

```
error TS1360: Type 'ZodObject<{ levier: … }>' does not satisfy the expected type
'ZodType<ClassifiedVolet, …>'.
  Property 'categorie' is missing in type '{ levier: … }'
  but required in type 'ClassifiedVolet'.
```

## Un effet de bord assumé

`LevierSecteur` perd son `export` : plus aucun consommateur hors de son fichier une fois la dérivation retirée. Le type reste utilisé sur place par `LEVIER_SECTEURS`. C'est un orphelin créé par cette PR, pas du nettoyage opportuniste — à dire si vous préférez le laisser exporté.

## Anti-scope

`LEVIER_SECTEURS`, les trajectoires et le groupement par secteur dans le prompt ne bougent pas. Les « huit secteurs » de `classify-fiches.prompt.spec.ts` concernent le **regroupement des leviers dans le prompt**, pas le champ de sortie — ils restent.

## Vérification

- `nx test backend 'priorisation'` : **13 fichiers, 96 tests, verts**
- un test de moins qu'avant : `dérive le secteur du levier annoncé` disparaît, il testait le champ retiré. Le mapping `levier` + `categorie` reste couvert par `développe un levier portant plusieurs catégories` et par le test bout-en-bout de `classify-fiches.spec.ts`
- typecheck backend : aucune erreur sur les fichiers touchés