### PR TITLE
Bloque la bascule CR pour les collectivités DROM

### DIFF
--- a/apps/app/src/labels/catalog.ts
+++ b/apps/app/src/labels/catalog.ts
@@ -1713,6 +1713,7 @@ export const appLabels = {
   referentielTeModeBlockedAuditEnCoursDescription: `Un audit est en cours. Attendez la fin de l'audit avant de basculer.`,
   referentielTeModeBlockedAuditDemandeDescription: `Une demande d'audit est en cours. Attendez la fin de l'audit avant de basculer.`,
   referentielTeModeBlockedSyndicatDescription: `La bascule n'est pas ouverte aux syndicats. Votre référentiel Économie Circulaire reste actif et modifiable.`,
+  referentielTeModeBlockedDromDescription: `La bascule n'est pas encore ouverte aux collectivités des DROM. Vos référentiels Climat Air Énergie et Économie Circulaire restent actifs et modifiables.`,
   referentielModeArchivedTitle: 'Référentiel archivé',
   referentielModeArchivedDescription:
     "Consultation seule — ce référentiel n'est plus modifiable.",

--- a/apps/app/src/referentiels/switch-to-te.banner/switch-to-te-blocked.banner.tsx
+++ b/apps/app/src/referentiels/switch-to-te.banner/switch-to-te-blocked.banner.tsx
@@ -19,6 +19,7 @@ const blockerTypeToDescription: Record<SwitchToTeBlocker['type'], string> = {
     appLabels.referentielTeModeBlockedAuditDemandeDescription,
   COLLECTIVITE_IS_SYNDICAT:
     appLabels.referentielTeModeBlockedSyndicatDescription,
+  COLLECTIVITE_IS_DROM: appLabels.referentielTeModeBlockedDromDescription,
 };
 
 export const SwitchToTeBlockedBanner = ({

--- a/apps/backend/src/referentiels/switch-to-te/get-switch-to-te-status.output.ts
+++ b/apps/backend/src/referentiels/switch-to-te/get-switch-to-te-status.output.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 const switchToTeBlockerSchema = z.discriminatedUnion('type', [
   z.object({ type: z.literal('COT_ACTIVE') }),
   z.object({ type: z.literal('COLLECTIVITE_IS_SYNDICAT') }),
+  z.object({ type: z.literal('COLLECTIVITE_IS_DROM') }),
   z.object({
     type: z.literal('AUDIT_IN_PROGRESS'),
     referentiel: z.enum(referentielIdEnumValues),

--- a/apps/backend/src/referentiels/switch-to-te/switch-to-te.errors.ts
+++ b/apps/backend/src/referentiels/switch-to-te/switch-to-te.errors.ts
@@ -14,6 +14,7 @@ const specificErrors = [
   'NOT_ELIGIBLE',
   'COT_ACTIVE',
   'COLLECTIVITE_IS_SYNDICAT',
+  'COLLECTIVITE_IS_DROM',
   'AUDIT_REQUEST_IN_PROGRESS',
   'AUDIT_IN_PROGRESS',
   'PRE_SWITCH_SNAPSHOT_FAILED',
@@ -51,6 +52,11 @@ export const switchToTeTrpcErrorEntries = {
     code: 'FORBIDDEN',
     message:
       "La bascule n'est pas possible : les collectivités de type syndicat ne sont pas éligibles au référentiel TE",
+  },
+  COLLECTIVITE_IS_DROM: {
+    code: 'FORBIDDEN',
+    message:
+      "La bascule n'est pas possible : les collectivités des DROM ne sont pas encore éligibles au référentiel TE",
   },
   AUDIT_REQUEST_IN_PROGRESS: {
     code: 'CONFLICT',

--- a/apps/backend/src/referentiels/switch-to-te/switch-to-te.router.e2e-spec.ts
+++ b/apps/backend/src/referentiels/switch-to-te/switch-to-te.router.e2e-spec.ts
@@ -536,6 +536,27 @@ describe('SwitchToTeRouter', () => {
       });
     });
 
+    test('BLOCKED (COLLECTIVITE_IS_DROM) pour une collectivité en DROM', async () => {
+      const { collectiviteId, adminCaller } = await setupEligibleCollectivite(
+        {
+          cae: { display: true, mode: 'write' },
+          eci: { display: false, mode: 'archived' },
+          te: { display: true, mode: 'readonly' },
+        },
+        // Guadeloupe : drom = true (data_layer/seed/imports/01-region.sql)
+        { regionCode: '01' }
+      );
+
+      const status = await adminCaller.referentiels.getSwitchToTeStatus({
+        collectiviteId,
+      });
+
+      expect(status).toEqual({
+        value: 'BLOCKED',
+        blockers: [{ type: 'COLLECTIVITE_IS_DROM' }],
+      });
+    });
+
     test('BLOCKED (AUDIT_IN_PROGRESS) quand un audit est en cours', async () => {
       const { collectiviteId, adminCaller } = await setupEligibleCollectivite({
         cae: { display: true, mode: 'write' },

--- a/apps/backend/src/referentiels/switch-to-te/switch-to-te.rules.spec.ts
+++ b/apps/backend/src/referentiels/switch-to-te/switch-to-te.rules.spec.ts
@@ -133,6 +133,7 @@ describe('getSwitchToTeBlockers', () => {
       getSwitchToTeBlockers({
         cotActif: true,
         isSyndicat: false,
+        isDrom: false,
         referentielsEnWrite: [],
       })
     ).toEqual([{ type: 'COT_ACTIVE' }]);
@@ -143,9 +144,21 @@ describe('getSwitchToTeBlockers', () => {
       getSwitchToTeBlockers({
         cotActif: false,
         isSyndicat: true,
+        isDrom: false,
         referentielsEnWrite: [],
       })
     ).toEqual([{ type: 'COLLECTIVITE_IS_SYNDICAT' }]);
+  });
+
+  test('collectivité DROM seule → un blocage COLLECTIVITE_IS_DROM', () => {
+    expect(
+      getSwitchToTeBlockers({
+        cotActif: false,
+        isSyndicat: false,
+        isDrom: true,
+        referentielsEnWrite: [],
+      })
+    ).toEqual([{ type: 'COLLECTIVITE_IS_DROM' }]);
   });
 
   test('audit en cours sur cae → AUDIT_IN_PROGRESS', () => {
@@ -153,6 +166,7 @@ describe('getSwitchToTeBlockers', () => {
       getSwitchToTeBlockers({
         cotActif: false,
         isSyndicat: false,
+        isDrom: false,
         referentielsEnWrite: [{ referentiel: 'cae', status: 'audit_en_cours' }],
       })
     ).toEqual([{ type: 'AUDIT_IN_PROGRESS', referentiel: 'cae' }]);
@@ -163,6 +177,7 @@ describe('getSwitchToTeBlockers', () => {
       getSwitchToTeBlockers({
         cotActif: false,
         isSyndicat: false,
+        isDrom: false,
         referentielsEnWrite: [
           { referentiel: 'eci', status: 'demande_envoyee' },
         ],
@@ -175,6 +190,7 @@ describe('getSwitchToTeBlockers', () => {
       getSwitchToTeBlockers({
         cotActif: false,
         isSyndicat: false,
+        isDrom: false,
         referentielsEnWrite: [
           { referentiel: 'cae', status: 'audit_valide' },
           { referentiel: 'eci', status: 'non_demandee' },
@@ -183,11 +199,12 @@ describe('getSwitchToTeBlockers', () => {
     ).toEqual([]);
   });
 
-  test('multi-blocages : syndicat puis COT puis cae avant eci', () => {
+  test('multi-blocages : syndicat puis DROM puis COT puis cae avant eci', () => {
     expect(
       getSwitchToTeBlockers({
         cotActif: true,
         isSyndicat: true,
+        isDrom: true,
         referentielsEnWrite: [
           { referentiel: 'cae', status: 'audit_en_cours' },
           { referentiel: 'eci', status: 'demande_envoyee' },
@@ -195,6 +212,7 @@ describe('getSwitchToTeBlockers', () => {
       })
     ).toEqual([
       { type: 'COLLECTIVITE_IS_SYNDICAT' },
+      { type: 'COLLECTIVITE_IS_DROM' },
       { type: 'COT_ACTIVE' },
       { type: 'AUDIT_IN_PROGRESS', referentiel: 'cae' },
       { type: 'AUDIT_REQUEST_IN_PROGRESS', referentiel: 'eci' },
@@ -208,6 +226,7 @@ describe('getSwitchToTeBlockers', () => {
       getSwitchToTeBlockers({
         cotActif: false,
         isSyndicat: false,
+        isDrom: false,
         referentielsEnWrite: [],
       })
     ).toEqual([]);

--- a/apps/backend/src/referentiels/switch-to-te/switch-to-te.rules.ts
+++ b/apps/backend/src/referentiels/switch-to-te/switch-to-te.rules.ts
@@ -58,19 +58,21 @@ export function canSwitchToTe(
 export type SwitchToTeBlocker =
   | { type: 'COT_ACTIVE' }
   | { type: 'COLLECTIVITE_IS_SYNDICAT' }
+  | { type: 'COLLECTIVITE_IS_DROM' }
   | { type: 'AUDIT_IN_PROGRESS'; referentiel: ReferentielId }
   | { type: 'AUDIT_REQUEST_IN_PROGRESS'; referentiel: ReferentielId };
 
 /**
  * Détermine les blocages à la bascule vers TE à partir de l'état fourni.
  *
- * Ordre des blocages : syndicat puis COT (niveau collectivité), puis par
- * référentiel dans l'ordre fourni (`cae` avant `eci`). Un audit en cours prime
- * sur une simple demande envoyée pour un même référentiel.
+ * Ordre des blocages : syndicat puis DROM puis COT (niveau collectivité),
+ * puis par référentiel dans l'ordre fourni (`cae` avant `eci`). Un audit en
+ * cours prime sur une simple demande envoyée pour un même référentiel.
  */
 export function getSwitchToTeBlockers(input: {
   cotActif: boolean;
   isSyndicat: boolean;
+  isDrom: boolean;
   referentielsEnWrite: {
     referentiel: ReferentielId;
     status: ParcoursLabellisationStatus;
@@ -80,6 +82,10 @@ export function getSwitchToTeBlockers(input: {
 
   if (input.isSyndicat) {
     blockers.push({ type: 'COLLECTIVITE_IS_SYNDICAT' });
+  }
+
+  if (input.isDrom) {
+    blockers.push({ type: 'COLLECTIVITE_IS_DROM' });
   }
 
   if (input.cotActif) {

--- a/apps/backend/src/referentiels/switch-to-te/switch-to-te.service.ts
+++ b/apps/backend/src/referentiels/switch-to-te/switch-to-te.service.ts
@@ -64,6 +64,7 @@ export class SwitchToTeService {
   > = {
     COT_ACTIVE: SwitchToTeErrorEnum.COT_ACTIVE,
     COLLECTIVITE_IS_SYNDICAT: SwitchToTeErrorEnum.COLLECTIVITE_IS_SYNDICAT,
+    COLLECTIVITE_IS_DROM: SwitchToTeErrorEnum.COLLECTIVITE_IS_DROM,
     AUDIT_REQUEST_IN_PROGRESS: SwitchToTeErrorEnum.AUDIT_REQUEST_IN_PROGRESS,
     AUDIT_IN_PROGRESS: SwitchToTeErrorEnum.AUDIT_IN_PROGRESS,
   };
@@ -81,35 +82,47 @@ export class SwitchToTeService {
       (referentiel) => prefs[referentiel].mode === 'write'
     );
 
-    const [cotActif, isSyndicat, referentielsEnWrite] = await Promise.all([
-      this.getLabellisationService.isCotActif(collectiviteId),
-      this.isSyndicat(collectiviteId),
-      Promise.all(
-        referentielsToCheck.map(async (referentiel) => {
-          const demandeEtAudit =
-            await this.getLabellisationService.getCurrentDemandeAndAudit(
-              collectiviteId,
-              referentiel
-            );
-          return {
-            referentiel,
-            status: getParcoursLabellisationStatus(demandeEtAudit),
-          };
-        })
-      ),
-    ]);
+    const [cotActif, { isSyndicat, isDrom }, referentielsEnWrite] =
+      await Promise.all([
+        this.getLabellisationService.isCotActif(collectiviteId),
+        this.getEligibiliteType(collectiviteId),
+        Promise.all(
+          referentielsToCheck.map(async (referentiel) => {
+            const demandeEtAudit =
+              await this.getLabellisationService.getCurrentDemandeAndAudit(
+                collectiviteId,
+                referentiel
+              );
+            return {
+              referentiel,
+              status: getParcoursLabellisationStatus(demandeEtAudit),
+            };
+          })
+        ),
+      ]);
 
-    return getSwitchToTeBlockers({ cotActif, isSyndicat, referentielsEnWrite });
+    return getSwitchToTeBlockers({
+      cotActif,
+      isSyndicat,
+      isDrom,
+      referentielsEnWrite,
+    });
   }
 
   /**
-   * Les collectivités de type syndicat (SMF, SMO, SIVU, SIVOM) ne sont pas
-   * éligibles au référentiel TE.
+   * Critères d'inéligibilité liés au type de collectivité, lus en un seul appel :
+   * - syndicat (SMF, SMO, SIVU, SIVOM) : pas éligible au référentiel TE ;
+   * - DROM : pas encore éligible au référentiel TE.
    */
-  private async isSyndicat(collectiviteId: number): Promise<boolean> {
-    const { soustype } =
+  private async getEligibiliteType(
+    collectiviteId: number
+  ): Promise<{ isSyndicat: boolean; isDrom: boolean }> {
+    const { soustype, drom } =
       await this.collectivitesService.getCollectiviteAvecType(collectiviteId);
-    return soustype === CollectiviteSousTypeEnum.SYNDICAT;
+    return {
+      isSyndicat: soustype === CollectiviteSousTypeEnum.SYNDICAT,
+      isDrom: drom === true,
+    };
   }
 
   /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Le passage au référentiel Climat Ressources est désormais bloqué pour les collectivités des DROM non encore éligibles.
  * Un message explicatif précise que les référentiels Climat Air Énergie et Économie Circulaire restent actifs et modifiables.
* **Corrections**
  * Le statut et la raison du blocage sont désormais correctement affichés pour les collectivités des DROM.
* **Tests**
  * Ajout de tests couvrant le blocage des collectivités situées dans les DROM et sa priorité parmi les autres blocages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->