### PR TITLE
feat(documents): la bibliothèque suit les droits de lecture du backend

### DIFF
--- a/apps/app/src/collectivites/documents/upload/use-upload-file.ts
+++ b/apps/app/src/collectivites/documents/upload/use-upload-file.ts
@@ -24,7 +24,10 @@ export const useUploadFile = (): UploadFile => {
   const { mutateAsync: createDocument } = useMutation(
     trpc.collectivites.documents.create.mutationOptions({
       onSuccess: () => {
-        queryClient.invalidateQueries({ queryKey: ['bibliotheque_fichier'] });
+        queryClient.invalidateQueries({
+          queryKey:
+            trpc.collectivites.documents.listBibliothequeDocuments.pathKey(),
+        });
       },
     })
   );

--- a/apps/app/src/referentiels/preuves/AddPreuveModal/AddFromLib.stories.tsx
+++ b/apps/app/src/referentiels/preuves/AddPreuveModal/AddFromLib.stories.tsx
@@ -1,35 +1,28 @@
-import { Meta} from '@storybook/nextjs-vite';
-import {action} from 'storybook/actions';
-import {AddFromLib} from './AddFromLib';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { action } from 'storybook/actions';
+import type { BibliothequeFichierListItem } from '../Bibliotheque/useFichiers';
+import { AddFromLib } from './AddFromLib';
 
-export default {
+const meta: Meta<typeof AddFromLib> = {
   component: AddFromLib,
   args: {
-    filters: {page: 1, search: ''},
-    setFilters: action('setFilters'),
-  },
-} as Meta;
-
-export const Vide = {
-  args: {
-    items: [],
-    total: 0,
+    onSearch: action('onSearch'),
+    onAddFileFromLib: action('onAddFileFromLib'),
+    onClose: action('onClose'),
   },
 };
 
-const genMockFile = (count: number) =>
-  Array(count)
-    .fill(null)
-    .map((_, i) => ({
-      id: i + 1,
-      filename: `exemple ${i + 1}`,
-      filesize: 100,
-      hash: 'fake',
-    }));
+type Story = StoryObj<typeof AddFromLib>;
 
-export const Fichiers = {
-  args: {
-    items: genMockFile(4),
-    total: 12,
-  },
-};
+const toMockFichiers = (count: number): BibliothequeFichierListItem[] =>
+  Array.from({ length: count }, (_, index) => ({
+    id: index + 1,
+    filename: `exemple ${index + 1}`,
+    confidentiel: index === 0,
+  }));
+
+export const Vide: Story = { args: { items: [] } };
+
+export const Fichiers: Story = { args: { items: toMockFichiers(4) } };
+
+export default meta;

--- a/apps/app/src/referentiels/preuves/AddPreuveModal/AddFromLib.tsx
+++ b/apps/app/src/referentiels/preuves/AddPreuveModal/AddFromLib.tsx
@@ -5,16 +5,15 @@ import { Button, Field, Icon, Option, SelectFilter } from '@tet/ui';
 import classNames from 'classnames';
 import { useState } from 'react';
 import {
-  FichierListe,
-  FichiersFilters,
+  BibliothequeFichierListItem,
   useFichiers,
 } from '../Bibliotheque/useFichiers';
 import { FileConstraints, keepWithinMaxFiles } from '../upload/constants';
 import { AddFileFromLibHandler } from './AddFile';
 
 export type AddFromLibProps = {
-  items: FichierListe[];
-  setFilters: (filters: FichiersFilters) => void;
+  items: BibliothequeFichierListItem[];
+  onSearch: (search: string) => void;
   /** Formats acceptés (par défaut : tous ceux de la bibliothèque). */
   fileConstraints?: FileConstraints;
   onAddFileFromLib: AddFileFromLibHandler;
@@ -47,7 +46,7 @@ export const AddFromLib = (props: AddFromLibProps) => {
     fileConstraints,
     onAddFileFromLib,
     onClose,
-    setFilters,
+    onSearch,
   } = props;
 
   const [selectedFiles, setSelectedFiles] = useState<Option[] | undefined>();
@@ -103,7 +102,7 @@ export const AddFromLib = (props: AddFromLibProps) => {
           }}
           enableDisplayLimitValue={false}
           values={values}
-          onSearch={(search) => setFilters({ search, page: 1 })}
+          onSearch={onSearch}
           onChange={({ values }) => {
             setSelectedFiles(
               limitSelection(
@@ -113,7 +112,7 @@ export const AddFromLib = (props: AddFromLibProps) => {
                 fileConstraints
               )
             );
-            setFilters({ search: '', page: 1 });
+            onSearch('');
           }}
           placeholder={appLabels.placeholderRecherchezIntitule}
           isSearcheable
@@ -136,10 +135,10 @@ export const AddFromLib = (props: AddFromLibProps) => {
 };
 
 const AddFromLibConnected = (
-  props: Omit<AddFromLibProps, 'items' | 'setFilters'>
+  props: Omit<AddFromLibProps, 'items' | 'onSearch'>
 ) => {
-  const [filters, setFilters] = useState({ search: '', page: 1 });
-  const { data, isLoading } = useFichiers(filters);
+  const [search, setSearch] = useState('');
+  const { data, isLoading } = useFichiers(search);
 
   if (isLoading) {
     return (
@@ -150,7 +149,7 @@ const AddFromLibConnected = (
   }
 
   return data ? (
-    <AddFromLib {...props} {...data} setFilters={setFilters} />
+    <AddFromLib {...props} items={data.items} onSearch={setSearch} />
   ) : null;
 };
 

--- a/apps/app/src/referentiels/preuves/Bibliotheque/useEditPreuve.ts
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/useEditPreuve.ts
@@ -194,7 +194,8 @@ export const useUpdateBibliothequeFichier = () => {
           trpc,
         });
         queryClient.invalidateQueries({
-          queryKey: ['bibliotheque_fichier'],
+          queryKey:
+            trpc.collectivites.documents.listBibliothequeDocuments.pathKey(),
         });
         queryClient.invalidateQueries({
           queryKey: trpc.plans.fiches.ficheAnnexes.pathKey(),

--- a/apps/app/src/referentiels/preuves/Bibliotheque/useFichiers.ts
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/useFichiers.ts
@@ -1,71 +1,33 @@
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
-import { DBClient, useSupabase } from '@tet/api';
+import { RouterOutput, TRPCUseQueryResult, useTRPC } from '@tet/api';
 import { useCollectiviteId } from '@tet/api/collectivites';
 import { createClientWithoutCookieOptions } from '@tet/api/utils/supabase/browser-client';
 import { BibliothequeFichier } from './types';
 
-export const NB_ITEMS_PER_PAGE = 5;
+const BIBLIOTHEQUE_DISPLAY_LIMIT = 5;
 
-export type FichiersFilters = { search: string; page: number };
-export type FichierListe = Pick<
-  BibliothequeFichier,
-  'id' | 'filename' | 'filesize' | 'hash' | 'confidentiel'
->;
+export type BibliothequeDocuments =
+  RouterOutput['collectivites']['documents']['listBibliothequeDocuments'];
+export type BibliothequeFichierListItem =
+  BibliothequeDocuments['items'][number];
 
 export type FichierParHash = Pick<
   BibliothequeFichier,
   'id' | 'filename' | 'filesize' | 'hash'
 >;
 
-type FetchedData = { items: FichierListe[]; total: number };
-
-/**
- * Donne la liste de tous les fichiers de la collectivité, éventuellement
- * filtrée pour ne conserver que ceux dont le nom correspond à une chaîne de
- * recherche
- */
-export const useFichiers = (filters: FichiersFilters) => {
+export const useFichiers = (
+  search: string
+): TRPCUseQueryResult<BibliothequeDocuments> => {
   const collectiviteId = useCollectiviteId();
-  const supabase = useSupabase();
+  const trpc = useTRPC();
 
-  return useQuery({
-    queryKey: ['bibliotheque_fichier', collectiviteId, filters],
-    queryFn: () =>
-      collectiviteId ? fetch(supabase, collectiviteId, filters) : null,
-    placeholderData: keepPreviousData,
-  });
-};
-
-// charge les données
-const fetch = async (
-  supabase: DBClient,
-  collectiviteId: number,
-  filters: FichiersFilters
-): Promise<FetchedData> => {
-  const { search, page } = filters;
-
-  // lit la liste des fichiers de la collectivité
-  const query = supabase
-    .from('bibliotheque_fichier')
-    .select('id,filename,filesize,hash,confidentiel', { count: 'exact' })
-    .eq('collectivite_id', collectiviteId)
-    .order('filename', { ascending: true })
-    .range(NB_ITEMS_PER_PAGE * (page - 1), NB_ITEMS_PER_PAGE * page - 1);
-
-  // éventuellement filtrée par nom de fichier
-  if (search) {
-    query.ilike('filename', `%${search}%`);
-  }
-
-  const { data, count, error } = await query;
-  if (error) {
-    throw new Error(error.message);
-  }
-
-  // `public.bibliotheque_fichier` est une vue : Postgres rend toutes ses
-  // colonnes nullables dans les types générés, y compris celles que la table
-  // sous-jacente déclare NOT NULL.
-  return { items: (data ?? []) as FichierListe[], total: count ?? 0 };
+  return useQuery(
+    trpc.collectivites.documents.listBibliothequeDocuments.queryOptions(
+      { collectiviteId, search, limit: BIBLIOTHEQUE_DISPLAY_LIMIT },
+      { placeholderData: keepPreviousData }
+    )
+  );
 };
 
 /**


### PR DESCRIPTION
La modale « ajouter depuis la bibliothèque » lit sa liste par `collectivites.documents.listBibliothequeDocuments` (#5051) au lieu de la vue PostgREST `bibliotheque_fichier`. La liste suit donc les droits de lecture du backend, ceux de `getDownloadUrl`.

Plan : `docs/plans/2026-09-10-001-refactor-cles-requete-litterales-plan.md` (compound-knowledge-db), PR 6.

**Prérequis de déploiement : le backend de #5051 doit être en ligne avant ce front**, sinon la modale appelle une procédure inconnue.

## Changements de comportement

| Profil ou cas | Avant (RLS de la vue) | Après (backend) |
|---|---|---|
| Compte ADEME non vérifié | rien | non confidentiels ; `FORBIDDEN` sur une restreinte |
| Super admin en mode activé | non confidentiels | tout |
| Auditeur d'un audit non démarré ou clos depuis moins de 15 jours | non confidentiels ; rien sur une restreinte | tout |
| Support sans mode super admin, collectivité restreinte | non confidentiels | `FORBIDDEN`, sans effet visible : il n'ouvre pas la modale |
| Recherche contenant `%` ou `_` | jokers | caractères pris littéralement |

Inchangé : les cinq premiers fichiers par nom, la recherche par nom, et les autres profils.

## Arbitrages

| Sujet | Choix |
|---|---|
| Invalidations | le dépôt et la mise à jour d'un fichier invalident `listBibliothequeDocuments.pathKey()` dans cette même PR, sinon la liste resterait périmée |
| `getFilesPerHash` | reste sur PostgREST ; la PR 8 le remplace par la réponse de `createUploadToken` |

## Tests

`nx test app`. Vérification manuelle : chercher dans la modale, espaces seuls compris ; déposer un fichier puis rouvrir la modale ; renommer un fichier et basculer sa confidentialité.
