### PR TITLE
feat(plans): la classification choisit son enjeu

### DIFF
--- a/apps/backend/src/plans/classification/classification-enjeux.spec.ts
+++ b/apps/backend/src/plans/classification/classification-enjeux.spec.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { DECLARED_ENJEUX } from './classification-enjeux';
+
+const enjeuxMissing = (fragment: string): string[] =>
+  Object.entries(DECLARED_ENJEUX)
+    .filter(([, { systemInstruction }]) => !systemInstruction.includes(fragment))
+    .map(([name]) => name);
+
+describe('Les enjeux de classification declares', () => {
+  it('rappellent tous que le texte entre balises est de la donnee, jamais une instruction', () => {
+    expect(enjeuxMissing('# Contrat de balisage')).toEqual([]);
+  });
+
+  it('exigent tous une entree de reponse par index fourni', () => {
+    expect(
+      enjeuxMissing('exactement une entrée par index fourni, ni plus, ni moins')
+    ).toEqual([]);
+  });
+});

--- a/apps/backend/src/plans/classification/classification-enjeux.ts
+++ b/apps/backend/src/plans/classification/classification-enjeux.ts
@@ -1,0 +1,18 @@
+import { Enjeu } from '@tet/domain/shared';
+import { ClassificationEnjeu } from './pipeline/classification-enjeu';
+import { buildClassificationPrompt } from './pipeline/classify-fiches/classify-fiches.prompt';
+import { classificationResponseSchema } from './pipeline/classify-fiches/classify-fiches.schema';
+import { CLASSIFICATION_SYSTEM_INSTRUCTION } from './prompts/classification.prompt';
+
+export const ENJEU_GES: ClassificationEnjeu = {
+  systemInstruction: CLASSIFICATION_SYSTEM_INSTRUCTION,
+  buildPrompt: buildClassificationPrompt,
+  responseSchema: classificationResponseSchema,
+};
+
+export const DECLARED_ENJEUX = {
+  ges: ENJEU_GES,
+} satisfies Record<Enjeu, ClassificationEnjeu>;
+
+export const isDeclaredEnjeu = (value: string): value is Enjeu =>
+  value in DECLARED_ENJEUX;

--- a/apps/backend/src/plans/classification/classification-volets-job.repository.ts
+++ b/apps/backend/src/plans/classification/classification-volets-job.repository.ts
@@ -3,6 +3,7 @@ import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { Transaction } from '@tet/backend/utils/database/transaction.utils';
 import { TokenUsage } from '@tet/backend/utils/llm/llm.repository';
 import { failure, success, type Result } from '@tet/backend/utils/result.type';
+import { Enjeu } from '@tet/domain/shared';
 import { getErrorMessage } from '@tet/domain/utils';
 import { and, eq, inArray, lt } from 'drizzle-orm';
 import {
@@ -29,6 +30,7 @@ const progressProjection = {
   id: classificationVoletsJobTable.id,
   collectiviteId: classificationVoletsJobTable.collectiviteId,
   planId: classificationVoletsJobTable.planId,
+  enjeu: classificationVoletsJobTable.enjeu,
   status: classificationVoletsJobTable.status,
   processedBatches: classificationVoletsJobTable.processedBatches,
   totalBatches: classificationVoletsJobTable.totalBatches,
@@ -43,6 +45,7 @@ export type ClassificationProgress = {
 export type CreateClassificationJobInput = {
   collectiviteId: number;
   planId: number;
+  enjeu: Enjeu;
   createdBy: string;
 };
 
@@ -64,7 +67,10 @@ export class ClassificationVoletsJobRepository {
         return success(job);
       }
 
-      const hasExpiredStaleJob = await this.expireStaleInFlight(input.planId);
+      const hasExpiredStaleJob = await this.expireStaleInFlight(
+        input.planId,
+        input.enjeu
+      );
       if (!hasExpiredStaleJob) {
         return failure(ClassificationVoletsErrorEnum.IN_FLIGHT_JOB_EXISTS);
       }
@@ -91,11 +97,15 @@ export class ClassificationVoletsJobRepository {
       .values({
         collectiviteId: input.collectiviteId,
         planId: input.planId,
+        enjeu: input.enjeu,
         createdBy: input.createdBy,
         status: ClassificationVoletsJobStatusEnum.PENDING,
       })
       .onConflictDoNothing({
-        target: classificationVoletsJobTable.planId,
+        target: [
+          classificationVoletsJobTable.planId,
+          classificationVoletsJobTable.enjeu,
+        ],
         where: inFlightStatusPredicate,
       })
       .returning();
@@ -103,7 +113,10 @@ export class ClassificationVoletsJobRepository {
     return job;
   }
 
-  private async expireStaleInFlight(planId: number): Promise<boolean> {
+  private async expireStaleInFlight(
+    planId: number,
+    enjeu: Enjeu
+  ): Promise<boolean> {
     const expiredJobs = await this.db
       .update(classificationVoletsJobTable)
       .set({
@@ -114,6 +127,7 @@ export class ClassificationVoletsJobRepository {
       .where(
         and(
           eq(classificationVoletsJobTable.planId, planId),
+          eq(classificationVoletsJobTable.enjeu, enjeu),
           inArray(
             classificationVoletsJobTable.status,
             classificationVoletsJobInFlightStatuses

--- a/apps/backend/src/plans/classification/classification.router.e2e-spec.ts
+++ b/apps/backend/src/plans/classification/classification.router.e2e-spec.ts
@@ -10,6 +10,7 @@ import {
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
+import { Enjeu } from '@tet/domain/shared';
 import { CollectiviteRole } from '@tet/domain/users';
 import { eq } from 'drizzle-orm';
 import { beforeAll, describe, expect, it, onTestFinished } from 'vitest';
@@ -99,10 +100,12 @@ describe('ClassificationRouter', { timeout: 30_000 }, () => {
   const insertJob = async ({
     status = ClassificationVoletsJobStatusEnum.DONE,
     planId,
+    enjeu = 'ges',
     modifiedAt,
   }: {
     status?: ClassificationVoletsJobStatus;
     planId?: number;
+    enjeu?: Enjeu;
     modifiedAt?: string;
   } = {}): Promise<string> => {
     const [job] = await db.db
@@ -110,6 +113,7 @@ describe('ClassificationRouter', { timeout: 30_000 }, () => {
       .values({
         collectiviteId,
         planId: planId ?? emptyPlanId,
+        enjeu,
         createdBy: editionUser.id,
         status,
         processedBatches: 2,
@@ -129,6 +133,7 @@ describe('ClassificationRouter', { timeout: 30_000 }, () => {
       await expect(
         callerFor(editionUser).enqueueClassification({
           planId: 999_999_999,
+          enjeu: 'ges',
         })
       ).rejects.toThrowError(/n'existe pas/);
     });
@@ -137,6 +142,7 @@ describe('ClassificationRouter', { timeout: 30_000 }, () => {
       await expect(
         callerFor(editionUser).enqueueClassification({
           planId: sousAxeId,
+          enjeu: 'ges',
         })
       ).rejects.toThrowError(/axe et non un plan/);
     });
@@ -145,6 +151,7 @@ describe('ClassificationRouter', { timeout: 30_000 }, () => {
       await expect(
         callerFor(editionUser).enqueueClassification({
           planId: emptyPlanId,
+          enjeu: 'ges',
         })
       ).rejects.toThrowError(/aucune fiche/);
     });
@@ -153,6 +160,7 @@ describe('ClassificationRouter', { timeout: 30_000 }, () => {
       await expect(
         callerFor(outsiderUser).enqueueClassification({
           planId: planWithFichesId,
+          enjeu: 'ges',
         })
       ).rejects.toThrowError(/n'existe pas/);
     });
@@ -160,7 +168,7 @@ describe('ClassificationRouter', { timeout: 30_000 }, () => {
     it('enfile un job et rend son identifiant', async () => {
       const { jobId } = await callerFor(
         editionUser
-      ).enqueueClassification({ planId: planWithFichesId });
+      ).enqueueClassification({ planId: planWithFichesId, enjeu: 'ges' });
 
       onTestFinished(async () => {
         await db.db
@@ -176,7 +184,7 @@ describe('ClassificationRouter', { timeout: 30_000 }, () => {
     it('refuse un second job tant que le premier est en vol', async () => {
       const { jobId } = await callerFor(
         editionUser
-      ).enqueueClassification({ planId: planWithFichesId });
+      ).enqueueClassification({ planId: planWithFichesId, enjeu: 'ges' });
 
       onTestFinished(async () => {
         await db.db
@@ -187,6 +195,7 @@ describe('ClassificationRouter', { timeout: 30_000 }, () => {
       await expect(
         callerFor(editionUser).enqueueClassification({
           planId: planWithFichesId,
+          enjeu: 'ges',
         })
       ).rejects.toThrowError(/déjà en cours/);
     });
@@ -202,6 +211,7 @@ describe('ClassificationRouter', { timeout: 30_000 }, () => {
       expect(status).toEqual({
         id: jobId,
         planId: emptyPlanId,
+        enjeu: 'ges',
         status: ClassificationVoletsJobStatusEnum.DONE,
         draft: {
           fiches: [],
@@ -221,6 +231,7 @@ describe('ClassificationRouter', { timeout: 30_000 }, () => {
       expect(status).toEqual({
         id: jobId,
         planId: emptyPlanId,
+        enjeu: 'ges',
         status: ClassificationVoletsJobStatusEnum.RUNNING,
         processedBatches: 2,
         totalBatches: 3,
@@ -264,7 +275,7 @@ describe('ClassificationRouter', { timeout: 30_000 }, () => {
 
       const { jobId } = await callerFor(
         editionUser
-      ).enqueueClassification({ planId: planWithFichesId });
+      ).enqueueClassification({ planId: planWithFichesId, enjeu: 'ges' });
 
       const [staleJob] = await db.db
         .select({
@@ -299,6 +310,7 @@ describe('ClassificationRouter', { timeout: 30_000 }, () => {
       await expect(
         callerFor(editionUser).enqueueClassification({
           planId: planWithFichesId,
+          enjeu: 'ges',
         })
       ).rejects.toThrowError(/déjà en cours/);
     });

--- a/apps/backend/src/plans/classification/enqueue-classification/enqueue-classification.input.ts
+++ b/apps/backend/src/plans/classification/enqueue-classification/enqueue-classification.input.ts
@@ -1,7 +1,9 @@
+import { enjeuEnumValues } from '@tet/domain/shared';
 import { z } from 'zod';
 
 export const enqueueClassificationInputSchema = z.object({
   planId: z.number().int().positive(),
+  enjeu: z.enum(enjeuEnumValues),
 });
 
 export type EnqueueClassificationInput = z.output<

--- a/apps/backend/src/plans/classification/enqueue-classification/enqueue-classification.service.ts
+++ b/apps/backend/src/plans/classification/enqueue-classification/enqueue-classification.service.ts
@@ -35,7 +35,7 @@ export class EnqueueClassificationService {
   ) {}
 
   async enqueue(
-    { planId }: EnqueueClassificationInput,
+    { planId, enjeu }: EnqueueClassificationInput,
     { user }: { user: AuthenticatedUser }
   ): Promise<Result<{ jobId: string }, ClassificationVoletsError>> {
     const axeResult = await this.getAxeRepository.getAxe(planId);
@@ -65,6 +65,7 @@ export class EnqueueClassificationService {
     const jobResult = await this.jobRepository.createUnlessInFlight({
       collectiviteId: axe.collectiviteId,
       planId,
+      enjeu,
       createdBy: user.id,
     });
     if (!jobResult.success) {

--- a/apps/backend/src/plans/classification/enqueue-classification/enqueue-classification.spec.ts
+++ b/apps/backend/src/plans/classification/enqueue-classification/enqueue-classification.spec.ts
@@ -70,7 +70,7 @@ describe('EnqueueClassificationService.enqueue', () => {
   it('refuse un plan sans aucune fiche a classer', async () => {
     const { service, queue } = toDependencies({ ficheCount: 0 });
 
-    const result = await service.enqueue({ planId }, { user });
+    const result = await service.enqueue({ planId, enjeu: 'ges' }, { user });
 
     expect({ result, queueCalls: queue.add.mock.calls.length }).toEqual({
       result: {
@@ -84,7 +84,7 @@ describe('EnqueueClassificationService.enqueue', () => {
   it('enfile un job pour un plan qui a des fiches', async () => {
     const { service } = toDependencies({ ficheCount: 900 });
 
-    const result = await service.enqueue({ planId }, { user });
+    const result = await service.enqueue({ planId, enjeu: 'ges' }, { user });
 
     expect(result).toEqual({ success: true, data: { jobId } });
   });
@@ -92,7 +92,7 @@ describe('EnqueueClassificationService.enqueue', () => {
   it("presente un sous-axe d'une autre collectivite comme un plan introuvable", async () => {
     const { service } = toDependencies({ parent: 12, isAllowed: false });
 
-    const result = await service.enqueue({ planId }, { user });
+    const result = await service.enqueue({ planId, enjeu: 'ges' }, { user });
 
     expect(result).toEqual({
       success: false,
@@ -104,7 +104,7 @@ describe('EnqueueClassificationService.enqueue', () => {
     const { service, jobRepository, queue } = toDependencies();
     queue.add.mockRejectedValue(new Error('redis down'));
 
-    const result = await service.enqueue({ planId }, { user });
+    const result = await service.enqueue({ planId, enjeu: 'ges' }, { user });
 
     expect({
       result,

--- a/apps/backend/src/plans/classification/generate-classification/generate-classification.service.ts
+++ b/apps/backend/src/plans/classification/generate-classification/generate-classification.service.ts
@@ -1,5 +1,9 @@
 import { Injectable, Logger } from '@nestjs/common';
 import ListFichesService from '@tet/backend/plans/fiches/list-fiches/list-fiches.service';
+import {
+  DECLARED_ENJEUX,
+  isDeclaredEnjeu,
+} from '../classification-enjeux';
 import { buildRequesterUser } from '@tet/backend/users/models/auth.models';
 import { LlmService } from '@tet/backend/utils/llm/llm.service';
 import { TransactionManager } from '@tet/backend/utils/transaction/transaction-manager.service';
@@ -98,8 +102,17 @@ export class GenerateClassificationService {
       });
     }
 
+    if (!isDeclaredEnjeu(job.enjeu)) {
+      return this.interrupt(
+        jobId,
+        `Cette classification porte un enjeu que l'application ne reconnaît pas : ${job.enjeu}. Signalez-le à l'équipe.`
+      );
+    }
+    const declaredEnjeu = DECLARED_ENJEUX[job.enjeu];
+
     const deadline = AbortSignal.timeout(CLASSIFICATION_DEADLINE_MS);
     const classification = await runClassification(this.llm, {
+      enjeu: declaredEnjeu,
       signal: deadline,
       fiches: fiches.map(({ id, titre, description }) => ({
         ficheId: id,

--- a/apps/backend/src/plans/classification/generate-classification/generate-classification.spec.ts
+++ b/apps/backend/src/plans/classification/generate-classification/generate-classification.spec.ts
@@ -26,6 +26,12 @@ const tokens = {
 
 const transaction = { marker: 'transaction' } as unknown as Transaction;
 
+type ClassifiableFiche = {
+  id: number;
+  titre: string | null;
+  description: string | null;
+};
+
 const toJobRow = (
   status: ClassificationVoletsJobStatus = ClassificationVoletsJobStatusEnum.PENDING
 ): ClassificationVoletsJob => ({
@@ -33,6 +39,7 @@ const toJobRow = (
   collectiviteId,
   planId,
   createdBy: 'a-user',
+  enjeu: 'ges',
   status,
   processedBatches: 0,
   totalBatches: 0,
@@ -67,10 +74,12 @@ const toClassifyingLlm = () => ({
 const toDependencies = ({
   job = toJobRow(),
   fiches = [{ id: 1, titre: 'Pistes cyclables', description: 'Dix km' }],
+  restrictedFiches = [],
   saveOutcome = success(undefined),
 }: {
-  job?: ReturnType<typeof toJobRow>;
-  fiches?: { id: number; titre: string | null; description: string | null }[];
+  job?: Omit<ReturnType<typeof toJobRow>, 'enjeu'> & { enjeu: string };
+  fiches?: ClassifiableFiche[];
+  restrictedFiches?: ClassifiableFiche[];
   saveOutcome?: unknown;
 } = {}) => {
   const jobRepository = {
@@ -81,9 +90,15 @@ const toDependencies = ({
     markFailed: vi.fn().mockResolvedValue(success(undefined)),
   };
   const listFichesService = {
-    getFichesActionResumes: vi
-      .fn()
-      .mockResolvedValue({ count: fiches.length, data: fiches }),
+    getFichesActionResumes: vi.fn(
+      async ({ filters }: { filters?: { restreint?: boolean } }) => {
+        const excludesRestricted = filters?.restreint === false;
+        const visibleFiches = excludesRestricted
+          ? fiches
+          : [...fiches, ...restrictedFiches];
+        return { count: visibleFiches.length, data: visibleFiches };
+      }
+    ),
   };
   const llm = toClassifyingLlm();
   const ficheActionVoletGesRepository = {
@@ -114,6 +129,56 @@ const toDependencies = ({
 };
 
 describe('GenerateClassificationService.generate', () => {
+  it('clot en echec un job dont l enjeu est inconnu de cette version', async () => {
+    const { service, llm, jobRepository } = toDependencies({
+      job: { ...toJobRow(), enjeu: 'biodiversite' },
+    });
+
+    const result = await service.generate(jobId);
+
+    expect({
+      success: result.success,
+      llmCalls: llm.generateStructured.mock.calls.length,
+      failureMessage: jobRepository.markFailed.mock.calls[0]?.[1],
+    }).toEqual({
+      success: false,
+      llmCalls: 0,
+      failureMessage:
+        "Cette classification porte un enjeu que l'application ne reconnaît pas : biodiversite. Signalez-le à l'équipe.",
+    });
+  });
+
+  it("n'envoie jamais au modele le texte d'une fiche restreinte", async () => {
+    const { service, llm } = toDependencies({
+      fiches: [{ id: 1, titre: 'Pistes cyclables', description: 'Dix km' }],
+      restrictedFiches: [
+        {
+          id: 2,
+          titre: 'Negociation fonciere',
+          description: 'Prix propose par parcelle',
+        },
+      ],
+    });
+
+    await service.generate(jobId);
+
+    const sentPrompts = llm.generateStructured.mock.calls
+      .map(([{ prompt }]) => prompt)
+      .join('\n');
+
+    expect({
+      hasReadableFiche: sentPrompts.includes('Pistes cyclables'),
+      hasRestrictedTitre: sentPrompts.includes('Negociation fonciere'),
+      hasRestrictedDescription: sentPrompts.includes(
+        'Prix propose par parcelle'
+      ),
+    }).toEqual({
+      hasReadableFiche: true,
+      hasRestrictedTitre: false,
+      hasRestrictedDescription: false,
+    });
+  });
+
   it("ignore une re-livraison d'un job deja termine sans rappeler le modele", async () => {
     const { service, llm, jobRepository } = toDependencies({
       job: toJobRow(ClassificationVoletsJobStatusEnum.DONE),

--- a/apps/backend/src/plans/classification/get-classification-status/get-classification-status.adapter.spec.ts
+++ b/apps/backend/src/plans/classification/get-classification-status/get-classification-status.adapter.spec.ts
@@ -28,6 +28,7 @@ const toProgress = ({
   id: jobId,
   collectiviteId: 3,
   planId,
+  enjeu: 'ges',
   status,
   processedBatches: 2,
   totalBatches: 3,
@@ -46,6 +47,7 @@ describe('toClassificationStatus', () => {
       data: {
         id: jobId,
         planId,
+        enjeu: 'ges',
         status: ClassificationVoletsJobStatusEnum.PENDING,
         processedBatches: 2,
         totalBatches: 3,
@@ -63,6 +65,7 @@ describe('toClassificationStatus', () => {
       data: {
         id: jobId,
         planId,
+        enjeu: 'ges',
         status: ClassificationVoletsJobStatusEnum.DONE,
         draft,
       },
@@ -82,6 +85,7 @@ describe('toClassificationStatus', () => {
       data: {
         id: jobId,
         planId,
+        enjeu: 'ges',
         status: ClassificationVoletsJobStatusEnum.FAILED,
         error: 'Aucune fiche à classer dans ce plan',
       },

--- a/apps/backend/src/plans/classification/get-classification-status/get-classification-status.adapter.ts
+++ b/apps/backend/src/plans/classification/get-classification-status/get-classification-status.adapter.ts
@@ -10,26 +10,27 @@ import { type ClassificationStatus } from './get-classification-status.output';
 export const toClassificationStatus = (
   progress: ClassificationProgress
 ): Result<ClassificationStatus, ClassificationVoletsError> => {
-  const { id, planId, status } = progress;
+  const { id, planId, enjeu, status } = progress;
 
   switch (status) {
     case ClassificationVoletsJobStatusEnum.DONE:
       if (!progress.draft) {
         return failure(ClassificationVoletsErrorEnum.GET_JOB_ERROR);
       }
-      return success({ id, planId, status, draft: progress.draft });
+      return success({ id, planId, enjeu, status, draft: progress.draft });
 
     case ClassificationVoletsJobStatusEnum.FAILED:
       if (!progress.error) {
         return failure(ClassificationVoletsErrorEnum.GET_JOB_ERROR);
       }
-      return success({ id, planId, status, error: progress.error });
+      return success({ id, planId, enjeu, status, error: progress.error });
 
     case ClassificationVoletsJobStatusEnum.PENDING:
     case ClassificationVoletsJobStatusEnum.RUNNING:
       return success({
         id,
         planId,
+        enjeu,
         status,
         processedBatches: progress.processedBatches,
         totalBatches: progress.totalBatches,

--- a/apps/backend/src/plans/classification/get-classification-status/get-classification-status.output.ts
+++ b/apps/backend/src/plans/classification/get-classification-status/get-classification-status.output.ts
@@ -1,5 +1,6 @@
 import {
   categorieActionEnumValues,
+  enjeuEnumValues,
   levierEnumValues,
 } from '@tet/domain/shared';
 import { z } from 'zod';
@@ -34,6 +35,7 @@ const classificationDraftSchema = z.object({
 const jobIdentity = {
   id: z.string().uuid(),
   planId: z.number().int().positive(),
+  enjeu: z.enum(enjeuEnumValues),
 };
 
 const inFlightStatusSchema = z.object({

--- a/apps/backend/src/plans/classification/models/classification-volets-job.table.ts
+++ b/apps/backend/src/plans/classification/models/classification-volets-job.table.ts
@@ -1,4 +1,5 @@
 import { collectiviteTable } from '@tet/backend/collectivites/shared/models/collectivite.table';
+import { enjeuEnumValues } from '@tet/domain/shared';
 import { axeTable } from '@tet/backend/plans/fiches/shared/models/axe.table';
 import { authUsersTable } from '@tet/backend/users/models/auth-users.table';
 import { TokenUsage } from '@tet/backend/utils/llm/llm.repository';
@@ -7,6 +8,7 @@ import { sql } from 'drizzle-orm';
 import {
   integer,
   jsonb,
+  pgEnum,
   pgTable,
   text,
   uniqueIndex,
@@ -17,6 +19,8 @@ import {
   classificationVoletsJobInFlightStatuses,
   classificationVoletsJobStatusValues,
 } from './classification-volets-job';
+
+export const enjeuEnum = pgEnum('enjeu', enjeuEnumValues);
 
 export const inFlightStatusPredicate = sql.raw(
   `status in (${classificationVoletsJobInFlightStatuses
@@ -37,6 +41,7 @@ export const classificationVoletsJobTable = pgTable(
     createdBy: uuid('created_by')
       .notNull()
       .references(() => authUsersTable.id, { onDelete: 'cascade' }),
+    enjeu: enjeuEnum('enjeu').notNull(),
     status: text('status', {
       enum: classificationVoletsJobStatusValues,
     }).notNull(),
@@ -50,7 +55,7 @@ export const classificationVoletsJobTable = pgTable(
   },
   (table) => [
     uniqueIndex('classification_volets_job_in_flight_unique')
-      .on(table.planId)
+      .on(table.planId, table.enjeu)
       .where(inFlightStatusPredicate),
   ]
 );

--- a/apps/backend/src/plans/classification/models/classification-volets-job.ts
+++ b/apps/backend/src/plans/classification/models/classification-volets-job.ts
@@ -1,3 +1,4 @@
+import { Enjeu } from '@tet/domain/shared';
 import { TokenUsage } from '@tet/backend/utils/llm/llm.repository';
 import { createEnumObject } from '@tet/domain/utils';
 import { ClassificationDraft } from './classification-draft';
@@ -33,6 +34,7 @@ export type ClassificationVoletsJob = {
   id: string;
   collectiviteId: number;
   planId: number;
+  enjeu: Enjeu;
   createdBy: string;
   status: ClassificationVoletsJobStatus;
   processedBatches: number;

--- a/apps/backend/src/plans/classification/pipeline/classification-enjeu.ts
+++ b/apps/backend/src/plans/classification/pipeline/classification-enjeu.ts
@@ -1,0 +1,8 @@
+import { ClassificationPromptInput } from './classify-fiches/classify-fiches.prompt';
+import { ClassificationResponseSchema } from './classify-fiches/classify-fiches.schema';
+
+export type ClassificationEnjeu = {
+  systemInstruction: string;
+  buildPrompt: (input: ClassificationPromptInput) => string;
+  responseSchema: ClassificationResponseSchema;
+};

--- a/apps/backend/src/plans/classification/pipeline/classify-fiches/classify-fiches.schema.ts
+++ b/apps/backend/src/plans/classification/pipeline/classify-fiches/classify-fiches.schema.ts
@@ -24,4 +24,6 @@ const ficheClassificationSchema = z.object({
 
 export const classificationResponseSchema = z.array(ficheClassificationSchema);
 
+export type ClassificationResponseSchema = typeof classificationResponseSchema;
+
 export type FicheClassification = z.output<typeof ficheClassificationSchema>;

--- a/apps/backend/src/plans/classification/pipeline/classify-fiches/classify-fiches.spec.ts
+++ b/apps/backend/src/plans/classification/pipeline/classify-fiches/classify-fiches.spec.ts
@@ -6,6 +6,7 @@ import {
 import { failure, success } from '@tet/backend/utils/result.type';
 import { describe, expect, it } from 'vitest';
 import { ZodType } from 'zod';
+import { ENJEU_GES } from '../../classification-enjeux';
 import { classifyFiches, MAX_FICHES_PER_BATCH } from './classify-fiches';
 import { FicheClassification } from './classify-fiches.schema';
 import { FicheToClassify } from './render-fiches-text';
@@ -60,7 +61,11 @@ const classifications: FicheClassification[] = [
   },
 ];
 
-const input = { fiches, nonce: 'nonce-de-test' };
+const input = {
+  enjeu: ENJEU_GES,
+  fiches,
+  nonce: 'nonce-de-test',
+};
 
 describe('classifyFiches', () => {
   it('rend les fiches classées accompagnées de la consommation de jetons', async () => {

--- a/apps/backend/src/plans/classification/pipeline/classify-fiches/classify-fiches.ts
+++ b/apps/backend/src/plans/classification/pipeline/classify-fiches/classify-fiches.ts
@@ -3,14 +3,12 @@ import { TokenUsage } from '@tet/backend/utils/llm/llm.repository';
 import { LlmService } from '@tet/backend/utils/llm/llm.service';
 import { failure, Result, success } from '@tet/backend/utils/result.type';
 import { randomUUID } from 'node:crypto';
-import { CLASSIFICATION_SYSTEM_INSTRUCTION } from '../../prompts/classification.prompt';
+import { ClassificationEnjeu } from '../classification-enjeu';
 import {
   applyClassification,
   ClassifiedFiche,
   InconsistentResponse,
 } from './apply-classification';
-import { buildClassificationPrompt } from './classify-fiches.prompt';
-import { classificationResponseSchema } from './classify-fiches.schema';
 import { FicheToClassify, renderFichesText } from './render-fiches-text';
 
 const CLASSIFICATION_THINKING_BUDGET = 512;
@@ -24,6 +22,7 @@ export type ClassifyFichesError =
   | { kind: 'batch_too_large'; count: number };
 
 export type ClassifyFichesInput = {
+  enjeu: ClassificationEnjeu;
   fiches: FicheToClassify[];
   nonce?: string;
   signal?: AbortSignal;
@@ -36,7 +35,7 @@ export type ClassifyFichesResult = {
 
 export const classifyFiches = async (
   llm: Pick<LlmService, 'generateStructured'>,
-  { fiches, nonce = randomUUID(), signal }: ClassifyFichesInput
+  { enjeu, fiches, nonce = randomUUID(), signal }: ClassifyFichesInput
 ): Promise<Result<ClassifyFichesResult, ClassifyFichesError>> => {
   if (fiches.length === 0) {
     return failure({ kind: 'empty_batch' });
@@ -49,9 +48,9 @@ export const classifyFiches = async (
   const { text, rendered } = renderFichesText(fiches, nonce);
 
   const completion = await llm.generateStructured({
-    prompt: buildClassificationPrompt({ actions: text }),
-    systemInstruction: CLASSIFICATION_SYSTEM_INSTRUCTION,
-    schema: classificationResponseSchema,
+    prompt: enjeu.buildPrompt({ actions: text }),
+    systemInstruction: enjeu.systemInstruction,
+    schema: enjeu.responseSchema,
     thinkingBudget: CLASSIFICATION_THINKING_BUDGET,
     signal,
   });

--- a/apps/backend/src/plans/classification/pipeline/run-classification.spec.ts
+++ b/apps/backend/src/plans/classification/pipeline/run-classification.spec.ts
@@ -7,6 +7,7 @@ import { failure, success } from '@tet/backend/utils/result.type';
 import { describe, expect, it } from 'vitest';
 import { ZodType } from 'zod';
 import { FicheClassification } from './classify-fiches/classify-fiches.schema';
+import { ENJEU_GES } from '../classification-enjeux';
 import { FicheToClassify } from './classify-fiches/render-fiches-text';
 import { FICHES_PER_BATCH, runClassification } from './run-classification';
 
@@ -68,6 +69,7 @@ const llmClassifying = (): StubbedLlm => llmFailingOnBatch([]);
 describe('runClassification', () => {
   it("classe toutes les fiches d'un lot unique", async () => {
     const run = await runClassification(llmClassifying(), {
+      enjeu: ENJEU_GES,
       fiches: toConsecutiveFiches(3),
     });
     expect(
@@ -77,6 +79,7 @@ describe('runClassification', () => {
 
   it('découpe au-delà de 25 fiches sans en perdre', async () => {
     const run = await runClassification(llmClassifying(), {
+      enjeu: ENJEU_GES,
       fiches: toConsecutiveFiches(26),
     });
     expect(run.kind === 'completed' && run.draft.fiches).toHaveLength(26);
@@ -84,6 +87,7 @@ describe('runClassification', () => {
 
   it('cumule les jetons de tous les lots', async () => {
     const run = await runClassification(llmClassifying(), {
+      enjeu: ENJEU_GES,
       fiches: toConsecutiveFiches(FICHES_PER_BATCH * 2),
     });
     expect(run.kind === 'completed' && run.tokens.totalTokens).toBe(
@@ -93,6 +97,7 @@ describe('runClassification', () => {
 
   it('conserve les lots réussis quand un lot échoue', async () => {
     const run = await runClassification(llmFailingOnBatch([0]), {
+      enjeu: ENJEU_GES,
       fiches: toConsecutiveFiches(FICHES_PER_BATCH * 3),
     });
     expect(run.kind === 'completed' && run.draft.fiches).toHaveLength(
@@ -102,6 +107,7 @@ describe('runClassification', () => {
 
   it('inscrit les fiches du lot en échec dans unclassified, avec leur raison', async () => {
     const run = await runClassification(llmFailingOnBatch([0]), {
+      enjeu: ENJEU_GES,
       fiches: toConsecutiveFiches(FICHES_PER_BATCH * 3),
     });
     expect(
@@ -114,6 +120,7 @@ describe('runClassification', () => {
 
   it('abandonne au-delà de la moitié des lots en échec', async () => {
     const run = await runClassification(llmFailingOnBatch([0, 1, 2]), {
+      enjeu: ENJEU_GES,
       fiches: toConsecutiveFiches(FICHES_PER_BATCH * 4),
     });
     expect(run).toEqual({
@@ -125,6 +132,7 @@ describe('runClassification', () => {
 
   it('accepte exactement la moitié des lots en échec', async () => {
     const run = await runClassification(llmFailingOnBatch([0, 1]), {
+      enjeu: ENJEU_GES,
       fiches: toConsecutiveFiches(FICHES_PER_BATCH * 4),
     });
     expect(run.kind).toBe('completed');
@@ -133,6 +141,7 @@ describe('runClassification', () => {
   it('signale la progression après chaque lot', async () => {
     const processedBatchCounts: number[] = [];
     await runClassification(llmClassifying(), {
+      enjeu: ENJEU_GES,
       fiches: toConsecutiveFiches(FICHES_PER_BATCH * 3),
       onBatchProcessed: (processedBatches) =>
         processedBatchCounts.push(processedBatches),

--- a/apps/backend/src/plans/classification/pipeline/run-classification.ts
+++ b/apps/backend/src/plans/classification/pipeline/run-classification.ts
@@ -7,6 +7,7 @@ import {
   ClassificationDraft,
   UnclassifiedFiche,
 } from '../models/classification-draft';
+import { ClassificationEnjeu } from './classification-enjeu';
 import { ClassifiedFiche } from './classify-fiches/apply-classification';
 import {
   ClassifyFichesError,
@@ -39,12 +40,20 @@ export type ClassificationRun =
       totalBatches: number;
     };
 
-const classifyBatch = async (
-  llm: Pick<LlmService, 'generateStructured'>,
-  fiches: FicheToClassify[],
-  signal?: AbortSignal
-): Promise<BatchOutcome> => {
-  const classifyResult = await classifyFiches(llm, { fiches, signal });
+type ClassifyBatchInput = {
+  llm: Pick<LlmService, 'generateStructured'>;
+  enjeu: ClassificationEnjeu;
+  fiches: FicheToClassify[];
+  signal?: AbortSignal;
+};
+
+const classifyBatch = async ({
+  llm,
+  enjeu,
+  fiches,
+  signal,
+}: ClassifyBatchInput): Promise<BatchOutcome> => {
+  const classifyResult = await classifyFiches(llm, { enjeu, fiches, signal });
 
   if (classifyResult.success) {
     return {
@@ -72,6 +81,7 @@ const toUnclassified = (outcome: BatchOutcome): UnclassifiedFiche[] => {
 };
 
 export type RunClassificationInput = {
+  enjeu: ClassificationEnjeu;
   fiches: FicheToClassify[];
   signal?: AbortSignal;
   onBatchProcessed?: (processedBatches: number) => void;
@@ -79,14 +89,14 @@ export type RunClassificationInput = {
 
 export const runClassification = async (
   llm: Pick<LlmService, 'generateStructured'>,
-  { fiches, signal, onBatchProcessed }: RunClassificationInput
+  { enjeu, fiches, signal, onBatchProcessed }: RunClassificationInput
 ): Promise<ClassificationRun> => {
   const batches = chunk(fiches, FICHES_PER_BATCH);
 
   const outcomes = await mapWithConcurrency(
     batches,
     BATCHES_IN_PARALLEL,
-    (batch) => classifyBatch(llm, batch, signal),
+    (batch) => classifyBatch({ llm, enjeu, fiches: batch, signal }),
     onBatchProcessed
   );
 

--- a/data_layer/sqitch/deploy/plan_action/classification_volets_enjeu.sql
+++ b/data_layer/sqitch/deploy/plan_action/classification_volets_enjeu.sql
@@ -1,0 +1,26 @@
+-- Deploy tet:plan_action/classification_volets_enjeu to pg
+-- requires: plan_action/classification_volets
+
+BEGIN;
+
+CREATE TYPE public.enjeu AS ENUM ('ges');
+
+COMMENT ON TYPE public.enjeu IS
+  'Enjeu environnemental classe par un job. La liste fait foi dans enjeuEnumValues (@tet/domain/shared). Il selectionne le prompt, le schema de reponse et la table de volets de destination.';
+
+ALTER TABLE public.classification_volets_job
+    ADD COLUMN enjeu public.enjeu NOT NULL DEFAULT 'ges';
+
+ALTER TABLE public.classification_volets_job
+    ALTER COLUMN enjeu DROP DEFAULT;
+
+COMMENT ON COLUMN public.classification_volets_job.enjeu IS
+  'Sans defaut : chaque enfilement nomme son enjeu. Le NOT NULL porte aussi l''unicite, un NULL n''entrant dans aucun conflit d''index.';
+
+DROP INDEX public.classification_volets_job_in_flight_unique;
+
+CREATE UNIQUE INDEX classification_volets_job_in_flight_unique
+    ON public.classification_volets_job (plan_id, enjeu)
+    WHERE status IN ('pending', 'running');
+
+COMMIT;

--- a/data_layer/sqitch/revert/plan_action/classification_volets_enjeu.sql
+++ b/data_layer/sqitch/revert/plan_action/classification_volets_enjeu.sql
@@ -1,0 +1,15 @@
+-- Revert tet:plan_action/classification_volets_enjeu from pg
+
+BEGIN;
+
+DROP INDEX public.classification_volets_job_in_flight_unique;
+
+CREATE UNIQUE INDEX classification_volets_job_in_flight_unique
+    ON public.classification_volets_job (plan_id)
+    WHERE status IN ('pending', 'running');
+
+ALTER TABLE public.classification_volets_job DROP COLUMN enjeu;
+
+DROP TYPE public.enjeu;
+
+COMMIT;

--- a/data_layer/sqitch/sqitch.plan
+++ b/data_layer/sqitch/sqitch.plan
@@ -1065,3 +1065,4 @@ plan_action/classification_leviers_job 2026-09-08T09:30:00Z Gaël Servaud <gaels
 plan_action/fiche_action_levier 2026-09-09T10:30:00Z Gaël Servaud <gaelservaud@gmail.com> # Cree la table fiche_action_levier (rattachement durable levier x categorie sur une fiche)
 utilisateur/dcp_email_lower_index [utilisateur/dcp] 2026-09-09T16:30:00Z Leny Bernard <leny.bernard.ext@beta.gouv.fr> # Index fonctionnel sur lower(dcp.email) : la table n'en avait aucun sur l'adresse, et chaque invitation la parcourait entierement
 plan_action/classification_volets [plan_action/classification_leviers_job plan_action/fiche_action_levier] 2026-09-10T09:37:55Z Gaël Servaud <gaelservaud@gmail.com> # Renomme les tables et types de classification en vocabulaire volet, et distingue le referentiel GES
+plan_action/classification_volets_enjeu [plan_action/classification_volets] 2026-09-10T14:23:25Z Gaël Servaud <gaelservaud@gmail.com> # Ajoute l'enjeu discriminant sur le job de classification

--- a/data_layer/sqitch/verify/plan_action/classification_volets_enjeu.sql
+++ b/data_layer/sqitch/verify/plan_action/classification_volets_enjeu.sql
@@ -1,0 +1,53 @@
+-- Verify tet:plan_action/classification_volets_enjeu on pg
+
+BEGIN;
+
+DO
+$$
+    DECLARE
+        colonnes_indexees text;
+    BEGIN
+        ASSERT (
+            SELECT COUNT(*) = 1
+            FROM pg_enum e
+                     JOIN pg_type t ON t.oid = e.enumtypid
+            WHERE t.typname = 'enjeu'
+              AND e.enumlabel = 'ges'
+        ), 'Le type enjeu doit declarer la valeur ges posee par ce change';
+
+        ASSERT (
+            SELECT is_nullable = 'NO' AND column_default IS NULL
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'classification_volets_job'
+              AND column_name = 'enjeu'
+        ), 'La colonne enjeu doit etre NOT NULL et sans defaut : chaque enfilement nomme son enjeu';
+
+        ASSERT (
+            SELECT atttypid = 'public.enjeu'::regtype
+            FROM pg_attribute
+            WHERE attrelid = 'public.classification_volets_job'::regclass
+              AND attname = 'enjeu'
+        ), 'La colonne enjeu doit porter le type enum, pas du texte libre';
+
+        SELECT string_agg(a.attname, ',' ORDER BY k.ord) INTO colonnes_indexees
+        FROM pg_index i
+                 JOIN pg_class c ON c.oid = i.indexrelid
+                 CROSS JOIN LATERAL unnest(i.indkey) WITH ORDINALITY AS k(attnum, ord)
+                 JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = k.attnum
+        WHERE c.relname = 'classification_volets_job_in_flight_unique';
+
+        ASSERT colonnes_indexees = 'plan_id,enjeu',
+            'L''index des jobs en vol doit porter sur (plan_id, enjeu) dans cet ordre, or : '
+                || coalesce(colonnes_indexees, 'index absent');
+
+        ASSERT (
+            SELECT indisunique AND indpred IS NOT NULL
+            FROM pg_index i
+                     JOIN pg_class c ON c.oid = i.indexrelid
+            WHERE c.relname = 'classification_volets_job_in_flight_unique'
+        ), 'L''index doit rester unique et partiel : un job termine ne bloque aucun nouvel enfilement';
+    END
+$$;
+
+ROLLBACK;

--- a/packages/domain/src/shared/enjeu.enum.ts
+++ b/packages/domain/src/shared/enjeu.enum.ts
@@ -1,0 +1,3 @@
+export const enjeuEnumValues = ['ges'] as const;
+
+export type Enjeu = (typeof enjeuEnumValues)[number];

--- a/packages/domain/src/shared/index.ts
+++ b/packages/domain/src/shared/index.ts
@@ -2,6 +2,7 @@ export * from './categorie-action.enum';
 export * from './categorie-fnv.schema';
 export * from './departement.schema';
 export * from './effet-attendu.schema';
+export * from './enjeu.enum';
 export * from './filtre-ressource-liees.schema';
 export * from './id-name.schema';
 export * from './levier.enum';


### PR DESCRIPTION
`classifyFiches` importait en dur l'instruction système GES, le texte des leviers et le schéma de réponse, et rien ne permettait de demander autre chose. Un second enjeu ne pouvait ni se brancher au pipeline, ni être choisi par l'appelant.

## La chaîne

```
enqueueClassification({ planId, enjeu })
     ↓  colonne enjeu sur la ligne de job
DECLARED_ENJEUX[job.enjeu]
     ↓
prompt · instruction système · schéma de réponse
```

Le prompt est choisi par l'enjeu. Aucun `ENJEU_GES` ne subsiste hors de son fichier de déclaration et des fixtures de test.

## Fichiers — 26

| | |
|---|---|
| `packages/domain/src/shared/enjeu.enum.ts` | **créé** — `enjeuEnumValues = ['ges']` |
| `deploy\|revert\|verify/plan_action/classification_volets_enjeu.sql` | **créés** — type pg, colonne, index |
| `pipeline/classification-enjeu.ts` | **créé** — le type du descripteur, sans dépendance GES |
| `classification-enjeux.ts` + son spec | **créés** — `ENJEU_GES`, `DECLARED_ENJEUX`, `isDeclaredEnjeu` |
| `models/classification-volets-job.{ts,table.ts}` | la colonne `enjeu`, l'enum pg, l'index sur `(planId, enjeu)` |
| `classification-volets-job.repository.ts` | projection, insert, `onConflictDoNothing`, `expireStaleInFlight` |
| `enqueue-classification.{input,service}.ts` | `{ planId, enjeu }` jusqu'à la ligne de job |
| `generate-classification.service.ts` | `DECLARED_ENJEUX[job.enjeu]`, avec rejet d'un enjeu inconnu |
| `get-classification-status.{output,adapter}.ts` | l'enjeu sur le statut |
| `pipeline/classify-fiches/*.ts`, `run-classification.ts` | le descripteur threadé |
| 6 specs | l'argument ajouté, plus les trois tests ci-dessous |

## Les enjeux sont typés

```ts
export const DECLARED_ENJEUX = {
  ges: ENJEU_GES,
} satisfies Record<Enjeu, ClassificationEnjeu>;
```

Ajouter une valeur à `enjeuEnumValues` sans déclarer son descripteur ne compile pas :

```
error TS2741: Property 'biodiversite' is missing in type '{ ges: ClassificationEnjeu; }'
but required in type 'Record<"biodiversite" | "ges", ClassificationEnjeu>'.
```

Le type du descripteur vit dans `pipeline/`, l'instance en dehors : sans cette séparation, `classify-fiches.ts` importerait transitivement le prompt GES.

## En base

```sql
CREATE TYPE public.enjeu AS ENUM ('ges');

ALTER TABLE classification_volets_job ADD COLUMN enjeu enjeu NOT NULL DEFAULT 'ges';
ALTER TABLE classification_volets_job ALTER COLUMN enjeu DROP DEFAULT;

DROP INDEX classification_volets_job_in_flight_unique;
CREATE UNIQUE INDEX classification_volets_job_in_flight_unique
    ON classification_volets_job (plan_id, enjeu)
    WHERE status IN ('pending', 'running');
```

**`NOT NULL` sans défaut** : chaque enfilement nomme son enjeu. Le `NOT NULL` porte aussi l'unicité — dans un index unique btree, `NULL ≠ NULL`, donc un `enjeu` nullable laisserait passer autant de jobs en vol qu'on veut sur le même plan.

Le `DEFAULT` puis `DROP DEFAULT` évite un pari : sur une table déjà peuplée, un `NOT NULL` nu échoue — et la CI ne le verrait pas, `classification_volets_job` n'étant pas seedée.

**`expireStaleInFlight` filtre désormais sur l'enjeu.** Sans ce filtre, l'expiration d'un job périmé tuerait le job en vol d'un autre enjeu sur le même plan.

## Un enjeu inconnu est rejeté explicitement

L'exhaustivité du type ne protège pas d'une valeur déjà en base qu'un backend rollbacké ne connaîtrait plus : l'enjeu est une **donnée**, le code est une **version**. Le job est clos en échec avec un message lisible plutôt que de propager un `undefined`.

## Trois gardes gagnent un test

**Aucune fiche restreinte n'atteint le modèle.** `restreint: false` était écrit en dur dans le service, sans test. Ce n'est pas une conséquence des droits : `plans.fiches.read_confidentiel` est une permission de lecture, `plans.fiches.bulk_update` — exigée pour lancer — une permission d'édition. Le demandeur peut lire ces fiches ; c'est le pipeline qui s'interdit de les envoyer à un tiers.

Retirer le filtre fait rougir le test : titre et description partent au modèle. Le test assert aussi que la fiche ordinaire arrive, sinon il passerait à vide.

**Chaque enjeu déclaré porte le contrat de balisage** et la clause « une entrée par index fourni ». Le prompt d'un second enjeu sera écrit par copie ; ces sections ressemblent à de la prose GES et peuvent sauter. La liste blanche de `render-fiches-text` tient les caractères, pas une injection en langage naturel. Le test itère `DECLARED_ENJEUX` : un enjeu ajouté tombe sous la garde.

**Un job d'enjeu inconnu est clos sans appeler le modèle.** En faisant retomber la sélection sur le GES au lieu de rejeter, le test rougit : un job biodiversité serait classé avec le prompt GES.

## Recette

- `deploy` → `verify` → `revert` → `deploy`. Le verify échoue sans la colonne ; le revert ramène l'index sur `(plan_id)` seul
- les 8 tests de `run-classification.spec.ts` gagnent un argument, **aucune assertion ne change**
- 100 tests verts, `nx typecheck` propre

## Le second commit

`ClassificationProgress` dérive de `progressProjection` en indexant `ClassificationVoletsJob`. La colonne `enjeu` avait été ajoutée à la projection mais pas au modèle : l'adaptateur rendait un `enjeu: unknown`, incompatible avec le contrat tRPC.

Invisible en test — vitest efface les types — et invisible au `tsc` d'un worktree, qui compile contre le `dist` de `@tet/domain`. Seul `nx typecheck` le voit, comme la CI.

## Hors scope, vérifiable par l'absence de ces fichiers dans le diff

- `prompts/classification.prompt.ts` — le prompt n'est ni scindé, ni réécrit, ni renommé
- `pipeline/classify-fiches/apply-classification.ts` — sa signature `(classifications, rendered)` ne bouge pas
- `pipeline/classify-fiches/render-fiches-text.ts` et son spec — le nonce, la liste blanche et le NFC ne sont pas paramétrables

Restent dehors : `restreint: false` demeure dans le service, et le type du pôle en sortie reste GES — l'union discriminée sur l'enjeu n'aurait rien à corréler avec une seule valeur. Le statut expose l'enjeu en champ plat.
