### PR TITLE
refactor(tableau-de-bord): remplace les clés écrites à la main des modules du tableau de bord personnel par celles de tRPC

### DIFF
--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/tableau-de-bord/personnel/[moduleKey]/_components/tdb-perso-module.page.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/tableau-de-bord/personnel/[moduleKey]/_components/tdb-perso-module.page.tsx
@@ -2,13 +2,11 @@
 
 import { makeTdbCollectiviteUrl } from '@/app/app/paths';
 import { MesuresModulePage } from '@/app/tableaux-de-bord/referentiels/mesures.module-page';
+import { useTRPC } from '@tet/api';
 import { PersonalDefaultModuleKeys } from '@tet/domain/metrics';
 
 import MesuresDontJeSuisLePiloteModal from '../../_components/mesures-dont-je-suis-le-pilote.modal';
-import {
-  getQueryKey as getFetchSingleKey,
-  useTdbPersoFetchSingle,
-} from '../../_hooks/use-tdb-perso-fetch-single';
+import { useTdbPersoFetchSingle } from '../../_hooks/use-tdb-perso-fetch-single';
 
 type Props = {
   moduleKey: PersonalDefaultModuleKeys;
@@ -16,6 +14,8 @@ type Props = {
 };
 
 const TdbPersoModulePage = ({ moduleKey, collectiviteId }: Props) => {
+  const trpc = useTRPC();
+
   const parentPage = {
     label: 'Mon suivi personnel',
     link: makeTdbCollectiviteUrl({
@@ -39,7 +39,10 @@ const TdbPersoModulePage = ({ moduleKey, collectiviteId }: Props) => {
             module={module}
             openState={openState}
             keysToInvalidate={[
-              getFetchSingleKey(parseInt(collectiviteId), module.defaultKey),
+              trpc.metrics.users.getModule.queryKey({
+                collectiviteId: module.collectiviteId,
+                defaultKey: moduleKey,
+              }),
             ]}
           />
         )}

--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/tableau-de-bord/personnel/_components/filtered-fiche-by-module.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/tableau-de-bord/personnel/_components/filtered-fiche-by-module.tsx
@@ -2,9 +2,9 @@ import { useState } from 'react';
 
 import { FichesActionModule } from '@/app/tableaux-de-bord/plans-action/fiches-action/fiches-action.module';
 import { QueryKey } from '@tanstack/react-query';
+import { useTRPC } from '@tet/api';
 import { ModuleFicheActionsSelect } from '@tet/domain/metrics';
 import React from 'react';
-import { getQueryKey } from '../_hooks/use-tdb-perso-fetch-modules';
 import { getModuleEditActions } from './get-module-edit-actions';
 
 type Props = {
@@ -24,6 +24,7 @@ export const FilteredFichesByModule = ({
   isEditionEnabled,
   ModalComponent,
 }: Props) => {
+  const trpc = useTRPC();
   const collectiviteId = module.collectiviteId;
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
 
@@ -41,7 +42,9 @@ export const FilteredFichesByModule = ({
       <ModalComponent
         module={module}
         openState={{ isOpen: isEditModalOpen, setIsOpen: setIsEditModalOpen }}
-        keysToInvalidate={[getQueryKey(collectiviteId)]}
+        keysToInvalidate={[
+          trpc.metrics.users.listModules.queryKey({ collectiviteId }),
+        ]}
       />
     </>
   );

--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/tableau-de-bord/personnel/_components/indicateurs-dont-je-suis-le-pilote.module.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/tableau-de-bord/personnel/_components/indicateurs-dont-je-suis-le-pilote.module.tsx
@@ -1,10 +1,10 @@
 import { useState } from 'react';
 
 import { IndicateursModule } from '@/app/tableaux-de-bord/indicateurs/indicateurs.module';
+import { useTRPC } from '@tet/api';
 import { ModuleIndicateursSelect } from '@tet/domain/metrics';
 
 import { Event, useEventTracker } from '@tet/ui';
-import { getQueryKey } from '../_hooks/use-tdb-perso-fetch-modules';
 import { getModuleEditActions } from './get-module-edit-actions';
 import IndicateursDontJeSuisLePiloteModal from './indicateurs-dont-je-suis-le-pilote.modal';
 
@@ -17,6 +17,7 @@ export const IndicateursDontJeSuisLePiloteModule = ({
   module,
   isEditionEnabled,
 }: Props) => {
+  const trpc = useTRPC();
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
 
   const tracker = useEventTracker();
@@ -39,7 +40,11 @@ export const IndicateursDontJeSuisLePiloteModule = ({
             isOpen: isEditModalOpen,
             setIsOpen: setIsEditModalOpen,
           }}
-          keysToInvalidate={[getQueryKey(module.collectiviteId)]}
+          keysToInvalidate={[
+            trpc.metrics.users.listModules.queryKey({
+              collectiviteId: module.collectiviteId,
+            }),
+          ]}
         />
       )}
     </>

--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/tableau-de-bord/personnel/_components/mesures-dont-je-suis-le-pilote.module.tsx
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/tableau-de-bord/personnel/_components/mesures-dont-je-suis-le-pilote.module.tsx
@@ -1,10 +1,10 @@
 import { useState } from 'react';
 
 import { MesuresModule } from '@/app/tableaux-de-bord/referentiels/mesures.module';
+import { useTRPC } from '@tet/api';
 import { ModuleMesuresSelect } from '@tet/domain/metrics';
 
 import { Event, useEventTracker } from '@tet/ui';
-import { getQueryKey } from '../_hooks/use-tdb-perso-fetch-modules';
 import { getModuleEditActions } from './get-module-edit-actions';
 import MesuresDontJeSuisLePiloteModal from './mesures-dont-je-suis-le-pilote.modal';
 
@@ -17,6 +17,7 @@ const MesuresDontJeSuisLePiloteModule = ({
   module,
   isEditionEnabled,
 }: Props) => {
+  const trpc = useTRPC();
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
 
   const tracker = useEventTracker();
@@ -35,7 +36,11 @@ const MesuresDontJeSuisLePiloteModule = ({
       <MesuresDontJeSuisLePiloteModal
         module={module}
         openState={{ isOpen: isEditModalOpen, setIsOpen: setIsEditModalOpen }}
-        keysToInvalidate={[getQueryKey(module.collectiviteId)]}
+        keysToInvalidate={[
+          trpc.metrics.users.listModules.queryKey({
+            collectiviteId: module.collectiviteId,
+          }),
+        ]}
       />
     </>
   );

--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/tableau-de-bord/personnel/_hooks/use-tdb-perso-fetch-modules.ts
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/tableau-de-bord/personnel/_hooks/use-tdb-perso-fetch-modules.ts
@@ -1,20 +1,13 @@
-import { QueryKey, useQuery } from '@tanstack/react-query';
-import { useTRPCClient } from '@tet/api';
+import { useQuery } from '@tanstack/react-query';
+import { useTRPC } from '@tet/api';
 import { useCollectiviteId } from '@tet/api/collectivites';
 
 /** Charges les différents modules du tableau de bord personnel */
 export const useTdbPersoFetchModules = () => {
-  const trpcClient = useTRPCClient();
+  const trpc = useTRPC();
   const collectiviteId = useCollectiviteId();
 
-  return useQuery({
-    queryKey: getQueryKey(collectiviteId),
-    queryFn: () =>
-      trpcClient.metrics.users.listModules.query({
-        collectiviteId,
-      }),
-  });
+  return useQuery(
+    trpc.metrics.users.listModules.queryOptions({ collectiviteId })
+  );
 };
-
-export const getQueryKey = (collectiviteId: number): QueryKey =>
-  ['personal-dashboard-modules', collectiviteId] as const;

--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/tableau-de-bord/personnel/_hooks/use-tdb-perso-fetch-single.ts
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/tableau-de-bord/personnel/_hooks/use-tdb-perso-fetch-single.ts
@@ -1,5 +1,5 @@
-import { QueryKey, useQuery } from '@tanstack/react-query';
-import { useTRPCClient } from '@tet/api';
+import { useQuery } from '@tanstack/react-query';
+import { useTRPC } from '@tet/api';
 import { useCollectiviteId } from '@tet/api/collectivites';
 import { PersonalDefaultModuleKeys } from '@tet/domain/metrics';
 
@@ -9,20 +9,13 @@ import { PersonalDefaultModuleKeys } from '@tet/domain/metrics';
 export const useTdbPersoFetchSingle = (
   defaultModuleKey: PersonalDefaultModuleKeys
 ) => {
-  const trpcClient = useTRPCClient();
+  const trpc = useTRPC();
   const collectiviteId = useCollectiviteId();
 
-  return useQuery({
-    queryKey: getQueryKey(collectiviteId, defaultModuleKey),
-    queryFn: () =>
-      trpcClient.metrics.users.getModule.query({
-        collectiviteId,
-        defaultKey: defaultModuleKey,
-      }),
-  });
+  return useQuery(
+    trpc.metrics.users.getModule.queryOptions({
+      collectiviteId,
+      defaultKey: defaultModuleKey,
+    })
+  );
 };
-
-export const getQueryKey = (
-  collectiviteId?: number,
-  defaultModuleKey?: string
-): QueryKey => ['personal-dashboard-module', collectiviteId, defaultModuleKey];

--- a/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/tableau-de-bord/personnel/_hooks/use-tdb-perso-upsert-module.ts
+++ b/apps/app/app/(authed)/collectivite/[collectiviteId]/(acces-restreint)/tableau-de-bord/personnel/_hooks/use-tdb-perso-upsert-module.ts
@@ -4,9 +4,6 @@ import { useTRPC } from '@tet/api';
 /**
  * Crée ou met à jour un module du tableau de bord personnel de l'utilisateur
  * courant.
- *
- * L'invalidation du cache est laissée à l'appelant (via `keysToInvalidate`) afin
- * de conserver la compatibilité avec les clés de cache existantes.
  */
 export const useUpsertModuleTdbPerso = () => {
   const trpc = useTRPC();


### PR DESCRIPTION
Les deux hooks du tableau de bord personnel appellent des procédures tRPC existantes sous des clés de cache écrites à la main. Cette PR les fait passer par le motif canonique `trpc.x.y.queryOptions()`.

Plan : `docs/plans/2026-09-10-001-refactor-cles-requete-litterales-plan.md` (compound-knowledge-db), PR 3. Suite de #5042 et #5043.

Aucun comportement ne change.

## Les clés remplacées

| Hook | Clé écrite à la main | Clé tRPC |
|---|---|---|
| `useTdbPersoFetchModules` | `['personal-dashboard-modules', collectiviteId]` | `metrics.users.listModules.queryKey({ collectiviteId })` |
| `useTdbPersoFetchSingle` | `['personal-dashboard-module', collectiviteId, defaultKey]` | `metrics.users.getModule.queryKey({ collectiviteId, defaultKey })` |

Les fabriques `getQueryKey` disparaissent. La donnée rendue est la même : `queryOptions` appelle la même procédure avec la même entrée que l'ancien `trpcClient.…query(…)`.

## Les invalidations suivent

Les trois modales de filtres reçoivent `keysToInvalidate` et l'invalident après `upsertModule`. Ces clés sortent désormais de `trpc.metrics.users.*.queryKey`, avec la même entrée que la requête visée : `{ collectiviteId }` pour la liste des modules, `{ collectiviteId, defaultKey: moduleKey }` pour la page d'un module. `moduleKey` est la valeur que la page passe à `useTdbPersoFetchSingle`, ce qui garantit l'égalité des deux clés. Les quatre sites prennent `collectiviteId` dans `module.collectiviteId`, un `number` validé par le schéma du module : l'entrée de ces procédures passe par `z.coerce.number()`, qui ne type pas `collectiviteId` dans `queryKey`.

Aucun autre site ne lit ni n'invalide ces procédures.

Le JSDoc de `useUpsertModuleTdbPerso` justifiait l'invalidation par l'appelant par « la compatibilité avec les clés de cache existantes ». Ces clés disparaissent, et le paragraphe avec elles.

## Surface de review

- Attention humaine : l'égalité de chaque clé transmise à `keysToInvalidate` avec la clé de la requête qu'elle vise.
- Mécaniques : les deux hooks.

## Recherche anti-duplication

Aucun utilitaire créé ; le motif est celui de `ui/dropdownLists/ficheAction/EffetsAttendusDropdown/useEffetsAttendus.ts`.

## Vérifications

- `nx run app:typecheck --skip-nx-cache` : vert.
- `nx run app:lint --quiet` : vert.
- `nx test app` : 100 fichiers, 666 tests passés.
