### PR TITLE
fix(ci): sérialise les typechecks et tests partageant le cache

### DIFF
--- a/.github/workflows/validate-affected-projects.yml
+++ b/.github/workflows/validate-affected-projects.yml
@@ -90,21 +90,21 @@ jobs:
       - name: Build affected projects
         run: pnpm nx affected -t build --base="${{ inputs.nx-base }}" --head="${{ inputs.nx-head }}" --exclude=app,backend,e2e --parallel=50%
 
-      - name: Materialise backend declarations before concurrent Nx commands
-        run: pnpm nx typecheck backend
+      # Keep these Nx commands sequential: with the daemon disabled in CI, cache
+      # hits restore shared dependency outputs even when they are already present.
+      # A concurrent restore can overwrite declarations while typecheck reads them.
+      - name: Typecheck affected projects
+        env:
+          SIRENE_API_KEY: ${{ secrets.SIRENE_API_KEY }}
+          SIRENE_API_URL: ${{ vars.SIRENE_API_URL }}
+        run: |
+          pnpm nx affected -t typecheck --base="${{ inputs.nx-base }}" --head="${{ inputs.nx-head }}" --parallel=50%
 
-      - parallel:
-          - name: Typecheck affected projects
-            env:
-              SIRENE_API_KEY: ${{ secrets.SIRENE_API_KEY }}
-              SIRENE_API_URL: ${{ vars.SIRENE_API_URL }}
-            run: |
-              pnpm nx affected -t typecheck --base="${{ inputs.nx-base }}" --head="${{ inputs.nx-head }}" --parallel=50%
-          - name: Test affected projects
-            env:
-              SIRENE_API_KEY: ${{ secrets.SIRENE_API_KEY }}
-              SIRENE_API_URL: ${{ vars.SIRENE_API_URL }}
-            run: |
-              pnpm nx affected -t test --base="${{ inputs.nx-base }}" --head="${{ inputs.nx-head }}" --exclude=backend,api,e2e --parallel=50%
+      - name: Test affected projects
+        env:
+          SIRENE_API_KEY: ${{ secrets.SIRENE_API_KEY }}
+          SIRENE_API_URL: ${{ vars.SIRENE_API_URL }}
+        run: |
+          pnpm nx affected -t test --base="${{ inputs.nx-base }}" --head="${{ inputs.nx-head }}" --exclude=backend,api,e2e --parallel=50%
 
       - wait-all:


### PR DESCRIPTION
Le préchauffage ajouté dans #5037 laisse les commandes de typecheck et de test restaurer leurs dépendances en parallèle. En CI, le daemon Nx est désactivé et un cache hit restaure les sorties même si elles sont déjà présentes. Les deux graphes partagent notamment `domain:build`, `design-tokens:build` et `pdf-components:build`, dont les sorties incluent tout `dist`, déclarations comprises : une restauration peut donc remplacer les fichiers pendant que l'autre commande les lit.

Cette PR, empilée sur `fix/typecheck-cache-declarations`, exécute le typecheck puis les tests et retire le préchauffage backend devenu inutile. Chaque commande conserve son parallélisme interne, ses filtres et ses variables d'environnement. Le lint reste en arrière-plan. Les sorties du build backend définies dans #5037 sont conservées.

Validation :

- Graphes Nx de `app:typecheck` et `app:test` : quatre tâches de build communes identifiées.
- Rejeu de `design-tokens:build` avec `CI=true` et `NX_DAEMON=false` : cache hit confirmé et événements de remplacement observés sur les déclarations déjà présentes, dont `index.d.ts`. La troncature historique de `AppRouter` n'a pas été reproduite.
- Typecheck backend et ses dépendances : succès.
- Vérification de la structure YAML, de la conservation exacte des commandes/filtres/environnements, Prettier et `git diff --check` : succès.
- Typecheck app : bloqué par l'installation locale (`tus-js-client` absent ; Next.js 16.2.10 installé pour 16.3.4 demandé, d'où l'erreur sur `useTypeScriptCli`).
- Tests app : 633 tests passent dans 95 fichiers ; 5 suites ne se chargent pas à cause de `tus-js-client` absent.

Le temps de validation peut augmenter puisque les deux commandes s'attendent désormais. La CI complète reste à confirmer avec les dépendances du lockfile.
