### PR TITLE
refactor(referentiels): retire les invalidations de clés sans lecteur

### DIFF
--- a/apps/app/src/referentiels/actions/action-statut/use-action-statut.ts
+++ b/apps/app/src/referentiels/actions/action-statut/use-action-statut.ts
@@ -25,9 +25,6 @@ export const useSaveActionStatuts = () => {
       onSuccess: async () => {
         await Promise.all([
           queryClient.invalidateQueries({
-            queryKey: ['action_statut', collectiviteId],
-          }),
-          queryClient.invalidateQueries({
             queryKey: trpc.referentiels.actions.listActionsGroupedById.queryKey(
               {
                 collectiviteId,

--- a/apps/app/src/referentiels/audits/cloture/data/use-validate-audit.ts
+++ b/apps/app/src/referentiels/audits/cloture/data/use-validate-audit.ts
@@ -9,21 +9,7 @@ export const useValidateAudit = () => {
 
   return useMutation(
     trpc.referentiels.labellisations.validateAudit.mutationOptions({
-      onSuccess: (audit) => {
-        queryClient.invalidateQueries(
-          {
-            queryKey: ['audit', audit.collectiviteId, audit.referentielId],
-          },
-          { cancelRefetch: true }
-        );
-
-        queryClient.invalidateQueries(
-          {
-            queryKey: ['labellisation_parcours', audit.collectiviteId],
-          },
-          { cancelRefetch: true }
-        );
-
+      onSuccess: () => {
         queryClient.invalidateQueries({
           queryKey: trpc.referentiels.labellisations.getParcours.queryKey(),
         });

--- a/apps/app/src/referentiels/labellisations/useStartAudit.ts
+++ b/apps/app/src/referentiels/labellisations/useStartAudit.ts
@@ -14,18 +14,6 @@ export const useStartAudit = () => {
         const { collectiviteId, referentielId } = audit;
 
         queryClient.invalidateQueries({
-          queryKey: ['audit', collectiviteId, referentielId],
-        });
-
-        queryClient.invalidateQueries({
-          queryKey: ['peut_commencer_audit', collectiviteId, referentielId],
-        });
-
-        queryClient.invalidateQueries({
-          queryKey: ['labellisation_parcours', collectiviteId],
-        });
-
-        queryClient.invalidateQueries({
           queryKey: trpc.referentiels.labellisations.getParcours.queryKey({
             collectiviteId,
             referentielId,

--- a/apps/app/src/referentiels/preuves/Bibliotheque/useEditPreuve.ts
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/useEditPreuve.ts
@@ -76,8 +76,9 @@ export const useRemovePreuve = () => {
     },
 
     onSuccess: (_data, variables) => {
-      invalidateQueries(queryClient, variables.collectiviteId, {
-        invalidateParcours: false,
+      invalidateQueries({
+        queryClient,
+        collectiviteId: variables.collectiviteId,
         trpc,
       });
       if (variables.preuveType === 'annexe') {
@@ -131,8 +132,9 @@ export const useUpdatePreuveLien = () => {
     },
 
     onSuccess: (_data, variables) => {
-      invalidateQueries(queryClient, variables.collectiviteId, {
-        invalidateParcours: false,
+      invalidateQueries({
+        queryClient,
+        collectiviteId: variables.collectiviteId,
         trpc,
       });
       if (variables.preuveType === 'annexe') {
@@ -165,8 +167,9 @@ const useUpdatePreuveCommentaire = () => {
     },
 
     onSuccess: (data, variables) => {
-      invalidateQueries(queryClient, variables.collectiviteId, {
-        invalidateParcours: false,
+      invalidateQueries({
+        queryClient,
+        collectiviteId: variables.collectiviteId,
         trpc,
       });
       if (variables.preuveType === 'annexe') {
@@ -185,8 +188,9 @@ export const useUpdateBibliothequeFichier = () => {
   return useMutation(
     trpc.collectivites.documents.update.mutationOptions({
       onSuccess: (_data, variables) => {
-        invalidateQueries(queryClient, variables.collectiviteId, {
-          invalidateParcours: false,
+        invalidateQueries({
+          queryClient,
+          collectiviteId: variables.collectiviteId,
           trpc,
         });
         queryClient.invalidateQueries({

--- a/apps/app/src/referentiels/preuves/Bibliotheque/useReplaceAuditReportFile.ts
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/useReplaceAuditReportFile.ts
@@ -9,10 +9,7 @@ export const useReplaceAuditReportFile = (collectiviteId: number) => {
   return useMutation(
     trpc.referentiels.labellisations.updateAuditReport.mutationOptions({
       onSuccess: () => {
-        invalidateQueries(queryClient, collectiviteId, {
-          invalidateParcours: false,
-          trpc,
-        });
+        invalidateQueries({ queryClient, collectiviteId, trpc });
         queryClient.invalidateQueries({
           queryKey: trpc.referentiels.documents.listDocumentsAudit.pathKey(),
         });

--- a/apps/app/src/referentiels/preuves/useAddPreuves.ts
+++ b/apps/app/src/referentiels/preuves/useAddPreuves.ts
@@ -3,7 +3,8 @@ import {
   useMutation,
   useQueryClient,
 } from '@tanstack/react-query';
-import { useSupabase, useTRPC, useTRPCClient } from '@tet/api';
+import { TRPCOptionsProxy } from '@trpc/tanstack-react-query';
+import { AppRouter, useSupabase, useTRPC, useTRPCClient } from '@tet/api';
 import { ReferentielId } from '@tet/domain/referentiels';
 
 // on peut ajouter une preuve sous forme de...
@@ -26,8 +27,9 @@ export const useAddPreuveReglementaire = () => {
   return useMutation(
     trpc.referentiels.actions.addPreuveReglementaire.mutationOptions({
       onSuccess: (_data, variables) => {
-        invalidateQueries(queryClient, variables.collectiviteId, {
-          invalidateParcours: false,
+        invalidateQueries({
+          queryClient,
+          collectiviteId: variables.collectiviteId,
           trpc,
         });
       },
@@ -41,8 +43,9 @@ export const useAddPreuveComplementaire = () => {
   return useMutation(
     trpc.referentiels.actions.addPreuveComplementaire.mutationOptions({
       onSuccess: (_data, variables) => {
-        invalidateQueries(queryClient, variables.collectiviteId, {
-          invalidateParcours: false,
+        invalidateQueries({
+          queryClient,
+          collectiviteId: variables.collectiviteId,
           trpc,
         });
       },
@@ -61,10 +64,7 @@ export const useAddPreuveLabellisation = (
   return useMutation(
     trpc.referentiels.labellisations.createLabellisationPreuve.mutationOptions({
       onSettled: (_data, _error, variables) => {
-        invalidateQueries(queryClient, collectiviteId, {
-          invalidateParcours: true,
-          trpc,
-        });
+        invalidateQueries({ queryClient, collectiviteId, trpc });
         queryClient.invalidateQueries({
           queryKey:
             trpc.referentiels.documents.listDocumentsDemandeLabellisation.queryKey({
@@ -103,8 +103,9 @@ export const useAddPreuveAudit = () => {
       }),
 
     onSuccess: (data, variables) => {
-      invalidateQueries(queryClient, variables.collectiviteId, {
-        invalidateParcours: true,
+      invalidateQueries({
+        queryClient,
+        collectiviteId: variables.collectiviteId,
         trpc,
       });
       queryClient.invalidateQueries({
@@ -130,8 +131,9 @@ export const useAddPreuveRapport = () => {
       supabase.from('preuve_rapport').insert(preuve),
 
     onSuccess: (data, variables) => {
-      invalidateQueries(queryClient, variables.collectivite_id, {
-        invalidateParcours: false,
+      invalidateQueries({
+        queryClient,
+        collectiviteId: variables.collectivite_id,
         trpc,
       });
     },
@@ -165,8 +167,9 @@ export const useAddPreuveAnnexe = () => {
     },
 
     onSuccess: (_data, variables) => {
-      invalidateQueries(queryClient, variables.collectivite_id, {
-        invalidateParcours: false,
+      invalidateQueries({
+        queryClient,
+        collectiviteId: variables.collectivite_id,
         trpc,
       });
       queryClient.invalidateQueries({
@@ -177,14 +180,15 @@ export const useAddPreuveAnnexe = () => {
 };
 
 // recharge la liste des preuves
-export const invalidateQueries = (
-  queryClient: QueryClient,
-  collectiviteId: number,
-  {
-    invalidateParcours,
-    trpc,
-  }: { invalidateParcours: boolean; trpc: ReturnType<typeof useTRPC> }
-) => {
+export const invalidateQueries = ({
+  queryClient,
+  collectiviteId,
+  trpc,
+}: {
+  queryClient: QueryClient;
+  collectiviteId: number;
+  trpc: TRPCOptionsProxy<AppRouter>;
+}): void => {
   queryClient.invalidateQueries({
     queryKey: trpc.referentiels.documents.listDocumentsReferentiel.pathKey(),
   });
@@ -192,16 +196,8 @@ export const invalidateQueries = (
     queryKey: trpc.referentiels.documents.listDocumentsMesure.pathKey(),
   });
   queryClient.invalidateQueries({
-    queryKey: ['fiche_action'],
-  });
-  queryClient.invalidateQueries({
     queryKey: trpc.referentiels.actions.countPreuves.queryKey({
       collectiviteId,
     }),
   });
-  if (invalidateParcours) {
-    queryClient.invalidateQueries({
-      queryKey: ['labellisation_parcours', collectiviteId],
-    });
-  }
 };


### PR DESCRIPTION
Cinq clés de cache écrites à la main n'ont plus aucune requête derrière elles : leur invalidation ne produit rien. Cette PR les retire.

Plan : `docs/plans/2026-09-10-001-refactor-cles-requete-litterales-plan.md` (compound-knowledge-db), PR 1. Les clés littérales restantes y sont inventoriées ; celles-ci sont les mortes du domaine référentiels.

Aucun comportement ne change.

## Les clés retirées

| Clé | Sites | Donnée réellement lue | Clé tRPC déjà invalidée au même site |
|---|---|---|---|
| `['audit', c, r]` | `useStartAudit`, `use-validate-audit` | l'audit dérive du parcours (`useAudit`) | `labellisations.getParcours` |
| `['peut_commencer_audit', c, r]` | `useStartAudit` | calcul client `canStartAuditRule(parcours)` | `labellisations.getParcours` |
| `['labellisation_parcours', c]` | `useStartAudit`, `use-validate-audit`, `invalidateQueries` | `labellisations.getParcours` | `labellisations.getParcours`, sauf dans `useAddPreuveAudit` : le parcours ne lit que `preuve_labellisation` (`get-labellisation.service.ts:475-483`), un rapport d'audit ne le change pas |
| `['action_statut', c]` | `use-action-statut` | `actions.listActionsGroupedById`, `snapshots.getCurrent` | les deux, plus `getParcours` |
| `['fiche_action']` | `invalidateQueries` | `plans.fiches.ficheAnnexes` | `ficheAnnexes.pathKey()` sur chaque chemin d'annexe |

## Pourquoi c'est neutre

Une clé tRPC commence par un tableau (`[['referentiels', 'labellisations', 'getParcours'], {…}]`), une clé littérale par une chaîne : aucun préfixe commun, donc retirer une clé littérale ne désinvalide aucune requête tRPC. Sans requête correspondante, `invalidateQueries` se résout au microtask suivant ; le retrait de `['action_statut', …]` du `Promise.all` ne change pas la durée de la mutation.

Absence de lecteur, vérifiable par :

```bash
for k in audit peut_commencer_audit labellisation_parcours action_statut fiche_action; do
  echo "== $k"; git grep -nF "'$k'" -- apps/app packages/api/src | grep -v "from('$k')"
done
```

Les résultats restants sont des noms de tables, des types d'historique et des `preuveType`, jamais une clé de requête.

## `invalidateQueries`

L'option `invalidateParcours` ne commandait que l'invalidation de `['labellisation_parcours', …]` : elle disparaît de la signature et de ses onze appelants (`useAddPreuves.ts`, `useEditPreuve.ts`, `useReplaceAuditReportFile.ts`). La fonction prend désormais ses arguments nommés, `trpc` typé `TRPCOptionsProxy<AppRouter>` comme dans `invalidate-fiche-queries-by-tag.ts`.

## Surface de review

- Attention humaine : chaque retrait face à la colonne « déjà invalidée » du tableau.
- Mécaniques : les onze appels de `invalidateQueries`.

## Recherche anti-duplication

Aucun utilitaire créé. Le typage de `trpc` reprend `invalidate-fiche-queries-by-tag.ts`.

## Zones de moindre confiance

Aucune sur le comportement. `useAddPreuves.ts` et `useEditPreuve.ts` gardent des écarts Prettier présents sur `main`, hors des lignes touchées.

## Vérifications

- `nx run app:typecheck --skip-nx-cache` : vert.
- `nx run app:lint --quiet` : vert.
- `nx test app` : 100 fichiers, 666 tests passés.
