### PR TITLE
chore(app): interdit les clés de requête littérales

### DIFF
--- a/apps/app/eslint.config.mjs
+++ b/apps/app/eslint.config.mjs
@@ -25,6 +25,24 @@ const eslintConfig = defineConfig([
   {
     files: ['**/*.ts', '**/*.tsx'],
     ignores: [
+      'src/collectivites/panier/data/useGetCollectivitePanierInfo.ts',
+      'src/referentiels/actions/action-documents.download-button.tsx',
+    ],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            "Property[key.name='queryKey'] > ArrayExpression > :matches(Literal, TemplateLiteral):first-child",
+          message:
+            'Clé de requête écrite à la main : tirer la clé du client tRPC (trpc.<domaine>.<procédure>.queryKey() ou queryOptions()).',
+        },
+      ],
+    },
+  },
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+    ignores: [
       'src/labels/**',
       '**/*.stories.tsx',
       '**/fixtures.tsx',


### PR DESCRIPTION
`apps/app` refuse en erreur une clé de requête écrite à la main : une `queryKey` dont le tableau commence par un littéral ou un gabarit. La clé se tire du client tRPC (`trpc.<domaine>.<procédure>.queryKey()` ou `queryOptions()`).

Plan : `docs/plans/2026-09-10-001-refactor-cles-requete-litterales-plan.md` (compound-knowledge-db), PR 11.

**À merger après la PR 6 du plan documents** (`2026-09-03-002`), qui réécrit `action-documents.download-button.tsx` et supprime ses clés `['zip-action']`. Avant le merge, retirer ce fichier de l'`ignores` : il ne restera que le panier.

```js
selector: "Property[key.name='queryKey'] > ArrayExpression > :matches(Literal, TemplateLiteral):first-child"
```

## Arbitrages

| Sujet | Choix |
|---|---|
| `useGetCollectivitePanierInfo.ts` | exempté : la lecture du panier reste sur PostgREST |
| `action-documents.download-button.tsx` | exempté tant que la PR 6 du plan documents n'est pas sur `main` ; l'exemption est retirée avant le merge |
| Formes non couvertes | une clé portée par une constante, une fabrique ou un paramètre ; la revue les couvre |

## Vérifications

| Cas | Résultat |
|---|---|
| fichier témoin : `queryKey: ['literal-key']`, ``queryKey: [`template-${id}`]``, `queryKey: buildKey(id)` | les deux premiers signalés, pas le troisième |
| les deux fichiers exemptés, exception retirée | 3 signalements |
| `nx run app:lint` | 0 erreur |
