### PR TITLE
refactor(documents): sort le contrôle d'accès aux documents d'une collectivité dans son propre service

### DIFF
--- a/apps/backend/src/collectivites/collectivites.module.ts
+++ b/apps/backend/src/collectivites/collectivites.module.ts
@@ -5,6 +5,7 @@ import { CollectivitePreferencesRepository } from '@tet/backend/collectivites/co
 import { CollectivitePreferencesRouter } from '@tet/backend/collectivites/collectivite-preferences/collectivite-preferences.router';
 import { CollectivitePreferencesService } from '@tet/backend/collectivites/collectivite-preferences/collectivite-preferences.service';
 import { CollectiviteBucketRepository } from '@tet/backend/collectivites/documents/collectivite-bucket.repository';
+import { CollectiviteDocumentsAccessService } from '@tet/backend/collectivites/documents/collectivite-documents-access.service';
 import { GetDownloadUrlRepository } from '@tet/backend/collectivites/documents/get-download-url/get-download-url.repository';
 import { GetDownloadUrlRouter } from '@tet/backend/collectivites/documents/get-download-url/get-download-url.router';
 import { GetDownloadUrlService } from '@tet/backend/collectivites/documents/get-download-url/get-download-url.service';
@@ -96,6 +97,7 @@ import { PersonnesService } from './services/personnes.service';
     StoreDocumentService,
     StoreDocumentRouter,
     CollectiviteBucketRepository,
+    CollectiviteDocumentsAccessService,
     CreateUploadTokenRepository,
     CreateUploadTokenService,
     CreateUploadTokenRouter,

--- a/apps/backend/src/collectivites/documents/collectivite-documents-access.service.spec.ts
+++ b/apps/backend/src/collectivites/documents/collectivite-documents-access.service.spec.ts
@@ -1,0 +1,143 @@
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { describe, expect, it, vi, type Mock } from 'vitest';
+import { CollectiviteDocumentsAccessService } from './collectivite-documents-access.service';
+
+const user: AuthenticatedUser = { id: 'user-id' } as AuthenticatedUser;
+
+type PermissionResult =
+  | { success: true; data: undefined }
+  | { success: false; error: 'UNAUTHORIZED' };
+
+const allowed: PermissionResult = { success: true, data: undefined };
+const denied: PermissionResult = { success: false, error: 'UNAUTHORIZED' };
+
+type ServiceUnderTest = {
+  service: CollectiviteDocumentsAccessService;
+  collectivitesService: { isPrivate: Mock };
+};
+
+function buildService({
+  isCollectivitePrivate = false,
+  canRead = true,
+  canReadConfidentiel = false,
+}: {
+  isCollectivitePrivate?: boolean;
+  canRead?: boolean;
+  canReadConfidentiel?: boolean;
+} = {}): ServiceUnderTest {
+  const grantedByOperation: Record<string, boolean> = {
+    'collectivites.documents.read': canRead,
+    'collectivites.documents.read_confidentiel': canReadConfidentiel,
+  };
+
+  const toPermissionResult = (operation: string): PermissionResult =>
+    grantedByOperation[operation] ? allowed : denied;
+
+  const permissionService = {
+    isAllowed: vi
+      .fn()
+      .mockImplementation((_user: AuthenticatedUser, operation: string) =>
+        Promise.resolve(toPermissionResult(operation))
+      ),
+  };
+
+  const collectivitesService = {
+    isPrivate: vi.fn().mockResolvedValue(isCollectivitePrivate),
+  };
+
+  const service = new CollectiviteDocumentsAccessService(
+    permissionService as never,
+    collectivitesService as never
+  );
+
+  return { service, collectivitesService };
+}
+
+describe('CollectiviteDocumentsAccessService', () => {
+  it('refuse une collectivite en acces restreint a un compte sans droit confidentiel', async () => {
+    const { service } = buildService({
+      isCollectivitePrivate: true,
+      canRead: true,
+      canReadConfidentiel: false,
+    });
+
+    const result = await service.checkUserCanReadDocuments(
+      { collectiviteId: 1 },
+      { user }
+    );
+
+    expect(result).toEqual({ success: false, error: 'UNAUTHORIZED' });
+  });
+
+  it('ouvre une collectivite en acces restreint, confidentiels compris, a un compte qui a le droit confidentiel', async () => {
+    const { service } = buildService({
+      isCollectivitePrivate: true,
+      canReadConfidentiel: true,
+    });
+
+    const result = await service.checkUserCanReadDocuments(
+      { collectiviteId: 1 },
+      { user }
+    );
+
+    expect(result).toEqual({
+      success: true,
+      data: { canReadConfidentiel: true },
+    });
+  });
+
+  it("ouvre une collectivite publique sans les confidentiels a un compte qui n'a que le droit de lecture", async () => {
+    const { service } = buildService();
+
+    const result = await service.checkUserCanReadDocuments(
+      { collectiviteId: 1 },
+      { user }
+    );
+
+    expect(result).toEqual({
+      success: true,
+      data: { canReadConfidentiel: false },
+    });
+  });
+
+  it('ouvre une collectivite publique, confidentiels compris, a un compte qui a les deux droits', async () => {
+    const { service } = buildService({ canReadConfidentiel: true });
+
+    const result = await service.checkUserCanReadDocuments(
+      { collectiviteId: 1 },
+      { user }
+    );
+
+    expect(result).toEqual({
+      success: true,
+      data: { canReadConfidentiel: true },
+    });
+  });
+
+  it('refuse une collectivite publique a un compte qui a le droit confidentiel sans le droit de lecture', async () => {
+    const { service } = buildService({
+      isCollectivitePrivate: false,
+      canRead: false,
+      canReadConfidentiel: true,
+    });
+
+    const result = await service.checkUserCanReadDocuments(
+      { collectiviteId: 1 },
+      { user }
+    );
+
+    expect(result).toEqual({ success: false, error: 'UNAUTHORIZED' });
+  });
+
+  it("refuse un compte sans aucun droit de lecture sans consulter l'acces restreint", async () => {
+    const { service, collectivitesService } = buildService({ canRead: false });
+
+    const result = await service.checkUserCanReadDocuments(
+      { collectiviteId: 1 },
+      { user }
+    );
+
+    expect(result).toEqual({ success: false, error: 'UNAUTHORIZED' });
+    expect(collectivitesService.isPrivate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/collectivites/documents/collectivite-documents-access.service.ts
+++ b/apps/backend/src/collectivites/documents/collectivite-documents-access.service.ts
@@ -1,0 +1,56 @@
+import { Injectable } from '@nestjs/common';
+import CollectivitesService from '@tet/backend/collectivites/services/collectivites.service';
+import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
+import { ServiceSecondArg } from '@tet/backend/utils/nest/service-second-arg.utils';
+import { failure, success, type Result } from '@tet/backend/utils/result.type';
+import { CommonErrorEnum } from '@tet/backend/utils/trpc/common-errors';
+import { ResourceType } from '@tet/domain/users';
+
+@Injectable()
+export class CollectiviteDocumentsAccessService {
+  constructor(
+    private readonly permissionService: PermissionService,
+    private readonly collectivitesService: CollectivitesService
+  ) {}
+
+  async checkUserCanReadDocuments(
+    { collectiviteId }: { collectiviteId: number },
+    { user, tx }: ServiceSecondArg
+  ): Promise<Result<{ canReadConfidentiel: boolean }, 'UNAUTHORIZED'>> {
+    const [readResult, readConfidentielResult] = await Promise.all([
+      this.permissionService.isAllowed(
+        user,
+        'collectivites.documents.read',
+        ResourceType.COLLECTIVITE,
+        { collectiviteId },
+        tx
+      ),
+      this.permissionService.isAllowed(
+        user,
+        'collectivites.documents.read_confidentiel',
+        ResourceType.COLLECTIVITE,
+        { collectiviteId },
+        tx
+      ),
+    ]);
+
+    const canReadConfidentiel = readConfidentielResult.success;
+    const hasNoDocumentsReadRight = !readResult.success && !canReadConfidentiel;
+    if (hasNoDocumentsReadRight) {
+      return failure(CommonErrorEnum.UNAUTHORIZED);
+    }
+
+    const isAccesRestreint = await this.collectivitesService.isPrivate(
+      collectiviteId
+    );
+
+    const canReachCollectivite = isAccesRestreint
+      ? canReadConfidentiel
+      : readResult.success;
+    if (!canReachCollectivite) {
+      return failure(CommonErrorEnum.UNAUTHORIZED);
+    }
+
+    return success({ canReadConfidentiel });
+  }
+}

--- a/apps/backend/src/collectivites/documents/get-download-url/get-download-url.repository.ts
+++ b/apps/backend/src/collectivites/documents/get-download-url/get-download-url.repository.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { and, eq } from 'drizzle-orm';
-import { collectiviteTable } from '@tet/backend/collectivites/shared/models/collectivite.table';
 import { bibliothequeFichierTable } from '../models/bibliotheque-fichier.table';
 
 export type DocumentToDownload = Pick<
@@ -12,19 +11,6 @@ export type DocumentToDownload = Pick<
 @Injectable()
 export class GetDownloadUrlRepository {
   constructor(private readonly databaseService: DatabaseService) {}
-
-  async isCollectiviteAccesRestreint(collectiviteId: number): Promise<boolean> {
-    const [collectivite] = await this.databaseService.db
-      .select({ accesRestreint: collectiviteTable.accesRestreint })
-      .from(collectiviteTable)
-      .where(eq(collectiviteTable.id, collectiviteId))
-      .limit(1);
-
-    if (collectivite === undefined) {
-      return true;
-    }
-    return collectivite.accesRestreint ?? false;
-  }
 
   async findDocument({
     collectiviteId,

--- a/apps/backend/src/collectivites/documents/get-download-url/get-download-url.router.e2e-spec.ts
+++ b/apps/backend/src/collectivites/documents/get-download-url/get-download-url.router.e2e-spec.ts
@@ -15,6 +15,7 @@ import {
 } from '../../../../test/app-utils';
 
 const UNKNOWN_FICHIER_ID = 999999999;
+const UNKNOWN_COLLECTIVITE_ID = 999999999;
 
 describe('GetDownloadUrlRouter', () => {
   let app: INestApplication;
@@ -105,5 +106,18 @@ describe('GetDownloadUrlRouter', () => {
         fichierId: documentAutreCollectivite.id,
       })
     ).rejects.toThrowError(/n'existe pas/i);
+  });
+
+  test('rend « collectivité introuvable » a un compte verifie non membre pour une collectivite inconnue', async () => {
+    const caller = router.createCaller({ user: nonMembreUser });
+
+    await expect(() =>
+      caller.collectivites.documents.getDownloadUrl({
+        collectiviteId: UNKNOWN_COLLECTIVITE_ID,
+        fichierId: UNKNOWN_FICHIER_ID,
+      })
+    ).rejects.toThrowError(
+      `Collectivité avec l'identifiant ${UNKNOWN_COLLECTIVITE_ID} introuvable`
+    );
   });
 });

--- a/apps/backend/src/collectivites/documents/get-download-url/get-download-url.service.spec.ts
+++ b/apps/backend/src/collectivites/documents/get-download-url/get-download-url.service.spec.ts
@@ -14,19 +14,17 @@ const FICHIER_ID = 42;
 
 const user: AuthenticatedUser = { id: 'user-id' } as AuthenticatedUser;
 
-const allowed = { success: true, data: undefined };
-const denied = { success: false, error: 'UNAUTHORIZED' };
+type DocumentsAccess = 'unauthorized' | 'public' | 'confidential';
 
 type ServiceUnderTest = {
   service: GetDownloadUrlService;
+  collectiviteDocumentsAccess: { checkUserCanReadDocuments: Mock };
   repository: { findDocument: Mock };
   documentStorage: { createSignedDownloadUrl: Mock };
 };
 
 function buildService({
-  isCollectivitePrivate = false,
-  canRead = true,
-  canReadConfidentiel = false,
+  access = 'public',
   document = {
     hash: HASH,
     filename: 'rapport.pdf',
@@ -36,34 +34,22 @@ function buildService({
   hasBucket = true,
   signatureFails = false,
 }: {
-  isCollectivitePrivate?: boolean;
-  canRead?: boolean;
-  canReadConfidentiel?: boolean;
+  access?: DocumentsAccess;
   document?: DocumentToDownload;
   documentExists?: boolean;
   hasBucket?: boolean;
   signatureFails?: boolean;
 } = {}): ServiceUnderTest {
-  const permissionService = {
-    isAllowed: vi
-      .fn()
-      .mockImplementation((_user, operation) =>
-        Promise.resolve(
-          operation === 'collectivites.documents.read_confidentiel'
-            ? canReadConfidentiel
-              ? allowed
-              : denied
-            : canRead
-            ? allowed
-            : denied
-        )
-      ),
+  const accessResult =
+    access === 'unauthorized'
+      ? failure('UNAUTHORIZED')
+      : success({ canReadConfidentiel: access === 'confidential' });
+
+  const collectiviteDocumentsAccess = {
+    checkUserCanReadDocuments: vi.fn().mockResolvedValue(accessResult),
   };
 
   const repository = {
-    isCollectiviteAccesRestreint: vi
-      .fn()
-      .mockResolvedValue(isCollectivitePrivate),
     findDocument: vi
       .fn()
       .mockResolvedValue(documentExists ? document : undefined),
@@ -86,22 +72,33 @@ function buildService({
   };
 
   const service = new GetDownloadUrlService(
-    permissionService as never,
+    collectiviteDocumentsAccess as never,
     repository as never,
     collectiviteBucket as never,
     documentStorage as never
   );
 
-  return { service, repository, documentStorage };
+  return { service, collectiviteDocumentsAccess, repository, documentStorage };
 }
 
 describe('GetDownloadUrlService', () => {
-  it("refuse un document non confidentiel d'une collectivite en acces restreint a un compte sans droit confidentiel", async () => {
-    const { service, documentStorage } = buildService({
-      isCollectivitePrivate: true,
-      canRead: true,
-      canReadConfidentiel: false,
-      document: { hash: HASH, filename: 'rapport.pdf', confidentiel: false },
+  it('controle les droits sur la collectivite du document demande, dans la transaction recue', async () => {
+    const { service, collectiviteDocumentsAccess } = buildService();
+    const tx = {} as never;
+
+    await service.getDownloadUrl(
+      { collectiviteId: 1, fichierId: FICHIER_ID },
+      { user, tx }
+    );
+
+    expect(
+      collectiviteDocumentsAccess.checkUserCanReadDocuments
+    ).toHaveBeenCalledWith({ collectiviteId: 1 }, { user, tx });
+  });
+
+  it('refuse un compte sans acces aux documents de la collectivite sans consulter le document', async () => {
+    const { service, repository, documentStorage } = buildService({
+      access: 'unauthorized',
     });
 
     const result = await service.getDownloadUrl(
@@ -110,24 +107,8 @@ describe('GetDownloadUrlService', () => {
     );
 
     expect(result).toEqual({ success: false, error: 'UNAUTHORIZED' });
+    expect(repository.findDocument).not.toHaveBeenCalled();
     expect(documentStorage.createSignedDownloadUrl).not.toHaveBeenCalled();
-  });
-
-  it("signe un document non confidentiel d'une collectivite en acces restreint pour un compte qui a le droit confidentiel", async () => {
-    const { service } = buildService({
-      isCollectivitePrivate: true,
-      canReadConfidentiel: true,
-    });
-
-    const result = await service.getDownloadUrl(
-      { collectiviteId: 1, fichierId: FICHIER_ID },
-      { user }
-    );
-
-    expect(result).toEqual({
-      success: true,
-      data: { signedUrl: 'https://signe.example/doc', filename: 'rapport.pdf' },
-    });
   });
 
   it("refuse un document confidentiel sans reveler qu'il existe", async () => {
@@ -146,20 +127,9 @@ describe('GetDownloadUrlService', () => {
 
   it('signe un document confidentiel pour un compte qui a le droit confidentiel', async () => {
     const { service } = buildService({
-      canReadConfidentiel: true,
+      access: 'confidential',
       document: { hash: HASH, filename: 'rapport.pdf', confidentiel: true },
     });
-
-    const result = await service.getDownloadUrl(
-      { collectiviteId: 1, fichierId: FICHIER_ID },
-      { user }
-    );
-
-    expect(result.success).toBe(true);
-  });
-
-  it('signe un document non confidentiel dune collectivite publique', async () => {
-    const { service } = buildService();
 
     const result = await service.getDownloadUrl(
       { collectiviteId: 1, fichierId: FICHIER_ID },
@@ -172,19 +142,18 @@ describe('GetDownloadUrlService', () => {
     });
   });
 
-  it('refuse un compte sans aucun droit de lecture sans consulter le document', async () => {
-    const { service, repository, documentStorage } = buildService({
-      canRead: false,
-    });
+  it('signe un document non confidentiel pour un compte qui a acces aux documents', async () => {
+    const { service } = buildService();
 
     const result = await service.getDownloadUrl(
       { collectiviteId: 1, fichierId: FICHIER_ID },
       { user }
     );
 
-    expect(result).toEqual({ success: false, error: 'UNAUTHORIZED' });
-    expect(repository.findDocument).not.toHaveBeenCalled();
-    expect(documentStorage.createSignedDownloadUrl).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      success: true,
+      data: { signedUrl: 'https://signe.example/doc', filename: 'rapport.pdf' },
+    });
   });
 
   it("rend DOCUMENT_NOT_FOUND quand l'identifiant ne designe aucun document de la collectivite", async () => {
@@ -225,20 +194,5 @@ describe('GetDownloadUrlService', () => {
       success: false,
       error: 'SIGN_DOWNLOAD_ERROR',
     });
-  });
-
-  it('traite une collectivite inconnue comme un acces restreint', async () => {
-    const { service, documentStorage } = buildService({
-      isCollectivitePrivate: true,
-      canReadConfidentiel: false,
-    });
-
-    const result = await service.getDownloadUrl(
-      { collectiviteId: 404, fichierId: FICHIER_ID },
-      { user }
-    );
-
-    expect(result).toEqual({ success: false, error: 'UNAUTHORIZED' });
-    expect(documentStorage.createSignedDownloadUrl).not.toHaveBeenCalled();
   });
 });

--- a/apps/backend/src/collectivites/documents/get-download-url/get-download-url.service.ts
+++ b/apps/backend/src/collectivites/documents/get-download-url/get-download-url.service.ts
@@ -1,10 +1,9 @@
 import { Injectable } from '@nestjs/common';
-import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
 import { ServiceSecondArg } from '@tet/backend/utils/nest/service-second-arg.utils';
 import { failure, success, type Result } from '@tet/backend/utils/result.type';
 import { DocumentStorageService } from '@tet/backend/utils/supabase/document-storage.service';
-import { ResourceType } from '@tet/domain/users';
 import { CollectiviteBucketRepository } from '../collectivite-bucket.repository';
+import { CollectiviteDocumentsAccessService } from '../collectivite-documents-access.service';
 import {
   GetDownloadUrlError,
   GetDownloadUrlErrorEnum,
@@ -18,7 +17,7 @@ const DOWNLOAD_URL_TTL_SECONDS = 60;
 @Injectable()
 export class GetDownloadUrlService {
   constructor(
-    private readonly permissionService: PermissionService,
+    private readonly collectiviteDocumentsAccess: CollectiviteDocumentsAccessService,
     private readonly repository: GetDownloadUrlRepository,
     private readonly collectiviteBucketRepository: CollectiviteBucketRepository,
     private readonly documentStorageService: DocumentStorageService
@@ -28,38 +27,15 @@ export class GetDownloadUrlService {
     { collectiviteId, fichierId }: GetDownloadUrlInput,
     { user, tx }: ServiceSecondArg
   ): Promise<Result<GetDownloadUrlOutput, GetDownloadUrlError>> {
-    const [readResult, readConfidentielResult] = await Promise.all([
-      this.permissionService.isAllowed(
-        user,
-        'collectivites.documents.read',
-        ResourceType.COLLECTIVITE,
+    const accessResult =
+      await this.collectiviteDocumentsAccess.checkUserCanReadDocuments(
         { collectiviteId },
-        tx
-      ),
-      this.permissionService.isAllowed(
-        user,
-        'collectivites.documents.read_confidentiel',
-        ResourceType.COLLECTIVITE,
-        { collectiviteId },
-        tx
-      ),
-    ]);
-
-    const canReadConfidentiel = readConfidentielResult.success;
-    if (!readResult.success && !canReadConfidentiel) {
+        { user, tx }
+      );
+    if (!accessResult.success) {
       return failure(GetDownloadUrlErrorEnum.UNAUTHORIZED);
     }
-
-    const isAccesRestreint = await this.repository.isCollectiviteAccesRestreint(
-      collectiviteId
-    );
-
-    const canReachCollectivite = isAccesRestreint
-      ? canReadConfidentiel
-      : readResult.success;
-    if (!canReachCollectivite) {
-      return failure(GetDownloadUrlErrorEnum.UNAUTHORIZED);
-    }
+    const { canReadConfidentiel } = accessResult.data;
 
     const document = await this.repository.findDocument({
       collectiviteId,


### PR DESCRIPTION
Le contrôle d'accès aux documents d'une collectivité sort de `GetDownloadUrlService` pour devenir son propre service. La prochaine procédure de la pile, la liste de la bibliothèque de documents, en sera le second consommateur.

Plan : `docs/plans/2026-09-10-001-refactor-cles-requete-litterales-plan.md` (compound-knowledge-db), PR 4.

## Avant / après

| | Avant | Après |
|---|---|---|
| Contrôle à deux étages | codé en ligne dans `GetDownloadUrlService.getDownloadUrl` | `CollectiviteDocumentsAccessService.checkUserCanReadDocuments({ collectiviteId })` |
| Lecture de `access_restreint` | `GetDownloadUrlRepository.isCollectiviteAccesRestreint` | `CollectivitesService.isPrivate`, comme `ReferentielDocumentsAccessService` |
| Dépendance de `GetDownloadUrlService` | `PermissionService` | `CollectiviteDocumentsAccessService` |
| Tests du contrôle | `get-download-url.service.spec.ts` | `collectivite-documents-access.service.spec.ts` |

## Le contrôle

| Situation | Résultat |
|---|---|
| ni `documents.read` ni `documents.read_confidentiel` | `UNAUTHORIZED`, sans lire `access_restreint` |
| collectivité en accès restreint, sans `read_confidentiel` | `UNAUTHORIZED` |
| collectivité en accès restreint, avec `read_confidentiel` | `{ canReadConfidentiel: true }` |
| collectivité publique, `documents.read` seul | `{ canReadConfidentiel: false }` |
| collectivité publique, `read_confidentiel` sans `documents.read` | `UNAUTHORIZED` |

`GetDownloadUrlService` rend toujours `DOCUMENT_NOT_FOUND` pour un document confidentiel quand `canReadConfidentiel` vaut `false`.

## Le seul comportement qui change

Les deux services d'accès lisent désormais `access_restreint` à la même source. Sur un identifiant de collectivité inexistant :

| | Avant | Après |
|---|---|---|
| Compte vérifié non membre | `UNAUTHORIZED` (403) | `NotFoundException` de `getCollectivite` : « Collectivité avec l'identifiant … introuvable » (404 en HTTP) |
| Remontée Sentry | non (`UNAUTHORIZED` filtré) | oui, comme pour les documents d'un référentiel |

`getCollectivite` lève dans un service qui rend un `Result` ; c'est déjà le cas du service d'accès référentiel.

## Surface de review

- Attention humaine : `collectivite-documents-access.service.ts`, comparé aux lignes retirées de `get-download-url.service.ts`.
- Mécaniques : la suppression de `isCollectiviteAccesRestreint`, l'enregistrement du provider, le partage des tests.

## Recherche anti-duplication

Le contrôle existait une fois, en ligne ; il existe toujours une fois, dans le service. La lecture de `access_restreint` réutilise `CollectivitesService.isPrivate` au lieu d'une requête propre.

## Tests

| Fichier | Cas |
|---|---|
| `collectivite-documents-access.service.spec.ts` | 6 : les cas d'accès repris de `get-download-url`, plus « droit confidentiel sans droit de lecture sur une collectivité publique → `UNAUTHORIZED` » et « les deux droits sur une collectivité publique → confidentiels compris » |
| `get-download-url.service.spec.ts` | 8 : cas propres au téléchargement, le service d'accès simulé ; la transaction reçue est transmise au contrôle |
| `get-download-url.router.e2e-spec.ts` | 5 : ajout de « collectivité inconnue → erreur « Collectivité avec l'identifiant … introuvable » pour un compte vérifié non membre » |

## Vérifications

- `nx run backend:typecheck --skip-nx-cache` et `nx run backend:lint --quiet` : verts.
- Specs unitaires : 14 passés.
- `get-download-url.router.e2e-spec.ts` : 5 passés.
