### PR TITLE
refactor(preuves-archive): l'assemblage d'archive cesse de dépendre de l'audit

### DIFF
--- a/apps/backend/src/referentiels/preuves-archive/build-archive/archive-arborescence.types.ts
+++ b/apps/backend/src/referentiels/preuves-archive/build-archive/archive-arborescence.types.ts
@@ -1,0 +1,26 @@
+import type { LienPreuve } from './build-liens-csv';
+
+export interface ArchiveFile {
+  folderSegments: string[];
+  filename: string;
+  bucketId: string;
+  hash: string;
+  filesize: number;
+}
+
+export interface ArchiveLinkFolder {
+  folderSegments: string[];
+  liens: LienPreuve[];
+}
+
+export interface SkippedFile {
+  filename: string;
+  emplacement: string;
+  raison: string;
+}
+
+export interface ArchiveFolderArborescence {
+  files: ArchiveFile[];
+  linkFolders: ArchiveLinkFolder[];
+  skippedFiles: SkippedFile[];
+}

--- a/apps/backend/src/referentiels/preuves-archive/build-archive/archive-assembly.errors.ts
+++ b/apps/backend/src/referentiels/preuves-archive/build-archive/archive-assembly.errors.ts
@@ -1,0 +1,6 @@
+import { createEnumObject } from '@tet/domain/utils';
+
+const ArchiveAssemblyErrors = ['ARCHIVE_ASSEMBLY_FAILED'] as const;
+export type ArchiveAssemblyError = (typeof ArchiveAssemblyErrors)[number];
+
+export const ArchiveAssemblyErrorEnum = createEnumObject(ArchiveAssemblyErrors);

--- a/apps/backend/src/referentiels/preuves-archive/build-archive/build-archive-manifests.spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/build-archive/build-archive-manifests.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { buildArchiveManifests } from './build-archive-manifests';
-import type { ArchiveFolderArborescence } from '../generate-preuves-archive/generate-archive-folder-arborescence';
+import type { ArchiveFolderArborescence } from './archive-arborescence.types';
 
 function emptyArborescence(
   overrides: Partial<ArchiveFolderArborescence> = {}
@@ -47,7 +47,7 @@ describe('buildArchiveManifests', () => {
     ]);
   });
 
-  it("agrège skippedFiles et failedDownloads dans `_manifeste/fichiers-manquants.txt`", () => {
+  it('agrège skippedFiles et failedDownloads dans `_manifeste/fichiers-manquants.txt`', () => {
     const entries = buildArchiveManifests({
       arborescence: emptyArborescence({
         skippedFiles: [

--- a/apps/backend/src/referentiels/preuves-archive/build-archive/build-archive-manifests.ts
+++ b/apps/backend/src/referentiels/preuves-archive/build-archive/build-archive-manifests.ts
@@ -1,4 +1,4 @@
-import { type ArchiveFolderArborescence } from '../generate-preuves-archive/generate-archive-folder-arborescence';
+import { type ArchiveFolderArborescence } from './archive-arborescence.types';
 import { buildArchivePath } from './build-archive-path';
 import { buildLiensCsv } from './build-liens-csv';
 
@@ -25,10 +25,7 @@ export function buildArchiveManifests({
   const liensCsv = arborescence.linkFolders
     .filter((folder) => folder.liens.length > 0)
     .map((folder) => ({
-      name: buildArchivePath([
-        ...folder.folderSegments,
-        LIENS_CSV_FILENAME,
-      ]),
+      name: buildArchivePath([...folder.folderSegments, LIENS_CSV_FILENAME]),
       content: buildLiensCsv(folder.liens),
     }));
 

--- a/apps/backend/src/referentiels/preuves-archive/build-archive/build-archive.service.spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/build-archive/build-archive.service.spec.ts
@@ -1,0 +1,83 @@
+import { DocumentStorageService } from '@tet/backend/utils/supabase/document-storage.service';
+import { success } from '@tet/backend/utils/result.type';
+import { Readable, Writable } from 'node:stream';
+import { describe, expect, test } from 'vitest';
+import { type ArchiveFolderArborescence } from './archive-arborescence.types';
+import { ArchiveAssemblyErrorEnum } from './archive-assembly.errors';
+import { BuildArchiveService } from './build-archive.service';
+
+const toArborescence = (
+  filenames: string[] = ['deliberation.pdf']
+): ArchiveFolderArborescence => ({
+  files: filenames.map((filename, index) => ({
+    folderSegments: [],
+    filename,
+    bucketId: 'collectivite-1',
+    hash: String(index).repeat(64),
+    filesize: 4,
+  })),
+  linkFolders: [],
+  skippedFiles: [],
+});
+
+const toDocumentStorage = (
+  delaysMs: number[] = [0]
+): DocumentStorageService => {
+  let callCount = 0;
+  return {
+    getDocumentStream: async () => {
+      const delay = delaysMs[callCount++] ?? 0;
+      await new Promise((resolve) => setTimeout(resolve, delay));
+      return success(Readable.from(['abcd']));
+    },
+  } as unknown as DocumentStorageService;
+};
+
+const toCollectingDestination = (): Writable & { collected: Buffer[] } => {
+  const collected: Buffer[] = [];
+  const destination = new Writable({
+    write(chunk, _encoding, callback) {
+      collected.push(Buffer.from(chunk));
+      callback();
+    },
+  });
+  return Object.assign(destination, { collected });
+};
+
+const toFailingDestination = (): Writable =>
+  new Writable({
+    write(_chunk, _encoding, callback) {
+      callback(new Error('destination unavailable'));
+    },
+  });
+
+describe('BuildArchiveService.assembleZip', () => {
+  test('écrit une archive dans la destination fournie', async () => {
+    const service = new BuildArchiveService(toDocumentStorage());
+    const destination = toCollectingDestination();
+
+    const result = await service.assembleZip({
+      arborescence: toArborescence(),
+      destination,
+    });
+
+    expect(result).toEqual(success({ totalFiles: 1 }));
+    expect(Buffer.concat(destination.collected).subarray(0, 2)).toEqual(
+      Buffer.from('PK')
+    );
+  });
+
+  test("rend un échec quand la destination refuse d'écrire pendant les téléchargements", async () => {
+    const service = new BuildArchiveService(toDocumentStorage([0, 200]));
+
+    const result = await service.assembleZip({
+      arborescence: toArborescence(['rapide.pdf', 'lent.pdf']),
+      destination: toFailingDestination(),
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      error: ArchiveAssemblyErrorEnum.ARCHIVE_ASSEMBLY_FAILED,
+    });
+  });
+});

--- a/apps/backend/src/referentiels/preuves-archive/build-archive/build-archive.service.ts
+++ b/apps/backend/src/referentiels/preuves-archive/build-archive/build-archive.service.ts
@@ -6,9 +6,14 @@ import { createWriteStream } from 'node:fs';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { type Writable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import { DocumentStorageService } from '@tet/backend/utils/supabase/document-storage.service';
-import { type ArchiveFolderArborescence } from '../generate-preuves-archive/generate-archive-folder-arborescence';
+import { type ArchiveFolderArborescence } from './archive-arborescence.types';
+import {
+  ArchiveAssemblyErrorEnum,
+  type ArchiveAssemblyError,
+} from './archive-assembly.errors';
 import {
   ARCHIVE_ZIP_CONTENT_TYPE,
   PREUVES_ARCHIVES_BUCKET,
@@ -37,9 +42,9 @@ type DownloadOutcome =
   | { kind: 'appended' }
   | { kind: 'failed'; message: string };
 
-interface AssembleZipInput {
+export interface AssembleZipInput {
   arborescence: ArchiveFolderArborescence;
-  tempZipPath: string;
+  destination: Writable;
   onProgress?: (processedFiles: number) => void;
 }
 
@@ -61,11 +66,14 @@ export class BuildArchiveService {
 
       const assembleResult = await this.assembleZip({
         arborescence,
-        tempZipPath,
+        destination: createWriteStream(tempZipPath),
         onProgress,
       });
       if (!assembleResult.success) {
-        return assembleResult;
+        return failure(
+          PreuvesArchiveErrorEnum.CREATE_ARCHIVE_ERROR,
+          assembleResult.cause
+        );
       }
 
       const uploadResult = await this.documentStorage.storeDocument({
@@ -105,35 +113,46 @@ export class BuildArchiveService {
     }
   }
 
-  private async assembleZip({
+  async assembleZip({
     arborescence,
-    tempZipPath,
+    destination,
     onProgress,
-  }: AssembleZipInput): Promise<Result<{ totalFiles: number }, PreuvesArchiveError>> {
+  }: AssembleZipInput): Promise<
+    Result<{ totalFiles: number }, ArchiveAssemblyError>
+  > {
     const archive = archiver('zip', { store: true });
-    const output = createWriteStream(tempZipPath);
-    const writeFinished = pipeline(archive, output);
+    const writeFinished = pipeline(archive, destination);
 
     const preparedEntries = prepareArchiveEntries(arborescence.files);
 
-    const outcomes = await mapWithConcurrency(
-      preparedEntries,
-      DOWNLOAD_CONCURRENCY,
-      (entry) => this.downloadAndAppendEntry({ entry, archive }),
-      (processed) => onProgress?.(processed)
-    );
-    const failedDownloads = outcomes.flatMap((outcome) =>
-      outcome.kind === 'failed' ? [outcome.message] : []
-    );
+    try {
+      const outcomes = await mapWithConcurrency(
+        preparedEntries,
+        DOWNLOAD_CONCURRENCY,
+        (entry) => this.downloadAndAppendEntry({ entry, archive }),
+        (processed) => onProgress?.(processed)
+      );
+      const failedDownloads = outcomes.flatMap((outcome) =>
+        outcome.kind === 'failed' ? [outcome.message] : []
+      );
 
-    buildArchiveManifests({ arborescence, failedDownloads }).forEach((entry) =>
-      archive.append(entry.content, { name: entry.name })
-    );
+      buildArchiveManifests({ arborescence, failedDownloads }).forEach(
+        (entry) => archive.append(entry.content, { name: entry.name })
+      );
 
-    await archive.finalize();
-    await writeFinished;
+      await archive.finalize();
+      await writeFinished;
 
-    return success({ totalFiles: preparedEntries.length });
+      return success({ totalFiles: preparedEntries.length });
+    } catch (error) {
+      this.logger.error(
+        `Assemblage de l'archive interrompu: ${getErrorMessage(error)}`
+      );
+      return failure(
+        ArchiveAssemblyErrorEnum.ARCHIVE_ASSEMBLY_FAILED,
+        error instanceof Error ? error : new Error(getErrorMessage(error))
+      );
+    }
   }
 
   private async downloadAndAppendEntry({

--- a/apps/backend/src/referentiels/preuves-archive/build-archive/build-archive.service.ts
+++ b/apps/backend/src/referentiels/preuves-archive/build-archive/build-archive.service.ts
@@ -31,6 +31,15 @@ import {
 
 const DOWNLOAD_CONCURRENCY = 8;
 
+const toSettledError = (
+  promise: Promise<unknown>
+): Promise<Error | undefined> =>
+  promise.then(
+    () => undefined,
+    (error: unknown) =>
+      error instanceof Error ? error : new Error(getErrorMessage(error))
+  );
+
 export interface BuildAndUploadInput {
   archiveId: string;
   arborescence: ArchiveFolderArborescence;
@@ -121,7 +130,7 @@ export class BuildArchiveService {
     Result<{ totalFiles: number }, ArchiveAssemblyError>
   > {
     const archive = archiver('zip', { store: true });
-    const writeFinished = pipeline(archive, destination);
+    const writeOutcome = toSettledError(pipeline(archive, destination));
 
     const preparedEntries = prepareArchiveEntries(arborescence.files);
 
@@ -140,19 +149,34 @@ export class BuildArchiveService {
         (entry) => archive.append(entry.content, { name: entry.name })
       );
 
-      await archive.finalize();
-      await writeFinished;
+      const finalizeOutcome = toSettledError(archive.finalize());
+
+      const writeError = await writeOutcome;
+      if (writeError) {
+        return this.toAssemblyFailure(writeError, archive);
+      }
+
+      const finalizeError = await finalizeOutcome;
+      if (finalizeError) {
+        return this.toAssemblyFailure(finalizeError, archive);
+      }
 
       return success({ totalFiles: preparedEntries.length });
     } catch (error) {
-      this.logger.error(
-        `Assemblage de l'archive interrompu: ${getErrorMessage(error)}`
-      );
-      return failure(
-        ArchiveAssemblyErrorEnum.ARCHIVE_ASSEMBLY_FAILED,
-        error instanceof Error ? error : new Error(getErrorMessage(error))
+      return this.toAssemblyFailure(
+        error instanceof Error ? error : new Error(getErrorMessage(error)),
+        archive
       );
     }
+  }
+
+  private toAssemblyFailure(
+    error: Error,
+    archive: Archiver
+  ): Result<{ totalFiles: number }, ArchiveAssemblyError> {
+    archive.abort();
+    this.logger.error(`Assemblage de l'archive interrompu: ${error.message}`);
+    return failure(ArchiveAssemblyErrorEnum.ARCHIVE_ASSEMBLY_FAILED, error);
   }
 
   private async downloadAndAppendEntry({

--- a/apps/backend/src/referentiels/preuves-archive/build-archive/build-liens-csv.spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/build-archive/build-liens-csv.spec.ts
@@ -10,11 +10,13 @@ describe('buildLiensCsv', () => {
 
   it('ecrit une ligne par lien', () => {
     const csv = buildLiensCsv([
-      { titre: 'Site officiel', url: 'https://exemple.fr', commentaire: 'a jour' },
+      {
+        titre: 'Site officiel',
+        url: 'https://exemple.fr',
+        commentaire: 'a jour',
+      },
     ]);
-    expect(csv).toBe(
-      `${HEADER}\nSite officiel,https://exemple.fr,a jour\n`
-    );
+    expect(csv).toBe(`${HEADER}\nSite officiel,https://exemple.fr,a jour\n`);
   });
 
   it('entoure de guillemets les champs contenant une virgule', () => {
@@ -52,7 +54,7 @@ describe('buildLiensCsv', () => {
     expect(csv).toBe(`${HEADER}\n'-2+3,https://x.fr,'\tcmd\n`);
   });
 
-  it("remplace les URLs aux schemes non sûrs par un placeholder (javascript:/data:/etc)", () => {
+  it('remplace les URLs aux schemes non sûrs par un placeholder (javascript:/data:/etc)', () => {
     const csv = buildLiensCsv([
       { titre: 'XSS', url: 'javascript:alert(1)', commentaire: '' },
       { titre: 'Data URI', url: 'data:text/html,xxx', commentaire: '' },

--- a/apps/backend/src/referentiels/preuves-archive/build-archive/check-archive-limits.spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/build-archive/check-archive-limits.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'vitest';
+import type { ArchiveFile } from './archive-arborescence.types';
+import {
+  checkArchiveLimits,
+  MAX_FILE_COUNT,
+  MAX_TOTAL_SIZE_BYTES,
+} from './check-archive-limits';
+
+const toArchiveFile = (filesize: number): ArchiveFile => ({
+  folderSegments: [],
+  filename: 'document.pdf',
+  bucketId: 'collectivite-1',
+  hash: 'a'.repeat(64),
+  filesize,
+});
+
+describe('checkArchiveLimits', () => {
+  test('accepte une archive sous les deux plafonds', () => {
+    expect(checkArchiveLimits([toArchiveFile(1024)])).toEqual({
+      withinLimits: true,
+    });
+  });
+
+  test('refuse au-dela de 500 fichiers', () => {
+    const files = Array.from({ length: MAX_FILE_COUNT + 1 }, () =>
+      toArchiveFile(1)
+    );
+
+    expect(checkArchiveLimits(files)).toEqual({
+      withinLimits: false,
+      exceeded: 'fileCount',
+      fileCount: 501,
+      limit: 500,
+    });
+  });
+
+  test('refuse au-dela de 2 Go au total', () => {
+    const files = [toArchiveFile(MAX_TOTAL_SIZE_BYTES), toArchiveFile(1)];
+
+    expect(checkArchiveLimits(files)).toEqual({
+      withinLimits: false,
+      exceeded: 'totalSize',
+      totalSize: MAX_TOTAL_SIZE_BYTES + 1,
+      limit: 2 * 1024 * 1024 * 1024,
+    });
+  });
+});

--- a/apps/backend/src/referentiels/preuves-archive/build-archive/check-archive-limits.ts
+++ b/apps/backend/src/referentiels/preuves-archive/build-archive/check-archive-limits.ts
@@ -1,0 +1,43 @@
+import type { ArchiveFile } from './archive-arborescence.types';
+
+export const MAX_FILE_COUNT = 500;
+export const MAX_TOTAL_SIZE_BYTES = 2 * 1024 * 1024 * 1024;
+
+export type ArchiveLimitsExceeded =
+  | {
+      withinLimits: false;
+      exceeded: 'fileCount';
+      fileCount: number;
+      limit: number;
+    }
+  | {
+      withinLimits: false;
+      exceeded: 'totalSize';
+      totalSize: number;
+      limit: number;
+    };
+
+export type ArchiveLimitsCheck = { withinLimits: true } | ArchiveLimitsExceeded;
+
+export function checkArchiveLimits(files: ArchiveFile[]): ArchiveLimitsCheck {
+  if (files.length > MAX_FILE_COUNT) {
+    return {
+      withinLimits: false,
+      exceeded: 'fileCount',
+      fileCount: files.length,
+      limit: MAX_FILE_COUNT,
+    };
+  }
+
+  const totalSize = files.reduce((sum, file) => sum + file.filesize, 0);
+  if (totalSize > MAX_TOTAL_SIZE_BYTES) {
+    return {
+      withinLimits: false,
+      exceeded: 'totalSize',
+      totalSize,
+      limit: MAX_TOTAL_SIZE_BYTES,
+    };
+  }
+
+  return { withinLimits: true };
+}

--- a/apps/backend/src/referentiels/preuves-archive/build-archive/prepare-archive-entries.spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/build-archive/prepare-archive-entries.spec.ts
@@ -1,10 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import type { ArchiveFile } from '../generate-preuves-archive/generate-archive-folder-arborescence';
+import type { ArchiveFile } from './archive-arborescence.types';
 import { prepareArchiveEntries } from './prepare-archive-entries';
 
-function makeFile(
-  overrides: Partial<ArchiveFile> = {}
-): ArchiveFile {
+function makeFile(overrides: Partial<ArchiveFile> = {}): ArchiveFile {
   return {
     folderSegments: ['mesures', 'axe-1'],
     filename: 'document.pdf',
@@ -30,7 +28,7 @@ describe('prepareArchiveEntries', () => {
     ]);
   });
 
-  it("suffixe `(2)`, `(3)`... pour les doublons de chemin", () => {
+  it('suffixe `(2)`, `(3)`... pour les doublons de chemin', () => {
     const files = [
       makeFile({ hash: 'a' }),
       makeFile({ hash: 'b' }),
@@ -57,7 +55,7 @@ describe('prepareArchiveEntries', () => {
     expect(entries[1].entryPath).toBe('mesures/axe-1/rapport.tar (2).gz');
   });
 
-  it("ajoute le suffixe en fin pour un fichier sans extension", () => {
+  it('ajoute le suffixe en fin pour un fichier sans extension', () => {
     const files = [
       makeFile({ filename: 'README', hash: 'a' }),
       makeFile({ filename: 'README', hash: 'b' }),
@@ -68,7 +66,7 @@ describe('prepareArchiveEntries', () => {
     expect(entries[1].entryPath).toBe('mesures/axe-1/README (2)');
   });
 
-  it("ajoute le suffixe en fin pour un fichier commençant par un point", () => {
+  it('ajoute le suffixe en fin pour un fichier commençant par un point', () => {
     const files = [
       makeFile({ filename: '.env', hash: 'a' }),
       makeFile({ filename: '.env', hash: 'b' }),
@@ -79,7 +77,7 @@ describe('prepareArchiveEntries', () => {
     expect(entries[1].entryPath).toBe('mesures/axe-1/.env (2)');
   });
 
-  it("ne déduplique pas entre dossiers distincts", () => {
+  it('ne déduplique pas entre dossiers distincts', () => {
     const files = [
       makeFile({ folderSegments: ['mesures', 'axe-1'], hash: 'a' }),
       makeFile({ folderSegments: ['mesures', 'axe-2'], hash: 'b' }),

--- a/apps/backend/src/referentiels/preuves-archive/build-archive/prepare-archive-entries.ts
+++ b/apps/backend/src/referentiels/preuves-archive/build-archive/prepare-archive-entries.ts
@@ -1,4 +1,4 @@
-import type { ArchiveFile } from '../generate-preuves-archive/generate-archive-folder-arborescence';
+import type { ArchiveFile } from './archive-arborescence.types';
 import { buildArchivePath } from './build-archive-path';
 
 export interface PreparedFileEntry {

--- a/apps/backend/src/referentiels/preuves-archive/build-archive/triage-archive-files.spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/build-archive/triage-archive-files.spec.ts
@@ -59,6 +59,27 @@ describe('triageArchiveFile', () => {
     });
   });
 
+  test('écarte un fichier dont la taille est négative', () => {
+    const triage = triageArchiveFile({
+      file: {
+        bucketId: 'collectivite-1',
+        hash: 'abc',
+        filename: 'taille-negative.pdf',
+        filesize: -1,
+      },
+      folderSegments: [],
+    });
+
+    expect(triage).toEqual({
+      kind: 'skipped',
+      skippedFile: {
+        filename: 'taille-negative.pdf',
+        emplacement: '',
+        raison: 'Taille du fichier invalide (-1 octets)',
+      },
+    });
+  });
+
   test('écarte un fichier au-dela de 100 Mo', () => {
     const triage = triageArchiveFile({
       file: {

--- a/apps/backend/src/referentiels/preuves-archive/build-archive/triage-archive-files.spec.ts
+++ b/apps/backend/src/referentiels/preuves-archive/build-archive/triage-archive-files.spec.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from 'vitest';
+import type { ArchiveFile } from './archive-arborescence.types';
+import {
+  MAX_FILE_SIZE_BYTES,
+  splitTriagedArchiveFiles,
+  triageArchiveFile,
+} from './triage-archive-files';
+
+const toArchiveFile = (filesize: number): ArchiveFile => ({
+  folderSegments: [],
+  filename: 'document.pdf',
+  bucketId: 'collectivite-1',
+  hash: 'a'.repeat(64),
+  filesize,
+});
+
+describe('triageArchiveFile', () => {
+  test('retient un fichier de taille connue sous la limite', () => {
+    const triage = triageArchiveFile({
+      file: {
+        bucketId: 'collectivite-1',
+        hash: 'abc',
+        filename: 'deliberation.pdf',
+        filesize: 1024,
+      },
+      folderSegments: ['mesures', '1.1.1'],
+    });
+
+    expect(triage).toEqual({
+      kind: 'collected',
+      file: {
+        folderSegments: ['mesures', '1.1.1'],
+        filename: 'deliberation.pdf',
+        bucketId: 'collectivite-1',
+        hash: 'abc',
+        filesize: 1024,
+      },
+    });
+  });
+
+  test('écarte un fichier dont la taille est inconnue', () => {
+    const triage = triageArchiveFile({
+      file: {
+        bucketId: 'collectivite-1',
+        hash: 'abc',
+        filename: 'sans-taille.pdf',
+        filesize: null,
+      },
+      folderSegments: ['mesures'],
+    });
+
+    expect(triage).toEqual({
+      kind: 'skipped',
+      skippedFile: {
+        filename: 'sans-taille.pdf',
+        emplacement: 'mesures',
+        raison: 'Taille du fichier inconnue',
+      },
+    });
+  });
+
+  test('écarte un fichier au-dela de 100 Mo', () => {
+    const triage = triageArchiveFile({
+      file: {
+        bucketId: 'collectivite-1',
+        hash: 'abc',
+        filename: 'enorme.pdf',
+        filesize: MAX_FILE_SIZE_BYTES + 1,
+      },
+      folderSegments: [],
+    });
+
+    expect(triage.kind).toBe('skipped');
+  });
+
+  test('nomme un fichier sans filename par son empreinte', () => {
+    const triage = triageArchiveFile({
+      file: {
+        bucketId: 'collectivite-1',
+        hash: 'abc',
+        filename: null,
+        filesize: 10,
+      },
+      folderSegments: [],
+    });
+
+    expect(triage).toMatchObject({
+      kind: 'collected',
+      file: { filename: 'abc' },
+    });
+  });
+});
+
+describe('splitTriagedArchiveFiles', () => {
+  test('sépare les fichiers retenus des fichiers consignés', () => {
+    const collectedFile = toArchiveFile(10);
+    const skippedFile = {
+      filename: 'absent.pdf',
+      emplacement: '',
+      raison: 'Taille du fichier inconnue',
+    };
+
+    expect(
+      splitTriagedArchiveFiles([
+        { kind: 'collected', file: collectedFile },
+        { kind: 'skipped', skippedFile },
+      ])
+    ).toEqual({ files: [collectedFile], skippedFiles: [skippedFile] });
+  });
+});

--- a/apps/backend/src/referentiels/preuves-archive/build-archive/triage-archive-files.ts
+++ b/apps/backend/src/referentiels/preuves-archive/build-archive/triage-archive-files.ts
@@ -32,6 +32,17 @@ export function triageArchiveFile({
     };
   }
 
+  if (file.filesize < 0) {
+    return {
+      kind: 'skipped',
+      skippedFile: {
+        filename,
+        emplacement,
+        raison: `Taille du fichier invalide (${file.filesize} octets)`,
+      },
+    };
+  }
+
   if (file.filesize > MAX_FILE_SIZE_BYTES) {
     return {
       kind: 'skipped',

--- a/apps/backend/src/referentiels/preuves-archive/build-archive/triage-archive-files.ts
+++ b/apps/backend/src/referentiels/preuves-archive/build-archive/triage-archive-files.ts
@@ -1,0 +1,74 @@
+import type { ArchiveFile, SkippedFile } from './archive-arborescence.types';
+
+export const MAX_FILE_SIZE_BYTES = 100 * 1024 * 1024;
+
+const FILE_SIZE_UNKNOWN = 'Taille du fichier inconnue';
+
+export interface ArchiveCandidateFile {
+  bucketId: string;
+  hash: string;
+  filename: string | null;
+  filesize: number | null;
+}
+
+export type ArchiveFileTriage =
+  | { kind: 'collected'; file: ArchiveFile }
+  | { kind: 'skipped'; skippedFile: SkippedFile };
+
+export function triageArchiveFile({
+  file,
+  folderSegments,
+}: {
+  file: ArchiveCandidateFile;
+  folderSegments: string[];
+}): ArchiveFileTriage {
+  const emplacement = folderSegments.join('/');
+  const filename = file.filename ?? file.hash;
+
+  if (file.filesize === null) {
+    return {
+      kind: 'skipped',
+      skippedFile: { filename, emplacement, raison: FILE_SIZE_UNKNOWN },
+    };
+  }
+
+  if (file.filesize > MAX_FILE_SIZE_BYTES) {
+    return {
+      kind: 'skipped',
+      skippedFile: {
+        filename,
+        emplacement,
+        raison: `Fichier trop volumineux (${file.filesize} octets, limite ${MAX_FILE_SIZE_BYTES})`,
+      },
+    };
+  }
+
+  return {
+    kind: 'collected',
+    file: {
+      folderSegments,
+      filename,
+      bucketId: file.bucketId,
+      hash: file.hash,
+      filesize: file.filesize,
+    },
+  };
+}
+
+export interface TriagedArchiveFiles {
+  files: ArchiveFile[];
+  skippedFiles: SkippedFile[];
+}
+
+export function splitTriagedArchiveFiles(
+  triaged: ArchiveFileTriage[]
+): TriagedArchiveFiles {
+  return {
+    files: triaged.flatMap((triage) =>
+      triage.kind === 'collected' ? [triage.file] : []
+    ),
+    skippedFiles: triaged.flatMap((triage) =>
+      triage.kind === 'skipped' ? [triage.skippedFile] : []
+    ),
+  };
+}

--- a/apps/backend/src/referentiels/preuves-archive/generate-preuves-archive/generate-archive-folder-arborescence.ts
+++ b/apps/backend/src/referentiels/preuves-archive/generate-preuves-archive/generate-archive-folder-arborescence.ts
@@ -7,45 +7,27 @@ import {
   type PreuvesArchiveError,
 } from '../preuves-archive.errors';
 import type {
-  CollectedFilePreuve,
   CollectedLinkPreuve,
   MissingFilePreuve,
 } from '../collect-audit-preuves/collect-preuves.repository';
-import type { LienPreuve } from '../build-archive/build-liens-csv';
-
-const MAX_FILE_SIZE_BYTES = 100 * 1024 * 1024;
-const MAX_FILE_COUNT = 500;
-const MAX_TOTAL_SIZE_BYTES = 2 * 1024 * 1024 * 1024;
+import {
+  checkArchiveLimits,
+  type ArchiveLimitsExceeded,
+} from '../build-archive/check-archive-limits';
+import {
+  splitTriagedArchiveFiles,
+  triageArchiveFile,
+} from '../build-archive/triage-archive-files';
+import type {
+  ArchiveFolderArborescence,
+  ArchiveLinkFolder,
+  SkippedFile,
+} from '../build-archive/archive-arborescence.types';
 
 const MESURES_FOLDER = 'mesures';
 const CYCLE_FOLDER = 'cycle-labellisation';
 const DEMANDE_FOLDER = 'demande';
 const AUDIT_FOLDER = 'audit';
-
-export interface ArchiveFile {
-  folderSegments: string[];
-  filename: string;
-  bucketId: string;
-  hash: string;
-  filesize: number;
-}
-
-export interface ArchiveLinkFolder {
-  folderSegments: string[];
-  liens: LienPreuve[];
-}
-
-export interface SkippedFile {
-  filename: string;
-  emplacement: string;
-  raison: string;
-}
-
-export interface ArchiveFolderArborescence {
-  files: ArchiveFile[];
-  linkFolders: ArchiveLinkFolder[];
-  skippedFiles: SkippedFile[];
-}
 
 export interface ReferentielTreeNode {
   actionId: string;
@@ -65,11 +47,6 @@ interface MesureFolder {
   folderSegments: string[];
 }
 
-type FileWithFolder = {
-  file: CollectedFilePreuve;
-  folderSegments: string[];
-};
-
 type LinkWithFolder = {
   link: CollectedLinkPreuve;
   folderSegments: string[];
@@ -81,7 +58,6 @@ type MissingFileWithFolder = {
 };
 
 const FILE_MISSING_FROM_STORAGE = 'Fichier introuvable dans le stockage';
-const FILE_SIZE_UNKNOWN = 'Taille du fichier inconnue';
 
 function toSkippedMissingFile({
   missingFile,
@@ -92,73 +68,6 @@ function toSkippedMissingFile({
     emplacement: folderSegments.join('/'),
     raison: FILE_MISSING_FROM_STORAGE,
   };
-}
-
-type FileTriage =
-  | { kind: 'collected'; file: ArchiveFile }
-  | { kind: 'skipped'; entry: SkippedFile };
-
-function triageFile({ file, folderSegments }: FileWithFolder): FileTriage {
-  const emplacement = folderSegments.join('/');
-  const filename = file.filename ?? file.hash;
-
-  if (file.filesize === null) {
-    return {
-      kind: 'skipped',
-      entry: {
-        filename,
-        emplacement,
-        raison: FILE_SIZE_UNKNOWN,
-      },
-    };
-  }
-
-  if (file.filesize > MAX_FILE_SIZE_BYTES) {
-    return {
-      kind: 'skipped',
-      entry: {
-        filename,
-        emplacement,
-        raison: `Fichier trop volumineux (${file.filesize} octets, limite ${MAX_FILE_SIZE_BYTES})`,
-      },
-    };
-  }
-
-  return {
-    kind: 'collected',
-    file: {
-      folderSegments,
-      filename,
-      bucketId: file.bucketId,
-      hash: file.hash,
-      filesize: file.filesize,
-    },
-  };
-}
-
-function checkArchiveLimits(
-  files: ArchiveFile[]
-): Result<undefined, PreuvesArchiveError> {
-  if (files.length > MAX_FILE_COUNT) {
-    return failure(
-      PreuvesArchiveErrorEnum.COLLECT_PREUVES_ERROR,
-      new Error(
-        `Trop de fichiers à archiver (${files.length}, limite ${MAX_FILE_COUNT})`
-      )
-    );
-  }
-
-  const totalSize = files.reduce((sum, file) => sum + file.filesize, 0);
-  if (totalSize > MAX_TOTAL_SIZE_BYTES) {
-    return failure(
-      PreuvesArchiveErrorEnum.COLLECT_PREUVES_ERROR,
-      new Error(
-        `Archive trop volumineuse (${totalSize} octets, limite ${MAX_TOTAL_SIZE_BYTES})`
-      )
-    );
-  }
-
-  return success(undefined);
 }
 
 function groupLinksByFolder(links: LinkWithFolder[]): ArchiveLinkFolder[] {
@@ -210,10 +119,16 @@ function mesureFolderSegments(
   }
   const match = mesureFolders.find(
     (mesure) =>
-      mesure.actionId === actionId ||
-      actionId.startsWith(`${mesure.actionId}.`)
+      mesure.actionId === actionId || actionId.startsWith(`${mesure.actionId}.`)
   );
   return match ? match.folderSegments : [MESURES_FOLDER];
+}
+
+function toLimitsExceededMessage(limitsCheck: ArchiveLimitsExceeded): string {
+  if (limitsCheck.exceeded === 'fileCount') {
+    return `Trop de fichiers à archiver (${limitsCheck.fileCount}, limite ${limitsCheck.limit})`;
+  }
+  return `Archive trop volumineuse (${limitsCheck.totalSize} octets, limite ${limitsCheck.limit})`;
 }
 
 export function generateArchiveFolderArborescence(
@@ -264,14 +179,12 @@ export function generateArchiveFolderArborescence(
     folderSegments: [CYCLE_FOLDER, AUDIT_FOLDER],
   }));
 
-  const triaged = [...mesureFiles, ...demandeFiles, ...auditFiles].map(triageFile);
-  const collectedFiles = triaged.flatMap((entry) =>
-    entry.kind === 'collected' ? [entry.file] : []
-  );
+  const { files: collectedFiles, skippedFiles: triagedSkippedFiles } =
+    splitTriagedArchiveFiles(
+      [...mesureFiles, ...demandeFiles, ...auditFiles].map(triageArchiveFile)
+    );
   const skippedFiles = [
-    ...triaged.flatMap((entry) =>
-      entry.kind === 'skipped' ? [entry.entry] : []
-    ),
+    ...triagedSkippedFiles,
     ...[
       ...mesureMissingFiles,
       ...demandeMissingFiles,
@@ -279,9 +192,12 @@ export function generateArchiveFolderArborescence(
     ].map(toSkippedMissingFile),
   ];
 
-  const limits = checkArchiveLimits(collectedFiles);
-  if (!limits.success) {
-    return limits;
+  const limitsCheck = checkArchiveLimits(collectedFiles);
+  if (!limitsCheck.withinLimits) {
+    return failure(
+      PreuvesArchiveErrorEnum.COLLECT_PREUVES_ERROR,
+      new Error(toLimitsExceededMessage(limitsCheck))
+    );
   }
 
   return success({

--- a/apps/backend/src/referentiels/preuves-archive/generate-preuves-archive/generate-preuves-archive.service.ts
+++ b/apps/backend/src/referentiels/preuves-archive/generate-preuves-archive/generate-preuves-archive.service.ts
@@ -20,9 +20,9 @@ import {
   type AuditPreuvesArchive,
 } from '../models/audit-preuves-archive.table';
 import { PreuvesArchiveRepository } from '../preuves-archive.repository';
+import type { ArchiveFolderArborescence } from '../build-archive/archive-arborescence.types';
 import {
   generateArchiveFolderArborescence,
-  type ArchiveFolderArborescence,
   type ReferentielTreeNode,
 } from './generate-archive-folder-arborescence';
 


### PR DESCRIPTION
**PR 5a** du plan documents. Deux effets.

**1. `assembleZip` n'a plus aucune dépendance à l'audit** — prérequis de 5b, qui la déplace hors de `preuves-archive/`.

**2. Elle rend une erreur au lieu de bloquer** quand la destination refuse d'écrire.

| | avant | après |
|---|---|---|
| destination | chemin de fichier temporaire | `Writable` en paramètre |
| erreur d'assemblage | `PreuvesArchiveError` | `ARCHIVE_ASSEMBLY_FAILED` |
| garde-fous de taille et types d'archive | dans l'arborescence d'audit | dans `build-archive/` |
| dépassement de plafond | phrase française | `{ exceeded: 'fileCount' \| 'totalSize', ... }` |
| destination en échec | requête suspendue, processus abattu | `failure(ARCHIVE_ASSEMBLY_FAILED, cause)` |
| fichier de taille négative | retenu, et **soustrait** du total | écarté et consigné au manifeste |

Hors chemin d'échec, le comportement de l'archive d'audit ne change pas.

Rouges observés : `9f988f2b74` — timeout 20 s **et** `Unhandled Rejection` ; et la taille négative ressortait en `collected`.

## Arbitrages

**L'ordre des deux attentes est porteur.** Destination d'abord, finalisation ensuite : `finalize()` ne se résout jamais sur une destination morte. L'inverser réintroduit le blocage ; le test le voit par timeout.

**La traduction d'erreur dans `buildAndUpload` est une indirection 1:1 aujourd'hui**, le second consommateur arrivant en 5c. Je la garde : le type d'erreur *est* une dépendance à l'audit, et en 5b importer un type du domaine qu'on vient de quitter serait impossible.

**`assembleZip` prend encore `arborescence`**, le modèle de données de l'audit, et construit le manifeste en son sein — le téléchargement par mesure héritera d'un `liens.csv` toujours vide. Une signature `{ files, extraEntries }` le sortirait. À trancher en 5b.

**`assembleZip` est publique sans `{ user, tx }`.** `BuildArchiveService` n'autorise rien et ne touche pas la base ; la convention vise les services applicatifs. 5b tranche en choisissant sa destination.

L'absence d'annulation des téléchargements sur échec de destination est préexistante et planifiée en PR 11.