### PR TITLE
feat(documents): liste la bibliothèque de documents d'une collectivité

### DIFF
--- a/apps/backend/src/collectivites/collectivites.module.ts
+++ b/apps/backend/src/collectivites/collectivites.module.ts
@@ -9,6 +9,9 @@ import { CollectiviteDocumentsAccessService } from '@tet/backend/collectivites/d
 import { GetDownloadUrlRepository } from '@tet/backend/collectivites/documents/get-download-url/get-download-url.repository';
 import { GetDownloadUrlRouter } from '@tet/backend/collectivites/documents/get-download-url/get-download-url.router';
 import { GetDownloadUrlService } from '@tet/backend/collectivites/documents/get-download-url/get-download-url.service';
+import { ListBibliothequeDocumentsRepository } from '@tet/backend/collectivites/documents/list-bibliotheque-documents/list-bibliotheque-documents.repository';
+import { ListBibliothequeDocumentsRouter } from '@tet/backend/collectivites/documents/list-bibliotheque-documents/list-bibliotheque-documents.router';
+import { ListBibliothequeDocumentsService } from '@tet/backend/collectivites/documents/list-bibliotheque-documents/list-bibliotheque-documents.service';
 import { CreateUploadTokenRepository } from '@tet/backend/collectivites/documents/create-upload-token/create-upload-token.repository';
 import { CreateUploadTokenRouter } from '@tet/backend/collectivites/documents/create-upload-token/create-upload-token.router';
 import { CreateUploadTokenService } from '@tet/backend/collectivites/documents/create-upload-token/create-upload-token.service';
@@ -104,6 +107,9 @@ import { PersonnesService } from './services/personnes.service';
     GetDownloadUrlRepository,
     GetDownloadUrlService,
     GetDownloadUrlRouter,
+    ListBibliothequeDocumentsRepository,
+    ListBibliothequeDocumentsService,
+    ListBibliothequeDocumentsRouter,
     UpdateDocumentService,
     UpdateDocumentRouter,
     EditPreuveDocumentRepository,

--- a/apps/backend/src/collectivites/documents/documents.router.ts
+++ b/apps/backend/src/collectivites/documents/documents.router.ts
@@ -3,6 +3,7 @@ import { TrpcService } from '@tet/backend/utils/trpc/trpc.service';
 import { CreateUploadTokenRouter } from './create-upload-token/create-upload-token.router';
 import { EditPreuveDocumentRouter } from './edit-preuve-document/edit-preuve-document.router';
 import { GetDownloadUrlRouter } from './get-download-url/get-download-url.router';
+import { ListBibliothequeDocumentsRouter } from './list-bibliotheque-documents/list-bibliotheque-documents.router';
 import { StoreDocumentRouter } from './store-document/store-document.router';
 import { UpdateDocumentRouter } from './update-document/update-document.router';
 
@@ -14,7 +15,8 @@ export class DocumentsRouter {
     private readonly updateDocumentRouter: UpdateDocumentRouter,
     private readonly editPreuveDocumentRouter: EditPreuveDocumentRouter,
     private readonly createUploadTokenRouter: CreateUploadTokenRouter,
-    private readonly getDownloadUrlRouter: GetDownloadUrlRouter
+    private readonly getDownloadUrlRouter: GetDownloadUrlRouter,
+    private readonly listBibliothequeDocumentsRouter: ListBibliothequeDocumentsRouter
   ) {}
 
   router = this.trpc.mergeRouters(
@@ -22,7 +24,8 @@ export class DocumentsRouter {
     this.updateDocumentRouter.router,
     this.editPreuveDocumentRouter.router,
     this.createUploadTokenRouter.router,
-    this.getDownloadUrlRouter.router
+    this.getDownloadUrlRouter.router,
+    this.listBibliothequeDocumentsRouter.router
   );
 
   createCaller = this.trpc.createCallerFactory(this.router);

--- a/apps/backend/src/collectivites/documents/list-bibliotheque-documents/list-bibliotheque-documents.errors.ts
+++ b/apps/backend/src/collectivites/documents/list-bibliotheque-documents/list-bibliotheque-documents.errors.ts
@@ -1,0 +1,11 @@
+import {
+  createErrorsEnum,
+  TrpcErrorHandlerConfig,
+} from '@tet/backend/utils/trpc/trpc-error-handler';
+
+export const listBibliothequeDocumentsErrorConfig: TrpcErrorHandlerConfig<never> =
+  {};
+
+export const ListBibliothequeDocumentsErrorEnum = createErrorsEnum();
+export type ListBibliothequeDocumentsError =
+  keyof typeof ListBibliothequeDocumentsErrorEnum;

--- a/apps/backend/src/collectivites/documents/list-bibliotheque-documents/list-bibliotheque-documents.input.ts
+++ b/apps/backend/src/collectivites/documents/list-bibliotheque-documents/list-bibliotheque-documents.input.ts
@@ -1,0 +1,11 @@
+import * as z from 'zod';
+
+export const listBibliothequeDocumentsInputSchema = z.object({
+  collectiviteId: z.number().int().positive(),
+  search: z.string().trim().max(255).optional(),
+  limit: z.number().int().min(1).max(100),
+});
+
+export type ListBibliothequeDocumentsInput = z.infer<
+  typeof listBibliothequeDocumentsInputSchema
+>;

--- a/apps/backend/src/collectivites/documents/list-bibliotheque-documents/list-bibliotheque-documents.output.ts
+++ b/apps/backend/src/collectivites/documents/list-bibliotheque-documents/list-bibliotheque-documents.output.ts
@@ -1,0 +1,15 @@
+import * as z from 'zod';
+
+export const listBibliothequeDocumentsOutputSchema = z.object({
+  items: z.array(
+    z.object({
+      id: z.number().int().positive(),
+      filename: z.string(),
+      confidentiel: z.boolean(),
+    })
+  ),
+});
+
+export type ListBibliothequeDocumentsOutput = z.infer<
+  typeof listBibliothequeDocumentsOutputSchema
+>;

--- a/apps/backend/src/collectivites/documents/list-bibliotheque-documents/list-bibliotheque-documents.repository.ts
+++ b/apps/backend/src/collectivites/documents/list-bibliotheque-documents/list-bibliotheque-documents.repository.ts
@@ -1,0 +1,75 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { escapeLikePattern } from '@tet/backend/utils/database/like-pattern.utils';
+import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { failure, success, type Result } from '@tet/backend/utils/result.type';
+import { CommonErrorEnum } from '@tet/backend/utils/trpc/common-errors';
+import { getErrorMessage } from '@tet/domain/utils';
+import { and, asc, eq, ilike } from 'drizzle-orm';
+import { buildFichierSubquery } from '../file-info.utils';
+import { hideConfidentielFilter } from '../hide-confidentiel.utils';
+import { bibliothequeFichierTable } from '../models/bibliotheque-fichier.table';
+import { ListBibliothequeDocumentsInput } from './list-bibliotheque-documents.input';
+
+export type BibliothequeDocument = Pick<
+  typeof bibliothequeFichierTable.$inferSelect,
+  'id' | 'filename' | 'confidentiel'
+>;
+
+@Injectable()
+export class ListBibliothequeDocumentsRepository {
+  private readonly logger = new Logger(
+    ListBibliothequeDocumentsRepository.name
+  );
+
+  constructor(private readonly databaseService: DatabaseService) {}
+
+  async listBibliothequeDocuments(
+    {
+      collectiviteId,
+      search,
+      limit,
+      canReadConfidentiel,
+    }: ListBibliothequeDocumentsInput & { canReadConfidentiel: boolean },
+    tx?: Transaction
+  ): Promise<Result<BibliothequeDocument[], 'DATABASE_ERROR'>> {
+    const db = tx ?? this.databaseService.db;
+    const fichier = buildFichierSubquery(db);
+    const hasSearchTerm = search !== undefined && search !== '';
+    const filenameFilter = hasSearchTerm
+      ? ilike(fichier.filename, `%${escapeLikePattern(search)}%`)
+      : undefined;
+
+    try {
+      const documents = await db
+        .select({
+          id: fichier.id,
+          filename: fichier.filename,
+          confidentiel: fichier.confidentiel,
+        })
+        .from(fichier)
+        .where(
+          and(
+            eq(fichier.collectiviteId, collectiviteId),
+            hideConfidentielFilter({
+              fichierIdColumn: fichier.id,
+              confidentielColumn: fichier.confidentiel,
+              canReadConfidentiel,
+            }),
+            filenameFilter
+          )
+        )
+        .orderBy(asc(fichier.filename), asc(fichier.id))
+        .limit(limit);
+
+      return success(documents);
+    } catch (error) {
+      this.logger.error(
+        `Échec de la lecture de la bibliothèque de la collectivité ${collectiviteId}: ${getErrorMessage(
+          error
+        )}`
+      );
+      return failure(CommonErrorEnum.DATABASE_ERROR);
+    }
+  }
+}

--- a/apps/backend/src/collectivites/documents/list-bibliotheque-documents/list-bibliotheque-documents.router.e2e-spec.ts
+++ b/apps/backend/src/collectivites/documents/list-bibliotheque-documents/list-bibliotheque-documents.router.e2e-spec.ts
@@ -1,0 +1,524 @@
+import { INestApplication } from '@nestjs/common';
+import { addTestCollectiviteAndUsers } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import {
+  seedTestDocument,
+  TestDocument,
+} from '@tet/backend/collectivites/documents/documents.test-fixture';
+import { bibliothequeFichierTable } from '@tet/backend/collectivites/documents/models/bibliotheque-fichier.table';
+import {
+  addAuditeurPermission,
+  createAudit,
+  CreateAuditArgs,
+} from '@tet/backend/referentiels/labellisations/labellisations.test-fixture';
+import { getAuthUserFromUserCredentials } from '@tet/backend/test';
+import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import {
+  addAndEnableUserSuperAdminMode,
+  addTestUser,
+  addUserRoleSupport,
+  TestUserArgs,
+} from '@tet/backend/users/users/users.test-fixture';
+import { DatabaseServiceInterface } from '@tet/backend/utils/database/database-service.interface';
+import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
+import { Collectivite } from '@tet/domain/collectivites';
+import { ReferentielIdEnum } from '@tet/domain/referentiels';
+import { CollectiviteRole } from '@tet/domain/users';
+import { randomUUID } from 'crypto';
+import {
+  getTestApp,
+  getTestDatabase,
+  getTestRouter,
+} from '../../../../test/app-utils';
+import { ListBibliothequeDocumentsOutput } from './list-bibliotheque-documents.output';
+
+const FORBIDDEN_MESSAGE = "Vous n'avez pas les permissions nécessaires";
+
+const PUBLIC_CONFIDENTIEL = 'public-confidentiel.pdf';
+const PUBLIC_NOT_CONFIDENTIEL = 'public-not-confidentiel.pdf';
+const RESTRICTED_CONFIDENTIEL = 'restricted-confidentiel.pdf';
+const RESTRICTED_NOT_CONFIDENTIEL = 'restricted-not-confidentiel.pdf';
+
+const SEARCH_FILENAMES = [
+  'Rapport-Annuel.pdf',
+  'a_b.pdf',
+  'axb.pdf',
+  '100%.pdf',
+  'a\\b.pdf',
+];
+
+type AuditeurFixture = {
+  auditeur: AuthenticatedUser;
+  restrictedCollectiviteId: number;
+};
+
+const daysAgo = (days: number): string =>
+  new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+
+const toListedDocument = ({
+  id,
+  filename,
+  confidentiel,
+}: TestDocument): ListBibliothequeDocumentsOutput['items'][number] => ({
+  id,
+  filename,
+  confidentiel,
+});
+
+describe('ListBibliothequeDocumentsRouter', () => {
+  let app: INestApplication;
+  let router: TrpcRouter;
+  let databaseService: DatabaseServiceInterface;
+
+  let publicCollectivite: Collectivite;
+  let restrictedCollectivite: Collectivite;
+
+  let publicLecteur: AuthenticatedUser;
+  let publicEditeurFichesIndicateurs: AuthenticatedUser;
+  let restrictedLecteur: AuthenticatedUser;
+  let verifiedNonMember: AuthenticatedUser;
+  let unverifiedUser: AuthenticatedUser;
+  let ademeUser: AuthenticatedUser;
+  let unverifiedAdemeUser: AuthenticatedUser;
+  let supportUser: AuthenticatedUser;
+  let superAdmin: AuthenticatedUser;
+  let auditeurOfOngoingAudit: AuditeurFixture;
+  let auditeurOfNotStartedAudit: AuditeurFixture;
+  let auditeurOfValidatedAudit: AuditeurFixture;
+  let auditeurOfAuditClosed5DaysAgo: AuditeurFixture;
+  let auditeurOfAuditClosed30DaysAgo: AuditeurFixture;
+
+  const addNonMemberUser = async (
+    args: TestUserArgs = {}
+  ): Promise<AuthenticatedUser> => {
+    const { user } = await addTestUser(databaseService, args);
+    return getAuthUserFromUserCredentials(user);
+  };
+
+  const seedConfidentielAndNotConfidentiel = async ({
+    collectiviteId,
+    confidentielFilename,
+    notConfidentielFilename,
+  }: {
+    collectiviteId: number;
+    confidentielFilename: string;
+    notConfidentielFilename: string;
+  }): Promise<void> => {
+    await Promise.all([
+      seedTestDocument({
+        databaseService,
+        collectiviteId,
+        filename: confidentielFilename,
+        confidentiel: true,
+      }),
+      seedTestDocument({
+        databaseService,
+        collectiviteId,
+        filename: notConfidentielFilename,
+      }),
+    ]);
+  };
+
+  const addRestrictedCollectivite = async (
+    users: Array<{ role: CollectiviteRole }>
+  ): Promise<{ collectivite: Collectivite; membres: AuthenticatedUser[] }> => {
+    const restrictedFixture = await addTestCollectiviteAndUsers(
+      databaseService,
+      { collectivite: { accesRestreint: true }, users }
+    );
+    await seedConfidentielAndNotConfidentiel({
+      collectiviteId: restrictedFixture.collectivite.id,
+      confidentielFilename: RESTRICTED_CONFIDENTIEL,
+      notConfidentielFilename: RESTRICTED_NOT_CONFIDENTIEL,
+    });
+    return {
+      collectivite: restrictedFixture.collectivite,
+      membres: restrictedFixture.users.map((user) =>
+        getAuthUserFromUserCredentials(user)
+      ),
+    };
+  };
+
+  const addAuditeurOfRestrictedCollectivite = async (
+    audit: Omit<
+      CreateAuditArgs,
+      'databaseService' | 'collectiviteId' | 'referentielId'
+    >
+  ): Promise<AuditeurFixture> => {
+    const { collectivite } = await addRestrictedCollectivite([]);
+    const { audit: createdAudit } = await createAudit({
+      databaseService,
+      collectiviteId: collectivite.id,
+      referentielId: ReferentielIdEnum.CAE,
+      ...audit,
+    });
+    const auditeur = await addNonMemberUser();
+    await addAuditeurPermission({
+      databaseService,
+      auditId: createdAudit.id,
+      userId: auditeur.id,
+    });
+    return { auditeur, restrictedCollectiviteId: collectivite.id };
+  };
+
+  const addCollectiviteWithLecteur = async (): Promise<{
+    collectivite: Collectivite;
+    lecteur: AuthenticatedUser;
+  }> => {
+    const collectiviteFixture = await addTestCollectiviteAndUsers(
+      databaseService,
+      { users: [{ role: CollectiviteRole.LECTURE }] }
+    );
+    return {
+      collectivite: collectiviteFixture.collectivite,
+      lecteur: getAuthUserFromUserCredentials(collectiviteFixture.users[0]),
+    };
+  };
+
+  const seedDocuments = (
+    collectivite: Collectivite,
+    filenames: string[]
+  ): Promise<TestDocument[]> =>
+    Promise.all(
+      filenames.map((filename) =>
+        seedTestDocument({
+          databaseService,
+          collectiviteId: collectivite.id,
+          filename,
+        })
+      )
+    );
+
+  const listFilenames = async (
+    user: AuthenticatedUser,
+    input: { collectiviteId: number; search?: string }
+  ): Promise<string[]> => {
+    const { items } = await router
+      .createCaller({ user })
+      .collectivites.documents.listBibliothequeDocuments({
+        limit: 100,
+        ...input,
+      });
+    return items.map(({ filename }) => filename);
+  };
+
+  const listFilenamesAsAuditeur = ({
+    auditeur,
+    restrictedCollectiviteId,
+  }: AuditeurFixture): Promise<string[]> =>
+    listFilenames(auditeur, { collectiviteId: restrictedCollectiviteId });
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    router = await getTestRouter(app);
+    databaseService = await getTestDatabase(app);
+
+    const publicFixture = await addTestCollectiviteAndUsers(databaseService, {
+      users: [
+        { role: CollectiviteRole.LECTURE },
+        { role: CollectiviteRole.EDITION_FICHES_INDICATEURS },
+      ],
+    });
+    publicCollectivite = publicFixture.collectivite;
+    publicLecteur = getAuthUserFromUserCredentials(publicFixture.users[0]);
+    publicEditeurFichesIndicateurs = getAuthUserFromUserCredentials(
+      publicFixture.users[1]
+    );
+    await seedConfidentielAndNotConfidentiel({
+      collectiviteId: publicCollectivite.id,
+      confidentielFilename: PUBLIC_CONFIDENTIEL,
+      notConfidentielFilename: PUBLIC_NOT_CONFIDENTIEL,
+    });
+
+    const restrictedFixture = await addRestrictedCollectivite([
+      { role: CollectiviteRole.LECTURE },
+    ]);
+    restrictedCollectivite = restrictedFixture.collectivite;
+    restrictedLecteur = restrictedFixture.membres[0];
+
+    verifiedNonMember = await addNonMemberUser();
+    unverifiedUser = await addNonMemberUser({ verified: false });
+    ademeUser = await addNonMemberUser({ nom: 'ademe' });
+    unverifiedAdemeUser = await addNonMemberUser({
+      nom: 'ademe',
+      verified: false,
+    });
+
+    supportUser = await addNonMemberUser();
+    await addUserRoleSupport({ databaseService, userId: supportUser.id });
+
+    superAdmin = await addNonMemberUser();
+    await addAndEnableUserSuperAdminMode({
+      app,
+      caller: router.createCaller({ user: superAdmin }),
+      userId: superAdmin.id,
+    });
+
+    auditeurOfOngoingAudit = await addAuditeurOfRestrictedCollectivite({});
+    auditeurOfNotStartedAudit = await addAuditeurOfRestrictedCollectivite({
+      dateDebut: null,
+    });
+    auditeurOfValidatedAudit = await addAuditeurOfRestrictedCollectivite({
+      valide: true,
+    });
+    auditeurOfAuditClosed5DaysAgo = await addAuditeurOfRestrictedCollectivite({
+      clos: true,
+      dateFin: daysAgo(5),
+    });
+    auditeurOfAuditClosed30DaysAgo = await addAuditeurOfRestrictedCollectivite({
+      clos: true,
+      dateFin: daysAgo(30),
+    });
+
+    return async () => {
+      await app.close();
+    };
+  });
+
+  describe('autorisation', () => {
+    test('rend à un membre en lecture les documents de sa collectivité, confidentiels compris, et eux seuls', async () => {
+      expect(
+        await listFilenames(publicLecteur, {
+          collectiviteId: publicCollectivite.id,
+        })
+      ).toEqual([PUBLIC_CONFIDENTIEL, PUBLIC_NOT_CONFIDENTIEL]);
+    });
+
+    test('rend à un membre en édition des fiches et indicateurs les confidentiels de sa collectivité', async () => {
+      expect(
+        await listFilenames(publicEditeurFichesIndicateurs, {
+          collectiviteId: publicCollectivite.id,
+        })
+      ).toEqual([PUBLIC_CONFIDENTIEL, PUBLIC_NOT_CONFIDENTIEL]);
+    });
+
+    test('rend à un membre en lecture tous les documents de sa collectivité en accès restreint', async () => {
+      expect(
+        await listFilenames(restrictedLecteur, {
+          collectiviteId: restrictedCollectivite.id,
+        })
+      ).toEqual([RESTRICTED_CONFIDENTIEL, RESTRICTED_NOT_CONFIDENTIEL]);
+    });
+
+    test("rend à un compte vérifié non membre les seuls non confidentiels d'une collectivité publique", async () => {
+      expect(
+        await listFilenames(verifiedNonMember, {
+          collectiviteId: publicCollectivite.id,
+        })
+      ).toEqual([PUBLIC_NOT_CONFIDENTIEL]);
+    });
+
+    test('ne rend pas à un compte vérifié non membre les confidentiels que sa recherche désigne', async () => {
+      expect(
+        await listFilenames(verifiedNonMember, {
+          collectiviteId: publicCollectivite.id,
+          search: 'confidentiel',
+        })
+      ).toEqual([PUBLIC_NOT_CONFIDENTIEL]);
+    });
+
+    test('refuse à un compte vérifié non membre une collectivité en accès restreint', async () => {
+      await expect(
+        listFilenames(verifiedNonMember, {
+          collectiviteId: restrictedCollectivite.id,
+        })
+      ).rejects.toThrowError(FORBIDDEN_MESSAGE);
+    });
+
+    test('refuse à un compte non vérifié une collectivité publique', async () => {
+      await expect(
+        listFilenames(unverifiedUser, { collectiviteId: publicCollectivite.id })
+      ).rejects.toThrowError(FORBIDDEN_MESSAGE);
+    });
+
+    test('refuse à un compte non vérifié une collectivité en accès restreint', async () => {
+      await expect(
+        listFilenames(unverifiedUser, {
+          collectiviteId: restrictedCollectivite.id,
+        })
+      ).rejects.toThrowError(FORBIDDEN_MESSAGE);
+    });
+
+    test("rend à un compte ADEME les seuls non confidentiels d'une collectivité publique", async () => {
+      expect(
+        await listFilenames(ademeUser, {
+          collectiviteId: publicCollectivite.id,
+        })
+      ).toEqual([PUBLIC_NOT_CONFIDENTIEL]);
+    });
+
+    test('refuse à un compte ADEME une collectivité en accès restreint', async () => {
+      await expect(
+        listFilenames(ademeUser, { collectiviteId: restrictedCollectivite.id })
+      ).rejects.toThrowError(FORBIDDEN_MESSAGE);
+    });
+
+    test("rend à un compte ADEME non vérifié les seuls non confidentiels d'une collectivité publique", async () => {
+      expect(
+        await listFilenames(unverifiedAdemeUser, {
+          collectiviteId: publicCollectivite.id,
+        })
+      ).toEqual([PUBLIC_NOT_CONFIDENTIEL]);
+    });
+
+    test('refuse à un compte ADEME non vérifié une collectivité en accès restreint', async () => {
+      await expect(
+        listFilenames(unverifiedAdemeUser, {
+          collectiviteId: restrictedCollectivite.id,
+        })
+      ).rejects.toThrowError(FORBIDDEN_MESSAGE);
+    });
+
+    test("rend au support, mode super admin inactif, les seuls non confidentiels d'une collectivité publique", async () => {
+      expect(
+        await listFilenames(supportUser, {
+          collectiviteId: publicCollectivite.id,
+        })
+      ).toEqual([PUBLIC_NOT_CONFIDENTIEL]);
+    });
+
+    test('refuse au support, mode super admin inactif, une collectivité en accès restreint', async () => {
+      await expect(
+        listFilenames(supportUser, {
+          collectiviteId: restrictedCollectivite.id,
+        })
+      ).rejects.toThrowError(FORBIDDEN_MESSAGE);
+    });
+
+    test("rend au super admin, mode activé, tous les documents d'une collectivité en accès restreint", async () => {
+      expect(
+        await listFilenames(superAdmin, {
+          collectiviteId: restrictedCollectivite.id,
+        })
+      ).toEqual([RESTRICTED_CONFIDENTIEL, RESTRICTED_NOT_CONFIDENTIEL]);
+    });
+
+    test("rend à l'auditeur d'un audit en cours tous les documents de la collectivité en accès restreint", async () => {
+      expect(await listFilenamesAsAuditeur(auditeurOfOngoingAudit)).toEqual([
+        RESTRICTED_CONFIDENTIEL,
+        RESTRICTED_NOT_CONFIDENTIEL,
+      ]);
+    });
+
+    test("rend à l'auditeur d'un audit non démarré tous les documents de la collectivité en accès restreint", async () => {
+      expect(await listFilenamesAsAuditeur(auditeurOfNotStartedAudit)).toEqual([
+        RESTRICTED_CONFIDENTIEL,
+        RESTRICTED_NOT_CONFIDENTIEL,
+      ]);
+    });
+
+    test("rend à l'auditeur d'un audit validé non clos tous les documents de la collectivité en accès restreint", async () => {
+      expect(await listFilenamesAsAuditeur(auditeurOfValidatedAudit)).toEqual([
+        RESTRICTED_CONFIDENTIEL,
+        RESTRICTED_NOT_CONFIDENTIEL,
+      ]);
+    });
+
+    test("rend à l'auditeur d'un audit clos depuis 5 jours tous les documents de la collectivité en accès restreint", async () => {
+      expect(
+        await listFilenamesAsAuditeur(auditeurOfAuditClosed5DaysAgo)
+      ).toEqual([RESTRICTED_CONFIDENTIEL, RESTRICTED_NOT_CONFIDENTIEL]);
+    });
+
+    test("refuse à l'auditeur d'un audit clos depuis 30 jours la collectivité en accès restreint", async () => {
+      await expect(
+        listFilenamesAsAuditeur(auditeurOfAuditClosed30DaysAgo)
+      ).rejects.toThrowError(FORBIDDEN_MESSAGE);
+    });
+  });
+
+  test('rend les premiers documents par nom puis par identifiant, dans la limite demandée', async () => {
+    const { collectivite, lecteur } = await addCollectiviteWithLecteur();
+    const [, b, firstC, a, secondC, d] = await seedDocuments(collectivite, [
+      'e.pdf',
+      'b.pdf',
+      'c.pdf',
+      'a.pdf',
+      'c.pdf',
+      'd.pdf',
+      'f.pdf',
+    ]);
+    const homonymsById = [firstC, secondC].toSorted(
+      (first, second) => first.id - second.id
+    );
+
+    const { items } = await router
+      .createCaller({ user: lecteur })
+      .collectivites.documents.listBibliothequeDocuments({
+        collectiviteId: collectivite.id,
+        limit: 5,
+      });
+
+    expect(items).toEqual([a, b, ...homonymsById, d].map(toListedDocument));
+  });
+
+  describe('recherche', () => {
+    let collectivite: Collectivite;
+    let lecteur: AuthenticatedUser;
+
+    beforeAll(async () => {
+      ({ collectivite, lecteur } = await addCollectiviteWithLecteur());
+      await seedDocuments(collectivite, SEARCH_FILENAMES);
+    });
+
+    test('trouve un document sans tenir compte de la casse', async () => {
+      expect(
+        await listFilenames(lecteur, {
+          collectiviteId: collectivite.id,
+          search: 'rapport-annuel',
+        })
+      ).toEqual(['Rapport-Annuel.pdf']);
+    });
+
+    test('prend le caractère _ au pied de la lettre', async () => {
+      expect(
+        await listFilenames(lecteur, {
+          collectiviteId: collectivite.id,
+          search: 'a_b',
+        })
+      ).toEqual(['a_b.pdf']);
+    });
+
+    test('prend le caractère % au pied de la lettre', async () => {
+      expect(
+        await listFilenames(lecteur, {
+          collectiviteId: collectivite.id,
+          search: '%',
+        })
+      ).toEqual(['100%.pdf']);
+    });
+
+    test('prend le caractère \\ au pied de la lettre', async () => {
+      expect(
+        await listFilenames(lecteur, {
+          collectiviteId: collectivite.id,
+          search: '\\',
+        })
+      ).toEqual(['a\\b.pdf']);
+    });
+
+    test("n'applique aucun filtre à une recherche faite d'espaces", async () => {
+      const filenames = await listFilenames(lecteur, {
+        collectiviteId: collectivite.id,
+        search: '   ',
+      });
+
+      expect(filenames.toSorted()).toEqual(SEARCH_FILENAMES.toSorted());
+    });
+  });
+
+  test("n'affiche pas un document de la bibliothèque sans objet de stockage", async () => {
+    const { collectivite, lecteur } = await addCollectiviteWithLecteur();
+
+    await seedDocuments(collectivite, ['present.pdf']);
+    await databaseService.db.insert(bibliothequeFichierTable).values({
+      collectiviteId: collectivite.id,
+      hash: randomUUID(),
+      filename: 'sans-objet.pdf',
+      confidentiel: false,
+    });
+
+    expect(
+      await listFilenames(lecteur, { collectiviteId: collectivite.id })
+    ).toEqual(['present.pdf']);
+  });
+});

--- a/apps/backend/src/collectivites/documents/list-bibliotheque-documents/list-bibliotheque-documents.router.ts
+++ b/apps/backend/src/collectivites/documents/list-bibliotheque-documents/list-bibliotheque-documents.router.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@nestjs/common';
+import { createTrpcErrorHandler } from '@tet/backend/utils/trpc/trpc-error-handler';
+import { TrpcService } from '@tet/backend/utils/trpc/trpc.service';
+import { listBibliothequeDocumentsErrorConfig } from './list-bibliotheque-documents.errors';
+import { listBibliothequeDocumentsInputSchema } from './list-bibliotheque-documents.input';
+import { listBibliothequeDocumentsOutputSchema } from './list-bibliotheque-documents.output';
+import { ListBibliothequeDocumentsService } from './list-bibliotheque-documents.service';
+
+@Injectable()
+export class ListBibliothequeDocumentsRouter {
+  constructor(
+    private readonly trpc: TrpcService,
+    private readonly service: ListBibliothequeDocumentsService
+  ) {}
+
+  private readonly getResultDataOrThrowError = createTrpcErrorHandler(
+    listBibliothequeDocumentsErrorConfig
+  );
+
+  router = this.trpc.router({
+    listBibliothequeDocuments: this.trpc.authedProcedure
+      .input(listBibliothequeDocumentsInputSchema)
+      .output(listBibliothequeDocumentsOutputSchema)
+      .query(async ({ input, ctx }) => {
+        const result = await this.service.listBibliothequeDocuments(input, {
+          user: ctx.user,
+        });
+        return this.getResultDataOrThrowError(result);
+      }),
+  });
+}

--- a/apps/backend/src/collectivites/documents/list-bibliotheque-documents/list-bibliotheque-documents.service.ts
+++ b/apps/backend/src/collectivites/documents/list-bibliotheque-documents/list-bibliotheque-documents.service.ts
@@ -1,0 +1,50 @@
+import { Injectable } from '@nestjs/common';
+import { ServiceSecondArg } from '@tet/backend/utils/nest/service-second-arg.utils';
+import { failure, success, type Result } from '@tet/backend/utils/result.type';
+import { CollectiviteDocumentsAccessService } from '../collectivite-documents-access.service';
+import {
+  ListBibliothequeDocumentsError,
+  ListBibliothequeDocumentsErrorEnum,
+} from './list-bibliotheque-documents.errors';
+import { ListBibliothequeDocumentsInput } from './list-bibliotheque-documents.input';
+import { ListBibliothequeDocumentsOutput } from './list-bibliotheque-documents.output';
+import { ListBibliothequeDocumentsRepository } from './list-bibliotheque-documents.repository';
+
+@Injectable()
+export class ListBibliothequeDocumentsService {
+  constructor(
+    private readonly collectiviteDocumentsAccess: CollectiviteDocumentsAccessService,
+    private readonly repository: ListBibliothequeDocumentsRepository
+  ) {}
+
+  async listBibliothequeDocuments(
+    { collectiviteId, search, limit }: ListBibliothequeDocumentsInput,
+    { user, tx }: ServiceSecondArg
+  ): Promise<
+    Result<ListBibliothequeDocumentsOutput, ListBibliothequeDocumentsError>
+  > {
+    const accessResult =
+      await this.collectiviteDocumentsAccess.checkUserCanReadDocuments(
+        { collectiviteId },
+        { user, tx }
+      );
+    if (!accessResult.success) {
+      return failure(ListBibliothequeDocumentsErrorEnum.UNAUTHORIZED);
+    }
+
+    const documentsResult = await this.repository.listBibliothequeDocuments(
+      {
+        collectiviteId,
+        search,
+        limit,
+        canReadConfidentiel: accessResult.data.canReadConfidentiel,
+      },
+      tx
+    );
+    if (!documentsResult.success) {
+      return documentsResult;
+    }
+
+    return success({ items: documentsResult.data });
+  }
+}

--- a/apps/backend/src/referentiels/labellisations/labellisations.test-fixture.ts
+++ b/apps/backend/src/referentiels/labellisations/labellisations.test-fixture.ts
@@ -21,23 +21,27 @@ import {
 import { labellisationDemandeTable } from './labellisation-demande.table';
 import { labellisationTable } from './labellisation.table';
 
+export type CreateAuditArgs = {
+  databaseService: DatabaseServiceInterface;
+  collectiviteId: number;
+  referentielId: ReferentielId;
+  dateDebut?: string | null;
+  clos?: boolean;
+  dateFin?: string;
+  valide?: boolean;
+  withDemande?: boolean;
+};
+
 export async function createAudit({
   databaseService,
   collectiviteId,
   referentielId,
   dateDebut = new Date('2025-01-01').toISOString(),
   clos = false,
+  dateFin,
   valide = false,
   withDemande = false,
-}: {
-  databaseService: DatabaseServiceInterface;
-  collectiviteId: number;
-  referentielId: ReferentielId;
-  dateDebut?: string | null;
-  clos?: boolean;
-  valide?: boolean;
-  withDemande?: boolean;
-}) {
+}: CreateAuditArgs) {
   const demande = withDemande
     ? await databaseService.db
         .insert(labellisationDemandeTable)
@@ -61,7 +65,7 @@ export async function createAudit({
       dateDebut: dateDebut,
       clos,
       valide,
-      dateFin: clos ? new Date().toISOString() : null,
+      dateFin: clos ? dateFin ?? new Date().toISOString() : null,
     })
     .returning();
 


### PR DESCRIPTION
Nouvelle procédure `collectivites.documents.listBibliothequeDocuments`, sans appelant : la PR 6 y branchera la bibliothèque du front à la place de la lecture PostgREST de la vue `bibliotheque_fichier`.

Plan : `docs/plans/2026-09-10-001-refactor-cles-requete-litterales-plan.md` (compound-knowledge-db), PR 5. S'appuie sur #5047 et #5050, mergées.

| | |
|---|---|
| Entrée | `{ collectiviteId, search?: string (≤ 255), limit: 1..100 }` |
| Sortie | `{ items: { id, filename, confidentiel }[] }`, triés par nom puis `id` |
| Accès | `CollectiviteDocumentsAccessService` : les règles de `getDownloadUrl` |
| Sans `read_confidentiel` | aucun confidentiel, recherche comprise |
| Recherche | insensible à la casse ; `%`, `_`, `\` pris littéralement (`escapeLikePattern`) |

## Arbitrages

| Sujet | Choix |
|---|---|
| Écarts avec la RLS de la vue | plus permissif pour l'ADEME non vérifiée, le super admin et les auditeurs d'un audit non démarré ou clos depuis moins de 15 jours ; plus strict pour le support sur une collectivité restreinte. Ce sont les écarts de `getDownloadUrl`. |
| Pas de pagination ni de `total` | le sélecteur de la bibliothèque affiche les premiers fichiers par nom et affine par recherche ; il ne lisait ni la page 2 ni `total` |
| Nommage | procédure, dossier et classes portent le même nom (`listBibliothequeDocuments`, `list-bibliotheque-documents`, `ListBibliothequeDocuments*`), comme `createUploadToken` et `getDownloadUrl` dans ce routeur ; distinct de `demarches.pcaet.documents.list` |
| Collectivité inconnue | `NOT_FOUND`, comme `getDownloadUrl` |

## Tests

`list-bibliotheque-documents.router.e2e-spec.ts`, 27 cas :

| Groupe | Cas | Vu rouge avec |
|---|---|---|
| Autorisation | 20 : chaque profil sur une collectivité publique et une restreinte, dont une recherche d'un non membre | confidentialité forcée à `true` → 5 échecs |
| Limite et tri | 1 : sept fichiers, `limit: 5`, homonymes par `id` | |
| Recherche | 5 : casse ; `_`, `%`, `\` littéraux ; espaces sans filtre | échappement retiré → 3 échecs |
| Jointure | 1 : un fichier sans objet de stockage est absent | |

`createAudit` (fixture) accepte une `dateFin` ; chaque auditeur a sa propre collectivité restreinte, un seul audit ouvert étant permis par collectivité et référentiel.

Prérequis de déploiement : la migration `labellisation/bibliotheque_fichier_not_null`, sinon un `filename` nul fait échouer le schéma de sortie.
