### PR TITLE
refactor(backend): partage l'échappement des motifs LIKE

### DIFF
--- a/apps/backend/src/referentiels/count-preuve/count-preuves.service.ts
+++ b/apps/backend/src/referentiels/count-preuve/count-preuves.service.ts
@@ -6,6 +6,7 @@ import CollectivitesService from '@tet/backend/collectivites/services/collectivi
 import { PermissionService } from '@tet/backend/users/authorizations/permission.service';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { escapeLikePattern } from '@tet/backend/utils/database/like-pattern.utils';
 import { getReferentielIdFromActionId } from '@tet/domain/referentiels';
 import { ResourceType } from '@tet/domain/users';
 import { and, Column, count, eq, like, or, SQL } from 'drizzle-orm';
@@ -143,7 +144,7 @@ export class CountPreuvesService {
     actionId: string,
     column: Column
   ): SQL | undefined {
-    const escapedActionId = actionId.replace(/[\\%_]/g, '\\$&');
+    const escapedActionId = escapeLikePattern(actionId);
     return or(eq(column, actionId), like(column, `${escapedActionId}.%`));
   }
 }

--- a/apps/backend/src/referentiels/historique/list-historique/list-historique.repository.ts
+++ b/apps/backend/src/referentiels/historique/list-historique/list-historique.repository.ts
@@ -11,6 +11,7 @@ import { questionActionTable } from '@tet/backend/referentiels/models/question-a
 import { createdByNom, dcpTable } from '@tet/backend/users/models/dcp.table';
 import { SYSTEM_MODIFIED_BY_SQL_LITERAL } from '@tet/backend/utils/column.utils';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { escapeLikePattern } from '@tet/backend/utils/database/like-pattern.utils';
 import { Transaction } from '@tet/backend/utils/database/transaction.utils';
 import {
   ActionTypeEnum,
@@ -124,17 +125,13 @@ export class ListHistoriqueRepository {
       eq(historiqueUnion.collectiviteId, collectiviteId),
     ];
     if (actionId) {
-      // On échappe les méta-caractères de LIKE dans actionId avant de
-      // construire le pattern. Le caractère d'échappement par défaut de
-      // Postgres est `\` ; on l'utilise donc pour échapper `\`, `%` et `_`.
-      //
       // Le LIKE est ancré sur le séparateur `.` (`<actionId>.%`) pour ne
       // remonter que les descendants stricts dans la hiérarchie pointée :
       // un préfixe nu (`<actionId>%`) ferait remonter `cae_1.10` en filtrant
       // sur `cae_1.1`. La correspondance exacte est gérée par un `eq`
       // dédié pour couvrir les lignes dont l'actionId est précisément la
       // valeur filtrée.
-      const escapedActionId = actionId.replace(/[\\%_]/g, '\\$&');
+      const escapedActionId = escapeLikePattern(actionId);
       const actionIdFilter = or(
         sql`${historiqueUnion.actionIds} @> array[${actionId}]::varchar(30)[]`,
         eq(historiqueUnion.actionId, actionId),

--- a/apps/backend/src/utils/database/like-pattern.utils.spec.ts
+++ b/apps/backend/src/utils/database/like-pattern.utils.spec.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { escapeLikePattern } from './like-pattern.utils';
+
+describe('escapeLikePattern', () => {
+  it('préfixe de \\ chaque caractère spécial de LIKE', () => {
+    expect(escapeLikePattern('a%b_c\\d')).toBe('a\\%b\\_c\\\\d');
+  });
+
+  it('laisse intacte une valeur sans caractère spécial', () => {
+    expect(escapeLikePattern('rapport-annuel.pdf')).toBe('rapport-annuel.pdf');
+  });
+});

--- a/apps/backend/src/utils/database/like-pattern.utils.ts
+++ b/apps/backend/src/utils/database/like-pattern.utils.ts
@@ -1,0 +1,2 @@
+export const escapeLikePattern = (value: string): string =>
+  value.replace(/[\\%_]/g, '\\$&');


### PR DESCRIPTION
L'échappement des motifs `LIKE` était écrit en ligne à deux endroits. Il devient `escapeLikePattern`, dans `apps/backend/src/utils/database/like-pattern.utils.ts`, avant que `collectivites.documents.list` (PR 5 du plan) n'en ajoute une troisième copie.

Plan : `docs/plans/2026-09-10-001-refactor-cles-requete-litterales-plan.md` (compound-knowledge-db), préalable à la PR 5.

| Site | Avant | Après |
|---|---|---|
| `count-preuves.service.ts` | `actionId.replace(/[\\%_]/g, '\\$&')` | `escapeLikePattern(actionId)` |
| `list-historique.repository.ts` | idem | idem |

Aucun changement de comportement : même expression régulière, mêmes appels.

## Tests

- `like-pattern.utils.spec.ts` : `%`, `_` et `\` préfixés de `\` ; une valeur sans caractère spécial reste intacte. Vu rouge avec un helper qui rend la valeur telle quelle.
- Les e2e de `count-preuves` passent inchangés ; `list-historique` n'a pas de test.

## Recherche anti-duplication

Aucun helper d'échappement `LIKE` dans `apps/backend/src/utils` ni dans `packages/domain` ; `es-toolkit` n'échappe que les expressions régulières.
