### PR TITLE
docs(app): point agents at the Vercel React skills for frontend work

### DIFF
--- a/apps/app/AGENTS.md
+++ b/apps/app/AGENTS.md
@@ -2,6 +2,13 @@
 
 Next.js 16 (App Router) admin dashboard for collectivites's users.
 
+## Skills
+
+Before writing, reviewing, or refactoring any React/Next.js code in this app,
+invoke the `vercel-react-best-practices` skill. For component API or composition
+design (compound components, render props, context providers, boolean-prop
+proliferation), also invoke `vercel-composition-patterns`.
+
 ## Layout
 
 - **`apps/app/app/`** = Next.js App Router routes only. **`apps/app/src/`** = all feature code.


### PR DESCRIPTION
## What

Adds a `## Skills` section at the top of `apps/app/AGENTS.md` (symlinked from `apps/app/CLAUDE.md`) directing agents to invoke the `vercel-react-best-practices` skill before writing/reviewing/refactoring React code, and `vercel-composition-patterns` for component API design.

## Why

Claude Code has no built-in "glob → skill" auto-activation — skill selection is model-driven off each skill's description. In practice the Vercel React skill was never being reached for. An explicit named instruction in `AGENTS.md`, which auto-loads whenever work touches `apps/app/`, is followed far more consistently.

## Notes

- `apps/app/CLAUDE.md` turned out to be a symlink to `AGENTS.md`, so a single edit covers both.
- This is a soft nudge, not enforcement. If it still slips through, the follow-up is a `PreToolUse` hook injecting the reminder on frontend file edits.

https://claude.ai/code/session_01NNjaDCM5B8pnPCHoDMLbqm