### PR TITLE
feat(documents): rend le nom du fichier déjà présent à la demande de dépôt

### DIFF
--- a/apps/backend/src/collectivites/documents/create-upload-token/create-upload-token.output.ts
+++ b/apps/backend/src/collectivites/documents/create-upload-token/create-upload-token.output.ts
@@ -1,9 +1,11 @@
+import { bibliothequeFichierSchema } from '@tet/domain/collectivites';
 import * as z from 'zod';
 
 export const createUploadTokenOutputSchema = z.discriminatedUnion('kind', [
   z.object({
     kind: z.literal('alreadyInBibliotheque'),
     fichierId: z.number().int().positive(),
+    filename: bibliothequeFichierSchema.shape.filename,
   }),
   z.object({
     kind: z.literal('readyToUpload'),

--- a/apps/backend/src/collectivites/documents/create-upload-token/create-upload-token.repository.ts
+++ b/apps/backend/src/collectivites/documents/create-upload-token/create-upload-token.repository.ts
@@ -1,21 +1,30 @@
 import { Injectable } from '@nestjs/common';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
+import { BibliothequeFichier, DocumentHash } from '@tet/domain/collectivites';
 import { and, eq } from 'drizzle-orm';
 import { bibliothequeFichierTable } from '../models/bibliotheque-fichier.table';
+
+export type FichierInBibliotheque = Pick<
+  BibliothequeFichier,
+  'id' | 'filename'
+>;
 
 @Injectable()
 export class CreateUploadTokenRepository {
   constructor(private readonly databaseService: DatabaseService) {}
 
-  async findFichierIdByHash({
+  async findFichierByHash({
     collectiviteId,
     hash,
   }: {
     collectiviteId: number;
-    hash: string;
-  }): Promise<number | undefined> {
+    hash: DocumentHash;
+  }): Promise<FichierInBibliotheque | undefined> {
     const [fichier] = await this.databaseService.db
-      .select({ id: bibliothequeFichierTable.id })
+      .select({
+        id: bibliothequeFichierTable.id,
+        filename: bibliothequeFichierTable.filename,
+      })
       .from(bibliothequeFichierTable)
       .where(
         and(
@@ -25,6 +34,6 @@ export class CreateUploadTokenRepository {
       )
       .limit(1);
 
-    return fichier?.id;
+    return fichier;
   }
 }

--- a/apps/backend/src/collectivites/documents/create-upload-token/create-upload-token.router.e2e-spec.ts
+++ b/apps/backend/src/collectivites/documents/create-upload-token/create-upload-token.router.e2e-spec.ts
@@ -1,11 +1,12 @@
 import { INestApplication } from '@nestjs/common';
 import { addTestCollectiviteAndUsers } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { seedTestDocument } from '@tet/backend/collectivites/documents/documents.test-fixture';
 import { getAuthUserFromUserCredentials } from '@tet/backend/test';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { addTestUser } from '@tet/backend/users/users/users.test-fixture';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
-import { Collectivite } from '@tet/domain/collectivites';
+import { Collectivite, toDocumentHash } from '@tet/domain/collectivites';
 import { CollectiviteRole } from '@tet/domain/users';
 import {
   getTestApp,
@@ -13,7 +14,15 @@ import {
   getTestRouter,
 } from '../../../../test/app-utils';
 
-const HASH = 'ec07d0538e44a333b23b936c9a4ba37fbd211c6272e632d2173b6abe102a0482';
+const HASH = toDocumentHash(
+  'ec07d0538e44a333b23b936c9a4ba37fbd211c6272e632d2173b6abe102a0482'
+);
+const HASH_IN_BIBLIOTHEQUE = toDocumentHash(
+  '5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef'
+);
+const HASH_IN_OTHER_COLLECTIVITE = toDocumentHash(
+  '9b74c9897bac770ffc029102a200c5de0de8a3bb61d6d17ba14d4be3b7ab8cb1'
+);
 
 describe('CreateUploadTokenRouter', () => {
   let app: INestApplication;
@@ -99,6 +108,52 @@ describe('CreateUploadTokenRouter', () => {
       token: expect.any(String),
       bucketId: expect.any(String),
       path: HASH,
+    });
+  });
+
+  test('rend le nom du fichier déjà présent dans la bibliothèque, confidentiel compris', async () => {
+    const document = await seedTestDocument({
+      databaseService,
+      collectiviteId: collectivite.id,
+      filename: 'rapport-confidentiel.pdf',
+      confidentiel: true,
+      hash: HASH_IN_BIBLIOTHEQUE,
+    });
+    const caller = router.createCaller({ user: editorUser });
+
+    const result = await caller.collectivites.documents.createUploadToken({
+      collectiviteId: collectivite.id,
+      hash: HASH_IN_BIBLIOTHEQUE,
+    });
+
+    expect(result).toEqual({
+      kind: 'alreadyInBibliotheque',
+      fichierId: document.id,
+      filename: 'rapport-confidentiel.pdf',
+    });
+  });
+
+  test("ne rend pas le nom d'un fichier au même hash dans une autre collectivité", async () => {
+    const { collectivite: otherCollectivite } =
+      await addTestCollectiviteAndUsers(databaseService, { users: [] });
+    await seedTestDocument({
+      databaseService,
+      collectiviteId: otherCollectivite.id,
+      filename: 'autre-collectivite.pdf',
+      hash: HASH_IN_OTHER_COLLECTIVITE,
+    });
+    const caller = router.createCaller({ user: editorUser });
+
+    const result = await caller.collectivites.documents.createUploadToken({
+      collectiviteId: collectivite.id,
+      hash: HASH_IN_OTHER_COLLECTIVITE,
+    });
+
+    expect(result).toEqual({
+      kind: 'readyToUpload',
+      token: expect.any(String),
+      bucketId: expect.any(String),
+      path: HASH_IN_OTHER_COLLECTIVITE,
     });
   });
 });

--- a/apps/backend/src/collectivites/documents/create-upload-token/create-upload-token.service.spec.ts
+++ b/apps/backend/src/collectivites/documents/create-upload-token/create-upload-token.service.spec.ts
@@ -4,6 +4,7 @@ import { DocumentStorageErrorEnum } from '@tet/backend/utils/supabase/document-s
 import { type DocumentStorageError } from '@tet/backend/utils/supabase/document-storage.errors';
 import { toDocumentHash } from '@tet/domain/collectivites';
 import { describe, expect, it, vi, type Mock } from 'vitest';
+import { type FichierInBibliotheque } from './create-upload-token.repository';
 import { CreateUploadTokenService } from './create-upload-token.service';
 
 const HASH = toDocumentHash(
@@ -25,11 +26,16 @@ type ServiceUnderTest = {
 function buildService({
   isAllowed = true,
   hasBucket = true,
-  fichierId = undefined as number | undefined,
+  fichier,
   signedUploadResult = success({
     token: 'jeton-signe',
     path: HASH,
-  }) as SignedUploadResult,
+  }),
+}: {
+  isAllowed?: boolean;
+  hasBucket?: boolean;
+  fichier?: FichierInBibliotheque;
+  signedUploadResult?: SignedUploadResult;
 } = {}): ServiceUnderTest {
   const permissions = {
     isAllowed: vi
@@ -42,7 +48,7 @@ function buildService({
   };
 
   const repository = {
-    findFichierIdByHash: vi.fn().mockResolvedValue(fichierId),
+    findFichierByHash: vi.fn().mockResolvedValue(fichier),
   };
 
   const collectiviteBucket = {
@@ -94,7 +100,9 @@ describe('CreateUploadTokenService', () => {
   });
 
   it('rend alreadyInBibliotheque sans signer quand le document a deja sa ligne', async () => {
-    const { service, documentStorage } = buildService({ fichierId: 42 });
+    const { service, documentStorage } = buildService({
+      fichier: { id: 42, filename: 'rapport.pdf' },
+    });
 
     const result = await service.createUploadToken(
       { collectiviteId: 1, hash: HASH },
@@ -103,7 +111,11 @@ describe('CreateUploadTokenService', () => {
 
     expect(result).toEqual({
       success: true,
-      data: { kind: 'alreadyInBibliotheque', fichierId: 42 },
+      data: {
+        kind: 'alreadyInBibliotheque',
+        fichierId: 42,
+        filename: 'rapport.pdf',
+      },
     });
     expect(documentStorage.createSignedUpload).not.toHaveBeenCalled();
   });

--- a/apps/backend/src/collectivites/documents/create-upload-token/create-upload-token.service.ts
+++ b/apps/backend/src/collectivites/documents/create-upload-token/create-upload-token.service.ts
@@ -46,12 +46,16 @@ export class CreateUploadTokenService {
       return failure(CreateUploadTokenErrorEnum.COLLECTIVITE_BUCKET_NOT_FOUND);
     }
 
-    const fichierId = await this.repository.findFichierIdByHash({
+    const fichier = await this.repository.findFichierByHash({
       collectiviteId,
       hash,
     });
-    if (fichierId !== undefined) {
-      return success({ kind: 'alreadyInBibliotheque', fichierId });
+    if (fichier !== undefined) {
+      return success({
+        kind: 'alreadyInBibliotheque',
+        fichierId: fichier.id,
+        filename: fichier.filename,
+      });
     }
 
     const signedUploadResult =

--- a/apps/backend/src/collectivites/documents/documents.test-fixture.ts
+++ b/apps/backend/src/collectivites/documents/documents.test-fixture.ts
@@ -2,10 +2,14 @@
 import { INestApplication } from '@nestjs/common';
 import { collectiviteBucketTable } from '@tet/backend/collectivites/shared/models/collectivite-bucket.table';
 import { DatabaseServiceInterface } from '@tet/backend/utils/database/database-service.interface';
-import { BibliothequeFichier } from '@tet/domain/collectivites';
+import {
+  BibliothequeFichier,
+  DocumentHash,
+  toDocumentHash,
+} from '@tet/domain/collectivites';
 import { eq, sql } from 'drizzle-orm';
 import fs from 'fs';
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import path from 'path';
 import { bibliothequeFichierTable } from './models/bibliotheque-fichier.table';
 import { StoreDocumentService } from './store-document/store-document.service';
@@ -49,17 +53,36 @@ export async function uploadCreateTestDocument({
 
 export type TestDocument = typeof bibliothequeFichierTable.$inferSelect;
 
-export async function seedTestDocument({
-  databaseService,
-  collectiviteId,
-  filename,
-  confidentiel = false,
-}: {
+const buildRandomDocumentHash = (): DocumentHash =>
+  toDocumentHash(createHash('sha256').update(randomUUID()).digest('hex'));
+
+type SeedTestDocumentArgs = {
   databaseService: DatabaseServiceInterface;
   collectiviteId: number;
   filename: string;
   confidentiel?: boolean;
-}): Promise<TestDocument> {
+};
+
+export async function seedTestDocument({
+  hash = buildRandomDocumentHash(),
+  ...args
+}: SeedTestDocumentArgs & { hash?: DocumentHash }): Promise<TestDocument> {
+  return insertTestDocument({ ...args, hash });
+}
+
+export async function seedTestDocumentWithLegacyUuidHash(
+  args: SeedTestDocumentArgs
+): Promise<TestDocument> {
+  return insertTestDocument({ ...args, hash: randomUUID() });
+}
+
+async function insertTestDocument({
+  databaseService,
+  collectiviteId,
+  filename,
+  confidentiel = false,
+  hash,
+}: SeedTestDocumentArgs & { hash: string }): Promise<TestDocument> {
   const [bucket] = await databaseService.db
     .select({ bucketId: collectiviteBucketTable.bucketId })
     .from(collectiviteBucketTable)
@@ -75,7 +98,7 @@ export async function seedTestDocument({
     .insert(bibliothequeFichierTable)
     .values({
       collectiviteId,
-      hash: randomUUID(),
+      hash,
       filename,
       confidentiel,
     })

--- a/apps/backend/src/collectivites/documents/get-download-url/get-download-url.router.e2e-spec.ts
+++ b/apps/backend/src/collectivites/documents/get-download-url/get-download-url.router.e2e-spec.ts
@@ -1,6 +1,9 @@
 import { INestApplication } from '@nestjs/common';
 import { addTestCollectiviteAndUsers } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
-import { seedTestDocument } from '@tet/backend/collectivites/documents/documents.test-fixture';
+import {
+  seedTestDocument,
+  seedTestDocumentWithLegacyUuidHash,
+} from '@tet/backend/collectivites/documents/documents.test-fixture';
 import { getAuthUserFromUserCredentials } from '@tet/backend/test';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
 import { addTestUser } from '@tet/backend/users/users/users.test-fixture';
@@ -69,7 +72,7 @@ describe('GetDownloadUrlRouter', () => {
   });
 
   test('signe un document dont le hash est un uuid herite, hors format sha-256', async () => {
-    const document = await seedTestDocument({
+    const document = await seedTestDocumentWithLegacyUuidHash({
       databaseService,
       collectiviteId: collectivite.id,
       filename: 'deliberation-heritee.pdf',

--- a/packages/domain/src/users/authorizations/permission.models.spec.ts
+++ b/packages/domain/src/users/authorizations/permission.models.spec.ts
@@ -12,4 +12,20 @@ describe('permissionsByRole', () => {
 
     expect(rolesGranting).toEqual([PlatformRole.SUPER_ADMIN]);
   });
+
+  it('accorde la lecture des documents confidentiels à tout rôle qui dépose des documents', () => {
+    const rolesMutatingWithoutConfidentielRead = Object.entries(
+      permissionsByRole
+    )
+      .filter(([, permissions]) =>
+        permissions.includes('collectivites.documents.mutate')
+      )
+      .filter(
+        ([, permissions]) =>
+          !permissions.includes('collectivites.documents.read_confidentiel')
+      )
+      .map(([role]) => role);
+
+    expect(rolesMutatingWithoutConfidentielRead).toEqual([]);
+  });
 });


### PR DESCRIPTION
`collectivites.documents.createUploadToken` rend le nom du fichier déjà présent quand le hash déposé est déjà dans la bibliothèque. La PR 8 s'en servira pour signaler les doublons au dépôt, sans lire la vue PostgREST `bibliotheque_fichier`.

Plan : `docs/plans/2026-09-10-001-refactor-cles-requete-litterales-plan.md` (compound-knowledge-db), PR 7.

| Branche de sortie | Avant | Après |
|---|---|---|
| `alreadyInBibliotheque` | `{ kind, fichierId }` | `{ kind, fichierId, filename }` |
| `readyToUpload` | inchangée | inchangée |

## Arbitrages

| Sujet | Choix |
|---|---|
| Rétrocompatibilité | champ ajouté ; le front actuel (`use-upload-file.ts`) ne lit que `kind` et `fichierId` |
| Confidentialité | le nom n'est rendu qu'après le contrôle `collectivites.documents.mutate` ; un spec du domaine verrouille que tout rôle qui a `mutate` a aussi `read_confidentiel` |
| Type du hash | `findFichierByHash` et `seedTestDocument` prennent un `DocumentHash` ; la fixture tire par défaut une empreinte SHA-256 aléatoire. Le hash UUID hérité, qui n'en est pas un, a sa fixture nommée `seedTestDocumentWithLegacyUuidHash`, utilisée par le seul test de `getDownloadUrl` qui le couvre |

## Tests

| Test | Vu rouge avec |
|---|---|
| E2E : un fichier confidentiel déjà présent rend `{ kind: 'alreadyInBibliotheque', fichierId, filename }` | un service qui omet `filename` |
| E2E : un fichier au même hash dans une autre collectivité n'est pas rendu | un repository sans filtre `collectiviteId` |
| Spec du service : la branche `alreadyInBibliotheque` porte `filename` | un service qui omet `filename` |
| Spec de `permissionsByRole` : aucun rôle n'a `mutate` sans `read_confidentiel` | une permission exigée inexistante |

Les e2e des autres appelants de `seedTestDocument` (`get-download-url`, `list-documents-mesure`, `list-bibliotheque-documents`) passent avec le nouveau hash par défaut.
