### PR TITLE
refactor(fiches): retire les clés de cache d'axes et de listes sans lecteur

### DIFF
--- a/apps/app/src/plans/fiches/data/use-create-fiche-action.ts
+++ b/apps/app/src/plans/fiches/data/use-create-fiche-action.ts
@@ -21,10 +21,6 @@ export const useCreateFicheAction = () => {
 
     onSuccess: (data) => {
       queryClient.invalidateQueries({
-        queryKey: ['axe_fiches', null],
-      });
-
-      queryClient.invalidateQueries({
         queryKey: trpcClient.plans.fiches.listFiches.queryKey({
           collectiviteId,
         }),

--- a/apps/app/src/plans/fiches/data/use-create-fiche-resume.ts
+++ b/apps/app/src/plans/fiches/data/use-create-fiche-resume.ts
@@ -38,8 +38,6 @@ export const useCreateFicheResume = (args: Args) => {
     collectiviteId,
   } = args;
 
-  const axe_fiches_key = ['axe_fiches', axeId];
-
   const openUrl = (url: string, openInNewTab?: boolean) => {
     if (openInNewTab) {
       window.open(url, '_blank');
@@ -67,7 +65,6 @@ export const useCreateFicheResume = (args: Args) => {
       await queryClient.cancelQueries({
         queryKey: trpcClient.plans.plans.get.queryKey({ planId }),
       });
-      await queryClient.cancelQueries({ queryKey: axe_fiches_key });
 
       if (axeId) {
         await queryClient.cancelQueries({
@@ -78,15 +75,9 @@ export const useCreateFicheResume = (args: Args) => {
         });
       }
 
-      const previousData = [
-        [
-          trpcClient.plans.plans.get.queryKey({ planId }),
-          queryClient.getQueryData(
-            trpcClient.plans.plans.get.queryKey({ planId })
-          ),
-        ],
-        [axe_fiches_key, queryClient.getQueryData(axe_fiches_key)],
-      ];
+      const previousPlan = queryClient.getQueryData(
+        trpcClient.plans.plans.get.queryKey({ planId })
+      );
 
       const tempFiche = ficheResumeFactory({
         tempId: TEMPORARY_ID,
@@ -94,13 +85,6 @@ export const useCreateFicheResume = (args: Args) => {
         axeId,
         axeFichesIds,
       });
-
-      queryClient.setQueryData(
-        axe_fiches_key,
-        (old: FicheListItem[] | undefined) => {
-          return old ? [tempFiche, ...old] : [tempFiche];
-        }
-      );
 
       // mise à jour optimiste du cache listFiches avec le filtre axesId
       if (axeId) {
@@ -151,32 +135,20 @@ export const useCreateFicheResume = (args: Args) => {
       );
 
       const context = {
-        previousData,
+        previousPlan,
         tempFiche,
       };
 
       return context;
     },
     onError: (err, args, context) => {
-      context?.previousData.forEach(([key, data]) =>
-        queryClient.setQueryData(key as string[], data)
+      queryClient.setQueryData(
+        trpcClient.plans.plans.get.queryKey({ planId }),
+        context?.previousPlan
       );
     },
     onSuccess: async (data) => {
       const newFiche = data as unknown as FicheListItem;
-
-      // On récupère la fiche renvoyer par le serveur pour la remplacer dans le cache avant invalidation
-      queryClient.setQueryData(
-        axe_fiches_key,
-        (old: FicheListItem[] | undefined): FicheListItem[] => {
-          const updatedData = old ?? [];
-          return sortFichesResume(
-            updatedData.map((f) => {
-              return f.id === TEMPORARY_ID ? newFiche : f;
-            })
-          );
-        }
-      );
 
       // Mise à jour du cache listFiches avec le filtre axesId pour rafraîchir immédiatement FichesList
       if (axeId) {
@@ -235,7 +207,6 @@ export const useCreateFicheResume = (args: Args) => {
         queryClient.invalidateQueries({
           queryKey: trpcClient.plans.plans.get.queryKey({ planId }),
         }),
-        queryClient.invalidateQueries({ queryKey: axe_fiches_key }),
         queryClient.invalidateQueries({
           queryKey: trpcClient.plans.fiches.countBy.queryKey({
             collectiviteId,

--- a/apps/app/src/plans/fiches/duplicate-fiche/data/use-duplicate-fiche.ts
+++ b/apps/app/src/plans/fiches/duplicate-fiche/data/use-duplicate-fiche.ts
@@ -33,7 +33,6 @@ export const useDuplicateFiche = ({
       queryClient.invalidateQueries({
         queryKey: trpc.plans.fiches.countBy.queryKey(),
       });
-      queryClient.invalidateQueries({ queryKey: ['axe_fiches'] });
       if (invalidatePlanId) {
         queryClient.invalidateQueries({
           queryKey: trpc.plans.plans.get.queryKey({

--- a/apps/app/src/plans/fiches/update-fiche/data/use-update-fiche.ts
+++ b/apps/app/src/plans/fiches/update-fiche/data/use-update-fiche.ts
@@ -224,12 +224,6 @@ export const useUpdateFiche = (args?: Args) => {
           queryKey: trpc.plans.plans.getPlanCompletion.queryKey(),
         });
 
-        if (ficheFields.axes) {
-          ficheFields.axes.forEach(({ id: axeId }) =>
-            queryClient.invalidateQueries({ queryKey: ['axe_fiches', axeId] })
-          );
-        }
-
         if (args?.invalidatePlanId) {
           queryClient.invalidateQueries({
             queryKey: trpc.plans.plans.get.queryKey({
@@ -242,29 +236,6 @@ export const useUpdateFiche = (args?: Args) => {
             }),
           });
         }
-
-        queryClient.invalidateQueries({ queryKey: ['axe_fiches', null] });
-        queryClient.invalidateQueries({
-          queryKey: ['structures', collectiviteId],
-        });
-        queryClient.invalidateQueries({
-          queryKey: ['partenaires', collectiviteId],
-        });
-        queryClient.invalidateQueries({
-          queryKey: ['personnes_pilotes', collectiviteId],
-        });
-        queryClient.invalidateQueries({
-          queryKey: ['personnes', collectiviteId],
-        });
-        queryClient.invalidateQueries({
-          queryKey: ['services_pilotes', collectiviteId],
-        });
-        queryClient.invalidateQueries({
-          queryKey: ['personnes_referentes', collectiviteId],
-        });
-        queryClient.invalidateQueries({
-          queryKey: ['financeurs', collectiviteId],
-        });
       },
       onSuccess: () => {
         if (args?.onUpdateCallback) {


### PR DESCRIPTION
Huit clés de cache écrites à la main n'ont plus aucune requête derrière elles : leur invalidation ne produit rien, et `use-create-fiche-resume` écrit dans une entrée qu'aucun composant n'observe. Cette PR les retire.

Plan : `docs/plans/2026-09-10-001-refactor-cles-requete-litterales-plan.md` (compound-knowledge-db), PR 2. Les clés littérales restantes y sont inventoriées ; celles-ci sont les mortes du domaine fiches.

Aucun comportement ne change.

## Les clés retirées

| Clé | Sites | Donnée réellement lue |
|---|---|---|
| `['axe_fiches', …]` | `use-update-fiche`, `use-create-fiche-action`, `use-duplicate-fiche`, `use-create-fiche-resume` | `plans.fiches.listFiches({ filters: { axesId } })` et `plans.plans.get`, déjà invalidées ou mises à jour aux mêmes sites |
| `structures`, `partenaires`, `personnes_pilotes`, `personnes`, `services_pilotes`, `personnes_referentes`, `financeurs` | `use-update-fiche` | `collectivites.tags.list`, `collectivites.personnes.list`, `collectivites.tags.personnes.list`. Une mise à jour de fiche ne crée ni tag ni personne ; `use-create-tag` invalide lui-même la liste des tags |

Dans `use-create-fiche-resume`, `axe_fiches_key` portait une annulation, une entrée d'instantané, deux `setQueryData` et une invalidation sur une entrée de cache sans observateur. La mise à jour optimiste visible passe par `listFiches` et `plans.get`, inchangés.

## Pourquoi c'est neutre

Une clé tRPC commence par un tableau, une clé littérale par une chaîne : aucun préfixe commun, donc retirer une clé littérale ne désinvalide aucune requête tRPC. Une entrée créée par `setQueryData` sans observateur n'est jamais rendue.

Absence de lecteur, vérifiable par :

```bash
for k in axe_fiches structures partenaires personnes_pilotes personnes services_pilotes personnes_referentes financeurs; do
  echo "== $k"; git grep -nF "'$k'" -- apps/app packages/api/src | grep -v "from('$k')"
done
```

Les résultats restants sont des libellés de champ et des types `RouterOutput`, jamais une clé de requête.

## Retour arrière de la création

L'instantané ne porte plus que le plan : le tableau de paires `[clé, données]` devient `previousPlan`, et `onError` le restaure sur `plans.plans.get` sans le cast `key as string[]`.

## Surface de review

- Attention humaine : `use-create-fiche-resume.ts` (`onMutate`, `onError`).
- Mécaniques : les retraits de `use-update-fiche.ts`, `use-create-fiche-action.ts`, `use-duplicate-fiche.ts`.

## Recherche anti-duplication

Aucun utilitaire créé.

## Zones de moindre confiance

Aucune sur les retraits. `onError` ne restaure pas l'écriture optimiste de `listFiches` ; c'est le cas sur `main` et hors du périmètre de cette PR.

## Vérifications

- `nx run app:typecheck --skip-nx-cache` : vert.
- `nx run app:lint --quiet` : vert.
- `nx test app` : 100 fichiers, 666 tests passés.
