### PR TITLE
ci: retire `environment: ci` des jobs de test

### DIFF
--- a/.github/workflows/prepare-test-db.yml
+++ b/.github/workflows/prepare-test-db.yml
@@ -25,7 +25,6 @@ jobs:
   prepare-test-db:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    environment: ci
     env:
       NX_CLOUD_ACCESS_TOKEN: ${{ inputs.nx-cloud-token-secret-type == 'read-write' && secrets.NX_CLOUD_ACCESS_TOKEN_RW || secrets.NX_CLOUD_ACCESS_TOKEN_RO }}
 

--- a/.github/workflows/test-backend-api.yml
+++ b/.github/workflows/test-backend-api.yml
@@ -27,7 +27,6 @@ on:
 
 jobs:
   test-backend-api:
-    environment: ci
     env:
       NX_CLOUD_ACCESS_TOKEN: ${{ inputs.nx-cloud-token-secret-type == 'read-write' && secrets.NX_CLOUD_ACCESS_TOKEN_RW || secrets.NX_CLOUD_ACCESS_TOKEN_RO }}
     runs-on: ubuntu-latest

--- a/.github/workflows/test-db-deploy.yml
+++ b/.github/workflows/test-db-deploy.yml
@@ -15,7 +15,6 @@ jobs:
   test-db-deploy:
     name: Test database deployment lifecycle
     runs-on: ubuntu-latest
-    environment: ci
 
     steps:
       - uses: actions/checkout@v7.0.1

--- a/.github/workflows/test-end-to-end.yml
+++ b/.github/workflows/test-end-to-end.yml
@@ -23,7 +23,6 @@ env:
 jobs:
   test-end-to-end:
     timeout-minutes: 30
-    environment: ci
     runs-on: ubuntu-latest
 
     # Une variable d'environnement de niveau job est héritée par les steps ET

--- a/.github/workflows/test-ui-storybook.yml
+++ b/.github/workflows/test-ui-storybook.yml
@@ -30,7 +30,6 @@ on:
 jobs:
   ui-storybook:
     if: ${{ inputs.run-ui }}
-    environment: ci
     env:
       NX_CLOUD_ACCESS_TOKEN: ${{ inputs.nx-cloud-token-secret-type == 'read-write' && secrets.NX_CLOUD_ACCESS_TOKEN_RW || secrets.NX_CLOUD_ACCESS_TOKEN_RO }}
     runs-on: ubuntu-latest
@@ -61,7 +60,6 @@ jobs:
   publish-storybook:
     if: ${{ inputs.run-ui }}
     needs: [ui-storybook]
-    environment: ci
     env:
       NX_CLOUD_ACCESS_TOKEN: ${{ inputs.nx-cloud-token-secret-type == 'read-write' && secrets.NX_CLOUD_ACCESS_TOKEN_RW || secrets.NX_CLOUD_ACCESS_TOKEN_RO }}
     runs-on: ubuntu-latest
@@ -88,7 +86,6 @@ jobs:
 
   app-storybook:
     if: ${{ inputs.run-app }}
-    environment: ci
     env:
       NX_CLOUD_ACCESS_TOKEN: ${{ inputs.nx-cloud-token-secret-type == 'read-write' && secrets.NX_CLOUD_ACCESS_TOKEN_RW || secrets.NX_CLOUD_ACCESS_TOKEN_RO }}
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-affected-projects.yml
+++ b/.github/workflows/validate-affected-projects.yml
@@ -24,7 +24,6 @@ on:
 
 jobs:
   validate-affected-projects:
-    environment: ci
     env:
       NX_CLOUD_ACCESS_TOKEN: ${{ inputs.nx-cloud-token-secret-type == 'read-write' && secrets.NX_CLOUD_ACCESS_TOKEN_RW || secrets.NX_CLOUD_ACCESS_TOKEN_RO }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
GitHub crée un enregistrement `deployment` dès qu'un job déclare la clé `environment:`, quoi que fasse le job. Nos 8 jobs de test la portaient, d'où 8 lignes « deployed to ci » dans la timeline à chaque push sur une PR — un bruit qui noyait les vrais déploiements.

L'environnement `ci` ne servait que de porte-secrets : `protection_rules: []`, `deployment_branch_policy: null`. Aucune règle, aucun reviewer, aucune restriction de branche.

## Ce que fait cette PR

Suppression de `environment: ci` sur les 8 jobs concernés :

| Workflow | Jobs |
|---|---|
| `test-ui-storybook.yml` | `ui-storybook`, `publish-storybook`, `app-storybook` |
| `prepare-test-db.yml` | `prepare-test-db` |
| `test-end-to-end.yml` | `test-end-to-end` |
| `validate-affected-projects.yml` | `validate-affected-projects` |
| `test-db-deploy.yml` | `test-db-deploy` |
| `test-backend-api.yml` | `test-backend-api` |

Les workflows `cd-*` et `backup-database` gardent leur `environment:` et restent les seuls à apparaître comme déploiements.

## Migration des variables et secrets — déjà faite

Les 19 variables de l'environnement `ci` sont remontées au niveau du dépôt (17 créées, 2 déjà présentes avec des valeurs identiques, 0 conflit). Les secrets Supabase et Brevo aussi.

Les valeurs d'environnement priment sur celles du dépôt : `prod`, `preprod` et `staging` ne sont pas affectés.

## ⚠️ Bloquant avant de sortir du draft

`NX_CLOUD_ACCESS_TOKEN_RO` et `NX_CLOUD_ACCESS_TOKEN_RW` ne sont **pas encore créés au niveau dépôt**. Comme `nx.json:190` déclare `"nxCloudId"`, Nx tente de s'authentifier à chaque commande : les 6 jobs qui consomment `NX_CLOUD_ACCESS_TOKEN` vont échouer tant que ces deux secrets manquent.

```
gh secret set NX_CLOUD_ACCESS_TOKEN_RO
gh secret set NX_CLOUD_ACCESS_TOKEN_RW
```

Une fois les secrets en place, relancer les jobs et vérifier que la CI est verte avant de passer la PR en « ready for review ».

## Suite

Après merge, l'historique des deployments `ci` (100+ entrées) peut être purgé via l'API — passage en `inactive` puis `DELETE` — pour nettoyer rétroactivement les timelines des PR existantes.

https://claude.ai/code/session_01VeEHs3ZV5hMP268Aw6fJyJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Les workflows automatisés de préparation, de validation et de test ne ciblent plus l’environnement CI dédié.
  - Ces tâches n’héritent donc plus des règles de protection ni des secrets associés à cet environnement.
  - Les étapes de test, de déploiement de la base de données, de validation et de publication Storybook restent inchangées.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->