### PR TITLE
feat(pcaet): allow bypassing diagnostic via PostHog feature flag

### DIFF
--- a/apps/backend/src/demarches/pcaet/clore-instruction/clore-instruction.service.ts
+++ b/apps/backend/src/demarches/pcaet/clore-instruction/clore-instruction.service.ts
@@ -109,7 +109,7 @@ export class CloreInstructionService {
     demarche: Parameters<DemarchePcaetGuardsService['loadContext']>[0],
     tx?: Transaction
   ): Promise<DemarchePcaetTransition | null> {
-    const context = await this.guardsService.loadContext(demarche, tx);
+    const context = await this.guardsService.loadContext(demarche, null, tx);
     const transitions = evaluateTransitions(
       demarche.status,
       this.guardsService.computeGuardResults(context, null)

--- a/apps/backend/src/demarches/pcaet/pcaet.module.ts
+++ b/apps/backend/src/demarches/pcaet/pcaet.module.ts
@@ -12,6 +12,7 @@ import { PlanModule } from '@tet/backend/plans/plans/plans.module';
 import { UsersModule } from '@tet/backend/users/users.module';
 import { NotificationsModule } from '@tet/backend/utils/notifications/notifications.module';
 import { TransactionModule } from '@tet/backend/utils/transaction/transaction.module';
+import { TrackingModule } from '@tet/backend/utils/tracking/tracking.module';
 import { AddVulnerabiliteThematiqueRouter } from './add-vulnerabilite-thematique/add-vulnerabilite-thematique.router';
 import { AddVulnerabiliteThematiqueService } from './add-vulnerabilite-thematique/add-vulnerabilite-thematique.service';
 import { ArchiverDemarchePcaetRouter } from './archiver-demarche/archiver-demarche.router';
@@ -123,6 +124,7 @@ import { ValiderAvisService } from './valider-avis/valider-avis.service';
     PlanModule,
     AxeModule,
     NotificationsModule,
+    TrackingModule,
   ],
   providers: [
     DemarchePcaetPilotesRepository,

--- a/apps/backend/src/demarches/pcaet/shared/demarche-pcaet-guards.service.ts
+++ b/apps/backend/src/demarches/pcaet/shared/demarche-pcaet-guards.service.ts
@@ -2,8 +2,8 @@ import { Injectable, Logger } from '@nestjs/common';
 import { DemarcheDocumentsRepository } from '@tet/backend/demarches/shared/demarche-documents.repository';
 import { DemarchePlanActionsRepository } from '@tet/backend/demarches/shared/demarche-plan-actions.repository';
 import { AuthenticatedUser } from '@tet/backend/users/models/auth.models';
-import ConfigurationService from '@tet/backend/utils/config/configuration.service';
 import { Transaction } from '@tet/backend/utils/database/transaction.utils';
+import { TrackingService } from '@tet/backend/utils/tracking/tracking.service';
 import {
   DemarcheTypeEnum,
   evaluateTransitions,
@@ -48,7 +48,8 @@ export type DemarchePcaetGuardContext = DemarchePcaetGuardTarget & {
   planActionIds?: readonly number[];
   /**
    * Environnements de démonstration : le dossier se passe d'un diagnostic
-   * complet (cf. DEMARCHE_PCAET_BYPASS_DIAGNOSTIC). Faux partout ailleurs.
+   * complet (cf. feature flag PostHog `is-demarche-pcaet-bypass-diagnostic-enabled`).
+   * Faux partout ailleurs.
    */
   isDiagnosticBypassed?: boolean;
   /** Pièces amont requises couvertes, au sens de la règle documentaire. */
@@ -127,21 +128,32 @@ export class DemarchePcaetGuardsService {
     private readonly documentsRepository: DemarcheDocumentsRepository,
     private readonly planActionsRepository: DemarchePlanActionsRepository,
     private readonly avisRepository: PcaetAvisRepository,
-    private readonly configurationService: ConfigurationService
+    private readonly trackingService: TrackingService
   ) {}
 
   /**
    * Le contournement s'annonce à chaque évaluation plutôt qu'une fois au
    * démarrage : un dossier transmis sans diagnostic complet doit être
    * explicable en lisant les logs de la transmission.
+   *
+   * Piloté par le feature flag PostHog `is-demarche-pcaet-bypass-diagnostic-enabled`,
+   * activable par utilisateur ou collectivité depuis l'interface PostHog.
    */
-  private isDiagnosticBypassed(): boolean {
-    const isBypassed =
-      this.configurationService.get('DEMARCHE_PCAET_BYPASS_DIAGNOSTIC') ===
-      true;
+  private async isDiagnosticBypassed(
+    user: AuthenticatedUser | null,
+    collectiviteId: number
+  ): Promise<boolean> {
+    if (!user) {
+      return false;
+    }
+    const isBypassed = await this.trackingService.isFeatureEnabled(
+      'is-demarche-pcaet-bypass-diagnostic-enabled',
+      user.id,
+      collectiviteId
+    );
     if (isBypassed) {
       this.logger.warn(
-        'DEMARCHE_PCAET_BYPASS_DIAGNOSTIC actif : le diagnostic n’est pas exigé pour compléter le dossier PCAET (environnement de démonstration)'
+        `Feature flag is-demarche-pcaet-bypass-diagnostic-enabled actif pour user ${user.id} / collectivité ${collectiviteId} : le diagnostic n'est pas exigé pour compléter le dossier PCAET (démonstration)`
       );
     }
     return isBypassed;
@@ -154,6 +166,7 @@ export class DemarchePcaetGuardsService {
    */
   async loadContext(
     demarche: DemarchePcaetGuardTarget,
+    user: AuthenticatedUser | null,
     tx?: Transaction
   ): Promise<DemarchePcaetGuardContext> {
     const requiredGuards = getRequiredGuards(demarche.status);
@@ -204,7 +217,9 @@ export class DemarchePcaetGuardsService {
       pilotes,
       planActionIds,
       demandesAvis,
-      isDiagnosticBypassed: needsDossier ? this.isDiagnosticBypassed() : false,
+      isDiagnosticBypassed: needsDossier
+        ? await this.isDiagnosticBypassed(user, demarche.collectiviteId)
+        : false,
       diagnostic,
       documentsComplets:
         needsDossier && documentsSnapshot
@@ -252,7 +267,7 @@ export class DemarchePcaetGuardsService {
     user: AuthenticatedUser | null,
     tx?: Transaction
   ): Promise<DemarchePcaet> {
-    const context = await this.loadContext(demarche, tx);
+    const context = await this.loadContext(demarche, user, tx);
     return {
       ...demarche,
       ...this.computeAvailableActions(context, user),

--- a/apps/backend/src/demarches/pcaet/shared/demarche-pcaet-transition.service.ts
+++ b/apps/backend/src/demarches/pcaet/shared/demarche-pcaet-transition.service.ts
@@ -144,6 +144,7 @@ export class DemarchePcaetTransitionService {
 
       const guardContext = await this.guardsService.loadContext(
         demarche,
+        user,
         transaction
       );
       const transitionResult = applyTransition(demarche.status, transition, {

--- a/apps/backend/src/demarches/pcaet/transmettre-pour-avis/transmettre-pour-avis.router.e2e-spec.ts
+++ b/apps/backend/src/demarches/pcaet/transmettre-pour-avis/transmettre-pour-avis.router.e2e-spec.ts
@@ -9,7 +9,7 @@ import {
   getTestApp,
   getTestDatabase,
 } from '@tet/backend/test';
-import ConfigurationService from '@tet/backend/utils/config/configuration.service';
+import { TrackingService } from '@tet/backend/utils/tracking/tracking.service';
 import { DatabaseService } from '@tet/backend/utils/database/database.service';
 import { TrpcRouter } from '@tet/backend/utils/trpc/trpc.router';
 import type { Collectivite, CollectiviteType } from '@tet/domain/collectivites';
@@ -366,14 +366,16 @@ describe('Cycle de vie de la démarche PCAET (transitions)', () => {
       })
     ).rejects.toThrow('DOSSIER_INCOMPLET');
 
-    // Seule cette clé est détournée : le reste de la configuration doit
-    // continuer de répondre, l'application entière la lit.
-    const configurationService = app.get(ConfigurationService);
-    const get = configurationService.get.bind(configurationService);
+    // Le bypass est piloté par le feature flag PostHog :
+    const trackingService = app.get(TrackingService);
+    const isFeatureEnabled =
+      trackingService.isFeatureEnabled.bind(trackingService);
     const spy = vi
-      .spyOn(configurationService, 'get')
-      .mockImplementation((key) =>
-        key === 'DEMARCHE_PCAET_BYPASS_DIAGNOSTIC' ? true : get(key)
+      .spyOn(trackingService, 'isFeatureEnabled')
+      .mockImplementation(async (feature, ...args) =>
+        feature === 'is-demarche-pcaet-bypass-diagnostic-enabled'
+          ? true
+          : isFeatureEnabled(feature, ...args)
       );
     onTestFinished(() => {
       spy.mockRestore();

--- a/apps/backend/src/utils/config/configuration.model.ts
+++ b/apps/backend/src/utils/config/configuration.model.ts
@@ -151,16 +151,6 @@ export const backendConfigurationSchema = z.object({
     .describe(
       'List of email addresses that are allowed to receive emails sent by the SMTP server'
     ),
-  // Contournement de démonstration : renseigner un diagnostic PCAET entier
-  // (plusieurs centaines de lignes d'indicateurs) n'est pas tenable en COPIL.
-  // Réservé aux environnements de démonstration — laissé à false partout
-  // ailleurs, la règle de complétude du dossier s'applique alors normalement.
-  DEMARCHE_PCAET_BYPASS_DIAGNOSTIC: z
-    .stringbool()
-    .default(false)
-    .describe(
-      'Environnements de démonstration uniquement : dispense le dossier PCAET d’un diagnostic complet pour être transmis pour avis'
-    ),
   DELAY_IN_MIN_BEFORE_NOTIFY_PILOTE: z.coerce
     .number()
     .int()

--- a/apps/backend/src/utils/tracking/posthog-event-tracker.ts
+++ b/apps/backend/src/utils/tracking/posthog-event-tracker.ts
@@ -55,11 +55,14 @@ export class PostHogEventTracker
     userId: string,
     collectiviteId?: number
   ): Promise<boolean> {
+    // Le flag de bypass diagnostic PCAET est un contournement d'exception (démonstration) :
+    // il ne doit jamais être activé par défaut en dev/test/ci, mais piloté explicitement via PostHog.
     if (
-      process.env.NODE_ENV === 'development' ||
-      process.env.NODE_ENV === 'test' ||
-      process.env.ENV_NAME === 'dev' ||
-      process.env.ENV_NAME === 'ci'
+      featureFlagKey !== 'is-demarche-pcaet-bypass-diagnostic-enabled' &&
+      (process.env.NODE_ENV === 'development' ||
+        process.env.NODE_ENV === 'test' ||
+        process.env.ENV_NAME === 'dev' ||
+        process.env.ENV_NAME === 'ci')
     ) {
       return true;
     }

--- a/packages/domain/src/utils/feature-flags.ts
+++ b/packages/domain/src/utils/feature-flags.ts
@@ -6,6 +6,7 @@ const FEATURE_FLAGS = [
   'is-share-fiche-enabled',
   'is-action-default-table-view-enabled',
   'is-demarche-pcaet-enabled',
+  'is-demarche-pcaet-bypass-diagnostic-enabled',
 ] as const;
 
 export const FeatureFlagEnum = createEnumObject(FEATURE_FLAGS);


### PR DESCRIPTION
Replace the global DEMARCHE_PCAET_BYPASS_DIAGNOSTIC environment variable with a PostHog feature flag `is-demarche-pcaet-bypass-diagnostic-enabled`. This allows selectively enabling the diagnostic bypass on demand for specific users or collectivités during demos, without bypassing it globally.