### PR TITLE
refactor(documents): détecte les doublons au dépôt par la demande de jeton

### DIFF
--- a/apps/app/src/collectivites/documents/upload/use-upload-file.ts
+++ b/apps/app/src/collectivites/documents/upload/use-upload-file.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useTRPC } from '@tet/api';
+import { RouterOutput, useTRPC } from '@tet/api';
 import { DocumentHash } from '@tet/domain/collectivites';
 import { uploadToStorage } from './upload-to-storage';
 
@@ -11,7 +11,14 @@ type UploadFileArgs = {
   onProgress?: (percent: number) => void;
 };
 
-export type UploadFile = (args: UploadFileArgs) => Promise<number>;
+type UploadDecision =
+  RouterOutput['collectivites']['documents']['createUploadToken'];
+
+export type UploadFileResult =
+  | Extract<UploadDecision, { kind: 'alreadyInBibliotheque' }>
+  | { kind: 'uploaded'; fichierId: number };
+
+export type UploadFile = (args: UploadFileArgs) => Promise<UploadFileResult>;
 
 export const useUploadFile = (): UploadFile => {
   const trpc = useTRPC();
@@ -35,7 +42,7 @@ export const useUploadFile = (): UploadFile => {
   return async ({ collectiviteId, file, hash, signal, onProgress }) => {
     const uploadDecision = await createUploadToken({ collectiviteId, hash });
     if (uploadDecision.kind === 'alreadyInBibliotheque') {
-      return uploadDecision.fichierId;
+      return uploadDecision;
     }
 
     await uploadToStorage({
@@ -52,6 +59,6 @@ export const useUploadFile = (): UploadFile => {
       filename: file.name,
       hash,
     });
-    return fichier.id;
+    return { kind: 'uploaded', fichierId: fichier.id };
   };
 };

--- a/apps/app/src/referentiels/audits/cloture/data/use-upload-audit-report.ts
+++ b/apps/app/src/referentiels/audits/cloture/data/use-upload-audit-report.ts
@@ -102,7 +102,7 @@ export const useUploadAuditReport = (
     uploadAbortRef.current = controller;
     setUploadingReport({ filename: file.name, progress: 0 });
     try {
-      const fichierId = await uploadFile({
+      const { fichierId } = await uploadFile({
         collectiviteId,
         file,
         hash: await hashFile(file),

--- a/apps/app/src/referentiels/preuves/AddPreuveModal/AddFile.spec.tsx
+++ b/apps/app/src/referentiels/preuves/AddPreuveModal/AddFile.spec.tsx
@@ -1,12 +1,21 @@
 /// <reference types="vitest/globals" />
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { toDocumentHash } from '@tet/domain/collectivites';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { AddFile } from './AddFile';
+import { FileUploadItem } from './FileItem';
 import { UploadStatusCode } from './types';
+
+const HASH = toDocumentHash('a'.repeat(64));
 
 const onAddFileFromLib = vi.fn();
 const onClose = vi.fn();
 const onDuplicatedDocumentsAdded = vi.fn();
+
+const { fileUploadItems } = vi.hoisted(() => {
+  const fileUploadItems: { current: FileUploadItem[] } = { current: [] };
+  return { fileUploadItems };
+});
 
 vi.mock('@tet/api/collectivites', () => ({
   useCollectiviteId: () => 1,
@@ -18,22 +27,32 @@ vi.mock('../Bibliotheque/useEditPreuve', () => ({
 
 vi.mock('./use-file-upload-list', () => ({
   useFileUploadList: () => ({
-    items: [
-      {
-        file: new File([''], 'nouveau nom.pdf', { type: 'application/pdf' }),
-        status: {
-          code: UploadStatusCode.duplicated,
-          fichierId: 1,
-          filename: 'nom-original.pdf',
-          hash: 'hash-1',
-        },
-      },
-    ],
+    items: fileUploadItems.current,
     onDropFiles: vi.fn(),
-    onStatusChange: vi.fn(),
     onDismissItem: vi.fn(),
   }),
 }));
+
+const duplicatedItem: FileUploadItem = {
+  id: 'item-1',
+  file: new File([''], 'nouveau nom.pdf', { type: 'application/pdf' }),
+  status: {
+    code: UploadStatusCode.duplicated,
+    fichierId: 1,
+    filename: 'nom-original.pdf',
+    hash: HASH,
+  },
+};
+
+const preparingItem: FileUploadItem = {
+  id: 'item-2',
+  file: new File([''], 'en cours.pdf', { type: 'application/pdf' }),
+  status: {
+    code: UploadStatusCode.preparing,
+    hash: HASH,
+    abort: vi.fn(),
+  },
+};
 
 describe('AddFile duplicate notice', () => {
   beforeEach(() => {
@@ -42,6 +61,7 @@ describe('AddFile duplicate notice', () => {
   });
 
   test('forwards duplicated files after confirmation', async () => {
+    fileUploadItems.current = [duplicatedItem];
     render(
       <AddFile
         docType="annexe"
@@ -58,12 +78,28 @@ describe('AddFile duplicate notice', () => {
     });
     expect(onDuplicatedDocumentsAdded).toHaveBeenCalledWith([
       {
-        hash: 'hash-1',
+        hash: HASH,
         preuveId: 42,
         preuveType: 'annexe',
         storedFilenameKept: true,
       },
     ]);
     expect(onClose).toHaveBeenCalled();
+  });
+
+  test("désactive l'ajout tant qu'un fichier est encore en préparation", () => {
+    fileUploadItems.current = [duplicatedItem, preparingItem];
+    render(
+      <AddFile
+        docType="annexe"
+        onAddFileFromLib={onAddFileFromLib}
+        onClose={onClose}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Ajouter' })).toHaveProperty(
+      'disabled',
+      true
+    );
   });
 });

--- a/apps/app/src/referentiels/preuves/AddPreuveModal/AddFile.stories.tsx
+++ b/apps/app/src/referentiels/preuves/AddPreuveModal/AddFile.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { toDocumentHash } from '@tet/domain/collectivites';
 import { action } from 'storybook/actions';
 import type { FileConstraints } from '../upload/constants';
 import { AddFile } from './AddFile';
@@ -130,7 +131,7 @@ export const DejaDansLaBibliotheque: Story = {
           code: UploadStatusCode.duplicated,
           fichierId: 1,
           filename: 'deliberation.pdf',
-          hash: 'hash-1',
+          hash: toDocumentHash('1'.repeat(64)),
         },
       },
       {
@@ -139,7 +140,7 @@ export const DejaDansLaBibliotheque: Story = {
           code: UploadStatusCode.duplicated,
           fichierId: 2,
           filename: 'budget prévisionnel.xls',
-          hash: 'hash-2',
+          hash: toDocumentHash('2'.repeat(64)),
         },
       },
     ],
@@ -158,7 +159,7 @@ export const TeleversementAbouti: Story = {
         status: {
           code: UploadStatusCode.completed,
           fichierId: 3,
-          hash: 'hash-3',
+          hash: toDocumentHash('3'.repeat(64)),
         },
       },
     ],

--- a/apps/app/src/referentiels/preuves/AddPreuveModal/AddFile.tsx
+++ b/apps/app/src/referentiels/preuves/AddPreuveModal/AddFile.tsx
@@ -21,10 +21,11 @@ import {
   AddedDuplicatedDocument,
   DocType,
   DuplicatedDocumentPreuveType,
+  isUploadInFlight,
   OnDuplicatedDocumentsAdded,
   UploadStatusCode,
   UploadStatusCompleted,
-  UploadStatusDuplicated,
+  ValidUploadStatus,
 } from './types';
 import { useFileUploadList } from './use-file-upload-list';
 
@@ -35,8 +36,6 @@ export type AddedPreuveResult = {
 export type AddFileFromLibHandler = (
   fichierId: number
 ) => Promise<AddedPreuveResult | void> | AddedPreuveResult | void;
-
-type ValidUploadStatus = UploadStatusCompleted | UploadStatusDuplicated;
 
 type ValidFileItem = FileUploadItem & {
   status: ValidUploadStatus;
@@ -128,7 +127,10 @@ export const AddFile = (props: AddFileProps) => {
   });
 
   const validFiles = currentSelection.filter(isValidFileItem);
-  const isDisabled = !validFiles?.length;
+  const hasUploadInFlight = currentSelection.some(({ status }) =>
+    isUploadInFlight(status)
+  );
+  const isDisabled = validFiles.length === 0 || hasUploadInFlight;
 
   const submitValidFile = async ({
     file,

--- a/apps/app/src/referentiels/preuves/AddPreuveModal/FileItem.spec.tsx
+++ b/apps/app/src/referentiels/preuves/AddPreuveModal/FileItem.spec.tsx
@@ -1,6 +1,9 @@
 import { render, screen } from '@testing-library/react';
+import { toDocumentHash } from '@tet/domain/collectivites';
 import { FileItem } from './FileItem';
 import { UploadStatusCode } from './types';
+
+const HASH = toDocumentHash('a'.repeat(64));
 
 const createMockFile = (name: string, size: number): File => {
   const file = new File([''], name, { type: 'application/pdf' });
@@ -19,7 +22,7 @@ describe('FileItem duplicate message', () => {
             code: UploadStatusCode.duplicated,
             fichierId: 1,
             filename: 'nom-original.pdf',
-            hash: 'hash-1',
+            hash: HASH,
           },
         }}
       />
@@ -42,7 +45,7 @@ describe('FileItem duplicate message', () => {
             code: UploadStatusCode.duplicated,
             fichierId: 1,
             filename: 'nom-original.pdf',
-            hash: 'hash-1',
+            hash: HASH,
           },
         }}
       />

--- a/apps/app/src/referentiels/preuves/AddPreuveModal/filesToUploadList.tsx
+++ b/apps/app/src/referentiels/preuves/AddPreuveModal/filesToUploadList.tsx
@@ -1,5 +1,4 @@
 import { DocumentHash } from '@tet/domain/collectivites';
-import { FichierParHash, getFilesPerHash } from '../Bibliotheque/useFichiers';
 import {
   DEFAULT_FILE_CONSTRAINTS,
   FileConstraints,
@@ -7,33 +6,19 @@ import {
 } from '../upload/constants';
 import { hashFile } from '@/app/collectivites/documents/upload/hash-file.utils';
 import { validateFile } from '../upload/validate-file';
-import {
-  UploadErrorCode,
-  UploadStatusCode,
-  UploadStatusDuplicated,
-  UploadStatusFailed,
-} from './types';
+import { UploadErrorCode, UploadStatusCode, UploadStatusFailed } from './types';
 
 export type PreparedFile =
   | { kind: 'toUpload'; file: File; hash: DocumentHash }
-  | {
-      kind: 'settled';
-      file: File;
-      status: UploadStatusFailed | UploadStatusDuplicated;
-    };
+  | { kind: 'rejected'; file: File; status: UploadStatusFailed };
 
 export const filesToUploadList = async (
-  collectiviteId: number | null,
-  files: FileList | null,
+  files: ArrayLike<File>,
   constraints: FileConstraints = DEFAULT_FILE_CONSTRAINTS
 ): Promise<PreparedFile[]> => {
-  if (!files || !collectiviteId) {
-    return [];
-  }
-
   // La limite du contexte s'applique avant le hachage : un glisser-déposer de
   // trente fichiers pour un contexte qui n'en accepte qu'un ne doit pas les
-  // hacher tous ni les chercher tous dans la bibliothèque.
+  // hacher tous.
   const filesToProcess = keepWithinMaxFiles(
     Array.from(files),
     constraints.maxFiles
@@ -47,43 +32,20 @@ export const filesToUploadList = async (
     }))
   );
 
-  // récupère la liste des éventuels doublons (fichiers déjà téléversés ayant la même clé)
-  const hashes = filesWithHash.map(({ hash }) => hash);
-  const duplicatedFiles = await getFilesPerHash(collectiviteId, hashes);
-
   return filesWithHash.map(({ file, hash }) => {
-    // La validation précède la détection de doublon : un fichier déjà présent
-    // dans la bibliothèque reste refusé s'il ne respecte pas les contraintes du
-    // contexte de dépôt (le PDF seul pour un dossier PCAET, par exemple).
     const validationError = validateFile(file, constraints);
     if (validationError) {
-      return toFailed(file, UploadErrorCode[validationError]);
-    }
-
-    const duplicatedFile = duplicatedFiles?.find((f) => f.hash === hash);
-    if (duplicatedFile) {
-      return toDuplicated(file, duplicatedFile);
+      return toRejected(file, UploadErrorCode[validationError]);
     }
     return { kind: 'toUpload', file, hash };
   });
 };
 
-const toFailed = (file: File, error: UploadErrorCode): PreparedFile => ({
-  kind: 'settled',
+const toRejected = (file: File, error: UploadErrorCode): PreparedFile => ({
+  kind: 'rejected',
   file,
   status: {
     code: UploadStatusCode.failed,
     error,
-  },
-});
-
-const toDuplicated = (file: File, fichier: FichierParHash): PreparedFile => ({
-  kind: 'settled',
-  file,
-  status: {
-    code: UploadStatusCode.duplicated,
-    fichierId: fichier.id,
-    filename: fichier.filename,
-    hash: fichier.hash,
   },
 });

--- a/apps/app/src/referentiels/preuves/AddPreuveModal/types.ts
+++ b/apps/app/src/referentiels/preuves/AddPreuveModal/types.ts
@@ -47,7 +47,7 @@ export type UploadStatusDuplicated = {
   code: UploadStatusCode.duplicated;
   fichierId: number;
   filename: string;
-  hash: string;
+  hash: DocumentHash;
 };
 
 export type UploadStatus =
@@ -56,6 +56,14 @@ export type UploadStatus =
   | UploadStatusCompleted
   | UploadStatusDuplicated
   | UploadStatusFailed;
+
+export type ValidUploadStatus = UploadStatusCompleted | UploadStatusDuplicated;
+
+export const isUploadInFlight = (
+  status: UploadStatus
+): status is UploadStatusPreparing | UploadStatusRunning =>
+  status.code === UploadStatusCode.preparing ||
+  status.code === UploadStatusCode.running;
 
 /** type des documents attendus */
 export type DocType =

--- a/apps/app/src/referentiels/preuves/AddPreuveModal/upload-file-result-to-status.ts
+++ b/apps/app/src/referentiels/preuves/AddPreuveModal/upload-file-result-to-status.ts
@@ -1,0 +1,33 @@
+import { UploadFileResult } from '@/app/collectivites/documents/upload/use-upload-file';
+import { DocumentHash } from '@tet/domain/collectivites';
+import { match } from 'ts-pattern';
+import {
+  UploadStatusCode,
+  UploadStatusCompleted,
+  UploadStatusDuplicated,
+  ValidUploadStatus,
+} from './types';
+
+export const uploadFileResultToStatus = (
+  uploadResult: UploadFileResult,
+  hash: DocumentHash
+): ValidUploadStatus =>
+  match(uploadResult)
+    .with(
+      { kind: 'alreadyInBibliotheque' },
+      ({ fichierId, filename }): UploadStatusDuplicated => ({
+        code: UploadStatusCode.duplicated,
+        fichierId,
+        filename,
+        hash,
+      })
+    )
+    .with(
+      { kind: 'uploaded' },
+      ({ fichierId }): UploadStatusCompleted => ({
+        code: UploadStatusCode.completed,
+        fichierId,
+        hash,
+      })
+    )
+    .exhaustive();

--- a/apps/app/src/referentiels/preuves/AddPreuveModal/use-file-upload-list.spec.ts
+++ b/apps/app/src/referentiels/preuves/AddPreuveModal/use-file-upload-list.spec.ts
@@ -1,0 +1,72 @@
+import { act, renderHook } from '@testing-library/react';
+import { toDocumentHash } from '@tet/domain/collectivites';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { UploadErrorCode, UploadStatus, UploadStatusCode } from './types';
+import { useFileUploadList } from './use-file-upload-list';
+
+const HASH = toDocumentHash(
+  'ec07d0538e44a333b23b936c9a4ba37fbd211c6272e632d2173b6abe102a0482'
+);
+
+const { uploadFile, hashFile } = vi.hoisted(() => ({
+  uploadFile: vi.fn(),
+  hashFile: vi.fn(),
+}));
+
+vi.mock('@/app/collectivites/documents/upload/use-upload-file', () => ({
+  useUploadFile: () => uploadFile,
+}));
+vi.mock('@/app/collectivites/documents/upload/hash-file.utils', () => ({
+  hashFile,
+}));
+
+const dropPdfAndListStatuses = async (): Promise<UploadStatus[]> => {
+  const { result } = renderHook(() => useFileUploadList({ collectiviteId: 1 }));
+  const pdf = new File(['%PDF'], 'rapport.pdf', { type: 'application/pdf' });
+
+  await act(async () => {
+    await result.current.onDropFiles([pdf]);
+  });
+
+  return result.current.items.map(({ status }) => status);
+};
+
+describe('useFileUploadList', () => {
+  beforeEach(() => {
+    uploadFile.mockReset();
+    hashFile.mockResolvedValue(HASH);
+  });
+
+  it('signale en doublon, sous son nom enregistré, un fichier que la demande de jeton trouve déjà dans la bibliothèque', async () => {
+    uploadFile.mockResolvedValue({
+      kind: 'alreadyInBibliotheque',
+      fichierId: 42,
+      filename: 'rapport-existant.pdf',
+    });
+
+    expect(await dropPdfAndListStatuses()).toEqual([
+      {
+        code: UploadStatusCode.duplicated,
+        fichierId: 42,
+        filename: 'rapport-existant.pdf',
+        hash: HASH,
+      },
+    ]);
+  });
+
+  it('marque téléversé un fichier ajouté à la bibliothèque', async () => {
+    uploadFile.mockResolvedValue({ kind: 'uploaded', fichierId: 7 });
+
+    expect(await dropPdfAndListStatuses()).toEqual([
+      { code: UploadStatusCode.completed, fichierId: 7, hash: HASH },
+    ]);
+  });
+
+  it('marque en échec de téléversement un fichier dont la demande de jeton échoue', async () => {
+    uploadFile.mockRejectedValue(new Error('SIGN_UPLOAD_ERROR'));
+
+    expect(await dropPdfAndListStatuses()).toEqual([
+      { code: UploadStatusCode.failed, error: UploadErrorCode.uploadError },
+    ]);
+  });
+});

--- a/apps/app/src/referentiels/preuves/AddPreuveModal/use-file-upload-list.ts
+++ b/apps/app/src/referentiels/preuves/AddPreuveModal/use-file-upload-list.ts
@@ -4,17 +4,23 @@ import { FileConstraints, keepWithinMaxFiles } from '../upload/constants';
 import { useUploadFile } from '@/app/collectivites/documents/upload/use-upload-file';
 import { FileUploadItem } from './FileItem';
 import { filesToUploadList, PreparedFile } from './filesToUploadList';
-import { UploadErrorCode, UploadStatus, UploadStatusCode } from './types';
+import {
+  isUploadInFlight,
+  UploadErrorCode,
+  UploadStatus,
+  UploadStatusCode,
+} from './types';
+import { uploadFileResultToStatus } from './upload-file-result-to-status';
 
 type UseFileUploadListInput = {
-  collectiviteId: number | undefined;
+  collectiviteId: number;
   initialItems?: Array<FileUploadItem>;
   constraints?: FileConstraints;
 };
 
 type UseFileUploadListResult = {
   items: Array<FileUploadItem>;
-  onDropFiles: (files: FileList | null) => Promise<void>;
+  onDropFiles: (files: ArrayLike<File> | null) => Promise<void>;
   onDismissItem: (itemId: string) => void;
 };
 
@@ -36,10 +42,7 @@ const isAbortError = (error: unknown): boolean =>
   error instanceof DOMException && error.name === 'AbortError';
 
 const abortWhenInFlight = ({ status }: FileUploadItem): void => {
-  const isInFlight =
-    status.code === UploadStatusCode.preparing ||
-    status.code === UploadStatusCode.running;
-  if (isInFlight) {
+  if (isUploadInFlight(status)) {
     status.abort();
   }
 };
@@ -58,7 +61,7 @@ const toEvictedItems = (
 
 const toListedFile = (prepared: PreparedFile): ListedFile => {
   const id = crypto.randomUUID();
-  if (prepared.kind === 'settled') {
+  if (prepared.kind === 'rejected') {
     return {
       kind: 'settled',
       item: { id, file: prepared.file, status: prepared.status },
@@ -104,11 +107,10 @@ export const useFileUploadList = ({
     hash,
     controller,
   }: FileToUpload): Promise<void> => {
-    if (!collectiviteId) return;
     const abort = (): void => controller.abort();
 
     try {
-      const fichierId = await uploadFile({
+      const uploadResult = await uploadFile({
         collectiviteId,
         file: item.file,
         hash,
@@ -125,11 +127,7 @@ export const useFileUploadList = ({
         removeItem(item.id);
         return;
       }
-      setStatus(item.id, {
-        code: UploadStatusCode.completed,
-        fichierId,
-        hash,
-      });
+      setStatus(item.id, uploadFileResultToStatus(uploadResult, hash));
     } catch (error) {
       if (isAbortError(error)) {
         removeItem(item.id);
@@ -142,11 +140,11 @@ export const useFileUploadList = ({
     }
   };
 
-  const onDropFiles = async (files: FileList | null): Promise<void> => {
-    if (!files || !collectiviteId) return;
-    const listedFiles = (
-      await filesToUploadList(collectiviteId, files, constraints)
-    ).map(toListedFile);
+  const onDropFiles = async (files: ArrayLike<File> | null): Promise<void> => {
+    if (!files) return;
+    const listedFiles = (await filesToUploadList(files, constraints)).map(
+      toListedFile
+    );
 
     // Le glisser-déposer n'est pas bridé par l'attribut `multiple` : on borne la
     // liste cumulée, en gardant les derniers déposés (ceux qui remplacent).

--- a/apps/app/src/referentiels/preuves/Bibliotheque/useFichiers.ts
+++ b/apps/app/src/referentiels/preuves/Bibliotheque/useFichiers.ts
@@ -1,8 +1,6 @@
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { RouterOutput, TRPCUseQueryResult, useTRPC } from '@tet/api';
 import { useCollectiviteId } from '@tet/api/collectivites';
-import { createClientWithoutCookieOptions } from '@tet/api/utils/supabase/browser-client';
-import { BibliothequeFichier } from './types';
 
 const BIBLIOTHEQUE_DISPLAY_LIMIT = 5;
 
@@ -10,11 +8,6 @@ export type BibliothequeDocuments =
   RouterOutput['collectivites']['documents']['listBibliothequeDocuments'];
 export type BibliothequeFichierListItem =
   BibliothequeDocuments['items'][number];
-
-export type FichierParHash = Pick<
-  BibliothequeFichier,
-  'id' | 'filename' | 'filesize' | 'hash'
->;
 
 export const useFichiers = (
   search: string
@@ -28,30 +21,4 @@ export const useFichiers = (
       { placeholderData: keepPreviousData }
     )
   );
-};
-
-/**
- * Renvoie les fichiers correspondants au tableau de clés de hachage donné.
- * Permet de vérifier l'existence des fichiers pour éviter le téléversement de doublons.
- */
-export const getFilesPerHash = async (
-  collectiviteId: number,
-  hashes: string[]
-): Promise<FichierParHash[] | null> => {
-  // TODO: replace with `useSupabase()`
-  const supabase = createClientWithoutCookieOptions();
-
-  const query = supabase
-    .from('bibliotheque_fichier')
-    .select('id,filename,filesize,hash')
-    .eq('collectivite_id', collectiviteId)
-    .in('hash', hashes);
-
-  const { data, error } = await query;
-
-  if (error) {
-    return null;
-  }
-
-  return (data ?? null) as FichierParHash[] | null;
 };

--- a/e2e/tests/collectivite/documents/depot-par-jeton-signe.spec.ts
+++ b/e2e/tests/collectivite/documents/depot-par-jeton-signe.spec.ts
@@ -90,4 +90,58 @@ test.describe("Dépôt d'un document par jeton signé", () => {
       "un fichier déposé ne doit demander qu'un seul jeton"
     ).toHaveLength(1);
   });
+
+  test('un fichier déjà dans la bibliothèque est signalé sans repartir sur le réseau', async ({
+    page,
+    referentielScoresPom,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    referentiels,
+  }) => {
+    await gotoActionWithDocuments(referentielScoresPom);
+    await referentielScoresPom.uploadPreuveReglementaire(preuveReglementaireId);
+    await expect(referentielScoresPom.documentsPom.documentCard).toBeVisible();
+
+    const transfers: ObservedRequest[] = [];
+    const uploadTokenRequests: ObservedRequest[] = [];
+
+    page.on('request', (request) => {
+      const observed: ObservedRequest = {
+        url: request.url(),
+        method: request.method(),
+        headers: request.headers(),
+      };
+      if (observed.url.includes(RESUMABLE_SIGNED_PATH)) {
+        transfers.push(observed);
+      }
+      if (
+        observed.url.includes(DIRECT_OBJECT_PATH) &&
+        WRITING_METHODS.includes(observed.method)
+      ) {
+        transfers.push(observed);
+      }
+      if (observed.url.includes(UPLOAD_TOKEN_PROCEDURE)) {
+        uploadTokenRequests.push(observed);
+      }
+    });
+
+    await referentielScoresPom
+      .getPreuveReglementaireButtonLocator(preuveReglementaireId)
+      .click();
+    await referentielScoresPom.documentsPom.chooseTestDocument();
+
+    await expect(
+      referentielScoresPom.documentsPom.duplicateNotice
+    ).toBeVisible();
+
+    expect(
+      uploadTokenRequests,
+      'le doublon est reconnu par la demande de jeton, qui doit donc partir'
+    ).toHaveLength(1);
+    expect(
+      transfers,
+      `aucun octet ne doit repartir pour un doublon ; observées : ${transfers
+        .map(({ method, url }) => `${method} ${url}`)
+        .join(', ')}`
+    ).toHaveLength(0);
+  });
 });

--- a/e2e/tests/collectivite/documents/documents.pom.ts
+++ b/e2e/tests/collectivite/documents/documents.pom.ts
@@ -15,6 +15,8 @@ export class DocumentsPom {
   readonly editModalNameInput: Locator;
   readonly editModalSaveButton: Locator;
   readonly editModalCancelButton: Locator;
+  readonly addButton: Locator;
+  readonly duplicateNotice: Locator;
   readonly documentCard: Locator;
   readonly documentCardConfidentielIcon: Locator;
   readonly deleteButton: Locator;
@@ -34,6 +36,10 @@ export class DocumentsPom {
     this.editModalNameInput = page.getByRole('textbox');
     this.editModalSaveButton = page.getByRole('button', { name: 'Valider' });
     this.editModalCancelButton = page.getByRole('button', { name: 'Annuler' });
+    this.addButton = page.getByRole('button', { name: 'Ajouter' });
+    this.duplicateNotice = page.getByText(
+      'Ce document existe déjà dans votre bibliothèque'
+    );
     this.documentCard = page.locator('[data-test="carte-doc"]');
     this.documentCardConfidentielIcon = page.locator(
       '[data-test="carte-doc-confidentiel"]'
@@ -51,7 +57,11 @@ export class DocumentsPom {
     await this.setDocument(TEST_PDF_PATH, 'document_test.pdf');
   }
 
-  public async setDocument(filePath: string, filename: string) {
+  public async chooseTestDocument() {
+    await this.chooseDocument(TEST_PDF_PATH);
+  }
+
+  public async chooseDocument(filePath: string) {
     await this.fileTab.click();
     const [fileChooser] = await Promise.all([
       this.page.waitForEvent('filechooser'),
@@ -59,10 +69,12 @@ export class DocumentsPom {
     ]);
 
     await fileChooser.setFiles(filePath);
-    await expect(
-      this.page.getByRole('button', { name: 'Ajouter' })
-    ).toBeEnabled();
-    await this.page.getByRole('button', { name: 'Ajouter' }).click();
+  }
+
+  public async setDocument(filePath: string, filename: string) {
+    await this.chooseDocument(filePath);
+    await expect(this.addButton).toBeEnabled();
+    await this.addButton.click();
     await expect(this.page.getByText(filename).first()).toBeVisible();
   }
 


### PR DESCRIPTION
Le dépôt d'un fichier ne cherche plus les doublons dans la vue PostgREST `bibliotheque_fichier` : la réponse de `createUploadToken` (#5054) dit si le fichier est déjà dans la bibliothèque, et sous quel nom. Plus aucune lecture de `bibliotheque_fichier` ne part du front.

Plan : `docs/plans/2026-09-10-001-refactor-cles-requete-litterales-plan.md` (compound-knowledge-db), PR 8.

**Prérequis de déploiement : le backend de #5054 doit être en ligne avant ce front**, sinon aucun doublon n'est signalé et `filename` manque à la réponse.

## Changements de comportement

| | Avant | Après |
|---|---|---|
| Moment où un doublon apparaît | à la construction de la liste, avant tout dépôt | au démarrage de son dépôt : « en préparation » le temps de la demande de jeton, puis « doublon » |
| Bouton « Ajouter » | actif dès qu'un fichier est prêt, même si un autre est encore en cours (celui-là était alors perdu) | désactivé tant qu'un fichier est en préparation ou en cours de dépôt |
| Octets transférés pour un doublon | aucun | aucun |

## Arbitrages

| Sujet | Choix |
|---|---|
| Résultat du dépôt | `useUploadFile` rend une union ; `uploadFileResultToStatus` la traduit en statut `duplicated` ou `completed` par un `match(...).exhaustive()` |
| Rapport d'audit | un rapport déjà présent est rattaché au fichier existant sans le signaler, comme avant : `useUploadAuditReport` ne lit que `fichierId` |
| Avis PCAET | inchangé : `useUploadAvisFile` n'utilise pas le résultat |
| `collectiviteId` | obligatoire dans `useFileUploadList` : son seul appelant, `AddFile.tsx`, le tient de `useCollectiviteId()` |

## Tests

| Test | Vu rouge avec |
|---|---|
| `useFileUploadList` : doublon trouvé par le jeton → « doublon » sous le nom existant ; fichier ajouté → « téléversé » ; échec du jeton → « échec » | une traduction qui rend toujours « téléversé » |
| `AddFile` : « Ajouter » désactivé tant qu'un fichier est en préparation | l'ancien calcul du bouton |

`nx test app`. Vérification manuelle : déposer un fichier déjà présent dans la bibliothèque → « doublon » avec son nom existant ; déposer un rapport d'audit et un avis PCAET.
