### PR TITLE
fix(pcaet): le rapport d'un avis est confidentiel dans la bibliothèque de son émetteur

### DIFF
--- a/apps/app/src/collectivites/documents/upload/use-upload-file.ts
+++ b/apps/app/src/collectivites/documents/upload/use-upload-file.ts
@@ -9,6 +9,8 @@ type UploadFileArgs = {
   hash: DocumentHash;
   signal?: AbortSignal;
   onProgress?: (percent: number) => void;
+  /** Pose la marque de confidentialité sur le fichier créé. */
+  confidentiel?: boolean;
 };
 
 export type UploadFile = (args: UploadFileArgs) => Promise<number>;
@@ -32,7 +34,14 @@ export const useUploadFile = (): UploadFile => {
     })
   );
 
-  return async ({ collectiviteId, file, hash, signal, onProgress }) => {
+  return async ({
+    collectiviteId,
+    file,
+    hash,
+    signal,
+    onProgress,
+    confidentiel,
+  }) => {
     const uploadDecision = await createUploadToken({ collectiviteId, hash });
     if (uploadDecision.kind === 'alreadyInBibliotheque') {
       return uploadDecision.fichierId;
@@ -51,6 +60,7 @@ export const useUploadFile = (): UploadFile => {
       collectiviteId,
       filename: file.name,
       hash,
+      confidentiel,
     });
     return fichier.id;
   };

--- a/apps/app/src/demarches/pcaet/instruction/dossier/data/use-upload-avis-file.ts
+++ b/apps/app/src/demarches/pcaet/instruction/dossier/data/use-upload-avis-file.ts
@@ -10,6 +10,11 @@ import { useInstructeurCollectiviteId } from '../../data/use-contexte-instructio
  * `get-avis-file-url` la résout par l'émetteur. La collectivité courante étant
  * la déposante depuis la bascule de contexte, s'y fier enverrait le rapport dans
  * une bibliothèque interdite à l'agent, et l'avis validé serait introuvable.
+ *
+ * Le rapport est confidentiel : il ne se lit que par le circuit de l'avis, pas
+ * en parcourant la bibliothèque de son émetteur. Le dépôt de l'avis repose la
+ * marque de son côté, pour les fichiers que la déduplication par empreinte
+ * rend sans repasser par ici.
  */
 export const useUploadAvisFile = (): ((
   file: File
@@ -21,7 +26,7 @@ export const useUploadAvisFile = (): ((
     if (!collectiviteId) return null;
 
     const hash = await hashFile(file);
-    await uploadFile({ collectiviteId, file, hash });
+    await uploadFile({ collectiviteId, file, hash, confidentiel: true });
     return hash;
   };
 };

--- a/apps/backend/src/demarches/pcaet/shared/pcaet-avis.repository.ts
+++ b/apps/backend/src/demarches/pcaet/shared/pcaet-avis.repository.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { bibliothequeFichierTable } from '@tet/backend/collectivites/documents/models/bibliotheque-fichier.table';
 import { collectiviteTable } from '@tet/backend/collectivites/shared/models/collectivite.table';
 import { demarcheTable } from '@tet/backend/demarches/shared/models/demarche.table';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
@@ -319,6 +320,31 @@ export class PcaetAvisRepository {
         target: [pcaetAvisTable.demandeAvisId, pcaetAvisTable.auTitreDe],
         set: { fichierRef, modifieLe: new Date().toISOString() },
       });
+  }
+
+  /**
+   * Le rapport d'un avis n'est pas un document de bibliothèque comme un autre :
+   * il est joint à un acte d'instruction et ne se lit que par le circuit de
+   * l'avis. La marque est posée ici, au moment où la pièce devient un rapport,
+   * et non à l'envoi du fichier : la bibliothèque déduplique par empreinte, et
+   * un rapport dont le fichier y figurait déjà ressortirait sans marque.
+   */
+  async marquerPieceConfidentielle(
+    {
+      emetteurCollectiviteId,
+      fichierRef,
+    }: { emetteurCollectiviteId: number; fichierRef: string },
+    tx?: Transaction
+  ): Promise<void> {
+    await (tx ?? this.databaseService.db)
+      .update(bibliothequeFichierTable)
+      .set({ confidentiel: true })
+      .where(
+        and(
+          eq(bibliothequeFichierTable.collectiviteId, emetteurCollectiviteId),
+          eq(bibliothequeFichierTable.hash, fichierRef)
+        )
+      );
   }
 
   async valider(

--- a/apps/backend/src/demarches/pcaet/upsert-avis/upsert-avis.router.e2e-spec.ts
+++ b/apps/backend/src/demarches/pcaet/upsert-avis/upsert-avis.router.e2e-spec.ts
@@ -1,5 +1,7 @@
 import { INestApplication } from '@nestjs/common';
 import { addTestCollectiviteAndUser } from '@tet/backend/collectivites/collectivites/collectivites.test-fixture';
+import { seedTestDocument } from '@tet/backend/collectivites/documents/documents.test-fixture';
+import { bibliothequeFichierTable } from '@tet/backend/collectivites/documents/models/bibliotheque-fichier.table';
 import { demarcheTable } from '@tet/backend/demarches/shared/models/demarche.table';
 import {
   getAuthUserFromUserCredentials,
@@ -8,10 +10,12 @@ import {
   getTestRouter,
 } from '@tet/backend/test';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
+import { addTestUser } from '@tet/backend/users/users/users.test-fixture';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { PcaetAvisAuTitreDe } from '@tet/domain/demarches';
 import { CollectiviteRole } from '@tet/domain/users';
 import { and, eq } from 'drizzle-orm';
+import { onTestFinished } from 'vitest';
 import { pcaetAvisTable } from '../shared/models/pcaet-avis.table';
 import { pcaetDemandeAvisTable } from '../shared/models/pcaet-demande-avis.table';
 
@@ -201,5 +205,184 @@ describe('upsertAvis', () => {
         fichierRef: 'avis-prefet-v3.pdf',
       })
     ).rejects.toThrow();
+  });
+});
+
+/**
+ * TETH-29. Le rapport d'un avis est versé dans la bibliothèque de son émetteur.
+ * Pour une DREAL, l'accès restreint forcé sur les services déconcentrés suffit
+ * à le fermer — mais le conseil régional dépose lui aussi un avis, au titre de
+ * son président, et c'est une collectivité de plein exercice : sa bibliothèque
+ * reste ouverte au mode visite. Sans marque de confidentialité, l'avis du
+ * président de région serait donc lisible et téléchargeable par n'importe quel
+ * compte vérifié de la plateforme, avant même sa validation.
+ */
+describe('la pièce jointe d’un avis est confidentielle', () => {
+  let app: INestApplication;
+  let db: DatabaseService;
+  let router: Awaited<ReturnType<typeof getTestRouter>>;
+
+  const REGION = 'S4';
+
+  beforeAll(async () => {
+    app = await getTestApp();
+    db = await getTestDatabase(app);
+    router = await getTestRouter(app);
+
+    return async () => {
+      await app.close();
+    };
+  });
+
+  const deposerAvisDuPresidentDeRegion = async () => {
+    const deposante = await addTestCollectiviteAndUser(db, {
+      user: { role: CollectiviteRole.ADMIN },
+      collectivite: { regionCode: REGION, nom: 'Agglo test avis confidentiel' },
+    });
+    const conseilRegional = await addTestCollectiviteAndUser(db, {
+      user: { role: CollectiviteRole.ADMIN },
+      collectivite: {
+        type: 'region',
+        regionCode: REGION,
+        nom: 'Conseil régional test avis confidentiel',
+      },
+    });
+    const visiteur = await addTestUser(db);
+
+    const [demarche] = await db.db
+      .insert(demarcheTable)
+      .values({
+        collectiviteId: deposante.collectivite.id,
+        type: 'pcaet',
+        titre: 'PCAET test avis confidentiel',
+        status: 'transmis_pour_avis',
+        transmittedAt: new Date().toISOString(),
+        avisDeadlineAt: new Date(
+          Date.now() + 30 * 24 * 3600 * 1000
+        ).toISOString(),
+      })
+      .returning({ id: demarcheTable.id });
+
+    const [demande] = await db.db
+      .insert(pcaetDemandeAvisTable)
+      .values({
+        demarcheId: demarche.id,
+        instructeurCollectiviteId: conseilRegional.collectivite.id,
+        source: 'seed',
+      })
+      .returning({ id: pcaetDemandeAvisTable.id });
+
+    onTestFinished(async () => {
+      await db.db
+        .delete(pcaetDemandeAvisTable)
+        .where(eq(pcaetDemandeAvisTable.id, demande.id));
+      await db.db
+        .delete(demarcheTable)
+        .where(eq(demarcheTable.id, demarche.id));
+      await visiteur.cleanup();
+      await conseilRegional.cleanup();
+      await deposante.cleanup();
+    });
+
+    // Le rapport est déjà dans la bibliothèque, sans marque : c'est ce que
+    // rend la déduplication par empreinte quand le même fichier y a déjà été
+    // déposé, et c'est donc l'état que le dépôt de l'avis doit corriger.
+    const rapport = await seedTestDocument({
+      databaseService: db,
+      collectiviteId: conseilRegional.collectivite.id,
+      filename: 'avis-president-region.pdf',
+    });
+    expect(rapport.confidentiel).toBe(false);
+
+    const avis = await router
+      .createCaller({
+        user: getAuthUserFromUserCredentials(conseilRegional.user),
+      })
+      .demarches.pcaet.upsertAvis({
+        demandeAvisId: demande.id,
+        auTitreDe: 'president_region',
+        fichierRef: rapport.hash,
+      });
+
+    return {
+      conseilRegionalId: conseilRegional.collectivite.id,
+      demandeAvisId: demande.id,
+      avisId: avis[0].id,
+      rapport,
+      membre: getAuthUserFromUserCredentials(conseilRegional.user),
+      visiteur: getAuthUserFromUserCredentials(visiteur.user),
+    };
+  };
+
+  it('marque le rapport confidentiel dans la bibliothèque de l’émetteur', async () => {
+    const { rapport } = await deposerAvisDuPresidentDeRegion();
+
+    const [enBase] = await db.db
+      .select({ confidentiel: bibliothequeFichierTable.confidentiel })
+      .from(bibliothequeFichierTable)
+      .where(eq(bibliothequeFichierTable.id, rapport.id));
+
+    expect(enBase.confidentiel).toBe(true);
+  });
+
+  it('le soustrait à la bibliothèque vue par un compte vérifié sans droit', async () => {
+    const { conseilRegionalId, rapport, visiteur } =
+      await deposerAvisDuPresidentDeRegion();
+
+    const { items } = await router
+      .createCaller({ user: visiteur })
+      .collectivites.documents.listBibliothequeDocuments({
+        collectiviteId: conseilRegionalId,
+        limit: 100,
+      });
+
+    expect(items.map(({ id }) => id)).not.toContain(rapport.id);
+
+    await expect(() =>
+      router
+        .createCaller({ user: visiteur })
+        .collectivites.documents.getDownloadUrl({
+          collectiviteId: conseilRegionalId,
+          fichierId: rapport.id,
+        })
+    ).rejects.toThrowError(/n'existe pas/i);
+  });
+
+  it('le laisse au membre du service qui l’a déposé', async () => {
+    const { conseilRegionalId, rapport, membre } =
+      await deposerAvisDuPresidentDeRegion();
+
+    const { signedUrl } = await router
+      .createCaller({ user: membre })
+      .collectivites.documents.getDownloadUrl({
+        collectiviteId: conseilRegionalId,
+        fichierId: rapport.id,
+      });
+
+    expect(signedUrl).toContain(rapport.hash);
+  });
+
+  it('laisse télécharger par le circuit de l’avis une pièce devenue confidentielle', async () => {
+    const {
+      demandeAvisId: demande,
+      avisId,
+      rapport,
+      membre,
+    } = await deposerAvisDuPresidentDeRegion();
+
+    const caller = router.createCaller({ user: membre });
+    await caller.demarches.pcaet.validerAvis({
+      demandeAvisId: demande,
+      avisId,
+    });
+
+    // La confidentialité protège la bibliothèque, pas le circuit de l'avis :
+    // `getAvisFileUrl` résout la pièce par son émetteur et signe l'URL sans
+    // repasser par les droits documents de la collectivité.
+    const { url } = await caller.demarches.pcaet.getAvisFileUrl({
+      demandeAvisId: demande,
+      avisId,
+    });
+    expect(url).toContain(rapport.hash);
   });
 });

--- a/apps/backend/src/demarches/pcaet/upsert-avis/upsert-avis.service.ts
+++ b/apps/backend/src/demarches/pcaet/upsert-avis/upsert-avis.service.ts
@@ -70,6 +70,13 @@ export class UpsertAvisService {
       tx
     );
 
+    if (fichierRef !== null) {
+      await this.pcaetAvisRepository.marquerPieceConfidentielle(
+        { emetteurCollectiviteId, fichierRef },
+        tx
+      );
+    }
+
     return success(
       await this.pcaetAvisRepository.listByDemande(demandeAvisId, tx)
     );


### PR DESCRIPTION
Issu de la passe sécurité TETH-20, constat S2. **Empilée sur #5063** (TETH-28), dont elle dépend : la relire après elle, ou comparer à sa branche.

## Le problème

Le rapport d'un avis est versé dans la bibliothèque de documents de son émetteur. Pour une DREAL, l'accès restreint posé par #5063 ferme cette bibliothèque. Mais **le conseil régional dépose lui aussi un avis**, au titre de son président, et ce n'est pas un service déconcentré : c'est une collectivité de plein exercice, avec son espace public et sa bibliothèque ouverte au mode visite.

Le rapport du président de région était donc listable et téléchargeable par n'importe quel compte vérifié de la plateforme — **y compris à l'état de brouillon**, alors même que `getAvisFileUrl` garantit par ailleurs qu'un brouillon ne sort jamais de l'espace de son auteur. La bibliothèque contournait la garantie.

## Ce que fait cette PR

**La marque est posée quand le fichier devient un rapport, pas quand il est envoyé.** C'est le point important : la bibliothèque déduplique par empreinte, et un rapport dont le fichier y figurait déjà revient par ce chemin sans repasser par l'envoi. Poser la marque à l'upload aurait donc laissé un trou ouvert par accident, et un client modifié aurait suffi à le rouvrir sciemment. Le dépôt de l'avis la pose côté serveur, quel que soit le client.

Le front la demande aussi à l'envoi, pour le chemin nominal.

## Ce qui ne change pas

Le circuit de l'avis est intact, et c'est vérifié : `getAvisFileUrl` résout la pièce par son émetteur et signe l'URL sans repasser par les droits documents de la collectivité. La collectivité déposante continue donc de télécharger l'avis qui lui est rendu, et le membre du service son propre rapport.

## Vérification

| Suite | Résultat |
|---|---|
| `nx test backend demarches documents membres` | 437 verts |
| `nx typecheck` backend + app | verts |
| `nx lint` backend + app | verts, 0 erreur |

Quatre tests ajoutés sur le dépôt d'avis d'un conseil régional, dont deux étaient rouges avant le correctif : la marque est bien posée en base, le rapport disparaît de la bibliothèque vue par un compte vérifié sans droit, le membre du service y accède toujours, et le circuit de l'avis continue de servir une pièce devenue confidentielle.

Le test part d'un document déjà présent et non marqué : c'est exactement ce que produit la déduplication par empreinte, donc le cas que le correctif doit rattraper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)